### PR TITLE
feat(logs-alerts): add ClickHouse alert check query

### DIFF
--- a/products/logs/backend/alert_check_query.py
+++ b/products/logs/backend/alert_check_query.py
@@ -1,0 +1,191 @@
+import time
+import datetime as dt
+from dataclasses import dataclass
+from zoneinfo import ZoneInfo
+
+from posthog.schema import (
+    DateRange,
+    FilterLogicalOperator,
+    HogQLFilters,
+    HogQLQueryResponse,
+    IntervalType,
+    LogsQuery,
+    PropertyGroupFilter,
+    PropertyGroupFilterValue,
+)
+
+from posthog.hogql import ast
+from posthog.hogql.constants import HogQLGlobalSettings, LimitContext
+from posthog.hogql.parser import parse_select
+from posthog.hogql.query import execute_hogql_query
+
+from posthog.clickhouse.client.connection import Workload
+from posthog.clickhouse.query_tagging import tag_queries
+from posthog.hogql_queries.utils.query_date_range import QueryDateRange
+from posthog.models import Team
+
+from products.logs.backend.logs_query_runner import LogsFilterBuilder
+from products.logs.backend.models import LogsAlertConfiguration
+
+
+@dataclass(frozen=True)
+class AlertCheckCountResult:
+    count: int
+    query_duration_ms: int
+
+
+@dataclass(frozen=True)
+class BucketedCount:
+    timestamp: dt.datetime
+    count: int
+
+
+class AlertCheckQuery:
+    """Lightweight count query against the logs ClickHouse cluster for alert checks.
+
+    Runs once per minute per alert, potentially for every org (~10K near-term),
+    against a table ingesting ~10M rows/min. Uses the projection_aggregate_counts
+    projection where possible and falls back to raw scans with bloom filter pruning
+    for body/attribute filters. Intentionally not an AnalyticsQueryRunner — this is
+    an internal query with its own timeout and byte limits, not user-facing.
+
+    See the [Logs Alerting RFC](https://github.com/PostHog/requests-for-comments-internal/blob/main/engineering/2026-03-03-logs-alerting.md)
+    """
+
+    SETTINGS = HogQLGlobalSettings(
+        max_execution_time=30,
+        max_bytes_to_read=50_000_000_000,  # 50GB
+        read_overflow_mode="throw",
+    )
+
+    def __init__(
+        self,
+        *,
+        team: Team,
+        alert: LogsAlertConfiguration,
+        date_from: dt.datetime,
+        date_to: dt.datetime,
+    ) -> None:
+        if alert.team_id != team.id:
+            raise ValueError(f"Alert {alert.id} belongs to team {alert.team_id}, not {team.id}")
+        self.team = team
+        self.alert = alert
+        self.date_range = DateRange(date_from=date_from.isoformat(), date_to=date_to.isoformat())
+
+        logs_query = self._build_logs_query()
+        query_date_range = QueryDateRange(
+            date_range=logs_query.dateRange,
+            team=team,
+            interval=IntervalType.MINUTE,
+            interval_count=1,
+            now=date_to,
+            timezone_info=ZoneInfo("UTC"),
+            exact_timerange=True,
+        )
+        builder = LogsFilterBuilder(logs_query, team, query_date_range)
+        self.where_expr = builder.where()
+
+    def execute(self) -> AlertCheckCountResult:
+        """Return a single aggregate count for the alert window."""
+        self._tag()
+
+        query = parse_select(
+            """
+            SELECT count() AS total
+            FROM logs
+            WHERE {where}
+            """,
+            placeholders={"where": self.where_expr},
+        )
+
+        start_ms = time.monotonic_ns() // 1_000_000
+        response = self._run_query(query)
+        duration_ms = time.monotonic_ns() // 1_000_000 - start_ms
+
+        count = response.results[0][0] if response.results else 0
+        return AlertCheckCountResult(count=count, query_duration_ms=duration_ms)
+
+    def execute_bucketed(self, interval_minutes: int) -> list[BucketedCount]:
+        """Return time-bucketed counts for preview charts."""
+        self._tag()
+
+        # Wrapping in toStartOfMinute() lets ClickHouse match the projection's
+        # `time_bucket` key column and read pre-aggregated data instead of raw rows.
+        time_field = (
+            ast.Call(name="toStartOfMinute", args=[ast.Field(chain=["timestamp"])])
+            if is_projection_eligible(self.alert.filters)
+            else ast.Field(chain=["timestamp"])
+        )
+        query = parse_select(
+            """
+            SELECT
+                toStartOfInterval({time_field}, toIntervalMinute({bucket_minutes})) AS bucket,
+                count() AS total
+            FROM logs
+            WHERE {where}
+            GROUP BY bucket
+            ORDER BY bucket ASC
+            LIMIT 10000
+            """,
+            placeholders={
+                "time_field": time_field,
+                "bucket_minutes": ast.Constant(value=interval_minutes),
+                "where": self.where_expr,
+            },
+        )
+
+        response = self._run_query(query)
+        return [BucketedCount(timestamp=row[0], count=row[1]) for row in response.results]
+
+    def _run_query(self, query: ast.SelectQuery | ast.SelectSetQuery) -> HogQLQueryResponse:
+        if not isinstance(query, ast.SelectQuery):
+            raise ValueError("Failed to build alert check query")
+
+        return execute_hogql_query(
+            query_type="alert_check",
+            query=query,
+            team=self.team,
+            workload=Workload.LOGS,
+            settings=self.SETTINGS,
+            limit_context=LimitContext.QUERY,
+            filters=HogQLFilters(dateRange=self.date_range),
+        )
+
+    def _tag(self) -> None:
+        tag_queries(source="logs_alert", kind="temporal", alert_config_id=str(self.alert.id), team_id=str(self.team.id))
+
+    def _build_logs_query(self) -> LogsQuery:
+        filters = self.alert.filters
+        filter_group = filters.get("filterGroup")
+        if filter_group:
+            pg = PropertyGroupFilter.model_validate(filter_group)
+        else:
+            pg = PropertyGroupFilter(
+                type=FilterLogicalOperator.AND_,
+                values=[PropertyGroupFilterValue(type=FilterLogicalOperator.AND_, values=[])],
+            )
+
+        return LogsQuery(
+            dateRange=self.date_range,
+            serviceNames=filters.get("serviceNames", []),
+            severityLevels=filters.get("severityLevels", []),
+            filterGroup=pg,
+            kind="LogsQuery",
+        )
+
+
+def is_projection_eligible(filters: dict) -> bool:
+    """True when filters use only serviceNames + severityLevels (no filterGroup values).
+
+    The projection_aggregate_counts projection groups by (team_id, time_bucket,
+    service_name, severity_text, resource_fingerprint), so it covers these two
+    filter types. Any filterGroup values reference columns outside the projection
+    and require a raw table scan.
+    """
+    filter_group = filters.get("filterGroup")
+    if not filter_group:
+        return True
+    for group in filter_group.get("values", []):
+        if group.get("values"):
+            return False
+    return True

