### PR TITLE
feat(flags): add sent_at delta metric for client-to-server transit time

### DIFF
--- a/rust/feature-flags/src/api/endpoint.rs
+++ b/rust/feature-flags/src/api/endpoint.rs
@@ -262,19 +262,9 @@ pub async fn flags(
     let user_agent = headers.get("user-agent").and_then(|v| v.to_str().ok());
     let ua_info = UserAgentInfo::parse(user_agent);
 
-    // Compute client-to-server transit time from sent_at query param.
-    // Deltas outside [0, 5min) are filtered: negative means client clock ahead,
-    // very large means stale/garbage timestamp.
-    const MAX_PLAUSIBLE_TRANSIT_MS: i64 = 300_000; // 5 minutes
-    let sent_at_delta_ms: Option<i64> = query_params.sent_at.and_then(|sent_at| {
-        let now_ms = chrono::Utc::now().timestamp_millis();
-        let delta = now_ms - sent_at;
-        if (0..MAX_PLAUSIBLE_TRANSIT_MS).contains(&delta) {
-            Some(delta)
-        } else {
-            None
-        }
-    });
+    let sent_at_delta_ms: Option<i64> = query_params
+        .sent_at
+        .and_then(|sent_at| compute_sent_at_delta(sent_at, chrono::Utc::now().timestamp_millis()));
 
     // Initialize canonical log with all upfront request metadata.
     // Fields discovered during processing (team_id, flags_evaluated, etc.) are set via with_canonical_log().
@@ -451,6 +441,19 @@ fn create_request_span(
         sent_at = %query_params.sent_at.unwrap_or(0).to_string(),
         request_id = %request_id
     )
+}
+
+/// Compute client-to-server transit time from a `sent_at` timestamp.
+/// Returns `None` if the delta is outside [0, 5min) — negative means client
+/// clock ahead, very large means stale/garbage timestamp.
+fn compute_sent_at_delta(sent_at_ms: i64, now_ms: i64) -> Option<i64> {
+    const MAX_PLAUSIBLE_TRANSIT_MS: i64 = 300_000; // 5 minutes
+    let delta = now_ms - sent_at_ms;
+    if (0..MAX_PLAUSIBLE_TRANSIT_MS).contains(&delta) {
+        Some(delta)
+    } else {
+        None
+    }
 }
 
 #[cfg(test)]
@@ -691,5 +694,30 @@ mod tests {
         // Two calls without header should generate different UUIDs
         let extracted_id_empty2 = extract_request_id(&empty_headers);
         assert_ne!(extracted_id_empty, extracted_id_empty2);
+    }
+
+    #[test]
+    fn test_compute_sent_at_delta() {
+        use super::compute_sent_at_delta;
+
+        let now = 1_700_000_000_000i64;
+
+        // Normal transit time (100ms)
+        assert_eq!(compute_sent_at_delta(now - 100, now), Some(100));
+
+        // Zero delta (sent_at == now)
+        assert_eq!(compute_sent_at_delta(now, now), Some(0));
+
+        // Just below 5min threshold
+        assert_eq!(compute_sent_at_delta(now - 299_999, now), Some(299_999));
+
+        // Exactly 5min — excluded
+        assert_eq!(compute_sent_at_delta(now - 300_000, now), None);
+
+        // Large delta (stale timestamp)
+        assert_eq!(compute_sent_at_delta(now - 600_000, now), None);
+
+        // Negative delta (client clock ahead)
+        assert_eq!(compute_sent_at_delta(now + 1000, now), None);
     }
 }

--- a/rust/feature-flags/src/api/endpoint.rs
+++ b/rust/feature-flags/src/api/endpoint.rs
@@ -10,6 +10,7 @@ use crate::{
         decoding, process_request, run_with_canonical_log, with_canonical_log,
         FlagsCanonicalLogLine, RequestContext,
     },
+    metrics::consts::FLAG_SENT_AT_DELTA_MS,
     router,
     utils::user_agent::UserAgentInfo,
 };
