### PR TITLE
fix(hogql): add ClickHouse join constraint validation for non-equality predicates

### DIFF
--- a/posthog/hogql/resolver.py
+++ b/posthog/hogql/resolver.py
@@ -156,6 +156,40 @@ class Resolver(CloningVisitor):
         self._scope_table_names: dict[int, dict[str, str]] = {}
         self._scope_table_column_aliases: dict[int, dict[str, list[str]]] = {}
 
+    def _validate_clickhouse_join_constraint(self, join_type: str | None, constraint: ast.JoinConstraint) -> None:
+        if self.dialect != "clickhouse" or constraint.constraint_type != "ON":
+            return
+
+        if join_type is not None and "ASOF" in join_type.upper():
+            return
+
+        unsupported_expr = self._find_clickhouse_unsupported_join_on_expr(constraint.expr)
+        if unsupported_expr is not None:
+            raise QueryError(
+                "ClickHouse dialect only supports equality predicates in JOIN ... ON clauses. "
+                "Move non-equality conditions to WHERE, or use an ASOF JOIN when appropriate.",
+                node=unsupported_expr,
+            )
+
+    def _find_clickhouse_unsupported_join_on_expr(self, expr: ast.Expr) -> ast.Expr | None:
+        if isinstance(expr, ast.And | ast.Or):
+            for inner_expr in expr.exprs:
+                unsupported_expr = self._find_clickhouse_unsupported_join_on_expr(inner_expr)
+                if unsupported_expr is not None:
+                    return unsupported_expr
+            return None
+
+        if isinstance(expr, ast.CompareOperation) and expr.op != ast.CompareOperationOp.Eq:
+            return expr
+
+        if isinstance(expr, ast.Not):
+            return self._find_clickhouse_unsupported_join_on_expr(expr.expr)
+
+        if isinstance(expr, ast.IsDistinctFrom):
+            return expr
+
+        return None
+
     def _get_scope_table_names(self, scope: ast.SelectQueryType) -> dict[str, str]:
         return self._scope_table_names.setdefault(id(scope), {})
 
@@ -1019,6 +1053,7 @@ class Resolver(CloningVisitor):
 
                 if node.constraint and node.constraint.constraint_type == "ON":
                     node.constraint = self.visit_join_constraint(node.constraint)
+                    self._validate_clickhouse_join_constraint(node.join_type, node.constraint)
                 node.sample = self.visit(node.sample)
 
                 return node
@@ -1112,6 +1147,7 @@ class Resolver(CloningVisitor):
 
             if node.constraint and node.constraint.constraint_type == "ON":
                 node.constraint = self.visit_join_constraint(node.constraint)
+                self._validate_clickhouse_join_constraint(node.join_type, node.constraint)
             node.sample = self.visit(node.sample)
 
             # In case we had a function call table, and had to add an alias where none was present, mark it here
@@ -1187,6 +1223,7 @@ class Resolver(CloningVisitor):
             node.next_join = self.visit(node.next_join)
             if node.constraint and node.constraint.constraint_type == "ON":
                 node.constraint = self.visit_join_constraint(node.constraint)
+                self._validate_clickhouse_join_constraint(node.join_type, node.constraint)
             node.sample = self.visit(node.sample)
 
             return node
@@ -1231,6 +1268,7 @@ class Resolver(CloningVisitor):
             node.next_join = self.visit(node.next_join)
             if node.constraint and node.constraint.constraint_type == "ON":
                 node.constraint = self.visit_join_constraint(node.constraint)
+                self._validate_clickhouse_join_constraint(node.join_type, node.constraint)
             node.sample = self.visit(node.sample)
 
             return node
@@ -1258,6 +1296,7 @@ class Resolver(CloningVisitor):
             node.next_join = self.visit(node.next_join)
             if node.constraint and node.constraint.constraint_type == "ON":
                 node.constraint = self.visit_join_constraint(node.constraint)
+                self._validate_clickhouse_join_constraint(node.join_type, node.constraint)
             node.sample = self.visit(node.sample)
 
             return node
@@ -1284,6 +1323,7 @@ class Resolver(CloningVisitor):
             node.next_join = self.visit(node.next_join)
             if node.constraint and node.constraint.constraint_type == "ON":
                 node.constraint = self.visit_join_constraint(node.constraint)
+                self._validate_clickhouse_join_constraint(node.join_type, node.constraint)
             node.sample = self.visit(node.sample)
 
             return node

--- a/posthog/hogql/resolver.py
+++ b/posthog/hogql/resolver.py
@@ -172,7 +172,7 @@ class Resolver(CloningVisitor):
             )
 
     def _find_clickhouse_unsupported_join_on_expr(self, expr: ast.Expr) -> ast.Expr | None:
-        if isinstance(expr, ast.And | ast.Or):
+        if isinstance(expr, (ast.And, ast.Or)):
             for inner_expr in expr.exprs:
                 unsupported_expr = self._find_clickhouse_unsupported_join_on_expr(inner_expr)
                 if unsupported_expr is not None:
@@ -183,9 +183,12 @@ class Resolver(CloningVisitor):
             return expr
 
         if isinstance(expr, ast.Not):
-            return self._find_clickhouse_unsupported_join_on_expr(expr.expr)
+            return expr
 
         if isinstance(expr, ast.IsDistinctFrom):
