### PR TITLE
feat(billing): tag get_teams_with_api_queries_metrics as endpoints

### DIFF
--- a/posthog/tasks/usage_report.py
+++ b/posthog/tasks/usage_report.py
@@ -28,7 +28,7 @@ from posthog import version_requirement
 from posthog.batch_exports.models import BatchExportDestination, BatchExportRun
 from posthog.clickhouse.client import sync_execute
 from posthog.clickhouse.client.connection import Workload
-from posthog.clickhouse.query_tagging import Product, tags_context
+from posthog.clickhouse.query_tagging import Feature, Product, tags_context
 from posthog.cloud_utils import get_cached_instance_license
 from posthog.constants import FlagRequestType
 from posthog.exceptions_capture import capture_exception
@@ -832,7 +832,11 @@ def get_teams_with_api_queries_metrics(
         AND JSONExtractBool(log_comment, 'chargeable')
         GROUP BY team_id
     """
-    with tags_context(usage_report="get_teams_with_api_queries_metrics"):
+    with tags_context(
+        product=Product.ENDPOINTS,
+        feature=Feature.USAGE_REPORT,
+        usage_report="get_teams_with_api_queries_metrics",
+    ):
         results = sync_execute(
             query,
             {


### PR DESCRIPTION
## Problem

`get_teams_with_api_queries_metrics` in the usage report queries `system.query_log` to count chargeable API queries per team.
This query currently has no product tag, making it harder to attribute its cost.

Split out from #52539 pending team confirmation on ownership.

## Changes

- Tag `get_teams_with_api_queries_metrics` with `Product.ENDPOINTS` and `Feature.USAGE_REPORT` via `tags_context`

## How did you test this code?

This is a tagging-only change with no behavioral impact. The tags are applied via `tags_context` which is the established pattern throughout the usage report module.

I'm an agent — no manual testing was performed.

## Publish to changelog?

No

## 🤖 LLM context

Split from #52539 to allow the main PR to merge without blocking on product ownership discussion for chargeable API query metrics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)