### PR TITLE
feat(flags): add golden fixture contract test for hypercache boundary

### DIFF
--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -49,6 +49,11 @@ jobs:
                         - 'posthog/migrations/**'
                         - 'ee/migrations/**'
                         - 'docker-compose.dev.yml'
+                        # Hypercache contract: Python serializer changes may break Rust deserialization
+                        - 'posthog/api/feature_flag.py'
+                        - 'posthog/models/feature_flag/flags_cache.py'
+                        - 'posthog/models/feature_flag/feature_flag.py'
+                        - 'rust/feature-flags/tests/fixtures/hypercache_contract.json'
 
             # Bin-pack packages into balanced test shards.
             # Weights are approximate test durations in seconds — update periodically.

--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -1781,6 +1781,11 @@ class UserBlastRadiusResponseSerializer(serializers.Serializer):
     total_users = serializers.IntegerField(help_text="Total number of users in the project")
 
 
+# HYPERCACHE CONTRACT: This serializer defines the JSON schema that the Rust feature-flags
+# service deserializes. Field changes (renames, removals, type changes) must follow the
+# expand-and-contract pattern. Run the contract tests to verify compatibility:
+#   pytest posthog/models/feature_flag/test/test_flags_cache.py -k "test_serializer_output_matches_fixture_schema"
+# See also: rust/feature-flags/src/flags/flag_models.rs (FeatureFlag struct)
 class MinimalFeatureFlagSerializer(serializers.ModelSerializer):
     filters = serializers.DictField(source="get_filters", required=False)
     evaluation_contexts = serializers.SerializerMethodField()

--- a/posthog/models/feature_flag/flags_cache.py
+++ b/posthog/models/feature_flag/flags_cache.py
@@ -198,10 +198,14 @@ def _get_referenced_cohorts(team_id: int, flags_data: list[dict[str, Any]]) -> l
 def _serialize_cohort(cohort: Cohort) -> dict[str, Any]:
     """Serialize a Cohort to a dict matching the Rust Cohort struct field names.
 
-    Keep in sync with rust/feature-flags/src/cohorts/cohort_models.rs::Cohort.
-    The Rust struct has no serde(default) on required fields (deleted, is_calculating,
-    is_static, errors_calculating, groups), so omitting any of these causes a
-    deserialization failure.
+    HYPERCACHE CONTRACT: These field names must match the Rust Cohort struct in
+    rust/feature-flags/src/cohorts/cohort_models.rs. Field changes must follow
+    the expand-and-contract pattern. The contract test will catch mismatches:
+      pytest posthog/models/feature_flag/test/test_flags_cache.py -k "test_serializer_output_matches_fixture_schema"
+
+    Note: deleted, is_calculating, is_static, errors_calculating, and groups
+    are required by the Rust struct (no #[serde(default)]), so omitting them
+    causes a deserialization failure.
     """
     return {
         "id": cohort.id,
@@ -220,6 +224,9 @@ def _serialize_cohort(cohort: Cohort) -> dict[str, Any]:
         "groups": cohort.groups,
         "created_by_id": cohort.created_by_id,
         "cohort_type": cohort.cohort_type,
+        "last_backfill_person_properties_at": (
+            cohort.last_backfill_person_properties_at.isoformat() if cohort.last_backfill_person_properties_at else None
+        ),
     }
 
 
