### PR TITLE
feat(logs-alerts): add Temporal workflow and activities for alert evaluation

### DIFF
--- a/posthog/management/commands/start_temporal_worker.py
+++ b/posthog/management/commands/start_temporal_worker.py
@@ -146,6 +146,10 @@ from products.batch_exports.backend.temporal import (
     ACTIVITIES as BATCH_EXPORTS_ACTIVITIES,
     WORKFLOWS as BATCH_EXPORTS_WORKFLOWS,
 )
+from products.logs.backend.temporal import (
+    ACTIVITIES as LOGS_ALERTING_ACTIVITIES,
+    WORKFLOWS as LOGS_ALERTING_WORKFLOWS,
+)
 from products.signals.backend.temporal import (
     ACTIVITIES as SIGNALS_PRODUCT_ACTIVITIES,
     WORKFLOWS as SIGNALS_PRODUCT_WORKFLOWS,
@@ -291,6 +295,11 @@ _task_queue_specs = [
         settings.EVENT_SCREENSHOTS_TASK_QUEUE,
         EVENT_SCREENSHOTS_WORKFLOWS,
         EVENT_SCREENSHOTS_ACTIVITIES,
+    ),
+    (
+        settings.LOGS_ALERTING_TASK_QUEUE,
+        LOGS_ALERTING_WORKFLOWS,
+        LOGS_ALERTING_ACTIVITIES,
     ),
 ]
 

