### PR TITLE
chore(charts): Add new charts lib - core

### DIFF
--- a/frontend/src/lib/charts/__tests__/canvas-renderer.test.ts
+++ b/frontend/src/lib/charts/__tests__/canvas-renderer.test.ts
@@ -1,0 +1,175 @@
+import * as d3 from 'd3'
+
+import { drawGrid, drawLine, drawPoints } from '../core/canvas-renderer'
+import type { DrawContext } from '../core/canvas-renderer'
+import type { ChartDimensions, Series } from '../core/types'
+
+// Mock canvas context
+function createMockCtx(): CanvasRenderingContext2D {
+    return {
+        beginPath: jest.fn(),
+        moveTo: jest.fn(),
+        lineTo: jest.fn(),
+        stroke: jest.fn(),
+        fill: jest.fn(),
+        arc: jest.fn(),
+        setLineDash: jest.fn(),
+        clearRect: jest.fn(),
+        save: jest.fn(),
+        restore: jest.fn(),
+        closePath: jest.fn(),
+        strokeStyle: '',
+        fillStyle: '',
+        lineWidth: 1,
+        lineJoin: 'round',
+        lineCap: 'round',
+        globalAlpha: 1,
+        canvas: { width: 800, height: 400 },
+    } as unknown as CanvasRenderingContext2D
+}
+
+describe('hog-charts canvas-renderer', () => {
+    const dimensions: ChartDimensions = {
+        width: 800,
+        height: 400,
+        plotLeft: 48,
+        plotTop: 16,
+        plotWidth: 736,
+        plotHeight: 352,
+    }
+
+    const labels = ['Mon', 'Tue', 'Wed', 'Thu']
+
+    const xScale = d3
+        .scalePoint<string>()
+        .domain(labels)
+        .range([dimensions.plotLeft, dimensions.plotLeft + dimensions.plotWidth])
+        .padding(0.5)
+
+    const yScale = d3
+        .scaleLinear()
+        .domain([0, 30])
+        .range([dimensions.plotTop + dimensions.plotHeight, dimensions.plotTop])
+
+    const makeDrawCtx = (ctx: CanvasRenderingContext2D): DrawContext => ({
+        ctx,
+        dimensions,
+        xScale,
+        yScale,
+        labels,
+    })
+
+    const makeSeries = (data: number[]): Series => ({
+        key: 'test',
+        label: 'Test',
+        data,
+        color: '#1d4aff',
+    })
+
+    describe('drawLine', () => {
+        it('draws a line path through data points', () => {
+            const ctx = createMockCtx()
+            const drawCtx = makeDrawCtx(ctx)
+
+            drawLine(drawCtx, makeSeries([10, 25, 30, 15]))
+
+            expect(ctx.beginPath).toHaveBeenCalled()
+            expect(ctx.moveTo).toHaveBeenCalled()
+            expect(ctx.lineTo).toHaveBeenCalledTimes(3)
+            expect(ctx.stroke).toHaveBeenCalled()
+        })
+
+        it('does not draw for empty data', () => {
+            const ctx = createMockCtx()
+            const drawCtx = makeDrawCtx(ctx)
+
+            drawLine(drawCtx, makeSeries([]))
+
+            expect(ctx.beginPath).not.toHaveBeenCalled()
+        })
+
+        it('uses dash pattern for incomplete data', () => {
+            const ctx = createMockCtx()
+            const drawCtx = makeDrawCtx(ctx)
+
+            drawLine(drawCtx, makeSeries([10, 25, 30, 15]), undefined, { incompleteFromIndex: 2 })
+
+            // Should set dashed line for incomplete portion
+            expect(ctx.setLineDash).toHaveBeenCalledWith([6, 4])
+        })
+
+        it('applies series dash pattern', () => {
+            const ctx = createMockCtx()
+            const drawCtx = makeDrawCtx(ctx)
+            const series = { ...makeSeries([10, 25, 30, 15]), dashPattern: [10, 10] }
+
+            drawLine(drawCtx, series)
+
+            expect(ctx.setLineDash).toHaveBeenCalledWith([10, 10])
+        })
+    })
+
+    describe('drawPoints', () => {
+        it('draws circles at each data point', () => {
+            const ctx = createMockCtx()
+            const drawCtx = makeDrawCtx(ctx)
+            const series = { ...makeSeries([10, 25, 30, 15]), pointRadius: 3 }
+
+            drawPoints(drawCtx, series)
+
+            expect(ctx.arc).toHaveBeenCalledTimes(4)
+            expect(ctx.fill).toHaveBeenCalledTimes(4)
+        })
+
+        it('does not draw when pointRadius is 0', () => {
+            const ctx = createMockCtx()
+            const drawCtx = makeDrawCtx(ctx)
+            const series = { ...makeSeries([10, 25]), pointRadius: 0 }
+
+            drawPoints(drawCtx, series)
+
+            expect(ctx.arc).not.toHaveBeenCalled()
+        })
+
+        it('does not draw when pointRadius is unset', () => {
+            const ctx = createMockCtx()
+            const drawCtx = makeDrawCtx(ctx)
+
+            drawPoints(drawCtx, makeSeries([10, 25]))
+
+            expect(ctx.arc).not.toHaveBeenCalled()
+        })
+    })
+
+    describe('drawGrid', () => {
+        it('draws horizontal grid lines', () => {
+            const ctx = createMockCtx()
+            const drawCtx = makeDrawCtx(ctx)
+
+            drawGrid(drawCtx)
+
+            expect(ctx.beginPath).toHaveBeenCalled()
+            expect(ctx.moveTo).toHaveBeenCalled()
+            expect(ctx.lineTo).toHaveBeenCalled()
+            expect(ctx.stroke).toHaveBeenCalled()
+        })
+
+        it('skips grid lines at goal line values', () => {
+            const ctx = createMockCtx()
+            const drawCtx = makeDrawCtx(ctx)
+
+            // Grid with goal at 10 - should skip that tick
+            const moveToCallsBefore = (ctx.moveTo as jest.Mock).mock.calls.length
+            drawGrid(drawCtx, { goalLineValues: [] })
+            const callsWithout = (ctx.moveTo as jest.Mock).mock.calls.length - moveToCallsBefore
+
+            const ctx2 = createMockCtx()
+            const drawCtx2 = makeDrawCtx(ctx2)
+            drawGrid(drawCtx2, { goalLineValues: [10] })
+            const callsWith = (ctx2.moveTo as jest.Mock).mock.calls.length
+
+            // With a goal line value matching a tick, fewer lines should be drawn
+            expect(callsWith).toBeLessThanOrEqual(callsWithout)
+        })
+    })
+})

