### PR TITLE
fix(phrocs): reduce bubbletea output rendering overhead

### DIFF
--- a/tools/phrocs/internal/process/proc.go
+++ b/tools/phrocs/internal/process/proc.go
@@ -59,7 +59,9 @@ type StatusMsg struct {
 // when a process produces output faster than the TUI can render it.
 // The TUI reads actual lines from p.Lines().
 type OutputMsg struct {
-	Name string
+	Name    string
+	Added   []string
+	Evicted int
 }
 
 // Metrics holds the most recent sampled resource usage for a process tree.
@@ -176,10 +178,7 @@ func (p *Process) Lines() []string {
 func (p *Process) AppendLine(line string) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	if len(p.lines) >= p.maxLines {
-		p.lines = p.lines[1:]
-	}
-	p.lines = append(p.lines, line)
+	p.appendLinesLocked([]string{line})
 }
 
 // Returns a consistent point-in-time view of the process
@@ -466,7 +465,7 @@ func (p *Process) readLoop(r io.Reader, send func(tea.Msg)) {
 		if !ok {
 			return
 		}
-		p.bufferLine(line, send)
+		batch := []string{line}
 
 		// Drain any additional lines that arrive within the flush interval
 		deadline := time.After(flushInterval)
@@ -475,41 +474,70 @@ func (p *Process) readLoop(r io.Reader, send func(tea.Msg)) {
 			select {
 			case line, ok := <-lineCh:
 				if !ok {
-					// EOF — send final notification and return
-					send(OutputMsg{Name: p.Name})
+					evicted := p.bufferLines(batch, send)
+					send(OutputMsg{Name: p.Name, Added: batch, Evicted: evicted})
 					return
 				}
-				p.bufferLine(line, send)
+				batch = append(batch, line)
 			case <-deadline:
 				break drain
 			}
 		}
 
-		send(OutputMsg{Name: p.Name})
+		evicted := p.bufferLines(batch, send)
+		send(OutputMsg{Name: p.Name, Added: batch, Evicted: evicted})
 	}
 }
 
-// bufferLine appends a single line to the scrollback buffer and checks the
+// bufferLines appends a batch of lines to the scrollback buffer and checks the
 // ready pattern. Only sends a StatusMsg if the process just became ready.
