### PR TITLE
feat: include personal API key in stripe provisioning access_configuration

### DIFF
--- a/ee/api/agentic_provisioning/test/test_resources.py
+++ b/ee/api/agentic_provisioning/test/test_resources.py
@@ -1,5 +1,7 @@
 from django.test import override_settings
 
+from posthog.models.personal_api_key import PersonalAPIKey
+
 from ee.api.agentic_provisioning.test.base import HMAC_SECRET, StripeProvisioningTestBase
 
 
@@ -92,3 +94,44 @@ class TestProvisioningResources(StripeProvisioningTestBase):
         )
         assert res.status_code == 200
         assert res.json()["service_id"] == "analytics"
+
+    def test_create_resource_includes_personal_api_key(self):
+        token = self._get_bearer_token()
+        res = self._post_signed_with_bearer(
+            "/api/agentic/provisioning/resources",
+            data={"service_id": "analytics"},
+            token=token,
+        )
+        assert res.status_code == 200
+        personal_api_key = res.json()["complete"]["access_configuration"]["personal_api_key"]
+        assert personal_api_key.startswith("phx_")
+
+    def test_create_resource_creates_pat_for_user(self):
+        initial_count = PersonalAPIKey.objects.filter(user=self.user).count()
+        token = self._get_bearer_token()
+        self._post_signed_with_bearer(
+            "/api/agentic/provisioning/resources",
+            data={"service_id": "analytics"},
+            token=token,
+        )
+        assert PersonalAPIKey.objects.filter(user=self.user).count() == initial_count + 1
+
+    def test_create_resource_pat_label_contains_stripe_projects(self):
+        token = self._get_bearer_token()
+        self._post_signed_with_bearer(
+            "/api/agentic/provisioning/resources",
+            data={"service_id": "analytics"},
+            token=token,
+        )
+        pat = PersonalAPIKey.objects.filter(user=self.user).order_by("-created_at").first()
+        assert pat is not None
+        assert pat.label.startswith("Stripe Projects")
+
+    def test_get_resource_does_not_include_personal_api_key(self):
+        token = self._get_bearer_token()
+        res = self._get_signed_with_bearer(
+            f"/api/agentic/provisioning/resources/{self.team.id}",
+            token=token,
+        )
+        assert res.status_code == 200
+        assert "personal_api_key" not in res.json()["complete"]["access_configuration"]

--- a/ee/api/agentic_provisioning/test/test_resources.py
+++ b/ee/api/agentic_provisioning/test/test_resources.py
@@ -127,7 +127,7 @@ class TestProvisioningResources(StripeProvisioningTestBase):
         assert pat is not None
         assert pat.label.startswith("Stripe Projects")
 
-    def test_create_resource_replaces_existing_stripe_pat(self):
+    def test_create_resource_does_not_delete_existing_pats(self):
         token = self._get_bearer_token()
         self._post_signed_with_bearer(
             "/api/agentic/provisioning/resources",
@@ -143,8 +143,8 @@ class TestProvisioningResources(StripeProvisioningTestBase):
             token=token,
         )
         stripe_pats = PersonalAPIKey.objects.filter(user=self.user, label__startswith="Stripe Projects")
-        assert stripe_pats.count() == 1
-        assert stripe_pats.first().id != first_pat.id
+        assert stripe_pats.count() == 2
+        assert PersonalAPIKey.objects.filter(id=first_pat.id).exists()
 
     def test_get_resource_does_not_include_personal_api_key(self):
         token = self._get_bearer_token()

--- a/ee/api/agentic_provisioning/test/test_resources.py
+++ b/ee/api/agentic_provisioning/test/test_resources.py
@@ -127,6 +127,25 @@ class TestProvisioningResources(StripeProvisioningTestBase):
         assert pat is not None
         assert pat.label.startswith("Stripe Projects")
 
