### PR TITLE
chore(error-tracking): batch cymbal calls to avoid max request limit

### DIFF
--- a/nodejs/src/ingestion/error-tracking/config.ts
+++ b/nodejs/src/ingestion/error-tracking/config.ts
@@ -26,6 +26,10 @@ export type ErrorTrackingConsumerConfig = {
     /** TTL in seconds for local cache entries */
     ERROR_TRACKING_STATEFUL_OVERFLOW_LOCAL_CACHE_TTL_SECONDS: number
 
+    /** Max HTTP body size in bytes per Cymbal API request. Used to proactively
+     *  split large batches before they hit Cymbal's body limit. */
+    ERROR_TRACKING_CYMBAL_MAX_BODY_BYTES: number
+
     /** Pipeline name for metrics labeling */
     INGESTION_PIPELINE: string | null
     /** Lane identifier (main, overflow) for metrics labeling */
@@ -46,6 +50,7 @@ export function getDefaultErrorTrackingConsumerConfig(): ErrorTrackingConsumerCo
         ERROR_TRACKING_STATEFUL_OVERFLOW_ENABLED: false,
         ERROR_TRACKING_STATEFUL_OVERFLOW_REDIS_TTL_SECONDS: 300, // 5 minutes
         ERROR_TRACKING_STATEFUL_OVERFLOW_LOCAL_CACHE_TTL_SECONDS: 60, // 1 minute
+        ERROR_TRACKING_CYMBAL_MAX_BODY_BYTES: 1_800_000,
         INGESTION_PIPELINE: null,
         INGESTION_LANE: null,
     }

--- a/nodejs/src/ingestion/error-tracking/cymbal-processing-step.test.ts
+++ b/nodejs/src/ingestion/error-tracking/cymbal-processing-step.test.ts
@@ -65,14 +65,18 @@ describe('createCymbalProcessingStep', () => {
         // Verify Cymbal request format
         expect(mockCymbalClient.processExceptions).toHaveBeenCalledWith([
             expect.objectContaining({
-                uuid: 'uuid-1',
-                event: '$exception',
-                team_id: 123,
+                request: expect.objectContaining({
+                    uuid: 'uuid-1',
+                    event: '$exception',
+                    team_id: 123,
+                }),
             }),
             expect.objectContaining({
-                uuid: 'uuid-2',
-                event: '$exception',
-                team_id: 123,
+                request: expect.objectContaining({
+                    uuid: 'uuid-2',
+                    event: '$exception',
+                    team_id: 123,
+                }),
             }),
         ])
     })