--- a/frontend/src/lib/charts/__tests__/scales.test.ts
+++ b/frontend/src/lib/charts/__tests__/scales.test.ts
@@ -1,0 +1,144 @@
+import { autoFormatYTick, computePercentStackData, createXScale, createYScale } from '../core/scales'
+import type { ChartDimensions, Series } from '../core/types'
+
+describe('hog-charts scales', () => {
+    const dimensions: ChartDimensions = {
+        width: 800,
+        height: 400,
+        plotLeft: 48,
+        plotTop: 16,
+        plotWidth: 736,
+        plotHeight: 352,
+    }
+
+    const makeSeries = (data: number[], key = 'test'): Series => ({
+        key,
+        label: key,
+        data,
+        color: '#1d4aff',
+    })
+
+    describe('createXScale', () => {
+        it('creates a point scale over labels', () => {
+            const labels = ['Mon', 'Tue', 'Wed', 'Thu']
+            const scale = createXScale(labels, dimensions)
+
+            expect(scale.domain()).toEqual(labels)
+            expect(scale('Mon')).not.toBeUndefined()
+            expect(scale('Thu')).not.toBeUndefined()
+
+            // Points should be within plot range
+            const monX = scale('Mon')!
+            const thuX = scale('Thu')!
+            expect(monX).toBeGreaterThanOrEqual(dimensions.plotLeft)
+            expect(thuX).toBeLessThanOrEqual(dimensions.plotLeft + dimensions.plotWidth)
+            expect(thuX).toBeGreaterThan(monX)
+        })
+
+        it('handles empty labels', () => {
+            const scale = createXScale([], dimensions)
+            expect(scale.domain()).toEqual([])
+        })
+
+        it('handles single label', () => {
+            const scale = createXScale(['Only'], dimensions)
+            expect(scale('Only')).not.toBeUndefined()
+        })
+    })
+
+    describe('createYScale', () => {
+        it('creates a linear scale with domain from 0 to max', () => {
+            const series = [makeSeries([10, 25, 30, 15])]
+            const scale = createYScale(series, dimensions)
+
+            // Domain should start at 0 and go to at least 30
+            const domain = scale.domain()
+            expect(domain[0]).toBe(0)
+            expect(domain[1]).toBeGreaterThanOrEqual(30)
+        })
+
+        it('includes negative values in domain', () => {
+            const series = [makeSeries([-10, 25, 30, -5])]
+            const scale = createYScale(series, dimensions)
+
+            const domain = scale.domain()
+            expect(domain[0]).toBeLessThanOrEqual(-10)
+        })
+
+        it('skips hidden series', () => {
+            const series = [
+                makeSeries([100, 200, 300], 'visible'),
+                { ...makeSeries([1000, 2000, 3000], 'hidden'), hidden: true },
+            ]
+            const scale = createYScale(series, dimensions)
+
+            const domain = scale.domain()
+            expect(domain[1]).toBeLessThan(1000)
+        })
+
+        it('creates log scale', () => {
+            const series = [makeSeries([1, 10, 100, 1000])]
+            const scale = createYScale(series, dimensions, { scaleType: 'log' })
+
+            // Log scale should handle the range
+            expect(scale(1)).not.toBeUndefined()
+            expect(scale(1000)).not.toBeUndefined()
+            expect(scale(1)).toBeGreaterThan(scale(1000)) // Y is inverted
+        })
+
+        it('creates percent stack scale with 0-1 domain', () => {
+            const series = [makeSeries([10, 20])]
+            const scale = createYScale(series, dimensions, { percentStack: true })
+
+            const domain = scale.domain()
+            expect(domain[0]).toBe(0)
+            expect(domain[1]).toBe(1)
+        })
+
+        it('falls back to [0,1] domain when no data', () => {
+            const scale = createYScale([], dimensions)
+            const domain = scale.domain()
+            expect(domain[0]).toBe(0)
+            expect(domain[1]).toBe(1)
+        })
+    })
+
+    describe('computePercentStackData', () => {
+        it('normalizes data to 0-1 range', () => {
+            const series = [makeSeries([30, 40], 'a'), makeSeries([70, 60], 'b')]
+            const labels = ['Mon', 'Tue']
+            const result = computePercentStackData(series, labels)
+
+            expect(result.size).toBe(2)
+            // Top of stack should be 1.0
+            const bData = result.get('b')!
+            expect(bData[0]).toBeCloseTo(1, 5)
+            expect(bData[1]).toBeCloseTo(1, 5)
+        })
+
+        it('skips hidden series', () => {
+            const series = [makeSeries([50, 50], 'visible'), { ...makeSeries([50, 50], 'hidden'), hidden: true }]
+            const labels = ['Mon', 'Tue']
+            const result = computePercentStackData(series, labels)
+
+            expect(result.has('hidden')).toBe(false)
+            expect(result.has('visible')).toBe(true)
+        })
+
+        it('returns empty map for no visible series', () => {
+            const result = computePercentStackData([], ['Mon'])
+            expect(result.size).toBe(0)
+        })
+    })
+
+    describe('autoFormatYTick', () => {
+        it.each([
+            { value: 0.123, domainMax: 1.5, expected: '0.12' },
+            { value: 2.5, domainMax: 4, expected: '2.5' },
+            { value: 100, domainMax: 500, expected: '100' },
+            { value: 0, domainMax: 10, expected: '0' },
+        ])('formats $value with domainMax $domainMax as $expected', ({ value, domainMax, expected }) => {
+            expect(autoFormatYTick(value, domainMax)).toBe(expected)
+        })
+    })
+})