--- a/posthog/settings/temporal.py
+++ b/posthog/settings/temporal.py
@@ -86,4 +86,5 @@ LLMA_EVALS_TASK_QUEUE = _set_temporal_task_queue("llm-analytics-evals-task-queue
 LLMA_SENTIMENT_TASK_QUEUE = _set_temporal_task_queue("llm-analytics-sentiment-task-queue")
 LLMA_TASK_QUEUE = _set_temporal_task_queue("llm-analytics-task-queue")
 EVENT_SCREENSHOTS_TASK_QUEUE = _set_temporal_task_queue("event-screenshots-task-queue")
+LOGS_ALERTING_TASK_QUEUE = _set_temporal_task_queue("logs-alerting-task-queue")
 RASTERIZATION_TASK_QUEUE = "rasterization-task-queue"  # Not collapsed in dev — separate Node.js worker process

--- a/posthog/temporal/logs_alerting/schedule.py
+++ b/posthog/temporal/logs_alerting/schedule.py
@@ -1,0 +1,38 @@
+"""Schedule registration for the logs alert check workflow."""
+
+from dataclasses import asdict
+
+from django.conf import settings
+
+from temporalio.client import (
+    Client,
+    Schedule,
+    ScheduleActionStartWorkflow,
+    ScheduleOverlapPolicy,
+    SchedulePolicy,
+    ScheduleSpec,
+)
+
+from posthog.temporal.common.schedule import a_create_schedule, a_schedule_exists, a_update_schedule
+
+from products.logs.backend.temporal.activities import CheckAlertsInput
+from products.logs.backend.temporal.constants import SCHEDULE_CRON, SCHEDULE_ID, WORKFLOW_NAME
+
+
+async def create_logs_alert_check_schedule(client: Client) -> None:
+    """Create or update the logs alert check schedule."""
+    schedule = Schedule(
+        action=ScheduleActionStartWorkflow(
+            WORKFLOW_NAME,
+            asdict(CheckAlertsInput()),
+            id=SCHEDULE_ID,
+            task_queue=settings.LOGS_ALERTING_TASK_QUEUE,
+        ),
+        spec=ScheduleSpec(cron_expressions=[SCHEDULE_CRON]),
+        policy=SchedulePolicy(overlap=ScheduleOverlapPolicy.SKIP),
+    )
+
+    if await a_schedule_exists(client, SCHEDULE_ID):
+        await a_update_schedule(client, SCHEDULE_ID, schedule)
+    else:
+        await a_create_schedule(client, SCHEDULE_ID, schedule, trigger_immediately=False)

--- a/posthog/temporal/schedule.py
+++ b/posthog/temporal/schedule.py
@@ -41,6 +41,7 @@ from posthog.temporal.llm_analytics.trace_summarization.schedule import (
     create_batch_generation_summarization_schedule,
     create_batch_trace_summarization_schedule,
 )
+from posthog.temporal.logs_alerting.schedule import create_logs_alert_check_schedule
 from posthog.temporal.messaging.schedule import create_all_realtime_cohort_calculation_schedules
 from posthog.temporal.product_analytics.upgrade_queries_workflow import UpgradeQueriesWorkflowInputs
 from posthog.temporal.quota_limiting.run_quota_limiting import RunQuotaLimitingInputs
@@ -373,6 +374,7 @@ schedules = [
     create_all_realtime_cohort_calculation_schedules,
     create_ingestion_acceptance_test_schedule,
     create_health_check_schedules,
+    create_logs_alert_check_schedule,
 ]
 
 if settings.EE_AVAILABLE:

--- a/products/logs/backend/temporal/__init__.py
+++ b/products/logs/backend/temporal/__init__.py
@@ -1,0 +1,12 @@
+from products.logs.backend.temporal.activities import check_alerts_activity
+from products.logs.backend.temporal.workflow import LogsAlertCheckWorkflow
+
+WORKFLOWS: list = [LogsAlertCheckWorkflow]
+ACTIVITIES: list = [check_alerts_activity]
+
+__all__ = [
+    "LogsAlertCheckWorkflow",
+    "check_alerts_activity",
+    "WORKFLOWS",
+    "ACTIVITIES",
+]

--- a/products/logs/backend/temporal/activities.py
+++ b/products/logs/backend/temporal/activities.py
@@ -1,0 +1,245 @@
+"""Temporal activities for logs alerting."""
+
+import asyncio
+import dataclasses
+from datetime import UTC, datetime, timedelta
+
+from django.db import transaction
+from django.db.models import Q
+
+import structlog
+import temporalio.activity
+
+from posthog.cdp.internal_events import InternalEventEvent, produce_internal_event
+from posthog.exceptions_capture import capture_exception
+
+from products.logs.backend.alert_check_query import AlertCheckQuery
+from products.logs.backend.alert_state_machine import (
+    AlertSnapshot,
+    AlertState,
+    CheckResult,
+    NotificationAction,
+    evaluate_alert_check,
+)
+from products.logs.backend.alert_utils import advance_next_check_at
+from products.logs.backend.models import LogsAlertCheck, LogsAlertConfiguration
+
+logger = structlog.get_logger(__name__)
+
+
+@dataclasses.dataclass(frozen=True)
+class CheckAlertsInput:
+    pass
+
+
+@dataclasses.dataclass(frozen=True)
+class CheckAlertsOutput:
+    alerts_checked: int
+    alerts_fired: int
+    alerts_resolved: int
+    alerts_errored: int
+
+
+@temporalio.activity.defn
+async def check_alerts_activity(input: CheckAlertsInput) -> CheckAlertsOutput:
+    """Find all due alerts and evaluate them sequentially."""
+    result = await asyncio.to_thread(_check_alerts_sync)
+    return result
+
+
+def _check_alerts_sync() -> CheckAlertsOutput:
+    """Synchronous alert checking — runs in a thread."""
+    now = datetime.now(UTC)
+
+    all_alerts = list(
+        LogsAlertConfiguration.objects.filter(
+            Q(enabled=True),
+            Q(next_check_at__lte=now) | Q(next_check_at__isnull=True),
+        )
+        .select_related("team")
+        .exclude(state=LogsAlertConfiguration.State.SNOOZED, snooze_until__gt=now)
+    )
+
+    stats = {"checked": 0, "fired": 0, "resolved": 0, "errored": 0}
+
+    # Sequential for now. TODO, stagger
+    # or cap concurrency to avoid bursting all ClickHouse queries at :00 each minute.
+    for alert in all_alerts:
+        try:
+            _evaluate_single_alert(alert, now, stats)
+        except Exception:
+            logger.exception(
+                "Unexpected error evaluating alert",
+                alert_id=str(alert.id),
+                alert_name=alert.name,
+                team_id=alert.team_id,
+            )
+            stats["errored"] += 1
+
+    if stats["checked"] > 0:
+        logger.info(
+            "Alert check cycle complete",
+            **stats,
+        )
+
+    return CheckAlertsOutput(
+        alerts_checked=stats["checked"],
+        alerts_fired=stats["fired"],
+        alerts_resolved=stats["resolved"],
+        alerts_errored=stats["errored"],
+    )
+
+
+def _evaluate_single_alert(
+    alert: LogsAlertConfiguration,
+    now: datetime,
+    stats: dict[str, int],
+) -> None:
+    """Run the ClickHouse query, apply state machine, persist, and emit events for a single alert."""
+
+    date_to = now
+    date_from = now - timedelta(minutes=alert.window_minutes)
+
+    check_result: CheckResult
+    try:
+        query_result = AlertCheckQuery(
+            team=alert.team,
+            alert=alert,
+            date_from=date_from,
+            date_to=date_to,
+        ).execute()
+        threshold_breached = (
+            query_result.count > alert.threshold_count
+            if alert.threshold_operator == "above"
+            else query_result.count < alert.threshold_count
+        )
+        check_result = CheckResult(
+            result_count=query_result.count,
+            threshold_breached=threshold_breached,
+            query_duration_ms=query_result.query_duration_ms,
+        )
+    except Exception as e:
+        logger.warning(
+            "Alert check query failed",
+            alert_id=str(alert.id),
+            alert_name=alert.name,
+            team_id=alert.team_id,
+            error=str(e),
+        )
+        check_result = CheckResult(
+            result_count=None,
+            threshold_breached=False,
+            error_message=str(e),
+        )
+
+    snapshot = AlertSnapshot(
+        state=AlertState(alert.state),
+        evaluation_periods=alert.evaluation_periods,
+        datapoints_to_alarm=alert.datapoints_to_alarm,
+        cooldown_minutes=alert.cooldown_minutes,
+        last_notified_at=alert.last_notified_at,
+        snooze_until=alert.snooze_until,
+        consecutive_failures=alert.consecutive_failures,
+        recent_checks_breached=alert.get_recent_breaches(),
+    )
+
+    outcome = evaluate_alert_check(snapshot, check_result, now)
+
+    # Attempt Kafka delivery BEFORE committing state transition.
+    # If delivery fails and we needed to notify, keep old state so the
+    # next tick retries the full transition (NOT_FIRING → FIRING again).
+    notified = False
+    notification_failed = False
+    if outcome.notification == NotificationAction.FIRE:
+        notified = _emit_alert_event(alert, "$logs_alert_firing", check_result, now)
+        notification_failed = not notified
+        if notified:
+            stats["fired"] += 1
+        logger.info(
+            "Alert fired",
+            alert_id=str(alert.id),
+            alert_name=alert.name,
+            team_id=alert.team_id,
+            result_count=check_result.result_count,
+            notified=notified,
+        )
+    elif outcome.notification == NotificationAction.RESOLVE:
+        notified = _emit_alert_event(alert, "$logs_alert_resolved", check_result, now)
+        notification_failed = not notified
+        if notified:
+            stats["resolved"] += 1
+        logger.info(
+            "Alert resolved",
+            alert_id=str(alert.id),
+            alert_name=alert.name,
+            team_id=alert.team_id,
+            notified=notified,
+        )
+
+    # If the notification delivery failed, don't commit the state transition
+    # so the next tick will re-evaluate and retry the notification.
+    committed_state = AlertState(alert.state) if notification_failed else outcome.new_state
+
+    state_before = alert.state
+    with transaction.atomic():
+        LogsAlertCheck.objects.create(
+            alert=alert,
+            result_count=check_result.result_count,
+            threshold_breached=check_result.threshold_breached,
+            state_before=state_before,
+            state_after=committed_state.value,
+            error_message=outcome.error_message,
+            query_duration_ms=check_result.query_duration_ms,
+        )
+
+        alert.state = committed_state.value
+        alert.consecutive_failures = outcome.consecutive_failures
+        alert.last_checked_at = now
+        alert.next_check_at = advance_next_check_at(alert.next_check_at, alert.check_interval_minutes, now)
+
+        update_fields = ["state", "consecutive_failures", "last_checked_at", "next_check_at", "updated_at"]
+
+        if notified and outcome.update_last_notified_at:
+            alert.last_notified_at = now
+            update_fields.append("last_notified_at")
+
+        alert.save(update_fields=update_fields)
+
+    stats["checked"] += 1
+
+    if outcome.error_message:
+        stats["errored"] += 1
+
+
+def _emit_alert_event(
+    alert: LogsAlertConfiguration,
+    event_name: str,
+    check_result: CheckResult,
+    now: datetime,
+) -> bool:
+    """Produce an internal event to Kafka for CDP processing. Returns True on success."""
+    properties: dict = {
+        "alert_id": str(alert.id),
+        "alert_name": alert.name,
+        "team_id": alert.team_id,
+        "threshold_count": alert.threshold_count,
+        "threshold_operator": alert.threshold_operator,
+        "window_minutes": alert.window_minutes,
+        "result_count": check_result.result_count,
+        "filters": alert.filters,
+    }
+
+    try:
+        produce_internal_event(
+            team_id=alert.team_id,
+            event=InternalEventEvent(
+                event=event_name,
+                distinct_id=f"team_{alert.team_id}",
+                properties=properties,
+                timestamp=now.isoformat(),
+            ),
+        )
+        return True
+    except Exception as e:
+        capture_exception(e, {"alert_id": str(alert.id), "event": event_name})
+        return False

--- a/products/logs/backend/temporal/constants.py
+++ b/products/logs/backend/temporal/constants.py
@@ -1,0 +1,19 @@
+from datetime import timedelta
+
+from temporalio.common import RetryPolicy
+
+# Workflow
+WORKFLOW_NAME = "logs-alert-check"
+
+# Schedule
+SCHEDULE_ID = "logs-alert-check-schedule"
+SCHEDULE_CRON = "* * * * *"
+
+# Activity
+ACTIVITY_TIMEOUT = timedelta(minutes=5)
+ACTIVITY_RETRY_POLICY = RetryPolicy(
+    maximum_attempts=3,
+    initial_interval=timedelta(seconds=5),
+    maximum_interval=timedelta(seconds=30),
+    backoff_coefficient=2.0,
+)

--- a/products/logs/backend/temporal/workflow.py
+++ b/products/logs/backend/temporal/workflow.py
@@ -1,0 +1,25 @@
+"""Temporal workflow for logs alert checking."""
+
+import temporalio
+from temporalio import workflow
+
+from posthog.temporal.common.base import PostHogWorkflow
+
+from products.logs.backend.temporal.activities import CheckAlertsInput, CheckAlertsOutput, check_alerts_activity
+from products.logs.backend.temporal.constants import ACTIVITY_RETRY_POLICY, ACTIVITY_TIMEOUT, WORKFLOW_NAME
+
+
+@temporalio.workflow.defn(name=WORKFLOW_NAME)
+class LogsAlertCheckWorkflow(PostHogWorkflow):
+    @staticmethod
+    def parse_inputs(inputs: list[str]) -> CheckAlertsInput:
+        return CheckAlertsInput()
+
+    @temporalio.workflow.run
+    async def run(self, input: CheckAlertsInput) -> CheckAlertsOutput:
+        return await workflow.execute_activity(
+            check_alerts_activity,
+            input,
+            start_to_close_timeout=ACTIVITY_TIMEOUT,
+            retry_policy=ACTIVITY_RETRY_POLICY,
+        )

--- a/products/logs/backend/test/test_logs_alerting_activities.py
+++ b/products/logs/backend/test/test_logs_alerting_activities.py
@@ -1,0 +1,363 @@
+from datetime import UTC, datetime
+
+from freezegun import freeze_time
+from posthog.test.base import APIBaseTest
+from unittest.mock import patch
+
+from parameterized import parameterized
+
+from products.logs.backend.alert_check_query import AlertCheckCountResult
+from products.logs.backend.models import LogsAlertCheck, LogsAlertConfiguration
+from products.logs.backend.temporal.activities import CheckAlertsOutput, _check_alerts_sync, _evaluate_single_alert
+
+
+def _make_stats() -> dict[str, int]:
+    return {"checked": 0, "fired": 0, "resolved": 0, "errored": 0}
+
+
+class TestCheckAlertsSync(APIBaseTest):
+    def _make_alert(self, **kwargs) -> LogsAlertConfiguration:
+        defaults = {
+            "team": self.team,
+            "name": "Test Alert",
+            "threshold_count": 10,
+            "threshold_operator": "above",
+            "window_minutes": 5,
+            "filters": {"serviceNames": ["test-service"]},
+            "next_check_at": datetime(2025, 1, 1, 0, 0, 0, tzinfo=UTC),
+        }
+        defaults.update(kwargs)
+        return LogsAlertConfiguration.objects.create(**defaults)
+
+    @freeze_time("2025-01-01T00:01:00Z")
+    @patch("products.logs.backend.temporal.activities.AlertCheckQuery")
+    def test_no_alerts_returns_zero_stats(self, mock_query_cls):
+        result = _check_alerts_sync()
+        assert result == CheckAlertsOutput(alerts_checked=0, alerts_fired=0, alerts_resolved=0, alerts_errored=0)
+        mock_query_cls.assert_not_called()
+
+    @freeze_time("2025-01-01T00:01:00Z")
+    @patch("products.logs.backend.temporal.activities.AlertCheckQuery")
+    def test_skips_disabled_alerts(self, mock_query_cls):
+        self._make_alert(enabled=False)
+        result = _check_alerts_sync()
+        assert result.alerts_checked == 0
+        mock_query_cls.assert_not_called()
+
+    @freeze_time("2025-01-01T00:01:00Z")
+    @patch("products.logs.backend.temporal.activities.AlertCheckQuery")
+    def test_skips_snoozed_alerts(self, mock_query_cls):
+        self._make_alert(
+            state=LogsAlertConfiguration.State.SNOOZED,
+            snooze_until=datetime(2025, 1, 2, 0, 0, 0, tzinfo=UTC),
+        )
+        result = _check_alerts_sync()
+        assert result.alerts_checked == 0
+
+    @freeze_time("2025-01-01T00:01:00Z")
+    @patch("products.logs.backend.temporal.activities.AlertCheckQuery")
+    def test_picks_up_due_alert(self, mock_query_cls):
+        mock_query_cls.return_value.execute.return_value = AlertCheckCountResult(count=5, query_duration_ms=100)
+        self._make_alert()
+        result = _check_alerts_sync()
+        assert result.alerts_checked == 1
+
+    @freeze_time("2025-01-01T00:01:00Z")
+    @patch("products.logs.backend.temporal.activities.AlertCheckQuery")
+    def test_picks_up_null_next_check_at(self, mock_query_cls):
+        mock_query_cls.return_value.execute.return_value = AlertCheckCountResult(count=5, query_duration_ms=100)
+        self._make_alert(next_check_at=None)
+        result = _check_alerts_sync()
+        assert result.alerts_checked == 1
+
+    @freeze_time("2025-01-01T00:01:00Z")
+    @patch("products.logs.backend.temporal.activities.AlertCheckQuery")
+    def test_skips_future_next_check_at(self, mock_query_cls):
+        self._make_alert(next_check_at=datetime(2025, 1, 1, 1, 0, 0, tzinfo=UTC))
+        result = _check_alerts_sync()
+        assert result.alerts_checked == 0
+
+    @freeze_time("2025-01-01T00:01:00Z")
+    @patch("products.logs.backend.temporal.activities.AlertCheckQuery")
+    def test_clickhouse_error_records_errored_check(self, mock_query_cls):
+        mock_query_cls.return_value.execute.side_effect = RuntimeError("boom")
+        self._make_alert()
+        result = _check_alerts_sync()
+        # ClickHouse error is caught inside _evaluate_single_alert, alert is still "checked"
+        assert result.alerts_checked == 1
+        assert result.alerts_errored == 1
+
+    @freeze_time("2025-01-01T00:01:00Z")
+    @patch("products.logs.backend.temporal.activities._evaluate_single_alert", side_effect=RuntimeError("unexpected"))
+    def test_unexpected_error_increments_errored(self, _mock_evaluate):
+        self._make_alert()
+        result = _check_alerts_sync()
+        # Truly unexpected error caught by outer except — not "checked"
+        assert result.alerts_errored == 1
+        assert result.alerts_checked == 0
+
+
+class TestEvaluateSingleAlert(APIBaseTest):
+    def _make_alert(self, **kwargs) -> LogsAlertConfiguration:
+        defaults = {
+            "team": self.team,
+            "name": "Test Alert",
+            "threshold_count": 10,
+            "threshold_operator": "above",
+            "window_minutes": 5,
+            "filters": {"serviceNames": ["test-service"]},
+        }
+        defaults.update(kwargs)
+        return LogsAlertConfiguration.objects.create(**defaults)
+
+    @freeze_time("2025-01-01T00:01:00Z")
+    @patch("products.logs.backend.temporal.activities.AlertCheckQuery")
+    @patch("products.logs.backend.temporal.activities.produce_internal_event")
+    def test_threshold_breached_transitions_to_firing(self, mock_produce, mock_query_cls):
+        mock_query_cls.return_value.execute.return_value = AlertCheckCountResult(count=50, query_duration_ms=100)
+        alert = self._make_alert()
+        stats = {"checked": 0, "fired": 0, "resolved": 0, "errored": 0}
+        now = datetime(2025, 1, 1, 0, 1, 0, tzinfo=UTC)
+
+        _evaluate_single_alert(alert, now, stats)
+
+        alert.refresh_from_db()
+        assert alert.state == LogsAlertConfiguration.State.FIRING
+        assert stats["checked"] == 1
+        assert stats["fired"] == 1
+        mock_produce.assert_called_once()
+        assert mock_produce.call_args.kwargs["event"].event == "$logs_alert_firing"
+
+    @freeze_time("2025-01-01T00:01:00Z")
+    @patch("products.logs.backend.temporal.activities.AlertCheckQuery")
+    @patch("products.logs.backend.temporal.activities.produce_internal_event")
+    def test_threshold_not_breached_stays_not_firing(self, mock_produce, mock_query_cls):
+        mock_query_cls.return_value.execute.return_value = AlertCheckCountResult(count=5, query_duration_ms=100)
+        alert = self._make_alert()
+        stats = {"checked": 0, "fired": 0, "resolved": 0, "errored": 0}
+        now = datetime(2025, 1, 1, 0, 1, 0, tzinfo=UTC)
+
+        _evaluate_single_alert(alert, now, stats)
+
+        alert.refresh_from_db()
+        assert alert.state == LogsAlertConfiguration.State.NOT_FIRING
+        assert stats["checked"] == 1
+        assert stats["fired"] == 0
+        mock_produce.assert_not_called()
+
+    @freeze_time("2025-01-01T00:01:00Z")
+    @patch("products.logs.backend.temporal.activities.AlertCheckQuery")
+    @patch("products.logs.backend.temporal.activities.produce_internal_event")
+    def test_creates_audit_row(self, mock_produce, mock_query_cls):
+        mock_query_cls.return_value.execute.return_value = AlertCheckCountResult(count=50, query_duration_ms=250)
+        alert = self._make_alert()
+        stats = {"checked": 0, "fired": 0, "resolved": 0, "errored": 0}
+        now = datetime(2025, 1, 1, 0, 1, 0, tzinfo=UTC)
+
+        _evaluate_single_alert(alert, now, stats)
+
+        check = LogsAlertCheck.objects.get(alert=alert)
+        assert check.result_count == 50
+        assert check.threshold_breached is True
+        assert check.state_before == "not_firing"
+        assert check.state_after == "firing"
+        assert check.query_duration_ms == 250
+        assert check.error_message is None
+
+    @freeze_time("2025-01-01T00:01:00Z")
+    @patch("products.logs.backend.temporal.activities.AlertCheckQuery")
+    @patch("products.logs.backend.temporal.activities.produce_internal_event")
+    def test_advances_next_check_at(self, mock_produce, mock_query_cls):
+        mock_query_cls.return_value.execute.return_value = AlertCheckCountResult(count=5, query_duration_ms=100)
+        alert = self._make_alert(next_check_at=datetime(2025, 1, 1, 0, 0, 0, tzinfo=UTC))
+        stats = {"checked": 0, "fired": 0, "resolved": 0, "errored": 0}
+        now = datetime(2025, 1, 1, 0, 1, 0, tzinfo=UTC)
+
+        _evaluate_single_alert(alert, now, stats)
+
+        alert.refresh_from_db()
+        assert alert.next_check_at is not None and alert.next_check_at > now
+
+    @freeze_time("2025-01-01T00:01:00Z")
+    @patch("products.logs.backend.temporal.activities.AlertCheckQuery")
+    @patch("products.logs.backend.temporal.activities.produce_internal_event")
+    def test_clickhouse_failure_creates_error_audit_row(self, mock_produce, mock_query_cls):
+        mock_query_cls.return_value.execute.side_effect = Exception("ClickHouse timeout")
+        alert = self._make_alert()
+        stats = {"checked": 0, "fired": 0, "resolved": 0, "errored": 0}
+        now = datetime(2025, 1, 1, 0, 1, 0, tzinfo=UTC)
+
+        _evaluate_single_alert(alert, now, stats)
+
+        check = LogsAlertCheck.objects.get(alert=alert)
+        assert check.result_count is None
+        assert check.threshold_breached is False
+        assert check.error_message == "ClickHouse timeout"
+        assert stats["errored"] == 1
+
+    @freeze_time("2025-01-01T00:01:00Z")
+    @patch("products.logs.backend.temporal.activities.AlertCheckQuery")
+    @patch("products.logs.backend.temporal.activities.produce_internal_event")
+    def test_emit_event_uses_team_distinct_id(self, mock_produce, mock_query_cls):
+        mock_query_cls.return_value.execute.return_value = AlertCheckCountResult(count=50, query_duration_ms=100)
+        alert = self._make_alert()
+        stats = {"checked": 0, "fired": 0, "resolved": 0, "errored": 0}
+        now = datetime(2025, 1, 1, 0, 1, 0, tzinfo=UTC)
+
+        _evaluate_single_alert(alert, now, stats)
+
+        event = mock_produce.call_args.kwargs["event"]
+        assert event.distinct_id == f"team_{self.team.id}"
+
+    @freeze_time("2025-01-01T00:01:00Z")
+    @patch("products.logs.backend.temporal.activities.AlertCheckQuery")
+    @patch("products.logs.backend.temporal.activities.produce_internal_event")
+    def test_last_notified_at_set_after_kafka_success(self, mock_produce, mock_query_cls):
+        mock_query_cls.return_value.execute.return_value = AlertCheckCountResult(count=50, query_duration_ms=100)
+        alert = self._make_alert()
+        stats = {"checked": 0, "fired": 0, "resolved": 0, "errored": 0}
+        now = datetime(2025, 1, 1, 0, 1, 0, tzinfo=UTC)
+
+        _evaluate_single_alert(alert, now, stats)
+
+        alert.refresh_from_db()
+        assert alert.last_notified_at == now
+
+    @freeze_time("2025-01-01T00:01:00Z")
+    @patch("products.logs.backend.temporal.activities.AlertCheckQuery")
+    @patch("products.logs.backend.temporal.activities.produce_internal_event", side_effect=Exception("Kafka down"))
+    @patch("products.logs.backend.temporal.activities.capture_exception")
+    def test_last_notified_at_not_set_on_kafka_failure(self, mock_capture, mock_produce, mock_query_cls):
+        mock_query_cls.return_value.execute.return_value = AlertCheckCountResult(count=50, query_duration_ms=100)
+        alert = self._make_alert()
+        stats = {"checked": 0, "fired": 0, "resolved": 0, "errored": 0}
+        now = datetime(2025, 1, 1, 0, 1, 0, tzinfo=UTC)
+
+        _evaluate_single_alert(alert, now, stats)
+
+        alert.refresh_from_db()
+        assert alert.last_notified_at is None
+        mock_capture.assert_called_once()
+
+    @parameterized.expand(
+        [
+            ("above_breached", "above", 50, True),
+            ("above_not_breached", "above", 5, False),
+            ("below_breached", "below", 5, True),
+            ("below_not_breached", "below", 50, False),
+        ]
+    )
+    @freeze_time("2025-01-01T00:01:00Z")
+    @patch("products.logs.backend.temporal.activities.AlertCheckQuery")
+    @patch("products.logs.backend.temporal.activities.produce_internal_event")
+    def test_threshold_operators(self, _name, operator, count, should_fire, mock_produce, mock_query_cls):
+        mock_query_cls.return_value.execute.return_value = AlertCheckCountResult(count=count, query_duration_ms=100)
+        alert = self._make_alert(threshold_operator=operator, threshold_count=10)
+        stats = {"checked": 0, "fired": 0, "resolved": 0, "errored": 0}
+        now = datetime(2025, 1, 1, 0, 1, 0, tzinfo=UTC)
+
+        _evaluate_single_alert(alert, now, stats)
+
+        alert.refresh_from_db()
+        if should_fire:
+            assert alert.state == LogsAlertConfiguration.State.FIRING
+            assert stats["fired"] == 1
+        else:
+            assert alert.state == LogsAlertConfiguration.State.NOT_FIRING
+            assert stats["fired"] == 0
+
+    @freeze_time("2025-01-01T00:01:00Z")
+    @patch("products.logs.backend.temporal.activities.AlertCheckQuery")
+    @patch("products.logs.backend.temporal.activities.produce_internal_event")
+    def test_resolution_emits_resolved_event(self, mock_produce, mock_query_cls):
+        alert = self._make_alert(state=LogsAlertConfiguration.State.FIRING)
+        # First check breached to create an audit row for get_recent_breaches
+        mock_query_cls.return_value.execute.return_value = AlertCheckCountResult(count=50, query_duration_ms=100)
+        _evaluate_single_alert(alert, datetime(2025, 1, 1, 0, 0, 0, tzinfo=UTC), _make_stats())
+        alert.refresh_from_db()
+        mock_produce.reset_mock()
+
+        # Second check not breached — should resolve
+        mock_query_cls.return_value.execute.return_value = AlertCheckCountResult(count=0, query_duration_ms=100)
+        stats = _make_stats()
+        _evaluate_single_alert(alert, datetime(2025, 1, 1, 0, 1, 0, tzinfo=UTC), stats)
+
+        alert.refresh_from_db()
+        assert alert.state == LogsAlertConfiguration.State.NOT_FIRING
+        assert stats["resolved"] == 1
+        mock_produce.assert_called_once()
+        assert mock_produce.call_args.kwargs["event"].event == "$logs_alert_resolved"
+
+    @freeze_time("2025-01-01T00:01:00Z")
+    @patch("products.logs.backend.temporal.activities.AlertCheckQuery")
+    @patch("products.logs.backend.temporal.activities.produce_internal_event")
+    def test_cooldown_suppresses_notification(self, mock_produce, mock_query_cls):
+        mock_query_cls.return_value.execute.return_value = AlertCheckCountResult(count=50, query_duration_ms=100)
+        alert = self._make_alert(
+            state=LogsAlertConfiguration.State.FIRING,
+            cooldown_minutes=60,
+            last_notified_at=datetime(2025, 1, 1, 0, 0, 0, tzinfo=UTC),
+        )
+        stats = _make_stats()
+        # 1 minute after last notification, within 60-min cooldown
+        _evaluate_single_alert(alert, datetime(2025, 1, 1, 0, 1, 0, tzinfo=UTC), stats)
+
+        alert.refresh_from_db()
+        # State transitions still happen, but no notification emitted
+        assert alert.state == LogsAlertConfiguration.State.FIRING
+        mock_produce.assert_not_called()
+
+    @freeze_time("2025-01-01T00:01:00Z")
+    @patch("products.logs.backend.temporal.activities.AlertCheckQuery")
+    @patch("products.logs.backend.temporal.activities.produce_internal_event")
+    def test_n_of_m_requires_multiple_breaches_to_fire(self, mock_produce, mock_query_cls):
+        alert = self._make_alert(evaluation_periods=3, datapoints_to_alarm=2)
+
+        # First check: breached but 1-of-3 not enough
+        mock_query_cls.return_value.execute.return_value = AlertCheckCountResult(count=50, query_duration_ms=100)
+        _evaluate_single_alert(alert, datetime(2025, 1, 1, 0, 0, 0, tzinfo=UTC), _make_stats())
+        alert.refresh_from_db()
+        assert alert.state == LogsAlertConfiguration.State.NOT_FIRING
+
+        # Second check: not breached, 1-of-3 still not enough
+        mock_query_cls.return_value.execute.return_value = AlertCheckCountResult(count=0, query_duration_ms=100)
+        _evaluate_single_alert(alert, datetime(2025, 1, 1, 0, 1, 0, tzinfo=UTC), _make_stats())
+        alert.refresh_from_db()
+        assert alert.state == LogsAlertConfiguration.State.NOT_FIRING
+
+        # Third check: breached, now 2-of-3 — should fire
+        mock_query_cls.return_value.execute.return_value = AlertCheckCountResult(count=50, query_duration_ms=100)
+        stats = _make_stats()
+        _evaluate_single_alert(alert, datetime(2025, 1, 1, 0, 2, 0, tzinfo=UTC), stats)
+        alert.refresh_from_db()
+        assert alert.state == LogsAlertConfiguration.State.FIRING
+        assert stats["fired"] == 1
+        mock_produce.assert_called_once()
+
+    @freeze_time("2025-01-01T00:01:00Z")
+    @patch("products.logs.backend.temporal.activities.AlertCheckQuery")
+    @patch("products.logs.backend.temporal.activities.produce_internal_event")
+    def test_resolution_within_cooldown_suppresses_resolved_event(self, mock_produce, mock_query_cls):
+        mock_query_cls.return_value.execute.return_value = AlertCheckCountResult(count=0, query_duration_ms=100)
+        alert = self._make_alert(
+            state=LogsAlertConfiguration.State.FIRING,
+            cooldown_minutes=60,
+            last_notified_at=datetime(2025, 1, 1, 0, 0, 0, tzinfo=UTC),
+        )
+        # Create an audit row so get_recent_breaches has data
+        LogsAlertCheck.objects.create(
+            alert=alert,
+            result_count=50,
+            threshold_breached=True,
+            state_before="not_firing",
+            state_after="firing",
+        )
+
+        stats = _make_stats()
+        _evaluate_single_alert(alert, datetime(2025, 1, 1, 0, 1, 0, tzinfo=UTC), stats)
+
+        alert.refresh_from_db()
+        # State transitions to NOT_FIRING regardless of cooldown
+        assert alert.state == LogsAlertConfiguration.State.NOT_FIRING
+        # But notification is suppressed by cooldown
+        mock_produce.assert_not_called()


### PR DESCRIPTION
## Problem

Logs alerting needs a Temporal workflow to evaluate alert rules every minute - query ClickHouse, apply the state machine, persist state, and emit notification events to Kafka.

## Changes

- `LogsAlertCheckWorkflow` + `check_alerts_activity` — cron workflow with 5-min timeout, 3x retry, `SKIP` overlap policy
- Activity queries due alerts from Postgres (`select_related("team")`), evaluates each sequentially via `AlertCheckQuery` + state machine, persists audit rows atomically, emits `$logs_alert_firing`/`$logs_alert_resolved` to Kafka
- `last_notified_at` only updated after Kafka confirms — retry on next tick if Kafka fails
- `constants.py` with workflow name, schedule ID, cron, timeout, retry policy
- Schedule registered in `posthog/temporal/schedule.py`, worker registered in `start_temporal_worker.py`

## How did you test this code?

- Manual e2e smoke test on local dev: alert created > Temporal fired > ClickHouse queried > state transitioned > webhook delivered
- 24 unit/integration tests covering: alert scheduling/filtering, fire/resolve transitions, audit row creation, threshold operators (above/below), N-of-M, cooldown suppression, resolution within cooldown, Kafka failure handling, error propagation. 

## Publish to changelog?

No