### PR TITLE
fix(grouping): provide next available index to backfill deleted group types

### DIFF
--- a/nodejs/src/worker/ingestion/group-type-manager.test.ts
+++ b/nodejs/src/worker/ingestion/group-type-manager.test.ts
@@ -1,6 +1,7 @@
 import { createTeam, getTeam, resetTestDatabase } from '../../../tests/helpers/sql'
-import { Hub, ProjectId } from '../../types'
+import { Hub, ProjectId, TeamId } from '../../types'
 import { closeHub, createHub } from '../../utils/db/hub'
+import { PostgresUse } from '../../utils/db/postgres'
 import { captureTeamEvent } from '../../utils/posthog'
 import { GroupTypeManager } from './group-type-manager'
 

--- a/nodejs/src/worker/ingestion/group-type-manager.test.ts
+++ b/nodejs/src/worker/ingestion/group-type-manager.test.ts
@@ -198,5 +198,69 @@ describe('GroupTypeManager()', () => {
                 g4: 4,
             })
         })
+
+        it('uses next available index after a group type is deleted from the dashboard', async () => {
+            await hub.groupRepository.insertGroupType(2 as TeamId, 2 as ProjectId, 'A', 0)
+            await hub.groupRepository.insertGroupType(2 as TeamId, 2 as ProjectId, 'B', 1)
+            await hub.groupRepository.insertGroupType(2 as TeamId, 2 as ProjectId, 'C', 2)
+            await hub.groupRepository.insertGroupType(2 as TeamId, 2 as ProjectId, 'D', 3)
+            await hub.groupRepository.insertGroupType(2 as TeamId, 2 as ProjectId, 'E', 4)
+
+            // Simulate deleting group type E (@ index 4). this is normally performed by a
+            // Django API endpoint which involves cache-busting, too. (we'll manually do this later)
+            await hub.postgres.query(
+                PostgresUse.PERSONS_WRITE,
+                "DELETE FROM posthog_grouptypemapping WHERE project_id = 2 AND team_id = 2 AND group_type = 'E'",
+                undefined,
+                'deleteGroupType'
+            )
+
+            expect(await groupTypeManager.fetchGroupTypes(2 as ProjectId)).toEqual({
+                A: 0,
+                B: 1,
+                C: 2,
+                D: 3,
+                // E: 4, // E is now deleted
+            })
+
+            // Creating a new group type F should get index 4 (the now-free slot at the end)
+            expect(await groupTypeManager.fetchGroupTypeIndex(2 as TeamId, 2 as ProjectId, 'F')).toEqual(4)
+            expect(await groupTypeManager.fetchGroupTypes(2 as ProjectId)).toEqual({
+                A: 0,
+                B: 1,
+                C: 2,
+                D: 3,
+                F: 4,
+            })
+
+            // // Simulate deleting group type C (@ index 2)
+            await hub.postgres.query(
+                PostgresUse.PERSONS_WRITE,
+                "DELETE FROM posthog_grouptypemapping WHERE project_id = 2 AND team_id = 2 AND group_type = 'C'",
+                undefined,
+                'deleteGroupType'
+            )
+            // bust the cache for project 2 as we've made a call to `.fetchGroupTypes()` earlier
+            // that cached the state of the group types.
+            groupTypeManager['loader'].markForRefresh('2')
+            expect(await groupTypeManager.fetchGroupTypes(2 as ProjectId)).toEqual({
+                A: 0,
+                B: 1,
+                // C is now deleted
+                // C: 2,
+                D: 3,
+                F: 4,
+            })
+
+            // Creating a new group type G should get index 2 (the now-free slot)
+            expect(await groupTypeManager.fetchGroupTypeIndex(2 as TeamId, 2 as ProjectId, 'G')).toEqual(2)
+            expect(await groupTypeManager.fetchGroupTypes(2 as ProjectId)).toEqual({
+                A: 0,
+                B: 1,
+                G: 2,
+                D: 3,
+                F: 4,
+            })
+        })
     })
 })

--- a/nodejs/src/worker/ingestion/group-type-manager.test.ts
+++ b/nodejs/src/worker/ingestion/group-type-manager.test.ts
@@ -234,14 +234,14 @@ describe('GroupTypeManager()', () => {
                 F: 4,
             })
 
