### PR TITLE
feat(llma): add summary and cluster event counts to usage report

### DIFF
--- a/posthog/tasks/llm_analytics_usage_report.py
+++ b/posthog/tasks/llm_analytics_usage_report.py
@@ -68,6 +68,10 @@ class TeamMetrics:
     ai_feedback_count: int = 0
     ai_evaluation_count: int = 0
     ai_trial_evaluation_count: int = 0
+    ai_trace_summary_count: int = 0
+    ai_generation_summary_count: int = 0
+    ai_trace_clusters_count: int = 0
+    ai_generation_clusters_count: int = 0
 
     # Cost metrics
     total_cost: float = 0.0
@@ -266,7 +270,7 @@ def _combine_all_metrics_results(results_list: list) -> dict[int, TeamMetrics]:
 
             metrics = team_metrics[team_id]
 
-            # Event counts (indices 1-7)
+            # Event counts (indices 1-11)
             metrics.ai_generation_count += row[1] or 0
             metrics.ai_embedding_count += row[2] or 0
             metrics.ai_span_count += row[3] or 0
@@ -274,22 +278,26 @@ def _combine_all_metrics_results(results_list: list) -> dict[int, TeamMetrics]:
             metrics.ai_metric_count += row[5] or 0
             metrics.ai_feedback_count += row[6] or 0
             metrics.ai_evaluation_count += row[7] or 0
+            metrics.ai_trace_summary_count += row[8] or 0
+            metrics.ai_generation_summary_count += row[9] or 0
+            metrics.ai_trace_clusters_count += row[10] or 0
+            metrics.ai_generation_clusters_count += row[11] or 0
 
-            # Cost metrics (indices 8-12)
-            metrics.total_cost += row[8] or 0.0
-            metrics.input_cost += row[9] or 0.0
-            metrics.output_cost += row[10] or 0.0
-            metrics.request_cost += row[11] or 0.0
-            metrics.web_search_cost += row[12] or 0.0
+            # Cost metrics (indices 12-16)
+            metrics.total_cost += row[12] or 0.0
+            metrics.input_cost += row[13] or 0.0
+            metrics.output_cost += row[14] or 0.0
+            metrics.request_cost += row[15] or 0.0
+            metrics.web_search_cost += row[16] or 0.0
 
-            # Token metrics (indices 13-18)
-            metrics.prompt_tokens += row[13] or 0
-            metrics.completion_tokens += row[14] or 0
-            metrics.total_tokens += row[15] or 0
-            metrics.reasoning_tokens += row[16] or 0
-            metrics.cache_read_tokens += row[17] or 0
-            metrics.cache_creation_tokens += row[18] or 0
-            metrics.ai_trial_evaluation_count += row[19] or 0
+            # Token metrics (indices 17-22)
+            metrics.prompt_tokens += row[17] or 0
+            metrics.completion_tokens += row[18] or 0
+            metrics.total_tokens += row[19] or 0
+            metrics.reasoning_tokens += row[20] or 0
+            metrics.cache_read_tokens += row[21] or 0
+            metrics.cache_creation_tokens += row[22] or 0
+            metrics.ai_trial_evaluation_count += row[23] or 0
 
     return team_metrics
 
