### PR TITLE
chore: move member joined notification to user settings pt 1

### DIFF
--- a/posthog/api/test/test_user.py
+++ b/posthog/api/test/test_user.py
@@ -1423,6 +1423,7 @@ class TestUserAPI(APIBaseTest):
                 "data_pipeline_error_threshold": 0.1,
                 "project_api_key_exposed": True,
                 "materialized_view_sync_failed": True,
+                "organization_member_join_email_disabled": {},
             },
         )
 
@@ -1439,6 +1440,7 @@ class TestUserAPI(APIBaseTest):
                 "data_pipeline_error_threshold": 0.1,
                 "project_api_key_exposed": True,
                 "materialized_view_sync_failed": True,
+                "organization_member_join_email_disabled": {},
             },
         )
 
@@ -1458,6 +1460,38 @@ class TestUserAPI(APIBaseTest):
         response_data = response.json()
         self.assertEqual(
             response_data["notification_settings"]["project_weekly_digest_disabled"], {"123": True, "456": True}
+        )
+
+    def test_notification_settings_organization_member_join_settings_are_merged_not_replaced(self):
+        # First update
+        response = self.client.patch(
+            "/api/users/@me/",
+            {
+                "notification_settings": {
+                    "organization_member_join_email_disabled": {"00000000-0000-0000-0000-000000000001": True}
+                }
+            },
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        # Second update with different organization
+        response = self.client.patch(
+            "/api/users/@me/",
+            {
+                "notification_settings": {
+                    "organization_member_join_email_disabled": {"00000000-0000-0000-0000-000000000002": True}
+                }
+            },
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        response_data = response.json()
+        self.assertEqual(
+            response_data["notification_settings"]["organization_member_join_email_disabled"],
+            {
+                "00000000-0000-0000-0000-000000000001": True,
+                "00000000-0000-0000-0000-000000000002": True,
+            },
         )
 
     def test_invalid_notification_settings_returns_error(self):
@@ -1488,7 +1522,7 @@ class TestUserAPI(APIBaseTest):
             {
                 "type": "validation_error",
                 "code": "invalid_input",
-                "detail": "Project notification setting values must be boolean, got <class 'str'> instead",
+                "detail": "Notification setting values must be boolean, got <class 'str'> instead",
                 "attr": "notification_settings",
             },
         )
@@ -1509,6 +1543,7 @@ class TestUserAPI(APIBaseTest):
                 "data_pipeline_error_threshold": 0.01,  # Default value
                 "project_api_key_exposed": True,  # Default value
                 "materialized_view_sync_failed": False,  # Default value
+                "organization_member_join_email_disabled": {},  # Default value
             },
         )
 

--- a/posthog/api/user.py
+++ b/posthog/api/user.py
@@ -287,16 +287,20 @@ class UserSerializer(serializers.ModelSerializer):
 
             expected_type = Notifications.__annotations__[key]
 
-            if key in ("project_weekly_digest_disabled", "error_tracking_weekly_digest_project_enabled"):
+            if key in (
+                "project_weekly_digest_disabled",
+                "error_tracking_weekly_digest_project_enabled",
+                "organization_member_join_email_disabled",
+            ):
                 if not isinstance(value, dict):
                     raise serializers.ValidationError(
-                        f"{key} must be a dictionary mapping project IDs to boolean values",
+                        f"{key} must be a dictionary mapping IDs to boolean values",
                         code="invalid_input",
                     )
                 for _, disabled in value.items():
                     if not isinstance(disabled, bool):
                         raise serializers.ValidationError(
-                            f"Project notification setting values must be boolean, got {type(disabled)} instead",
+                            f"Notification setting values must be boolean, got {type(disabled)} instead",
                             code="invalid_input",
                         )
                 current_settings[key] = {**current_settings.get(key, {}), **value}

--- a/posthog/models/user.py
+++ b/posthog/models/user.py
@@ -37,6 +37,9 @@ class Notifications(TypedDict, total=False):
     )
     project_api_key_exposed: bool
     materialized_view_sync_failed: bool
+    organization_member_join_email_disabled: dict[
+        str, bool
+    ]  # Maps organization ID (str) to disabled status (True = do not email when a new member joins)
 
 
 NOTIFICATION_DEFAULTS: Notifications = {
@@ -49,6 +52,7 @@ NOTIFICATION_DEFAULTS: Notifications = {
     "data_pipeline_error_threshold": 0.01,  # Default: notify when failure rate exceeds 1%
     "project_api_key_exposed": True,  # Private project API key (secure API key) exposure alerts enabled by default
     "materialized_view_sync_failed": False,  # Materialized view failure disabled by default
+    "organization_member_join_email_disabled": {},  # No per-org opt-out until user configures
 }
 
 # We don't need the following attributes in most cases, so we defer them by default


### PR DESCRIPTION
## Problem

The member joined notification is in the wrong spot. This PR is 1/2 PRs to migrate this setting from organization settings to user settings.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Add a new notification setting attribute in the notification column. Also updated the error message to be more accurate when the type is invalid.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Tests

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
