### PR TITLE
chore(flags): add local_evaluation endpoint to rust service

### DIFF
--- a/rust/feature-flags/src/router.rs
+++ b/rust/feature-flags/src/router.rs
@@ -256,6 +256,16 @@ pub fn router(
             .route(
                 "/flags/definitions/",
                 any(flag_definitions::flags_definitions),
+            )
+            // Alias for Django's local_evaluation endpoint — allows Contour to route
+            // traffic to Rust without path rewriting (same pattern as /decide → /flags)
+            .route(
+                "/api/feature_flag/local_evaluation",
+                any(flag_definitions::flags_definitions),
+            )
+            .route(
+                "/api/feature_flag/local_evaluation/",
+                any(flag_definitions::flags_definitions),
             );
     }
 

--- a/rust/feature-flags/tests/test_service_mode.rs
+++ b/rust/feature-flags/tests/test_service_mode.rs
@@ -14,6 +14,7 @@ async fn service_mode_route_availability() {
                 ("/flags", true),
                 ("/decide", true),
                 ("/flags/definitions", true),
+                ("/api/feature_flag/local_evaluation", true),
             ],
         ),
         (
@@ -22,6 +23,7 @@ async fn service_mode_route_availability() {
                 ("/flags", true),
                 ("/decide", true),
                 ("/flags/definitions", false),
+                ("/api/feature_flag/local_evaluation", false),
             ],
         ),
         (
@@ -30,6 +32,7 @@ async fn service_mode_route_availability() {
                 ("/flags", false),
                 ("/decide", false),
                 ("/flags/definitions", true),
+                ("/api/feature_flag/local_evaluation", true),
             ],
         ),
     ];


### PR DESCRIPTION
## Summary

Adds `/api/feature_flag/local_evaluation` as a route alias in the Rust feature-flags service, pointing to the same `flags_definitions` handler. This will allow Contour route Django's local evaluation traffic to Rust
without path rewriting, same pattern used for `/decide` → `/flags`.

No traffic change, Contour still routes to Django until we update the routing config.

## Test plan

- [x] Service mode tests updated: route is reachable in `All` and `Definitions` modes, not in `Flags` mode