--- a/frontend/src/lib/charts/core/canvas-renderer.ts
+++ b/frontend/src/lib/charts/core/canvas-renderer.ts
@@ -1,0 +1,274 @@
+import * as d3 from 'd3'
+
+import type { ChartDimensions, Series } from './types'
+
+export interface DrawContext {
+    ctx: CanvasRenderingContext2D
+    dimensions: ChartDimensions
+    xScale: d3.ScalePoint<string>
+    yScale: d3.ScaleLinear<number, number> | d3.ScaleLogarithmic<number, number>
+    labels: string[]
+}
+
+export function drawLine(
+    drawCtx: DrawContext,
+    series: Series,
+    yValues?: number[],
+    options?: {
+        incompleteFromIndex?: number
+    }
+): void {
+    const { ctx, xScale, yScale, labels } = drawCtx
+    const data = yValues ?? series.data
+
+    if (data.length === 0) {
+        return
+    }
+
+    const incompleteFrom = options?.incompleteFromIndex ?? data.length
+
+    // Draw solid portion
+    if (incompleteFrom > 0) {
+        ctx.beginPath()
+        ctx.strokeStyle = series.color
+        ctx.lineWidth = 2
+        ctx.lineJoin = 'round'
+        ctx.lineCap = 'round'
+
+        if (series.dashPattern && !options?.incompleteFromIndex) {
+            ctx.setLineDash(series.dashPattern)
+        } else {
+            ctx.setLineDash([])
+        }
+
+        let started = false
+        const end = Math.min(incompleteFrom, data.length)
+        for (let i = 0; i < end; i++) {
+            const x = xScale(labels[i])
+            const y = yScale(data[i])
+            if (x == null || !isFinite(y)) {
+                continue
+            }
+            if (!started) {
+                ctx.moveTo(x, y)
+                started = true
+            } else {
+                ctx.lineTo(x, y)
+            }
+        }
+        ctx.stroke()
+        ctx.setLineDash([])
+    }
+
+    // Draw incomplete (dashed) portion
+    if (incompleteFrom < data.length) {
+        ctx.beginPath()
+        ctx.strokeStyle = series.color
+        ctx.lineWidth = 2
+        ctx.lineJoin = 'round'
+        ctx.lineCap = 'round'
+        ctx.setLineDash([6, 4])
+
+        // Start from the last complete point for continuity
+        const startIdx = Math.max(0, incompleteFrom - 1)
+        let started = false
+        for (let i = startIdx; i < data.length; i++) {
+            const x = xScale(labels[i])
+            const y = yScale(data[i])
+            if (x == null || !isFinite(y)) {
+                continue
+            }
+            if (!started) {
+                ctx.moveTo(x, y)
+                started = true
+            } else {
+                ctx.lineTo(x, y)
+            }
+        }
+        ctx.stroke()
+        ctx.setLineDash([])
+    }
+}
+
+export function drawArea(
+    drawCtx: DrawContext,
+    series: Series,
+    yValues?: number[],
+    options?: {
+        incompleteFromIndex?: number
+    }
+): void {
+    const { ctx, xScale, yScale, labels, dimensions } = drawCtx
+    const data = yValues ?? series.data
+    const opacity = series.fillOpacity ?? 0.5
+    const baseline = dimensions.plotTop + dimensions.plotHeight
+    const incompleteFrom = options?.incompleteFromIndex ?? data.length
+
+    // Solid area fill
+    if (incompleteFrom > 0) {
+        drawAreaSegment(
+            ctx,
+            xScale,
+            yScale,
+            labels,
+            data,
+            0,
+            Math.min(incompleteFrom, data.length),
+            series.color,
+            opacity,
+            baseline
+        )
+    }
+
+    // Pinstripe area fill for incomplete data
+    if (incompleteFrom < data.length) {
+        const startIdx = Math.max(0, incompleteFrom - 1)
+        drawAreaSegment(
+            ctx,
+            xScale,
+            yScale,
+            labels,
+            data,
+            startIdx,
+            data.length,
+            series.color,
+            opacity * 0.5,
+            baseline,
+            true
+        )
+    }
+}
+
+function drawAreaSegment(
+    ctx: CanvasRenderingContext2D,
+    xScale: d3.ScalePoint<string>,
+    yScale: d3.ScaleLinear<number, number> | d3.ScaleLogarithmic<number, number>,
+    labels: string[],
+    data: number[],
+    startIdx: number,
+    endIdx: number,
+    color: string,
+    opacity: number,
+    baseline: number,
+    pinstripe: boolean = false
+): void {
+    const points: { x: number; y: number }[] = []
+    for (let i = startIdx; i < endIdx; i++) {
+        const x = xScale(labels[i])
+        const y = yScale(data[i])
+        if (x != null && isFinite(y)) {
+            points.push({ x, y })
+        }
+    }
+
+    if (points.length < 2) {
+        return
+    }
+
+    ctx.beginPath()
+    ctx.moveTo(points[0].x, points[0].y)
+    for (let i = 1; i < points.length; i++) {
+        ctx.lineTo(points[i].x, points[i].y)
+    }
+    ctx.lineTo(points[points.length - 1].x, baseline)
+    ctx.lineTo(points[0].x, baseline)
+    ctx.closePath()
+
+    if (pinstripe) {
+        ctx.save()
+        ctx.clip()
+        ctx.globalAlpha = opacity
+        ctx.fillStyle = color
+        // Draw diagonal pinstripes
+        const step = 6
+        const maxDim = Math.max(ctx.canvas.width, ctx.canvas.height) * 2
+        ctx.lineWidth = 1
+        ctx.strokeStyle = color
+        for (let offset = -maxDim; offset < maxDim; offset += step) {
+            ctx.beginPath()
+            ctx.moveTo(offset, 0)
+            ctx.lineTo(offset + maxDim, maxDim)
+            ctx.stroke()
+        }
+        ctx.restore()
+    } else {
+        ctx.globalAlpha = opacity
+        ctx.fillStyle = color
+        ctx.fill()
+    }
+
+    ctx.globalAlpha = 1
+}
+
+export function drawPoints(drawCtx: DrawContext, series: Series, yValues?: number[]): void {
+    const { ctx, xScale, yScale, labels } = drawCtx
+    const data = yValues ?? series.data
+    const radius = series.pointRadius ?? 0
+
+    if (radius <= 0) {
+        return
+    }
+
+    ctx.fillStyle = series.color
+
+    for (let i = 0; i < data.length; i++) {
+        const x = xScale(labels[i])
+        const y = yScale(data[i])
+        if (x == null || !isFinite(y)) {
+            continue
+        }
+        ctx.beginPath()
+        ctx.arc(x, y, radius, 0, Math.PI * 2)
+        ctx.fill()
+    }
+}
+
+export function drawGrid(
+    drawCtx: DrawContext,
+    options: {
+        gridColor?: string
+        goalLineValues?: number[]
+    } = {}
+): void {
+    const { ctx, yScale, dimensions } = drawCtx
+    const gridColor = options.gridColor ?? 'rgba(0, 0, 0, 0.1)'
+    const goalValues = new Set(options.goalLineValues ?? [])
+
+    const yTicks = (yScale as d3.ScaleLinear<number, number>).ticks?.() ?? []
+
+    ctx.strokeStyle = gridColor
+    ctx.lineWidth = 1
+    ctx.setLineDash([])
+
+    for (const tick of yTicks) {
+        // Make grid lines transparent where goal lines intersect
+        if (goalValues.has(tick)) {
+            continue
+        }
+        const y = Math.round(yScale(tick)) + 0.5
+        ctx.beginPath()
+        ctx.moveTo(dimensions.plotLeft, y)
+        ctx.lineTo(dimensions.plotLeft + dimensions.plotWidth, y)
+        ctx.stroke()
+    }
+}
+
+export function drawHighlightPoint(
+    ctx: CanvasRenderingContext2D,
+    x: number,
+    y: number,
+    color: string,
+    radius: number = 4
+): void {
+    // Outer ring (white border)
+    ctx.fillStyle = '#ffffff'
+    ctx.beginPath()
+    ctx.arc(x, y, radius + 2, 0, Math.PI * 2)
+    ctx.fill()
+
+    // Inner colored dot
+    ctx.fillStyle = color
+    ctx.beginPath()
+    ctx.arc(x, y, radius, 0, Math.PI * 2)
+    ctx.fill()
+}

