### PR TITLE
fix: some older versions not flagged as outdated unless newer versions also present

### DIFF
--- a/frontend/src/lib/components/HealthMenu/HealthMenu.tsx
+++ b/frontend/src/lib/components/HealthMenu/HealthMenu.tsx
@@ -159,12 +159,21 @@ const UnifiedHealthMenu = ({ iconOnly = false }: { iconOnly?: boolean }): JSX.El
         useValues(healthMenuLogic)
     const { setHealthMenuOpen } = useActions(healthMenuLogic)
     const { triggerBadgeContent, triggerBadgeStatus, totalIssues } = useValues(unifiedHealthMenuLogic)
+    const { needsAttention, needsUpdatingCount, sdkHealth } = useValues(sdkDoctorLogic)
     const { featureFlags } = useValues(featureFlagLogic)
     const pipelineStatusEnabled = !!featureFlags[FEATURE_FLAGS.PIPELINE_STATUS_PAGE]
 
-    const combinedBadgeContent = postHogStatusBadgeContent === '!' || triggerBadgeContent === '!' ? '!' : '✓'
+    const sdkDoctorTooltip = needsAttention
+        ? 'Needs attention'
+        : needsUpdatingCount > 0
+          ? 'Outdated SDKs found'
+          : 'SDK health is good'
+
+    const hasSdkIssues = needsAttention || needsUpdatingCount > 0
+    const combinedBadgeContent =
+        postHogStatusBadgeContent === '!' || triggerBadgeContent === '!' || hasSdkIssues ? '!' : '✓'
     const combinedBadgeStatus: 'danger' | 'warning' | 'success' =
-        postHogStatusBadgeStatus === 'danger' || triggerBadgeStatus === 'danger'
+        postHogStatusBadgeStatus === 'danger' || triggerBadgeStatus === 'danger' || hasSdkIssues
             ? 'danger'
             : postHogStatusBadgeStatus === 'warning' || triggerBadgeStatus === 'warning'
               ? 'warning'
@@ -230,9 +239,14 @@ const UnifiedHealthMenu = ({ iconOnly = false }: { iconOnly?: boolean }): JSX.El
                         {...props}
                         to={urls.sdkDoctor()}
                         buttonProps={{ menuItem: true }}
+                        tooltip={sdkDoctorTooltip}
+                        tooltipPlacement="right"
+                        tooltipCloseDelayMs={0}
                         data-attr="health-menu-sdk-doctor-button"
                     >
-                        <IconCode className="size-5" />
+                        <IconWithBadge size="xsmall" content={needsUpdatingCount > 0 ? '!' : '✓'} status={sdkHealth}>
+                            <IconCode className="size-5" />
+                        </IconWithBadge>
                         SDK Doctor
                     </Link>
                 )}

--- a/frontend/src/scenes/onboarding/sdks/SdkDoctorComponents.tsx
+++ b/frontend/src/scenes/onboarding/sdks/SdkDoctorComponents.tsx
@@ -94,7 +94,22 @@ const activityPageUrlForSdkVersion = (sdkType: SdkType, version: string): string
 
 const COLUMNS: LemonTableColumns<AugmentedTeamSdkVersionsInfoRelease> = [
     {
-        title: 'Version',
+        title: (
+            <span>
+                VERSION{' '}
+                <Tooltip
+                    title={
+                        <>
+                            Click on a version number to view events captured.
+                            <br />
+                            Hover over status for version age and/or suggestion.
+                        </>
+                    }
+                >
+                    <IconInfo />
+                </Tooltip>
+            </span>
+        ),
         dataIndex: 'version',
         render: function RenderVersion(_, record) {
             return (

--- a/frontend/src/scenes/onboarding/sdks/sdkDoctorLogic.tsx
+++ b/frontend/src/scenes/onboarding/sdks/sdkDoctorLogic.tsx
@@ -412,8 +412,8 @@ function computeAugmentedInfoRelease(
         // but no new events with the new version exist yet, causing confusing "Outdated" warnings
         const SINGLE_VERSION_GRACE_PERIOD_DAYS = 30
 
-        if (isSingleVersion && diff && diff.kind !== 'patch') {
-            isOutdated = daysSinceRelease !== undefined && daysSinceRelease > SINGLE_VERSION_GRACE_PERIOD_DAYS
+        if (isSingleVersion && diff && diff.kind !== 'patch' && daysSinceRelease !== undefined) {
+            isOutdated = daysSinceRelease > SINGLE_VERSION_GRACE_PERIOD_DAYS
         } else if (isRecentRelease) {
             // Apply grace period - don't flag anything <7 days old
             isOutdated = false


### PR DESCRIPTION
## Changes

  - Fix for some outdated SDK versions incorrectly showing as "Recent" when they are the only version present for an SDK type
  - Fix for SDK Doctor health badge on the unified health nav menu (was missing when unified-health-page flag is enabled)                 
  - Add info tooltip to the Version column header, calling out click-to-explore and hover-for-status goodies 

## How did you test this code?

Tested on my local with a test script that sends test events with the actual SDK versions.

## Publish to changelog?
No
## Docs update

🤖 LLM context
Opus 4.6 in VS Code, with an assist from phrocs MCP, and a lot of guidance from the human
