### PR TITLE
chore: add no-cap to tooltips

### DIFF
--- a/frontend/src/scenes/insights/useInsightTooltip.ts
+++ b/frontend/src/scenes/insights/useInsightTooltip.ts
@@ -105,7 +105,7 @@ export function ensureTooltip(id: string): [Root, HTMLElement] {
     if (!instance) {
         const tooltipEl = document.createElement('div')
         tooltipEl.id = `InsightTooltipWrapper-${id}`
-        tooltipEl.classList.add('InsightTooltipWrapper')
+        tooltipEl.classList.add('InsightTooltipWrapper', 'ph-no-capture')
         tooltipEl.setAttribute('data-attr', 'insight-tooltip-wrapper')
         tooltipEl.style.pointerEvents = 'none'
         document.body.appendChild(tooltipEl)

--- a/frontend/src/scenes/insights/views/BoldNumber/BoldNumber.tsx
+++ b/frontend/src/scenes/insights/views/BoldNumber/BoldNumber.tsx
@@ -133,7 +133,7 @@ export function BoldNumber({ showPersonsModal = true, context }: ChartParams): J
     const resultSeries = insightData?.result?.[0] as TrendResult | undefined
 
     return resultSeries ? (
-        <div className="BoldNumber">
+        <div className="BoldNumber ph-no-capture">
             <div
                 className={clsx('BoldNumber__value', showPersonsModal ? 'cursor-pointer' : 'cursor-default')}
                 data-attr="bold-number-value"
@@ -281,7 +281,7 @@ export function HogQLBoldNumber(): JSX.Element {
     const value = formattedValue ?? directValue ?? resultsValue ?? resultValue
 
     return (
-        <div className="BoldNumber LemonTable HogQL">
+        <div className="BoldNumber LemonTable HogQL ph-no-capture">
             <div className="BoldNumber__value">
                 <Textfit min={32} max={120}>
                     {String(value ?? 'Error')}


### PR DESCRIPTION
## Problem

Session recordings and analytics need to exclude certain UI elements from being captured. The BoldNumber components and insight tooltips should be marked to prevent PostHog from capturing their content during session recordings.

## Changes

Added the `ph-no-capture` class to the following elements:
- `BoldNumber` component root div (line 136)
- `HogQLBoldNumber` component root div (line 284)
- `InsightTooltipWrapper` element created in `useInsightTooltip.ts` (line 108)

This class is a PostHog convention that prevents session recording and analytics from capturing the marked elements.

## How did you test this code?

No testing needed. This is a straightforward addition of a CSS class to DOM elements that prevents PostHog from capturing their content during session recordings. The change is purely declarative and doesn't affect component logic or functionality.

## Publish to changelog?

no

https://claude.ai/code/session_01A5TdxCH1yPZVxfCgYLKmCf