+    def test_create_resource_replaces_existing_stripe_pat(self):
+        token = self._get_bearer_token()
+        self._post_signed_with_bearer(
+            "/api/agentic/provisioning/resources",
+            data={"service_id": "analytics"},
+            token=token,
+        )
+        first_pat = PersonalAPIKey.objects.filter(user=self.user, label__startswith="Stripe Projects").first()
+        assert first_pat is not None
+
+        self._post_signed_with_bearer(
+            "/api/agentic/provisioning/resources",
+            data={"service_id": "analytics"},
+            token=token,
+        )
+        stripe_pats = PersonalAPIKey.objects.filter(user=self.user, label__startswith="Stripe Projects")
+        assert stripe_pats.count() == 1
+        assert stripe_pats.first().id != first_pat.id
+
     def test_get_resource_does_not_include_personal_api_key(self):
         token = self._get_bearer_token()
         res = self._get_signed_with_bearer(

--- a/ee/api/agentic_provisioning/test/test_rotate_credentials.py
+++ b/ee/api/agentic_provisioning/test/test_rotate_credentials.py
@@ -95,7 +95,7 @@ class TestProvisioningRotateCredentials(StripeProvisioningTestBase):
         personal_api_key = res.json()["complete"]["access_configuration"]["personal_api_key"]
         assert personal_api_key.startswith("phx_")
 
-    def test_rotate_deletes_old_stripe_pat_and_creates_new(self):
+    def test_rotate_preserves_existing_pats(self):
         token = self._get_bearer_token()
         self._post_signed_with_bearer(
             "/api/agentic/provisioning/resources",
@@ -109,10 +109,8 @@ class TestProvisioningRotateCredentials(StripeProvisioningTestBase):
             f"/api/agentic/provisioning/resources/{self.team.id}/rotate_credentials",
             token=token,
         )
-        assert not PersonalAPIKey.objects.filter(id=initial_pat.id).exists()
-        new_pat = PersonalAPIKey.objects.filter(user=self.user, label__startswith="Stripe Projects").first()
-        assert new_pat is not None
-        assert new_pat.id != initial_pat.id
+        assert PersonalAPIKey.objects.filter(id=initial_pat.id).exists()
+        assert PersonalAPIKey.objects.filter(user=self.user, label__startswith="Stripe Projects").count() == 2
 
     @patch("posthog.models.team.team.Team.reset_token_and_save", side_effect=Exception("db error"))
     def test_rotate_returns_500_when_reset_token_fails(self, _mock_reset):

--- a/ee/api/agentic_provisioning/test/test_rotate_credentials.py
+++ b/ee/api/agentic_provisioning/test/test_rotate_credentials.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 from django.test import override_settings
 
 from posthog.models.oauth import OAuthAccessToken
+from posthog.models.personal_api_key import PersonalAPIKey
 from posthog.models.team.team import Team
 
 from ee.api.agentic_provisioning.test.base import HMAC_SECRET, StripeProvisioningTestBase
@@ -83,6 +84,35 @@ class TestProvisioningRotateCredentials(StripeProvisioningTestBase):
         )
         assert res.status_code == 200
         assert res.json()["service_id"] == "analytics"
+
+    def test_rotate_includes_new_personal_api_key(self):
+        token = self._get_bearer_token()
+        res = self._post_signed_with_bearer(
+            f"/api/agentic/provisioning/resources/{self.team.id}/rotate_credentials",
+            token=token,
+        )
+        assert res.status_code == 200
+        personal_api_key = res.json()["complete"]["access_configuration"]["personal_api_key"]
+        assert personal_api_key.startswith("phx_")
+
+    def test_rotate_deletes_old_stripe_pat_and_creates_new(self):
+        token = self._get_bearer_token()
+        self._post_signed_with_bearer(
+            "/api/agentic/provisioning/resources",
+            data={"service_id": "analytics"},
+            token=token,
+        )
+        initial_pat = PersonalAPIKey.objects.filter(user=self.user, label__startswith="Stripe Projects").first()
+        assert initial_pat is not None
+
+        self._post_signed_with_bearer(
+            f"/api/agentic/provisioning/resources/{self.team.id}/rotate_credentials",
+            token=token,
+        )
+        assert not PersonalAPIKey.objects.filter(id=initial_pat.id).exists()
+        new_pat = PersonalAPIKey.objects.filter(user=self.user, label__startswith="Stripe Projects").first()
+        assert new_pat is not None
+        assert new_pat.id != initial_pat.id
 
     @patch("posthog.models.team.team.Team.reset_token_and_save", side_effect=Exception("db error"))
     def test_rotate_returns_500_when_reset_token_fails(self, _mock_reset):

