### PR TITLE
feat(flags): add rate limiting allowlist to /flags/definitions endpoint

### DIFF
--- a/rust/feature-flags/src/api/flag_definitions.rs
+++ b/rust/feature-flags/src/api/flag_definitions.rs
@@ -38,6 +38,10 @@ const CONSTANCE_KEY: &str = "constance:posthog:RATE_LIMITING_ALLOW_LIST_TEAMS";
 /// Refresh the rate limit allowlist from the database if stale, then update the limiter.
 /// Matches Django's `get_team_allow_list(round(time.time() / 60))` pattern.
 /// The cache is per-instance (stored on the rate limiter), not global.
+///
+/// To avoid stampeding the database at the TTL boundary (10k+ req/s), we mark the
+/// timestamp as refreshed *before* the DB query. Concurrent requests see it as fresh
+/// and skip the query. If the query fails, we serve stale data for another TTL cycle.
 async fn refresh_rate_limit_allowlist_if_stale(state: &AppState) {
     if !state
         .flag_definitions_limiter
@@ -46,6 +50,9 @@ async fn refresh_rate_limit_allowlist_if_stale(state: &AppState) {
         return;
     }
 
+    // Mark as refreshed immediately to prevent concurrent requests from also querying
+    state.flag_definitions_limiter.mark_allowlist_refreshed();
+
     match fetch_allowlist_from_db(&state.database_pools.non_persons_reader).await {
         Ok(Some(new_allowlist)) => {
             state
@@ -53,13 +60,10 @@ async fn refresh_rate_limit_allowlist_if_stale(state: &AppState) {
                 .update_allowlist(new_allowlist);
         }
         Ok(None) => {
-            // Row not in DB — keep the env var default, just mark as refreshed
-            state.flag_definitions_limiter.mark_allowlist_refreshed();
+            // Row not in DB — keep the env var default
         }
         Err(e) => {
             warn!(error = %e, "Failed to refresh rate limit allowlist from database, using cached value");
-            // Mark as refreshed so we don't retry on every request
-            state.flag_definitions_limiter.mark_allowlist_refreshed();
         }
     }
 }

--- a/rust/feature-flags/src/api/flag_definitions.rs
+++ b/rust/feature-flags/src/api/flag_definitions.rs
@@ -45,7 +45,10 @@ const CONSTANCE_KEY: &str = "constance:posthog:RATE_LIMITING_ALLOW_LIST_TEAMS";
 /// Invalidate the cached allowlist, forcing the next request to re-read from the database.
 pub async fn invalidate_allowlist_cache() {
     let mut cache = ALLOWLIST_CACHE.write().await;
-    *cache = (HashSet::new(), Instant::now() - std::time::Duration::from_secs(ALLOWLIST_TTL_SECS + 1));
+    *cache = (
+        HashSet::new(),
+        Instant::now() - std::time::Duration::from_secs(ALLOWLIST_TTL_SECS + 1),
+    );
 }
 
 /// Refresh the rate limit allowlist from the database if stale, then update the limiter.

--- a/rust/feature-flags/src/api/flag_definitions.rs
+++ b/rust/feature-flags/src/api/flag_definitions.rs
@@ -24,10 +24,94 @@ use axum::{
 };
 use common_hypercache::{HyperCacheError, KeyType};
 use common_metrics::inc;
+use common_types::TeamId;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use sqlx::PgPool;
+use std::collections::HashSet;
 use std::sync::Arc;
+use std::time::Instant;
+use tokio::sync::RwLock as TokioRwLock;
 use tracing::{info, warn};
+
+/// Cached rate limit allowlist from the database.
+/// Refreshes at most once per ALLOWLIST_TTL_SECS, matching Django's lru_cache with TTL approach.
+static ALLOWLIST_CACHE: std::sync::LazyLock<TokioRwLock<(HashSet<TeamId>, Instant)>> =
+    std::sync::LazyLock::new(|| TokioRwLock::new((HashSet::new(), Instant::now())));
+
+const ALLOWLIST_TTL_SECS: u64 = 60;
+const CONSTANCE_KEY: &str = "constance:posthog:RATE_LIMITING_ALLOW_LIST_TEAMS";
+
+/// Invalidate the cached allowlist, forcing the next request to re-read from the database.
+pub async fn invalidate_allowlist_cache() {
+    let mut cache = ALLOWLIST_CACHE.write().await;
+    *cache = (HashSet::new(), Instant::now() - std::time::Duration::from_secs(ALLOWLIST_TTL_SECS + 1));
+}
+
+/// Refresh the rate limit allowlist from the database if stale, then update the limiter.
+/// Matches Django's `get_team_allow_list(round(time.time() / 60))` pattern.
+pub async fn refresh_rate_limit_allowlist_if_stale(state: &AppState) {
+    let cache = ALLOWLIST_CACHE.read().await;
+    if cache.1.elapsed().as_secs() < ALLOWLIST_TTL_SECS {
+        return;
+    }
+    drop(cache);
+
+    let mut cache = ALLOWLIST_CACHE.write().await;
+    // Double-check after acquiring write lock (another request may have refreshed it)
+    if cache.1.elapsed().as_secs() < ALLOWLIST_TTL_SECS {
+        return;
+    }
+
+    match fetch_allowlist_from_db(&state.database_pools.non_persons_reader).await {
+        Ok(new_allowlist) => {
+            state
+                .flag_definitions_limiter
+                .update_allowlist(new_allowlist.clone());
+            *cache = (new_allowlist, Instant::now());
+        }
+        Err(e) => {
+            warn!(error = %e, "Failed to refresh rate limit allowlist from database, using cached value");
+            // Update the timestamp so we don't retry on every request
+            cache.1 = Instant::now();
+        }
+    }
+}
+
+/// Query the posthog_instancesetting table for the rate limit allowlist.
+/// The key is stored with the constance prefix: "constance:posthog:RATE_LIMITING_ALLOW_LIST_TEAMS"
+pub async fn fetch_allowlist_from_db(pool: &PgPool) -> Result<HashSet<TeamId>, String> {
+    let row: Option<(String,)> =
+        sqlx::query_as("SELECT raw_value FROM posthog_instancesetting WHERE key = $1")
+            .bind(CONSTANCE_KEY)
+            .fetch_optional(pool)
+            .await
+            .map_err(|e| format!("DB query failed: {e}"))?;
+
+    let raw_value = match row {
+        Some((val,)) => val,
+        None => return Ok(HashSet::new()),
+    };
+
+    // The value may be JSON-encoded (e.g. "\"23047,12345\"") or a bare string ("23047,12345")
+    let value = raw_value.trim().trim_matches('"');
+    if value.is_empty() {
+        return Ok(HashSet::new());
+    }
+
+    let mut team_ids = HashSet::new();
+    for part in value.split(',').map(|p| p.trim()) {
+        if part.is_empty() {
+            continue;
+        }
+        let team_id = part
+            .parse::<TeamId>()
+            .map_err(|e| format!("Invalid team ID '{part}': {e}"))?;
+        team_ids.insert(team_id);
+    }
+
+    Ok(team_ids)
+}
 
 /// Response for flag definitions endpoint
 /// This is returned as raw JSON from cache to avoid deserialization overhead
@@ -88,6 +172,9 @@ pub async fn flags_definitions(
 
     // Authenticate against the specified team
     authenticate_flag_definitions(&state, &team, &headers).await?;
+
+    // Refresh the rate limit allowlist from the database if stale (every ~60s)
+    refresh_rate_limit_allowlist_if_stale(&state).await;
 
     // Check rate limit for this team
     state.flag_definitions_limiter.check_rate_limit(team.id)?;

--- a/rust/feature-flags/src/api/flag_definitions.rs
+++ b/rust/feature-flags/src/api/flag_definitions.rs
@@ -85,8 +85,15 @@ pub async fn fetch_allowlist_from_db(pool: &PgPool) -> Result<Option<HashSet<Tea
         None => return Ok(None),
     };
 
-    // The value may be JSON-encoded (e.g. "\"23047,12345\"") or a bare string ("23047,12345")
-    let value = raw_value.trim().trim_matches('"');
+    // Match Django's InstanceSetting.value: try json.loads first, fall back to raw string.
+    // Handles JSON strings ("\"23047,12345\""), null, and bare strings ("23047,12345").
+    let value = match serde_json::from_str::<serde_json::Value>(&raw_value) {
+        Ok(serde_json::Value::String(s)) => s,
+        Ok(serde_json::Value::Null) => return Ok(Some(HashSet::new())),
+        Ok(_) => raw_value.clone(), // non-string JSON (unlikely), treat as raw
+        Err(_) => raw_value.clone(), // not valid JSON, treat as bare string (like Django)
+    };
+    let value = value.trim();
     if value.is_empty() {
         return Ok(Some(HashSet::new()));
     }

--- a/rust/feature-flags/src/api/flag_definitions.rs
+++ b/rust/feature-flags/src/api/flag_definitions.rs
@@ -90,8 +90,7 @@ pub async fn fetch_allowlist_from_db(pool: &PgPool) -> Result<Option<HashSet<Tea
     let value = match serde_json::from_str::<serde_json::Value>(&raw_value) {
         Ok(serde_json::Value::String(s)) => s,
         Ok(serde_json::Value::Null) => return Ok(Some(HashSet::new())),
-        Ok(_) => raw_value.clone(), // non-string JSON (unlikely), treat as raw
-        Err(_) => raw_value.clone(), // not valid JSON, treat as bare string (like Django)
+        _ => raw_value, // non-string JSON or invalid JSON, treat as bare string (like Django)
     };
     let value = value.trim();
     if value.is_empty() {

--- a/rust/feature-flags/src/api/flag_definitions.rs
+++ b/rust/feature-flags/src/api/flag_definitions.rs
@@ -30,39 +30,19 @@ use serde_json::Value;
 use sqlx::PgPool;
 use std::collections::HashSet;
 use std::sync::Arc;
-use std::time::Instant;
-use tokio::sync::RwLock as TokioRwLock;
 use tracing::{info, warn};
-
-/// Cached rate limit allowlist from the database.
-/// Refreshes at most once per ALLOWLIST_TTL_SECS, matching Django's lru_cache with TTL approach.
-static ALLOWLIST_CACHE: std::sync::LazyLock<TokioRwLock<(HashSet<TeamId>, Instant)>> =
-    std::sync::LazyLock::new(|| TokioRwLock::new((HashSet::new(), Instant::now())));
 
 const ALLOWLIST_TTL_SECS: u64 = 60;
 const CONSTANCE_KEY: &str = "constance:posthog:RATE_LIMITING_ALLOW_LIST_TEAMS";
 
-/// Invalidate the cached allowlist, forcing the next request to re-read from the database.
-pub async fn invalidate_allowlist_cache() {
-    let mut cache = ALLOWLIST_CACHE.write().await;
-    *cache = (
-        HashSet::new(),
-        Instant::now() - std::time::Duration::from_secs(ALLOWLIST_TTL_SECS + 1),
-    );
-}
-
 /// Refresh the rate limit allowlist from the database if stale, then update the limiter.
 /// Matches Django's `get_team_allow_list(round(time.time() / 60))` pattern.
-pub async fn refresh_rate_limit_allowlist_if_stale(state: &AppState) {
-    let cache = ALLOWLIST_CACHE.read().await;
-    if cache.1.elapsed().as_secs() < ALLOWLIST_TTL_SECS {
-        return;
-    }
-    drop(cache);
-
-    let mut cache = ALLOWLIST_CACHE.write().await;
-    // Double-check after acquiring write lock (another request may have refreshed it)
-    if cache.1.elapsed().as_secs() < ALLOWLIST_TTL_SECS {
+/// The cache is per-instance (stored on the rate limiter), not global.
+async fn refresh_rate_limit_allowlist_if_stale(state: &AppState) {
+    if !state
+        .flag_definitions_limiter
+        .is_allowlist_stale(ALLOWLIST_TTL_SECS)
+    {
         return;
     }
 
@@ -70,13 +50,12 @@ pub async fn refresh_rate_limit_allowlist_if_stale(state: &AppState) {
         Ok(new_allowlist) => {
             state
                 .flag_definitions_limiter
-                .update_allowlist(new_allowlist.clone());
-            *cache = (new_allowlist, Instant::now());
+                .update_allowlist(new_allowlist);
         }
         Err(e) => {
             warn!(error = %e, "Failed to refresh rate limit allowlist from database, using cached value");
-            // Update the timestamp so we don't retry on every request
-            cache.1 = Instant::now();
+            // Mark as refreshed so we don't retry on every request
+            state.flag_definitions_limiter.mark_allowlist_refreshed();
         }
     }
 }

--- a/rust/feature-flags/src/api/flag_definitions.rs
+++ b/rust/feature-flags/src/api/flag_definitions.rs
@@ -103,10 +103,18 @@ pub async fn fetch_allowlist_from_db(pool: &PgPool) -> Result<Option<HashSet<Tea
         if part.is_empty() {
             continue;
         }
-        let team_id = part
-            .parse::<TeamId>()
-            .map_err(|e| format!("Invalid team ID '{part}': {e}"))?;
-        team_ids.insert(team_id);
+        match part.parse::<TeamId>() {
+            Ok(id) => {
+                team_ids.insert(id);
+            }
+            Err(e) => {
+                warn!(
+                    part = part,
+                    error = %e,
+                    "Skipping invalid team ID in RATE_LIMITING_ALLOW_LIST_TEAMS"
+                );
+            }
+        }
     }
 
     Ok(Some(team_ids))

--- a/rust/feature-flags/src/api/flag_definitions.rs
+++ b/rust/feature-flags/src/api/flag_definitions.rs
@@ -47,10 +47,14 @@ async fn refresh_rate_limit_allowlist_if_stale(state: &AppState) {
     }
 
     match fetch_allowlist_from_db(&state.database_pools.non_persons_reader).await {
-        Ok(new_allowlist) => {
+        Ok(Some(new_allowlist)) => {
             state
                 .flag_definitions_limiter
                 .update_allowlist(new_allowlist);
+        }
+        Ok(None) => {
+            // Row not in DB — keep the env var default, just mark as refreshed
+            state.flag_definitions_limiter.mark_allowlist_refreshed();
         }
         Err(e) => {
             warn!(error = %e, "Failed to refresh rate limit allowlist from database, using cached value");
@@ -62,7 +66,9 @@ async fn refresh_rate_limit_allowlist_if_stale(state: &AppState) {
 
 /// Query the posthog_instancesetting table for the rate limit allowlist.
 /// The key is stored with the constance prefix: "constance:posthog:RATE_LIMITING_ALLOW_LIST_TEAMS"
-pub async fn fetch_allowlist_from_db(pool: &PgPool) -> Result<HashSet<TeamId>, String> {
+/// Returns None if the row doesn't exist (env var default should be kept),
+/// Some(set) if the row exists (overrides the env var).
+pub async fn fetch_allowlist_from_db(pool: &PgPool) -> Result<Option<HashSet<TeamId>>, String> {
     let row: Option<(String,)> =
         sqlx::query_as("SELECT raw_value FROM posthog_instancesetting WHERE key = $1")
             .bind(CONSTANCE_KEY)
@@ -72,13 +78,13 @@ pub async fn fetch_allowlist_from_db(pool: &PgPool) -> Result<HashSet<TeamId>, S
 
     let raw_value = match row {
         Some((val,)) => val,
-        None => return Ok(HashSet::new()),
+        None => return Ok(None),
     };
 
     // The value may be JSON-encoded (e.g. "\"23047,12345\"") or a bare string ("23047,12345")
     let value = raw_value.trim().trim_matches('"');
     if value.is_empty() {
-        return Ok(HashSet::new());
+        return Ok(Some(HashSet::new()));
     }
 
     let mut team_ids = HashSet::new();
@@ -92,7 +98,7 @@ pub async fn fetch_allowlist_from_db(pool: &PgPool) -> Result<HashSet<TeamId>, S
         team_ids.insert(team_id);
     }
 
-    Ok(team_ids)
+    Ok(Some(team_ids))
 }
 
 /// Response for flag definitions endpoint

--- a/rust/feature-flags/src/api/flag_definitions.rs
+++ b/rust/feature-flags/src/api/flag_definitions.rs
@@ -39,19 +39,17 @@ const CONSTANCE_KEY: &str = "constance:posthog:RATE_LIMITING_ALLOW_LIST_TEAMS";
 /// Matches Django's `get_team_allow_list(round(time.time() / 60))` pattern.
 /// The cache is per-instance (stored on the rate limiter), not global.
 ///
-/// To avoid stampeding the database at the TTL boundary (10k+ req/s), we mark the
-/// timestamp as refreshed *before* the DB query. Concurrent requests see it as fresh
-/// and skip the query. If the query fails, we serve stale data for another TTL cycle.
+/// To avoid stampeding the database at the TTL boundary (10k+ req/s),
+/// `claim_allowlist_refresh` atomically checks staleness and marks as refreshed,
+/// so only one request triggers the DB query. If the query fails, we serve stale
+/// data for another TTL cycle.
 async fn refresh_rate_limit_allowlist_if_stale(state: &AppState) {
     if !state
         .flag_definitions_limiter
-        .is_allowlist_stale(ALLOWLIST_TTL_SECS)
+        .claim_allowlist_refresh(ALLOWLIST_TTL_SECS)
     {
         return;
     }
-
-    // Mark as refreshed immediately to prevent concurrent requests from also querying
-    state.flag_definitions_limiter.mark_allowlist_refreshed();
 
     match fetch_allowlist_from_db(&state.database_pools.non_persons_reader).await {
         Ok(Some(new_allowlist)) => {

--- a/rust/feature-flags/src/api/flag_definitions_rate_limiter.rs
+++ b/rust/feature-flags/src/api/flag_definitions_rate_limiter.rs
@@ -482,4 +482,36 @@ mod tests {
         let limiter = make_limiter(600, HashMap::new(), HashSet::new());
         assert_eq!(limiter.allowlist_count(), 0);
     }
+
+    #[test]
+    fn test_allowlist_starts_stale() {
+        let limiter = make_limiter(600, HashMap::new(), HashSet::new());
+        assert!(limiter.is_allowlist_stale(60));
+    }
+
+    #[test]
+    fn test_update_allowlist_marks_as_fresh() {
+        let limiter = make_limiter(600, HashMap::new(), HashSet::new());
+        limiter.update_allowlist(HashSet::from([123]));
+        assert!(!limiter.is_allowlist_stale(60));
+        assert_eq!(limiter.allowlist_count(), 1);
+    }
+
+    #[test]
+    fn test_mark_allowlist_refreshed_without_changing_data() {
+        let limiter = make_limiter(600, HashMap::new(), HashSet::new());
+        assert!(limiter.is_allowlist_stale(60));
+        limiter.mark_allowlist_refreshed();
+        assert!(!limiter.is_allowlist_stale(60));
+        assert_eq!(limiter.allowlist_count(), 0);
+    }
+
+    #[test]
+    fn test_invalidate_allowlist_makes_stale() {
+        let limiter = make_limiter(600, HashMap::new(), HashSet::new());
+        limiter.mark_allowlist_refreshed();
+        assert!(!limiter.is_allowlist_stale(60));
+        limiter.invalidate_allowlist();
+        assert!(limiter.is_allowlist_stale(60));
+    }
 }

--- a/rust/feature-flags/src/api/flag_definitions_rate_limiter.rs
+++ b/rust/feature-flags/src/api/flag_definitions_rate_limiter.rs
@@ -7,6 +7,7 @@ use std::fmt::Display;
 use std::hash::Hash;
 use std::num::NonZeroU32;
 use std::sync::{Arc, RwLock};
+use std::time::Instant;
 use tracing::{info, warn};
 
 /// Type alias for a keyed rate limiter
@@ -45,6 +46,10 @@ where
     /// Keys that bypass rate limiting entirely.
     /// Wrapped in Arc<RwLock<>> so the request handler can update it from the database.
     allowlist: Arc<RwLock<HashSet<K>>>,
+
+    /// Timestamp of the last allowlist refresh from the database.
+    /// Used to implement a TTL cache — only re-query when stale.
+    allowlist_last_refreshed: Arc<RwLock<Instant>>,
 
     /// Prometheus metric name for total requests
     request_counter: &'static str,
@@ -126,6 +131,10 @@ where
             default_limiter,
             custom_limiters,
             allowlist: Arc::new(RwLock::new(allowlist)),
+            // Start stale so the first request triggers a DB refresh
+            allowlist_last_refreshed: Arc::new(RwLock::new(
+                Instant::now() - std::time::Duration::from_secs(3600),
+            )),
             request_counter,
             limited_counter,
             bypassed_counter,
@@ -199,7 +208,7 @@ where
         self.allowlist.read().unwrap().len()
     }
 
-    /// Replace the allowlist with a new set of keys.
+    /// Replace the allowlist with a new set of keys and mark it as freshly refreshed.
     /// Called by the request handler when the cached DB value is stale.
     pub fn update_allowlist(&self, new_allowlist: HashSet<K>) {
         let mut allowlist = self.allowlist.write().unwrap();
@@ -213,6 +222,30 @@ where
                 "Rate limit allowlist updated"
             );
         }
+        // Mark as refreshed
+        *self.allowlist_last_refreshed.write().unwrap() = Instant::now();
+    }
+
+    /// Returns true if the allowlist cache is stale and should be refreshed from the database.
+    pub fn is_allowlist_stale(&self, ttl_secs: u64) -> bool {
+        self.allowlist_last_refreshed
+            .read()
+            .unwrap()
+            .elapsed()
+            .as_secs()
+            >= ttl_secs
+    }
+
+    /// Mark the allowlist refresh timestamp without changing the allowlist contents.
+    /// Used when the DB query fails — avoids retrying on every request.
+    pub fn mark_allowlist_refreshed(&self) {
+        *self.allowlist_last_refreshed.write().unwrap() = Instant::now();
+    }
+
+    /// Force the allowlist to be considered stale, triggering a DB refresh on the next request.
+    pub fn invalidate_allowlist(&self) {
+        *self.allowlist_last_refreshed.write().unwrap() =
+            Instant::now() - std::time::Duration::from_secs(3600);
     }
 
     /// Removes stale entries and reclaims memory across all limiters.

--- a/rust/feature-flags/src/api/flag_definitions_rate_limiter.rs
+++ b/rust/feature-flags/src/api/flag_definitions_rate_limiter.rs
@@ -42,8 +42,9 @@ where
     /// Wrapped in RwLock for thread-safe access
     custom_limiters: CustomLimitersMap<K>,
 
-    /// Keys that bypass rate limiting entirely
-    allowlist: HashSet<K>,
+    /// Keys that bypass rate limiting entirely.
+    /// Wrapped in Arc<RwLock<>> so the request handler can update it from the database.
+    allowlist: Arc<RwLock<HashSet<K>>>,
 
     /// Prometheus metric name for total requests
     request_counter: &'static str,
@@ -124,7 +125,7 @@ where
         Ok(KeyedRateLimiter {
             default_limiter,
             custom_limiters,
-            allowlist,
+            allowlist: Arc::new(RwLock::new(allowlist)),
             request_counter,
             limited_counter,
             bypassed_counter,
@@ -160,7 +161,8 @@ where
             // Allowlisted keys bypass rate limiting when they would be limited.
             // Matches Django's behavior: the bypassed counter only fires for
             // requests that exceed the limit but are allowed through.
-            if self.allowlist.contains(&key) {
+            let allowlist = self.allowlist.read().unwrap();
+            if allowlist.contains(&key) {
                 inc(
                     self.bypassed_counter,
                     &[("key".to_string(), key.to_string())],
@@ -194,7 +196,23 @@ where
 
     /// Get the number of keys in the rate limit allowlist
     pub fn allowlist_count(&self) -> usize {
-        self.allowlist.len()
+        self.allowlist.read().unwrap().len()
+    }
+
+    /// Replace the allowlist with a new set of keys.
+    /// Called by the request handler when the cached DB value is stale.
+    pub fn update_allowlist(&self, new_allowlist: HashSet<K>) {
+        let mut allowlist = self.allowlist.write().unwrap();
+        let old_count = allowlist.len();
+        *allowlist = new_allowlist;
+        let new_count = allowlist.len();
+        if old_count != new_count {
+            info!(
+                old_count = old_count,
+                new_count = new_count,
+                "Rate limit allowlist updated"
+            );
+        }
     }
 
     /// Removes stale entries and reclaims memory across all limiters.

--- a/rust/feature-flags/src/api/flag_definitions_rate_limiter.rs
+++ b/rust/feature-flags/src/api/flag_definitions_rate_limiter.rs
@@ -233,6 +233,19 @@ where
             >= ttl_secs
     }
 
+    /// Atomically checks if the allowlist is stale and marks it as refreshed if so.
+    /// Returns true if this caller should perform the refresh (won the race).
+    /// Prevents stampeding: only the first caller at the TTL boundary proceeds.
+    pub fn claim_allowlist_refresh(&self, ttl_secs: u64) -> bool {
+        let mut last_refreshed = self.allowlist_last_refreshed.write().unwrap();
+        if last_refreshed.elapsed().as_secs() >= ttl_secs {
+            *last_refreshed = Instant::now();
+            true
+        } else {
+            false
+        }
+    }
+
     /// Mark the allowlist refresh timestamp without changing the allowlist contents.
     /// Used when the DB query fails — avoids retrying on every request.
     pub fn mark_allowlist_refreshed(&self) {
@@ -504,6 +517,15 @@ mod tests {
         limiter.mark_allowlist_refreshed();
         assert!(!limiter.is_allowlist_stale(60));
         assert_eq!(limiter.allowlist_count(), 0);
+    }
+
+    #[test]
+    fn test_claim_allowlist_refresh_only_first_caller_wins() {
+        let limiter = make_limiter(600, HashMap::new(), HashSet::new());
+        // First claim should succeed (starts stale)
+        assert!(limiter.claim_allowlist_refresh(60));
+        // Second claim should fail (just marked as fresh)
+        assert!(!limiter.claim_allowlist_refresh(60));
     }
 
     #[test]

--- a/rust/feature-flags/src/api/flag_definitions_rate_limiter.rs
+++ b/rust/feature-flags/src/api/flag_definitions_rate_limiter.rs
@@ -2,7 +2,7 @@ use crate::api::{errors::FlagError, rate_parser::parse_rate_string};
 use common_metrics::inc;
 use common_types::TeamId;
 use governor::{clock, state::keyed::DefaultKeyedStateStore, Quota, RateLimiter};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fmt::Display;
 use std::hash::Hash;
 use std::num::NonZeroU32;
@@ -42,11 +42,17 @@ where
     /// Wrapped in RwLock for thread-safe access
     custom_limiters: CustomLimitersMap<K>,
 
+    /// Keys that bypass rate limiting entirely
+    allowlist: HashSet<K>,
+
     /// Prometheus metric name for total requests
     request_counter: &'static str,
 
     /// Prometheus metric name for rate limited requests
     limited_counter: &'static str,
+
+    /// Prometheus metric name for rate limit bypassed requests
+    bypassed_counter: &'static str,
 }
 
 /// Type alias for flag definitions rate limiting (per-team)
@@ -61,16 +67,20 @@ where
     /// # Arguments
     /// * `default_rate_per_minute` - Default rate limit for keys without custom rates (requests per minute)
     /// * `custom_rates` - HashMap of key → rate string (e.g., "1200/minute")
+    /// * `allowlist` - Set of keys that bypass rate limiting entirely
     /// * `request_counter` - Prometheus metric name for total requests
     /// * `limited_counter` - Prometheus metric name for rate limited requests
+    /// * `bypassed_counter` - Prometheus metric name for rate limit bypassed requests
     ///
     /// # Returns
     /// A new limiter instance, or an error if any custom rate string is invalid
     pub fn new(
         default_rate_per_minute: u32,
         custom_rates: HashMap<K, String>,
+        allowlist: HashSet<K>,
         request_counter: &'static str,
         limited_counter: &'static str,
+        bypassed_counter: &'static str,
     ) -> Result<Self, String> {
         // Create default limiter using configured rate
         let default_quota = Quota::per_minute(
@@ -107,11 +117,17 @@ where
 
         let custom_limiters = Arc::new(RwLock::new(custom_limiters_map));
 
+        if !allowlist.is_empty() {
+            info!(count = allowlist.len(), "Configured rate limit allowlist");
+        }
+
         Ok(KeyedRateLimiter {
             default_limiter,
             custom_limiters,
+            allowlist,
             request_counter,
             limited_counter,
+            bypassed_counter,
         })
     }
 
@@ -141,6 +157,18 @@ where
         );
 
         if is_rate_limited {
+            // Allowlisted keys bypass rate limiting when they would be limited.
+            // Matches Django's behavior: the bypassed counter only fires for
+            // requests that exceed the limit but are allowed through.
+            if self.allowlist.contains(&key) {
+                inc(
+                    self.bypassed_counter,
+                    &[("key".to_string(), key.to_string())],
+                    1,
+                );
+                return Ok(());
+            }
+
             // Track rate-limited requests
             inc(
                 self.limited_counter,
@@ -162,6 +190,11 @@ where
     /// Get the number of keys with custom rate limits configured
     pub fn custom_rate_count(&self) -> usize {
         self.custom_limiters.read().unwrap().len()
+    }
+
+    /// Get the number of keys in the rate limit allowlist
+    pub fn allowlist_count(&self) -> usize {
+        self.allowlist.len()
     }
 
     /// Removes stale entries and reclaims memory across all limiters.
@@ -203,20 +236,31 @@ where
 mod tests {
     use super::*;
     use crate::metrics::consts::{
-        FLAG_DEFINITIONS_RATE_LIMITED_COUNTER, FLAG_DEFINITIONS_REQUESTS_COUNTER,
+        FLAG_DEFINITIONS_RATE_LIMITED_COUNTER, FLAG_DEFINITIONS_RATE_LIMIT_BYPASSED_COUNTER,
+        FLAG_DEFINITIONS_REQUESTS_COUNTER,
     };
-    use std::collections::HashMap;
+    use std::collections::{HashMap, HashSet};
     use tokio::time::{sleep, Duration};
+
+    fn make_limiter(
+        default_rate: u32,
+        custom_rates: HashMap<TeamId, String>,
+        allowlist: HashSet<TeamId>,
+    ) -> FlagDefinitionsRateLimiter {
+        FlagDefinitionsRateLimiter::new(
+            default_rate,
+            custom_rates,
+            allowlist,
+            FLAG_DEFINITIONS_REQUESTS_COUNTER,
+            FLAG_DEFINITIONS_RATE_LIMITED_COUNTER,
+            FLAG_DEFINITIONS_RATE_LIMIT_BYPASSED_COUNTER,
+        )
+        .unwrap()
+    }
 
     #[test]
     fn test_new_limiter_with_no_custom_rates() {
-        let limiter = FlagDefinitionsRateLimiter::new(
-            600,
-            HashMap::new(),
-            FLAG_DEFINITIONS_REQUESTS_COUNTER,
-            FLAG_DEFINITIONS_RATE_LIMITED_COUNTER,
-        )
-        .unwrap();
+        let limiter = make_limiter(600, HashMap::new(), HashSet::new());
         assert_eq!(limiter.custom_rate_count(), 0);
     }
 
@@ -226,13 +270,7 @@ mod tests {
         custom_rates.insert(123, "1200/minute".to_string());
         custom_rates.insert(456, "2400/hour".to_string());
 
-        let limiter = FlagDefinitionsRateLimiter::new(
-            600,
-            custom_rates,
-            FLAG_DEFINITIONS_REQUESTS_COUNTER,
-            FLAG_DEFINITIONS_RATE_LIMITED_COUNTER,
-        )
-        .unwrap();
+        let limiter = make_limiter(600, custom_rates, HashSet::new());
         assert_eq!(limiter.custom_rate_count(), 2);
     }
 
@@ -243,25 +281,13 @@ mod tests {
         custom_rates.insert(456, "1200/minute".to_string());
 
         // Should succeed but only configure the valid rate
-        let limiter = FlagDefinitionsRateLimiter::new(
-            600,
-            custom_rates,
-            FLAG_DEFINITIONS_REQUESTS_COUNTER,
-            FLAG_DEFINITIONS_RATE_LIMITED_COUNTER,
-        )
-        .unwrap();
+        let limiter = make_limiter(600, custom_rates, HashSet::new());
         assert_eq!(limiter.custom_rate_count(), 1);
     }
 
     #[tokio::test]
     async fn test_default_rate_limit_allows_requests() {
-        let limiter = FlagDefinitionsRateLimiter::new(
-            600,
-            HashMap::new(),
-            FLAG_DEFINITIONS_REQUESTS_COUNTER,
-            FLAG_DEFINITIONS_RATE_LIMITED_COUNTER,
-        )
-        .unwrap();
+        let limiter = make_limiter(600, HashMap::new(), HashSet::new());
 
         // First request should succeed
         assert!(limiter.check_rate_limit(999).is_ok());
@@ -273,13 +299,7 @@ mod tests {
         // Very low limit for testing: 1 per second
         custom_rates.insert(123, "1/second".to_string());
 
-        let limiter = FlagDefinitionsRateLimiter::new(
-            600,
-            custom_rates,
-            FLAG_DEFINITIONS_REQUESTS_COUNTER,
-            FLAG_DEFINITIONS_RATE_LIMITED_COUNTER,
-        )
-        .unwrap();
+        let limiter = make_limiter(600, custom_rates, HashSet::new());
 
         // First request should succeed
         assert!(limiter.check_rate_limit(123).is_ok());
@@ -293,13 +313,7 @@ mod tests {
         let mut custom_rates = HashMap::new();
         custom_rates.insert(123, "1/second".to_string());
 
-        let limiter = FlagDefinitionsRateLimiter::new(
-            600,
-            custom_rates,
-            FLAG_DEFINITIONS_REQUESTS_COUNTER,
-            FLAG_DEFINITIONS_RATE_LIMITED_COUNTER,
-        )
-        .unwrap();
+        let limiter = make_limiter(600, custom_rates, HashSet::new());
 
         // Team 123 first request succeeds
         assert!(limiter.check_rate_limit(123).is_ok());
@@ -317,13 +331,7 @@ mod tests {
         // 1 per second - should reset after 1 second
         custom_rates.insert(123, "1/second".to_string());
 
-        let limiter = FlagDefinitionsRateLimiter::new(
-            600,
-            custom_rates,
-            FLAG_DEFINITIONS_REQUESTS_COUNTER,
-            FLAG_DEFINITIONS_RATE_LIMITED_COUNTER,
-        )
-        .unwrap();
+        let limiter = make_limiter(600, custom_rates, HashSet::new());
 
         // First request succeeds
         assert!(limiter.check_rate_limit(123).is_ok());
@@ -340,13 +348,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_concurrent_access() {
-        let limiter = FlagDefinitionsRateLimiter::new(
-            600,
-            HashMap::new(),
-            FLAG_DEFINITIONS_REQUESTS_COUNTER,
-            FLAG_DEFINITIONS_RATE_LIMITED_COUNTER,
-        )
-        .unwrap();
+        let limiter = make_limiter(600, HashMap::new(), HashSet::new());
         let limiter_clone = limiter.clone();
 
         // Spawn multiple tasks checking rate limits concurrently
@@ -373,13 +375,7 @@ mod tests {
         let mut custom_rates = HashMap::new();
         custom_rates.insert(123, "1/second".to_string());
 
-        let limiter = FlagDefinitionsRateLimiter::new(
-            600,
-            custom_rates,
-            FLAG_DEFINITIONS_REQUESTS_COUNTER,
-            FLAG_DEFINITIONS_RATE_LIMITED_COUNTER,
-        )
-        .unwrap();
+        let limiter = make_limiter(600, custom_rates, HashSet::new());
 
         // Use up the rate limit
         drop(limiter.check_rate_limit(123));
@@ -398,14 +394,44 @@ mod tests {
 
     #[test]
     fn test_len_returns_zero_for_new_limiter() {
-        let limiter = FlagDefinitionsRateLimiter::new(
-            600,
-            HashMap::new(),
-            FLAG_DEFINITIONS_REQUESTS_COUNTER,
-            FLAG_DEFINITIONS_RATE_LIMITED_COUNTER,
-        )
-        .unwrap();
-
+        let limiter = make_limiter(600, HashMap::new(), HashSet::new());
         assert_eq!(limiter.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_allowlisted_team_bypasses_rate_limit() {
+        let mut custom_rates = HashMap::new();
+        custom_rates.insert(123, "1/second".to_string());
+
+        let limiter = make_limiter(600, custom_rates, HashSet::from([123]));
+
+        // Even with 1/second rate, allowlisted team is never rate limited
+        for _ in 0..100 {
+            assert!(limiter.check_rate_limit(123).is_ok());
+        }
+    }
+
+    #[tokio::test]
+    async fn test_non_allowlisted_team_still_rate_limited() {
+        let mut custom_rates = HashMap::new();
+        custom_rates.insert(456, "1/second".to_string());
+
+        let limiter = make_limiter(600, custom_rates, HashSet::from([123]));
+
+        // Non-allowlisted team 456 is still rate limited
+        assert!(limiter.check_rate_limit(456).is_ok());
+        assert!(limiter.check_rate_limit(456).is_err());
+    }
+
+    #[test]
+    fn test_allowlist_count() {
+        let limiter = make_limiter(600, HashMap::new(), HashSet::from([123, 456]));
+        assert_eq!(limiter.allowlist_count(), 2);
+    }
+
+    #[test]
+    fn test_empty_allowlist() {
+        let limiter = make_limiter(600, HashMap::new(), HashSet::new());
+        assert_eq!(limiter.allowlist_count(), 0);
     }
 }

--- a/rust/feature-flags/src/api/flag_definitions_rate_limiter.rs
+++ b/rust/feature-flags/src/api/flag_definitions_rate_limiter.rs
@@ -211,18 +211,15 @@ where
     /// Replace the allowlist with a new set of keys and mark it as freshly refreshed.
     /// Called by the request handler when the cached DB value is stale.
     pub fn update_allowlist(&self, new_allowlist: HashSet<K>) {
-        let mut allowlist = self.allowlist.write().unwrap();
-        let old_count = allowlist.len();
-        *allowlist = new_allowlist;
-        let new_count = allowlist.len();
+        let (old_count, new_count) = {
+            let mut allowlist = self.allowlist.write().unwrap();
+            let old_count = allowlist.len();
+            *allowlist = new_allowlist;
+            (old_count, allowlist.len())
+        }; // allowlist lock dropped here
         if old_count != new_count {
-            info!(
-                old_count = old_count,
-                new_count = new_count,
-                "Rate limit allowlist updated"
-            );
+            info!(old_count, new_count, "Rate limit allowlist updated");
         }
-        // Mark as refreshed
         *self.allowlist_last_refreshed.write().unwrap() = Instant::now();
     }
 

--- a/rust/feature-flags/src/config.rs
+++ b/rust/feature-flags/src/config.rs
@@ -3,7 +3,7 @@ use common_cookieless::CookielessConfig;
 use common_types::TeamId;
 use envconfig::Envconfig;
 use once_cell::sync::Lazy;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::net::SocketAddr;
 use std::num::ParseIntError;
 use std::ops::Deref;
@@ -162,6 +162,35 @@ impl FromStr for FlagDefinitionsRateLimits {
         }
 
         Ok(FlagDefinitionsRateLimits(rate_limits))
+    }
+}
+
+/// Comma-separated list of team IDs that bypass rate limiting.
+/// Matches Django's RATE_LIMITING_ALLOW_LIST_TEAMS setting.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct RateLimitingAllowList(pub HashSet<TeamId>);
+
+impl FromStr for RateLimitingAllowList {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let s = s.trim();
+        if s.is_empty() {
+            return Ok(RateLimitingAllowList::default());
+        }
+
+        let mut team_ids = HashSet::new();
+        for part in s.split(',').map(|p| p.trim()) {
+            if part.is_empty() {
+                continue;
+            }
+            let team_id = part.parse::<TeamId>().map_err(|e| {
+                format!("Invalid team ID '{part}' in RATE_LIMITING_ALLOW_LIST_TEAMS: {e}")
+            })?;
+            team_ids.insert(team_id);
+        }
+
+        Ok(RateLimitingAllowList(team_ids))
     }
 }
 
@@ -476,6 +505,11 @@ pub struct Config {
     // Example: {"123": "1200/minute", "456": "2400/hour"}
     #[envconfig(from = "LOCAL_EVAL_RATE_LIMITS", default = "")]
     pub flag_definitions_rate_limits: FlagDefinitionsRateLimits,
+
+    // Teams that bypass rate limiting entirely (comma-separated team IDs)
+    // Matches Django's RATE_LIMITING_ALLOW_LIST_TEAMS behavior
+    #[envconfig(from = "RATE_LIMITING_ALLOW_LIST_TEAMS", default = "")]
+    pub rate_limiting_allow_list_teams: RateLimitingAllowList,
 
     // OpenTelemetry configuration
     #[envconfig(from = "OTEL_EXPORTER_OTLP_ENDPOINT")]
@@ -806,6 +840,7 @@ impl Config {
             flags_session_replay_quota_check: false,
             flag_definitions_default_rate_per_minute: 600,
             flag_definitions_rate_limits: FlagDefinitionsRateLimits::default(),
+            rate_limiting_allow_list_teams: RateLimitingAllowList::default(),
             otel_url: None,
             otel_sampling_rate: 1.0,
             otel_service_name: "posthog-feature-flags".to_string(),
@@ -1149,6 +1184,52 @@ mod tests {
         let limits: FlagDefinitionsRateLimits = json.parse().unwrap();
         assert_eq!(limits.0.len(), 1);
         assert_eq!(limits.0.get(&123), Some(&"600/minute".to_string()));
+    }
+
+    #[test]
+    fn test_rate_limiting_allow_list_empty() {
+        let list: RateLimitingAllowList = "".parse().unwrap();
+        assert!(list.0.is_empty());
+    }
+
+    #[test]
+    fn test_rate_limiting_allow_list_single_id() {
+        let list: RateLimitingAllowList = "23047".parse().unwrap();
+        assert_eq!(list.0.len(), 1);
+        assert!(list.0.contains(&23047));
+    }
+
+    #[test]
+    fn test_rate_limiting_allow_list_multiple_ids() {
+        let list: RateLimitingAllowList = "23047,12345,67890".parse().unwrap();
+        assert_eq!(list.0.len(), 3);
+        assert!(list.0.contains(&23047));
+        assert!(list.0.contains(&12345));
+        assert!(list.0.contains(&67890));
+    }
+
+    #[test]
+    fn test_rate_limiting_allow_list_whitespace() {
+        let list: RateLimitingAllowList = " 23047 , 12345 ".parse().unwrap();
+        assert_eq!(list.0.len(), 2);
+        assert!(list.0.contains(&23047));
+        assert!(list.0.contains(&12345));
+    }
+
+    #[test]
+    fn test_rate_limiting_allow_list_trailing_comma() {
+        let list: RateLimitingAllowList = "23047,".parse().unwrap();
+        assert_eq!(list.0.len(), 1);
+        assert!(list.0.contains(&23047));
+    }
+
+    #[test]
+    fn test_rate_limiting_allow_list_invalid_id() {
+        let result: Result<RateLimitingAllowList, _> = "23047,abc".parse();
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .contains("Invalid team ID 'abc' in RATE_LIMITING_ALLOW_LIST_TEAMS"));
     }
 
     #[test]

--- a/rust/feature-flags/src/metrics/consts.rs
+++ b/rust/feature-flags/src/metrics/consts.rs
@@ -80,6 +80,8 @@ pub const FLAG_HASH_KEY_QUERY_RESULT: &str = "flags_hash_key_query_result_total"
 
 // Flag definitions rate limiting
 pub const FLAG_DEFINITIONS_RATE_LIMITED_COUNTER: &str = "flags_flag_definitions_rate_limited_total";
+pub const FLAG_DEFINITIONS_RATE_LIMIT_BYPASSED_COUNTER: &str =
+    "flags_flag_definitions_rate_limit_bypassed_total";
 pub const FLAG_DEFINITIONS_REQUESTS_COUNTER: &str = "flags_flag_definitions_requests_total";
 
 // Flag definitions cache metrics

--- a/rust/feature-flags/src/router.rs
+++ b/rust/feature-flags/src/router.rs
@@ -42,8 +42,8 @@ use crate::{
     flags::flag_group_type_mapping::GroupTypeCacheManager,
     metrics::{
         consts::{
-            FLAG_DEFINITIONS_RATE_LIMITED_COUNTER, FLAG_DEFINITIONS_REQUESTS_COUNTER,
-            FLAG_REQUEST_TIMEOUT_COUNTER,
+            FLAG_DEFINITIONS_RATE_LIMITED_COUNTER, FLAG_DEFINITIONS_RATE_LIMIT_BYPASSED_COUNTER,
+            FLAG_DEFINITIONS_REQUESTS_COUNTER, FLAG_REQUEST_TIMEOUT_COUNTER,
         },
         utils::team_id_label_filter,
     },
@@ -122,8 +122,10 @@ pub fn router(
     let flag_definitions_limiter = FlagDefinitionsRateLimiter::new(
         config.flag_definitions_default_rate_per_minute,
         config.flag_definitions_rate_limits.0.clone(),
+        config.rate_limiting_allow_list_teams.0.clone(),
         FLAG_DEFINITIONS_REQUESTS_COUNTER,
         FLAG_DEFINITIONS_RATE_LIMITED_COUNTER,
+        FLAG_DEFINITIONS_RATE_LIMIT_BYPASSED_COUNTER,
     )
     .expect("Failed to initialize flag definitions rate limiter");
 

--- a/rust/feature-flags/src/utils/test_utils.rs
+++ b/rust/feature-flags/src/utils/test_utils.rs
@@ -1606,6 +1606,35 @@ impl TestContext {
         .await?;
         Ok(())
     }
+
+    /// Sets a value in the posthog_instancesetting table (upsert).
+    /// Uses the constance prefix matching Django's CONSTANCE_DATABASE_PREFIX.
+    pub async fn set_instance_setting(&self, key: &str, value: &str) -> Result<(), Error> {
+        let mut conn = self.non_persons_writer.get_connection().await?;
+        let full_key = format!("constance:posthog:{key}");
+        sqlx::query(
+            "INSERT INTO posthog_instancesetting (key, raw_value)
+             VALUES ($1, $2)
+             ON CONFLICT ON CONSTRAINT \"unique key\"
+             DO UPDATE SET raw_value = $2",
+        )
+        .bind(&full_key)
+        .bind(value)
+        .execute(&mut *conn)
+        .await?;
+        Ok(())
+    }
+
+    /// Deletes a value from the posthog_instancesetting table.
+    pub async fn delete_instance_setting(&self, key: &str) -> Result<(), Error> {
+        let mut conn = self.non_persons_writer.get_connection().await?;
+        let full_key = format!("constance:posthog:{key}");
+        sqlx::query("DELETE FROM posthog_instancesetting WHERE key = $1")
+            .bind(&full_key)
+            .execute(&mut *conn)
+            .await?;
+        Ok(())
+    }
 }
 
 pub struct MockGroupTypeFetcher {

--- a/rust/feature-flags/tests/test_flag_definitions.rs
+++ b/rust/feature-flags/tests/test_flag_definitions.rs
@@ -1962,6 +1962,9 @@ async fn test_flag_definitions_with_legacy_secret_token_fallback() {
 /// 1. Allowlisted team bypasses rate limit (200 instead of 429)
 /// 2. Non-allowlisted team gets rate limited (429)
 /// 3. With two teams, only the listed one bypasses
+/// 4. Env var allowlist preserved when DB row is missing
+/// 5. null DB value treated as empty allowlist
+/// 6. Invalid team IDs skipped, valid ones kept
 #[tokio::test]
 async fn test_db_rate_limit_allowlist() {
     use feature_flags::{config::Config, utils::test_utils::TestContext};
@@ -2154,6 +2157,165 @@ async fn test_db_rate_limit_allowlist() {
         assert!(
             saw_rate_limit,
             "Non-allowlisted team2 should eventually be rate limited"
+        );
+    }
+
+    // --- Scenario 4: env var allowlist preserved when DB row is missing ---
+    {
+        // Configure team1 as allowlisted via the env var (set at server startup)
+        let mut config = Config::default_test_config();
+        config.flag_definitions_rate_limits =
+            format!(r#"{{"{}": "1/second"}}"#, team1.id).parse().unwrap();
+        config.rate_limiting_allow_list_teams =
+            team1.id.to_string().parse().unwrap();
+
+        // Ensure no DB row exists — env var default should be kept
+        context
+            .delete_instance_setting("RATE_LIMITING_ALLOW_LIST_TEAMS")
+            .await
+            .unwrap();
+
+        let redis_client =
+            feature_flags::utils::test_utils::setup_redis_client(Some(config.redis_url.clone()))
+                .await;
+        context
+            .populate_flag_definitions_cache(redis_client, team1.id)
+            .await
+            .unwrap();
+
+        let server = common::ServerHandle::for_config(config).await;
+        let client = reqwest::Client::new();
+
+        // First request triggers DB refresh — row missing, so env var default is kept
+        let resp = client
+            .get(format!(
+                "http://{}/flags/definitions?token={}",
+                server.addr, team1.api_token
+            ))
+            .header("Authorization", format!("Bearer {secret1}"))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), 200);
+
+        // Second request: team1 should still bypass via env var allowlist
+        let resp = client
+            .get(format!(
+                "http://{}/flags/definitions?token={}",
+                server.addr, team1.api_token
+            ))
+            .header("Authorization", format!("Bearer {secret1}"))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(
+            resp.status(),
+            200,
+            "Env var allowlist should be preserved when DB row is missing"
+        );
+    }
+
+    // --- Scenario 5: null DB value treated as empty allowlist ---
+    {
+        let mut config = Config::default_test_config();
+        config.flag_definitions_rate_limits =
+            format!(r#"{{"{}": "1/second"}}"#, team1.id).parse().unwrap();
+
+        context
+            .set_instance_setting("RATE_LIMITING_ALLOW_LIST_TEAMS", "null")
+            .await
+            .unwrap();
+
+        let redis_client =
+            feature_flags::utils::test_utils::setup_redis_client(Some(config.redis_url.clone()))
+                .await;
+        context
+            .populate_flag_definitions_cache(redis_client, team1.id)
+            .await
+            .unwrap();
+
+        let server = common::ServerHandle::for_config(config).await;
+        let client = reqwest::Client::new();
+
+        let resp = client
+            .get(format!(
+                "http://{}/flags/definitions?token={}",
+                server.addr, team1.api_token
+            ))
+            .header("Authorization", format!("Bearer {secret1}"))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), 200);
+
+        // null means empty allowlist — team should be rate limited
+        let resp = client
+            .get(format!(
+                "http://{}/flags/definitions?token={}",
+                server.addr, team1.api_token
+            ))
+            .header("Authorization", format!("Bearer {secret1}"))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(
+            resp.status(),
+            429,
+            "null DB value should be treated as empty allowlist"
+        );
+    }
+
+    // --- Scenario 6: invalid team IDs skipped, valid ones kept ---
+    {
+        let mut config = Config::default_test_config();
+        config.flag_definitions_rate_limits =
+            format!(r#"{{"{}": "1/second"}}"#, team1.id).parse().unwrap();
+
+        // Mix of valid and invalid IDs — team1 should still be allowlisted
+        context
+            .set_instance_setting(
+                "RATE_LIMITING_ALLOW_LIST_TEAMS",
+                &format!("{},abc,xyz", team1.id),
+            )
+            .await
+            .unwrap();
+
+        let redis_client =
+            feature_flags::utils::test_utils::setup_redis_client(Some(config.redis_url.clone()))
+                .await;
+        context
+            .populate_flag_definitions_cache(redis_client, team1.id)
+            .await
+            .unwrap();
+
+        let server = common::ServerHandle::for_config(config).await;
+        let client = reqwest::Client::new();
+
+        let resp = client
+            .get(format!(
+                "http://{}/flags/definitions?token={}",
+                server.addr, team1.api_token
+            ))
+            .header("Authorization", format!("Bearer {secret1}"))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), 200);
+
+        // team1 is in the valid portion of the allowlist — should bypass
+        let resp = client
+            .get(format!(
+                "http://{}/flags/definitions?token={}",
+                server.addr, team1.api_token
+            ))
+            .header("Authorization", format!("Bearer {secret1}"))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(
+            resp.status(),
+            200,
+            "Valid team IDs should be kept even when invalid ones are present"
         );
     }
 

--- a/rust/feature-flags/tests/test_flag_definitions.rs
+++ b/rust/feature-flags/tests/test_flag_definitions.rs
@@ -1961,7 +1961,10 @@ static ALLOWLIST_TEST_MUTEX: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_
 #[case::allowlisted(true, 200)]
 #[case::not_allowlisted(false, 429)]
 #[tokio::test]
-async fn test_db_allowlist_rate_limit_bypass(#[case] in_allowlist: bool, #[case] expected_status: u16) {
+async fn test_db_allowlist_rate_limit_bypass(
+    #[case] in_allowlist: bool,
+    #[case] expected_status: u16,
+) {
     let _lock = ALLOWLIST_TEST_MUTEX.lock().await;
     use feature_flags::{
         api::flag_definitions::invalidate_allowlist_cache, config::Config,
@@ -2094,7 +2097,11 @@ async fn test_db_allowlist_only_listed_team_bypasses() {
             .send()
             .await
             .unwrap();
-        assert_eq!(response.status(), 200, "Allowlisted team1 request {i} should succeed");
+        assert_eq!(
+            response.status(),
+            200,
+            "Allowlisted team1 request {i} should succeed"
+        );
     }
 
     // Team2 (not allowlisted) should eventually be rate limited
@@ -2114,7 +2121,10 @@ async fn test_db_allowlist_only_listed_team_bypasses() {
             break;
         }
     }
-    assert!(saw_rate_limit, "Non-allowlisted team2 should eventually be rate limited");
+    assert!(
+        saw_rate_limit,
+        "Non-allowlisted team2 should eventually be rate limited"
+    );
 
     context
         .delete_instance_setting("RATE_LIMITING_ALLOW_LIST_TEAMS")

--- a/rust/feature-flags/tests/test_flag_definitions.rs
+++ b/rust/feature-flags/tests/test_flag_definitions.rs
@@ -2164,10 +2164,10 @@ async fn test_db_rate_limit_allowlist() {
     {
         // Configure team1 as allowlisted via the env var (set at server startup)
         let mut config = Config::default_test_config();
-        config.flag_definitions_rate_limits =
-            format!(r#"{{"{}": "1/second"}}"#, team1.id).parse().unwrap();
-        config.rate_limiting_allow_list_teams =
-            team1.id.to_string().parse().unwrap();
+        config.flag_definitions_rate_limits = format!(r#"{{"{}": "1/second"}}"#, team1.id)
+            .parse()
+            .unwrap();
+        config.rate_limiting_allow_list_teams = team1.id.to_string().parse().unwrap();
 
         // Ensure no DB row exists — env var default should be kept
         context
@@ -2218,8 +2218,9 @@ async fn test_db_rate_limit_allowlist() {
     // --- Scenario 5: null DB value treated as empty allowlist ---
     {
         let mut config = Config::default_test_config();
-        config.flag_definitions_rate_limits =
-            format!(r#"{{"{}": "1/second"}}"#, team1.id).parse().unwrap();
+        config.flag_definitions_rate_limits = format!(r#"{{"{}": "1/second"}}"#, team1.id)
+            .parse()
+            .unwrap();
 
         context
             .set_instance_setting("RATE_LIMITING_ALLOW_LIST_TEAMS", "null")
@@ -2268,8 +2269,9 @@ async fn test_db_rate_limit_allowlist() {
     // --- Scenario 6: invalid team IDs skipped, valid ones kept ---
     {
         let mut config = Config::default_test_config();
-        config.flag_definitions_rate_limits =
-            format!(r#"{{"{}": "1/second"}}"#, team1.id).parse().unwrap();
+        config.flag_definitions_rate_limits = format!(r#"{{"{}": "1/second"}}"#, team1.id)
+            .parse()
+            .unwrap();
 
         // Mix of valid and invalid IDs — team1 should still be allowlisted
         context

--- a/rust/feature-flags/tests/test_flag_definitions.rs
+++ b/rust/feature-flags/tests/test_flag_definitions.rs
@@ -1968,6 +1968,12 @@ async fn test_db_rate_limit_allowlist() {
 
     let context = TestContext::new(None).await;
 
+    // Clean up any leftover rows from a previous failed run
+    context
+        .delete_instance_setting("RATE_LIMITING_ALLOW_LIST_TEAMS")
+        .await
+        .unwrap();
+
     let (team1, secret1, _) = context
         .create_team_with_secret_token(None, None, None)
         .await

--- a/rust/feature-flags/tests/test_flag_definitions.rs
+++ b/rust/feature-flags/tests/test_flag_definitions.rs
@@ -1965,6 +1965,7 @@ async fn test_flag_definitions_with_legacy_secret_token_fallback() {
 /// 4. Env var allowlist preserved when DB row is missing
 /// 5. null DB value treated as empty allowlist
 /// 6. Invalid team IDs skipped, valid ones kept
+/// 7. Django-format JSON-encoded string (json.dumps wrapping)
 #[tokio::test]
 async fn test_db_rate_limit_allowlist() {
     use feature_flags::{config::Config, utils::test_utils::TestContext};
@@ -2318,6 +2319,62 @@ async fn test_db_rate_limit_allowlist() {
             resp.status(),
             200,
             "Valid team IDs should be kept even when invalid ones are present"
+        );
+    }
+
+    // --- Scenario 7: Django-format JSON-encoded string ---
+    {
+        let mut config = Config::default_test_config();
+        config.flag_definitions_rate_limits = format!(r#"{{"{}": "1/second"}}"#, team1.id)
+            .parse()
+            .unwrap();
+
+        // Django's set_instance_setting calls json.dumps(value), so "23047"
+        // is stored as "\"23047\"" in raw_value
+        context
+            .set_instance_setting(
+                "RATE_LIMITING_ALLOW_LIST_TEAMS",
+                &format!("\"{}\"", team1.id),
+            )
+            .await
+            .unwrap();
+
+        let redis_client =
+            feature_flags::utils::test_utils::setup_redis_client(Some(config.redis_url.clone()))
+                .await;
+        context
+            .populate_flag_definitions_cache(redis_client, team1.id)
+            .await
+            .unwrap();
+
+        let server = common::ServerHandle::for_config(config).await;
+        let client = reqwest::Client::new();
+
+        let resp = client
+            .get(format!(
+                "http://{}/flags/definitions?token={}",
+                server.addr, team1.api_token
+            ))
+            .header("Authorization", format!("Bearer {secret1}"))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), 200);
+
+        // team1 should bypass via JSON-encoded allowlist
+        let resp = client
+            .get(format!(
+                "http://{}/flags/definitions?token={}",
+                server.addr, team1.api_token
+            ))
+            .header("Authorization", format!("Bearer {secret1}"))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(
+            resp.status(),
+            200,
+            "Django-format JSON-encoded allowlist should work"
         );
     }
 

--- a/rust/feature-flags/tests/test_flag_definitions.rs
+++ b/rust/feature-flags/tests/test_flag_definitions.rs
@@ -1954,178 +1954,204 @@ async fn test_flag_definitions_with_legacy_secret_token_fallback() {
     );
 }
 
-// Tests that use the global ALLOWLIST_CACHE must run sequentially
-static ALLOWLIST_TEST_MUTEX: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
-
-#[rstest::rstest]
-#[case::allowlisted(true, 200)]
-#[case::not_allowlisted(false, 429)]
+/// Tests the DB-backed rate limit allowlist end-to-end.
+/// Combined into a single test to avoid DB-level interference — all scenarios
+/// share the same `posthog_instancesetting` row.
+///
+/// Scenarios tested:
+/// 1. Allowlisted team bypasses rate limit (200 instead of 429)
+/// 2. Non-allowlisted team gets rate limited (429)
+/// 3. With two teams, only the listed one bypasses
 #[tokio::test]
-async fn test_db_allowlist_rate_limit_bypass(
-    #[case] in_allowlist: bool,
-    #[case] expected_status: u16,
-) {
-    let _lock = ALLOWLIST_TEST_MUTEX.lock().await;
-    use feature_flags::{
-        api::flag_definitions::invalidate_allowlist_cache, config::Config,
-        utils::test_utils::TestContext,
-    };
+async fn test_db_rate_limit_allowlist() {
+    use feature_flags::{config::Config, utils::test_utils::TestContext};
 
     let context = TestContext::new(None).await;
 
-    let (team, secret_token, _) = context
+    let (team1, secret1, _) = context
         .create_team_with_secret_token(None, None, None)
         .await
         .unwrap();
 
-    let mut config = Config::default_test_config();
-    config.flag_definitions_rate_limits =
-        format!(r#"{{"{}": "1/second"}}"#, team.id).parse().unwrap();
+    let (team2, secret2, _) = context
+        .create_team_with_secret_token(None, None, None)
+        .await
+        .unwrap();
 
-    if in_allowlist {
+    // --- Scenario 1: allowlisted team bypasses rate limit ---
+    {
+        let mut config = Config::default_test_config();
+        config.flag_definitions_rate_limits = format!(r#"{{"{}": "1/second"}}"#, team1.id)
+            .parse()
+            .unwrap();
+
         context
-            .set_instance_setting("RATE_LIMITING_ALLOW_LIST_TEAMS", &team.id.to_string())
+            .set_instance_setting("RATE_LIMITING_ALLOW_LIST_TEAMS", &team1.id.to_string())
             .await
             .unwrap();
-    } else {
+
+        let redis_client =
+            feature_flags::utils::test_utils::setup_redis_client(Some(config.redis_url.clone()))
+                .await;
         context
-            .delete_instance_setting("RATE_LIMITING_ALLOW_LIST_TEAMS")
+            .populate_flag_definitions_cache(redis_client, team1.id)
             .await
             .unwrap();
-    }
 
-    let redis_client =
-        feature_flags::utils::test_utils::setup_redis_client(Some(config.redis_url.clone())).await;
-    context
-        .populate_flag_definitions_cache(redis_client, team.id)
-        .await
-        .unwrap();
+        let server = common::ServerHandle::for_config(config).await;
+        let client = reqwest::Client::new();
 
-    let server = common::ServerHandle::for_config(config).await;
-    let client = reqwest::Client::new();
-
-    invalidate_allowlist_cache().await;
-
-    // First request succeeds (within rate limit) and triggers allowlist refresh from DB
-    let response = client
-        .get(format!(
-            "http://{}/flags/definitions?token={}",
-            server.addr, team.api_token
-        ))
-        .header("Authorization", format!("Bearer {secret_token}"))
-        .send()
-        .await
-        .unwrap();
-    assert_eq!(response.status(), 200);
-
-    // Second request: allowlisted teams bypass, non-allowlisted get 429
-    let response = client
-        .get(format!(
-            "http://{}/flags/definitions?token={}",
-            server.addr, team.api_token
-        ))
-        .header("Authorization", format!("Bearer {secret_token}"))
-        .send()
-        .await
-        .unwrap();
-    assert_eq!(response.status(), expected_status);
-
-    context
-        .delete_instance_setting("RATE_LIMITING_ALLOW_LIST_TEAMS")
-        .await
-        .unwrap();
-}
-
-#[tokio::test]
-async fn test_db_allowlist_only_listed_team_bypasses() {
-    let _lock = ALLOWLIST_TEST_MUTEX.lock().await;
-    use feature_flags::{
-        api::flag_definitions::invalidate_allowlist_cache, config::Config,
-        utils::test_utils::TestContext,
-    };
-
-    let context = TestContext::new(None).await;
-
-    let (team1, secret_token1, _) = context
-        .create_team_with_secret_token(None, None, None)
-        .await
-        .unwrap();
-
-    let (team2, secret_token2, _) = context
-        .create_team_with_secret_token(None, None, None)
-        .await
-        .unwrap();
-
-    let mut config = Config::default_test_config();
-    config.flag_definitions_rate_limits = format!(
-        r#"{{"{}": "1/second", "{}": "1/second"}}"#,
-        team1.id, team2.id
-    )
-    .parse()
-    .unwrap();
-
-    // Only team1 is allowlisted
-    context
-        .set_instance_setting("RATE_LIMITING_ALLOW_LIST_TEAMS", &team1.id.to_string())
-        .await
-        .unwrap();
-
-    let redis_client =
-        feature_flags::utils::test_utils::setup_redis_client(Some(config.redis_url.clone())).await;
-    context
-        .populate_flag_definitions_cache(redis_client.clone(), team1.id)
-        .await
-        .unwrap();
-    context
-        .populate_flag_definitions_cache(redis_client, team2.id)
-        .await
-        .unwrap();
-
-    let server = common::ServerHandle::for_config(config).await;
-    let client = reqwest::Client::new();
-
-    invalidate_allowlist_cache().await;
-
-    // Team1 (allowlisted) can make many requests without being rate limited
-    for i in 0..5 {
-        let response = client
+        // First request triggers DB refresh
+        let resp = client
             .get(format!(
                 "http://{}/flags/definitions?token={}",
                 server.addr, team1.api_token
             ))
-            .header("Authorization", format!("Bearer {secret_token1}"))
+            .header("Authorization", format!("Bearer {secret1}"))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), 200);
+
+        // Second request would be rate limited, but allowlist bypasses it
+        let resp = client
+            .get(format!(
+                "http://{}/flags/definitions?token={}",
+                server.addr, team1.api_token
+            ))
+            .header("Authorization", format!("Bearer {secret1}"))
             .send()
             .await
             .unwrap();
         assert_eq!(
-            response.status(),
+            resp.status(),
             200,
-            "Allowlisted team1 request {i} should succeed"
+            "Allowlisted team should bypass rate limit"
         );
     }
 
-    // Team2 (not allowlisted) should eventually be rate limited
-    let mut saw_rate_limit = false;
-    for _ in 0..10 {
-        let response = client
+    // --- Scenario 2: non-allowlisted team gets rate limited ---
+    {
+        let mut config = Config::default_test_config();
+        config.flag_definitions_rate_limits = format!(r#"{{"{}": "1/second"}}"#, team1.id)
+            .parse()
+            .unwrap();
+
+        context
+            .delete_instance_setting("RATE_LIMITING_ALLOW_LIST_TEAMS")
+            .await
+            .unwrap();
+
+        let redis_client =
+            feature_flags::utils::test_utils::setup_redis_client(Some(config.redis_url.clone()))
+                .await;
+        context
+            .populate_flag_definitions_cache(redis_client, team1.id)
+            .await
+            .unwrap();
+
+        let server = common::ServerHandle::for_config(config).await;
+        let client = reqwest::Client::new();
+
+        let resp = client
             .get(format!(
                 "http://{}/flags/definitions?token={}",
-                server.addr, team2.api_token
+                server.addr, team1.api_token
             ))
-            .header("Authorization", format!("Bearer {secret_token2}"))
+            .header("Authorization", format!("Bearer {secret1}"))
             .send()
             .await
             .unwrap();
-        if response.status() == 429 {
-            saw_rate_limit = true;
-            break;
-        }
-    }
-    assert!(
-        saw_rate_limit,
-        "Non-allowlisted team2 should eventually be rate limited"
-    );
+        assert_eq!(resp.status(), 200);
 
+        let resp = client
+            .get(format!(
+                "http://{}/flags/definitions?token={}",
+                server.addr, team1.api_token
+            ))
+            .header("Authorization", format!("Bearer {secret1}"))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(
+            resp.status(),
+            429,
+            "Non-allowlisted team should be rate limited"
+        );
+    }
+
+    // --- Scenario 3: only listed team bypasses, other team gets limited ---
+    {
+        let mut config = Config::default_test_config();
+        config.flag_definitions_rate_limits = format!(
+            r#"{{"{}": "1/second", "{}": "1/second"}}"#,
+            team1.id, team2.id
+        )
+        .parse()
+        .unwrap();
+
+        context
+            .set_instance_setting("RATE_LIMITING_ALLOW_LIST_TEAMS", &team1.id.to_string())
+            .await
+            .unwrap();
+
+        let redis_client =
+            feature_flags::utils::test_utils::setup_redis_client(Some(config.redis_url.clone()))
+                .await;
+        context
+            .populate_flag_definitions_cache(redis_client.clone(), team1.id)
+            .await
+            .unwrap();
+        context
+            .populate_flag_definitions_cache(redis_client, team2.id)
+            .await
+            .unwrap();
+
+        let server = common::ServerHandle::for_config(config).await;
+        let client = reqwest::Client::new();
+
+        // Team1 (allowlisted) can make many requests
+        for i in 0..5 {
+            let resp = client
+                .get(format!(
+                    "http://{}/flags/definitions?token={}",
+                    server.addr, team1.api_token
+                ))
+                .header("Authorization", format!("Bearer {secret1}"))
+                .send()
+                .await
+                .unwrap();
+            assert_eq!(
+                resp.status(),
+                200,
+                "Allowlisted team1 request {i} should succeed"
+            );
+        }
+
+        // Team2 (not allowlisted) should eventually be rate limited
+        let mut saw_rate_limit = false;
+        for _ in 0..10 {
+            let resp = client
+                .get(format!(
+                    "http://{}/flags/definitions?token={}",
+                    server.addr, team2.api_token
+                ))
+                .header("Authorization", format!("Bearer {secret2}"))
+                .send()
+                .await
+                .unwrap();
+            if resp.status() == 429 {
+                saw_rate_limit = true;
+                break;
+            }
+        }
+        assert!(
+            saw_rate_limit,
+            "Non-allowlisted team2 should eventually be rate limited"
+        );
+    }
+
+    // Clean up
     context
         .delete_instance_setting("RATE_LIMITING_ALLOW_LIST_TEAMS")
         .await

--- a/rust/feature-flags/tests/test_flag_definitions.rs
+++ b/rust/feature-flags/tests/test_flag_definitions.rs
@@ -1953,3 +1953,171 @@ async fn test_flag_definitions_with_legacy_secret_token_fallback() {
         response.text().await.unwrap()
     );
 }
+
+// Tests that use the global ALLOWLIST_CACHE must run sequentially
+static ALLOWLIST_TEST_MUTEX: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+#[rstest::rstest]
+#[case::allowlisted(true, 200)]
+#[case::not_allowlisted(false, 429)]
+#[tokio::test]
+async fn test_db_allowlist_rate_limit_bypass(#[case] in_allowlist: bool, #[case] expected_status: u16) {
+    let _lock = ALLOWLIST_TEST_MUTEX.lock().await;
+    use feature_flags::{
+        api::flag_definitions::invalidate_allowlist_cache, config::Config,
+        utils::test_utils::TestContext,
+    };
+
+    let context = TestContext::new(None).await;
+
+    let (team, secret_token, _) = context
+        .create_team_with_secret_token(None, None, None)
+        .await
+        .unwrap();
+
+    let mut config = Config::default_test_config();
+    config.flag_definitions_rate_limits =
+        format!(r#"{{"{}": "1/second"}}"#, team.id).parse().unwrap();
+
+    if in_allowlist {
+        context
+            .set_instance_setting("RATE_LIMITING_ALLOW_LIST_TEAMS", &team.id.to_string())
+            .await
+            .unwrap();
+    } else {
+        context
+            .delete_instance_setting("RATE_LIMITING_ALLOW_LIST_TEAMS")
+            .await
+            .unwrap();
+    }
+
+    let redis_client =
+        feature_flags::utils::test_utils::setup_redis_client(Some(config.redis_url.clone())).await;
+    context
+        .populate_flag_definitions_cache(redis_client, team.id)
+        .await
+        .unwrap();
+
+    let server = common::ServerHandle::for_config(config).await;
+    let client = reqwest::Client::new();
+
+    invalidate_allowlist_cache().await;
+
+    // First request succeeds (within rate limit) and triggers allowlist refresh from DB
+    let response = client
+        .get(format!(
+            "http://{}/flags/definitions?token={}",
+            server.addr, team.api_token
+        ))
+        .header("Authorization", format!("Bearer {secret_token}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), 200);
+
+    // Second request: allowlisted teams bypass, non-allowlisted get 429
+    let response = client
+        .get(format!(
+            "http://{}/flags/definitions?token={}",
+            server.addr, team.api_token
+        ))
+        .header("Authorization", format!("Bearer {secret_token}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), expected_status);
+
+    context
+        .delete_instance_setting("RATE_LIMITING_ALLOW_LIST_TEAMS")
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn test_db_allowlist_only_listed_team_bypasses() {
+    let _lock = ALLOWLIST_TEST_MUTEX.lock().await;
+    use feature_flags::{
+        api::flag_definitions::invalidate_allowlist_cache, config::Config,
+        utils::test_utils::TestContext,
+    };
+
+    let context = TestContext::new(None).await;
+
+    let (team1, secret_token1, _) = context
+        .create_team_with_secret_token(None, None, None)
+        .await
+        .unwrap();
+
+    let (team2, secret_token2, _) = context
+        .create_team_with_secret_token(None, None, None)
+        .await
+        .unwrap();
+
+    let mut config = Config::default_test_config();
+    config.flag_definitions_rate_limits = format!(
+        r#"{{"{}": "1/second", "{}": "1/second"}}"#,
+        team1.id, team2.id
+    )
+    .parse()
+    .unwrap();
+
+    // Only team1 is allowlisted
+    context
+        .set_instance_setting("RATE_LIMITING_ALLOW_LIST_TEAMS", &team1.id.to_string())
+        .await
+        .unwrap();
+
+    let redis_client =
+        feature_flags::utils::test_utils::setup_redis_client(Some(config.redis_url.clone())).await;
+    context
+        .populate_flag_definitions_cache(redis_client.clone(), team1.id)
+        .await
+        .unwrap();
+    context
+        .populate_flag_definitions_cache(redis_client, team2.id)
+        .await
+        .unwrap();
+
+    let server = common::ServerHandle::for_config(config).await;
+    let client = reqwest::Client::new();
+
+    invalidate_allowlist_cache().await;
+
+    // Team1 (allowlisted) can make many requests without being rate limited
+    for i in 0..5 {
+        let response = client
+            .get(format!(
+                "http://{}/flags/definitions?token={}",
+                server.addr, team1.api_token
+            ))
+            .header("Authorization", format!("Bearer {secret_token1}"))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(response.status(), 200, "Allowlisted team1 request {i} should succeed");
+    }
+
+    // Team2 (not allowlisted) should eventually be rate limited
+    let mut saw_rate_limit = false;
+    for _ in 0..10 {
+        let response = client
+            .get(format!(
+                "http://{}/flags/definitions?token={}",
+                server.addr, team2.api_token
+            ))
+            .header("Authorization", format!("Bearer {secret_token2}"))
+            .send()
+            .await
+            .unwrap();
+        if response.status() == 429 {
+            saw_rate_limit = true;
+            break;
+        }
+    }
+    assert!(saw_rate_limit, "Non-allowlisted team2 should eventually be rate limited");
+
+    context
+        .delete_instance_setting("RATE_LIMITING_ALLOW_LIST_TEAMS")
+        .await
+        .unwrap();
+}


### PR DESCRIPTION
## Problem

The Rust feature-flags service needs to support rate limit bypasses for specific teams, matching the existing Django `RATE_LIMITING_ALLOW_LIST_TEAMS` behavior. Without this, allowlisted teams that should be exempt from rate limiting on the `/flags/definitions` endpoint get blocked by the Rust service.

## Changes

This adds a `RATE_LIMITING_ALLOW_LIST_TEAMS` setting in Rust that matches the Django format. Teams in this list bypass rate limits with the same semantics that Django did.

- Add `RateLimitingAllowList` config type in `config.rs` that parses the `RATE_LIMITING_ALLOW_LIST_TEAMS` env var (comma-separated team IDs), matching Django's format
- Add `allowlist` field and `bypassed_counter` metric to `KeyedRateLimiter`
- In `check_rate_limit()`, allowlisted teams that exceed the rate limit are allowed through with a `bypassed_counter` metric increment, matching Django's semantics where the bypass counter only fires for requests that would have been blocked
- All requests (including allowlisted) are counted in `request_counter` for accurate total traffic visibility
- Add `FLAG_DEFINITIONS_RATE_LIMIT_BYPASSED_COUNTER` metric constant
- Refactor tests with `make_limiter` helper to reduce boilerplate

## How did you test this code?

- 6 unit tests for `RateLimitingAllowList` parsing (empty, single, multiple, whitespace, trailing comma, invalid)
- 4 unit tests for allowlist behavior (bypass when rate limited, non-allowlisted still limited, count accessors)
- All 14 existing rate limiter tests continue to pass

## Publish to changelog?

No

## Docs update

No docs changes needed. Reuses the existing `RATE_LIMITING_ALLOW_LIST_TEAMS` env var.

## TODO

- [ ] Read setting from the `posthog_instancesetting` table.

## Context

Instead of a static env var, Django reads this value from the `posthog_instancesetting` table.