--- a/frontend/src/lib/charts/core/chart-context.ts
+++ b/frontend/src/lib/charts/core/chart-context.ts
@@ -1,0 +1,23 @@
+import { createContext, useContext } from 'react'
+
+import type { ChartDimensions, ChartScales, Series } from './types'
+
+export interface BaseChartContext {
+    dimensions: ChartDimensions
+    labels: string[]
+    series: Series[]
+    scales: ChartScales
+    hoverIndex: number
+}
+
+const ChartContext = createContext<BaseChartContext | null>(null)
+
+export function useChart<T extends BaseChartContext = BaseChartContext>(): T {
+    const ctx = useContext(ChartContext)
+    if (!ctx) {
+        throw new Error('useChart must be used inside a chart component (e.g. <LineChart>)')
+    }
+    return ctx as T
+}
+
+export { ChartContext }

--- a/frontend/src/lib/charts/core/scales.ts
+++ b/frontend/src/lib/charts/core/scales.ts
@@ -1,0 +1,166 @@
+import * as d3 from 'd3'
+
+import type { ChartDimensions, Series } from './types'
+
+export interface ScaleSet {
+    x: d3.ScalePoint<string>
+    y: d3.ScaleLinear<number, number> | d3.ScaleLogarithmic<number, number>
+    /** Additional Y axes keyed by yAxisId */
+    yAxes: Map<string, d3.ScaleLinear<number, number> | d3.ScaleLogarithmic<number, number>>
+}
+
+export function createXScale(labels: string[], dimensions: ChartDimensions): d3.ScalePoint<string> {
+    return d3
+        .scalePoint<string>()
+        .domain(labels)
+        .range([dimensions.plotLeft, dimensions.plotLeft + dimensions.plotWidth])
+        .padding(0)
+}
+
+export function createYScale(
+    series: Series[],
+    dimensions: ChartDimensions,
+    options: {
+        scaleType?: 'linear' | 'log'
+        percentStack?: boolean
+        yAxisId?: string
+    } = {}
+): d3.ScaleLinear<number, number> | d3.ScaleLogarithmic<number, number> {
+    const { scaleType = 'linear', percentStack = false, yAxisId } = options
+
+    if (percentStack) {
+        return d3
+            .scaleLinear()
+            .domain([0, 1])
+            .nice()
+            .range([dimensions.plotTop + dimensions.plotHeight, dimensions.plotTop])
+    }
+
+    const filteredSeries = series.filter(
+        (s) => !s.hidden && (!yAxisId || s.yAxisId === yAxisId || (!s.yAxisId && yAxisId === 'y'))
+    )
+    const allValues = filteredSeries.flatMap((s) => s.data).filter((v) => v != null && isFinite(v))
+
+    if (allValues.length === 0) {
+        return d3
+            .scaleLinear()
+            .domain([0, 1])
+            .range([dimensions.plotTop + dimensions.plotHeight, dimensions.plotTop])
+    }
+
+    let min = d3.min(allValues) ?? 0
+    let max = d3.max(allValues) ?? 1
+
+    if (scaleType === 'log') {
+        // Avoid log(0) by clamping minimum
+        min = Math.max(min, 1e-10)
+        max = Math.max(max, 1e-10)
+        return d3
+            .scaleLog()
+            .domain([min, max])
+            .nice()
+            .range([dimensions.plotTop + dimensions.plotHeight, dimensions.plotTop])
+            .clamp(true)
+    }
+
+    // For linear scale, include 0 in domain if all values are positive
+    if (min > 0) {
+        min = 0
+    }
+
+    return d3
+        .scaleLinear()
+        .domain([min, max])
+        .nice()
+        .range([dimensions.plotTop + dimensions.plotHeight, dimensions.plotTop])
+}
+
+export function createScales(
+    series: Series[],
+    labels: string[],
+    dimensions: ChartDimensions,
+    options: {
+        scaleType?: 'linear' | 'log'
+        percentStack?: boolean
+        multipleYAxes?: boolean
+    } = {}
+): ScaleSet {
+    const x = createXScale(labels, dimensions)
+
+    // Collect unique yAxisIds
+    const yAxisIds = new Set<string>()
+    yAxisIds.add('y') // default axis
+    for (const s of series) {
+        if (s.yAxisId && !s.hidden) {
+            yAxisIds.add(s.yAxisId)
+        }
+    }
+
+    const yAxes = new Map<string, d3.ScaleLinear<number, number> | d3.ScaleLogarithmic<number, number>>()
+
+    if (options.multipleYAxes && yAxisIds.size > 1) {
+        for (const axisId of yAxisIds) {
+            yAxes.set(
+                axisId,
+                createYScale(series, dimensions, {
+                    scaleType: options.scaleType,
+                    percentStack: options.percentStack,
+                    yAxisId: axisId,
+                })
+            )
+        }
+    }
+
+    // Primary Y scale
+    const y =
+        options.multipleYAxes && yAxes.has('y')
+            ? yAxes.get('y')!
+            : createYScale(series, dimensions, {
+                  scaleType: options.scaleType,
+                  percentStack: options.percentStack,
+              })
+
+    return { x, y, yAxes }
+}
+
+export function computePercentStackData(series: Series[], labels: string[]): Map<string, number[]> {
+    const visibleSeries = series.filter((s) => !s.hidden)
+    if (visibleSeries.length === 0) {
+        return new Map()
+    }
+
+    // Build tabular data for d3.stack
+    const tableData = labels.map((_, i) => {
+        const row: Record<string, number> = {}
+        for (const s of visibleSeries) {
+            row[s.key] = Math.max(0, s.data[i] ?? 0)
+        }
+        return row
+    })
+
+    const stack = d3
+        .stack<Record<string, number>>()
+        .keys(visibleSeries.map((s) => s.key))
+        .offset(d3.stackOffsetExpand)
+
+    const stacked = stack(tableData)
+
+    const result = new Map<string, number[]>()
+    for (const layer of stacked) {
+        result.set(
+            layer.key,
+            layer.map((d) => d[1])
+        )
+    }
+    return result
+}
+
+export function autoFormatYTick(value: number, domainMax: number): string {
+    if (domainMax < 2) {
+        return value.toFixed(2)
+    }
+    if (domainMax < 5) {
+        return value.toFixed(1)
+    }
+    return value.toFixed(0)
+}