@@ -322,6 +330,10 @@ def get_all_ai_metrics(
             countIf(event = '$ai_metric') as ai_metric_count,
             countIf(event = '$ai_feedback') as ai_feedback_count,
             countIf(event = '$ai_evaluation') as ai_evaluation_count,
+            countIf(event = '$ai_trace_summary') as ai_trace_summary_count,
+            countIf(event = '$ai_generation_summary') as ai_generation_summary_count,
+            countIf(event = '$ai_trace_clusters') as ai_trace_clusters_count,
+            countIf(event = '$ai_generation_clusters') as ai_generation_clusters_count,
             -- Cost metrics
             SUM(toFloat64OrNull(properties_group_ai['$ai_total_cost_usd'])) as total_cost,
             SUM(toFloat64OrNull(properties_group_ai['$ai_input_cost_usd'])) as input_cost,
@@ -681,6 +693,10 @@ def _get_all_llm_analytics_reports(
                 "ai_feedback_count": 0,
                 "ai_evaluation_count": 0,
                 "ai_trial_evaluation_count": 0,
+                "ai_trace_summary_count": 0,
+                "ai_generation_summary_count": 0,
+                "ai_trace_clusters_count": 0,
+                "ai_generation_clusters_count": 0,
                 "llm_prompt_fetched_count": 0,
                 "active_llm_feedback_survey_count": 0,
                 "llm_feedback_survey_response_count": 0,
@@ -718,6 +734,10 @@ def _get_all_llm_analytics_reports(
             report["ai_feedback_count"] += metrics.ai_feedback_count
             report["ai_evaluation_count"] += metrics.ai_evaluation_count
             report["ai_trial_evaluation_count"] += metrics.ai_trial_evaluation_count
+            report["ai_trace_summary_count"] += metrics.ai_trace_summary_count
+            report["ai_generation_summary_count"] += metrics.ai_generation_summary_count
+            report["ai_trace_clusters_count"] += metrics.ai_trace_clusters_count
+            report["ai_generation_clusters_count"] += metrics.ai_generation_clusters_count
 
             report["total_ai_cost_usd"] += metrics.total_cost
             report["input_cost_usd"] += metrics.input_cost

--- a/posthog/tasks/test/test_llm_analytics_usage_report.py
+++ b/posthog/tasks/test/test_llm_analytics_usage_report.py
@@ -96,6 +96,10 @@ class TestLLMAnalyticsUsageReport(APIBaseTest, ClickhouseTestMixin, ClickhouseDe
             self.team, distinct_id, "$ai_evaluation", 2, properties={"$ai_evaluation_key_type": "byok"}
         )
         self._create_ai_events(self.team, distinct_id, "$ai_evaluation", 1)
+        self._create_ai_events(self.team, distinct_id, "$ai_trace_summary", 7)
+        self._create_ai_events(self.team, distinct_id, "$ai_generation_summary", 12)
+        self._create_ai_events(self.team, distinct_id, "$ai_trace_clusters", 2)
+        self._create_ai_events(self.team, distinct_id, "$ai_generation_clusters", 3)
         # Create events with cost and token properties
         self._create_ai_events(
             self.team,
@@ -136,6 +140,10 @@ class TestLLMAnalyticsUsageReport(APIBaseTest, ClickhouseTestMixin, ClickhouseDe
         assert metrics.ai_feedback_count == 4
         assert metrics.ai_evaluation_count == 6
         assert metrics.ai_trial_evaluation_count == 3
+        assert metrics.ai_trace_summary_count == 7
+        assert metrics.ai_generation_summary_count == 12
+        assert metrics.ai_trace_clusters_count == 2
+        assert metrics.ai_generation_clusters_count == 3
 
         # Verify cost metrics (3 events with costs)
         assert metrics.total_cost == pytest.approx(0.045, rel=1e-6)  # 3 * 0.015
@@ -407,6 +415,10 @@ class TestLLMAnalyticsUsageReport(APIBaseTest, ClickhouseTestMixin, ClickhouseDe
                 "$ai_cost_model_provider": "openai",
             },
         )
+        self._create_ai_events(self.team, distinct_id_1, "$ai_trace_summary", 6)
+        self._create_ai_events(self.team, distinct_id_1, "$ai_generation_summary", 8)
+        self._create_ai_events(self.team, distinct_id_1, "$ai_trace_clusters", 1)
+        self._create_ai_events(self.team, distinct_id_1, "$ai_generation_clusters", 2)
         self._create_ai_events(self.team, distinct_id_1, "$llm_prompt_fetched", 4)
 
         # Create survey events linked to LLM traces for team 1
@@ -447,6 +459,10 @@ class TestLLMAnalyticsUsageReport(APIBaseTest, ClickhouseTestMixin, ClickhouseDe
         assert org_1_report["ai_generation_count"] == 13  # 10 + 3
         assert org_1_report["ai_evaluation_count"] == 5
         assert org_1_report["ai_trial_evaluation_count"] == 3
+        assert org_1_report["ai_trace_summary_count"] == 6
+        assert org_1_report["ai_generation_summary_count"] == 8
+        assert org_1_report["ai_trace_clusters_count"] == 1
+        assert org_1_report["ai_generation_clusters_count"] == 2
         assert org_1_report["llm_prompt_fetched_count"] == 4
         assert org_1_report["total_ai_cost_usd"] == pytest.approx(0.150, rel=1e-6)  # 3 * 0.050
         assert org_1_report["input_cost_usd"] == pytest.approx(0.060, rel=1e-6)  # 3 * 0.020
@@ -461,7 +477,7 @@ class TestLLMAnalyticsUsageReport(APIBaseTest, ClickhouseTestMixin, ClickhouseDe
         assert org_1_report["total_cache_creation_tokens"] == 1500  # 3 * 500
         assert org_1_report["model_breakdown"] == {"gpt-4o-mini": 3}
         assert org_1_report["provider_breakdown"] == {"openai": 3}
-        assert org_1_report["framework_breakdown"] == {"langchain": 3, "none": 15}
+        assert org_1_report["framework_breakdown"] == {"langchain": 3, "none": 32}
         assert org_1_report["library_breakdown"] == {"posthog-python": 3}
         assert org_1_report["cost_model_used_breakdown"] == {"openai/gpt-4o-mini": 3}
         assert org_1_report["cost_model_source_breakdown"] == {"openrouter": 3}
@@ -476,6 +492,10 @@ class TestLLMAnalyticsUsageReport(APIBaseTest, ClickhouseTestMixin, ClickhouseDe
         assert org_2_report["ai_generation_count"] == 2
         assert org_2_report["llm_prompt_fetched_count"] == 1
         assert org_2_report["total_ai_cost_usd"] == pytest.approx(0.050, rel=1e-6)  # 2 * 0.025
+        assert org_2_report["ai_trace_summary_count"] == 0
+        assert org_2_report["ai_generation_summary_count"] == 0
+        assert org_2_report["ai_trace_clusters_count"] == 0
+        assert org_2_report["ai_generation_clusters_count"] == 0
         assert org_2_report["active_llm_feedback_survey_count"] == 0
         assert org_2_report["llm_feedback_survey_response_count"] == 0
 
@@ -545,6 +565,10 @@ class TestLLMAnalyticsUsageReport(APIBaseTest, ClickhouseTestMixin, ClickhouseDe
         assert org_report["ai_metric_count"] == 0
         assert org_report["ai_feedback_count"] == 0
         assert org_report["ai_evaluation_count"] == 0
+        assert org_report["ai_trace_summary_count"] == 0
+        assert org_report["ai_generation_summary_count"] == 0
+        assert org_report["ai_trace_clusters_count"] == 0
+        assert org_report["ai_generation_clusters_count"] == 0
         assert org_report["llm_prompt_fetched_count"] == 2
 
     def test_multiple_teams_in_same_org(self) -> None:


### PR DESCRIPTION
## Problem

The LLM analytics usage report does not track summarization and clustering events, so we have no visibility into adoption of these features across organizations.

## Changes

Add four new metrics to the LLM analytics usage report:
- `ai_trace_summary_count` - count of `$ai_trace_summary` events
- `ai_generation_summary_count` - count of `$ai_generation_summary` events
- `ai_trace_clusters_count` - count of `$ai_trace_clusters` events
- `ai_generation_clusters_count` - count of `$ai_generation_clusters` events

These events are already in the `AIEventType` enum and included in the `AI_EVENTS` list, so they were already being scanned in the query but not counted individually.

## How did you test this code?

- Ran `test_get_all_ai_metrics` - verifies the new counts are correctly extracted from the combined query
- Ran `test_full_llm_analytics_report` - verifies end-to-end report generation with the new metrics aggregated by org
- Ran `test_prompt_fetched_only_team_generates_report_with_zero_ai_metrics` - verifies zero counts when no summary/cluster events exist