@@ -306,6 +313,10 @@ def _compute_flag_dependencies(flags_data: list[dict[str, Any]]) -> dict[str, An
 def _get_feature_flags_for_service(team: Team) -> dict[str, Any]:
     """
     Get feature flags for the feature-flags service.
+
+    HYPERCACHE CONTRACT: The top-level keys (flags, evaluation_metadata, cohorts)
+    must match rust/feature-flags/src/flags/flag_models.rs::HypercacheFlagsWrapper.
+    Changes to this structure must follow the expand-and-contract pattern.
 
     Fetches all feature flags for the team (including inactive, excluding deleted)
     and returns them wrapped in a dict that HyperCache can serialize. The actual

--- a/posthog/models/feature_flag/test/test_flags_cache.py
+++ b/posthog/models/feature_flag/test/test_flags_cache.py
@@ -8,6 +8,9 @@ Tests cover:
 - Data format compatibility with service
 """
 
+import json
+from datetime import UTC, datetime
+from pathlib import Path
 from typing import Any
 
 from posthog.test.base import BaseTest
@@ -20,6 +23,7 @@ from parameterized import parameterized
 
 from posthog.models import FeatureFlag, Team
 from posthog.models.cohort.cohort import Cohort
+from posthog.models.evaluation_context import EvaluationContext, FeatureFlagEvaluationContext
 from posthog.models.feature_flag.flags_cache import (
     _compute_flag_dependencies,
     _extract_cohort_ids_from_flag_filters,
@@ -612,6 +616,90 @@ class TestServiceFlagsCeleryTasks(BaseTest):
         update_team_service_flags_cache(999999)
 
 
+# Path from this test file up to the repo root (4 levels: test/ -> feature_flag/ -> models/ -> posthog/ -> repo)
+_REPO_ROOT = Path(__file__).resolve().parents[4]
+
+
+def _extract_schema(obj: Any) -> Any:
+    """Extract a type skeleton from a JSON-like object for structural comparison.
+
+    Returns a nested structure of dicts, lists, and leaf type names.
+    Dicts with all-numeric keys (e.g. transitive_deps keyed by flag ID) are
+    treated as maps — represented as {"<map>": value_schema} so the comparison
+    checks value structure, not specific keys.
+    """
+    if obj is None:
+        return "null"
+    if isinstance(obj, bool):
+        return "bool"
+    if isinstance(obj, (int, float)):
+        return "number"
+    if isinstance(obj, str):
+        return "str"
+    if isinstance(obj, list):
+        if not obj:
+            return ["empty_list"]
+        return [_extract_schema(obj[0])]
+    if isinstance(obj, dict):
+        if not obj:
+            return {}
+        # Dicts with all-numeric keys are ID-keyed maps, not fixed schemas.
+        # Derive the map value schema from the first informative (non-empty-list) value
+        # so that a breaking type change in non-empty entries isn't masked by leading
+        # empty lists (e.g. transitive_deps: {"1": [], "4": [2]}).
+        if all(k.isdigit() for k in obj.keys()):
+            map_schema = None
+            fallback_schema = None
+            for val in obj.values():
+                candidate = _extract_schema(val)
+                if fallback_schema is None:
+                    fallback_schema = candidate
+                if isinstance(candidate, list) and candidate and candidate[0] == "empty_list":
+                    continue
+                map_schema = candidate
+                break
+            return {"<map>": map_schema if map_schema is not None else fallback_schema}
+        return {k: _extract_schema(v) for k, v in sorted(obj.items())}
+    return type(obj).__name__
+
+
+def _compare_schemas(fixture_schema: Any, result_schema: Any, path: str = "") -> list[str]:
+    """Compare two type skeletons and return human-readable diffs."""
+    diffs: list[str] = []
+    # If the fixture declares a field as null, the serializer must also return null.
+    # This prevents null in the fixture from acting as a wildcard that accepts any
+    # non-null type, which would allow breaking type changes on nullable fields to
+    # slip through undetected (e.g. changing an Option<i32> field to emit a string).
+    if fixture_schema == "null":
+        if result_schema != "null":
+            diffs.append(f"Fixture expects null at `{path}` but serializer returned {result_schema}")
+        return diffs
+    if result_schema == "null":
+        diffs.append(f"Fixture expects non-null at `{path}` ({fixture_schema}) but serializer returned null")
+        return diffs
+    if type(fixture_schema) is not type(result_schema):
+        diffs.append(f"Type mismatch at `{path}`: fixture={fixture_schema}, serializer={result_schema}")
+        return diffs
+    if isinstance(fixture_schema, dict):
+        all_keys = set(fixture_schema.keys()) | set(result_schema.keys())
+        for key in sorted(all_keys):
+            child_path = f"{path}.{key}" if path else key
+            if key not in result_schema:
+                diffs.append(f"Key `{child_path}` in fixture but not in serializer output")
+            elif key not in fixture_schema:
+                diffs.append(f"Key `{child_path}` in serializer output but not in fixture")
+            else:
+                diffs.extend(_compare_schemas(fixture_schema[key], result_schema[key], child_path))
+    elif isinstance(fixture_schema, list) and fixture_schema and result_schema:
+        # empty_list is compatible with any element type
+        if fixture_schema[0] == "empty_list" or result_schema[0] == "empty_list":
+            return diffs
+        diffs.extend(_compare_schemas(fixture_schema[0], result_schema[0], f"{path}[]"))
+    elif fixture_schema != result_schema:
+        diffs.append(f"Type mismatch at `{path}`: fixture={fixture_schema}, serializer={result_schema}")
+    return diffs
+
+
 @override_settings(FLAGS_REDIS_URL="redis://test")
 class TestServiceFlagsDataFormat(BaseTest):
     """Test that cached data format matches service expectations."""
@@ -620,18 +708,58 @@ class TestServiceFlagsDataFormat(BaseTest):
         super().setUp()
         clear_flags_cache(self.team, kinds=["redis", "s3"])
 
-    def test_flag_data_contains_required_rust_fields(self):
-        """Test that flag data includes all fields expected by Rust."""
-        FeatureFlag.objects.create(
+    def test_serializer_output_matches_fixture_schema(self):
+        """Golden fixture validation: Python serializer output must match the fixture schema.
+
+        Recursively compares the type skeleton (keys + value types at every nesting
+        level) of the fixture against actual serializer output. If this test fails,
+        update the golden fixture and verify Rust tests pass.
+        """
+        fixture_path = _REPO_ROOT / "rust" / "feature-flags" / "tests" / "fixtures" / "hypercache_contract.json"
+        fixture = json.loads(fixture_path.read_text())
+
+        # --- Create test data mirroring the 4 fixture flag variants ---
+
+        cohort = Cohort.objects.create(
             team=self.team,
-            key="rust-compatible-flag",
-            name="Rust Compatible Flag",
+            name="Test Cohort",
             created_by=self.user,
+            version=1,
+            count=42,
+            filters={
+                "properties": {
+                    "type": "AND",
+                    "values": [
+                        {
+                            "type": "AND",
+                            "values": [
+                                {"key": "email", "value": "test@example.com", "type": "person", "operator": "exact"}
+                            ],
+                        }
+                    ],
+                }
+            },
+            last_backfill_person_properties_at=datetime(2024, 1, 15, 12, 0, 0, tzinfo=UTC),
+        )
+
+        # 1) full-flag: exercises all optional nested structures
+        full_flag = FeatureFlag.objects.create(
+            team=self.team,
+            key="full-flag",
+            name="Full feature flag",
+            created_by=self.user,
+            ensure_experience_continuity=True,
+            version=3,
+            evaluation_runtime="all",
+            bucketing_identifier="device_id",
             filters={
                 "groups": [
                     {
-                        "properties": [{"key": "email", "value": "test@example.com", "type": "person"}],
+                        "properties": [
+                            {"key": "email", "value": "test@example.com", "type": "person", "operator": "exact"}
+                        ],
                         "rollout_percentage": 50,
+                        "variant": None,
                     }
                 ],
                 "multivariate": {
@@ -640,39 +768,165 @@ class TestServiceFlagsDataFormat(BaseTest):
                         {"key": "test", "name": "Test", "rollout_percentage": 50},
                     ]
                 },
+                "payloads": {"control": "payload-value"},
+                "super_groups": [
+                    {
+                        "properties": [
+                            {
+                                "key": "$feature_enrollment/full-flag",
+                                "type": "person",
+                                "value": ["true"],
+                                "operator": "exact",
+                            }
+                        ],
+                        "rollout_percentage": None,
+                        "variant": None,
+                    }
+                ],
+                "feature_enrollment": True,
+                "holdout": {"id": 42, "exclusion_percentage": 10.0},
+                "aggregation_group_type_index": None,
             },
-            ensure_experience_continuity=True,
+        )
+
+        # Attach evaluation contexts to full-flag
+        for ctx_name in ["docs-page", "marketing-site"]:
+            ctx, _ = EvaluationContext.objects.get_or_create(team=self.team, name=ctx_name)
+            FeatureFlagEvaluationContext.objects.create(feature_flag=full_flag, evaluation_context=ctx)
+
+        # 2) minimal-flag: only required fields, empty/null optionals
+        minimal_flag = FeatureFlag.objects.create(
+            team=self.team,
+            key="minimal-flag",
+            name="",
+            created_by=self.user,
+            version=1,
+            evaluation_runtime="all",
+            filters={
+                "groups": [{"properties": [], "rollout_percentage": 100, "variant": None}],
+                "multivariate": None,
+                "payloads": {},
+            },
+        )
+
+        # 3) cohort-flag: cohort-type property
+        FeatureFlag.objects.create(
+            team=self.team,
+            key="cohort-flag",
+            name="Cohort flag",
+            created_by=self.user,
+            version=1,
+            evaluation_runtime="all",
+            filters={
+                "groups": [
+                    {
+                        "properties": [{"key": "id", "value": cohort.id, "type": "cohort", "operator": "in"}],
+                        "rollout_percentage": 100,
+                        "variant": None,
+                    }
+                ],
+                "multivariate": None,
+                "payloads": {},
+            },
+        )
+
+        # 4) dependent-flag: flag-type property with label
+        FeatureFlag.objects.create(
+            team=self.team,
+            key="dependent-flag",
+            name="Flag with dependency",
+            created_by=self.user,
+            version=2,
+            evaluation_runtime="all",
+            filters={
+                "groups": [
+                    {
+                        "properties": [
+                            {
+                                "key": str(minimal_flag.id),
+                                "label": "minimal-flag",
+                                "operator": "flag_evaluates_to",
+                                "type": "flag",
+                                "value": True,
+                            }
+                        ],
+                        "rollout_percentage": 100,
+                        "variant": None,
+                    }
+                ],
+                "multivariate": None,
+                "payloads": {},
+            },
         )
 
         result = _get_feature_flags_for_service(self.team)
-        flags = result["flags"]
-        flag_data = flags[0]
 
-        # Required fields for service FeatureFlag struct
-        required_fields = [
-            "id",
-            "team_id",
-            "name",
-            "key",
-            "filters",
-            "deleted",
-            "active",
-            "ensure_experience_continuity",
-            "version",
-        ]
+        # --- Deep recursive schema comparison ---
 
-        for field in required_fields:
-            assert field in flag_data, f"Missing required field: {field}"
+        all_diffs: list[str] = []
 
-        # Verify filters structure
-        assert "groups" in flag_data["filters"]
-        assert len(flag_data["filters"]["groups"]) == 1
-        assert "multivariate" in flag_data["filters"]
+        # Top-level keys
+        fixture_top = set(fixture.keys())
+        result_top = set(result.keys())
+        if fixture_top != result_top:
+            if fixture_top - result_top:
+                all_diffs.append(f"Top-level keys in fixture but not in serializer: {sorted(fixture_top - result_top)}")
+            if result_top - fixture_top:
+                all_diffs.append(f"Top-level keys in serializer but not in fixture: {sorted(result_top - fixture_top)}")
+
+        # Per-flag comparison by key — guard against KeyError when "flags" is missing
+        # (missing-key diffs are already recorded above; we continue to collect other diffs)
+        if "flags" in fixture and "flags" in result:
+            fixture_flags_by_key = {f["key"]: f for f in fixture["flags"]}
+            result_flags_by_key = {f["key"]: f for f in result["flags"]}
+
+            fixture_keys = set(fixture_flags_by_key.keys())
+            result_keys = set(result_flags_by_key.keys())
+            missing = fixture_keys - result_keys
+            extra = result_keys - fixture_keys
+            if missing:
+                all_diffs.append(f"Fixture flag keys not in serializer output: {sorted(missing)}")
+            if extra:
+                all_diffs.append(f"Serializer flag keys not in fixture: {sorted(extra)}")
+            for key in sorted(fixture_keys & result_keys):
+                all_diffs.extend(
+                    _compare_schemas(
+                        _extract_schema(fixture_flags_by_key[key]),
+                        _extract_schema(result_flags_by_key[key]),
+                        f"flags[key={key}]",
+                    )
+                )
+
+        # evaluation_metadata
+        if "evaluation_metadata" in fixture and "evaluation_metadata" in result:
+            all_diffs.extend(
+                _compare_schemas(
+                    _extract_schema(fixture["evaluation_metadata"]),
+                    _extract_schema(result["evaluation_metadata"]),
+                    "evaluation_metadata",
+                )
+            )
+
+        # cohorts
+        assert result.get("cohorts"), "Expected cohorts in serializer output (flags reference a cohort)"
+        if "cohorts" in fixture and "cohorts" in result:
+            all_diffs.extend(
+                _compare_schemas(
+                    _extract_schema(fixture["cohorts"][0]),
+                    _extract_schema(result["cohorts"][0]),
+                    "cohorts[0]",
+                )
+            )
+
+        assert not all_diffs, (
+            f"Fixture schema mismatch ({len(all_diffs)} differences):\n"
+            + "\n".join(f"  - {d}" for d in all_diffs)
+            + "\n\nUpdate the golden fixture at rust/feature-flags/tests/fixtures/hypercache_contract.json"
+            + "\nand verify Rust tests pass: cargo test -p feature-flags test_hypercache_contract"
+        )
 
     def test_flag_data_serializes_to_json(self):
         """Test that flag data can be serialized to JSON (for Redis/S3 storage)."""
-        import json
-
         FeatureFlag.objects.create(
             team=self.team,
             key="json-test-flag",
@@ -2758,7 +3012,7 @@ class TestSerializeCohort(BaseTest):
         )
         result = _serialize_cohort(cohort)
 
-        # All 16 fields required by the Rust Cohort struct must be present
+        # All 17 fields required by the Rust Cohort struct must be present
         expected_fields = {
             "id",
             "name",
@@ -2776,6 +3030,7 @@ class TestSerializeCohort(BaseTest):
             "groups",
             "created_by_id",
             "cohort_type",
+            "last_backfill_person_properties_at",
         }
         assert set(result.keys()) == expected_fields
         assert result["id"] == cohort.id

--- a/posthog/models/feature_flag/test/test_flags_cache.py
+++ b/posthog/models/feature_flag/test/test_flags_cache.py
@@ -731,7 +731,12 @@ class TestExtractSchema:
             ("str_vs_null", "str", "null", ["Fixture expects non-null at `root` (str) but serializer returned null"]),
             ("int_vs_float", "int", "float", ["Type mismatch at `root`: fixture=int, serializer=float"]),
             ("empty_list_compat_rhs", ["int"], ["empty_list"], []),
-            ("empty_list_compat_lhs", ["empty_list"], ["str"], ["Type mismatch at `root[]`: fixture=empty_list, serializer=str"]),
+            (
+                "empty_list_compat_lhs",
+                ["empty_list"],
+                ["str"],
+                ["Type mismatch at `root[]`: fixture=empty_list, serializer=str"],
+            ),
             (
                 "extra_key",
                 {"a": "int"},

--- a/posthog/models/feature_flag/test/test_flags_cache.py
+++ b/posthog/models/feature_flag/test/test_flags_cache.py
@@ -695,8 +695,8 @@ def _compare_schemas(fixture_schema: Any, result_schema: Any, path: str = "") ->
             else:
                 diffs.extend(_compare_schemas(fixture_schema[key], result_schema[key], child_path))
     elif isinstance(fixture_schema, list) and fixture_schema:
-        # empty_list is compatible with any element type
-        if fixture_schema[0] == "empty_list" or result_schema[0] == "empty_list":
+        # If the serializer returned an empty list we can't check element type
+        if result_schema[0] == "empty_list":
             return diffs
         diffs.extend(_compare_schemas(fixture_schema[0], result_schema[0], f"{path}[]"))
     elif fixture_schema != result_schema:
@@ -731,7 +731,7 @@ class TestExtractSchema:
             ("str_vs_null", "str", "null", ["Fixture expects non-null at `root` (str) but serializer returned null"]),
             ("int_vs_float", "int", "float", ["Type mismatch at `root`: fixture=int, serializer=float"]),
             ("empty_list_compat_rhs", ["int"], ["empty_list"], []),
-            ("empty_list_compat_lhs", ["empty_list"], ["str"], []),
+            ("empty_list_compat_lhs", ["empty_list"], ["str"], ["Type mismatch at `root[]`: fixture=empty_list, serializer=str"]),
             (
                 "extra_key",
                 {"a": "int"},
@@ -910,6 +910,37 @@ class TestServiceFlagsDataFormat(BaseTest):
             },
         )
 
+        # 5) missing-dep-flag: depends on a flag that doesn't exist,
+        # exercises flags_with_missing_deps element type (int)
+        FeatureFlag.objects.create(
+            team=self.team,
+            key="missing-dep-flag",
+            name="Flag with missing dependency",
+            created_by=self.user,
+            version=1,
+            evaluation_runtime="all",
+            bucketing_identifier=None,
+            filters={
+                "groups": [
+                    {
+                        "properties": [
+                            {
+                                "key": "99999",
+                                "label": "nonexistent-flag",
+                                "operator": "flag_evaluates_to",
+                                "type": "flag",
+                                "value": True,
+                            }
+                        ],
+                        "rollout_percentage": 100,
+                        "variant": None,
+                    }
+                ],
+                "multivariate": None,
+                "payloads": {},
+            },
+        )
+
         result = _get_feature_flags_for_service(self.team)
 
         # --- Deep recursive schema comparison ---
@@ -964,13 +995,14 @@ class TestServiceFlagsDataFormat(BaseTest):
             assert len(result["cohorts"]) == len(fixture["cohorts"]), (
                 f"Cohort count mismatch: fixture has {len(fixture['cohorts'])}, serializer has {len(result['cohorts'])}"
             )
-            all_diffs.extend(
-                _compare_schemas(
-                    _extract_schema(fixture["cohorts"][0]),
-                    _extract_schema(result["cohorts"][0]),
-                    "cohorts[0]",
+            for i, (f_cohort, r_cohort) in enumerate(zip(fixture["cohorts"], result["cohorts"])):
+                all_diffs.extend(
+                    _compare_schemas(
+                        _extract_schema(f_cohort),
+                        _extract_schema(r_cohort),
+                        f"cohorts[{i}]",
+                    )
                 )
-            )
 
         assert not all_diffs, (
             "\n"

--- a/posthog/models/feature_flag/test/test_flags_cache.py
+++ b/posthog/models/feature_flag/test/test_flags_cache.py
@@ -641,6 +641,8 @@ def _extract_schema(obj: Any) -> Any:
     if isinstance(obj, list):
         if not obj:
             return ["empty_list"]
+        # Assumes homogeneous lists (all elements same type), which holds for
+        # the hypercache JSON schema. Only the first element is inspected.
         return [_extract_schema(obj[0])]
     if isinstance(obj, dict):
         if not obj:
@@ -692,7 +694,7 @@ def _compare_schemas(fixture_schema: Any, result_schema: Any, path: str = "") ->
                 diffs.append(f"Key `{child_path}` in serializer output but not in fixture")
             else:
                 diffs.extend(_compare_schemas(fixture_schema[key], result_schema[key], child_path))
-    elif isinstance(fixture_schema, list) and fixture_schema and result_schema:
+    elif isinstance(fixture_schema, list) and fixture_schema:
         # empty_list is compatible with any element type
         if fixture_schema[0] == "empty_list" or result_schema[0] == "empty_list":
             return diffs
@@ -700,6 +702,48 @@ def _compare_schemas(fixture_schema: Any, result_schema: Any, path: str = "") ->
     elif fixture_schema != result_schema:
         diffs.append(f"Type mismatch at `{path}`: fixture={fixture_schema}, serializer={result_schema}")
     return diffs
+
+
+class TestExtractSchema:
+    @parameterized.expand(
+        [
+            ("none", None, "null"),
+            ("bool_true", True, "bool"),
+            ("bool_false", False, "bool"),
+            ("int", 42, "int"),
+            ("float", 3.14, "float"),
+            ("str", "hi", "str"),
+            ("empty_list", [], ["empty_list"]),
+            ("list_of_int", [1, 2], ["int"]),
+            ("empty_dict", {}, {}),
+            ("simple_dict", {"a": 1}, {"a": "int"}),
+            ("map_skips_empty", {"1": [], "2": [3]}, {"<map>": ["int"]}),
+            ("map_all_empty", {"1": [], "2": []}, {"<map>": ["empty_list"]}),
+        ]
+    )
+    def test_extract_schema(self, _name: str, obj: Any, expected: Any):
+        assert _extract_schema(obj) == expected
+
+    @parameterized.expand(
+        [
+            ("null_match", "null", "null", []),
+            ("null_vs_str", "null", "str", ["Fixture expects null at `root` but serializer returned str"]),
+            ("str_vs_null", "str", "null", ["Fixture expects non-null at `root` (str) but serializer returned null"]),
+            ("int_vs_float", "int", "float", ["Type mismatch at `root`: fixture=int, serializer=float"]),
+            ("empty_list_compat_rhs", ["int"], ["empty_list"], []),
+            ("empty_list_compat_lhs", ["empty_list"], ["str"], []),
+            (
+                "extra_key",
+                {"a": "int"},
+                {"a": "int", "b": "str"},
+                ["Key `root.b` in serializer output but not in fixture"],
+            ),
+            ("matching_dict", {"a": "int"}, {"a": "int"}, []),
+        ]
+    )
+    def test_compare_schemas(self, _name: str, fixture_schema: Any, result_schema: Any, expected_diffs: list[str]):
+        diffs = _compare_schemas(fixture_schema, result_schema, "root")
+        assert diffs == expected_diffs
 
 
 @override_settings(FLAGS_REDIS_URL="redis://test")
@@ -744,7 +788,9 @@ class TestServiceFlagsDataFormat(BaseTest):
             last_backfill_person_properties_at=datetime(2024, 1, 15, 12, 0, 0, tzinfo=UTC),
         )
 
-        # 1) full-flag: exercises all optional nested structures
+        # 1) full-flag: exercises all optional nested structures.
+        # Every nullable field that has a typed schema should be non-null here
+        # so _compare_schemas can verify its type.
         full_flag = FeatureFlag.objects.create(
             team=self.team,
             key="full-flag",
@@ -915,6 +961,9 @@ class TestServiceFlagsDataFormat(BaseTest):
         # cohorts
         assert result.get("cohorts"), "Expected cohorts in serializer output (flags reference a cohort)"
         if "cohorts" in fixture and "cohorts" in result:
+            assert len(result["cohorts"]) == len(fixture["cohorts"]), (
+                f"Cohort count mismatch: fixture has {len(fixture['cohorts'])}, serializer has {len(result['cohorts'])}"
+            )
             all_diffs.extend(
                 _compare_schemas(
                     _extract_schema(fixture["cohorts"][0]),

--- a/posthog/models/feature_flag/test/test_flags_cache.py
+++ b/posthog/models/feature_flag/test/test_flags_cache.py
@@ -973,10 +973,33 @@ class TestServiceFlagsDataFormat(BaseTest):
             )
 
         assert not all_diffs, (
-            f"Fixture schema mismatch ({len(all_diffs)} differences):\n"
-            + "\n".join(f"  - {d}" for d in all_diffs)
-            + "\n\nUpdate the golden fixture at rust/feature-flags/tests/fixtures/hypercache_contract.json"
-            + "\nand verify Rust tests pass: cargo test -p feature-flags test_hypercache_contract"
+            "\n"
+            + "=" * 78
+            + "\n"
+            + " WARNING: HYPERCACHE BOUNDARY CONTRACT VIOLATION\n"
+            + "=" * 78
+            + "\n\n"
+            + f"  {len(all_diffs)} schema difference(s) between the Python serializer and\n"
+            + "  the golden fixture used by the Rust feature-flags service:\n\n"
+            + "\n".join(f"    - {d}" for d in all_diffs)
+            + "\n\n"
+            + "-" * 78
+            + "\n"
+            + "  DO NOT just update the fixture to make this test green.\n"
+            + "  The Rust service deserializes this data — a schema change can\n"
+            + "  break flag evaluation in production.\n\n"
+            + "  Before proceeding, consider:\n"
+            + "    1. Is the change backwards-compatible? (adding a new nullable\n"
+            + "       field is usually safe; renaming/removing a field is not)\n"
+            + "    2. Do you need a phased rollout? (deploy Rust changes first\n"
+            + "       so the new schema is understood before Python writes it)\n"
+            + "    3. Will the cache need re-warming? (old cached payloads will\n"
+            + "       still have the previous shape until they expire or are\n"
+            + "       invalidated)\n\n"
+            + "  Once you have a plan:\n"
+            + "    - Update the fixture: rust/feature-flags/tests/fixtures/hypercache_contract.json\n"
+            + "    - Verify Rust tests: cargo test -p feature-flags test_hypercache_contract\n"
+            + "=" * 78
         )
 
     def test_flag_data_serializes_to_json(self):

--- a/posthog/models/feature_flag/test/test_flags_cache.py
+++ b/posthog/models/feature_flag/test/test_flags_cache.py
@@ -632,8 +632,10 @@ def _extract_schema(obj: Any) -> Any:
         return "null"
     if isinstance(obj, bool):
         return "bool"
-    if isinstance(obj, (int, float)):
-        return "number"
+    if isinstance(obj, int):
+        return "int"
+    if isinstance(obj, float):
+        return "float"
     if isinstance(obj, str):
         return "str"
     if isinstance(obj, list):

--- a/posthog/models/feature_flag/test/test_flags_cache.py
+++ b/posthog/models/feature_flag/test/test_flags_cache.py
@@ -3015,7 +3015,7 @@ class TestSerializeCohort(BaseTest):
         )
         result = _serialize_cohort(cohort)
 
-        # All 17 fields required by the Rust Cohort struct must be present
+        # Hypercache/service cohort schema: these 17 fields must always be present in the serialized payload
         expected_fields = {
             "id",
             "name",

--- a/posthog/models/feature_flag/test/test_flags_cache.py
+++ b/posthog/models/feature_flag/test/test_flags_cache.py
@@ -802,6 +802,7 @@ class TestServiceFlagsDataFormat(BaseTest):
             created_by=self.user,
             version=1,
             evaluation_runtime="all",
+            bucketing_identifier=None,
             filters={
                 "groups": [{"properties": [], "rollout_percentage": 100, "variant": None}],
                 "multivariate": None,
@@ -817,6 +818,7 @@ class TestServiceFlagsDataFormat(BaseTest):
             created_by=self.user,
             version=1,
             evaluation_runtime="all",
+            bucketing_identifier=None,
             filters={
                 "groups": [
                     {
@@ -838,6 +840,7 @@ class TestServiceFlagsDataFormat(BaseTest):
             created_by=self.user,
             version=2,
             evaluation_runtime="all",
+            bucketing_identifier=None,
             filters={
                 "groups": [
                     {

--- a/rust/feature-flags/src/cohorts/cohort_models.rs
+++ b/rust/feature-flags/src/cohorts/cohort_models.rs
@@ -14,6 +14,10 @@ pub enum CohortType {
     Analytical,
 }
 
+/// HYPERCACHE CONTRACT: These fields are deserialized from JSON written by Python's
+/// `_serialize_cohort()` in posthog/models/feature_flag/flags_cache.py. Field changes
+/// must follow the expand-and-contract pattern. Golden fixture contract test:
+///   cargo test -p feature-flags test_hypercache_contract
 #[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
 pub struct Cohort {
     pub id: i32,

--- a/rust/feature-flags/src/flags/feature_flag_list.rs
+++ b/rust/feature-flags/src/flags/feature_flag_list.rs
@@ -1195,7 +1195,7 @@ mod tests {
         );
 
         // Verify flags parsed correctly
-        assert_eq!(flags.len(), 4, "Expected 4 flags in contract fixture");
+        assert_eq!(flags.len(), 5, "Expected 5 flags in contract fixture");
 
         // Full flag with all optional fields
         let full_flag = &flags[0];
@@ -1247,13 +1247,18 @@ mod tests {
         assert_eq!(dep_flag.filters.groups.len(), 1);
         assert_eq!(dep_flag.version, Some(2));
 
+        // Flag with missing dependency: verify it parses despite referencing a nonexistent flag
+        let missing_dep_flag = &flags[4];
+        assert_eq!(missing_dep_flag.key, "missing-dep-flag");
+        assert_eq!(missing_dep_flag.filters.groups.len(), 1);
+
         // Verify evaluation_metadata parsed correctly
         let meta = metadata;
         assert_eq!(meta.dependency_stages.len(), 2);
-        assert_eq!(meta.dependency_stages[0], vec![1, 2, 3]);
+        assert_eq!(meta.dependency_stages[0], vec![1, 2, 3, 5]);
         assert_eq!(meta.dependency_stages[1], vec![4]);
-        assert!(meta.flags_with_missing_deps.is_empty());
-        assert_eq!(meta.transitive_deps.len(), 4);
+        assert_eq!(meta.flags_with_missing_deps, vec![5]);
+        assert_eq!(meta.transitive_deps.len(), 5);
         assert!(meta.transitive_deps[&4].contains(&2));
 
         // Verify cohorts parsed correctly

--- a/rust/feature-flags/src/flags/feature_flag_list.rs
+++ b/rust/feature-flags/src/flags/feature_flag_list.rs
@@ -1172,13 +1172,26 @@ mod tests {
 
         let result = FeatureFlagList::parse_hypercache_value(data, 99);
         let (flags, metadata, cohorts) = result.expect(
-            "HYPERCACHE CONTRACT VIOLATION: Rust failed to deserialize the golden fixture.\n\n\
-             This means a schema change has broken the cache format that Python writes \
-             and Rust reads. Schema changes must follow the expand-and-contract pattern:\n\
-             1. Add #[serde(default)] or #[serde(alias = ...)] in Rust, deploy\n\
-             2. Change Python serializer, deploy, run warm_flags_cache\n\
-             3. Remove compatibility shim in follow-up PR\n\n\
-             See: rust/feature-flags/tests/fixtures/hypercache_contract.json",
+            "\n\
+             ==============================================================================\n\
+             WARNING: HYPERCACHE BOUNDARY CONTRACT VIOLATION\n\
+             ==============================================================================\n\n\
+             Rust failed to deserialize the golden fixture. This means a schema change\n\
+             has broken the cache format that Python writes and Rust reads.\n\n\
+             DO NOT just update the fixture or tweak the struct to make this test green.\n\
+             The Python serializer is already writing this shape to production caches.\n\n\
+             Before proceeding, consider:\n\
+             \x20 1. Is the change backwards-compatible? (adding a new Optional/default\n\
+             \x20    field is usually safe; renaming/removing a field is not)\n\
+             \x20 2. Do you need a phased rollout? Schema changes must follow\n\
+             \x20    expand-and-contract:\n\
+             \x20    a. Add #[serde(default)] or #[serde(alias = ...)] in Rust, deploy\n\
+             \x20    b. Change Python serializer, deploy, run warm_flags_cache\n\
+             \x20    c. Remove compatibility shim in follow-up PR\n\
+             \x20 3. Will the cache need re-warming? Old cached payloads will still\n\
+             \x20    have the previous shape until they expire or are invalidated.\n\n\
+             See: rust/feature-flags/tests/fixtures/hypercache_contract.json\n\
+             ==============================================================================",
         );
 
         // Verify flags parsed correctly

--- a/rust/feature-flags/src/flags/feature_flag_list.rs
+++ b/rust/feature-flags/src/flags/feature_flag_list.rs
@@ -1155,6 +1155,117 @@ mod tests {
         ));
     }
 
+    /// Golden fixture contract test: verifies that Rust can deserialize the hypercache
+    /// format that Python produces. If this test fails, you've changed the cache schema
+    /// in a way that breaks deserialization.
+    ///
+    /// See the expand-and-contract process in the HYPERCACHE CONTRACT comments at:
+    ///   - posthog/api/feature_flag.py (MinimalFeatureFlagSerializer)
+    ///   - rust/feature-flags/src/flags/flag_models.rs (FeatureFlag struct)
+    #[test]
+    fn test_hypercache_contract() {
+        let fixture = include_str!("../../tests/fixtures/hypercache_contract.json");
+        let data: serde_json::Value = serde_json::from_str(fixture).expect(
+            "Failed to parse hypercache_contract.json as JSON. \
+             The fixture file must be valid JSON.",
+        );
+
+        let result = FeatureFlagList::parse_hypercache_value(data, 99);
+        let (flags, metadata, cohorts) = result.expect(
+            "HYPERCACHE CONTRACT VIOLATION: Rust failed to deserialize the golden fixture.\n\n\
+             This means a schema change has broken the cache format that Python writes \
+             and Rust reads. Schema changes must follow the expand-and-contract pattern:\n\
+             1. Add #[serde(default)] or #[serde(alias = ...)] in Rust, deploy\n\
+             2. Change Python serializer, deploy, run warm_flags_cache\n\
+             3. Remove compatibility shim in follow-up PR\n\n\
+             See: rust/feature-flags/tests/fixtures/hypercache_contract.json",
+        );
+
+        // Verify flags parsed correctly
+        assert_eq!(flags.len(), 4, "Expected 4 flags in contract fixture");
+
+        // Full flag with all optional fields
+        let full_flag = &flags[0];
+        assert_eq!(full_flag.key, "full-flag");
+        assert_eq!(full_flag.id, 1);
+        assert!(full_flag.active);
+        assert!(!full_flag.deleted);
+        assert_eq!(full_flag.ensure_experience_continuity, Some(true));
+        assert_eq!(full_flag.version, Some(3));
+        assert_eq!(full_flag.evaluation_runtime, Some("all".to_string()));
+        assert_eq!(
+            full_flag.bucketing_identifier,
+            Some("device_id".to_string())
+        );
+        // evaluation_contexts is aliased to evaluation_tags in Rust
+        let tags = full_flag
+            .evaluation_tags
+            .as_ref()
+            .expect("evaluation_tags (aliased from evaluation_contexts) should be present");
+        assert_eq!(
+            tags,
+            &vec!["docs-page".to_string(), "marketing-site".to_string()]
+        );
+        // Filter structure
+        assert_eq!(full_flag.filters.groups.len(), 1);
+        assert!(full_flag.filters.multivariate.is_some());
+        assert!(full_flag.filters.super_groups.is_some());
+        assert_eq!(full_flag.filters.feature_enrollment, Some(true));
+        assert!(full_flag.filters.holdout.is_some());
+        let holdout = full_flag.filters.holdout.as_ref().unwrap();
+        assert_eq!(holdout.id, 42);
+        assert!((holdout.exclusion_percentage - 10.0).abs() < f64::EPSILON);
+
+        // Minimal flag: verify defaults for absent optional fields
+        let minimal_flag = &flags[1];
+        assert_eq!(minimal_flag.key, "minimal-flag");
+        assert_eq!(minimal_flag.ensure_experience_continuity, Some(false));
+        assert!(minimal_flag.bucketing_identifier.is_none());
+        assert!(minimal_flag.filters.multivariate.is_none());
+
+        // Cohort flag: verify cohort property type parsed
+        let cohort_flag = &flags[2];
+        assert_eq!(cohort_flag.key, "cohort-flag");
+        assert_eq!(cohort_flag.filters.groups.len(), 1);
+
+        // Flag with dependency: verify dependency property type parsed
+        let dep_flag = &flags[3];
+        assert_eq!(dep_flag.key, "dependent-flag");
+        assert_eq!(dep_flag.filters.groups.len(), 1);
+        assert_eq!(dep_flag.version, Some(2));
+
+        // Verify evaluation_metadata parsed correctly
+        let meta = metadata;
+        assert_eq!(meta.dependency_stages.len(), 2);
+        assert_eq!(meta.dependency_stages[0], vec![1, 2, 3]);
+        assert_eq!(meta.dependency_stages[1], vec![4]);
+        assert!(meta.flags_with_missing_deps.is_empty());
+        assert_eq!(meta.transitive_deps.len(), 4);
+        assert!(meta.transitive_deps[&4].contains(&2));
+
+        // Verify cohorts parsed correctly
+        let cohorts = cohorts.expect("cohorts should be present in contract fixture");
+        assert_eq!(cohorts.len(), 1);
+        assert_eq!(cohorts[0].id, 100);
+        assert_eq!(cohorts[0].name, Some("Test Cohort".to_string()));
+        assert_eq!(cohorts[0].team_id, 99);
+        assert!(!cohorts[0].deleted);
+
+        assert!(
+            cohorts[0].last_backfill_person_properties_at.is_some(),
+            "last_backfill_person_properties_at should deserialize from ISO 8601 timestamp"
+        );
+
+        // Verify cohort filters can parse into the expected CohortProperty structure
+        let filters_value = cohorts[0]
+            .filters
+            .as_ref()
+            .expect("cohort should have filters");
+        let _parsed: crate::cohorts::cohort_models::CohortProperty =
+            serde_json::from_value(filters_value.clone())
+                .expect("Cohort filters should parse as CohortProperty");
+    }
+
     #[test]
     fn test_prepare_regexes_compiles_regex_filters_only() {
         let mut flag_list = FeatureFlagList::new(vec![FeatureFlag {

--- a/rust/feature-flags/src/flags/flag_models.rs
+++ b/rust/feature-flags/src/flags/flag_models.rs
@@ -93,11 +93,16 @@ impl EvaluationMetadata {
 }
 
 /// Wrapper struct for deserializing hypercache format:
-/// `{"flags": [...], "evaluation_metadata": {...}, "cohorts": [...]}`
+/// `{"flags": [...], "evaluation_metadata": {...}, "cohorts": [...] | null}`.
 ///
 /// `evaluation_metadata` is always present in cache entries (written by Django).
 /// The PG fallback path constructs this struct with `EvaluationMetadata::single_stage()`,
 /// which places all flags in one evaluation stage with empty transitive deps.
+///
+/// HYPERCACHE CONTRACT: These fields must match the top-level keys returned by
+/// `_get_feature_flags_for_service()` in posthog/models/feature_flag/flags_cache.py.
+/// Field changes must follow the expand-and-contract pattern — see contract tests in
+/// posthog/models/feature_flag/test/test_flags_cache.py.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct HypercacheFlagsWrapper {
     pub flags: Vec<FeatureFlag>,
@@ -203,6 +208,14 @@ pub enum BucketingIdentifier {
 // TODO: see if you can combine these two structs, like we do with cohort models
 // this will require not deserializing on read and instead doing it lazily, on-demand
 // (which, tbh, is probably a better idea)
+///
+/// HYPERCACHE CONTRACT: These fields are deserialized from JSON written by Python's
+/// MinimalFeatureFlagSerializer (posthog/api/feature_flag.py). Field changes must
+/// follow the expand-and-contract pattern. Golden fixture contract test:
+///   cargo test -p feature-flags test_hypercache_contract
+///
+/// Note: Python also emits `has_encrypted_payloads`, which Rust intentionally
+/// ignores (serde drops unknown fields).
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct FeatureFlag {
     pub id: FeatureFlagId,

--- a/rust/feature-flags/tests/fixtures/hypercache_contract.json
+++ b/rust/feature-flags/tests/fixtures/hypercache_contract.json
@@ -146,19 +146,53 @@
             "evaluation_runtime": "all",
             "bucketing_identifier": null,
             "evaluation_contexts": []
+        },
+        {
+            "id": 5,
+            "team_id": 99,
+            "name": "Flag with missing dependency",
+            "key": "missing-dep-flag",
+            "filters": {
+                "groups": [
+                    {
+                        "properties": [
+                            {
+                                "key": "99999",
+                                "label": "nonexistent-flag",
+                                "operator": "flag_evaluates_to",
+                                "type": "flag",
+                                "value": true
+                            }
+                        ],
+                        "rollout_percentage": 100,
+                        "variant": null
+                    }
+                ],
+                "multivariate": null,
+                "payloads": {}
+            },
+            "deleted": false,
+            "active": true,
+            "ensure_experience_continuity": false,
+            "has_encrypted_payloads": false,
+            "version": 1,
+            "evaluation_runtime": "all",
+            "bucketing_identifier": null,
+            "evaluation_contexts": []
         }
     ],
     "evaluation_metadata": {
         "dependency_stages": [
-            [1, 2, 3],
+            [1, 2, 3, 5],
             [4]
         ],
-        "flags_with_missing_deps": [],
+        "flags_with_missing_deps": [5],
         "transitive_deps": {
             "1": [],
             "2": [],
             "3": [],
-            "4": [2]
+            "4": [2],
+            "5": []
         }
     },
     "cohorts": [

--- a/rust/feature-flags/tests/fixtures/hypercache_contract.json
+++ b/rust/feature-flags/tests/fixtures/hypercache_contract.json
@@ -1,0 +1,185 @@
+{
+    "flags": [
+        {
+            "id": 1,
+            "team_id": 99,
+            "name": "Full feature flag with all optional fields",
+            "key": "full-flag",
+            "filters": {
+                "groups": [
+                    {
+                        "properties": [
+                            {
+                                "key": "email",
+                                "value": "test@example.com",
+                                "type": "person",
+                                "operator": "exact"
+                            }
+                        ],
+                        "rollout_percentage": 50,
+                        "variant": null
+                    }
+                ],
+                "multivariate": {
+                    "variants": [
+                        {"key": "control", "name": "Control", "rollout_percentage": 50},
+                        {"key": "test", "name": "Test", "rollout_percentage": 50}
+                    ]
+                },
+                "payloads": {"control": "payload-value"},
+                "super_groups": [
+                    {
+                        "properties": [
+                            {
+                                "key": "$feature_enrollment/full-flag",
+                                "type": "person",
+                                "value": ["true"],
+                                "operator": "exact"
+                            }
+                        ],
+                        "rollout_percentage": null,
+                        "variant": null
+                    }
+                ],
+                "feature_enrollment": true,
+                "holdout": {
+                    "id": 42,
+                    "exclusion_percentage": 10.0
+                },
+                "aggregation_group_type_index": null
+            },
+            "deleted": false,
+            "active": true,
+            "ensure_experience_continuity": true,
+            "has_encrypted_payloads": false,
+            "version": 3,
+            "evaluation_runtime": "all",
+            "bucketing_identifier": "device_id",
+            "evaluation_contexts": ["docs-page", "marketing-site"]
+        },
+        {
+            "id": 2,
+            "team_id": 99,
+            "name": "",
+            "key": "minimal-flag",
+            "filters": {
+                "groups": [
+                    {
+                        "properties": [],
+                        "rollout_percentage": 100,
+                        "variant": null
+                    }
+                ],
+                "multivariate": null,
+                "payloads": {}
+            },
+            "deleted": false,
+            "active": true,
+            "ensure_experience_continuity": false,
+            "has_encrypted_payloads": false,
+            "version": 1,
+            "evaluation_runtime": "all",
+            "bucketing_identifier": null,
+            "evaluation_contexts": []
+        },
+        {
+            "id": 3,
+            "team_id": 99,
+            "name": "Cohort flag",
+            "key": "cohort-flag",
+            "filters": {
+                "groups": [
+                    {
+                        "properties": [
+                            {
+                                "key": "id",
+                                "value": 100,
+                                "type": "cohort",
+                                "operator": "in"
+                            }
+                        ],
+                        "rollout_percentage": 100,
+                        "variant": null
+                    }
+                ],
+                "multivariate": null,
+                "payloads": {}
+            },
+            "deleted": false,
+            "active": true,
+            "ensure_experience_continuity": false,
+            "has_encrypted_payloads": false,
+            "version": 1,
+            "evaluation_runtime": "all",
+            "bucketing_identifier": null,
+            "evaluation_contexts": []
+        },
+        {
+            "id": 4,
+            "team_id": 99,
+            "name": "Flag with dependency",
+            "key": "dependent-flag",
+            "filters": {
+                "groups": [
+                    {
+                        "properties": [
+                            {
+                                "key": "2",
+                                "label": "minimal-flag",
+                                "operator": "flag_evaluates_to",
+                                "type": "flag",
+                                "value": true
+                            }
+                        ],
+                        "rollout_percentage": 100,
+                        "variant": null
+                    }
+                ],
+                "multivariate": null,
+                "payloads": {}
+            },
+            "deleted": false,
+            "active": true,
+            "ensure_experience_continuity": false,
+            "has_encrypted_payloads": false,
+            "version": 2,
+            "evaluation_runtime": "all",
+            "bucketing_identifier": null,
+            "evaluation_contexts": []
+        }
+    ],
+    "evaluation_metadata": {
+        "dependency_stages": [
+            [1, 2, 3],
+            [4]
+        ],
+        "flags_with_missing_deps": [],
+        "transitive_deps": {
+            "1": [],
+            "2": [],
+            "3": [],
+            "4": [2]
+        }
+    },
+    "cohorts": [
+        {
+            "id": 100,
+            "name": "Test Cohort",
+            "description": "A test cohort for the contract fixture",
+            "team_id": 99,
+            "deleted": false,
+            "filters": {"properties": {"type": "AND", "values": [{"type": "AND", "values": [{"key": "email", "value": "test@example.com", "type": "person", "operator": "exact"}]}]}},
+            "query": null,
+            "version": 1,
+            "pending_version": null,
+            "count": 42,
+            "is_calculating": false,
+            "is_static": false,
+            "errors_calculating": 0,
+            "groups": [],
+            "created_by_id": 1,
+            "cohort_type": null,
+            "last_backfill_person_properties_at": "2024-01-15T12:00:00+00:00"
+        }
+    ]
+}


### PR DESCRIPTION
## Problem

The hypercache serializes feature flag data in Python and deserializes it in Rust, but there's no
contract test to catch schema mismatches between the two languages. A field rename or type change
in either side could cause silent deserialization failures in production.

Additionally, the cohort serializer hardcoded `last_backfill_person_properties_at` to `None`
instead of reading the actual model value, which would silently skip realtime cohort membership
lookups once `enable_realtime_cohort_evaluation` is enabled.

## Changes

> [!NOTE]
> This only changes test behavior except for a tiny fix to the cohort serializer.

- Add a golden JSON fixture (`rust/feature-flags/tests/fixtures/hypercache_contract.json`) that
  represents the full hypercache format with flags, evaluation metadata, and cohorts
- **Python contract test**: validates that the serializer output schema matches the fixture via
  deep key/type comparison, catching field additions, removals, or type changes
- **Rust contract test**: validates full deserialization of the fixture including flags with all
  optional field combinations, evaluation metadata, and cohorts with timestamp and filter parsing
- Fix cohort serializer to serialize actual `last_backfill_person_properties_at` as ISO 8601
  instead of hardcoded `None`
- Add `HYPERCACHE CONTRACT` comments documenting the expand-and-contract pattern for schema changes

## How did you test this code?

Automated contract tests on both sides:
- Python: `pytest posthog/models/feature_flag/test/test_flags_cache.py -k "test_serializer_output_matches_fixture_schema"`
- Rust: `cargo test test_hypercache_contract`

## Publish to changelog?

no

## Docs update

no