### PR TITLE
feat(phrocs): Add interactive stdin support for processes

### DIFF
--- a/tools/phrocs/internal/process/proc.go
+++ b/tools/phrocs/internal/process/proc.go
@@ -187,6 +187,7 @@ func (p *Process) AppendLine(line string) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	if len(p.lines) >= p.maxLines {
+		p.lines[0] = "" // allow GC of evicted string data
 		p.lines = p.lines[1:]
 	}
 	p.lines = append(p.lines, line)
@@ -583,6 +584,7 @@ func (p *Process) readLoop(r io.Reader, send func(tea.Msg)) {
 func (p *Process) bufferLine(line string, send func(tea.Msg)) {
 	p.mu.Lock()
 	if len(p.lines) >= p.maxLines {
+		p.lines[0] = "" // allow GC of evicted string data
 		p.lines = p.lines[1:]
 	}
 	p.lines = append(p.lines, line)

--- a/tools/phrocs/internal/process/proc.go
+++ b/tools/phrocs/internal/process/proc.go
@@ -57,9 +57,13 @@ type StatusMsg struct {
 // Notification that a process has new output available.
 // Lines are batched (flushed every ~16ms) to avoid backpressure on the PTY
 // when a process produces output faster than the TUI can render it.
-// The TUI reads actual lines from p.Lines().
+// Added contains the new lines; Evicted is the number of lines dropped from
+// the front of the scrollback buffer. The TUI can use these for incremental
+// viewport updates instead of calling p.Lines().
 type OutputMsg struct {
-	Name string
+	Name    string
+	Added   []string
+	Evicted int
 }
 
 // Metrics holds the most recent sampled resource usage for a process tree.
@@ -505,7 +509,8 @@ func (p *Process) readLoop(r io.Reader, send func(tea.Msg)) {
 	}()
 
 	var partial []byte
-	dirty := false
+	var batch []string
+	var evicted int
 
 	partialTimer := time.NewTimer(0)
 	if !partialTimer.Stop() {
@@ -520,9 +525,13 @@ func (p *Process) readLoop(r io.Reader, send func(tea.Msg)) {
 		case data, ok := <-chunkCh:
 			if !ok {
 				if len(partial) > 0 {
-					p.bufferLine(string(partial), send)
+					s := string(partial)
+					if p.bufferLine(s, send) {
+						evicted++
+					}
+					batch = append(batch, s)
 				}
-				send(OutputMsg{Name: p.Name})
+				send(OutputMsg{Name: p.Name, Added: batch, Evicted: evicted})
 				return
 			}
 
@@ -539,7 +548,11 @@ func (p *Process) readLoop(r io.Reader, send func(tea.Msg)) {
 				if len(line) > 0 && line[len(line)-1] == '\r' {
 					line = line[:len(line)-1]
 				}
-				p.bufferLine(string(line), send)
+				s := string(line)
+				if p.bufferLine(s, send) {
+					evicted++
+				}
+				batch = append(batch, s)
 				data = data[idx+1:]
 			}
 
@@ -560,20 +573,24 @@ func (p *Process) readLoop(r io.Reader, send func(tea.Msg)) {
 				partialTimer.Reset(flushInterval * 3)
 			}
 
-			dirty = true
-
 		case <-flushTicker.C:
-			if dirty {
-				dirty = false
-				send(OutputMsg{Name: p.Name})
+			if len(batch) > 0 {
+				send(OutputMsg{Name: p.Name, Added: batch, Evicted: evicted})
+				batch = nil
+				evicted = 0
 			}
 
 		case <-partialTimer.C:
 			if len(partial) > 0 {
-				p.bufferLine(string(partial), send)
+				s := string(partial)
+				if p.bufferLine(s, send) {
+					evicted++
+				}
+				batch = append(batch, s)
 				partial = nil
-				dirty = false
-				send(OutputMsg{Name: p.Name})
+				send(OutputMsg{Name: p.Name, Added: batch, Evicted: evicted})
+				batch = nil
+				evicted = 0
 			}
 		}
 	}
@@ -581,11 +598,14 @@ func (p *Process) readLoop(r io.Reader, send func(tea.Msg)) {
 
 // bufferLine appends a single line to the scrollback buffer and checks the
 // ready pattern. Only sends a StatusMsg if the process just became ready.
-func (p *Process) bufferLine(line string, send func(tea.Msg)) {
+// Returns true if a line was evicted from the front of the buffer.
+func (p *Process) bufferLine(line string, send func(tea.Msg)) bool {
 	p.mu.Lock()
+	evicted := false
 	if len(p.lines) >= p.maxLines {
 		p.lines[0] = "" // allow GC of evicted string data
 		p.lines = p.lines[1:]
+		evicted = true
 	}
 	p.lines = append(p.lines, line)
 
@@ -601,6 +621,7 @@ func (p *Process) bufferLine(line string, send func(tea.Msg)) {
 	if shouldNotify {
 		send(StatusMsg{Name: p.Name, Status: StatusRunning})
 	}
+	return evicted
 }
 
 // Sampling CPU/mem/threads every metricsSampleInterval for the process tree

--- a/tools/phrocs/internal/process/proc.go
+++ b/tools/phrocs/internal/process/proc.go
@@ -496,10 +496,15 @@ func (p *Process) readLoop(r io.Reader, send func(tea.Msg)) {
 	}()
 
 	var partial []byte
+	dirty := false
+
 	partialTimer := time.NewTimer(0)
 	if !partialTimer.Stop() {
 		<-partialTimer.C
 	}
+
+	flushTicker := time.NewTicker(flushInterval)
+	defer flushTicker.Stop()
 
 	for {
 		select {
@@ -538,15 +543,22 @@ func (p *Process) readLoop(r io.Reader, send func(tea.Msg)) {
 					default:
 					}
 				}
-				partialTimer.Reset(50 * time.Millisecond)
+				partialTimer.Reset(flushInterval * 3)
 			}
 
-			send(OutputMsg{Name: p.Name})
+			dirty = true
+
+		case <-flushTicker.C:
+			if dirty {
+				dirty = false
+				send(OutputMsg{Name: p.Name})
+			}
 
 		case <-partialTimer.C:
 			if len(partial) > 0 {
 				p.bufferLine(string(partial), send)
 				partial = nil
+				dirty = false
 				send(OutputMsg{Name: p.Name})
 			}
 		}

--- a/tools/phrocs/internal/process/proc.go
+++ b/tools/phrocs/internal/process/proc.go
@@ -1,7 +1,7 @@
 package process
 
 import (
-	"bufio"
+	"bytes"
 	"fmt"
 	"io"
 	"os"
@@ -108,9 +108,11 @@ type Process struct {
 	lines         []string
 	cmd           *exec.Cmd
 	ptmx          *os.File // pty master; nil when using pipes
+	stdinPipe     *os.File // write end of stdin pipe; nil when using PTY
 	readyPattern  *regexp.Regexp
 	ready         bool // whether we've seen the ready pattern (or no pattern is set)
 	stopRequested bool // set by Stop() to catch races with in-flight Start()
+	hasPrompt     bool // last output was a partial line (no trailing \n), suggesting a prompt
 
 	startedAt time.Time
 	readyAt   time.Time
@@ -159,6 +161,14 @@ func (p *Process) MemRSSMB() float64 {
 		return 0
 	}
 	return p.metrics.MemRSSMB
+}
+
+// HasPrompt returns true when the last output was a partial line (no trailing \n),
+// indicating the process is likely waiting for input.
+func (p *Process) HasPrompt() bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.hasPrompt
 }
 
 // Returns a copy of the output lines
@@ -252,6 +262,10 @@ func (p *Process) Start(send func(tea.Msg)) error {
 	p.lines = nil
 	p.metrics = nil
 	p.exitCode = nil
+	if p.stdinPipe != nil {
+		_ = p.stdinPipe.Close()
+		p.stdinPipe = nil
+	}
 	p.startedAt = time.Now()
 	p.readyAt = time.Time{}
 	p.stopRequested = false
@@ -354,19 +368,30 @@ func (p *Process) startWithPipe(cmd *exec.Cmd, send func(tea.Msg)) error {
 	// kill the full process tree via Kill(-pid, SIGTERM).
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	// pty.Start also sets Stdin/Stdout/Stderr to the (now-closed) tty slave.
-	// Reset them so the child gets /dev/null for stdin and our pipe for output.
+	// Reset them so the child uses pipes for I/O.
 	cmd.Stdin = nil
 	cmd.Stdout = nil
 	cmd.Stderr = nil
 
+	// Create a stdin pipe so interactive processes can receive input via WriteInput
+	stdinR, stdinW, err := os.Pipe()
+	if err != nil {
+		return err
+	}
+	cmd.Stdin = stdinR
+
 	pr, pw, err := os.Pipe()
 	if err != nil {
+		_ = stdinR.Close()
+		_ = stdinW.Close()
 		return err
 	}
 	cmd.Stdout = pw
 	cmd.Stderr = pw
 
 	if err := cmd.Start(); err != nil {
+		_ = stdinR.Close()
+		_ = stdinW.Close()
 		_ = pr.Close()
 		_ = pw.Close()
 		p.mu.Lock()
@@ -376,12 +401,18 @@ func (p *Process) startWithPipe(cmd *exec.Cmd, send func(tea.Msg)) error {
 		return err
 	}
 
+	// Child has inherited the read end; close it in the parent
+	_ = stdinR.Close()
+
 	p.mu.Lock()
 	p.cmd = cmd
+	p.stdinPipe = stdinW
 
 	// Stop() was called while cmd.Start was in progress — kill immediately
 	if p.stopRequested {
 		p.killProcessGroup()
+		_ = stdinW.Close()
+		p.stdinPipe = nil
 		p.status = StatusStopped
 		p.mu.Unlock()
 		_ = pr.Close()
@@ -442,50 +473,83 @@ func (p *Process) startWithPipe(cmd *exec.Cmd, send func(tea.Msg)) error {
 	return nil
 }
 
-// Reads lines from the process output, buffering them internally and sending
-// batched OutputMsg notifications to the TUI. Lines are flushed every
-// ~flushInterval so burst output is coalesced into a single UI update,
-// preventing backpressure on the PTY that would throttle the child process.
+// Reads output from the process, buffering it internally and sending batched
+// OutputMsg notifications to the TUI. Complete lines (terminated by \n) are
+// buffered immediately; partial lines (e.g. interactive prompts that don't end
+// with \n) are flushed after a short timeout so they appear without delay.
 func (p *Process) readLoop(r io.Reader, send func(tea.Msg)) {
-	// Scanner goroutine reads lines as fast as possible into a buffered
-	// channel, decoupling I/O from the (potentially slower) TUI send path.
-	scanner := bufio.NewScanner(r)
-	scanner.Buffer(make([]byte, 256*1024), 256*1024)
-
-	lineCh := make(chan string, 4096)
+	chunkCh := make(chan []byte, 64)
 	go func() {
-		for scanner.Scan() {
-			lineCh <- scanner.Text()
-		}
-		close(lineCh)
-	}()
-
-	for {
-		// Block until at least one line arrives
-		line, ok := <-lineCh
-		if !ok {
-			return
-		}
-		p.bufferLine(line, send)
-
-		// Drain any additional lines that arrive within the flush interval
-		deadline := time.After(flushInterval)
-	drain:
+		buf := make([]byte, 256*1024)
 		for {
-			select {
-			case line, ok := <-lineCh:
-				if !ok {
-					// EOF — send final notification and return
-					send(OutputMsg{Name: p.Name})
-					return
-				}
-				p.bufferLine(line, send)
-			case <-deadline:
-				break drain
+			n, err := r.Read(buf)
+			if n > 0 {
+				data := make([]byte, n)
+				copy(data, buf[:n])
+				chunkCh <- data
+			}
+			if err != nil {
+				close(chunkCh)
+				return
 			}
 		}
+	}()
 
-		send(OutputMsg{Name: p.Name})
+	var partial []byte
+	partialTimer := time.NewTimer(0)
+	if !partialTimer.Stop() {
+		<-partialTimer.C
+	}
+
+	for {
+		select {
+		case data, ok := <-chunkCh:
+			if !ok {
+				if len(partial) > 0 {
+					p.bufferLine(string(partial), send)
+				}
+				send(OutputMsg{Name: p.Name})
+				return
+			}
+
+			data = append(partial, data...)
+			partial = nil
+
+			for {
+				idx := bytes.IndexByte(data, '\n')
+				if idx == -1 {
+					break
+				}
+				p.bufferLine(string(data[:idx]), send)
+				data = data[idx+1:]
+			}
+
+			p.mu.Lock()
+			p.hasPrompt = len(data) > 0
+			p.mu.Unlock()
+
+			if len(data) > 0 {
+				partial = data
+				// Flush the partial line after a short timeout so interactive
+				// prompts (which don't end with \n) appear promptly.
+				if !partialTimer.Stop() {
+					select {
+					case <-partialTimer.C:
+					default:
+					}
+				}
+				partialTimer.Reset(50 * time.Millisecond)
+			}
+
+			send(OutputMsg{Name: p.Name})
+
+		case <-partialTimer.C:
+			if len(partial) > 0 {
+				p.bufferLine(string(partial), send)
+				partial = nil
+				send(OutputMsg{Name: p.Name})
+			}
+		}
 	}
 }
 
@@ -653,6 +717,10 @@ func (p *Process) Stop() {
 		_ = p.ptmx.Close()
 		p.ptmx = nil
 	}
+	if p.stdinPipe != nil {
+		_ = p.stdinPipe.Close()
+		p.stdinPipe = nil
+	}
 	p.status = StatusStopped
 }
 
@@ -671,6 +739,27 @@ func (p *Process) PID() int {
 		return p.cmd.Process.Pid
 	}
 	return 0
+}
+
+// WriteInput sends raw bytes to the process's stdin (PTY master or stdin pipe).
+// Returns an error if neither is available.
+func (p *Process) WriteInput(data []byte) error {
+	p.mu.Lock()
+	ptmx := p.ptmx
+	stdinPipe := p.stdinPipe
+	p.mu.Unlock()
+	if ptmx != nil {
+		_, err := ptmx.Write(data)
+		return err
+	}
+	if stdinPipe != nil {
+		// No terminal line discipline in pipe mode: translate \r to \n
+		// so programs that read lines (e.g. Python's input()) see a proper newline.
+		translated := bytes.ReplaceAll(data, []byte("\r"), []byte("\n"))
+		_, err := stdinPipe.Write(translated)
+		return err
+	}
+	return fmt.Errorf("process %s has no PTY or stdin pipe", p.Name)
 }
 
 // Updates the pty window size to keep output correctly reflowed

--- a/tools/phrocs/internal/process/proc.go
+++ b/tools/phrocs/internal/process/proc.go
@@ -443,6 +443,14 @@ func (p *Process) startWithPipe(cmd *exec.Cmd, send func(tea.Msg)) error {
 		// Close the write end so readLoop sees EOF
 		_ = pw.Close()
 
+		// Close the stdin pipe, no more input to send
+		p.mu.Lock()
+		if p.stdinPipe != nil {
+			_ = p.stdinPipe.Close()
+			p.stdinPipe = nil
+		}
+		p.mu.Unlock()
+
 		<-readDone
 		_ = pr.Close()
 
@@ -525,7 +533,12 @@ func (p *Process) readLoop(r io.Reader, send func(tea.Msg)) {
 				if idx == -1 {
 					break
 				}
-				p.bufferLine(string(data[:idx]), send)
+				line := data[:idx]
+				// PTY mode uses \r\n (ONLCR); strip trailing \r
+				if len(line) > 0 && line[len(line)-1] == '\r' {
+					line = line[:len(line)-1]
+				}
+				p.bufferLine(string(line), send)
 				data = data[idx+1:]
 			}
 

--- a/tools/phrocs/internal/process/proc_test.go
+++ b/tools/phrocs/internal/process/proc_test.go
@@ -337,6 +337,119 @@ func TestReadLoop_batchesOutput(t *testing.T) {
 	}
 }
 
+func TestHasPrompt_partialLine(t *testing.T) {
+	// printf writes a partial line (no trailing \n), which readLoop should
+	// detect and set HasPrompt = true.
+	p := NewProcess("prompt-test", config.ProcConfig{
+		Shell: `printf "Enter name: "`,
+	}, 100)
+
+	send, _, _ := collectMsgs()
+	if err := p.Start(send); err != nil {
+		t.Skipf("skipping: cannot spawn subprocess: %v", err)
+	}
+
+	deadline := time.After(5 * time.Second)
+	for {
+		select {
+		case <-deadline:
+			t.Fatal("timed out waiting for HasPrompt")
+		default:
+		}
+		if p.HasPrompt() {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	lines := p.Lines()
+	if len(lines) == 0 {
+		t.Fatal("expected at least one buffered line")
+	}
+	if !strings.Contains(lines[len(lines)-1], "Enter name:") {
+		t.Errorf("expected partial line containing 'Enter name:', got %q", lines[len(lines)-1])
+	}
+}
+
+func TestHasPrompt_completeLine(t *testing.T) {
+	// echo writes a complete line (with trailing \n), so HasPrompt should
+	// be false once the process finishes.
+	p := NewProcess("no-prompt", config.ProcConfig{
+		Shell: `echo "hello"`,
+	}, 100)
+
+	send, _, _ := collectMsgs()
+	if err := p.Start(send); err != nil {
+		t.Skipf("skipping: cannot spawn subprocess: %v", err)
+	}
+
+	deadline := time.After(5 * time.Second)
+	for {
+		select {
+		case <-deadline:
+			t.Fatal("timed out waiting for process to finish")
+		default:
+		}
+		st := p.Status()
+		if st == StatusDone || st == StatusCrashed {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	if p.HasPrompt() {
+		t.Error("HasPrompt should be false after a complete line")
+	}
+}
+
+func TestWriteInput_pipeMode(t *testing.T) {
+	// head -1 reads exactly one line from stdin and echoes it to stdout.
+	// We use startWithPipe indirectly — on CI PTY may or may not be
+	// available, so we use a shell command that works either way and
+	// verify the \r→\n translation by sending "hello\r".
+	p := NewProcess("pipe-input", config.ProcConfig{
+		Shell: `head -1`,
+	}, 100)
+
+	send, _, _ := collectMsgs()
+	if err := p.Start(send); err != nil {
+		t.Skipf("skipping: cannot spawn subprocess: %v", err)
+	}
+
+	// Give the process a moment to start reading
+	time.Sleep(100 * time.Millisecond)
+
+	if err := p.WriteInput([]byte("hello\r")); err != nil {
+		t.Fatalf("WriteInput failed: %v", err)
+	}
+
+	deadline := time.After(5 * time.Second)
+	for {
+		select {
+		case <-deadline:
+			t.Fatal("timed out waiting for process to finish")
+		default:
+		}
+		st := p.Status()
+		if st == StatusDone || st == StatusCrashed {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	lines := p.Lines()
+	found := false
+	for _, l := range lines {
+		if strings.Contains(l, "hello") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected 'hello' in output, got lines: %v", lines)
+	}
+}
+
 func TestSnapshot_noReadyAt(t *testing.T) {
 	p := NewProcess("svc", config.ProcConfig{Shell: "true", ReadyPattern: "ready"}, 1000)
 	// readyAt is left as zero value; startedAt is also zero

--- a/tools/phrocs/internal/tui/app.go
+++ b/tools/phrocs/internal/tui/app.go
@@ -177,19 +177,20 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case process.OutputMsg:
 		// Rebuild viewport content only for the active process to keep rendering cheap
-		if m.ready && m.activeProc() != nil && m.activeProc().Name == msg.Name {
+		if p := m.activeProc(); m.ready && p != nil && p.Name == msg.Name {
 			// In docker mode the viewport shows the status table or container logs,
 			// not the process's combined output
 			if m.isDockerMode() || m.infoMode {
 				break
 			}
-			m.viewport.SetContent(m.buildContent())
+			lines := p.Lines()
+			m.viewport.SetContent(strings.Join(lines, "\n"))
 			// Don't auto-scroll while the user is selecting text in copy mode
 			if m.viewportAtBottom && !m.copyMode && !m.searchMode {
 				m.viewport.GotoBottom()
 			}
 			if m.searchQuery != "" {
-				m.recomputeSearch()
+				m.recomputeSearchWith(lines)
 			}
 		}
 

--- a/tools/phrocs/internal/tui/app.go
+++ b/tools/phrocs/internal/tui/app.go
@@ -56,6 +56,8 @@ type Model struct {
 	// Center viewport with output of the active process
 	viewport         viewport.Model
 	viewportAtBottom bool
+	activeContent    string
+	activeLineCount  int
 
 	// Copy mode: keyboard-driven line selection within the output pane
 	copyMode   bool
@@ -183,14 +185,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if m.isDockerMode() || m.infoMode {
 				break
 			}
-			lines := p.Lines()
-			m.viewport.SetContent(strings.Join(lines, "\n"))
+			m.applyOutputDelta(msg)
 			// Don't auto-scroll while the user is selecting text in copy mode
 			if m.viewportAtBottom && !m.copyMode && !m.searchMode {
 				m.viewport.GotoBottom()
-			}
-			if m.searchQuery != "" {
-				m.recomputeSearchWith(lines)
 			}
 		}
 
@@ -425,6 +423,8 @@ func (m Model) loadActiveProc() (Model, []tea.Cmd) {
 		m.searchQuery = ""
 		m.searchMatches = nil
 		m.searchCursor = 0
+		m.activeContent = ""
+		m.activeLineCount = 0
 		m.keys.LazyDocker.SetEnabled(true)
 		m.keys.ProcViewer.SetEnabled(false)
 		m.viewport.SetContent(docker.RenderContainerStatusTable(m.containers, m.viewport.Width()))
@@ -434,7 +434,13 @@ func (m Model) loadActiveProc() (Model, []tea.Cmd) {
 		m.containers = nil
 		m.keys.LazyDocker.SetEnabled(false)
 		m.keys.ProcViewer.SetEnabled(true)
-		m.viewport.SetContent(m.buildContent())
+		m.activeContent = m.buildContent()
+		if m.activeContent == "" {
+			m.activeLineCount = 0
+		} else {
+			m.activeLineCount = strings.Count(m.activeContent, "\n") + 1
+		}
+		m.viewport.SetContent(m.activeContent)
 	}
 
 	if m.viewportAtBottom {
@@ -454,6 +460,39 @@ func (m Model) buildContent() string {
 		return ""
 	}
 	return strings.Join(p.Lines(), "\n")
+}
+
+// applyOutputDelta incrementally updates the viewport content using the
+// batch metadata in OutputMsg. Falls back to a full rebuild on eviction.
+func (m *Model) applyOutputDelta(msg process.OutputMsg) {
+	if msg.Evicted > 0 || len(msg.Added) == 0 {
+		m.activeContent = m.buildContent()
+		if m.activeContent == "" {
+			m.activeLineCount = 0
+		} else {
+			m.activeLineCount = strings.Count(m.activeContent, "\n") + 1
+		}
+		m.viewport.SetContent(m.activeContent)
+		if m.searchQuery != "" {
+			m.recomputeSearch()
+		}
+		return
+	}
+
+	if m.activeLineCount == 0 || m.activeContent == "" {
+		m.activeContent = strings.Join(msg.Added, "\n")
+	} else {
+		m.activeContent += "\n" + strings.Join(msg.Added, "\n")
+	}
+	m.activeLineCount += len(msg.Added)
+	m.viewport.SetContent(m.activeContent)
+
+	if m.searchQuery != "" {
+		startIdx := m.activeLineCount - len(msg.Added)
+		for i, line := range msg.Added {
+			m.updateSearchForLine(line, startIdx+i, false)
+		}
+	}
 }
 
 // statusSortOrder returns a numeric rank for sorting by status.

--- a/tools/phrocs/internal/tui/app.go
+++ b/tools/phrocs/internal/tui/app.go
@@ -82,6 +82,9 @@ type Model struct {
 	containerLogStream *docker.ContainerLogStream
 	composeArgs        docker.ComposeArgs
 
+	// Buffered text for PTY input when the output pane is focused
+	inputBuffer string
+
 	// Info mode: replaces the output viewport with process stats
 	infoMode bool
 
@@ -404,6 +407,7 @@ func (m Model) loadActiveProc() (Model, []tea.Cmd) {
 
 	m.copyMode = false
 	m.searchMode = false
+	m.inputBuffer = ""
 	m.viewport.StyleLineFunc = nil
 
 	// Resize viewport to account for container sidebar appearing/disappearing

--- a/tools/phrocs/internal/tui/keys.go
+++ b/tools/phrocs/internal/tui/keys.go
@@ -207,29 +207,6 @@ func (m Model) handleHedgehogKey(msg tea.KeyPressMsg, cmds []tea.Cmd) (Model, []
 	return m, cmds, true
 }
 
-// PrevProc   key.Binding
-// 	NextProc   key.Binding
-// 	ScrollUp   key.Binding
-// 	ScrollDown key.Binding
-// 	GotoTop    key.Binding
-// 	GotoBottom key.Binding
-// 	NextPane   key.Binding
-// 	PrevPane   key.Binding
-// 	Restart    key.Binding
-// 	Stop       key.Binding
-// 	CopyMode   key.Binding
-// 	Search     key.Binding
-// 	SearchNext key.Binding
-// 	SearchPrev key.Binding
-// 	Quit       key.Binding
-// 	Help       key.Binding
-// 	Backspace  key.Binding
-// 	Hedgehog   key.Binding
-// 	Info       key.Binding
-// 	Sort       key.Binding
-// 	LazyDocker key.Binding
-// 	ProcViewer key.Binding
-
 func (m Model) handleNormalKey(msg tea.KeyPressMsg, cmds []tea.Cmd) (tea.Model, tea.Cmd) {
 	// When the active process is waiting for input, buffer keystrokes and send them on Enter.
 	p := m.activeProc()
@@ -265,14 +242,12 @@ func (m Model) handleNormalKey(msg tea.KeyPressMsg, cmds []tea.Cmd) (tea.Model, 
 			}
 		}
 
-		if len(input) > 0 {
-			if err := p.WriteInput(input); err != nil {
-				m.dbg("pty write error: %v", err)
-			} else {
-				m.dbg("pty send: %q", input)
-			}
-			return m, tea.Batch(cmds...)
+		if err := p.WriteInput(input); err != nil {
+			m.dbg("pty write error: %v", err)
+		} else {
+			m.dbg("pty send: %q", input)
 		}
+		return m, tea.Batch(cmds...)
 	}
 
 	switch {

--- a/tools/phrocs/internal/tui/keys.go
+++ b/tools/phrocs/internal/tui/keys.go
@@ -242,10 +242,12 @@ func (m Model) handleNormalKey(msg tea.KeyPressMsg, cmds []tea.Cmd) (tea.Model, 
 			}
 		}
 
-		if err := p.WriteInput(input); err != nil {
-			m.dbg("pty write error: %v", err)
-		} else {
-			m.dbg("pty send: %q", input)
+		if input != nil {
+			if err := p.WriteInput(input); err != nil {
+				m.dbg("pty write error: %v", err)
+			} else {
+				m.dbg("pty send: %q", input)
+			}
 		}
 		return m, tea.Batch(cmds...)
 	}

--- a/tools/phrocs/internal/tui/keys.go
+++ b/tools/phrocs/internal/tui/keys.go
@@ -224,16 +224,16 @@ func (m Model) handleNormalKey(msg tea.KeyPressMsg, cmds []tea.Cmd) (tea.Model, 
 	if procHasPrompt && !isControlKey {
 		var input []byte
 
-		switch {
-		case msg.Code == tea.KeyEnter:
+		switch msg.Code {
+		case tea.KeyEnter:
 			input = []byte(m.inputBuffer + "\r")
 			m.inputBuffer = ""
-		case msg.Code == tea.KeyBackspace:
+		case tea.KeyBackspace:
 			if len(m.inputBuffer) > 0 {
 				runes := []rune(m.inputBuffer)
 				m.inputBuffer = string(runes[:len(runes)-1])
 			}
-		case msg.Code == tea.KeySpace:
+		case tea.KeySpace:
 			m.inputBuffer += " "
 		default:
 			s := msg.String()

--- a/tools/phrocs/internal/tui/keys.go
+++ b/tools/phrocs/internal/tui/keys.go
@@ -175,7 +175,13 @@ func (m Model) handleInfoKey(msg tea.KeyPressMsg, cmds []tea.Cmd) (Model, []tea.
 	case key.Matches(msg, m.keys.Info), msg.Code == tea.KeyEscape:
 		m.infoMode = false
 		if !m.isDockerMode() {
-			m.viewport.SetContent(m.buildContent())
+			m.activeContent = m.buildContent()
+			if m.activeContent == "" {
+				m.activeLineCount = 0
+			} else {
+				m.activeLineCount = strings.Count(m.activeContent, "\n") + 1
+			}
+			m.viewport.SetContent(m.activeContent)
 			m.viewport.GotoBottom()
 			m.viewportAtBottom = true
 		}

--- a/tools/phrocs/internal/tui/keys.go
+++ b/tools/phrocs/internal/tui/keys.go
@@ -207,7 +207,74 @@ func (m Model) handleHedgehogKey(msg tea.KeyPressMsg, cmds []tea.Cmd) (Model, []
 	return m, cmds, true
 }
 
+// PrevProc   key.Binding
+// 	NextProc   key.Binding
+// 	ScrollUp   key.Binding
+// 	ScrollDown key.Binding
+// 	GotoTop    key.Binding
+// 	GotoBottom key.Binding
+// 	NextPane   key.Binding
+// 	PrevPane   key.Binding
+// 	Restart    key.Binding
+// 	Stop       key.Binding
+// 	CopyMode   key.Binding
+// 	Search     key.Binding
+// 	SearchNext key.Binding
+// 	SearchPrev key.Binding
+// 	Quit       key.Binding
+// 	Help       key.Binding
+// 	Backspace  key.Binding
+// 	Hedgehog   key.Binding
+// 	Info       key.Binding
+// 	Sort       key.Binding
+// 	LazyDocker key.Binding
+// 	ProcViewer key.Binding
+
 func (m Model) handleNormalKey(msg tea.KeyPressMsg, cmds []tea.Cmd) (tea.Model, tea.Cmd) {
+	// When the active process is waiting for input, buffer keystrokes and send them on Enter.
+	p := m.activeProc()
+	procHasPrompt := p != nil && m.focusedPane == focusOutput && p.HasPrompt()
+	// Control keys are excluded so navigation still works.
+	isControlKey := key.Matches(msg, m.keys.NextProc) ||
+		key.Matches(msg, m.keys.PrevProc) ||
+		key.Matches(msg, m.keys.NextPane) ||
+		key.Matches(msg, m.keys.PrevPane) ||
+		key.Matches(msg, m.keys.GotoTop) ||
+		key.Matches(msg, m.keys.GotoBottom) ||
+		key.Matches(msg, m.keys.ScrollDown) ||
+		key.Matches(msg, m.keys.ScrollUp)
+
+	if procHasPrompt && !isControlKey {
+		var input []byte
+
+		switch {
+		case msg.Code == tea.KeyEnter:
+			input = []byte(m.inputBuffer + "\r")
+			m.inputBuffer = ""
+		case msg.Code == tea.KeyBackspace:
+			if len(m.inputBuffer) > 0 {
+				runes := []rune(m.inputBuffer)
+				m.inputBuffer = string(runes[:len(runes)-1])
+			}
+		case msg.Code == tea.KeySpace:
+			m.inputBuffer += " "
+		default:
+			s := msg.String()
+			if runes := []rune(s); len(runes) == 1 && runes[0] >= 32 {
+				m.inputBuffer += s
+			}
+		}
+
+		if len(input) > 0 {
+			if err := p.WriteInput(input); err != nil {
+				m.dbg("pty write error: %v", err)
+			} else {
+				m.dbg("pty send: %q", input)
+			}
+			return m, tea.Batch(cmds...)
+		}
+	}
+
 	switch {
 	case key.Matches(msg, m.keys.Quit):
 		m.mgr.StopAll()

--- a/tools/phrocs/internal/tui/mouse.go
+++ b/tools/phrocs/internal/tui/mouse.go
@@ -9,6 +9,11 @@ func (m Model) handleMouseClick(msg tea.MouseClickMsg, cmds []tea.Cmd) (tea.Mode
 			m.focusedPane = focusServices
 			m.dbg("focus: mouse click → sidebar")
 			row := msg.Y - headerHeight - 1
+			// Decremented by 1 to account for the arrow taking up a row
+			canScrollUp, _, _ := m.sidebarScrollState()
+			if canScrollUp {
+				row--
+			}
 			idx := m.servicesOffset + row
 			if idx >= 0 && idx < len(m.services) {
 				prev := m.servicesCursor

--- a/tools/phrocs/internal/tui/render.go
+++ b/tools/phrocs/internal/tui/render.go
@@ -176,6 +176,7 @@ func (m Model) renderOutput() string {
 }
 
 // Overlays a -line counter in the top-right corner of the viewport
+// and appends the typed input buffer after the last output line.
 func (m Model) viewportWithIndicator() string {
 	view := m.viewport.View()
 	if m.hedgehogMode {
@@ -184,29 +185,30 @@ func (m Model) viewportWithIndicator() string {
 	if m.infoMode {
 		return view
 	}
-	total := m.viewport.TotalLineCount()
-	if total <= m.viewport.Height() {
-		return view
-	}
-
-	scrollLines := total - m.viewport.YOffset() - m.viewport.Height()
-	if scrollLines <= 0 {
-		return view
-	}
-
-	indicator := scrollIndicatorStyle.Render(fmt.Sprintf("-%d", scrollLines))
-	indicatorW := lipgloss.Width(indicator)
 
 	lines := strings.Split(view, "\n")
-	if len(lines) == 0 {
-		return view
+
+	// Show a cursor after the last line when the process is waiting for input.
+	if p := m.activeProc(); p != nil {
+		showCursor := m.focusedPane == focusOutput && p.HasPrompt()
+		if showCursor {
+			lastLine := len(lines) - 1
+			lines[lastLine] = strings.TrimRight(lines[lastLine], " ") + " " + m.inputBuffer + "▌"
+		}
 	}
-	firstLine := lines[0]
-	firstLineW := lipgloss.Width(firstLine)
-	if firstLineW >= indicatorW {
-		// Truncate the first line to make room for the indicator
-		lines[0] = ansi.Truncate(firstLine, firstLineW-indicatorW, "") + indicator
+
+	total := m.viewport.TotalLineCount()
+	scrollLines := total - m.viewport.YOffset() - m.viewport.Height()
+	if scrollLines > 0 && len(lines) > 0 {
+		indicator := scrollIndicatorStyle.Render(fmt.Sprintf("-%d", scrollLines))
+		indicatorW := lipgloss.Width(indicator)
+		firstLine := lines[0]
+		firstLineW := lipgloss.Width(firstLine)
+		if firstLineW >= indicatorW {
+			lines[0] = ansi.Truncate(firstLine, firstLineW-indicatorW, "") + indicator
+		}
 	}
+
 	return strings.Join(lines, "\n")
 }
 

--- a/tools/phrocs/internal/tui/search.go
+++ b/tools/phrocs/internal/tui/search.go
@@ -7,7 +7,7 @@ import (
 	"github.com/charmbracelet/x/ansi"
 )
 
-// Recomputes searchMatches from current process output
+// recomputeSearch fetches lines and delegates to recomputeSearchWith.
 func (m *Model) recomputeSearch() {
 	if m.searchQuery == "" {
 		m.searchMatches = nil
@@ -15,7 +15,12 @@ func (m *Model) recomputeSearch() {
 		m.viewport.StyleLineFunc = nil
 		return
 	}
-	lines := m.searchableLines()
+	m.recomputeSearchWith(m.searchableLines())
+}
+
+// recomputeSearchWith scans the provided lines for the current query.
+// Use this when lines are already available to avoid a redundant copy.
+func (m *Model) recomputeSearchWith(lines []string) {
 	if len(lines) == 0 {
 		m.searchMatches = nil
 		return


### PR DESCRIPTION
## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

Add PTY/pipe stdin forwarding so processes can receive keyboard input. When a process outputs a partial line (prompt without trailing newline), phrocs detects it via HasPrompt and automatically captures keystrokes and shows a cursor.

- Chunk-based readLoop replaces line-based scanner to flush partial lines
- Pipe fallback creates a stdin pipe instead of /dev/null, with \r→\n translation
- Input buffer rendered inline after last output line when prompt detected

<img width="991" height="387" alt="Screenshot 2026-03-27 at 12 34 05 PM" src="https://github.com/user-attachments/assets/96250d8f-8849-4978-9218-35cde9094892" />

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

no

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
