### PR TITLE
fix: Fix schema update logic in dataWarehouseSettingsLogic

### DIFF
--- a/frontend/src/scenes/data-warehouse/settings/dataWarehouseSettingsLogic.ts
+++ b/frontend/src/scenes/data-warehouse/settings/dataWarehouseSettingsLogic.ts
@@ -65,13 +65,9 @@ export const dataWarehouseSettingsLogic = kea<dataWarehouseSettingsLogicType>([
                     const clonedSources = JSON.parse(
                         JSON.stringify(values.dataWarehouseSources?.results ?? [])
                     ) as ExternalDataSource[]
-                    const sourceIndex = clonedSources.findIndex((n) =>
-                        n.schemas?.find((m) => m.id === schema.id)
-                    )
+                    const sourceIndex = clonedSources.findIndex((n) => n.schemas?.find((m) => m.id === schema.id))
                     if (sourceIndex !== -1) {
-                        const schemaIndex = clonedSources[sourceIndex].schemas.findIndex(
-                            (n) => n.id === schema.id
-                        )
+                        const schemaIndex = clonedSources[sourceIndex].schemas.findIndex((n) => n.id === schema.id)
                         clonedSources[sourceIndex].schemas[schemaIndex] = schema
 
                         actions.loadSourcesSuccess({

--- a/frontend/src/scenes/data-warehouse/settings/dataWarehouseSettingsLogic.ts
+++ b/frontend/src/scenes/data-warehouse/settings/dataWarehouseSettingsLogic.ts
@@ -65,14 +65,20 @@ export const dataWarehouseSettingsLogic = kea<dataWarehouseSettingsLogicType>([
                     const clonedSources = JSON.parse(
                         JSON.stringify(values.dataWarehouseSources?.results ?? [])
                     ) as ExternalDataSource[]
-                    const sourceIndex = clonedSources.findIndex((n) => n.schemas.find((m) => m.id === schema.id))
-                    const schemaIndex = clonedSources[sourceIndex].schemas.findIndex((n) => n.id === schema.id)
-                    clonedSources[sourceIndex].schemas[schemaIndex] = schema
+                    const sourceIndex = clonedSources.findIndex((n) =>
+                        n.schemas?.find((m) => m.id === schema.id)
+                    )
+                    if (sourceIndex !== -1) {
+                        const schemaIndex = clonedSources[sourceIndex].schemas.findIndex(
+                            (n) => n.id === schema.id
+                        )
+                        clonedSources[sourceIndex].schemas[schemaIndex] = schema
 
-                    actions.loadSourcesSuccess({
-                        ...values.dataWarehouseSources,
-                        results: clonedSources,
-                    })
+                        actions.loadSourcesSuccess({
+                            ...values.dataWarehouseSources,
+                            results: clonedSources,
+                        })
+                    }
 
                     await api.externalDataSchemas.update(schema.id, schema)
                     actions.loadSources()


### PR DESCRIPTION
## Problem

Causing https://us.posthog.com/project/2/error_tracking/019afe36-746d-7a51-ab42-fd7bc880c512?timestamp=2026-03-27%2006%3A55%3A14.267000-07%3A00&searchQuery=%22reading%20%27schemas%27%22.

When users click 'pull new schemas' then immediately try to configure one of the new schemas, the error was being thrown because the new schemas ID didn't exist.

## Changes

Added a guard for `sourceIndex === -1` to skip optimistic UI update for new schemas.