### PR TITLE
fix(dagster): don't report dry runs as failures in part breaker

### DIFF
--- a/posthog/dags/part_breaker.py
+++ b/posthog/dags/part_breaker.py
@@ -1200,14 +1200,20 @@ def break_part(
 @dagster.op
 def report_results(
     context: dagster.OpExecutionContext,
+    config: PartBreakerConfig,
     results: list[Optional[BreakResult]],
 ):
     """Summarize the results of the part breaking run."""
     completed = [r for r in results if r is not None]
     failed_count = len(results) - len(completed)
 
+    if config.dry_run:
+        context.log.info(f"DRY RUN complete — checked {len(results)} part(s), no modifications made")
+        context.add_output_metadata({"parts_checked": len(results), "status": "dry_run"})
+        return
+
     if not completed and failed_count == 0:
-        context.log.info("No parts were processed (dry run or nothing to do)")
+        context.log.info("No parts were processed (nothing to do)")
         context.add_output_metadata({"parts_processed": 0, "status": "no_work"})
         return
 

--- a/posthog/dags/part_breaker.py
+++ b/posthog/dags/part_breaker.py
@@ -120,11 +120,12 @@ class BreakResult:
     """Result of breaking a single oversized part."""
 
     part: PartStats
-    source_count: int
-    post_count: int
-    new_largest_part_gib: float
-    new_part_count: int
-    duration_seconds: float
+    source_count: int = 0
+    post_count: int = 0
+    new_largest_part_gib: float = 0.0
+    new_part_count: int = 0
+    duration_seconds: float = 0.0
+    dry_run: bool = False
 
     @property
     def count_diff_pct(self) -> float:
@@ -824,7 +825,7 @@ def break_part(
             ).result()
         except Exception:
             context.log.exception(f"Dry run failed for {source_table} shard {shard}, part {part.part_name}")
-        return None
+        return BreakResult(part=part, dry_run=True)
 
     start_time = time.time()
 
@@ -1200,16 +1201,16 @@ def break_part(
 @dagster.op
 def report_results(
     context: dagster.OpExecutionContext,
-    config: PartBreakerConfig,
     results: list[Optional[BreakResult]],
 ):
     """Summarize the results of the part breaking run."""
-    completed = [r for r in results if r is not None]
-    failed_count = len(results) - len(completed)
+    dry_runs = [r for r in results if r is not None and r.dry_run]
+    completed = [r for r in results if r is not None and not r.dry_run]
+    failed_count = len(results) - len(completed) - len(dry_runs)
 
-    if config.dry_run:
-        context.log.info(f"DRY RUN complete — checked {len(results)} part(s), no modifications made")
-        context.add_output_metadata({"parts_checked": len(results), "status": "dry_run"})
+    if dry_runs and not completed and failed_count == 0:
+        context.log.info(f"DRY RUN complete — checked {len(dry_runs)} part(s), no modifications made")
+        context.add_output_metadata({"parts_checked": len(dry_runs), "status": "dry_run"})
         return
 
     if not completed and failed_count == 0:


### PR DESCRIPTION
## Problem

Dry runs of the part breaker return `None` from `break_part` (by design as no modifications are made). But `report_results` treats all `None` results as failures, so dry runs raise `dagster.Failure`.

Since each Dagster op has its own config namespace, passing a `dry_run` config flag to `report_results` would require setting it in multiple places.

## Changes

- Add `dry_run: bool` field to `BreakResult` dataclass
- Dry runs now return `BreakResult(part=part, dry_run=True)` instead of `None`
- `report_results` distinguishes dry runs from real failures via the `dry_run` flag on the result object, no cross-op config dependency
- Real failures still return `None` → counted as failures → `dagster.Failure` → Slack alert

**Result classification in `report_results`:**
- `dry_runs`: `BreakResult` with `dry_run=True` → SUCCESS, "DRY RUN complete"
- `completed`: `BreakResult` with `dry_run=False` → SUCCESS with stats
- `failed`: `None` results → always real failures → raises `dagster.Failure`

## How did you test this code?

- Ran dry run on dev
- Verified real failure path still returns `None` (exception caught in `break_part`)

## Publish to changelog?

No

## Docs update

No
