### PR TITLE
fix(error-tracking): fix updates for error tracking rules

### DIFF
--- a/products/error_tracking/backend/api/assignment_rules.py
+++ b/products/error_tracking/backend/api/assignment_rules.py
@@ -74,6 +74,9 @@ class ErrorTrackingAssignmentRuleViewSet(TeamAndOrgViewSetMixin, viewsets.ModelV
 
         return Response({"ok": True}, status=status.HTTP_204_NO_CONTENT)
 
+    def partial_update(self, request, *args, **kwargs) -> Response:
+        return self.update(request, *args, **kwargs)
+
     def destroy(self, request, *args, **kwargs) -> Response:
         response = super().destroy(request, *args, **kwargs)
 

--- a/products/error_tracking/backend/api/grouping_rules.py
+++ b/products/error_tracking/backend/api/grouping_rules.py
@@ -114,6 +114,9 @@ class ErrorTrackingGroupingRuleViewSet(TeamAndOrgViewSetMixin, viewsets.ModelVie
 
         return Response({"ok": True}, status=status.HTTP_204_NO_CONTENT)
 
+    def partial_update(self, request, *args, **kwargs) -> Response:
+        return self.update(request, *args, **kwargs)
+
     def destroy(self, request, *args, **kwargs) -> Response:
         response = super().destroy(request, *args, **kwargs)
 

--- a/products/error_tracking/backend/api/suppression_rules.py
+++ b/products/error_tracking/backend/api/suppression_rules.py
@@ -70,6 +70,10 @@ class ErrorTrackingSuppressionRuleViewSet(TeamAndOrgViewSetMixin, viewsets.Model
         return Response({"ok": True}, status=status.HTTP_204_NO_CONTENT)
 
     @override
+    def partial_update(self, request, *args, **kwargs) -> Response:
+        return self.update(request, *args, **kwargs)
+
+    @override
     def destroy(self, request, *args, **kwargs) -> Response:
         response = super().destroy(request, *args, **kwargs)
 

--- a/products/error_tracking/backend/api/test/test_suppression_rules.py
+++ b/products/error_tracking/backend/api/test/test_suppression_rules.py
@@ -577,3 +577,22 @@ class TestSuppressionRuleAPI(APIBaseTest):
 
         rule = ErrorTrackingSuppressionRule.objects.get(id=rule_id)
         assert rule.sampling_rate == 0.25
+
+    def test_partial_update_sampling_rate(self) -> None:
+        create_response = self.client.post(
+            self._url(),
+            data={"filters": VALID_FILTERS},
+            format="json",
+        )
+        rule_id = create_response.json()["id"]
+
+        response = self.client.patch(
+            self._url(rule_id),
+            data={"sampling_rate": 0.25},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+
+        rule = ErrorTrackingSuppressionRule.objects.get(id=rule_id)
+        assert rule.sampling_rate == 0.25


### PR DESCRIPTION
## Problem

Updating rules in Error Tracking can fail because the frontend sends `PATCH` requests, while the custom rule update logic only lived in `update()` on the backend. That meant partial updates could bypass the custom handling for rule updates.

## Changes

- route `partial_update()` through the existing custom `update()` implementation for:
  - suppression rules
  - assignment rules
  - grouping rules
- add a regression test covering `PATCH` updates for suppression rule sampling rate

## How did you test this code?

- Added an automated regression test in `products/error_tracking/backend/api/test/test_suppression_rules.py`
- I was not able to run the test suite in this environment because the available `uv` version does not satisfy the repo requirement (`~=0.10.2`)

## Publish to changelog?

no

## Docs update

No docs update needed.

## 🤖 LLM context

This PR was prepared by an agent. It fixes the Error Tracking rule update path so `PATCH` requests use the same backend logic as `PUT`.