+            return expr
+
+        if isinstance(expr, ast.BetweenExpr):
             return expr
 
         return None

--- a/posthog/hogql/test/test_resolver.py
+++ b/posthog/hogql/test/test_resolver.py
@@ -789,6 +789,29 @@ class TestResolver(BaseTest):
         assert isinstance(node.select_from.next_join.constraint, ast.JoinConstraint)
         assert node.select_from.next_join.constraint.constraint_type == "USING"
 
+    def test_clickhouse_join_on_non_equality_guard(self):
+        node = self._select("SELECT * FROM (SELECT 1 AS x) AS a LEFT JOIN (SELECT 2 AS y) AS b ON b.y >= a.x")
+
+        with self.assertRaises(QueryError) as error:
+            resolve_types(node, self.context, dialect="clickhouse")
+
+        self.assertEqual(
+            str(error.exception),
+            "ClickHouse dialect only supports equality predicates in JOIN ... ON clauses. "
+            "Move non-equality conditions to WHERE, or use an ASOF JOIN when appropriate.",
+        )
+
+    def test_clickhouse_asof_join_allows_non_equality_guard(self):
+        node = self._select(
+            "SELECT * FROM (SELECT 1 AS x, now() AS ts) AS a "
+            "ASOF LEFT JOIN (SELECT 1 AS y, now() AS ts) AS b ON a.x = b.y AND a.ts >= b.ts"
+        )
+
+        resolved = cast(ast.SelectQuery, resolve_types(node, self.context, dialect="clickhouse"))
+        assert isinstance(resolved.select_from, ast.JoinExpr)
+        assert isinstance(resolved.select_from.next_join, ast.JoinExpr)
+        assert resolved.select_from.next_join.join_type == "ASOF LEFT JOIN"
+
     @override_settings(PERSON_ON_EVENTS_OVERRIDE=False, PERSON_ON_EVENTS_V2_OVERRIDE=False)
     @pytest.mark.usefixtures("unittest_snapshot")
     def test_asterisk_expander_table(self):

--- a/posthog/hogql/test/test_resolver.py
+++ b/posthog/hogql/test/test_resolver.py
@@ -789,28 +789,38 @@ class TestResolver(BaseTest):
         assert isinstance(node.select_from.next_join.constraint, ast.JoinConstraint)
         assert node.select_from.next_join.constraint.constraint_type == "USING"
 
-    def test_clickhouse_join_on_non_equality_guard(self):
-        node = self._select("SELECT * FROM (SELECT 1 AS x) AS a LEFT JOIN (SELECT 2 AS y) AS b ON b.y >= a.x")
+    @parameterized.expand(
+        [
+            ["gte", "b.y >= a.x"],
+            ["lte", "b.y <= a.x"],
+            ["gt", "b.y > a.x"],
+            ["lt", "b.y < a.x"],
+            ["neq", "b.y != a.x"],
+            ["not_expr", "NOT a.x"],
+            ["between", "a.x BETWEEN b.y AND b.y"],
+        ]
+    )
+    def test_clickhouse_join_on_non_equality_guard(self, _name: str, predicate: str):
+        node = self._select(f"SELECT a.x FROM (SELECT 1 AS x) AS a LEFT JOIN (SELECT 2 AS y) AS b ON {predicate}")
 
         with self.assertRaises(QueryError) as error:
             resolve_types(node, self.context, dialect="clickhouse")
 
-        self.assertEqual(
+        self.assertIn(
+            "ClickHouse dialect only supports equality predicates",
             str(error.exception),
-            "ClickHouse dialect only supports equality predicates in JOIN ... ON clauses. "
-            "Move non-equality conditions to WHERE, or use an ASOF JOIN when appropriate.",
         )
 
     def test_clickhouse_asof_join_allows_non_equality_guard(self):
         node = self._select(
-            "SELECT * FROM (SELECT 1 AS x, now() AS ts) AS a "
+            "SELECT a.x FROM (SELECT 1 AS x, now() AS ts) AS a "
             "ASOF LEFT JOIN (SELECT 1 AS y, now() AS ts) AS b ON a.x = b.y AND a.ts >= b.ts"
         )
 
         resolved = cast(ast.SelectQuery, resolve_types(node, self.context, dialect="clickhouse"))
         assert isinstance(resolved.select_from, ast.JoinExpr)
         assert isinstance(resolved.select_from.next_join, ast.JoinExpr)
-        assert resolved.select_from.next_join.join_type == "ASOF LEFT JOIN"
+        assert resolved.select_from.next_join.join_type == "LEFT ASOF JOIN"
 
     @override_settings(PERSON_ON_EVENTS_OVERRIDE=False, PERSON_ON_EVENTS_V2_OVERRIDE=False)
     @pytest.mark.usefixtures("unittest_snapshot")


### PR DESCRIPTION
## Problem

Some HogQL queries parse correctly but fail later in ClickHouse when a regular JOIN ... ON includes non-equality predicates like >= or <=.

## Changes

Added a ClickHouse-specific resolver guard that rejects unsupported non-equality predicates in regular JOIN ... ON clauses with a friendly QueryError.

## How did you test this code?

Unit tests

## Publish to changelog?

No