### PR TITLE
fix(dagster): retry experimental sessions backfill on ClickHouse OOM

### DIFF
--- a/posthog/dags/sessions.py
+++ b/posthog/dags/sessions.py
@@ -6,6 +6,7 @@ from typing import Any, Optional
 
 from django.conf import settings
 
+from clickhouse_connect.driver.exceptions import DatabaseError as ClickHouseDatabaseError
 from clickhouse_driver import Client
 from dagster import (
     AssetExecutionContext,
@@ -39,6 +40,10 @@ from posthog.models.raw_sessions.sessions_v3 import (
 
 # This is the number of days to backfill in one SQL operation
 MAX_PARTITIONS_PER_RUN = 1
+
+# Number of sub-chunks to split a chunk into when retrying after a ClickHouse OOM error.
+# Each chunk_i is retried at most once by splitting into this many sub-queries.
+OOM_RETRY_SUB_CHUNKS = 10
 
 # Keep the number of concurrent runs low to avoid overloading ClickHouse and running into the dread "Too many parts".
 # This tag needs to also exist in Dagster Cloud (and the local dev dagster.yaml) for the concurrency limit to take effect.
@@ -462,6 +467,25 @@ def _get_experimental_chunking(config: ExperimentalSessionsBackfillConfig) -> tu
         return 1, "team_id", lambda i: "1"
 
 
+def _is_oom_error(exc: Exception) -> bool:
+    """Check if an exception is a ClickHouse MEMORY_LIMIT_EXCEEDED error."""
+    return isinstance(exc, ClickHouseDatabaseError) and "MEMORY_LIMIT_EXCEEDED" in str(exc)
+
+
+def _sub_chunk_where(base_where: str, sub_chunk_i: int, total_sub_chunks: int) -> str:
+    """Add a cityHash64(distinct_id) range filter for sub-chunk splitting on OOM retry."""
+    max_uint64 = 2**64
+    chunk_size = max_uint64 // total_sub_chunks
+    low = sub_chunk_i * chunk_size
+    high = (sub_chunk_i + 1) * chunk_size
+
+    if sub_chunk_i == 0:
+        return f"({base_where}) AND cityHash64(distinct_id) < {high}"
+    if sub_chunk_i == total_sub_chunks - 1:
+        return f"({base_where}) AND cityHash64(distinct_id) >= {low}"
+    return f"({base_where}) AND cityHash64(distinct_id) >= {low} AND cityHash64(distinct_id) < {high}"
+
+
 def _do_experimental_backfill(
     sql_template: Callable,
     timestamp_field: str,
@@ -517,7 +541,37 @@ def _do_experimental_backfill(
                     include_session_timestamp=True,
                 )
                 context.log.info(backfill_sql)
-                sync_execute(backfill_sql, settings=merged_settings, sync_client=client)
+
+                try:
+                    sync_execute(backfill_sql, settings=merged_settings, sync_client=client)
+                except Exception as e:
+                    if not _is_oom_error(e):
+                        raise
+
+                    context.log.warning(
+                        f"OOM error on chunk {chunk_i + 1}/{num_chunks}, "
+                        f"retrying by splitting into {OOM_RETRY_SUB_CHUNKS} sub-chunks: {e}"
+                    )
+
+                    for sub_i in range(OOM_RETRY_SUB_CHUNKS):
+                        wait_for_parts_to_merge(
+                            context, config, sync_client=client, table=target_table, use_cluster=False
+                        )
+
+                        sub_where = _sub_chunk_where(chunk_where_clause, sub_i, OOM_RETRY_SUB_CHUNKS)
+                        sub_sql = sql_template(
+                            where=sub_where,
+                            target_table=target_table,
+                            include_session_timestamp=True,
+                        )
+                        context.log.info(
+                            f"Running sub-chunk {sub_i + 1}/{OOM_RETRY_SUB_CHUNKS} for chunk {chunk_i + 1}/{num_chunks}"
+                        )
+                        context.log.info(sub_sql)
+                        sync_execute(sub_sql, settings=merged_settings, sync_client=client)
+                        context.log.info(
+                            f"Completed sub-chunk {sub_i + 1}/{OOM_RETRY_SUB_CHUNKS} for chunk {chunk_i + 1}/{num_chunks}"
+                        )
 
                 if num_chunks > 1:
                     context.log.info(f"Completed chunk {chunk_i + 1}/{num_chunks}")

--- a/posthog/dags/sessions.py
+++ b/posthog/dags/sessions.py
@@ -6,8 +6,8 @@ from typing import Any, Optional
 
 from django.conf import settings
 
-from clickhouse_connect.driver.exceptions import DatabaseError as ClickHouseDatabaseError
 from clickhouse_driver import Client
+from clickhouse_driver.errors import ErrorCodes
 from dagster import (
     AssetExecutionContext,
     BackfillPolicy,
@@ -469,7 +469,8 @@ def _get_experimental_chunking(config: ExperimentalSessionsBackfillConfig) -> tu
 
 def _is_oom_error(exc: Exception) -> bool:
     """Check if an exception is a ClickHouse MEMORY_LIMIT_EXCEEDED error."""
-    return isinstance(exc, ClickHouseDatabaseError) and "MEMORY_LIMIT_EXCEEDED" in str(exc)
+    error_str = str(exc)
+    return f"error code {ErrorCodes.MEMORY_LIMIT_EXCEEDED}" in error_str or "MEMORY_LIMIT_EXCEEDED" in error_str
 
 
 def _sub_chunk_where(base_where: str, sub_chunk_i: int, total_sub_chunks: int) -> str:


### PR DESCRIPTION
## Problem

The experimental sessions v3 backfill can fail with ClickHouse `MEMORY_LIMIT_EXCEEDED` (error code 241) when a single chunk requires too much memory. This crashes the entire dagster run and requires manual intervention.

## Changes

- On OOM, catch the error and retry the failed chunk by splitting it into 10 sub-queries using `cityHash64(distinct_id)` range filtering
- Each sub-query covers 1/10th of the distinct_id hash space, reducing memory pressure
- Limited to one retry per chunk — sub-chunks are not further split if they also OOM
- Added `OOM_RETRY_SUB_CHUNKS = 10` constant to control the split factor
- Each sub-chunk also checks `wait_for_parts_to_merge` before executing

## How did you test this code?

This was authored by an AI agent. No manual testing was performed. The change is isolated to the `_do_experimental_backfill` code path and the retry logic mirrors the existing `cityHash64(distinct_id)` range splitting pattern already used in `_get_experimental_chunking`.

## Publish to changelog?

No

## Docs update

N/A

## 🤖 LLM context

Co-authored by Claude Opus 4.6. The OOM retry approach was specified by the user based on production failure analysis.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._