### PR TITLE
chore(mcp): Add SQL search example for discovering existing insights

### DIFF
--- a/services/mcp/src/templates/instructions-v2.md
+++ b/services/mcp/src/templates/instructions-v2.md
@@ -127,3 +127,21 @@ Assistant: I'll help you create a revenue dashboard. Let me plan the steps.
 4. New insights should only be created when no existing insight matches the requirement.
 </reasoning>
 </example>
+
+#### Searching for existing data with SQL
+
+<example>
+User: Do we have any insights tracking revenue or payments?
+Assistant: I'll search for existing insights related to revenue and payments using SQL.
+1. Search insights by name for revenue-related terms (`execute-sql` with `SELECT id, name, short_id, description FROM system.insights WHERE NOT deleted AND (name ILIKE '%revenue%' OR name ILIKE '%payment%') ORDER BY last_modified_at DESC LIMIT 20`)
+2. If results are sparse, broaden the search to dashboards (`execute-sql` with `SELECT id, name, description FROM system.dashboards WHERE NOT deleted AND (name ILIKE '%revenue%' OR name ILIKE '%payment%')`)
+3. Validate promising insights by retrieving their full details (the `insight-retrieve` tool)
+4. Summarize findings with links to relevant insights and dashboards
+*Begins working on the first task*
+<reasoning>
+1. SQL search against system tables is the fastest way to discover existing data across the project.
+2. Using ILIKE with multiple terms catches different naming conventions (e.g., "Monthly Revenue", "Payment Events", "MRR").
+3. Searching both insights and dashboards gives a complete picture of what already exists.
+4. Validating with the retrieve tool confirms the insights are still relevant and shows their query configuration.
+</reasoning>
+</example>


### PR DESCRIPTION
## Problem

The instructions for the MCP assistant need to include guidance on how to efficiently search for existing insights and dashboards using SQL queries. This helps users discover relevant data that may already exist in their project before creating new insights.

## Changes

Added a new example section "Searching for existing data with SQL" to `instructions-v2.md` that demonstrates:

1. How to search insights by name using SQL with ILIKE pattern matching for revenue and payment-related terms
2. How to broaden searches to dashboards when initial results are sparse
3. How to validate promising insights by retrieving their full details
4. Reasoning for why SQL search is the fastest discovery method and why searching both insights and dashboards provides a complete picture

The example includes specific SQL queries using the `execute-sql` tool and explains the benefits of using ILIKE with multiple search terms to catch different naming conventions.

## How did you test this code?

N/A - This is a documentation update to instruction templates. The SQL queries provided follow existing patterns in the codebase and use standard PostgreSQL syntax (ILIKE, NOT deleted filtering, ORDER BY, LIMIT).

## Publish to changelog?

No - This is an internal documentation update for assistant instructions.

https://claude.ai/code/session_01L7MkciRXYxu8XyaVH7c63N