-            // // Simulate deleting group type C (@ index 2)
+            // Simulate deleting group type C (@ index 2)
             await hub.postgres.query(
                 PostgresUse.PERSONS_WRITE,
                 "DELETE FROM posthog_grouptypemapping WHERE project_id = 2 AND team_id = 2 AND group_type = 'C'",
                 undefined,
                 'deleteGroupType'
             )
-            // bust the cache for project 2 as we've made a call to `.fetchGroupTypes()` earlier
+            // Bust the cache for project 2 as we've made a call to `.fetchGroupTypes()` earlier
             // that cached the state of the group types.
             groupTypeManager['loader'].markForRefresh('2')
             expect(await groupTypeManager.fetchGroupTypes(2 as ProjectId)).toEqual({

--- a/nodejs/src/worker/ingestion/group-type-manager.test.ts
+++ b/nodejs/src/worker/ingestion/group-type-manager.test.ts
@@ -200,7 +200,7 @@ describe('GroupTypeManager()', () => {
             })
         })
 
-        it('uses next available index after a group type is deleted from the dashboard', async () => {
+        it('uses next available index after a group type is deleted', async () => {
             await hub.groupRepository.insertGroupType(2 as TeamId, 2 as ProjectId, 'A', 0)
             await hub.groupRepository.insertGroupType(2 as TeamId, 2 as ProjectId, 'B', 1)
             await hub.groupRepository.insertGroupType(2 as TeamId, 2 as ProjectId, 'C', 2)
@@ -247,8 +247,7 @@ describe('GroupTypeManager()', () => {
             expect(await groupTypeManager.fetchGroupTypes(2 as ProjectId)).toEqual({
                 A: 0,
                 B: 1,
-                // C is now deleted
-                // C: 2,
+                // C: 2,  // C is now deleted
                 D: 3,
                 F: 4,
             })

--- a/nodejs/src/worker/ingestion/group-type-manager.ts
+++ b/nodejs/src/worker/ingestion/group-type-manager.ts
@@ -63,6 +63,10 @@ export class GroupTypeManager {
         }
 
         const usedIndexes = new Set(Object.values(groupTypes))
+        if (usedIndexes.size >= MAX_GROUP_TYPES_PER_TEAM) {
+            return null
+        }
+
         let nextAvailableIndex = 0
         while (usedIndexes.has(nextAvailableIndex as GroupTypeIndex)) {
             nextAvailableIndex++

--- a/nodejs/src/worker/ingestion/group-type-manager.ts
+++ b/nodejs/src/worker/ingestion/group-type-manager.ts
@@ -62,11 +62,17 @@ export class GroupTypeManager {
             return groupTypes[groupType]
         }
 
+        const usedIndexes = new Set(Object.values(groupTypes))
+        let nextAvailableIndex = 0
+        while (usedIndexes.has(nextAvailableIndex as GroupTypeIndex)) {
+            nextAvailableIndex++
+        }
+
         const [groupTypeIndex, isInsert] = await this.groupRepository.insertGroupType(
             teamId,
             projectId,
             groupType,
-            Object.keys(groupTypes).length
+            nextAvailableIndex
         )
         if (groupTypeIndex !== null) {
             this.loader.markForRefresh(projectId.toString())


### PR DESCRIPTION
## Problem

If you have 5 group types, and delete one of them from your dashboard: you cannot create a new group type even though you only have 4 group types now. 

For example, if you have the following group types:

```
group type name => group type index
A => 0
B => 1
C => 2
D => 3
E => 4
```

If you now delete group type `E` (index 4), and create a new group type `F`, you'll end up with

```
group type name => group type index
A => 0
B => 1
C => 2
D => 3
F => 4
```

If however, you now delete group type `A` (index 0), and create a new group type `G`, you'll end up with the following, because we tried to insert group type G with index 4, which already existed.

```
group type name => group type index
B => 1
C => 2
D => 3
F => 4
```

## Changes

Finds the next available group type index, rather than just taking the length of the current group types. The glaring issue with this though is that because we assign events by group type index, in the scenario above where group type `E` is replaced by group type `F`, all events that were originally assigned to group type `E` will show up under group type `F`. There is no easy way to get around this with the current architecture as far as I'm aware.

## How did you test this code?

Tested in local development.

## Publish to changelog?

no.

## Docs update

`skip-inkeep-docs`