### PR TITLE
feat(llma): add beta label to sentiment tab

### DIFF
--- a/products/llm_analytics/frontend/LLMAnalyticsScene.tsx
+++ b/products/llm_analytics/frontend/LLMAnalyticsScene.tsx
@@ -2,7 +2,7 @@ import { BindLogic, useActions, useValues } from 'kea'
 import { combineUrl, router } from 'kea-router'
 import React, { useMemo } from 'react'
 
-import { LemonBanner, LemonButton, LemonTab, LemonTabs, Link, Spinner } from '@posthog/lemon-ui'
+import { LemonBanner, LemonButton, LemonTab, LemonTabs, LemonTag, Link, Spinner } from '@posthog/lemon-ui'
 
 import { AccessControlAction } from 'lib/components/AccessControlAction'
 import { keyBinds } from 'lib/components/AppShortcuts/shortcuts'
@@ -589,7 +589,14 @@ function LLMAnalyticsSceneContent(): JSX.Element {
     if (featureFlags[FEATURE_FLAGS.LLM_ANALYTICS_SENTIMENT_TAB]) {
         tabs.push({
             key: 'sentiment',
-            label: 'Sentiment',
+            label: (
+                <>
+                    Sentiment
+                    <LemonTag type="warning" className="ml-1.5 uppercase">
+                        Beta
+                    </LemonTag>
+                </>
+            ),
             content: (
                 <LLMAnalyticsSetupPrompt>
                     <LLMAnalyticsSentiment />


### PR DESCRIPTION
## Problem

The sentiment tab in LLM analytics is a beta feature but has no visual indicator communicating this to users.

## Changes

Added a `LemonTag` beta label to the sentiment tab in `LLMAnalyticsScene`, matching the existing pattern used across other beta features in PostHog (e.g., session summaries, AI analysis).

## How did you test this code?

Visual inspection of the diff. The change follows the established `LemonTag type="warning"` pattern used for beta labels elsewhere in the codebase.

## Publish to changelog?

No