### PR TITLE
fix: use codespace-aware URLs for Vite dev assets

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -11,6 +11,9 @@ import { publicAssetsPlugin } from './vite-public-assets-plugin'
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => {
     const isDev = mode === 'development'
+    const codespace = process.env.CODESPACE_NAME
+    const csDomain = process.env.GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN
+    const viteOrigin = codespace && csDomain ? `https://${codespace}-8234.${csDomain}` : 'http://localhost:8234'
 
     return {
         plugins: [
@@ -99,12 +102,12 @@ export default defineConfig(({ mode }) => {
         },
         server: {
             port: 8234,
-            host: process.argv.includes('--host') ? '0.0.0.0' : 'localhost',
+            host: process.argv.includes('--host') || (codespace && csDomain) ? '0.0.0.0' : 'localhost',
             // this is just used in dev
             // nosemgrep: trailofbits.javascript.apollo-graphql.v3-cors-audit.v3-potentially-bad-cors
             cors: true, // This disables CORS in dev, key for using ngrok (e.g. for testing Slack integration)
             // Configure origin for proper asset URL generation
-            origin: 'http://localhost:8234',
+            origin: viteOrigin,
             proxy: {
                 '/static': {
                     target: 'http://localhost:8000',

--- a/posthog/middleware.py
+++ b/posthog/middleware.py
@@ -823,11 +823,16 @@ class CSPMiddleware:
         else:
             resource_url = "https://*.posthog.com"
             if settings.DEBUG or settings.TEST:
-                resource_url = "http://localhost:8234"
+                resource_url = settings.JS_URL or "http://localhost:8234"
             elif settings.SITE_URL.endswith(".dev.posthog.dev"):
                 resource_url = "https://*.dev.posthog.dev"
 
-            connect_debug_url = "ws://localhost:8234" if settings.DEBUG or settings.TEST else ""
+            connect_debug_url = ""
+            if settings.DEBUG or settings.TEST:
+                if resource_url.startswith("https://"):
+                    connect_debug_url = resource_url.replace("https://", "wss://")
+                else:
+                    connect_debug_url = resource_url.replace("http://", "ws://")
             csp_parts = [
                 "default-src 'self'",
                 f"style-src 'self' 'unsafe-inline' {resource_url} https://fonts.googleapis.com",

--- a/posthog/settings/__init__.py
+++ b/posthog/settings/__init__.py
@@ -70,7 +70,13 @@ NGROK_URL: str | None = os.getenv("NGROK_URL", None)
 INSTANCE_TAG: str = os.getenv("INSTANCE_TAG", "none")
 
 if DEBUG:
-    JS_URL: str = os.getenv("JS_URL", "http://localhost:8234").rstrip("/")
+    _codespace_name = os.getenv("CODESPACE_NAME")
+    _codespace_domain = os.getenv("GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN")
+    if _codespace_name and _codespace_domain:
+        _default_js_url = f"https://{_codespace_name}-8234.{_codespace_domain}"
+    else:
+        _default_js_url = "http://localhost:8234"
+    JS_URL: str = os.getenv("JS_URL", _default_js_url).rstrip("/")
 else:
     JS_URL = os.getenv("JS_URL", "").rstrip("/")
 

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -399,17 +399,18 @@ def get_context_for_template(
         elif template_name == "render_query.html":
             source_path = "src/render-query/index.tsx"
         # Add vite dev scripts for development
+        js_url = get_js_url(request)
         context["vite_dev_scripts"] = f"""
         <script nonce="{request.csp_nonce}" type="module">
-            import RefreshRuntime from 'http://localhost:8234/@react-refresh'
+            import RefreshRuntime from '{js_url}/@react-refresh'
             RefreshRuntime.injectIntoGlobalHook(window)
             window.$RefreshReg$ = () => {{}}
             window.$RefreshSig$ = () => (type) => type
             window.__vite_plugin_react_preamble_installed__ = true
         </script>
         <!-- Vite development server -->
-        <script type="module" src="http://localhost:8234/@vite/client"></script>
-        <script type="module" src="http://localhost:8234/{source_path}"></script>"""
+        <script type="module" src="{js_url}/@vite/client"></script>
+        <script type="module" src="{js_url}/{source_path}"></script>"""
 
     if settings.E2E_TESTING:
         context["e2e_testing"] = True


### PR DESCRIPTION
## Problem

PostHog renders a blank page when accessed via GitHub Codespaces. The Django backend correctly sets `window.JS_URL` to the Codespace-forwarded origin, but the Vite dev script tags (`@react-refresh`, `@vite/client`, `src/index.tsx`) are hardcoded to `http://localhost:8234`, which is unreachable from the browser in Codespaces where forwarded ports use the pattern `https://<CODESPACE_NAME>-<PORT>.<DOMAIN>`.

## Changes

Four independent `http://localhost:8234` references replaced with Codespace-aware equivalents:

- **`posthog/settings/__init__.py`** -- Auto-detect Codespace via `CODESPACE_NAME` and
`GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN` env vars (set automatically by GitHub) to construct the correct default `JS_URL`

- **`posthog/utils.py`** -- `vite_dev_scripts` now uses `get_js_url(request)` instead of hardcoding
localhost

- **`posthog/middleware.py`** -- CSP `resource_url` and `connect_debug_url` derive from `settings.JS_URL`, using `wss://` for HTTPS origins

- **`frontend/vite.config.ts`** -- `server.origin` and `server.host` are Codespace-aware for correct HMR asset URL generation

Local dev behavior is unchanged -- all defaults remain `http://localhost:8234` when the Codespace env vars are absent.

## How did you test this code?

- Verified `JS_URL` resolves correctly in both environments:
  - Local: `http://localhost:8234`
  - Simulated Codespace (`CODESPACE_NAME=test GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN=app.github.dev`): `https://test-8234.app.github.dev`
- CSP middleware tests pass (`TestCSPMiddleware`)
- Linting clean (`ruff check`)

## Publish to changelog?

No

## Docs update

N/A