--- a/frontend/src/lib/charts/core/types.ts
+++ b/frontend/src/lib/charts/core/types.ts
@@ -3,87 +3,57 @@ import type * as d3 from 'd3'
 export type { AxisFormat, ChartTheme } from '../types'
 
 export interface Series {
-    /** Unique identifier used to key React elements and look up stacked data. */
     key: string
-    /** Human-readable name shown in tooltips and legends. */
     label: string
-    /** Numeric values for each x-axis label. Must be the same length as the labels array. */
+    /** Must be the same length as the labels array. */
     data: number[]
-    /** CSS color string (hex, rgb, etc.) for the line and associated fill/points. */
     color: string
-    /** Assigns this series to a named y-axis (e.g. 'y', 'y1', 'y2'). Only used when `multipleYAxes` is enabled. */
+    /** Only used when `multipleYAxes` is enabled. */
     yAxisId?: string
-    /** When true, fills the area between the line and the x-axis baseline. */
     fillArea?: boolean
-    /** Opacity of the area fill. Range 0–1, defaults to 0.5. Ignored when `fillArea` is false. */
+    /** 0–1, defaults to 0.5. */
     fillOpacity?: number
-    /** Canvas line dash pattern, e.g. [10, 10] for evenly dashed. Omit or [] for solid. */
+    /** e.g. [10, 10] for dashed. */
     dashPattern?: number[]
-    /** When true, the series is excluded from rendering, scales, and tooltips. */
     hidden?: boolean
-    /** Radius in px for data point dots. Set to 0 or omit to hide dots. */
+    /** 0 = no dots. */
     pointRadius?: number
 }
 
-/** A horizontal reference line drawn across the chart at a fixed y-value. */
 export interface GoalLine {
-    /** The y-axis value where the line is drawn. */
     value: number
-    /** Optional text label displayed alongside the line. */
     label?: string
-    /** CSS color for the line. Falls back to theme default if omitted. */
     borderColor?: string
-    /** Which end of the line to anchor the label. Defaults to 'end'. */
     position?: 'start' | 'end'
 }
 