--- a/ee/api/agentic_provisioning/views.py
+++ b/ee/api/agentic_provisioning/views.py
@@ -623,12 +623,16 @@ def _exchange_refresh_token(request: Request) -> Response:
 
 def _create_provisioned_pat(user: User, team: Team) -> str:
     """Create a Personal API Key for a Stripe-provisioned user and return the raw key value."""
+    PersonalAPIKey.objects.filter(
+        user=user,
+        label__startswith=STRIPE_PROVISIONED_PAT_LABEL_PREFIX,
+    ).delete()
+
     api_key_value = generate_random_token_personal()
 
-    timestamp = timezone.now().strftime("%Y-%m-%d %H:%M")
-    max_team_name_len = 40 - len(f"{STRIPE_PROVISIONED_PAT_LABEL_PREFIX} - ") - len(f" - {timestamp}")
+    max_team_name_len = 40 - len(f"{STRIPE_PROVISIONED_PAT_LABEL_PREFIX} - ")
     team_name = team.name[:max_team_name_len] if len(team.name) > max_team_name_len else team.name
-    label = f"{STRIPE_PROVISIONED_PAT_LABEL_PREFIX} - {team_name} - {timestamp}"
+    label = f"{STRIPE_PROVISIONED_PAT_LABEL_PREFIX} - {team_name}"
 
     PersonalAPIKey.objects.create(
         user=user,

--- a/ee/api/agentic_provisioning/views.py
+++ b/ee/api/agentic_provisioning/views.py
@@ -635,6 +635,7 @@ def _create_provisioned_pat(user: User, team: Team) -> str:
         label=label,
         secure_value=hash_key_value(api_key_value),
         mask_value=mask_key_value(api_key_value),
+        scopes=[],
     )
 
     return api_key_value

--- a/ee/api/agentic_provisioning/views.py
+++ b/ee/api/agentic_provisioning/views.py
@@ -621,26 +621,24 @@ def _exchange_refresh_token(request: Request) -> Response:
     )
 
 
-def _create_provisioned_pat(user: User, team: Team) -> str:
+def _create_provisioned_pat(user: User, team: Team) -> str | None:
     """Create a Personal API Key for a Stripe-provisioned user and return the raw key value."""
-    PersonalAPIKey.objects.filter(
-        user=user,
-        label__startswith=STRIPE_PROVISIONED_PAT_LABEL_PREFIX,
-    ).delete()
+    try:
+        api_key_value = generate_random_token_personal()
+        label = f"{STRIPE_PROVISIONED_PAT_LABEL_PREFIX} - {team.name}"[:40]
 
-    api_key_value = generate_random_token_personal()
+        PersonalAPIKey.objects.create(
+            user=user,
+            label=label,
+            secure_value=hash_key_value(api_key_value),
+            mask_value=mask_key_value(api_key_value),
+            scopes=[],
+        )
 
-    label = f"{STRIPE_PROVISIONED_PAT_LABEL_PREFIX} - {team.name}"[:40]
-
-    PersonalAPIKey.objects.create(
-        user=user,
-        label=label,
-        secure_value=hash_key_value(api_key_value),
-        mask_value=mask_key_value(api_key_value),
-        scopes=[],
-    )
-
-    return api_key_value
+        return api_key_value
+    except Exception:
+        capture_exception(additional_properties={"user_id": user.id, "team_id": team.id})
+        return None
 
 
 # ---------------------------------------------------------------------------
@@ -690,17 +688,20 @@ def provisioning_resources_create(request: Request) -> Response:
 
     personal_api_key = _create_provisioned_pat(user, team)
 
+    access_configuration: dict[str, str] = {
+        "api_key": team.api_token,
+        "host": host,
+    }
+    if personal_api_key:
+        access_configuration["personal_api_key"] = personal_api_key
+
     return Response(
         {
             "status": "complete",
             "id": str(team_id),
             "service_id": resolved_service_id,
             "complete": {
-                "access_configuration": {
-                    "api_key": team.api_token,
-                    "personal_api_key": personal_api_key,
-                    "host": host,
-                },
+                "access_configuration": access_configuration,
             },
         }
     )
@@ -771,17 +772,20 @@ def provisioning_rotate_credentials(request: Request, resource_id: str) -> Respo
     region = get_instance_region() or "US"
     host = _region_to_host(region)
 
