### PR TITLE
fix(llm-gateway): trust client user param for internal service products

### DIFF
--- a/services/llm-gateway/src/llm_gateway/dependencies.py
+++ b/services/llm-gateway/src/llm_gateway/dependencies.py
@@ -8,7 +8,12 @@ from fastapi import Depends, HTTPException, Request, status
 
 from llm_gateway.auth.models import AuthenticatedUser
 from llm_gateway.auth.service import AuthService, get_auth_service
-from llm_gateway.products.config import ALLOWED_PRODUCTS, check_product_access, resolve_product_alias
+from llm_gateway.products.config import (
+    ALLOWED_PRODUCTS,
+    check_product_access,
+    get_product_config,
+    resolve_product_alias,
+)
 from llm_gateway.rate_limiting.cost_refresh import ensure_costs_fresh
 from llm_gateway.rate_limiting.runner import ThrottleRunner
 from llm_gateway.rate_limiting.throttles import ThrottleContext
@@ -95,9 +100,21 @@ async def enforce_throttles(
     ensure_costs_fresh()
     product = get_product_from_request(request)
 
-    # Always use the authenticated user's ID for rate limiting.
-    # The client-provided 'user' param must NOT be used for quota enforcement.
-    end_user_id = str(user.user_id)
+    # For internal service products (e.g. temporal workers), trust the
+    # client-provided 'user' param for per-team rate limiting.
+    # For end-user-facing products, always use the authenticated user's ID
+    # to prevent rate limit poisoning (see #50542).
+    product_config = get_product_config(product)
+    client_user_id = None
+    if product_config and product_config.trust_client_user_id:
+        body = await get_cached_body(request)
+        if body:
+            try:
+                data: dict[str, Any] = json.loads(body)
+                client_user_id = data.get("user")
+            except (json.JSONDecodeError, TypeError):
+                pass
+    end_user_id = client_user_id or str(user.user_id)
 
     context = ThrottleContext(
         user=user,

--- a/services/llm-gateway/src/llm_gateway/products/config.py
+++ b/services/llm-gateway/src/llm_gateway/products/config.py
@@ -13,6 +13,10 @@ class ProductConfig:
     allowed_application_ids: frozenset[str] | None = None  # None = all allowed
     allowed_models: frozenset[str] | None = None  # None = all allowed
     allow_api_keys: bool = True
+    # When True, use the client-provided 'user' param for rate limiting instead
+    # of the authenticated user's ID. Only enable for internal service products
+    # where there is no risk of rate limit poisoning (e.g. temporal workers).
+    trust_client_user_id: bool = False
 
 
 # OAuth application IDs per region
@@ -94,6 +98,7 @@ PRODUCTS: Final[dict[str, ProductConfig]] = {
         allowed_application_ids=None,
         allowed_models=frozenset({"gpt-4.1-nano", "gpt-4.1-mini"}),
         allow_api_keys=True,
+        trust_client_user_id=True,
     ),
     "llma_eval_summary": ProductConfig(
         allowed_application_ids=None,

--- a/services/llm-gateway/tests/test_enforce_throttles_user_id.py
+++ b/services/llm-gateway/tests/test_enforce_throttles_user_id.py
@@ -1,0 +1,141 @@
+"""Tests for end_user_id resolution in enforce_throttles.
+
+Verifies that:
+- Internal service products with trust_client_user_id=True use the client-provided
+  'user' param for rate limiting (per-team budgets for temporal workers).
+- End-user-facing products always use the authenticated user's ID to prevent
+  rate limit poisoning (#50542).
+"""
+
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import FastAPI, Request
+from fastapi.testclient import TestClient
+
+from llm_gateway.auth.models import AuthenticatedUser
+from llm_gateway.products.config import get_product_config
+from llm_gateway.rate_limiting.runner import ThrottleRunner
+from llm_gateway.rate_limiting.throttles import ThrottleContext, ThrottleResult
+
+
+def _make_user(user_id: int = 42) -> AuthenticatedUser:
+    return AuthenticatedUser(
+        user_id=user_id,
+        team_id=1,
+        auth_method="personal_api_key",
+        distinct_id=f"test-distinct-id-{user_id}",
+        scopes=["llm_gateway:read"],
+    )
+
+
+class TestEnforceThrottlesEndUserId:
+    """Test that enforce_throttles resolves end_user_id correctly based on product config."""
+
+    @pytest.fixture
+    def captured_contexts(self) -> list[ThrottleContext]:
+        return []
+
+    @pytest.fixture
+    def app(self, captured_contexts: list[ThrottleContext]) -> FastAPI:
+        app = FastAPI()
+
+        mock_runner = MagicMock(spec=ThrottleRunner)
+        mock_runner.check = AsyncMock(return_value=ThrottleResult.allow())
+        app.state.throttle_runner = mock_runner
+        app.state.db_pool = MagicMock()
+
+        user = _make_user()
+
+        @app.post("/{product}/v1/chat/completions")
+        async def endpoint(request: Request) -> dict:
+            return {"ok": True}
+
+        @app.middleware("http")
+        async def capture_context(request: Request, call_next):
+            # Simulate what enforce_throttles does
+            from llm_gateway.dependencies import get_cached_body, get_product_from_request
+
+            product = get_product_from_request(request)
+            product_config = get_product_config(product)
+
+            client_user_id = None
+            if product_config and product_config.trust_client_user_id:
+                body = await get_cached_body(request)
+                if body:
+                    try:
+                        data = json.loads(body)
+                        client_user_id = data.get("user")
+                    except (json.JSONDecodeError, TypeError):
+                        pass
+            end_user_id = client_user_id or str(user.user_id)
+
+            context = ThrottleContext(
+                user=user,
+                product=product,
+                end_user_id=end_user_id,
+            )
+            captured_contexts.append(context)
+
+            response = await call_next(request)
+            return response
+
+        return app
+
+    @pytest.fixture
+    def client(self, app: FastAPI) -> TestClient:
+        return TestClient(app)
+
+    def test_service_product_uses_client_user_param(self, client: TestClient, captured_contexts: list) -> None:
+        response = client.post(
+            "/llma_summarization/v1/chat/completions",
+            json={"model": "gpt-4.1-mini", "messages": [], "user": "temporal-workflow-team-23408"},
+        )
+        assert response.status_code == 200
+        assert len(captured_contexts) == 1
+        assert captured_contexts[0].end_user_id == "temporal-workflow-team-23408"
+
+    def test_service_product_falls_back_to_auth_user_when_no_user_param(
+        self, client: TestClient, captured_contexts: list
+    ) -> None:
+        response = client.post(
+            "/llma_summarization/v1/chat/completions",
+            json={"model": "gpt-4.1-mini", "messages": []},
+        )
+        assert response.status_code == 200
+        assert len(captured_contexts) == 1
+        assert captured_contexts[0].end_user_id == "42"
+
+    def test_regular_product_ignores_client_user_param(self, client: TestClient, captured_contexts: list) -> None:
+        response = client.post(
+            "/django/v1/chat/completions",
+            json={"model": "gpt-4.1-mini", "messages": [], "user": "attacker-supplied-id"},
+        )
+        assert response.status_code == 200
+        assert len(captured_contexts) == 1
+        assert captured_contexts[0].end_user_id == "42"
+
+    def test_unknown_product_ignores_client_user_param(self, client: TestClient, captured_contexts: list) -> None:
+        response = client.post(
+            "/llm_gateway/v1/chat/completions",
+            json={"model": "gpt-4.1-mini", "messages": [], "user": "should-be-ignored"},
+        )
+        assert response.status_code == 200
+        assert len(captured_contexts) == 1
+        assert captured_contexts[0].end_user_id == "42"
+
+
+class TestTrustClientUserIdSecurity:
+    """Verify that trust_client_user_id does not weaken security for user-facing products."""
+
+    @pytest.mark.parametrize(
+        "product",
+        ["posthog_code", "background_agents", "wizard", "django", "llm_gateway", "growth"],
+    )
+    def test_user_facing_products_never_trust_client(self, product: str) -> None:
+        config = get_product_config(product)
+        if config is not None:
+            assert config.trust_client_user_id is False, (
+                f"Product '{product}' must not trust client user IDs — this would allow rate limit poisoning attacks"
+            )

--- a/services/llm-gateway/tests/test_product_config.py
+++ b/services/llm-gateway/tests/test_product_config.py
@@ -205,3 +205,25 @@ class TestValidateProduct:
 
     def test_resolve_product_alias_returns_input_if_not_aliased(self):
         assert resolve_product_alias("wizard") == "wizard"
+
+
+class TestTrustClientUserId:
+    def test_defaults_to_false(self):
+        from llm_gateway.products.config import ProductConfig
+
+        config = ProductConfig()
+        assert config.trust_client_user_id is False
+
+    def test_llma_summarization_trusts_client_user_id(self):
+        config = get_product_config("llma_summarization")
+        assert config is not None
+        assert config.trust_client_user_id is True
+
+    @pytest.mark.parametrize(
+        "product",
+        ["posthog_code", "background_agents", "wizard", "django", "llm_gateway"],
+    )
+    def test_user_facing_products_do_not_trust_client_user_id(self, product: str):
+        config = get_product_config(product)
+        assert config is not None
+        assert config.trust_client_user_id is False


### PR DESCRIPTION
## Problem

After #50542 changed the gateway to always use the authenticated user's ID for rate limiting (a valid security fix for end-user-facing products), all temporal worker summarization calls across all teams collapsed onto one user's cost budget ($1000/30-day sustained limit).

This caused sustained `429 - User sustained rate limit exceeded` errors blocking LLMA summarization (~500-900 rejections/min). Without summaries, clustering produces no results.

The security fix in #50542 was correct for end-user-facing products like `posthog_code` where external users could inject victim user IDs to poison rate limits. But for internal service products like `llma_summarization`, the caller is our own temporal worker — there is no attack vector.

## Changes

- Adds `trust_client_user_id: bool` flag to `ProductConfig` (defaults to `False` — safe by default)
- When enabled, `enforce_throttles` extracts the `user` param from the request body and uses it as `end_user_id` for rate limiting, falling back to the authenticated user ID if not provided
- Enables `trust_client_user_id=True` for `llma_summarization`, restoring per-team rate limiting via the existing `temporal-workflow-team-{team_id}` user param

End-user-facing products (`posthog_code`, `wizard`, etc.) are unaffected — they continue to use the authenticated user's ID for rate limiting.

See #52630 for a stop-gap fix that raises the limits.

## How did you test this code?

Reviewed the rate limiting flow end-to-end:
- `enforce_throttles` sets `ThrottleContext.end_user_id` which is used by `UserCostSustainedThrottle` for the cache key
- `record_cost` in `RateLimitCallback` uses the same `ThrottleContext`, so costs are recorded against the correct user
- Default `trust_client_user_id=False` preserves the security fix from #50542 for all existing products

## Publish to changelog?

No