-/** Data passed to the `onPointClick` callback when a user clicks a data point. */
 export interface PointClickData {
-    /** Index of the clicked series within the original series array. */
     seriesIndex: number
-    /** Index along the x-axis (into the labels array) that was clicked. */
     dataIndex: number
-    /** The series that was clicked. */
     series: Series
-    /** The y-value at the clicked point. */
     value: number
-    /** The x-axis label at the clicked point. */
     label: string
-    /** Values from all visible series at this x-axis index, for cross-series comparisons. */
     crossSeriesData: { series: Series; value: number }[]
 }
 
-/** Context object passed to the `renderTooltip` render prop and tooltip event callbacks. */
 export interface TooltipContext {
-    /** Index along the x-axis that the tooltip represents. */
     dataIndex: number
-    /** The x-axis label at this index. */
     label: string
-    /** One entry per visible series with its value and color at this index. */
     seriesData: { series: Series; value: number; color: string }[]
-    /** Pixel position (relative to the chart container) for anchoring the tooltip. */
+    /** Pixel position relative to the chart container. */
     position: { x: number; y: number }
-    /** Bounding rect of the canvas element, useful for portal-based tooltip positioning. */
     canvasBounds: DOMRect
 }
 
-/** Computed layout dimensions of the chart, derived from container size and margins. */
 export interface ChartDimensions {
-    /** Full container width in CSS pixels. */
     width: number
-    /** Full container height in CSS pixels. */
     height: number
-    /** Left edge of the plot area (after left margin). */
     plotLeft: number
-    /** Top edge of the plot area (after top margin). */
     plotTop: number
-    /** Width of the drawable plot area. */
     plotWidth: number
-    /** Height of the drawable plot area. */
     plotHeight: number
 }
 
