### PR TITLE
fix(llma): raise user cost limits for llma_summarization product

### DIFF
--- a/services/llm-gateway/src/llm_gateway/config.py
+++ b/services/llm-gateway/src/llm_gateway/config.py
@@ -44,6 +44,12 @@ DEFAULT_USER_COST_LIMITS: dict[str, "UserCostLimit"] = {
         sustained_limit_usd=1000.0,
         sustained_window_seconds=2592000,
     ),
+    "llma_summarization": UserCostLimit(
+        burst_limit_usd=1000.0,
+        burst_window_seconds=86400,
+        sustained_limit_usd=50000.0,
+        sustained_window_seconds=2592000,
+    ),
 }
 
 


### PR DESCRIPTION
## Problem

After #50542 changed the LLM gateway to always resolve `end_user_id` from the authenticated user (a valid security fix for end-user-facing products), all temporal worker summarization calls across all teams now share a single user's cost budget ($1000/30-day sustained limit).

This caused the 30-day sliding window to fill up ~10 days after the change, resulting in sustained `429 - User sustained rate limit exceeded` errors blocking all LLMA summarization on EU (~500-900 rejections/min).

Without summaries being generated, clustering has no input data, so users see no clusters.

## Changes

Adds explicit user cost limits for the `llma_summarization` gateway product with higher thresholds appropriate for a backend service processing many teams:
- Burst: $1000/day (10x default)
- Sustained: $50,000/30-day (50x default)

This is a stop-gap fix. Longer term we should consider exempting internal service products from per-user cost throttling entirely, since the security concern from #50542 (rate limit poisoning via client-provided user param) doesn't apply to service-to-service calls.

## How did you test this code?

Verified the config change is picked up by the existing `parse_user_cost_limits` validator. The gateway's `_UserCostThrottleBase._get_config()` will now return the explicit limits instead of falling back to `DEFAULT_USER_COST_LIMIT`.

## Publish to changelog?

No