### PR TITLE
fix(email): match Customer.io fallback for Ubuntu font

### DIFF
--- a/frontend/src/scenes/hog-functions/email-templater/EmailTemplater.tsx
+++ b/frontend/src/scenes/hog-functions/email-templater/EmailTemplater.tsx
@@ -574,7 +574,7 @@ function NativeEmailTemplaterForm({
                                                   customFonts: [
                                                       {
                                                           label: 'Ubuntu',
-                                                          value: "'Ubuntu',sans-serif",
+                                                          value: "'Ubuntu',Tahoma,Verdana,Segoe,sans-serif",
                                                           url: 'https://fonts.googleapis.com/css?family=Ubuntu:300,400,500,700',
                                                           weights: [
                                                               { label: 'Light', value: 300 },


### PR DESCRIPTION
## Problem

Turns out customer.io's ubuntu is also not making it through to gmail web client, they just use different fallback fonts that we were:
<img width="1085" height="217" alt="Screenshot 2026-03-27 at 11 35 04 AM" src="https://github.com/user-attachments/assets/080933f0-f9d0-44d0-9e08-09c2c093ae6f" />
<img width="1072" height="210" alt="Screenshot 2026-03-27 at 11 35 14 AM" src="https://github.com/user-attachments/assets/0bb14649-5b9d-4c34-a4e2-61f2f17b2335" />
<img width="1017" height="247" alt="Screenshot 2026-03-27 at 11 35 27 AM" src="https://github.com/user-attachments/assets/b87173ce-7069-401d-a988-987acac65823" />



## Changes

Use the same fallback fonts as cio

## How did you test this code?

Sent test email to maildev client and the font-family shows as expected

## Publish to changelog?

No