-func (p *Process) bufferLine(line string, send func(tea.Msg)) {
+// Returns the number of evicted lines due to scrollback limit.
+func (p *Process) bufferLines(lines []string, send func(tea.Msg)) int {
 	p.mu.Lock()
-	if len(p.lines) >= p.maxLines {
-		p.lines = p.lines[1:]
-	}
-	p.lines = append(p.lines, line)
+	evicted := p.appendLinesLocked(lines)
 
 	shouldNotify := false
-	if !p.ready && p.readyPattern != nil && p.readyPattern.MatchString(line) {
-		p.ready = true
-		p.readyAt = time.Now()
-		p.status = StatusRunning
-		shouldNotify = true
+	if !p.ready && p.readyPattern != nil {
+		for _, line := range lines {
+			if p.readyPattern.MatchString(line) {
+				p.ready = true
+				p.readyAt = time.Now()
+				p.status = StatusRunning
+				shouldNotify = true
+				break
+			}
+		}
 	}
 	p.mu.Unlock()
 
 	if shouldNotify {
 		send(StatusMsg{Name: p.Name, Status: StatusRunning})
 	}
+	return evicted
+}
+
+// appendLinesLocked appends lines while honoring scrollback limits.
+// Must be called with p.mu held.
+func (p *Process) appendLinesLocked(lines []string) int {
+	if len(lines) == 0 {
+		return 0
+	}
+	if p.maxLines <= 0 {
+		p.lines = nil
+		return len(lines)
+	}
+
+	evicted := 0
+	if overflow := len(p.lines) + len(lines) - p.maxLines; overflow > 0 {
+		if overflow >= len(p.lines) {
+			p.lines = p.lines[:0]
+		} else {
+			p.lines = append(p.lines[:0], p.lines[overflow:]...)
+		}
+		evicted = overflow
+	}
+	p.lines = append(p.lines, lines...)
+	return evicted
 }
 
 // Sampling CPU/mem/threads every metricsSampleInterval for the process tree

--- a/tools/phrocs/internal/tui/app.go
+++ b/tools/phrocs/internal/tui/app.go
@@ -56,6 +56,8 @@ type Model struct {
 	// Center viewport with output of the active process
 	viewport         viewport.Model
 	viewportAtBottom bool
+	activeContent    string
+	activeLineCount  int
 
 	// Copy mode: keyboard-driven line selection within the output pane
 	copyMode   bool
@@ -180,13 +182,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if m.isDockerMode() || m.infoMode {
 				break
 			}
-			m.viewport.SetContent(m.buildContent())
+			m.applyOutputDelta(msg)
 			// Don't auto-scroll while the user is selecting text in copy mode
 			if m.viewportAtBottom && !m.copyMode && !m.searchMode {
 				m.viewport.GotoBottom()
-			}
-			if m.searchQuery != "" {
-				m.recomputeSearch()
 			}
 		}
 
@@ -420,6 +419,8 @@ func (m Model) loadActiveProc() (Model, []tea.Cmd) {
 		m.searchQuery = ""
 		m.searchMatches = nil
 		m.searchCursor = 0
+		m.activeContent = ""
+		m.activeLineCount = 0
 		m.keys.LazyDocker.SetEnabled(true)
 		m.keys.ProcViewer.SetEnabled(false)
 		m.viewport.SetContent(docker.RenderContainerStatusTable(m.containers, m.viewport.Width()))
@@ -429,7 +430,13 @@ func (m Model) loadActiveProc() (Model, []tea.Cmd) {
 		m.containers = nil
 		m.keys.LazyDocker.SetEnabled(false)
 		m.keys.ProcViewer.SetEnabled(true)
-		m.viewport.SetContent(m.buildContent())
+		m.activeContent = m.buildContent()
+		if p := m.activeProc(); p != nil {
+			m.activeLineCount = len(p.Lines())
+		} else {
+			m.activeLineCount = 0
+		}
+		m.viewport.SetContent(m.activeContent)
 	}
 
 	if m.viewportAtBottom {
@@ -449,6 +456,40 @@ func (m Model) buildContent() string {
 		return ""
 	}
 	return strings.Join(p.Lines(), "\n")
+}
+
+// applyOutputDelta applies a process output batch to the active viewport.
+// It incrementally appends new lines when possible and falls back to a full
+// rebuild when lines were evicted from scrollback.
+func (m *Model) applyOutputDelta(msg process.OutputMsg) {
+	if msg.Evicted > 0 || len(msg.Added) == 0 {
+		m.activeContent = m.buildContent()
+		if p := m.activeProc(); p != nil {
+			m.activeLineCount = len(p.Lines())
+		} else {
+			m.activeLineCount = 0
+		}
+		m.viewport.SetContent(m.activeContent)
+		if m.searchQuery != "" {
+			m.recomputeSearch()
+		}
+		return
+	}
+
+	if m.activeLineCount == 0 || m.activeContent == "" {
+		m.activeContent = strings.Join(msg.Added, "\n")
+	} else {
+		m.activeContent += "\n" + strings.Join(msg.Added, "\n")
+	}
+	m.activeLineCount += len(msg.Added)
+	m.viewport.SetContent(m.activeContent)
+
+	if m.searchQuery != "" {
+		startIdx := m.activeLineCount - len(msg.Added)
+		for i, line := range msg.Added {
+			m.updateSearchForLine(line, startIdx+i, false)
+		}
+	}
 }
 
 // statusSortOrder returns a numeric rank for sorting by status.


### PR DESCRIPTION
### Motivation

- Reduce CPU and allocation overhead in the phrocs TUI by avoiding a full `strings.Join(p.Lines(), "\n")` rebuild on every `OutputMsg` when a process emits high-volume logs.
- Make scrollback updates and search match maintenance more efficient by batching lines and applying incremental deltas to the viewport where possible.

### Description

- Extended `process.OutputMsg` to include batched payload metadata (`Added []string`, `Evicted int`) so the TUI can apply deltas instead of always rebuilding the full buffer. (edited `tools/phrocs/internal/process/proc.go`)
- Reworked process output buffering: `readLoop` flushes line batches once and sends richer `OutputMsg` payloads, and new helpers `bufferLines` and `appendLinesLocked` perform batched append + scrollback eviction while preserving ready-pattern detection. (edited `tools/phrocs/internal/process/proc.go`)
- TUI caching and incremental updates: added `activeContent` and `activeLineCount` to the model and implemented `applyOutputDelta` to append new lines in the common non-eviction path, fall back to a full rebuild on eviction or legacy/empty payloads, and incrementally update search matches for appended lines. (edited `tools/phrocs/internal/tui/app.go`)
- Ensured `loadActiveProc` initializes/resets cached output state for both normal and docker modes to avoid stale content after view switches. (edited `tools/phrocs/internal/tui/app.go`)

### Testing

- Ran `go test ./...` from `tools/phrocs` which initially surfaced regressions and failed, prompting follow-up fixes. (initial run: failed)
- Re-ran `go test ./...` from `tools/phrocs` after fixes and the suite completed successfully. (passed)
- Ran targeted tests `go test ./internal/process ./internal/tui` and they passed. (passed)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c58b0ebe50832e8dd4212199fdae3e)