### PR TITLE
feat(messaging): optimize person properties backfill with FINAL query

### DIFF
--- a/posthog/temporal/messaging/backfill_precalculated_person_properties_workflow.py
+++ b/posthog/temporal/messaging/backfill_precalculated_person_properties_workflow.py
@@ -223,9 +223,7 @@ async def backfill_precalculated_person_properties_activity(
                 # Use JSON extract to get only the specific property
                 escaped_prop = prop.replace("'", "''")  # Escape single quotes for SQL safety
                 safe_alias = f"prop_{i}"  # Use safe numeric aliases
-                property_selects.append(
-                    f"JSONExtractString(argMax(properties, version), '{escaped_prop}') as `{safe_alias}`"
-                )
+                property_selects.append(f"JSONExtractString(properties, '{escaped_prop}') as `{safe_alias}`")
                 property_alias_mapping[safe_alias] = prop
 
             properties_clause = ",\n                ".join(property_selects)
@@ -234,7 +232,7 @@ async def backfill_precalculated_person_properties_activity(
             )
         else:
             # Fallback to all properties if we have too many properties or can't determine which ones are needed
-            properties_clause = "argMax(properties, version) as properties"
+            properties_clause = "properties"
             if person_properties and len(person_properties) > MAX_OPTIMIZED_PROPERTIES:
                 logger.warning(
                     f"Too many properties ({len(person_properties)} > {MAX_OPTIMIZED_PROPERTIES}) - falling back to fetching all properties for performance"
@@ -248,11 +246,10 @@ async def backfill_precalculated_person_properties_activity(
             SELECT
                 id as person_id,
                 {properties_clause}
-            FROM person
+            FROM person FINAL
             WHERE team_id = %(team_id)s
               AND id > %(cursor)s
-            GROUP BY id
-            HAVING argMax(is_deleted, version) = 0
+              AND is_deleted = 0
             ORDER BY id
             LIMIT %(batch_size)s
             FORMAT JSONEachRow

--- a/posthog/temporal/messaging/test/test_backfill_precalculated_person_properties_workflow.py
+++ b/posthog/temporal/messaging/test/test_backfill_precalculated_person_properties_workflow.py
@@ -681,9 +681,7 @@ class TestBackfillPrecalculatedPersonPropertiesActivity:
             # Use JSON extract to get only the specific property
             escaped_prop = prop.replace("'", "''")  # Escape single quotes for SQL safety
             safe_alias = f"prop_{i}"  # Use safe numeric aliases
-            property_selects.append(
-                f"JSONExtractString(argMax(properties, version), '{escaped_prop}') as `{safe_alias}`"
-            )
+            property_selects.append(f"JSONExtractString(properties, '{escaped_prop}') as `{safe_alias}`")
             property_alias_mapping[safe_alias] = prop
 
         properties_clause = ",\n                ".join(property_selects)
@@ -693,11 +691,10 @@ class TestBackfillPrecalculatedPersonPropertiesActivity:
             SELECT
                 id as person_id,
                 {properties_clause}
-            FROM person
+            FROM person FINAL
             WHERE team_id = %(team_id)s
               AND id > %(cursor)s
-            GROUP BY id
-            HAVING argMax(is_deleted, version) = 0
+              AND is_deleted = 0
             ORDER BY id
             LIMIT %(batch_size)s
             FORMAT JSONEachRow
@@ -725,3 +722,9 @@ class TestBackfillPrecalculatedPersonPropertiesActivity:
         assert property_alias_mapping["prop_1"] == "prop`with`backticks"
         assert property_alias_mapping["prop_2"] == "`malicious`DROP TABLE person--"
         assert property_alias_mapping["prop_3"] == "prop`; DELETE FROM person; --"
+
+        # Verify the new FINAL query structure
+        assert "FROM person FINAL" in query
+        assert "AND is_deleted = 0" in query
+        assert "GROUP BY" not in query
+        assert "HAVING" not in query


### PR DESCRIPTION
## Problem

The person properties backfill workflow was using memory-intensive `argMax` aggregations and `GROUP BY` operations, which could cause timeouts and high memory usage on large person tables.

## Changes

Replace complex `argMax` aggregations with `FINAL` modifier for better memory efficiency:

**Before:**
```sql
SELECT id as person_id,
    JSONExtractString(argMax(properties, version), '$browser') as `prop_0`,
    JSONExtractString(argMax(properties, version), '$browser_version') as `prop_1`,
    JSONExtractString(argMax(properties, version), '$email') as `prop_2`,
    JSONExtractString(
        argMax(properties, version),
        '$feature_enrollment/tree-view'
    ) as `prop_3`,
    JSONExtractString(argMax(properties, version), '$geoip_city_name') as `prop_4`,
    JSONExtractString(
        argMax(properties, version),
        '$geoip_continent_name'
    ) as `prop_5`,
    JSONExtractString(
        argMax(properties, version),
        '$geoip_country_code'
    ) as `prop_6`,
    JSONExtractString(
        argMax(properties, version),
        '$geoip_country_name'
    ) as `prop_7`,
    JSONExtractString(
        argMax(properties, version),
        '$geoip_subdivision_1_name'
    ) as `prop_8`,
    JSONExtractString(
        argMax(properties, version),
        '$initial_current_url'
    ) as `prop_9`,
    JSONExtractString(
        argMax(properties, version),
        '$initial_geoip_country_name'
    ) as `prop_10`,
    JSONExtractString(
        argMax(properties, version),
        '$initial_utm_campaign'
    ) as `prop_11`,
    JSONExtractString(
        argMax(properties, version),
        '$initial_utm_medium'
    ) as `prop_12`,
    JSONExtractString(
        argMax(properties, version),
        '$initial_utm_source'
    ) as `prop_13`,
    JSONExtractString(argMax(properties, version), '$os') as `prop_14`,
    JSONExtractString(
        argMax(properties, version),
        '$survey_dismissed/019276b3-f216-0000-1675-5b9304202c46'
    ) as `prop_15`,
    JSONExtractString(
        argMax(properties, version),
        '$survey_responded/019276b3-f216-0000-1675-5b9304202c46'
    ) as `prop_16`,
    JSONExtractString(argMax(properties, version), '$virt_mrr') as `prop_17`,
    JSONExtractString(argMax(properties, version), 'anonymize_data') as `prop_18`,
    JSONExtractString(
        argMax(properties, version),
        'billing-page-thrifty'
    ) as `prop_19`,
    JSONExtractString(argMax(properties, version), 'billing_plan') as `prop_20`,
    JSONExtractString(argMax(properties, version), 'clearbit') as `prop_21`,
    JSONExtractString(
        argMax(properties, version),
        'clearbit__company__metrics__employees'
    ) as `prop_22`,
    JSONExtractString(
        argMax(properties, version),
        'clearbit__person__employment__title'
    ) as `prop_23`,
    JSONExtractString(argMax(properties, version), 'country') as `prop_24`,
    JSONExtractString(argMax(properties, version), 'created_at') as `prop_25`,
    JSONExtractString(
        argMax(properties, version),
        'current_organization_membership_level'
    ) as `prop_26`
FROM person
WHERE team_id = 2
    AND id > '00000000-0000-0000-0000-000000000000'
GROUP BY id
HAVING argMax(is_deleted, version) = 0
ORDER BY id
LIMIT 10 FORMAT JSONEachRow;
```

**After:**
```sql
SELECT id as person_id,
  JSONExtractString(properties, '$browser') as `prop_0`,
  JSONExtractString(properties, '$browser_version') as `prop_1`,
  JSONExtractString(properties, '$email') as `prop_2`,
  JSONExtractString(properties, '$feature_enrollment/tree-view') as `prop_3`,
  JSONExtractString(properties, '$geoip_city_name') as `prop_4`,
  JSONExtractString(properties, '$geoip_continent_name') as `prop_5`,
  JSONExtractString(properties, '$geoip_country_code') as `prop_6`,
  JSONExtractString(properties, '$geoip_country_name') as `prop_7`,
  JSONExtractString(properties, '$geoip_subdivision_1_name') as `prop_8`,
  JSONExtractString(properties, '$initial_current_url') as `prop_9`,
  JSONExtractString(properties, '$initial_geoip_country_name') as `prop_10`,
  JSONExtractString(properties, '$initial_utm_campaign') as `prop_11`,
  JSONExtractString(properties, '$initial_utm_medium') as `prop_12`,
  JSONExtractString(properties, '$initial_utm_source') as `prop_13`,
  JSONExtractString(properties, '$os') as `prop_14`,
  JSONExtractString(properties, '$survey_dismissed/019276b3-f216-0000-1675-5b9304202c46') as `prop_15`,
  JSONExtractString(properties, '$survey_responded/019276b3-f216-0000-1675-5b9304202c46') as `prop_16`,
  JSONExtractString(properties, '$virt_mrr') as `prop_17`,
  JSONExtractString(properties, 'anonymize_data') as `prop_18`,
  JSONExtractString(properties, 'billing-page-thrifty') as `prop_19`,
  JSONExtractString(properties, 'billing_plan') as `prop_20`,
  JSONExtractString(properties, 'clearbit') as `prop_21`,
  JSONExtractString(properties, 'clearbit__company__metrics__employees') as `prop_22`,
  JSONExtractString(properties, 'clearbit__person__employment__title') as `prop_23`,
  JSONExtractString(properties, 'country') as `prop_24`,
  JSONExtractString(properties, 'created_at') as `prop_25`,
  JSONExtractString(properties, 'current_organization_membership_level') as `prop_26`
FROM person FINAL
WHERE team_id = 2
  AND id > '00000000-0000-0000-0000-000000000000'
  AND is_deleted = 0
ORDER BY id
LIMIT 10000
FORMAT JSONEachRow;
```

Key improvements:
- Remove `argMax(properties, version)` calls and use direct `properties` access  
- Use `FROM person FINAL` instead of `GROUP BY` with `argMax` aggregations
- Replace `HAVING argMax(is_deleted, version) = 0` with `WHERE is_deleted = 0`
- Eliminates memory-intensive grouping operations
- ClickHouse `FINAL` modifier automatically handles version selection for ReplacingMergeTree

## How did you test this code?

- Verified query syntax is correct
- Confirmed `FINAL` modifier works with ReplacingMergeTree tables for automatic version handling
- Maintains same logical behavior while improving performance and reducing memory usage