### PR TITLE
chore(endpoints): add basic metrics

### DIFF
--- a/products/endpoints/backend/api.py
+++ b/products/endpoints/backend/api.py
@@ -1,4 +1,5 @@
 import re
+import time
 import uuid
 import builtins
 import dataclasses
@@ -98,6 +99,18 @@ from products.endpoints.backend.materialization import (
     get_reaggregation,
     transform_query_for_materialization,
     transform_select_for_materialized_table,
+)
+from products.endpoints.backend.metrics import (
+    ENDPOINT_CACHE_RESULT_TOTAL,
+    ENDPOINT_CONCURRENCY_REJECTED_TOTAL,
+    ENDPOINT_DUCKLAKE_FALLBACK_TOTAL,
+    ENDPOINT_EXECUTION_DURATION_SECONDS,
+    ENDPOINT_EXECUTION_TOTAL,
+    ENDPOINT_HOGQL_RESULT_ROWS,
+    ENDPOINT_MATERIALIZATION_EVENT_TOTAL,
+    ENDPOINT_MATERIALIZED_AGE_SECONDS,
+    ENDPOINT_VALIDATION_ERROR_TOTAL,
+    query_kind_label,
 )
 from products.endpoints.backend.models import Endpoint, EndpointVersion
 from products.endpoints.backend.openapi import generate_openapi_spec
