### PR TITLE
fix: Don't wrap strings in quotes when copying from JSON

### DIFF
--- a/frontend/src/lib/components/JSONViewer.tsx
+++ b/frontend/src/lib/components/JSONViewer.tsx
@@ -28,6 +28,12 @@ export function JSONViewer({
             name={name}
             displayDataTypes={displayDataTypes}
             displayObjectSize={displayObjectSize}
+            enableClipboard={(copy) => {
+                // The library wraps string values in quotes.
+                // Re-copy with raw string value so users get the actual content.
+                const text = typeof copy.src === 'string' ? copy.src : JSON.stringify(copy.src, null, 2)
+                void navigator.clipboard.writeText(text)
+            }}
             {...props}
         />
     )

--- a/frontend/src/lib/components/JSONViewer.tsx
+++ b/frontend/src/lib/components/JSONViewer.tsx
@@ -32,7 +32,7 @@ export function JSONViewer({
                 // The library wraps string values in quotes.
                 // Re-copy with raw string value so users get the actual content.
                 const text = typeof copy.src === 'string' ? copy.src : JSON.stringify(copy.src, null, 2)
-                void navigator.clipboard.writeText(text)
+                navigator.clipboard.writeText(text).catch((e) => console.warn('Failed to copy to clipboard', e))
             }}
             {...props}
         />


### PR DESCRIPTION
## Problem

https://posthog.slack.com/archives/C0ACRAMJUAG/p1774605227124809 - I've found this super annoying for a while now.

## Changes

The [library](https://github.com/microlinkhq/react-json-view/blob/fdcd6c71dd25e28cf5e7c7450298b5c3b661bea6/src/js/components/CopyToClipboard.js#L40) calls JSON.stringify on the value - use the `enableClipboard` callback to **not** stringify strings.

## How did you test this code?

Tested locally.