@@ -138,11 +142,13 @@ describe('createCymbalProcessingStep', () => {
 
         expect(mockCymbalClient.processExceptions).toHaveBeenCalledWith([
             expect.objectContaining({
-                properties: expect.objectContaining({
-                    $geoip_country_code: 'US',
-                    $geoip_city_name: 'San Francisco',
-                    $geoip_subdivision_1_code: 'CA',
-                    $geoip_subdivision_1_name: 'California',
+                request: expect.objectContaining({
+                    properties: expect.objectContaining({
+                        $geoip_country_code: 'US',
+                        $geoip_city_name: 'San Francisco',
+                        $geoip_subdivision_1_code: 'CA',
+                        $geoip_subdivision_1_name: 'California',
+                    }),
                 }),
             }),
         ])
@@ -164,9 +170,11 @@ describe('createCymbalProcessingStep', () => {
         // Group properties are passed through in the properties object
         expect(mockCymbalClient.processExceptions).toHaveBeenCalledWith([
             expect.objectContaining({
-                properties: expect.objectContaining({
-                    $group_0: 'company-1',
-                    $group_1: 'project-1',
+                request: expect.objectContaining({
+                    properties: expect.objectContaining({
+                        $group_0: 'company-1',
+                        $group_1: 'project-1',
+                    }),
                 }),
             }),
         ])
@@ -203,7 +211,9 @@ describe('createCymbalProcessingStep', () => {
 
         expect(mockCymbalClient.processExceptions).toHaveBeenCalledWith([
             expect.objectContaining({
-                properties: { some_prop: 'value' },
+                request: expect.objectContaining({
+                    properties: { some_prop: 'value' },
+                }),
             }),
         ])
     })
@@ -219,7 +229,9 @@ describe('createCymbalProcessingStep', () => {
 
             expect(mockCymbalClient.processExceptions).toHaveBeenCalledWith([
                 expect.objectContaining({
-                    timestamp: '2024-01-15T10:30:00.000Z',
+                    request: expect.objectContaining({
+                        timestamp: '2024-01-15T10:30:00.000Z',
+                    }),
                 }),
             ])
         })
@@ -238,7 +250,9 @@ describe('createCymbalProcessingStep', () => {
 
                 expect(mockCymbalClient.processExceptions).toHaveBeenCalledWith([
                     expect.objectContaining({
-                        timestamp: '2024-01-20T12:00:00.000Z',
+                        request: expect.objectContaining({
+                            timestamp: '2024-01-20T12:00:00.000Z',
+                        }),
                     }),
                 ])
             } finally {

--- a/nodejs/src/ingestion/error-tracking/cymbal-processing-step.test.ts
+++ b/nodejs/src/ingestion/error-tracking/cymbal-processing-step.test.ts
@@ -65,6 +65,7 @@ describe('createCymbalProcessingStep', () => {
         // Verify Cymbal request format
         expect(mockCymbalClient.processExceptions).toHaveBeenCalledWith([
             expect.objectContaining({
+                estimatedSize: expect.any(Number),
                 request: expect.objectContaining({
                     uuid: 'uuid-1',
                     event: '$exception',
@@ -72,6 +73,7 @@ describe('createCymbalProcessingStep', () => {
                 }),
             }),
             expect.objectContaining({
+                estimatedSize: expect.any(Number),
                 request: expect.objectContaining({
                     uuid: 'uuid-2',
                     event: '$exception',
@@ -142,6 +144,7 @@ describe('createCymbalProcessingStep', () => {
 
         expect(mockCymbalClient.processExceptions).toHaveBeenCalledWith([
             expect.objectContaining({
+                estimatedSize: expect.any(Number),
                 request: expect.objectContaining({
                     properties: expect.objectContaining({
                         $geoip_country_code: 'US',
@@ -170,6 +173,7 @@ describe('createCymbalProcessingStep', () => {
         // Group properties are passed through in the properties object
         expect(mockCymbalClient.processExceptions).toHaveBeenCalledWith([
             expect.objectContaining({
+                estimatedSize: expect.any(Number),
                 request: expect.objectContaining({
                     properties: expect.objectContaining({
                         $group_0: 'company-1',
@@ -211,6 +215,7 @@ describe('createCymbalProcessingStep', () => {
 
         expect(mockCymbalClient.processExceptions).toHaveBeenCalledWith([
             expect.objectContaining({
+                estimatedSize: expect.any(Number),
                 request: expect.objectContaining({
                     properties: { some_prop: 'value' },
                 }),
@@ -229,6 +234,7 @@ describe('createCymbalProcessingStep', () => {
 
             expect(mockCymbalClient.processExceptions).toHaveBeenCalledWith([
                 expect.objectContaining({
+                    estimatedSize: expect.any(Number),
                     request: expect.objectContaining({
                         timestamp: '2024-01-15T10:30:00.000Z',
                     }),
@@ -250,6 +256,7 @@ describe('createCymbalProcessingStep', () => {
 
                 expect(mockCymbalClient.processExceptions).toHaveBeenCalledWith([
                     expect.objectContaining({
+                        estimatedSize: expect.any(Number),
                         request: expect.objectContaining({
                             timestamp: '2024-01-20T12:00:00.000Z',
                         }),

--- a/nodejs/src/ingestion/error-tracking/cymbal-processing-step.ts
+++ b/nodejs/src/ingestion/error-tracking/cymbal-processing-step.ts
@@ -8,11 +8,13 @@ import { BatchProcessingStep } from '../pipelines/base-batch-pipeline'
 import { PipelineWarning } from '../pipelines/pipeline.interface'
 import { PipelineResult, drop, ok } from '../pipelines/results'
 import { CymbalClient } from './cymbal/client'
-import { CymbalRequest, CymbalResponse } from './cymbal/types'
+import { CymbalResponse } from './cymbal/types'
 
 export interface CymbalProcessingInput {
     event: PluginEvent
     team: Team
+    /** Byte size of the original Kafka message, used to estimate HTTP payload size. */
+    messageBytes?: number
 }
 
 /**
@@ -87,17 +89,23 @@ export function createCymbalProcessingStep<T extends CymbalProcessingInput>(
             return { input, timestamp, warnings }
         })
 
-        // Build requests for all inputs - Cymbal expects AnyEvent format
-        const requests: CymbalRequest[] = validatedInputs.map(({ input, timestamp }) => ({
-            uuid: input.event.uuid,
-            event: input.event.event,
-            team_id: input.team.id,
-            timestamp,
-            properties: input.event.properties ?? {},
+        // Build requests paired with estimated sizes for proactive chunking.
+        // Kafka message sizes overestimate the CymbalRequest size (they include
+        // headers, distinct_id, and other fields stripped from the request),
+        // which is conservative — we split slightly earlier than needed, never too late.
+        const items = validatedInputs.map(({ input, timestamp }) => ({
+            request: {
+                uuid: input.event.uuid,
+                event: input.event.event,
+                team_id: input.team.id,
+                timestamp,
+                properties: input.event.properties ?? {},
+            },
+            estimatedSize: input.messageBytes ?? 0,
         }))
 
         try {
-            const responses = await cymbalClient.processExceptions(requests)
+            const responses = await cymbalClient.processExceptions(items)
 
             // Map responses back to results, maintaining 1:1 correspondence
             return responses.map((response, index) => {

--- a/nodejs/src/ingestion/error-tracking/cymbal/client.test.ts
+++ b/nodejs/src/ingestion/error-tracking/cymbal/client.test.ts
@@ -1,3 +1,5 @@
+import { parseJSON } from '~/utils/json-parse'
+
 import { CymbalClient, FetchFunction } from './client'
 import { CymbalRequest, CymbalResponse } from './types'
 
@@ -10,6 +12,9 @@ jest.mock('~/utils/logger', () => ({
         error: jest.fn(),
     },
 }))
+
+/** Wrap requests into items with a default size estimate (small enough that batches never split). */
+const toItems = (requests: CymbalRequest[], size = 100) => requests.map((request) => ({ request, estimatedSize: size }))
 
 describe('CymbalClient', () => {
     let client: CymbalClient
@@ -41,6 +46,7 @@ describe('CymbalClient', () => {
         return new CymbalClient({
             baseUrl: 'http://cymbal.example.com',
             timeoutMs: 5000,
+            maxBodyBytes: 1_800_000,
             fetch: fetchMock as FetchFunction,
         })
     }
@@ -73,7 +79,7 @@ describe('CymbalClient', () => {
                 json: () => Promise.resolve(responses),
             })
 
-            const results = await client.processExceptions(requests)
+            const results = await client.processExceptions(toItems(requests))
 
             expect(results).toEqual(responses)
             expect(mockFetch).toHaveBeenCalledTimes(1)
@@ -97,7 +103,7 @@ describe('CymbalClient', () => {
                 json: () => Promise.resolve(responses),
             })
 
-            const results = await client.processExceptions(requests)
+            const results = await client.processExceptions(toItems(requests))
 
             expect(results).toEqual([null])
         })
@@ -111,7 +117,7 @@ describe('CymbalClient', () => {
             })
 
             try {
-                await client.processExceptions(requests)
+                await client.processExceptions(toItems(requests))
                 fail('Expected error to be thrown')
             } catch (error: any) {
                 expect(error.message).toContain('Cymbal returned 500')
@@ -128,7 +134,7 @@ describe('CymbalClient', () => {
             })
 
             try {
-                await client.processExceptions(requests)
+                await client.processExceptions(toItems(requests))
                 fail('Expected error to be thrown')
             } catch (error: any) {
                 expect(error.message).toContain('Cymbal returned 429')
@@ -145,7 +151,7 @@ describe('CymbalClient', () => {
             })
 
             try {
-                await client.processExceptions(requests)
+                await client.processExceptions(toItems(requests))
                 fail('Expected error to be thrown')
             } catch (error: any) {
                 expect(error.message).toContain('Cymbal returned 400')
@@ -162,7 +168,7 @@ describe('CymbalClient', () => {
                 json: () => Promise.resolve(responses),
             })
 
-            await expect(client.processExceptions(requests)).rejects.toThrow(
+            await expect(client.processExceptions(toItems(requests))).rejects.toThrow(
                 'Cymbal response length mismatch: got 1, expected 2'
             )
         })
@@ -175,7 +181,7 @@ describe('CymbalClient', () => {
                 json: () => Promise.resolve({ error: 'unexpected error format' }),
             })
 
-            await expect(client.processExceptions(requests)).rejects.toThrow('Invalid Cymbal response')
+            await expect(client.processExceptions(toItems(requests))).rejects.toThrow('Invalid Cymbal response')
         })
 
         it('throws when response element has invalid structure', async () => {
@@ -186,7 +192,7 @@ describe('CymbalClient', () => {
                 json: () => Promise.resolve([{ invalid: 'no uuid field' }]),
             })
 
-            await expect(client.processExceptions(requests)).rejects.toThrow('Invalid Cymbal response')
+            await expect(client.processExceptions(toItems(requests))).rejects.toThrow('Invalid Cymbal response')
         })
 
         it('accepts null elements in response array', async () => {
@@ -198,7 +204,7 @@ describe('CymbalClient', () => {
                 json: () => Promise.resolve(responses),
             })
 
-            const results = await client.processExceptions(requests)
+            const results = await client.processExceptions(toItems(requests))
 
             expect(results).toEqual(responses)
             expect(results[1]).toBeNull()
@@ -210,7 +216,7 @@ describe('CymbalClient', () => {
             mockFetch.mockRejectedValueOnce(new Error('Network error'))
 
             try {
-                await client.processExceptions(requests)
+                await client.processExceptions(toItems(requests))
                 fail('Expected error to be thrown')
             } catch (error: any) {
                 expect(error.message).toContain('Network error')
@@ -227,7 +233,7 @@ describe('CymbalClient', () => {
             mockFetch.mockRejectedValueOnce(timeoutError)
 
             try {
-                await client.processExceptions(requests)
+                await client.processExceptions(toItems(requests))
                 fail('Expected error to be thrown')
             } catch (error: any) {
                 expect(error.message).toContain('Timeout')
@@ -239,6 +245,7 @@ describe('CymbalClient', () => {
             const clientWithTrailingSlash = new CymbalClient({
                 baseUrl: 'http://cymbal.example.com/',
                 timeoutMs: 5000,
+                maxBodyBytes: 1_800_000,
                 fetch: mockFetch as FetchFunction,
             })
 
@@ -248,9 +255,138 @@ describe('CymbalClient', () => {
                 json: () => Promise.resolve(responses),
             })
 
-            await clientWithTrailingSlash.processExceptions([createRequest()])
+            await clientWithTrailingSlash.processExceptions(toItems([createRequest()]))
 
             expect(mockFetch).toHaveBeenCalledWith('http://cymbal.example.com/process', expect.any(Object))
+        })
+    })
+
+    describe('size-based chunking', () => {
+        it('sends a single request when total size is under the limit', async () => {
+            const requests = [createRequest({ uuid: 'uuid-1' }), createRequest({ uuid: 'uuid-2' })]
+            const responses = [createResponse({ uuid: 'uuid-1' }), createResponse({ uuid: 'uuid-2' })]
+
+            mockFetch.mockResolvedValueOnce({
+                status: 200,
+                json: () => Promise.resolve(responses),
+            })
+
+            const results = await client.processExceptions(toItems(requests))
+
+            expect(results).toEqual(responses)
+            expect(mockFetch).toHaveBeenCalledTimes(1)
+        })
+
+        it('splits into multiple requests when total size exceeds the limit', async () => {
+            const smallClient = new CymbalClient({
+                baseUrl: 'http://cymbal.example.com',
+                timeoutMs: 5000,
+                maxBodyBytes: 150,
+                fetch: mockFetch as FetchFunction,
+            })
+
+            const requests = [
+                createRequest({ uuid: 'uuid-1' }),
+                createRequest({ uuid: 'uuid-2' }),
+                createRequest({ uuid: 'uuid-3' }),
+            ]
+
+            mockFetch.mockImplementation((_url: string, options: { body: string }) => {
+                const parsed = parseJSON(options.body)
+                const responses = parsed.map((req: CymbalRequest) => createResponse({ uuid: req.uuid }))
+                return Promise.resolve({
+                    status: 200,
+                    json: () => Promise.resolve(responses),
+                })
+            })
+
+            // Each request is estimated at 100 bytes, limit is 150 — so max 1 per chunk
+            const results = await smallClient.processExceptions(toItems(requests, 100))
+
+            expect(results).toHaveLength(3)
+            expect(results.map((r) => r!.uuid)).toEqual(['uuid-1', 'uuid-2', 'uuid-3'])
+            expect(mockFetch).toHaveBeenCalledTimes(3)
+        })
+
+        it('preserves 1:1 position correspondence across chunks', async () => {
+            const smallClient = new CymbalClient({
+                baseUrl: 'http://cymbal.example.com',
+                timeoutMs: 5000,
+                maxBodyBytes: 500,
+                fetch: mockFetch as FetchFunction,
+            })
+
+            const requests = Array.from({ length: 5 }, (_, i) => createRequest({ uuid: `uuid-${i}` }))
+            mockFetch.mockImplementation((_url: string, options: { body: string }) => {
+                const parsed = parseJSON(options.body)
+                const responses = parsed.map((req: CymbalRequest) => createResponse({ uuid: req.uuid }))
+                return Promise.resolve({
+                    status: 200,
+                    json: () => Promise.resolve(responses),
+                })
+            })
+
+            // 200 bytes each, limit 500 — chunks of 2, 2, 1
+            const results = await smallClient.processExceptions(toItems(requests, 200))
+
+            expect(results.map((r) => r!.uuid)).toEqual(['uuid-0', 'uuid-1', 'uuid-2', 'uuid-3', 'uuid-4'])
+            expect(mockFetch).toHaveBeenCalledTimes(3)
+        })
+
+        it('puts a single oversized request in its own chunk', async () => {
+            const smallClient = new CymbalClient({
+                baseUrl: 'http://cymbal.example.com',
+                timeoutMs: 5000,
+                maxBodyBytes: 50,
+                fetch: mockFetch as FetchFunction,
+            })
+
+            const requests = [createRequest({ uuid: 'uuid-1' }), createRequest({ uuid: 'uuid-2' })]
+
+            mockFetch.mockImplementation((_url: string, options: { body: string }) => {
+                const parsed = parseJSON(options.body)
+                const responses = parsed.map((req: CymbalRequest) => createResponse({ uuid: req.uuid }))
+                return Promise.resolve({
+                    status: 200,
+                    json: () => Promise.resolve(responses),
+                })
+            })
+
+            // Each request is 100 bytes, limit is 50 — each gets its own chunk
+            const results = await smallClient.processExceptions(toItems(requests, 100))
+
+            expect(results).toHaveLength(2)
+            expect(mockFetch).toHaveBeenCalledTimes(2)
+        })
+
+        it('aborts remaining chunks if one fails', async () => {
+            const smallClient = new CymbalClient({
+                baseUrl: 'http://cymbal.example.com',
+                timeoutMs: 5000,
+                maxBodyBytes: 150,
+                fetch: mockFetch as FetchFunction,
+            })
+
+            const requests = [
+                createRequest({ uuid: 'uuid-1' }),
+                createRequest({ uuid: 'uuid-2' }),
+                createRequest({ uuid: 'uuid-3' }),
+            ]
+
+            let callCount = 0
+            mockFetch.mockImplementation((_url: string, options: { body: string }) => {
+                callCount++
+                if (callCount === 1) {
+                    const parsed = parseJSON(options.body)
+                    return Promise.resolve({
+                        status: 200,
+                        json: () => Promise.resolve(parsed.map((r: CymbalRequest) => createResponse({ uuid: r.uuid }))),
+                    })
+                }
+                return Promise.resolve({ status: 500, text: () => Promise.resolve('Internal Server Error') })
+            })
+
+            await expect(smallClient.processExceptions(toItems(requests, 100))).rejects.toThrow('Cymbal returned 500')
         })
     })
 

--- a/nodejs/src/ingestion/error-tracking/cymbal/client.ts
+++ b/nodejs/src/ingestion/error-tracking/cymbal/client.ts
@@ -36,6 +36,12 @@ const cymbalBatchSizeHistogram = new Histogram({
     buckets: [1, 5, 10, 25, 50, 100, 250, 500],
 })
 
+const cymbalChunksPerBatchHistogram = new Histogram({
+    name: 'error_tracking_cymbal_chunks_per_batch',
+    help: 'Number of HTTP requests per batch (1 = no chunking needed)',
+    buckets: [1, 2, 3, 4, 5, 10],
+})
+
 /** Function signature for fetch implementation */
 export type FetchFunction = (
     url: string,
@@ -45,6 +51,8 @@ export type FetchFunction = (
 export interface CymbalClientConfig {
     baseUrl: string
     timeoutMs: number
+    /** Target max body size in bytes for proactive chunking. */
+    maxBodyBytes: number
     /** Custom fetch implementation for testing. Defaults to internalFetch. */
     fetch?: FetchFunction
 }
@@ -77,30 +85,56 @@ class CymbalError extends Error {
 export class CymbalClient {
     private baseUrl: string
     private timeoutMs: number
+    private maxBodyBytes: number
     private fetch: FetchFunction
 
     constructor(config: CymbalClientConfig) {
         this.baseUrl = config.baseUrl.replace(/\/$/, '') // Remove trailing slash
         this.timeoutMs = config.timeoutMs
+        this.maxBodyBytes = config.maxBodyBytes
         this.fetch = config.fetch ?? internalFetch
     }
 
     /**
      * Process a batch of exception events through Cymbal.
      *
-     * @param requests - Array of exception events to process
+     * Uses estimated byte sizes (from the original Kafka messages) to proactively
+     * split batches that would exceed Cymbal's body size limit. This avoids
+     * wasted HTTP roundtrips from 413 rejections without requiring serialization
+     * to measure size.
+     *
+     * @param items - Array of requests paired with their estimated byte size
+     *        (e.g. from Kafka message.value.length).
      * @returns Array of processed events with symbolicated stack traces and fingerprints.
      *          Null entries indicate events that should be dropped (e.g., suppressed issues).
      *          Maintains 1:1 position correspondence with input array.
      * @throws CymbalError with isRetriable flag indicating whether the error should be retried
      */
-    async processExceptions(requests: CymbalRequest[]): Promise<(CymbalResponse | null)[]> {
-        if (requests.length === 0) {
+    async processExceptions(
+        items: { request: CymbalRequest; estimatedSize: number }[]
+    ): Promise<(CymbalResponse | null)[]> {
+        if (items.length === 0) {
             return []
         }
 
-        cymbalBatchSizeHistogram.observe(requests.length)
+        cymbalBatchSizeHistogram.observe(items.length)
 
+        const chunks = this.chunkByEstimatedSize(items)
+        cymbalChunksPerBatchHistogram.observe(chunks.length)
+        const allResults: (CymbalResponse | null)[] = []
+
+        for (const chunk of chunks) {
+            const results = await this.processChunk(chunk.map((item) => item.request))
+            allResults.push(...results)
+        }
+
+        return allResults
+    }
+
+    /**
+     * Process a single chunk of requests through Cymbal's HTTP API.
+     */
+    private async processChunk(requests: CymbalRequest[]): Promise<(CymbalResponse | null)[]> {
         const { response, durationMs } = await this.makeRequest(requests)
 
         if (response.status >= 400) {
@@ -138,6 +172,36 @@ export class CymbalClient {
 
         this.recordMetrics('success', durationMs, requests.length)
         return results as (CymbalResponse | null)[]
+    }
+
+    /**
+     * Split items into chunks using estimated byte sizes. Greedily fills
+     * each chunk until adding the next item would exceed maxBodyBytes.
+     * A single item that exceeds the limit gets its own chunk.
+     */
+    private chunkByEstimatedSize(
+        items: { request: CymbalRequest; estimatedSize: number }[]
+    ): { request: CymbalRequest; estimatedSize: number }[][] {
+        const chunks: { request: CymbalRequest; estimatedSize: number }[][] = []
+        let currentChunk: { request: CymbalRequest; estimatedSize: number }[] = []
+        let currentSize = 0
+
+        for (const item of items) {
+            if (currentChunk.length > 0 && currentSize + item.estimatedSize > this.maxBodyBytes) {
+                chunks.push(currentChunk)
+                currentChunk = [item]
+                currentSize = item.estimatedSize
+            } else {
+                currentChunk.push(item)
+                currentSize += item.estimatedSize
+            }
+        }
+
+        if (currentChunk.length > 0) {
+            chunks.push(currentChunk)
+        }
+
+        return chunks
     }
 
     /**

--- a/nodejs/src/ingestion/error-tracking/error-tracking-consumer.test.ts
+++ b/nodejs/src/ingestion/error-tracking/error-tracking-consumer.test.ts
@@ -75,17 +75,17 @@ const createMockPersonRepository = (): jest.Mocked<PersonRepository> => ({
 // Cymbal receives event properties and returns them with fingerprint/issue_id added
 jest.mock('./cymbal', () => ({
     CymbalClient: jest.fn().mockImplementation(() => ({
-        processExceptions: jest.fn().mockImplementation((requests) =>
-            // Return a valid response for each request, preserving input properties
-            requests.map((req: any) => ({
-                uuid: req.uuid,
-                event: req.event,
-                team_id: req.team_id,
-                timestamp: req.timestamp,
+        processExceptions: jest.fn().mockImplementation((items) =>
+            // Return a valid response for each item, preserving input properties
+            items.map((item: any) => ({
+                uuid: item.request.uuid,
+                event: item.request.event,
+                team_id: item.request.team_id,
+                timestamp: item.request.timestamp,
                 properties: {
-                    ...req.properties,
-                    $exception_fingerprint: `fingerprint-${req.uuid}`,
-                    $exception_issue_id: `issue-${req.uuid}`,
+                    ...item.request.properties,
+                    $exception_fingerprint: `fingerprint-${item.request.uuid}`,
+                    $exception_issue_id: `issue-${item.request.uuid}`,
                 },
             }))
         ),
@@ -147,6 +147,7 @@ describe('ErrorTrackingConsumer', () => {
             outputTopic: hub.ERROR_TRACKING_CONSUMER_OUTPUT_TOPIC,
             cymbalBaseUrl: hub.ERROR_TRACKING_CYMBAL_BASE_URL,
             cymbalTimeoutMs: hub.ERROR_TRACKING_CYMBAL_TIMEOUT_MS,
+            cymbalMaxBodyBytes: hub.ERROR_TRACKING_CYMBAL_MAX_BODY_BYTES,
             lane: hub.INGESTION_LANE ?? ('main' as const),
             overflowBucketCapacity: hub.ERROR_TRACKING_OVERFLOW_BUCKET_CAPACITY,
             overflowBucketReplenishRate: hub.ERROR_TRACKING_OVERFLOW_BUCKET_REPLENISH_RATE,

--- a/nodejs/src/ingestion/error-tracking/error-tracking-consumer.ts
+++ b/nodejs/src/ingestion/error-tracking/error-tracking-consumer.ts
@@ -44,6 +44,7 @@ export interface ErrorTrackingConsumerOptions {
     outputTopic: string
     cymbalBaseUrl: string
     cymbalTimeoutMs: number
+    cymbalMaxBodyBytes: number
     lane: IngestionLane
     overflowBucketCapacity: number
     overflowBucketReplenishRate: number
@@ -121,6 +122,7 @@ export class ErrorTrackingConsumer {
         this.cymbalClient = new CymbalClient({
             baseUrl: config.cymbalBaseUrl,
             timeoutMs: config.cymbalTimeoutMs,
+            maxBodyBytes: config.cymbalMaxBodyBytes,
         })
 
         this.promiseScheduler = new PromiseScheduler()

--- a/nodejs/src/ingestion/error-tracking/error-tracking-pipeline.test.ts
+++ b/nodejs/src/ingestion/error-tracking/error-tracking-pipeline.test.ts
@@ -400,6 +400,23 @@ describe('ErrorTrackingPipeline', () => {
             expect(producedEvents).toHaveLength(2)
         })
 
+        it('passes Kafka message byte size to Cymbal for batch chunking', async () => {
+            mockPersonRepository.fetchPerson.mockResolvedValue(undefined)
+
+            const cymbalResponse = createCymbalResponseWithEnrichedProperties({
+                $exception_list: [{ type: 'Error', value: 'Test error' }],
+            })
+            mockCymbalClient.processExceptions.mockResolvedValue([cymbalResponse])
+
+            const message = createKafkaMessage({})
+            const pipeline = createErrorTrackingPipeline(pipelineConfig)
+            await runErrorTrackingPipeline(pipeline, [message])
+
+            const cymbalItems = mockCymbalClient.processExceptions.mock.calls[0][0]
+            expect(cymbalItems).toHaveLength(1)
+            expect(cymbalItems[0].estimatedSize).toBe(message.value!.length)
+        })
+
         it('handles events with group types', async () => {
             mockPersonRepository.fetchPerson.mockResolvedValue(undefined)
 

--- a/nodejs/src/ingestion/error-tracking/error-tracking-pipeline.ts
+++ b/nodejs/src/ingestion/error-tracking/error-tracking-pipeline.ts
@@ -25,6 +25,7 @@ import { newBatchPipelineBuilder } from '../pipelines/builders'
 import { TopHogRegistry, count, countOk, createTopHogWrapper } from '../pipelines/extensions/tophog'
 import { createBatch, createUnwrapper } from '../pipelines/helpers'
 import { PipelineConfig } from '../pipelines/result-handling-pipeline'
+import { ok } from '../pipelines/results'
 import { OverflowRedirectService } from '../utils/overflow-redirect/overflow-redirect-service'
 import { createCymbalProcessingStep } from './cymbal-processing-step'
 import { CymbalClient } from './cymbal/client'
@@ -140,10 +141,14 @@ export function createErrorTrackingPipeline(
                             ])
                         )
                 )
-                // Map team to context for handleIngestionWarnings
+                // Map team to context for handleIngestionWarnings, and carry
+                // the Kafka message byte size through for Cymbal batch chunking.
                 .filterMap(
                     (element) => ({
-                        result: element.result,
+                        result: ok({
+                            ...element.result.value,
+                            messageBytes: element.context.message.value?.length ?? 0,
+                        }),
                         context: {
                             ...element.context,
                             team: { id: element.result.value.team.id },

--- a/nodejs/src/servers/error-tracking-server.ts
+++ b/nodejs/src/servers/error-tracking-server.ts
@@ -155,6 +155,7 @@ export class ErrorTrackingServer implements NodeServer {
                     outputTopic: this.config.ERROR_TRACKING_CONSUMER_OUTPUT_TOPIC,
                     cymbalBaseUrl: this.config.ERROR_TRACKING_CYMBAL_BASE_URL,
                     cymbalTimeoutMs: this.config.ERROR_TRACKING_CYMBAL_TIMEOUT_MS,
+                    cymbalMaxBodyBytes: this.config.ERROR_TRACKING_CYMBAL_MAX_BODY_BYTES,
                     lane: this.config.INGESTION_LANE ?? 'main',
                     overflowBucketCapacity: this.config.ERROR_TRACKING_OVERFLOW_BUCKET_CAPACITY,
                     overflowBucketReplenishRate: this.config.ERROR_TRACKING_OVERFLOW_BUCKET_REPLENISH_RATE,


### PR DESCRIPTION
## Problem

the error tracking ingestion pipeline is dlq-ing messages because the batch exceeds the cymbal api limit of 2mb (returning a 413). we have a few options:

- drop the pipeline batch size: this doesn't provide a firm guarantee on batch size to the api still, and could have a hit on throughput for some of our other steps (i.e. persons lookups)
- serialize each event within cymbal client to figure out if requests need to be split into sub batches (this is contained, but means we would be serializing every event twice)
- thread the kafka message size through the pipeline and infer from there

## Changes

- pass the kafka message size through the pipeline
- use that in the cymbal client to estimate request batch sizes, and split accordingly