@@ -1009,9 +1022,12 @@ class EndpointViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.Model
         """
         try:
             self._enable_materialization_inner(endpoint, sync_frequency, request, version, bucket_overrides)
+            ENDPOINT_MATERIALIZATION_EVENT_TOTAL.labels(action="enable", status="success").inc()
         except ValidationError:
+            ENDPOINT_MATERIALIZATION_EVENT_TOTAL.labels(action="enable", status="validation_error").inc()
             raise
         except Exception:
+            ENDPOINT_MATERIALIZATION_EVENT_TOTAL.labels(action="enable", status="error").inc()
             raise ValidationError("Failed to enable materialization.")
 
     def _enable_materialization_inner(
@@ -1113,7 +1129,12 @@ class EndpointViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.Model
                             "saved_query_id": version.saved_query.id if version and version.saved_query else None,
                         },
                     )
-            version.disable_materialization()
+                try:
+                    version.disable_materialization()
+                except Exception:
+                    ENDPOINT_MATERIALIZATION_EVENT_TOTAL.labels(action="disable", status="error").inc()
+                    raise
+                ENDPOINT_MATERIALIZATION_EVENT_TOTAL.labels(action="disable", status="success").inc()
         clear_endpoint_materialization_cache(self.team_id, endpoint.name)
 
     def destroy(self, request: Request, name=None, *args, **kwargs) -> Response:
@@ -1643,6 +1664,10 @@ class EndpointViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.Model
                     trigger_saved_query_schedule(saved_query)
                     raise
 
+            if saved_query.last_run_at:
+                age_seconds = max((timezone.now() - saved_query.last_run_at).total_seconds(), 0.0)
+                ENDPOINT_MATERIALIZED_AGE_SECONDS.observe(age_seconds)
+
             return result
         except Exception as e:
             logger.exception(
@@ -2039,6 +2064,10 @@ class EndpointViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.Model
         use_materialized = self._should_use_materialized_table(endpoint, data, version_obj)
 
         debug = data.debug or False
+        execution_type = "materialized" if use_materialized else "inline"
+        query_kind_metric = query_kind_label(version_obj.query if version_obj else None)
+        execution_status: str | None = None
+        _start_time = time.monotonic()
 
         try:
             if use_materialized:
@@ -2058,11 +2087,14 @@ class EndpointViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.Model
                 if use_ducklake:
                     try:
                         result = self._execute_ducklake_endpoint(endpoint, query_to_use, debug=debug)
+                        execution_type = "ducklake"
                     except Exception:
                         logger.warning(
                             "DuckLake execution failed, falling back to inline",
                             endpoint_name=endpoint.name,
                         )
+                        ENDPOINT_DUCKLAKE_FALLBACK_TOTAL.inc()
+                        execution_type = "ducklake_fallback"
                         result = self._execute_inline_endpoint(
                             endpoint,
                             data,
@@ -2084,8 +2116,9 @@ class EndpointViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.Model
                         limit=limit,
                         offset=offset,
                     )
-
+            execution_status = "success"
         except (ExposedHogQLError, ExposedCHQueryError) as e:
+            execution_status = "error"
             logger.exception(
                 "Endpoint execution failed",
                 endpoint_name=endpoint.name,
@@ -2093,19 +2126,50 @@ class EndpointViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.Model
             )
             raise ValidationError("Query execution failed.", getattr(e, "code_name", None))
         except HogVMException:
+            execution_status = "error"
             logger.exception(
                 "Endpoint execution failed (HogVM)",
                 endpoint_name=endpoint.name,
             )
             raise ValidationError("Query execution failed: HogQL virtual machine error")
         except ResolutionError:
+            execution_status = "error"
             logger.exception(
                 "Endpoint resolution failed",
                 endpoint_name=endpoint.name,
             )
             raise ValidationError("Query resolution failed: unable to resolve table or field references.")
         except ConcurrencyLimitExceeded:
+            ENDPOINT_CONCURRENCY_REJECTED_TOTAL.inc()
             raise Throttled(detail="Too many concurrent requests. Please try again later.")
+        except Exception:
+            execution_status = "error"
+            raise
+        finally:
+            if execution_status is not None:
+                _duration = time.monotonic() - _start_time
+                ENDPOINT_EXECUTION_DURATION_SECONDS.labels(
+                    execution_type=execution_type, query_kind=query_kind_metric
+                ).observe(_duration)
+                ENDPOINT_EXECUTION_TOTAL.labels(
+                    execution_type=execution_type, query_kind=query_kind_metric, status=execution_status
+                ).inc()
+
+        try:
+            if isinstance(result.data, dict):
+                # DuckLake bypasses the query result cache entirely — don't claim hit/miss for it.
+                if execution_type != "ducklake":
+                    cache_outcome = "hit" if bool(result.data.get("is_cached")) else "miss"
+                    ENDPOINT_CACHE_RESULT_TOTAL.labels(
+                        execution_type=execution_type, query_kind=query_kind_metric, outcome=cache_outcome
+                    ).inc()
+
+                if query_kind_metric == "hogql":
+                    results_value = result.data.get("results")
+                    if isinstance(results_value, list):
+                        ENDPOINT_HOGQL_RESULT_ROWS.labels(execution_type=execution_type).observe(len(results_value))
+        except Exception:
+            logger.debug("Failed to record endpoint result metrics", exc_info=True)
 
         if get_query_tag_value("access_method") == "personal_api_key":
             now = timezone.now()
@@ -2125,21 +2189,17 @@ class EndpointViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.Model
         self, data: EndpointRunRequest, endpoint: Endpoint, version: EndpointVersion | None = None
     ) -> None:
         version = version or endpoint.get_version()
-        if version is None:
-            raise ValidationError("No active version found for this endpoint.")
 
         query = version.query
         is_materialized = bool(version.is_materialized and version.saved_query)
 
         if version and not version.is_active:
+            ENDPOINT_VALIDATION_ERROR_TOTAL.labels(reason="inactive_version").inc()
             raise ValidationError(f"Version {version.version} is inactive and cannot be executed.")
-
-        # Reject query_override (always)
-        if hasattr(data, "query_override") and data.query_override is not None:
-            raise ValidationError({"query_override": "Not allowed. Use variables instead."})
 
         # Validate refresh mode
         if data.refresh == EndpointRefreshMode.DIRECT and not is_materialized:
+            ENDPOINT_VALIDATION_ERROR_TOTAL.labels(reason="direct_refresh_not_materialized").inc()
             raise ValidationError(
                 {
                     "refresh": "'direct' refresh mode is only valid for materialized endpoints. "
@@ -2152,6 +2212,7 @@ class EndpointViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.Model
             allowed_vars = self._get_allowed_variables(query, is_materialized)
             unknown_vars = set(data.variables.keys()) - allowed_vars
             if unknown_vars:
+                ENDPOINT_VALIDATION_ERROR_TOTAL.labels(reason="unknown_variable").inc()
                 raise ValidationError({"variables": f"Unknown variable(s): {', '.join(sorted(unknown_vars))}"})
 
         # SECURITY: For materialized endpoints with required variables, ALL must be provided.
@@ -2162,6 +2223,7 @@ class EndpointViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.Model
                 provided = set(data.variables.keys()) if data.variables else set()
                 missing = sorted(required_vars - provided)
                 if missing:
+                    ENDPOINT_VALIDATION_ERROR_TOTAL.labels(reason="missing_required_variable").inc()
                     raise ValidationError(
                         {"variables": f"Required variable(s) {', '.join(repr(v) for v in missing)} not provided"}
                     )

--- a/products/endpoints/backend/metrics.py
+++ b/products/endpoints/backend/metrics.py
@@ -1,0 +1,68 @@
+from prometheus_client import Counter, Histogram
+
+
+def query_kind_label(query: dict | None) -> str:
+    if query and query.get("kind") == "HogQLQuery":
+        return "hogql"
+    return "insight"
+
+
+ENDPOINT_EXECUTION_TOTAL = Counter(
+    "posthog_endpoint_execution_total",
+    "Endpoint executions that reached query execution (excludes concurrency rejections; see posthog_endpoint_concurrency_rejected_total)",
+    labelnames=["execution_type", "query_kind", "status"],
+)
+
+ENDPOINT_EXECUTION_DURATION_SECONDS = Histogram(
+    "posthog_endpoint_execution_duration_seconds",
+    "End-to-end endpoint execution duration (excludes concurrency rejections)",
+    labelnames=["execution_type", "query_kind"],
+    buckets=(0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 20, 45, 90, 180, 300, float("inf")),
+)
+
+ENDPOINT_MATERIALIZATION_EVENT_TOTAL = Counter(
+    "posthog_endpoint_materialization_event_total",
+    "Materialization lifecycle events (enable/disable/deactivate_stale)",
+    labelnames=["action", "status"],
+)
+
+ENDPOINT_DUCKLAKE_FALLBACK_TOTAL = Counter(
+    "posthog_endpoint_ducklake_fallback_total",
+    "DuckLake executions that fell back to inline",
+)
+
+ENDPOINT_RATE_LIMITED_TOTAL = Counter(
+    "posthog_endpoint_rate_limited_total",
+    "Rate-limited endpoint requests",
+    labelnames=["scope"],
+)
+
+ENDPOINT_CONCURRENCY_REJECTED_TOTAL = Counter(
+    "posthog_endpoint_concurrency_rejected_total",
+    "Endpoint executions rejected because the concurrency limit was exceeded",
+)
+
+ENDPOINT_CACHE_RESULT_TOTAL = Counter(
+    "posthog_endpoint_cache_result_total",
+    "Endpoint responses by query-result cache outcome (hit or miss)",
+    labelnames=["execution_type", "query_kind", "outcome"],
+)
+
+ENDPOINT_HOGQL_RESULT_ROWS = Histogram(
+    "posthog_endpoint_hogql_result_rows",
+    "Number of rows returned by a HogQL endpoint response",
+    labelnames=["execution_type"],
+    buckets=(10, 100, 1_000, 10_000, 100_000, 1_000_000, float("inf")),
+)
+
+ENDPOINT_VALIDATION_ERROR_TOTAL = Counter(
+    "posthog_endpoint_validation_error_total",
+    "Endpoint requests rejected at validation time, by reason",
+    labelnames=["reason"],
+)
+
+ENDPOINT_MATERIALIZED_AGE_SECONDS = Histogram(
+    "posthog_endpoint_materialized_age_seconds",
+    "Age of the materialized data served, observed when a materialized table is used",
+    buckets=(60, 300, 1800, 3600, 21600, 43200, 86400, 172800, 259200, 604800, 2592000, float("inf")),
+)

--- a/products/endpoints/backend/rate_limit.py
+++ b/products/endpoints/backend/rate_limit.py
@@ -2,6 +2,8 @@ from django.core.cache import cache
 
 from posthog.rate_limit import APIQueriesBurstThrottle, APIQueriesSustainedThrottle
 
+from products.endpoints.backend.metrics import ENDPOINT_RATE_LIMITED_TOTAL
+
 MATERIALIZED_ENDPOINT_CACHE_KEY = "endpoint_materialized_ready:{team_id}:{endpoint_name}"
 MATERIALIZED_ENDPOINT_CACHE_TTL = 3600  # 1 hour fallback TTL
 
@@ -102,7 +104,13 @@ class EndpointBurstThrottle(APIQueriesBurstThrottle):
             self.scope = "materialized_endpoint_burst"
             self.num_requests, self.duration = self.parse_rate(self.rate)
 
-        return super().allow_request(request, view)
+        allowed = super().allow_request(request, view)
+        if not allowed:
+            try:
+                ENDPOINT_RATE_LIMITED_TOTAL.labels(scope=self.scope).inc()
+            except Exception:
+                pass
+        return allowed
 
 
 class EndpointSustainedThrottle(APIQueriesSustainedThrottle):
@@ -118,4 +126,10 @@ class EndpointSustainedThrottle(APIQueriesSustainedThrottle):
             self.scope = "materialized_endpoint_sustained"
             self.num_requests, self.duration = self.parse_rate(self.rate)
 
-        return super().allow_request(request, view)
+        allowed = super().allow_request(request, view)
+        if not allowed:
+            try:
+                ENDPOINT_RATE_LIMITED_TOTAL.labels(scope=self.scope).inc()
+            except Exception:
+                pass
+        return allowed

--- a/products/endpoints/backend/tasks.py
+++ b/products/endpoints/backend/tasks.py
@@ -5,6 +5,7 @@ from django.utils import timezone
 from celery import shared_task
 from structlog import get_logger
 
+from products.endpoints.backend.metrics import ENDPOINT_MATERIALIZATION_EVENT_TOTAL
 from products.endpoints.backend.models import EndpointVersion
 
 logger = get_logger(__name__)
@@ -48,7 +49,6 @@ def deactivate_stale_materializations() -> None:
     for version in stale_versions:
         try:
             _deactivate_version_materialization(version)
-            deactivated_count += 1
         except Exception as e:
             logger.exception(
                 "deactivate_stale_materialization_failed",
@@ -58,6 +58,10 @@ def deactivate_stale_materializations() -> None:
                 team_id=version.endpoint.team_id,
                 error=str(e),
             )
+            ENDPOINT_MATERIALIZATION_EVENT_TOTAL.labels(action="deactivate_stale", status="error").inc()
+            continue
+        deactivated_count += 1
+        ENDPOINT_MATERIALIZATION_EVENT_TOTAL.labels(action="deactivate_stale", status="success").inc()
 
     logger.info(
         "deactivate_stale_materializations_completed",

--- a/products/endpoints/backend/tests/test_endpoint_execution.py
+++ b/products/endpoints/backend/tests/test_endpoint_execution.py
@@ -1875,3 +1875,168 @@ class TestEndpointExecution(ClickhouseTestMixin, APIBaseTest):
         # cte2 filters by event_name, so should return count for $pageleave only
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0][0], 10)
+
+    # =========================================================================
+    # METRICS
+    # =========================================================================
+
+    def _make_simple_hogql_endpoint(self, name: str):
+        return create_endpoint_with_version(
+            name=name,
+            team=self.team,
+            query={
+                "kind": "HogQLQuery",
+                "query": "SELECT count() FROM events",
+            },
+            created_by=self.user,
+            is_active=True,
+        )
+
+    def test_execution_metric_records_query_kind_label(self):
+        from prometheus_client import REGISTRY
+
+        endpoint = self._make_simple_hogql_endpoint("metric_query_kind")
+        labels = {"execution_type": "inline", "query_kind": "hogql", "status": "success"}
+        before = REGISTRY.get_sample_value("posthog_endpoint_execution_total", labels) or 0.0
+
+        response = self.client.post(
+            f"/api/environments/{self.team.id}/endpoints/{endpoint.name}/run/", {}, format="json"
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        after = REGISTRY.get_sample_value("posthog_endpoint_execution_total", labels) or 0.0
+        self.assertEqual(after - before, 1.0)
+
+    def test_validation_error_metric_unknown_variable(self):
+        from prometheus_client import REGISTRY
+
+        endpoint = create_endpoint_with_version(
+            name="metric_unknown_var",
+            team=self.team,
+            query={
+                "kind": "HogQLQuery",
+                "query": "SELECT count() FROM events WHERE event = {variables.event_name}",
+                "variables": {
+                    str(self.event_name_var.id): {
+                        "variableId": str(self.event_name_var.id),
+                        "code_name": "event_name",
+                        "value": "$pageview",
+                    }
+                },
+            },
+            created_by=self.user,
+            is_active=True,
+        )
+        labels = {"reason": "unknown_variable"}
+        before = REGISTRY.get_sample_value("posthog_endpoint_validation_error_total", labels) or 0.0
+
+        response = self.client.post(
+            f"/api/environments/{self.team.id}/endpoints/{endpoint.name}/run/",
+            {"variables": {"nonexistent": "x"}},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+        after = REGISTRY.get_sample_value("posthog_endpoint_validation_error_total", labels) or 0.0
+        self.assertEqual(after - before, 1.0)
+
+    def test_hogql_result_rows_metric_observed_on_success(self):
+        from prometheus_client import REGISTRY
+
+        endpoint = self._make_simple_hogql_endpoint("metric_result_rows")
+        labels = {"execution_type": "inline"}
+        before = REGISTRY.get_sample_value("posthog_endpoint_hogql_result_rows_count", labels) or 0.0
+
+        response = self.client.post(
+            f"/api/environments/{self.team.id}/endpoints/{endpoint.name}/run/", {}, format="json"
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        after = REGISTRY.get_sample_value("posthog_endpoint_hogql_result_rows_count", labels) or 0.0
+        self.assertEqual(after - before, 1.0)
+
+    def test_hogql_result_rows_metric_not_observed_for_insight_endpoint(self):
+        from prometheus_client import REGISTRY
+
+        endpoint = create_endpoint_with_version(
+            name="metric_insight_no_rows",
+            team=self.team,
+            query=TrendsQuery(series=[EventsNode(event="$pageview")]).model_dump(),
+            created_by=self.user,
+            is_active=True,
+        )
+
+        def total_count() -> float:
+            total = 0.0
+            for metric in REGISTRY.collect():
+                if metric.name != "posthog_endpoint_hogql_result_rows":
+                    continue
+                for sample in metric.samples:
+                    if sample.name.endswith("_count"):
+                        total += sample.value
+            return total
+
+        before = total_count()
+
+        response = self.client.post(
+            f"/api/environments/{self.team.id}/endpoints/{endpoint.name}/run/", {}, format="json"
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        after = total_count()
+        self.assertEqual(after - before, 0.0)
+
+    def test_cache_outcome_metric_records_miss_on_first_execution(self):
+        from prometheus_client import REGISTRY
+
+        endpoint = self._make_simple_hogql_endpoint("metric_cache_outcome")
+        labels = {"execution_type": "inline", "query_kind": "hogql", "outcome": "miss"}
+        before = REGISTRY.get_sample_value("posthog_endpoint_cache_result_total", labels) or 0.0
+
+        response = self.client.post(
+            f"/api/environments/{self.team.id}/endpoints/{endpoint.name}/run/",
+            {"refresh": "force"},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        after = REGISTRY.get_sample_value("posthog_endpoint_cache_result_total", labels) or 0.0
+        self.assertEqual(after - before, 1.0)
+
+    def test_cache_outcome_only_uses_hit_or_miss_labels(self):
+        from prometheus_client import REGISTRY
+
+        endpoint = self._make_simple_hogql_endpoint("metric_no_stale_served")
+        for _ in range(2):
+            response = self.client.post(
+                f"/api/environments/{self.team.id}/endpoints/{endpoint.name}/run/", {}, format="json"
+            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        observed_outcomes: set[str] = set()
+        for metric in REGISTRY.collect():
+            if metric.name != "posthog_endpoint_cache_result_total":
+                continue
+            for sample in metric.samples:
+                outcome = sample.labels.get("outcome")
+                if outcome and sample.value > 0:
+                    observed_outcomes.add(outcome)
+
+        self.assertTrue(observed_outcomes.issubset({"hit", "miss"}), f"Unexpected outcomes: {observed_outcomes}")
+        self.assertNotIn("stale_served", observed_outcomes)
+
+    def test_disable_materialization_no_op_does_not_increment_counter(self):
+        from prometheus_client import REGISTRY
+
+        from products.endpoints.backend.api import EndpointViewSet
+
+        endpoint = self._make_simple_hogql_endpoint("metric_disable_no_op")
+        labels = {"action": "disable", "status": "success"}
+        before = REGISTRY.get_sample_value("posthog_endpoint_materialization_event_total", labels) or 0.0
+
+        viewset = EndpointViewSet()
+        viewset.team_id = self.team.id
+        viewset._disable_materialization(endpoint)
+
+        after = REGISTRY.get_sample_value("posthog_endpoint_materialization_event_total", labels) or 0.0
+        self.assertEqual(after - before, 0.0)


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

no visibility

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

## Changes

add some prom metrics

```
ENDPOINT_CACHE_RESULT_TOTAL,
ENDPOINT_CONCURRENCY_REJECTED_TOTAL,
ENDPOINT_DUCKLAKE_FALLBACK_TOTAL,
ENDPOINT_EXECUTION_DURATION_SECONDS,
ENDPOINT_EXECUTION_TOTAL,
ENDPOINT_HOGQL_RESULT_ROWS,
ENDPOINT_MATERIALIZATION_EVENT_TOTAL,
ENDPOINT_MATERIALIZED_AGE_SECONDS,
ENDPOINT_VALIDATION_ERROR_TOTAL,
```

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

ran locally, checked the metrics in a local prometheus

<!-- Briefly describe the steps you took. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

no

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->