### PR TITLE
chore(error-tracking): preserve partition key on overflow

### DIFF
--- a/nodejs/src/ingestion/error-tracking/error-tracking-pipeline.ts
+++ b/nodejs/src/ingestion/error-tracking/error-tracking-pipeline.ts
@@ -127,7 +127,7 @@ export function createErrorTrackingPipeline(
                         .pipe(
                             createApplyEventRestrictionsStep(eventIngestionRestrictionManager, {
                                 overflowEnabled,
-                                preservePartitionLocality: false,
+                                preservePartitionLocality: true,
                             })
                         )
                         // Parse Kafka message body [REUSE]
@@ -162,7 +162,7 @@ export function createErrorTrackingPipeline(
                                     // Rate limit high-volume token:distinct_id pairs to overflow
                                     .pipeBatch(
                                         createRateLimitToOverflowStep(
-                                            false, // preservePartitionLocality
+                                            true, // preservePartitionLocality
                                             overflowRedirectService
                                         )
                                     )


### PR DESCRIPTION
## Problem

we weren't preserving the partition key when routing to overflow, meaning events would be processed out of order.