--- a/products/logs/backend/test/test_alert_check_query.py
+++ b/products/logs/backend/test/test_alert_check_query.py
@@ -1,0 +1,327 @@
+import os
+import json
+from datetime import UTC, datetime
+
+import unittest
+from freezegun import freeze_time
+from posthog.test.base import APIBaseTest, ClickhouseTestMixin
+from unittest.mock import patch
+
+from parameterized import parameterized
+
+from posthog.clickhouse.client import sync_execute
+
+from products.logs.backend.alert_check_query import (
+    AlertCheckCountResult,
+    AlertCheckQuery,
+    BucketedCount,
+    is_projection_eligible,
+)
+from products.logs.backend.models import LogsAlertConfiguration
+
+
+class TestIsProjectionEligible(unittest.TestCase):
+    @parameterized.expand(
+        [
+            ("empty_filters", {}, True),
+            ("service_only", {"serviceNames": ["argo-rollouts"]}, True),
+            ("severity_only", {"severityLevels": ["error"]}, True),
+            ("service_and_severity", {"serviceNames": ["argo-rollouts"], "severityLevels": ["error"]}, True),
+            (
+                "empty_filter_group",
+                {"filterGroup": {"type": "AND", "values": [{"type": "AND", "values": []}]}},
+                True,
+            ),
+            (
+                "body_filter_present",
+                {
+                    "filterGroup": {
+                        "type": "AND",
+                        "values": [
+                            {
+                                "type": "AND",
+                                "values": [
+                                    {"key": "message", "value": "error", "operator": "icontains", "type": "log"}
+                                ],
+                            }
+                        ],
+                    }
+                },
+                False,
+            ),
+            (
+                "attribute_filter_present",
+                {
+                    "filterGroup": {
+                        "type": "AND",
+                        "values": [
+                            {
+                                "type": "AND",
+                                "values": [
+                                    {
+                                        "key": "logtag",
+                                        "value": ["F"],
+                                        "operator": "exact",
+                                        "type": "log_attribute",
+                                    }
+                                ],
+                            }
+                        ],
+                    }
+                },
+                False,
+            ),
+        ]
+    )
+    def test_projection_eligibility(self, _name, filters, expected):
+        assert is_projection_eligible(filters) == expected
+
+
+class TestAlertCheckQuery(ClickhouseTestMixin, APIBaseTest):
+    CLASS_DATA_LEVEL_SETUP = True
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        with open(os.path.join(os.path.dirname(__file__), "test_logs.jsonnd")) as f:
+            rows = ""
+            for line in f:
+                log_item = json.loads(line)
+                log_item["team_id"] = cls.team.id
+                rows += json.dumps(log_item) + "\n"
+            sync_execute("INSERT INTO logs FORMAT JSONEachRow\n" + rows)
+
+    def _make_alert(self, **kwargs) -> LogsAlertConfiguration:
+        defaults = {
+            "team": self.team,
+            "name": "Test Alert",
+            "threshold_count": 10,
+            "threshold_operator": "above",
+            "window_minutes": 5,
+            "filters": {},
+        }
+        defaults.update(kwargs)
+        return LogsAlertConfiguration.objects.create(**defaults)
+
+    def _make_query(self, alert: LogsAlertConfiguration) -> AlertCheckQuery:
+        return AlertCheckQuery(
+            team=self.team,
+            alert=alert,
+            date_from=datetime(2025, 12, 16, 9, 0, 0, tzinfo=UTC),
+            date_to=datetime(2025, 12, 16, 10, 33, 0, tzinfo=UTC),
+        )
+
+    @freeze_time("2025-12-16T10:33:00Z")
+    def test_projection_path_service_severity_only(self):
+        alert = self._make_alert(
+            filters={
+                "serviceNames": ["argo-rollouts"],
+                "severityLevels": ["info"],
+            }
+        )
+        result = self._make_query(alert).execute()
+        assert isinstance(result, AlertCheckCountResult)
+        # argo-rollouts has 100 logs, some are info severity
+        assert result.count > 0
+        assert result.query_duration_ms >= 0
+
+    @freeze_time("2025-12-16T10:33:00Z")
+    def test_projection_path_service_only(self):
+        alert = self._make_alert(
+            filters={
+                "serviceNames": ["billing"],
+            }
+        )
+        result = self._make_query(alert).execute()
+        assert isinstance(result, AlertCheckCountResult)
+        assert result.count == 100
+
+    @freeze_time("2025-12-16T10:33:00Z")
+    def test_empty_filters_returns_all_logs(self):
+        alert = self._make_alert(filters={})
+        result = self._make_query(alert).execute()
+        assert isinstance(result, AlertCheckCountResult)
+        assert result.count > 0
+
+    @freeze_time("2025-12-16T10:33:00Z")
+    def test_raw_scan_path_body_filter(self):
+        alert = self._make_alert(
+            filters={
+                "serviceNames": ["argo-rollouts"],
+                "filterGroup": {
+                    "type": "AND",
+                    "values": [
+                        {
+                            "type": "AND",
+                            "values": [
+                                {
+                                    "key": "message",
+                                    "value": "Argo Rollouts Dashboard",
+                                    "operator": "icontains",
+                                    "type": "log",
+                                }
+                            ],
+                        }
+                    ],
+                },
+            }
+        )
+        result = self._make_query(alert).execute()
+        assert isinstance(result, AlertCheckCountResult)
+        assert result.count > 0
+
+    @freeze_time("2025-12-16T10:33:00Z")
+    def test_raw_scan_path_resource_attribute_filter(self):
+        alert = self._make_alert(
+            filters={
+                "filterGroup": {
+                    "type": "AND",
+                    "values": [
+                        {
+                            "type": "AND",
+                            "values": [
+                                {
+                                    "key": "k8s.container.name",
+                                    "value": "argo-rollouts-dashboard",
+                                    "operator": "icontains",
+                                    "type": "log_resource_attribute",
+                                }
+                            ],
+                        }
+                    ],
+                },
+            }
+        )
+        result = self._make_query(alert).execute()
+        assert isinstance(result, AlertCheckCountResult)
+        assert result.count > 0
+
+    @freeze_time("2025-12-16T10:33:00Z")
+    def test_empty_results_return_zero(self):
+        alert = self._make_alert(
+            filters={
+                "serviceNames": ["nonexistent-service"],
+            }
+        )
+        result = self._make_query(alert).execute()
+        assert isinstance(result, AlertCheckCountResult)
+        assert result.count == 0
+
+    @freeze_time("2025-12-16T10:33:00Z")
+    def test_bucketed_output(self):
+        alert = self._make_alert(
+            filters={
+                "serviceNames": ["argo-rollouts"],
+            }
+        )
+        result = self._make_query(alert).execute_bucketed(interval_minutes=5)
+        assert isinstance(result, list)
+        assert len(result) > 0
+        for item in result:
+            assert isinstance(item, BucketedCount)
+            assert item.count > 0
+        # buckets should be sorted by timestamp
+        timestamps = [item.timestamp for item in result]
+        assert timestamps == sorted(timestamps)
+
+    @freeze_time("2025-12-16T10:33:00Z")
+    def test_bucketed_empty_results(self):
+        alert = self._make_alert(
+            filters={
+                "serviceNames": ["nonexistent-service"],
+            }
+        )
+        result = self._make_query(alert).execute_bucketed(interval_minutes=5)
+        assert result == []
+
+    @freeze_time("2025-12-16T10:33:00Z")
+    def test_bucketed_output_with_body_filter(self):
+        alert = self._make_alert(
+            filters={
+                "serviceNames": ["argo-rollouts"],
+                "filterGroup": {
+                    "type": "AND",
+                    "values": [
+                        {
+                            "type": "AND",
+                            "values": [
+                                {
+                                    "key": "message",
+                                    "value": "Argo Rollouts Dashboard",
+                                    "operator": "icontains",
+                                    "type": "log",
+                                }
+                            ],
+                        }
+                    ],
+                },
+            }
+        )
+        result = self._make_query(alert).execute_bucketed(interval_minutes=10)
+        assert isinstance(result, list)
+        total = sum(item.count for item in result)
+        assert total > 0
+
+    @freeze_time("2025-12-16T10:33:00Z")
+    def test_bucketed_projection_path(self):
+        alert = self._make_alert(
+            filters={
+                "serviceNames": ["argo-rollouts"],
+                "severityLevels": ["info"],
+            }
+        )
+        result = self._make_query(alert).execute_bucketed(interval_minutes=5)
+        assert isinstance(result, list)
+        assert len(result) > 0
+
+    @freeze_time("2025-12-16T10:33:00Z")
+    def test_bucketed_raw_scan_path(self):
+        alert = self._make_alert(
+            filters={
+                "serviceNames": ["argo-rollouts"],
+                "filterGroup": {
+                    "type": "AND",
+                    "values": [
+                        {
+                            "type": "AND",
+                            "values": [
+                                {
+                                    "key": "message",
+                                    "value": "Argo Rollouts Dashboard",
+                                    "operator": "icontains",
+                                    "type": "log",
+                                }
+                            ],
+                        }
+                    ],
+                },
+            }
+        )
+        result = self._make_query(alert).execute_bucketed(interval_minutes=5)
+        assert isinstance(result, list)
+        assert len(result) > 0
+
+    def test_team_mismatch_raises(self):
+        from posthog.models import Organization, Team
+
+        other_org = Organization.objects.create(name="Other Org")
+        other_team = Team.objects.create(organization=other_org, name="Other Team")
+        alert = self._make_alert()
+
+        with self.assertRaisesRegex(ValueError, f"belongs to team {self.team.id}, not {other_team.id}"):
+            AlertCheckQuery(
+                team=other_team,
+                alert=alert,
+                date_from=datetime(2025, 12, 16, 9, 0, 0, tzinfo=UTC),
+                date_to=datetime(2025, 12, 16, 10, 33, 0, tzinfo=UTC),
+            )
+
+    def test_timeout_propagates(self):
+        alert = self._make_alert(filters={"serviceNames": ["argo-rollouts"]})
+        query = self._make_query(alert)
+        with patch(
+            "products.logs.backend.alert_check_query.execute_hogql_query",
+            side_effect=Exception("ClickHouse timeout"),
+        ):
+            with self.assertRaisesRegex(Exception, "ClickHouse timeout"):
+                query.execute()


### PR DESCRIPTION
## Problem

Logs alerting needs a lightweight ClickHouse query for alert checks, running once per minute per alert on temporal at scale.

## Changes

- `AlertCheckQuery` class with two methods: `execute()` (single count for alert checks) and `execute_bucketed()` (time-series for preview charts)
- Projection-eligible detection (`_is_projection_eligible`) to route simple service+severity filters to the pre-aggregated projection
- 30s timeout, 50GB `max_bytes_to_read`, routed to logs ClickHouse cluster via `Workload.LOGS`
- Query tagged with `source=logs_alert`, `alert_config_id`, `team_id` for observability

## How did you test this code?

New tests

## Publish to changelog?

No