### PR TITLE
feat(sql): 2d heatmap null labels

### DIFF
--- a/frontend/src/queries/nodes/DataVisualization/Components/Heatmap/HeatmapSeriesTab.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Heatmap/HeatmapSeriesTab.tsx
@@ -124,6 +124,18 @@ export const HeatmapSeriesTab = (): JSX.Element => {
                     disabledReason={responseLoading ? 'Query loading...' : undefined}
                     onChange={(value) => updateHeatmapSettings({ valueColumn: value ?? undefined })}
                 />
+                <LemonLabel className="mt-2 mb-1">Label for null</LemonLabel>
+                <LemonInput
+                    value={heatmapSettings.nullLabel ?? 'null'}
+                    placeholder="null"
+                    onChange={(value) => updateHeatmapSettings({ nullLabel: value ?? '' })}
+                />
+                <LemonLabel className="mt-2 mb-1">Value for null</LemonLabel>
+                <LemonInput
+                    value={heatmapSettings.nullValue ?? ''}
+                    placeholder="Blank"
+                    onChange={(value) => updateHeatmapSettings({ nullValue: value ?? '' })}
+                />
             </div>
 
             <div>

--- a/frontend/src/queries/nodes/DataVisualization/Components/Heatmap/TwoDimensionalHeatmap.test.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Heatmap/TwoDimensionalHeatmap.test.tsx
@@ -1,0 +1,109 @@
+import '@testing-library/jest-dom'
+
+import { act, cleanup, render, screen } from '@testing-library/react'
+import { BindLogic, Provider } from 'kea'
+
+import { DataVisualizationNode, NodeKind } from '~/queries/schema/schema-general'
+import { initKeaTests } from '~/test/init'
+import { ChartDisplayType } from '~/types'
+
+import { dataNodeLogic } from '../../../DataNode/dataNodeLogic'
+import { DataVisualizationLogicProps, dataVisualizationLogic } from '../../dataVisualizationLogic'
+import { TwoDimensionalHeatmap } from './TwoDimensionalHeatmap'
+
+const dataNodeCollectionId = 'new-test-SQL-heatmap'
+let logicCounter = 0
+
+const makeQuery = (nullLabel = '(header null)', nullValue = ''): DataVisualizationNode => ({
+    kind: NodeKind.DataVisualizationNode,
+    source: {
+        kind: NodeKind.HogQLQuery,
+        query: 'select 1',
+    },
+    display: ChartDisplayType.TwoDimensionalHeatmap,
+    chartSettings: {
+        heatmap: {
+            xAxisColumn: 'region',
+            yAxisColumn: 'segment',
+            valueColumn: 'count',
+            nullLabel,
+            nullValue,
+        },
+    },
+})
+
+const response = {
+    columns: ['region', 'segment', 'count'],
+    types: [
+        ['region', 'String'],
+        ['segment', 'String'],
+        ['count', 'Int64'],
+    ] as [string, string][],
+    results: [
+        [null, 'Enterprise', 10],
+        ['US', null, 20],
+        ['US', 'Enterprise', null],
+    ],
+}
+
+const setup = (nullLabel = '(header null)', nullValue = ''): ReturnType<typeof dataVisualizationLogic.build> => {
+    logicCounter += 1
+    const testKey = `test-two-dimensional-heatmap-${logicCounter}`
+    const query = makeQuery(nullLabel, nullValue)
+    const props: DataVisualizationLogicProps = {
+        key: testKey,
+        query,
+        dataNodeCollectionId,
+    }
+
+    const logic = dataVisualizationLogic(props)
+    logic.mount()
+    dataNodeLogic({ key: testKey, query: query.source, dataNodeCollectionId }).actions.setResponse(response)
+
+    render(
+        <Provider>
+            <BindLogic logic={dataVisualizationLogic} props={props}>
+                <TwoDimensionalHeatmap />
+            </BindLogic>
+        </Provider>
+    )
+
+    return logic
+}
+
+describe('TwoDimensionalHeatmap', () => {
+    afterEach(() => {
+        cleanup()
+    })
+
+    beforeEach(() => {
+        initKeaTests()
+    })
+
+    it('uses the null label in headers and the null value in cell contents', async () => {
+        setup('(header null)', '(cell null)')
+
+        expect(await screen.findAllByText('(header null)')).toHaveLength(2)
+        expect(screen.getAllByText('(cell null)')).toHaveLength(2)
+        expect(screen.queryByText(/^null$/)).not.toBeInTheDocument()
+    })
+
+    it('updates cell contents when the null value setting changes', async () => {
+        const logic = setup('(header null)')
+
+        await screen.findAllByText('(header null)')
+        expect(screen.queryByText('(cell null)')).not.toBeInTheDocument()
+
+        await act(async () => {
+            logic.actions.updateChartSettings({
+                heatmap: {
+                    ...logic.values.chartSettings.heatmap,
+                    nullValue: '(cell null)',
+                },
+            })
+        })
+
+        expect(await screen.findAllByText('(cell null)')).toHaveLength(2)
+        expect(screen.getAllByText('(header null)')).toHaveLength(2)
+    })
+})

--- a/frontend/src/queries/nodes/DataVisualization/Components/Heatmap/TwoDimensionalHeatmap.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Heatmap/TwoDimensionalHeatmap.tsx
@@ -8,22 +8,18 @@ import { InsightEmptyState } from 'scenes/insights/EmptyStates'
 
 import { HeatmapSettings } from '~/queries/schema/schema-general'
 
-import { dataVisualizationLogic, formatDataWithSettings } from '../../dataVisualizationLogic'
+import { dataVisualizationLogic } from '../../dataVisualizationLogic'
 import {
     buildFallbackGradientStops,
+    formatHeatmapLabel,
+    formatHeatmapValue,
+    getHeatmapNullLabel,
+    getHeatmapNullValue,
     getHeatmapTextClassName,
     interpolateHeatmapColor,
     resolveGradientStops,
     stretchGradientStopsToValues,
 } from './heatmapUtils'
-
-const formatCategoryValue = (value: unknown): string => {
-    if (value === null || value === undefined || value === '') {
-        return '[No value]'
-    }
-
-    return String(value)
-}
 
 const parseNumericValue = (value: unknown): number | null => {
     if (value === null || value === undefined || value === '') {
@@ -74,10 +70,11 @@ const buildHeatmapData = (
     const xIndexMap = new Map<string, number>()
     const yIndexMap = new Map<string, number>()
     const seenCells = new Set<string>()
+    const nullLabel = getHeatmapNullLabel(heatmapSettings)
 
     rows.forEach((row) => {
-        const xLabel = formatCategoryValue(row[xIndex])
-        const yLabel = formatCategoryValue(row[yIndex])
+        const xLabel = formatHeatmapLabel(row[xIndex], nullLabel)
+        const yLabel = formatHeatmapLabel(row[yIndex], nullLabel)
         const numericValue = parseNumericValue(row[valueIndex])
 
         if (!xIndexMap.has(xLabel)) {
@@ -170,6 +167,7 @@ export const TwoDimensionalHeatmap = (): JSX.Element => {
             : gradientStops
     const xAxisLabel = heatmapSettings.xAxisLabel || heatmapSettings.xAxisColumn || 'X-axis'
     const yAxisLabel = heatmapSettings.yAxisLabel || heatmapSettings.yAxisColumn || 'Y-axis'
+    const nullValue = getHeatmapNullValue(heatmapSettings)
 
     if (!hasSelection || !hasValidColumns) {
         return (
@@ -226,7 +224,6 @@ export const TwoDimensionalHeatmap = (): JSX.Element => {
                                         cellValue === null
                                             ? 'transparent'
                                             : interpolateHeatmapColor(cellValue, scaledGradientStops)
-                                    const formattedValue = formatDataWithSettings(cellValue, undefined)
 
                                     return (
                                         <td
@@ -237,9 +234,7 @@ export const TwoDimensionalHeatmap = (): JSX.Element => {
                                             )}
                                             style={{ backgroundColor: cellColor }}
                                         >
-                                            {typeof formattedValue === 'object'
-                                                ? JSON.stringify(formattedValue)
-                                                : (formattedValue ?? '')}
+                                            {formatHeatmapValue(cellValue, nullValue)}
                                         </td>
                                     )
                                 })}

--- a/frontend/src/queries/nodes/DataVisualization/Components/Heatmap/heatmapUtils.test.ts
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Heatmap/heatmapUtils.test.ts
@@ -1,0 +1,72 @@
+import { formatHeatmapLabel, formatHeatmapValue, getHeatmapNullLabel, getHeatmapNullValue } from './heatmapUtils'
+
+describe('formatHeatmapLabel', () => {
+    it('uses the configured null label for nullish category values', () => {
+        expect(formatHeatmapLabel(null, 'N/A')).toBe('N/A')
+        expect(formatHeatmapLabel(undefined, 'N/A')).toBe('N/A')
+        expect(formatHeatmapLabel('', 'N/A')).toBe('N/A')
+        expect(formatHeatmapLabel('null', 'N/A')).toBe('N/A')
+        expect(formatHeatmapLabel(' NULL ', 'N/A')).toBe('N/A')
+    })
+
+    it('defaults nullish category values to the string null', () => {
+        expect(formatHeatmapLabel(null)).toBe('null')
+        expect(formatHeatmapLabel(undefined)).toBe('null')
+        expect(formatHeatmapLabel('')).toBe('null')
+    })
+
+    it('preserves non-null values', () => {
+        expect(formatHeatmapLabel('nullify', 'N/A')).toBe('nullify')
+        expect(formatHeatmapLabel('US', 'N/A')).toBe('US')
+        expect(formatHeatmapLabel(0, 'N/A')).toBe('0')
+    })
+})
+
+describe('formatHeatmapValue', () => {
+    it('uses the configured null value for nullish cell values', () => {
+        expect(formatHeatmapValue(null, 'N/A')).toBe('N/A')
+        expect(formatHeatmapValue(undefined, 'N/A')).toBe('N/A')
+        expect(formatHeatmapValue('', 'N/A')).toBe('N/A')
+        expect(formatHeatmapValue('null', 'N/A')).toBe('N/A')
+        expect(formatHeatmapValue(' NULL ', 'N/A')).toBe('N/A')
+    })
+
+    it('defaults nullish cell values to blank', () => {
+        expect(formatHeatmapValue(null)).toBe('')
+        expect(formatHeatmapValue(undefined)).toBe('')
+        expect(formatHeatmapValue('')).toBe('')
+    })
+
+    it('preserves non-null cell values', () => {
+        expect(formatHeatmapValue('nullify', 'N/A')).toBe('nullify')
+        expect(formatHeatmapValue(0, 'N/A')).toBe('0')
+    })
+})
+
+describe('getHeatmapNullValue', () => {
+    it('defaults null values to blank', () => {
+        expect(getHeatmapNullValue({})).toBe('')
+    })
+
+    it('uses the explicit null value when configured', () => {
+        expect(getHeatmapNullValue({ nullLabel: 'null', nullValue: 'N/A' })).toBe('N/A')
+    })
+
+    it('stays blank when only a null label is configured', () => {
+        expect(getHeatmapNullValue({ nullLabel: 'N/A' })).toBe('')
+    })
+})
+
+describe('getHeatmapNullLabel', () => {
+    it('defaults header null labels to the string null', () => {
+        expect(getHeatmapNullLabel({})).toBe('null')
+    })
+
+    it('uses the label override for rendered heatmap headers', () => {
+        expect(getHeatmapNullLabel({ nullLabel: 'N/A' })).toBe('N/A')
+    })
+
+    it('does not let the null value override affect heatmap headers', () => {
+        expect(getHeatmapNullLabel({ nullLabel: 'N/A', nullValue: '(blank)' })).toBe('N/A')
+    })
+})

--- a/frontend/src/queries/nodes/DataVisualization/Components/Heatmap/heatmapUtils.ts
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Heatmap/heatmapUtils.ts
@@ -1,6 +1,6 @@
 import { hexToRGB } from 'lib/utils'
 
-import { HeatmapGradientStop } from '~/queries/schema/schema-general'
+import { HeatmapGradientStop, HeatmapSettings } from '~/queries/schema/schema-general'
 
 const DEFAULT_GRADIENT_COLORS = ['#E2E8F0', '#2563EB']
 const DEFAULT_GRADIENT_STOPS: HeatmapGradientStop[] = [
@@ -187,4 +187,40 @@ export const getHeatmapTextClassName = (color: string): string => {
     const { r, g, b } = hexToRGB(color)
     const luminance = 0.2126 * r + 0.7152 * g + 0.0722 * b
     return luminance < 140 ? 'text-white' : 'text-primary'
+}
+
+const isNullishHeatmapValue = (value: unknown): boolean => {
+    if (value === null || value === undefined || value === '') {
+        return true
+    }
+
+    return typeof value === 'string' && value.trim().toLowerCase() === 'null'
+}
+
+export const formatHeatmapLabel = (value: unknown, nullLabel = 'null'): string => {
+    if (isNullishHeatmapValue(value)) {
+        return nullLabel
+    }
+
+    return String(value)
+}
+
+export const formatHeatmapValue = (value: unknown, nullValue = ''): string => {
+    if (isNullishHeatmapValue(value)) {
+        return nullValue
+    }
+
+    if (typeof value === 'object') {
+        return JSON.stringify(value)
+    }
+
+    return String(value)
+}
+
+export const getHeatmapNullLabel = (settings: Pick<HeatmapSettings, 'nullLabel' | 'nullValue'>): string => {
+    return settings.nullLabel ?? 'null'
+}
+
+export const getHeatmapNullValue = (settings: Pick<HeatmapSettings, 'nullLabel' | 'nullValue'>): string => {
+    return settings.nullValue ?? ''
 }

--- a/frontend/src/queries/nodes/DataVisualization/DataVisualization.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/DataVisualization.tsx
@@ -1,7 +1,7 @@
 import clsx from 'clsx'
 import { BindLogic, BuiltLogic, LogicWrapper, useActions, useValues } from 'kea'
 import { router } from 'kea-router'
-import { useCallback, useState } from 'react'
+import { useCallback, useRef, useState } from 'react'
 
 import { IconGear } from '@posthog/icons'
 import { LemonButton, LemonDivider } from '@posthog/lemon-ui'
@@ -42,6 +42,7 @@ import { VariablesForInsight } from './Components/Variables/Variables'
 import { VariablesLogicProps, variablesLogic } from './Components/Variables/variablesLogic'
 import { DataVisualizationLogicProps, dataVisualizationLogic } from './dataVisualizationLogic'
 import { displayLogic } from './displayLogic'
+import { applyDataVisualizationQueryUpdate } from './queryUpdateUtils'
 
 export interface DataTableVisualizationProps {
     uniqueKey?: string | number
@@ -76,6 +77,9 @@ export function DataTableVisualization({
     embedded,
 }: DataTableVisualizationProps): JSX.Element {
     const [key] = useState(`DataVisualizationNode.${uniqueKey ?? uniqueNode++}`)
+    const queryRef = useRef(query)
+    queryRef.current = query
+
     const insightProps: InsightLogicProps<DataVisualizationNode> = context?.insightProps || {
         dashboardItemId: `new-AdHoc.${key}`,
         query,
@@ -93,7 +97,7 @@ export function DataTableVisualization({
         loadPriority: insightProps.loadPriority,
         editMode,
         setQuery: (setter) => {
-            setQuery(setter(query))
+            applyDataVisualizationQueryUpdate(queryRef, setter, setQuery)
         },
         cachedResults,
         variablesOverride,

--- a/frontend/src/queries/nodes/DataVisualization/queryUpdateUtils.test.ts
+++ b/frontend/src/queries/nodes/DataVisualization/queryUpdateUtils.test.ts
@@ -1,0 +1,48 @@
+import { DataVisualizationNode, NodeKind } from '~/queries/schema/schema-general'
+import { ChartDisplayType } from '~/types'
+
+import { applyDataVisualizationQueryUpdate } from './queryUpdateUtils'
+
+describe('applyDataVisualizationQueryUpdate', () => {
+    it('composes consecutive updates against the latest query state', () => {
+        const queryRef = {
+            current: {
+                kind: NodeKind.DataVisualizationNode,
+                source: {
+                    kind: NodeKind.HogQLQuery,
+                    query: 'SELECT 1',
+                },
+                display: ChartDisplayType.Auto,
+            } as DataVisualizationNode,
+        }
+        const updates: DataVisualizationNode[] = []
+
+        applyDataVisualizationQueryUpdate(
+            queryRef,
+            (query) => ({
+                ...query,
+                display: ChartDisplayType.TwoDimensionalHeatmap,
+            }),
+            (query) => updates.push(query)
+        )
+
+        applyDataVisualizationQueryUpdate(
+            queryRef,
+            (query) => ({
+                ...query,
+                chartSettings: {
+                    ...query.chartSettings,
+                    heatmap: {
+                        ...query.chartSettings?.heatmap,
+                        xAxisColumn: 'screen_width',
+                    },
+                },
+            }),
+            (query) => updates.push(query)
+        )
+
+        expect(updates).toHaveLength(2)
+        expect(updates[1].display).toBe(ChartDisplayType.TwoDimensionalHeatmap)
+        expect(updates[1].chartSettings?.heatmap?.xAxisColumn).toBe('screen_width')
+    })
+})

--- a/frontend/src/queries/nodes/DataVisualization/queryUpdateUtils.ts
+++ b/frontend/src/queries/nodes/DataVisualization/queryUpdateUtils.ts
@@ -1,0 +1,13 @@
+import type { MutableRefObject } from 'react'
+
+import { DataVisualizationNode } from '~/queries/schema/schema-general'
+
+export const applyDataVisualizationQueryUpdate = (
+    queryRef: MutableRefObject<DataVisualizationNode>,
+    setter: (query: DataVisualizationNode) => DataVisualizationNode,
+    setQuery: (query: DataVisualizationNode) => void
+): void => {
+    const nextQuery = setter(queryRef.current)
+    queryRef.current = nextQuery
+    setQuery(nextQuery)
+}

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -18082,6 +18082,12 @@
                     "enum": ["absolute", "relative"],
                     "type": "string"
                 },
+                "nullLabel": {
+                    "type": "string"
+                },
+                "nullValue": {
+                    "type": "string"
+                },
                 "valueColumn": {
                     "type": "string"
                 },

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -1079,6 +1079,8 @@ export interface HeatmapSettings {
     valueColumn?: string
     xAxisLabel?: string
     yAxisLabel?: string
+    nullLabel?: string
+    nullValue?: string
     gradient?: HeatmapGradientStop[]
     gradientPreset?: string
     gradientScaleMode?: 'absolute' | 'relative'

--- a/frontend/src/scenes/data-warehouse/editor/OutputPane.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/OutputPane.tsx
@@ -661,7 +661,6 @@ function InternalDataTableVisualization(props: DataTableVisualizationProps): JSX
     const {
         query,
         effectiveVisualizationType,
-        showEditingUI,
         response,
         responseLoading,
         isChartSettingsPanelOpen,
@@ -679,7 +678,7 @@ function InternalDataTableVisualization(props: DataTableVisualizationProps): JSX
     let component: JSX.Element | null = null
 
     // TODO(@Gilbert09): Better loading support for all components - e.g. using the `loading` param of `Table`
-    if (!showEditingUI && (!response || responseLoading)) {
+    if (!response || responseLoading) {
         component = (
             <div className="flex flex-col flex-1 justify-center items-center bg-surface-primary h-full">
                 <LoadingBar />
@@ -834,6 +833,36 @@ const Content = ({
         )
     }
 
+    if (activeTab === OutputTab.Visualization) {
+        if (!response && !responseLoading && !insightLoading) {
+            return (
+                <div
+                    className="flex flex-1 justify-center items-center border-t"
+                    data-attr="sql-editor-output-pane-empty-state"
+                >
+                    <span className="text-secondary mt-3">
+                        Query results will be visualized here. Press <KeyboardShortcut command enter /> to run the
+                        query.
+                    </span>
+                </div>
+            )
+        }
+
+        return (
+            <div className="flex-1 absolute inset-0 hide-scrollbar border-t">
+                <InternalDataTableVisualization
+                    uniqueKey={vizKey}
+                    query={sourceQuery}
+                    setQuery={setSourceQuery}
+                    context={{}}
+                    cachedResults={undefined}
+                    exportContext={exportContext}
+                    editMode
+                />
+            </div>
+        )
+    }
+
     if (responseLoading || insightLoading) {
         return (
             <div className="flex flex-1 p-2 w-full justify-center items-center border-t">
@@ -886,22 +915,6 @@ const Content = ({
                     onSortColumnsChange={setSortColumns}
                 />
             </TabScroller>
-        )
-    }
-
-    if (activeTab === OutputTab.Visualization) {
-        return (
-            <div className="flex-1 absolute inset-0 hide-scrollbar border-t">
-                <InternalDataTableVisualization
-                    uniqueKey={vizKey}
-                    query={sourceQuery}
-                    setQuery={setSourceQuery}
-                    context={{}}
-                    cachedResults={undefined}
-                    exportContext={exportContext}
-                    editMode
-                />
-            </div>
         )
     }
     return null

--- a/frontend/src/scenes/data-warehouse/editor/SQLEditor.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/SQLEditor.tsx
@@ -25,6 +25,7 @@ import {
     dataVisualizationLogic,
 } from '~/queries/nodes/DataVisualization/dataVisualizationLogic'
 import { displayLogic } from '~/queries/nodes/DataVisualization/displayLogic'
+import { applyDataVisualizationQueryUpdate } from '~/queries/nodes/DataVisualization/queryUpdateUtils'
 
 import { dataWarehouseViewsLogic } from '../saved_queries/dataWarehouseViewsLogic'
 import { ViewLinkModal } from '../ViewLinkModal'
@@ -109,6 +110,8 @@ export function SQLEditor({
 
     const { sourceQuery, dataLogicKey } = useValues(logic)
     const { setSourceQuery } = useActions(logic)
+    const sourceQueryRef = useRef(sourceQuery)
+    sourceQueryRef.current = sourceQuery
 
     const dataVisualizationLogicProps: DataVisualizationLogicProps = {
         key: dataLogicKey,
@@ -119,7 +122,7 @@ export function SQLEditor({
         loadPriority: undefined,
         cachedResults: undefined,
         variablesOverride: undefined,
-        setQuery: (setter) => setSourceQuery(setter(sourceQuery)),
+        setQuery: (setter) => applyDataVisualizationQueryUpdate(sourceQueryRef, setter, setSourceQuery),
     }
 
     const dataNodeLogicProps: DataNodeLogicProps = {

--- a/frontend/src/scenes/data-warehouse/editor/sqlEditorLogic.test.ts
+++ b/frontend/src/scenes/data-warehouse/editor/sqlEditorLogic.test.ts
@@ -299,7 +299,7 @@ describe('sqlEditorLogic', () => {
     })
 
     describe('open_view behavior', () => {
-        it('switches to the materialization tab when opening a view from the URL', async () => {
+        it('respects the requested output tab when opening a view from the URL', async () => {
             logic = sqlEditorLogic({
                 tabId: TAB_ID,
                 monaco: createMockMonaco(),
@@ -307,15 +307,15 @@ describe('sqlEditorLogic', () => {
             })
             logic.mount()
 
-            router.actions.push(urls.sqlEditor(), { open_view: MOCK_VIEW.id, output_tab: OutputTab.Results })
+            router.actions.push(urls.sqlEditor(), { open_view: MOCK_VIEW.id }, { output_tab: OutputTab.Results })
 
             await expectLogic(logic)
-                .toDispatchActions(['setActiveTab', 'setViewLoading', 'editView', 'createTab', 'updateTab'])
+                .toDispatchActions(['setViewLoading', 'createTab', 'updateTab'])
                 .toMatchValues({
                     editingView: partial({
                         id: MOCK_VIEW.id,
                     }),
-                    outputActiveTab: OutputTab.Materialization,
+                    outputActiveTab: OutputTab.Results,
                 })
         })
 
@@ -337,6 +337,50 @@ describe('sqlEditorLogic', () => {
                     }),
                     outputActiveTab: OutputTab.Materialization,
                 })
+        })
+    })
+
+    describe('output tab hash parameter', () => {
+        it('restores the selected output tab from the hash', async () => {
+            logic = sqlEditorLogic({
+                tabId: TAB_ID,
+                monaco: createMockMonaco(),
+                editor: createMockEditor(),
+            })
+            logic.mount()
+
+            router.actions.push(urls.sqlEditor(), undefined, {
+                q: 'SELECT 1',
+                output_tab: OutputTab.Visualization,
+            })
+
+            await expectLogic(logic).toDispatchActions(['setActiveTab', 'createTab', 'updateTab']).toMatchValues({
+                outputActiveTab: OutputTab.Visualization,
+            })
+
+            logic.actions.setQueryInput('SELECT 2')
+            await new Promise((resolve) => setTimeout(resolve, 600))
+
+            expect(router.values.hashParams.q).toEqual('SELECT 2')
+            expect(router.values.hashParams.output_tab).toEqual(OutputTab.Visualization)
+        })
+
+        it('replaces the hash output tab when the selected tab changes', async () => {
+            logic = sqlEditorLogic({
+                tabId: TAB_ID,
+                monaco: createMockMonaco(),
+                editor: createMockEditor(),
+            })
+            logic.mount()
+
+            logic.actions.createTab('SELECT 1')
+            await expectLogic(logic).toDispatchActions(['createTab', 'updateTab'])
+
+            logic.actions.setActiveTab(OutputTab.Materialization)
+            await new Promise((resolve) => setTimeout(resolve, 0))
+
+            expect(router.values.hashParams.q).toEqual('SELECT 1')
+            expect(router.values.hashParams.output_tab).toEqual(OutputTab.Materialization)
         })
     })
 

--- a/frontend/src/scenes/data-warehouse/editor/sqlEditorLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/sqlEditorLogic.tsx
@@ -159,6 +159,7 @@ function sanitizeSourceQuery(sourceQuery: DataVisualizationNode): DataVisualizat
 function getTabHash(values: sqlEditorLogicType['values']): Record<string, any> {
     const hash: Record<string, any> = {
         q: values.queryInput ?? '',
+        output_tab: values.outputActiveTab,
     }
     const connectionId = values.sourceQuery?.source.connectionId
     if (values.featureFlags[FEATURE_FLAGS.DWH_POSTGRES_DIRECT_QUERY] && connectionId) {
@@ -178,6 +179,14 @@ function getTabHash(values: sqlEditorLogicType['values']): Record<string, any> {
     }
 
     return hash
+}
+
+function parseOutputTab(value: unknown): OutputTab | null {
+    if (Object.values(OutputTab).includes(value as OutputTab)) {
+        return value as OutputTab
+    }
+
+    return null
 }
 
 export function getDisplayTypeToSaveInsight(
@@ -1518,6 +1527,12 @@ export const sqlEditorLogic = kea<sqlEditorLogicType>([
             }
             return [urls.sqlEditor(), undefined, getTabHash(values), { replace: true }]
         },
+        setActiveTab: () => {
+            if (values.isEmbeddedMode || !values.activeTab) {
+                return
+            }
+            return [urls.sqlEditor(), undefined, getTabHash(values), { replace: true }]
+        },
     })),
     tabAwareUrlToAction(({ actions, values, props }) => ({
         [urls.sqlEditor()]: async (_, searchParams, hashParams) => {
@@ -1528,6 +1543,9 @@ export const sqlEditorLogic = kea<sqlEditorLogicType>([
             if (searchParams.source === 'endpoint' || searchParams.source === 'insight') {
                 actions.setEditorSource(searchParams.source)
             }
+
+            const outputTabFromUrl = parseOutputTab(searchParams.output_tab ?? hashParams.output_tab)
+
             if (
                 !searchParams.open_query &&
                 !searchParams.open_view &&
@@ -1539,6 +1557,8 @@ export const sqlEditorLogic = kea<sqlEditorLogicType>([
                 !hashParams.raw &&
                 !hashParams.view &&
                 !hashParams.insight &&
+                !hashParams.draft &&
+                !hashParams.output_tab &&
                 values.queryInput !== null
             ) {
                 return
@@ -1571,8 +1591,8 @@ export const sqlEditorLogic = kea<sqlEditorLogicType>([
             let tabAdded = false
 
             const createQueryTab = async (): Promise<void> => {
-                if (searchParams.output_tab) {
-                    actions.setActiveTab(searchParams.output_tab as OutputTab)
+                if (outputTabFromUrl && values.outputActiveTab !== outputTabFromUrl) {
+                    actions.setActiveTab(outputTabFromUrl)
                 }
                 if (searchParams.open_draft || (hashParams.draft && values.queryInput === null)) {
                     const draftId = searchParams.open_draft || hashParams.draft
@@ -1599,7 +1619,9 @@ export const sqlEditorLogic = kea<sqlEditorLogicType>([
                     // Open view
                     const viewId = searchParams.open_view || hashParams.view
 
-                    actions.setActiveTab(OutputTab.Materialization)
+                    if (!outputTabFromUrl) {
+                        actions.setActiveTab(OutputTab.Materialization)
+                    }
                     actions.setViewLoading(true)
 
                     if (values.dataWarehouseSavedQueries.length === 0) {
@@ -1626,7 +1648,11 @@ export const sqlEditorLogic = kea<sqlEditorLogicType>([
 
                     const queryToOpen = searchParams.open_query ? searchParams.open_query : (view.query?.query ?? '')
 
-                    actions.editView(queryToOpen, view)
+                    if (outputTabFromUrl) {
+                        actions.createTab(queryToOpen, view)
+                    } else {
+                        actions.editView(queryToOpen, view)
+                    }
                     actions.setViewLoading(false)
                     tabAdded = true
                     router.actions.replace(urls.sqlEditor(), undefined, getTabHash(values))
@@ -1673,7 +1699,9 @@ export const sqlEditorLogic = kea<sqlEditorLogicType>([
                         actions.setSourceQuery(insight.query as DataVisualizationNode)
                     }
                     actions.editInsight(queryToOpen, insight)
-                    actions.setActiveTab(OutputTab.Visualization)
+                    if (!outputTabFromUrl) {
+                        actions.setActiveTab(OutputTab.Visualization)
+                    }
 
                     // Only run the query if the results aren't already cached locally and we're not using the open_query search param
                     if (

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -2126,6 +2126,8 @@ class HeatmapSettings(BaseModel):
     gradient: list[HeatmapGradientStop] | None = None
     gradientPreset: str | None = None
     gradientScaleMode: GradientScaleMode | None = None
+    nullLabel: str | None = None
+    nullValue: str | None = None
     valueColumn: str | None = None
     xAxisColumn: str | None = None
     xAxisLabel: str | None = None

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -6524,6 +6524,10 @@ export namespace Schemas {
       gradientPreset?: string | null;
       gradientScaleMode?: GradientScaleMode | null;
       /** @nullable */
+      nullLabel?: string | null;
+      /** @nullable */
+      nullValue?: string | null;
+      /** @nullable */
       valueColumn?: string | null;
       /** @nullable */
       xAxisColumn?: string | null;


### PR DESCRIPTION
## Problem

The 2d heatmap visualization's null values were just shown as "null" and labels were shown as ""

## Changes

Make them configurable:

<img width="1201" height="714" alt="Screenshot 2026-03-27 at 15 04 58" src="https://github.com/user-attachments/assets/c0363a11-f5e1-490c-a4ed-9cdbe0b65e5a" />

Also adds support for persisting the open tab in the visualization page in the URL

## How did you test this code?

👀 
