### PR TITLE
chore(dwh): remove feature flags from fully rolled out sources

### DIFF
--- a/posthog/temporal/data_imports/sources/attio/source.py
+++ b/posthog/temporal/data_imports/sources/attio/source.py
@@ -64,7 +64,6 @@ You can generate an API key in your Attio workspace settings. Check out [this gu
                     ),
                 ],
             ),
-            featureFlag="dwh_attio",
         )
 
     def get_schemas(

--- a/posthog/temporal/data_imports/sources/bing_ads/source.py
+++ b/posthog/temporal/data_imports/sources/bing_ads/source.py
@@ -39,7 +39,6 @@ class BingAdsSource(SimpleSource[BingAdsSourceConfig], OAuthMixin):
             label="Bing Ads",
             caption="Ensure you have granted PostHog access to your Bing Ads account, learn how to do this in [the documentation](https://posthog.com/docs/cdp/sources/bing-ads).",
             betaSource=True,
-            featureFlag="bing-ads-source",
             iconPath="/static/services/bing-ads.svg",
             docsUrl="https://posthog.com/docs/cdp/sources/bing-ads",
             fields=cast(

--- a/posthog/temporal/data_imports/sources/klaviyo/source.py
+++ b/posthog/temporal/data_imports/sources/klaviyo/source.py
@@ -62,7 +62,6 @@ Make sure to grant the following read permissions:
                     ),
                 ],
             ),
-            featureFlag="dwh_klaviyo",
         )
 
     def get_schemas(

--- a/posthog/temporal/data_imports/sources/meta_ads/source.py
+++ b/posthog/temporal/data_imports/sources/meta_ads/source.py
@@ -102,7 +102,6 @@ class MetaAdsSource(SimpleSource[MetaAdsSourceConfig]):
                 ],
             ),
             betaSource=True,
-            featureFlag="meta-ads-dwh",
             suggestedTables=[
                 SuggestedTable(
                     table="campaigns",

--- a/posthog/temporal/data_imports/sources/pinterest_ads/source.py
+++ b/posthog/temporal/data_imports/sources/pinterest_ads/source.py
@@ -47,8 +47,6 @@ class PinterestAdsSource(SimpleSource[PinterestAdsSourceConfig], OAuthMixin):
             label="Pinterest Ads",
             caption="Collect campaign data, ad performance, and advertising metrics from Pinterest Ads. Ensure you have granted PostHog access to your Pinterest Ads account, learn how to do this in [the documentation](https://posthog.com/docs/cdp/sources/pinterest-ads).",
             betaSource=True,
-            unreleasedSource=True,
-            featureFlag="pinterest-ads-source",
             iconPath="/static/services/pinterest_ads.png",
             docsUrl="https://posthog.com/docs/cdp/sources/pinterest-ads",
             fields=cast(

--- a/posthog/temporal/data_imports/sources/pinterest_ads/tests/test_pinterest_source.py
+++ b/posthog/temporal/data_imports/sources/pinterest_ads/tests/test_pinterest_source.py
@@ -24,7 +24,7 @@ class TestPinterestAdsSource:
         assert config.name.value == "PinterestAds"
         assert config.label == "Pinterest Ads"
         assert config.betaSource is True
-        assert config.featureFlag == "pinterest-ads-source"
+        assert config.featureFlag is None
         assert len(config.fields) == 2
 
         account_field = config.fields[0]

--- a/posthog/temporal/data_imports/sources/shopify/source.py
+++ b/posthog/temporal/data_imports/sources/shopify/source.py
@@ -63,7 +63,6 @@ class ShopifySource(SimpleSource[ShopifySourceConfig]):
                 ],
             ),
             betaSource=True,
-            featureFlag="shopify-dwh",
         )
 
     def validate_credentials(

--- a/posthog/temporal/data_imports/sources/snapchat_ads/source.py
+++ b/posthog/temporal/data_imports/sources/snapchat_ads/source.py
@@ -39,8 +39,6 @@ class SnapchatAdsSource(SimpleSource[SnapchatAdsSourceConfig], OAuthMixin):
             label="Snapchat Ads",
             caption="Collect campaign data, ad performance, and advertising metrics from Snapchat Ads. Ensure you have granted PostHog access to your Snapchat Ads account, learn how to do this in [the documentation](https://posthog.com/docs/cdp/sources/snapchat-ads).",
             betaSource=True,
-            unreleasedSource=True,
-            featureFlag="snapchat-ads-source",
             iconPath="/static/services/snapchat.png",
             docsUrl="https://posthog.com/docs/cdp/sources/snapchat-ads",
             fields=cast(


### PR DESCRIPTION
## Summary

- Remove stale `featureFlag` and `unreleasedSource` config from 7 data warehouse sources that are already fully rolled out:
  - Pinterest Ads (`pinterest-ads-source` — 100% rollout)
  - Snapchat Ads (`snapchat-ads-source` — 100% rollout)
  - Bing Ads (`bing-ads-source` — 100% rollout)
  - Meta Ads (`meta-ads-dwh` — 100% rollout)
  - Shopify (`shopify-dwh` — 0% rollout, source already visible)
  - Klaviyo (`dwh_klaviyo` — flag doesn't exist)
  - Attio (`dwh_attio` — flag doesn't exist)

## Test plan

- [x] Verify all 7 sources still appear in the data warehouse source picker