### PR TITLE
fix(ci): update semgrep image path

### DIFF
--- a/.github/workflows/ci-security.yaml
+++ b/.github/workflows/ci-security.yaml
@@ -32,7 +32,7 @@ jobs:
         runs-on: ubuntu-latest
         timeout-minutes: 15
         container:
-            image: returntocorp/semgrep
+            image: semgrep/semgrep
 
         steps:
             - name: Checkout
@@ -58,7 +58,7 @@ jobs:
         runs-on: ubuntu-latest
         timeout-minutes: 5
         container:
-            image: returntocorp/semgrep
+            image: semgrep/semgrep
 
         steps:
             - name: Checkout
@@ -82,7 +82,7 @@ jobs:
         runs-on: ubuntu-latest
         timeout-minutes: 5
         container:
-            image: returntocorp/semgrep
+            image: semgrep/semgrep
 
         steps:
             - name: Checkout
@@ -108,7 +108,7 @@ jobs:
         runs-on: ubuntu-latest
         timeout-minutes: 10
         container:
-            image: returntocorp/semgrep
+            image: semgrep/semgrep
 
         steps:
             - name: Checkout
@@ -132,7 +132,7 @@ jobs:
         runs-on: ubuntu-latest
         timeout-minutes: 10
         container:
-            image: returntocorp/semgrep
+            image: semgrep/semgrep
 
         steps:
             - name: Checkout
@@ -169,7 +169,7 @@ jobs:
         runs-on: ubuntu-latest
         timeout-minutes: 5
         container:
-            image: returntocorp/semgrep
+            image: semgrep/semgrep
 
         steps:
             - name: Checkout


### PR DESCRIPTION
## Problem
The security workflow pulls the deprecated `returntocorp/semgrep` container image for every Semgrep job. That leaves the checks depending on an outdated image path.

## Changes
- switch Semgrep job containers in `ci-security.yaml` from `returntocorp/semgrep` to `semgrep/semgrep`
- keep the workflow structure otherwise unchanged

## How did you test this code?
- reviewed the workflow diff locally
- verified there are no remaining `returntocorp/semgrep` references in the repo

## Publish to changelog?
no

## Docs update
no docs update needed