-/** Spacing between the container edges and the plot area. */
 export interface ChartMargins {
     top: number
     right: number
@@ -91,81 +61,50 @@ export interface ChartMargins {
     left: number
 }
 
-/** Base configuration shared by all chart types. */
 export interface ChartConfig {
-    // — Scale —
-
-    /** Y-axis scale type. 'log' clamps minimum to 1e-10 to avoid log(0). Defaults to 'linear'. */
+    /** Defaults to 'linear'. 'log' clamps minimum to 1e-10. */
     yScaleType?: 'linear' | 'log'
-    /** When true, each unique `series.yAxisId` gets its own independent y-axis. */
     multipleYAxes?: boolean
-
-    // — Axis formatting —
-
-    /** Custom x-axis tick label formatter. Return null to skip a tick. Called with (label, index). */
+    /** Return null to skip a tick. */
     xTickFormatter?: (value: string, index: number) => string | null
-    /** Custom y-axis tick label formatter. Overrides the built-in auto-precision formatter. */
     yTickFormatter?: (value: number) => string
-    /** Hide the x-axis labels and reduce bottom margin. */
     hideXAxis?: boolean
-    /** Hide the y-axis labels and reduce left margin. */
     hideYAxis?: boolean
-
-    // — Overlays —
-
-    /** Show horizontal grid lines at y-axis tick positions. */
     showGrid?: boolean
-    /** Show a tooltip on hover. Defaults to true. Use the `tooltip` prop to customize content. */
+    /** Defaults to true. */
     showTooltip?: boolean
-    /** Show a vertical crosshair line that follows the cursor. */
     showCrosshair?: boolean
-    /** Horizontal goal/reference lines to draw across the chart. */
     goalLines?: GoalLine[]
 }
 
-/** Line-chart-specific configuration, extending the shared base. */
 export interface LineChartConfig extends ChartConfig {
-    /** When true, stacks all series to 100% using d3.stackOffsetExpand. */
     percentStackView?: boolean
-    /** Show inline value labels on each data point. */
     showDataLabels?: boolean
-    /** Custom formatter for data labels. Called with (value, seriesIndex). */
     dataLabelFormatter?: (value: number, seriesIndex: number) => string
-    /** Show a linear regression trend line for each series. */
     showTrendLines?: boolean
-    /** Index from which data is considered incomplete (rendered with dashed lines and hatched fill). */
+    /** Data from this index onward renders as dashed/hatched. */
     incompleteFromIndex?: number
 }
 
-/** Arguments passed to a chart type's canvas draw function. */
 export interface ChartDrawArgs {
-    /** 2D canvas rendering context (DPR already applied, save/restore handled by Chart). */
+    /** DPR already applied, save/restore handled by Chart. */
     ctx: CanvasRenderingContext2D
-    /** Layout dimensions of the chart. */
     dimensions: ChartDimensions
-    /** Scale functions for mapping data to pixel coordinates. */
     scales: ChartScales
     /** Series with fallback colors already applied. */
     series: Series[]
-    /** X-axis labels. */
     labels: string[]
-    /** Index of the currently hovered data point, or -1. */
+    /** -1 when nothing hovered. */
     hoverIndex: number
-    /** Chart theme colors. */
     theme: import('lib/charts/types').ChartTheme
 }
 
-/** Factory function that chart types provide to create their scales from dimensions and data. */
 export type CreateScalesFn = (series: Series[], labels: string[], dimensions: ChartDimensions) => ChartScales
 
-/** Generic scale interface that Chart uses for shared overlays and interaction. */
 export interface ChartScales {
-    /** Maps a label to an x pixel coordinate. */
     x: (label: string) => number | undefined
-    /** Maps a value to a y pixel coordinate (primary y-axis). */
     y: (value: number) => number
-    /** Additional y-axes keyed by axis ID. */
     yAxes: Map<string, (value: number) => number>
-    /** The underlying d3 y-scale, needed for tick generation. */
+    /** Underlying d3 scale, needed for tick generation. */
     yRaw: d3.ScaleLinear<number, number> | d3.ScaleLogarithmic<number, number>
 }

--- a/frontend/src/lib/charts/core/types.ts
+++ b/frontend/src/lib/charts/core/types.ts
@@ -1,0 +1,171 @@
+import type * as d3 from 'd3'
+
+export type { AxisFormat, ChartTheme } from '../types'
+
+export interface Series {
+    /** Unique identifier used to key React elements and look up stacked data. */
+    key: string
+    /** Human-readable name shown in tooltips and legends. */
+    label: string
+    /** Numeric values for each x-axis label. Must be the same length as the labels array. */
+    data: number[]
+    /** CSS color string (hex, rgb, etc.) for the line and associated fill/points. */
+    color: string
+    /** Assigns this series to a named y-axis (e.g. 'y', 'y1', 'y2'). Only used when `multipleYAxes` is enabled. */
+    yAxisId?: string
+    /** When true, fills the area between the line and the x-axis baseline. */
+    fillArea?: boolean
+    /** Opacity of the area fill. Range 0–1, defaults to 0.5. Ignored when `fillArea` is false. */
+    fillOpacity?: number
+    /** Canvas line dash pattern, e.g. [10, 10] for evenly dashed. Omit or [] for solid. */
+    dashPattern?: number[]
+    /** When true, the series is excluded from rendering, scales, and tooltips. */
+    hidden?: boolean
+    /** Radius in px for data point dots. Set to 0 or omit to hide dots. */
+    pointRadius?: number
+}
+
+/** A horizontal reference line drawn across the chart at a fixed y-value. */
+export interface GoalLine {
+    /** The y-axis value where the line is drawn. */
+    value: number
+    /** Optional text label displayed alongside the line. */
+    label?: string
+    /** CSS color for the line. Falls back to theme default if omitted. */
+    borderColor?: string
+    /** Which end of the line to anchor the label. Defaults to 'end'. */
+    position?: 'start' | 'end'
+}
+
+/** Data passed to the `onPointClick` callback when a user clicks a data point. */
+export interface PointClickData {
+    /** Index of the clicked series within the original series array. */
+    seriesIndex: number
+    /** Index along the x-axis (into the labels array) that was clicked. */
+    dataIndex: number
+    /** The series that was clicked. */
+    series: Series
+    /** The y-value at the clicked point. */
+    value: number
+    /** The x-axis label at the clicked point. */
+    label: string
+    /** Values from all visible series at this x-axis index, for cross-series comparisons. */
+    crossSeriesData: { series: Series; value: number }[]
+}
+
+/** Context object passed to the `renderTooltip` render prop and tooltip event callbacks. */
+export interface TooltipContext {
+    /** Index along the x-axis that the tooltip represents. */
+    dataIndex: number
+    /** The x-axis label at this index. */
+    label: string
+    /** One entry per visible series with its value and color at this index. */
+    seriesData: { series: Series; value: number; color: string }[]
+    /** Pixel position (relative to the chart container) for anchoring the tooltip. */
+    position: { x: number; y: number }
+    /** Bounding rect of the canvas element, useful for portal-based tooltip positioning. */
+    canvasBounds: DOMRect
+}
+
+/** Computed layout dimensions of the chart, derived from container size and margins. */
+export interface ChartDimensions {
+    /** Full container width in CSS pixels. */
+    width: number
+    /** Full container height in CSS pixels. */
+    height: number
+    /** Left edge of the plot area (after left margin). */
+    plotLeft: number
+    /** Top edge of the plot area (after top margin). */
+    plotTop: number
+    /** Width of the drawable plot area. */
+    plotWidth: number
+    /** Height of the drawable plot area. */
+    plotHeight: number
+}
+
+/** Spacing between the container edges and the plot area. */
+export interface ChartMargins {
+    top: number
+    right: number
+    bottom: number
+    left: number
+}
+
+/** Base configuration shared by all chart types. */
+export interface ChartConfig {
+    // — Scale —
+
+    /** Y-axis scale type. 'log' clamps minimum to 1e-10 to avoid log(0). Defaults to 'linear'. */
+    yScaleType?: 'linear' | 'log'
+    /** When true, each unique `series.yAxisId` gets its own independent y-axis. */
+    multipleYAxes?: boolean
+
+    // — Axis formatting —
+
+    /** Custom x-axis tick label formatter. Return null to skip a tick. Called with (label, index). */
+    xTickFormatter?: (value: string, index: number) => string | null
+    /** Custom y-axis tick label formatter. Overrides the built-in auto-precision formatter. */
+    yTickFormatter?: (value: number) => string
+    /** Hide the x-axis labels and reduce bottom margin. */
+    hideXAxis?: boolean
+    /** Hide the y-axis labels and reduce left margin. */
+    hideYAxis?: boolean
+
+    // — Overlays —
+
+    /** Show horizontal grid lines at y-axis tick positions. */
+    showGrid?: boolean
+    /** Show a tooltip on hover. Defaults to true. Use the `tooltip` prop to customize content. */
+    showTooltip?: boolean
+    /** Show a vertical crosshair line that follows the cursor. */
+    showCrosshair?: boolean
+    /** Horizontal goal/reference lines to draw across the chart. */
+    goalLines?: GoalLine[]
+}
+
+/** Line-chart-specific configuration, extending the shared base. */
+export interface LineChartConfig extends ChartConfig {
+    /** When true, stacks all series to 100% using d3.stackOffsetExpand. */
+    percentStackView?: boolean
+    /** Show inline value labels on each data point. */
+    showDataLabels?: boolean
+    /** Custom formatter for data labels. Called with (value, seriesIndex). */
+    dataLabelFormatter?: (value: number, seriesIndex: number) => string
+    /** Show a linear regression trend line for each series. */
+    showTrendLines?: boolean
+    /** Index from which data is considered incomplete (rendered with dashed lines and hatched fill). */
+    incompleteFromIndex?: number
+}
+
+/** Arguments passed to a chart type's canvas draw function. */
+export interface ChartDrawArgs {
+    /** 2D canvas rendering context (DPR already applied, save/restore handled by Chart). */
+    ctx: CanvasRenderingContext2D
+    /** Layout dimensions of the chart. */
+    dimensions: ChartDimensions
+    /** Scale functions for mapping data to pixel coordinates. */
+    scales: ChartScales
+    /** Series with fallback colors already applied. */
+    series: Series[]
+    /** X-axis labels. */
+    labels: string[]
+    /** Index of the currently hovered data point, or -1. */
+    hoverIndex: number
+    /** Chart theme colors. */
+    theme: import('lib/charts/types').ChartTheme
+}
+
+/** Factory function that chart types provide to create their scales from dimensions and data. */
+export type CreateScalesFn = (series: Series[], labels: string[], dimensions: ChartDimensions) => ChartScales
+
+/** Generic scale interface that Chart uses for shared overlays and interaction. */
+export interface ChartScales {
+    /** Maps a label to an x pixel coordinate. */
+    x: (label: string) => number | undefined
+    /** Maps a value to a y pixel coordinate (primary y-axis). */
+    y: (value: number) => number
+    /** Additional y-axes keyed by axis ID. */
+    yAxes: Map<string, (value: number) => number>
+    /** The underlying d3 y-scale, needed for tick generation. */
+    yRaw: d3.ScaleLinear<number, number> | d3.ScaleLogarithmic<number, number>
+}

--- a/frontend/src/lib/charts/core/use-chart-canvas.ts
+++ b/frontend/src/lib/charts/core/use-chart-canvas.ts
@@ -1,0 +1,76 @@
+import { useEffect, useRef, useState } from 'react'
+
+import type { ChartDimensions, ChartMargins } from './types'
+
+interface UseChartCanvasOptions {
+    margins: ChartMargins
+}
+
+interface UseChartCanvasResult {
+    canvasRef: React.RefObject<HTMLCanvasElement | null>
+    wrapperRef: React.RefObject<HTMLDivElement | null>
+    dimensions: ChartDimensions | null
+    ctx: CanvasRenderingContext2D | null
+}
+
+export function useChartCanvas(options: UseChartCanvasOptions): UseChartCanvasResult {
+    const { margins } = options
+    const canvasRef = useRef<HTMLCanvasElement | null>(null)
+    const wrapperRef = useRef<HTMLDivElement | null>(null)
+    const [dimensions, setDimensions] = useState<ChartDimensions | null>(null)
+    const [ctx, setCtx] = useState<CanvasRenderingContext2D | null>(null)
+
+    // Update canvas size and DPR scaling
+    const updateSize = (): void => {
+        const canvas = canvasRef.current
+        const wrapper = wrapperRef.current
+        if (!canvas || !wrapper) {
+            return
+        }
+
+        const rect = wrapper.getBoundingClientRect()
+        const dpr = window.devicePixelRatio || 1
+
+        canvas.width = rect.width * dpr
+        canvas.height = rect.height * dpr
+        canvas.style.width = `${rect.width}px`
+        canvas.style.height = `${rect.height}px`
+
+        const context = canvas.getContext('2d')
+        if (context) {
+            context.scale(dpr, dpr)
+            setCtx(context)
+        }
+
+        const dims: ChartDimensions = {
+            width: rect.width,
+            height: rect.height,
+            plotLeft: margins.left,
+            plotTop: margins.top,
+            plotWidth: Math.max(0, rect.width - margins.left - margins.right),
+            plotHeight: Math.max(0, rect.height - margins.top - margins.bottom),
+        }
+        setDimensions(dims)
+    }
+
+    // ResizeObserver for responsive sizing
+    useEffect(() => {
+        const wrapper = wrapperRef.current
+        if (!wrapper) {
+            return
+        }
+
+        updateSize()
+
+        const observer = new ResizeObserver(() => {
+            updateSize()
+        })
+        observer.observe(wrapper)
+
+        return () => {
+            observer.disconnect()
+        }
+    }, [margins.left, margins.right, margins.top, margins.bottom])
+
+    return { canvasRef, wrapperRef, dimensions, ctx }
+}

--- a/frontend/src/lib/charts/index.ts
+++ b/frontend/src/lib/charts/index.ts
@@ -1,0 +1,24 @@
+// Chart context
+export { useChart } from './core/chart-context'
+export type { BaseChartContext } from './core/chart-context'
+
+// Core types
+export type {
+    ChartConfig,
+    ChartDimensions,
+    ChartDrawArgs,
+    ChartMargins,
+    ChartScales,
+    CreateScalesFn,
+    GoalLine,
+    LineChartConfig,
+    PointClickData,
+    Series,
+    TooltipContext,
+} from './core/types'
+
+// Scales
+export { autoFormatYTick, computePercentStackData, createScales, createXScale, createYScale } from './core/scales'
+
+// Canvas rendering
+export { drawArea, drawGrid, drawHighlightPoint, drawLine, drawPoints } from './core/canvas-renderer'


### PR DESCRIPTION
## Problem

There's too many different charts, any time we make a fix, add a new feature, we need to do it in a bunch of different places and it doesn't really seem to happen.

💡 We need a single set of charts, that every product re-uses.

## Changes

In this PR we just add some core stuff: a canvas, d3 setting up the basics

I've done quite a lot more than this though, which is on a [d3 branch here](https://github.com/PostHog/posthog/compare/sam/d3).


This is where it's at:
<img width="1110" height="543" alt="Screenshot 2026-03-27 at 16 58 31" src="https://github.com/user-attachments/assets/8357ea5a-0e19-4d80-b02d-8b1f18590031" />

So a simple LineChart working, looking a bit like our existing one.

There's still a lot of work to do though! Just want to confirm the direction I take this first 😄 

