### PR TITLE
fix(ci): add rasterize_recording to session-replay temporal worker deploy trigger

### DIFF
--- a/.github/workflows/container-images-cd.yml
+++ b/.github/workflows/container-images-cd.yml
@@ -266,7 +266,7 @@ jobs:
             - name: Check for changes that affect session replay temporal worker
               id: check_changes_session_replay_temporal_worker
               run: |
-                  echo "changed=$((git diff --name-only HEAD^ HEAD | grep -qE '^posthog/temporal/enforce_max_replay_retention|^posthog/temporal/delete_recordings|^posthog/temporal/export_recording|^posthog/temporal/import_recording|^posthog/temporal/common|^posthog/management/commands/start_temporal_worker.py$|^pyproject.toml$|^bin/temporal-django-worker$' && echo true) || echo false)" >> $GITHUB_OUTPUT
+                  echo "changed=$((git diff --name-only HEAD^ HEAD | grep -qE '^posthog/temporal/enforce_max_replay_retention|^posthog/temporal/delete_recordings|^posthog/temporal/export_recording|^posthog/temporal/import_recording|^posthog/temporal/rasterize_recording|^posthog/temporal/common|^posthog/management/commands/start_temporal_worker.py$|^pyproject.toml$|^bin/temporal-django-worker$' && echo true) || echo false)" >> $GITHUB_OUTPUT
 
             - name: Check for changes that affect weekly digest temporal worker
               id: check_changes_weekly_digest_temporal_worker


### PR DESCRIPTION
## Summary

- The CD workflow's change-detection for the `temporal-worker-session-replay` deployment was missing `posthog/temporal/rasterize_recording` from its grep pattern
- This meant changes to the rasterization workflow code (e.g. timeout updates in #52498) did not trigger a redeploy of the Python temporal worker that dispatches rasterization activities
- Root-caused after a production timeout: the `start_to_close_timeout` was changed from 10m to 30m but the worker pods were still running old code

## Test plan

- [x] Verify the grep pattern now includes `^posthog/temporal/rasterize_recording`
- [ ] Merge and confirm next change to `posthog/temporal/rasterize_recording/` triggers a session-replay temporal worker deploy