### PR TITLE
fix: remove duplicate property labels in feature flag conditions

### DIFF
--- a/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditions.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditions.tsx
@@ -301,12 +301,17 @@ export function FeatureFlagReleaseConditions({
                                     )}
                                     {property?.type !== PropertyFilterType.Cohort &&
                                         property?.type !== PropertyFilterType.Flag &&
-                                        getFilterLabel(
-                                            property.key,
-                                            property.type === PropertyFilterType.Person
-                                                ? TaxonomicFilterGroupType.PersonProperties
-                                                : TaxonomicFilterGroupType.EventProperties
-                                        )}
+                                        (() => {
+                                            const propertyLabel = getFilterLabel(
+                                                property.key,
+                                                property.type === PropertyFilterType.Person
+                                                    ? TaxonomicFilterGroupType.PersonProperties
+                                                    : TaxonomicFilterGroupType.EventProperties
+                                            )
+                                            return propertyLabel && propertyLabel !== property.key ? (
+                                                <span className="text-muted">{propertyLabel}</span>
+                                            ) : null
+                                        })()}
                                     {property.type === PropertyFilterType.Flag &&
                                         (() => {
                                             const flagId = property.key || ''

--- a/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditionsReadonly.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditionsReadonly.tsx
@@ -79,7 +79,7 @@ function PropertyFilterRow({ property, isFirst }: { property: AnyPropertyFilter;
             ) : (
                 <LemonButton icon={<span className="text-xs font-medium">&</span>} size="small" noPadding />
             )}
-            {propertyLabel && <span className="text-muted">{propertyLabel}</span>}
+            {propertyLabel && propertyLabel !== property.key && <span className="text-muted">{propertyLabel}</span>}
             <LemonSnack>{property.type === PropertyFilterType.Cohort ? 'Cohort' : property.key}</LemonSnack>
             <span className="text-muted">{operator}</span>
             <PropertyValueDisplay property={property} />


### PR DESCRIPTION
## Problem

In the feature flag release conditions UI, property labels were being displayed twice when they matched the property key (e.g., "id id" instead of just "id", "name name" instead of just "name").

<img width="1270" height="488" alt="image" src="https://github.com/user-attachments/assets/daaf172f-1879-4cce-930d-e5ef93f6225f" />

## Changes

- Modified `FeatureFlagReleaseConditions.tsx` to only show the human-friendly label when it differs from the property key
- Updated `FeatureFlagReleaseConditionsReadonly.tsx` with the same logic
- Preserved display of both labels when they differ (e.g., "Email address" and "email") to maintain clarity
- Kept existing behavior for cohort and feature flag properties

## How did you test this code?

Manually tested the feature flag conditions UI to verify:
- Single "name" label displays instead of "name name" 
- "Email address" + "email" still shows both when they differ
- Cohort properties still show "Cohort" label correctly
- Feature flag properties display correctly