### PR TITLE
fix: auto-create project for existing users with only demo teams

### DIFF
--- a/ee/api/agentic_provisioning/views.py
+++ b/ee/api/agentic_provisioning/views.py
@@ -371,8 +371,10 @@ def agentic_authorize(request: Any) -> HttpResponseBase:
     non_demo_teams = list(Team.objects.filter(organization_id__in=org_ids, is_demo=False))
 
     if not non_demo_teams:
-        _capture_provisioning_event("authorize", "no_team")
-        return HttpResponseRedirect(f"{settings.SITE_URL}?error=no_team")
+        organization = memberships[0].organization
+        team = Team.objects.create_with_data(initiating_user=user, organization=organization)
+        non_demo_teams = [team]
+        _capture_provisioning_event("authorize", "auto_created_project", team_id=team.id)
 
     if len(memberships) == 1 and len(non_demo_teams) == 1:
         cache.delete(pending_key)


### PR DESCRIPTION
## Problem

~75% of existing user authorize attempts via Stripe Projects are failing with `no_team`. This happens when a user signed up for PostHog but never created a real project - they only have the auto-generated demo project (e.g. "HogFlix Demo App"). The authorize flow filters these out with `is_demo=False` and returns an error, blocking the Stripe connection entirely.

Data from the agentic provisioning dashboard: 6 out of 8 authorize attempts ended in `no_team`.

## Changes

Instead of returning an error when an existing user has no non-demo teams, auto-create a real project for them in their first organization - the same thing we already do for brand new users via `User.objects.bootstrap`.

The 4-line change replaces the `no_team` error redirect with:
1. Pick the user's first organization
2. `Team.objects.create_with_data(initiating_user=user, organization=organization)`
3. Continue the authorize flow with the new team

Also tracks an `auto_created_project` analytics event so we can monitor how often this happens.

## How did you test this code

- Existing authorize tests pass (they use `APIBaseTest` which creates a real team, so they don't hit this path)
- The new path uses `Team.objects.create_with_data` which is the standard team creation method used by the signup flow and team API
- Monitoring via dashboard at https://us.posthog.com/project/2/dashboard/1401455

🤖 Generated with [Claude Code](https://claude.com/claude-code)