+    access_configuration: dict[str, str] = {
+        "api_key": team.api_token,
+        "host": host,
+    }
+    if personal_api_key:
+        access_configuration["personal_api_key"] = personal_api_key
+
     return Response(
         {
             "status": "complete",
             "id": resource_id,
             "service_id": service_id,
             "complete": {
-                "access_configuration": {
-                    "api_key": team.api_token,
-                    "personal_api_key": personal_api_key,
-                    "host": host,
-                },
+                "access_configuration": access_configuration,
             },
         }
     )

--- a/ee/api/agentic_provisioning/views.py
+++ b/ee/api/agentic_provisioning/views.py
@@ -29,9 +29,15 @@ from rest_framework.response import Response
 from posthog.exceptions_capture import capture_exception
 from posthog.models.integration import StripeIntegration
 from posthog.models.oauth import OAuthAccessToken, OAuthRefreshToken, find_oauth_refresh_token
+from posthog.models.personal_api_key import PersonalAPIKey, hash_key_value
 from posthog.models.team.team import Team
 from posthog.models.user import User
-from posthog.models.utils import generate_random_oauth_access_token, generate_random_oauth_refresh_token
+from posthog.models.utils import (
+    generate_random_oauth_access_token,
+    generate_random_oauth_refresh_token,
+    generate_random_token_personal,
+    mask_key_value,
+)
 from posthog.utils import get_instance_region
 
 from ee.settings import BILLING_SERVICE_URL
@@ -54,6 +60,7 @@ DEEP_LINK_RATE_LIMIT_WINDOW_SECONDS = 300
 _SAFE_STATE_RE = re.compile(r"^[A-Za-z0-9_\-]{1,256}$")
 
 STRIPE_APP_NAME = "PostHog Stripe App"
+STRIPE_PROVISIONED_PAT_LABEL_PREFIX = "Stripe Projects"
 
 ACCESS_TOKEN_EXPIRY_SECONDS = 365 * 24 * 3600
 
@@ -614,6 +621,25 @@ def _exchange_refresh_token(request: Request) -> Response:
     )
 
 
+def _create_provisioned_pat(user: User, team: Team) -> str:
+    """Create a Personal API Key for a Stripe-provisioned user and return the raw key value."""
+    api_key_value = generate_random_token_personal()
+
+    timestamp = timezone.now().strftime("%Y-%m-%d %H:%M")
+    max_team_name_len = 40 - len(f"{STRIPE_PROVISIONED_PAT_LABEL_PREFIX} - ") - len(f" - {timestamp}")
+    team_name = team.name[:max_team_name_len] if len(team.name) > max_team_name_len else team.name
+    label = f"{STRIPE_PROVISIONED_PAT_LABEL_PREFIX} - {team_name} - {timestamp}"
+
+    PersonalAPIKey.objects.create(
+        user=user,
+        label=label,
+        secure_value=hash_key_value(api_key_value),
+        mask_value=mask_key_value(api_key_value),
+    )
+
+    return api_key_value
+
+
 # ---------------------------------------------------------------------------
 # POST /provisioning/resources
 # ---------------------------------------------------------------------------
@@ -659,6 +685,8 @@ def provisioning_resources_create(request: Request) -> Response:
 
     _capture_provisioning_event("resource_created", "success", service_id=resolved_service_id, team_id=team_id)
 
