### PR TITLE
fix: use correct duckgres image tag (full SHA, no build- prefix)

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -418,8 +418,8 @@ services:
             - 'seaweedfs-data:/data'
 
     duckgres:
-        # DuckLake 0.4 + DuckDB 1.5.1 (posthog/duckgres@153607b)
-        image: ghcr.io/posthog/duckgres:build-153607b
+        # DuckLake 0.4 + DuckDB 1.5.1 (posthog/duckgres@4b787d7)
+        image: ghcr.io/posthog/duckgres:4b787d7a5c576cba92ff53d6e95f10c7b6464a39
         restart: on-failure
         profiles: ['duckgres']
         ports:


### PR DESCRIPTION
## Summary

- Fix duckgres Docker image tag in `docker-compose.dev.yml` — the `build-153607b` tag from #52490 doesn't exist on GHCR
- Duckgres CI (`container-image-cd.yml`) tags images with the **full 40-char git SHA**, not `build-<short-sha>`
- Pin to latest duckgres main (`4b787d7`) which includes 6 additional bug fixes since #52490's target commit

## Test plan

- [ ] `docker compose --profile duckgres pull` succeeds (previously fails with "manifest unknown")
- [ ] `docker compose --profile duckgres up` starts duckgres correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)