@@ -261,6 +262,20 @@ pub async fn flags(
     let user_agent = headers.get("user-agent").and_then(|v| v.to_str().ok());
     let ua_info = UserAgentInfo::parse(user_agent);
 
+    // Compute client-to-server transit time from sent_at query param.
+    // Deltas outside [0, 5min) are filtered: negative means client clock ahead,
+    // very large means stale/garbage timestamp.
+    const MAX_PLAUSIBLE_TRANSIT_MS: i64 = 300_000; // 5 minutes
+    let sent_at_delta_ms: Option<i64> = query_params.sent_at.and_then(|sent_at| {
+        let now_ms = chrono::Utc::now().timestamp_millis();
+        let delta = now_ms - sent_at;
+        if (0..MAX_PLAUSIBLE_TRANSIT_MS).contains(&delta) {
+            Some(delta)
+        } else {
+            None
+        }
+    });
+
     // Initialize canonical log with all upfront request metadata.
     // Fields discovered during processing (team_id, flags_evaluated, etc.) are set via with_canonical_log().
     let canonical_log = FlagsCanonicalLogLine {
@@ -271,6 +286,7 @@ pub async fn flags(
         // Browser SDK sends ver= query param, server SDKs send version in User-Agent
         lib_version: query_params.lib_version.clone().or(ua_info.sdk_version),
         api_version: query_params.version.clone(),
+        sent_at_delta_ms,
         ..Default::default()
     };
 
@@ -367,6 +383,11 @@ pub async fn flags(
 
     // Emit DB operations metrics before the canonical log
     log.emit_db_operations_metrics();
+
+    // Emit sent_at delta histogram for transit time dashboards
+    if let Some(delta) = log.sent_at_delta_ms {
+        common_metrics::histogram(FLAG_SENT_AT_DELTA_MS, &[], delta as f64);
+    }
 
     match result {
         Ok(response) => {

--- a/rust/feature-flags/src/handler/canonical_log.rs
+++ b/rust/feature-flags/src/handler/canonical_log.rs
@@ -252,7 +252,8 @@ pub struct FlagsCanonicalLogLine {
 
     // Transit time
     /// Client-to-server transit time in milliseconds (server_now - sent_at).
-    /// None when sent_at is missing or delta is negative (client clock ahead).
+    /// None when sent_at is missing or delta is outside [0, 5min) (negative = client clock
+    /// ahead, >= 5min = stale/garbage timestamp).
     pub sent_at_delta_ms: Option<i64>,
 
     // Cache sources (populated during data fetching)

--- a/rust/feature-flags/src/handler/canonical_log.rs
+++ b/rust/feature-flags/src/handler/canonical_log.rs
@@ -250,6 +250,11 @@ pub struct FlagsCanonicalLogLine {
     /// True when a rate limit warn threshold was exceeded but the request was still allowed.
     pub rate_limit_warned: bool,
 
+    // Transit time
+    /// Client-to-server transit time in milliseconds (server_now - sent_at).
+    /// None when sent_at is missing or delta is negative (client clock ahead).
+    pub sent_at_delta_ms: Option<i64>,
+
     // Cache sources (populated during data fetching)
     /// Where team metadata was fetched from: "redis", "s3", "fallback", or None if not fetched
     pub team_cache_source: Option<&'static str>,
@@ -296,6 +301,7 @@ impl Default for FlagsCanonicalLogLine {
             evaluation_type: None,
             rate_limited: false,
             rate_limit_warned: false,
+            sent_at_delta_ms: None,
             team_cache_source: None,
             http_status: 200,
             error_code: None,
@@ -360,6 +366,7 @@ impl FlagsCanonicalLogLine {
             evaluation_type = self.evaluation_type.map(|t| t.as_str()),
             rate_limited = self.rate_limited,
             rate_limit_warned = self.rate_limit_warned,
+            sent_at_delta_ms = self.sent_at_delta_ms,
             team_cache_source = self.team_cache_source,
             error_code = self.error_code,
             "canonical_log_line"

--- a/rust/feature-flags/src/metrics/consts.rs
+++ b/rust/feature-flags/src/metrics/consts.rs
@@ -29,6 +29,7 @@ pub const DB_PERSON_AND_GROUP_PROPERTIES_READS_COUNTER: &str =
     "flags_db_person_and_group_properties_reads_total";
 pub const FLAG_REQUESTS_COUNTER: &str = "flags_requests_total";
 pub const FLAG_REQUESTS_LATENCY: &str = "flags_requests_duration_ms";
+pub const FLAG_SENT_AT_DELTA_MS: &str = "flags_sent_at_delta_ms";
 pub const FLAG_REQUEST_FAULTS_COUNTER: &str = "flags_request_faults_total";
 
 // Performance monitoring


### PR DESCRIPTION
## Problem

We have no visibility into client-to-server transit time for feature flag evaluation requests. Understanding this latency helps identify SDK performance issues and network bottlenecks affecting flag delivery.

## Changes

- Compute the delta between server time and the client-provided `sent_at` query parameter in the Rust feature flags endpoint
- Filter to plausible values in the range [0, 5 minutes) — negative deltas indicate client clock skew, very large values indicate stale timestamps
- Log the delta in the canonical log line (`sent_at_delta_ms` field)
- Emit a `flags_sent_at_delta_ms` histogram metric for transit time dashboards

Also includes frontend feature flag overview UI refinements (dividers, expanded variants by default, recording button, feedback button).

## How did you test this code?

- Verified the delta computation logic handles edge cases: missing `sent_at`, negative deltas (client clock ahead), and values exceeding the 5-minute threshold
- Confirmed the canonical log line includes the new field
- Confirmed histogram metric is emitted only for plausible deltas

## Publish to changelog?

no

## Docs update

No docs changes needed.