+    personal_api_key = _create_provisioned_pat(user, team)
+
     return Response(
         {
             "status": "complete",
@@ -667,6 +695,7 @@ def provisioning_resources_create(request: Request) -> Response:
             "complete": {
                 "access_configuration": {
                     "api_key": team.api_token,
+                    "personal_api_key": personal_api_key,
                     "host": host,
                 },
             },
@@ -733,6 +762,8 @@ def provisioning_rotate_credentials(request: Request, resource_id: str) -> Respo
 
     _capture_provisioning_event("credential_rotation", "success", team_id=team_id)
 
+    personal_api_key = _create_provisioned_pat(user, team)
+
     service_id = cache.get(f"{RESOURCE_SERVICE_CACHE_PREFIX}{team_id}") or ANALYTICS_SERVICE_ID
     region = get_instance_region() or "US"
     host = _region_to_host(region)
@@ -745,6 +776,7 @@ def provisioning_rotate_credentials(request: Request, resource_id: str) -> Respo
             "complete": {
                 "access_configuration": {
                     "api_key": team.api_token,
+                    "personal_api_key": personal_api_key,
                     "host": host,
                 },
             },

--- a/ee/api/agentic_provisioning/views.py
+++ b/ee/api/agentic_provisioning/views.py
@@ -764,8 +764,6 @@ def provisioning_rotate_credentials(request: Request, resource_id: str) -> Respo
 
     _capture_provisioning_event("credential_rotation", "success", team_id=team_id)
 
-    personal_api_key = _create_provisioned_pat(user, team)
-
     service_id = cache.get(f"{RESOURCE_SERVICE_CACHE_PREFIX}{team_id}") or ANALYTICS_SERVICE_ID
     region = get_instance_region() or "US"
     host = _region_to_host(region)
@@ -774,7 +772,7 @@ def provisioning_rotate_credentials(request: Request, resource_id: str) -> Respo
         "api_key": team.api_token,
         "host": host,
     }
-    if personal_api_key:
+    if personal_api_key := _create_provisioned_pat(user, team):
         access_configuration["personal_api_key"] = personal_api_key
 
     return Response(

--- a/ee/api/agentic_provisioning/views.py
+++ b/ee/api/agentic_provisioning/views.py
@@ -686,13 +686,11 @@ def provisioning_resources_create(request: Request) -> Response:
 
     _capture_provisioning_event("resource_created", "success", service_id=resolved_service_id, team_id=team_id)
 
-    personal_api_key = _create_provisioned_pat(user, team)
-
     access_configuration: dict[str, str] = {
         "api_key": team.api_token,
         "host": host,
     }
-    if personal_api_key:
+    if personal_api_key := _create_provisioned_pat(user, team):
         access_configuration["personal_api_key"] = personal_api_key
 
     return Response(

--- a/ee/api/agentic_provisioning/views.py
+++ b/ee/api/agentic_provisioning/views.py
@@ -630,9 +630,7 @@ def _create_provisioned_pat(user: User, team: Team) -> str:
 
     api_key_value = generate_random_token_personal()
 
-    max_team_name_len = 40 - len(f"{STRIPE_PROVISIONED_PAT_LABEL_PREFIX} - ")
-    team_name = team.name[:max_team_name_len] if len(team.name) > max_team_name_len else team.name
-    label = f"{STRIPE_PROVISIONED_PAT_LABEL_PREFIX} - {team_name}"
+    label = f"{STRIPE_PROVISIONED_PAT_LABEL_PREFIX} - {team.name}"[:40]
 
     PersonalAPIKey.objects.create(
         user=user,


### PR DESCRIPTION
## Problem

Users provisioned via Stripe Projects can't use PostHog's MCP server without opening a browser for OAuth. The provisioning flow already creates a user, org, and project server-side, but the MCP server requires a separate authentication step. This means Stripe Projects users have to set up a password, go through onboarding, and manually get API keys - defeating the "everything from the terminal" promise.

## Changes

- Generate a Personal API Key (PAT) for the provisioned user during `provisioning_resources_create` and include it in `access_configuration`
- On `rotate_credentials`, also create a new PAT (existing PATs are preserved - users may be using them elsewhere)
- The GET resource endpoint intentionally does NOT return the PAT (only delivered on create/rotate)
- PAT creation is wrapped in try/except so provisioning still succeeds if it fails
- PATs are created with empty scopes and labeled `"Stripe Projects - {team_name}"` (truncated to 40 chars)

Stripe syncs `access_configuration` to the user's `.env` file automatically. The wizard can then read the PAT from `.env` and configure the MCP server - no browser needed.

## How did you test this code

- All 25 existing + new agentic provisioning tests pass
- Tested wizard end-to-end: created `.env` with `POSTHOG_PERSONAL_API_KEY`, ran `mcp add`, verified Cursor/Zed/Claude Desktop configs all got the API key auth header
- Verified label format fits within 40-char limit (22 chars available for team name)
- Verified PAT creation failure doesn't break provisioning (PAT omitted from response)

## Follow-up work

- Update the wizard to read `POSTHOG_PERSONAL_API_KEY` from `.env` and configure MCP with it (PostHog/wizard#356)
- Add LLM context instructions to tell agents to run the wizard (PostHog/posthog.com#16013)
- Consider scoping the PAT to only MCP-relevant permissions
- Consider agent accounts as a longer-term replacement for user-scoped PATs

🤖 Generated with [Claude Code](https://claude.com/claude-code)