### PR TITLE
fix(dashboard): fixes a zindex problem using new dialog primitive popovers

### DIFF
--- a/frontend/src/lib/components/Cards/TextCard/TextCardModal.tsx
+++ b/frontend/src/lib/components/Cards/TextCard/TextCardModal.tsx
@@ -47,7 +47,10 @@ export function TextCardModal({
             disablePointerDismissal={hasUnsavedInput}
             className={cn(
                 'w-[min(100vw-3rem,72rem)] min-w-full lg:min-w-6xl max-h-[calc(100vh-4rem)] top-8',
-                'bg-surface-primary'
+                'bg-surface-primary',
+                // DialogPrimitive defaults to z above --z-popover; rich editor toolbars portal to body at
+                // --z-popover and would sit under the panel. Sit the dialog just below that layer instead.
+                'z-[calc(var(--z-popover)-1)]'
             )}
         >
             <div className="flex shrink-0 items-center justify-between gap-2 border-b border-primary py-2 pl-4 pr-2">


### PR DESCRIPTION
## Problem

Z-index on dialog primitives was higher than the one set for popovers, this caused the popovers to actually render underneath the modal.

## Changes

Swap zindex 

## How did you test this code?

Locally

## Publish to changelog?

No.