### PR TITLE
feat(demo): Create more demo experiments with metrics

### DIFF
--- a/posthog/demo/products/hedgebox/matrix.py
+++ b/posthog/demo/products/hedgebox/matrix.py
@@ -75,6 +75,7 @@ from .taxonomy import (
     EVENT_DELETED_FILE,
     EVENT_DOWNGRADED_PLAN,
     EVENT_DOWNLOADED_FILE,
+    EVENT_LOGGED_IN,
     EVENT_PAID_BILL,
     EVENT_SHARED_FILE_LINK,
     EVENT_SIGNED_UP,
@@ -83,6 +84,11 @@ from .taxonomy import (
     FILE_ENGAGEMENT_FLAG_KEY,
     FILE_PREVIEWS_FLAG_KEY,
     ONBOARDING_EXPERIMENT_FLAG_KEY,
+    PRICING_PAGE_FLAG_KEY,
+    RETENTION_NUDGE_FLAG_KEY,
+    SHARING_INCENTIVE_FLAG_KEY,
+    TEAM_COLLAB_FLAG_KEY,
+    UPGRADE_PROMPT_FLAG_KEY,
     URL_HOME,
     URL_SIGNUP,
 )
@@ -148,16 +154,40 @@ class HedgeboxMatrix(Matrix):
     onboarding_experiment_start: dt.datetime
     onboarding_experiment_end: dt.datetime
     file_engagement_experiment_start: dt.datetime
+    pricing_experiment_start: dt.datetime
+    pricing_experiment_end: dt.datetime
+    sharing_experiment_start: dt.datetime
+    sharing_experiment_end: dt.datetime
+    upgrade_prompt_experiment_start: dt.datetime
+    team_collab_experiment_start: dt.datetime
+    team_collab_experiment_end: dt.datetime
     extended_end: dt.datetime
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        elapsed = self.now - self.start
+
         # Legacy experiment (complete) - runs from 30% to 60% of simulation
-        self.onboarding_experiment_start = self.start + (self.now - self.start) * 0.3
-        self.onboarding_experiment_end = self.start + (self.now - self.start) * 0.6
+        self.onboarding_experiment_start = self.start + elapsed * 0.3
+        self.onboarding_experiment_end = self.start + elapsed * 0.6
 
         # New experiment (running) - starts at 70% of simulation, extends beyond now
-        self.file_engagement_experiment_start = self.start + (self.now - self.start) * 0.7
+        self.file_engagement_experiment_start = self.start + elapsed * 0.7
+
+        # Pricing page redesign (inconclusive) - 15% to 45%
+        self.pricing_experiment_start = self.start + elapsed * 0.15
+        self.pricing_experiment_end = self.start + elapsed * 0.45
+
+        # File sharing incentive (lost) - 40% to 65%
+        self.sharing_experiment_start = self.start + elapsed * 0.4
+        self.sharing_experiment_end = self.start + elapsed * 0.65
+
+        # Upgrade prompt (running, recent) - 90% onward
+        self.upgrade_prompt_experiment_start = self.start + elapsed * 0.9
+
+        # Team collaboration boost (stopped early) - 50% to 70%
+        self.team_collab_experiment_start = self.start + elapsed * 0.5
+        self.team_collab_experiment_end = self.start + elapsed * 0.7
 
         # Extended simulation for running experiment
         self.extended_end = self.now + dt.timedelta(days=30)
@@ -914,10 +944,106 @@ class HedgeboxMatrix(Matrix):
                 created_by=user,
                 created_at=self.file_engagement_experiment_start - dt.timedelta(hours=2),
             )
+
+            # Pricing page redesign flag (inconclusive)
+            pricing_flag = FeatureFlag.objects.create(
+                team=team,
+                key=PRICING_PAGE_FLAG_KEY,
+                name="Pricing page redesign",
+                filters={
+                    "groups": [{"properties": [], "rollout_percentage": None}],
+                    "multivariate": {
+                        "variants": [
+                            {"key": "control", "rollout_percentage": 50},
+                            {"key": "test", "rollout_percentage": 50},
+                        ]
+                    },
+                },
+                created_by=user,
+                created_at=self.pricing_experiment_start - dt.timedelta(hours=1),
+            )
+
+            # File sharing incentive flag (lost)
+            sharing_flag = FeatureFlag.objects.create(
+                team=team,
+                key=SHARING_INCENTIVE_FLAG_KEY,
+                name="File sharing incentive",
+                filters={
+                    "groups": [{"properties": [], "rollout_percentage": None}],
+                    "multivariate": {
+                        "variants": [
+                            {"key": "control", "rollout_percentage": 50},
+                            {"key": "test", "rollout_percentage": 50},
+                        ]
+                    },
+                },
+                created_by=user,
+                created_at=self.sharing_experiment_start - dt.timedelta(hours=1),
+            )
+
+            # Upgrade prompt flag (running)
+            upgrade_prompt_flag = FeatureFlag.objects.create(
+                team=team,
+                key=UPGRADE_PROMPT_FLAG_KEY,
+                name="Upgrade prompt experiment",
+                filters={
+                    "groups": [{"properties": [], "rollout_percentage": None}],
+                    "multivariate": {
+                        "variants": [
+                            {"key": "control", "rollout_percentage": 34},
+                            {"key": "aggressive", "rollout_percentage": 33},
+                            {"key": "subtle", "rollout_percentage": 33},
+                        ]
+                    },
+                },
+                created_by=user,
+                created_at=self.upgrade_prompt_experiment_start - dt.timedelta(hours=1),
+            )
+
+            # Retention nudge flag (draft)
+            retention_nudge_flag = FeatureFlag.objects.create(
+                team=team,
+                key=RETENTION_NUDGE_FLAG_KEY,
+                name="Retention nudge",
+                filters={
+                    "groups": [{"properties": [], "rollout_percentage": None}],
+                    "multivariate": {
+                        "variants": [
+                            {"key": "control", "rollout_percentage": 50},
+                            {"key": "test", "rollout_percentage": 50},
+                        ]
+                    },
+                },
+                created_by=user,
+                created_at=self.now - dt.timedelta(days=2),
+            )
+
+            # Team collaboration boost flag (stopped early)
+            team_collab_flag = FeatureFlag.objects.create(
+                team=team,
+                key=TEAM_COLLAB_FLAG_KEY,
+                name="Team collaboration boost",
+                filters={
+                    "groups": [{"properties": [], "rollout_percentage": None}],
+                    "multivariate": {
+                        "variants": [
+                            {"key": "control", "rollout_percentage": 50},
+                            {"key": "test", "rollout_percentage": 50},
+                        ]
+                    },
+                },
+                created_by=user,
+                created_at=self.team_collab_experiment_start - dt.timedelta(hours=1),
+            )
         except IntegrityError:
             # Flags already exist, fetch them
             onboarding_flag = FeatureFlag.objects.get(team=team, key=ONBOARDING_EXPERIMENT_FLAG_KEY)
             file_engagement_flag = FeatureFlag.objects.get(team=team, key=FILE_ENGAGEMENT_FLAG_KEY)
+            pricing_flag = FeatureFlag.objects.get(team=team, key=PRICING_PAGE_FLAG_KEY)
+            sharing_flag = FeatureFlag.objects.get(team=team, key=SHARING_INCENTIVE_FLAG_KEY)
+            upgrade_prompt_flag = FeatureFlag.objects.get(team=team, key=UPGRADE_PROMPT_FLAG_KEY)
+            retention_nudge_flag = FeatureFlag.objects.get(team=team, key=RETENTION_NUDGE_FLAG_KEY)
+            team_collab_flag = FeatureFlag.objects.get(team=team, key=TEAM_COLLAB_FLAG_KEY)
 
         # Experiments and shared metrics
 
@@ -1228,6 +1354,235 @@ class HedgeboxMatrix(Matrix):
             ExperimentToSavedMetric.objects.create(
                 experiment=new_experiment, saved_metric=metric, metadata={"type": "secondary"}
             )
+
+        # --- Additional experiments for coverage of various states ---
+
+        # Pricing page redesign (inconclusive) — uses high-volume pageview→signup funnel
+        Experiment.objects.create(
+            team=team,
+            name="Pricing page redesign",
+            description="Testing a simplified pricing page layout to improve signup conversion from the pricing page.",
+            feature_flag=pricing_flag,
+            created_by=user,
+            metrics=[
+                {
+                    "kind": "ExperimentMetric",
+                    "metric_type": "funnel",
+                    "uuid": str(uuid.uuid4()),
+                    "name": "Pricing page to signup",
+                    "series": [
+                        {"kind": "EventsNode", "event": "$pageview"},
+                        {"kind": "EventsNode", "event": EVENT_SIGNED_UP},
+                    ],
+                    "goal": "increase",
+                    "conversion_window": 14,
+                    "conversion_window_unit": "day",
+                },
+                {
+                    "kind": "ExperimentMetric",
+                    "metric_type": "mean",
+                    "uuid": str(uuid.uuid4()),
+                    "name": "Pageviews per user",
+                    "source": {"kind": "EventsNode", "event": "$pageview"},
+                    "goal": "increase",
+                },
+            ],
+            metrics_secondary=[],
+            parameters={
+                "feature_flag_variants": [
+                    {"key": "control", "rollout_percentage": 50},
+                    {"key": "test", "rollout_percentage": 50},
+                ],
+                "recommended_sample_size": int(len(self.clusters) * 0.30),
+                "minimum_detectable_effect": 10,
+            },
+            start_date=self.pricing_experiment_start,
+            end_date=self.pricing_experiment_end,
+            conclusion="inconclusive",
+            conclusion_comment="No statistically significant difference detected between the control and test variants after the full run. Needs a larger sample size or bolder design change.",
+            created_at=pricing_flag.created_at,
+        )
+
+        # File sharing incentive (lost) — uses upload→download funnel and upload mean
+        Experiment.objects.create(
+            team=team,
+            name="File sharing incentive",
+            description="Testing whether a sharing prompt after upload increases file engagement and downloads.",
+            feature_flag=sharing_flag,
+            created_by=user,
+            metrics=[
+                {
+                    "kind": "ExperimentMetric",
+                    "metric_type": "mean",
+                    "uuid": str(uuid.uuid4()),
+                    "name": "Uploads per user",
+                    "source": {"kind": "EventsNode", "event": EVENT_UPLOADED_FILE},
+                    "goal": "increase",
+                },
+                {
+                    "kind": "ExperimentMetric",
+                    "metric_type": "funnel",
+                    "uuid": str(uuid.uuid4()),
+                    "name": "Upload to download",
+                    "series": [
+                        {"kind": "EventsNode", "event": EVENT_UPLOADED_FILE},
+                        {"kind": "EventsNode", "event": EVENT_DOWNLOADED_FILE},
+                    ],
+                    "goal": "increase",
+                    "conversion_window": 7,
+                    "conversion_window_unit": "day",
+                },
+            ],
+            metrics_secondary=[],
+            parameters={
+                "feature_flag_variants": [
+                    {"key": "control", "rollout_percentage": 50},
+                    {"key": "test", "rollout_percentage": 50},
+                ],
+                "recommended_sample_size": int(len(self.clusters) * 0.25),
+                "minimum_detectable_effect": 12,
+            },
+            start_date=self.sharing_experiment_start,
+            end_date=self.sharing_experiment_end,
+            conclusion="lost",
+            conclusion_comment="The sharing prompt annoyed users and led to fewer uploads overall. The test variant performed significantly worse than control.",
+            created_at=sharing_flag.created_at,
+        )
+
+        # Upgrade prompt experiment (running, recently started) — uses high-volume events
+        Experiment.objects.create(
+            team=team,
+            name="Upgrade prompt experiment",
+            description="Testing different prompt styles to increase user engagement and file activity.",
+            feature_flag=upgrade_prompt_flag,
+            created_by=user,
+            metrics=[
+                {
+                    "kind": "ExperimentMetric",
+                    "metric_type": "funnel",
+                    "uuid": str(uuid.uuid4()),
+                    "name": "Login to upload",
+                    "series": [
+                        {"kind": "EventsNode", "event": EVENT_LOGGED_IN},
+                        {"kind": "EventsNode", "event": EVENT_UPLOADED_FILE},
+                    ],
+                    "goal": "increase",
+                    "conversion_window": 7,
+                    "conversion_window_unit": "day",
+                },
+                {
+                    "kind": "ExperimentMetric",
+                    "metric_type": "mean",
+                    "uuid": str(uuid.uuid4()),
+                    "name": "Downloads per user",
+                    "source": {"kind": "EventsNode", "event": EVENT_DOWNLOADED_FILE},
+                    "goal": "increase",
+                },
+            ],
+            metrics_secondary=[],
+            parameters={
+                "feature_flag_variants": [
+                    {"key": "control", "rollout_percentage": 34},
+                    {"key": "aggressive", "rollout_percentage": 33},
+                    {"key": "subtle", "rollout_percentage": 33},
+                ],
+                "recommended_sample_size": int(len(self.clusters) * 0.35),
+                "minimum_detectable_effect": 15,
+            },
+            start_date=self.upgrade_prompt_experiment_start,
+            end_date=None,
+            created_at=upgrade_prompt_flag.created_at,
+        )
+
+        # Retention nudge (draft - not yet started)
+        Experiment.objects.create(
+            team=team,
+            name="Retention nudge",
+            description="Planning to test email and in-app nudges for users who haven't logged in for 3+ days.",
+            feature_flag=retention_nudge_flag,
+            created_by=user,
+            metrics=[
+                {
+                    "kind": "ExperimentMetric",
+                    "metric_type": "retention",
+                    "uuid": str(uuid.uuid4()),
+                    "name": "7-day login retention",
+                    "goal": "increase",
+                    "start_event": {"kind": "EventsNode", "event": EVENT_LOGGED_IN},
+                    "start_handling": "first_seen",
+                    "completion_event": {"kind": "EventsNode", "event": EVENT_UPLOADED_FILE, "math": "total"},
+                    "retention_window_start": 1,
+                    "retention_window_end": 7,
+                    "retention_window_unit": "day",
+                },
+                {
+                    "kind": "ExperimentMetric",
+                    "metric_type": "mean",
+                    "uuid": str(uuid.uuid4()),
+                    "name": "Downloads per user",
+                    "source": {"kind": "EventsNode", "event": EVENT_DOWNLOADED_FILE},
+                    "goal": "increase",
+                },
+            ],
+            metrics_secondary=[],
+            parameters={
+                "feature_flag_variants": [
+                    {"key": "control", "rollout_percentage": 50},
+                    {"key": "test", "rollout_percentage": 50},
+                ],
+                "recommended_sample_size": int(len(self.clusters) * 0.30),
+                "minimum_detectable_effect": 10,
+            },
+            start_date=None,
+            end_date=None,
+            created_at=retention_nudge_flag.created_at,
+        )
+
+        # Team collaboration boost (stopped early) — uses high-volume events
+        Experiment.objects.create(
+            team=team,
+            name="Team collaboration boost",
+            description="Testing a team activity feed to encourage more file uploads and engagement.",
+            feature_flag=team_collab_flag,
+            created_by=user,
+            metrics=[
+                {
+                    "kind": "ExperimentMetric",
+                    "metric_type": "mean",
+                    "uuid": str(uuid.uuid4()),
+                    "name": "Files uploaded per user",
+                    "source": {"kind": "EventsNode", "event": EVENT_UPLOADED_FILE},
+                    "goal": "increase",
+                },
+                {
+                    "kind": "ExperimentMetric",
+                    "metric_type": "funnel",
+                    "uuid": str(uuid.uuid4()),
+                    "name": "Signup to upload",
+                    "series": [
+                        {"kind": "EventsNode", "event": EVENT_SIGNED_UP},
+                        {"kind": "EventsNode", "event": EVENT_UPLOADED_FILE},
+                    ],
+                    "goal": "increase",
+                    "conversion_window": 7,
+                    "conversion_window_unit": "day",
+                },
+            ],
+            metrics_secondary=[],
+            parameters={
+                "feature_flag_variants": [
+                    {"key": "control", "rollout_percentage": 50},
+                    {"key": "test", "rollout_percentage": 50},
+                ],
+                "recommended_sample_size": int(len(self.clusters) * 0.30),
+                "minimum_detectable_effect": 12,
+            },
+            start_date=self.team_collab_experiment_start,
+            end_date=self.team_collab_experiment_end,
+            conclusion="stopped_early",
+            conclusion_comment="Stopped early due to a bug in the activity feed causing excessive notifications. Need to fix the notification throttling before re-running.",
+            created_at=team_collab_flag.created_at,
+        )
 
         self._set_up_demo_data_warehouse_tables(team, user)
 

--- a/posthog/demo/products/hedgebox/matrix.py
+++ b/posthog/demo/products/hedgebox/matrix.py
@@ -879,6 +879,21 @@ class HedgeboxMatrix(Matrix):
             pass  # This can happen if demo data generation is re-run for the same project
 
         # Feature flags
+        def create_experiment_flag(
+            key: str, name: str, variants: list[tuple[str, int]], created_at: dt.datetime
+        ) -> FeatureFlag:
+            return FeatureFlag.objects.create(
+                team=team,
+                key=key,
+                name=name,
+                filters={
+                    "groups": [{"properties": [], "rollout_percentage": None}],
+                    "multivariate": {"variants": [{"key": k, "rollout_percentage": pct} for k, pct in variants]},
+                },
+                created_by=user,
+                created_at=created_at,
+            )
+
         try:
             FeatureFlag.objects.create(
                 team=team,
@@ -907,133 +922,48 @@ class HedgeboxMatrix(Matrix):
                 created_at=self.now - dt.timedelta(days=15),
             )
 
-            # LEGACY Experiment feature flag
-            onboarding_flag = FeatureFlag.objects.create(
-                team=team,
-                key=FLAG_ONBOARDING_EXPERIMENT,
-                name="Onboarding flow test",
-                filters={
-                    "groups": [{"properties": [], "rollout_percentage": None}],
-                    "multivariate": {
-                        "variants": [
-                            {"key": "control", "rollout_percentage": 34},
-                            {"key": "red", "rollout_percentage": 33},
-                            {"key": "blue", "rollout_percentage": 33},
-                        ]
-                    },
-                },
-                created_by=user,
-                created_at=self.onboarding_experiment_start - dt.timedelta(hours=1),
+            # Experiment feature flags
+            onboarding_flag = create_experiment_flag(
+                FLAG_ONBOARDING_EXPERIMENT,
+                "Onboarding flow test",
+                [("control", 34), ("red", 33), ("blue", 33)],
+                self.onboarding_experiment_start - dt.timedelta(hours=1),
             )
-
-            # Experiment feature flag
-            file_engagement_flag = FeatureFlag.objects.create(
-                team=team,
-                key=FLAG_FILE_ENGAGEMENT_EXPERIMENT,
-                name="File engagement boost",
-                filters={
-                    "groups": [{"properties": [], "rollout_percentage": None}],
-                    "multivariate": {
-                        "variants": [
-                            {"key": "control", "rollout_percentage": 34},
-                            {"key": "red", "rollout_percentage": 33},
-                            {"key": "blue", "rollout_percentage": 33},
-                        ]
-                    },
-                },
-                created_by=user,
-                created_at=self.file_engagement_experiment_start - dt.timedelta(hours=2),
+            file_engagement_flag = create_experiment_flag(
+                FLAG_FILE_ENGAGEMENT_EXPERIMENT,
+                "File engagement boost",
+                [("control", 34), ("red", 33), ("blue", 33)],
+                self.file_engagement_experiment_start - dt.timedelta(hours=2),
             )
-
-            # Pricing page redesign flag (inconclusive)
-            pricing_flag = FeatureFlag.objects.create(
-                team=team,
-                key=FLAG_PRICING_PAGE_EXPERIMENT,
-                name="Pricing page redesign",
-                filters={
-                    "groups": [{"properties": [], "rollout_percentage": None}],
-                    "multivariate": {
-                        "variants": [
-                            {"key": "control", "rollout_percentage": 50},
-                            {"key": "test", "rollout_percentage": 50},
-                        ]
-                    },
-                },
-                created_by=user,
-                created_at=self.pricing_experiment_start - dt.timedelta(hours=1),
+            pricing_flag = create_experiment_flag(
+                FLAG_PRICING_PAGE_EXPERIMENT,
+                "Pricing page redesign",
+                [("control", 50), ("test", 50)],
+                self.pricing_experiment_start - dt.timedelta(hours=1),
             )
-
-            # File sharing incentive flag (lost)
-            sharing_flag = FeatureFlag.objects.create(
-                team=team,
-                key=FLAG_SHARING_INCENTIVE_EXPERIMENT,
-                name="File sharing incentive",
-                filters={
-                    "groups": [{"properties": [], "rollout_percentage": None}],
-                    "multivariate": {
-                        "variants": [
-                            {"key": "control", "rollout_percentage": 50},
-                            {"key": "test", "rollout_percentage": 50},
-                        ]
-                    },
-                },
-                created_by=user,
-                created_at=self.sharing_experiment_start - dt.timedelta(hours=1),
+            sharing_flag = create_experiment_flag(
+                FLAG_SHARING_INCENTIVE_EXPERIMENT,
+                "File sharing incentive",
+                [("control", 50), ("test", 50)],
+                self.sharing_experiment_start - dt.timedelta(hours=1),
             )
-
-            # Upgrade prompt flag (running)
-            upgrade_prompt_flag = FeatureFlag.objects.create(
-                team=team,
-                key=FLAG_UPGRADE_PROMPT_EXPERIMENT,
-                name="Upgrade prompt experiment",
-                filters={
-                    "groups": [{"properties": [], "rollout_percentage": None}],
-                    "multivariate": {
-                        "variants": [
-                            {"key": "control", "rollout_percentage": 34},
-                            {"key": "aggressive", "rollout_percentage": 33},
-                            {"key": "subtle", "rollout_percentage": 33},
-                        ]
-                    },
-                },
-                created_by=user,
-                created_at=self.upgrade_prompt_experiment_start - dt.timedelta(hours=1),
+            upgrade_prompt_flag = create_experiment_flag(
+                FLAG_UPGRADE_PROMPT_EXPERIMENT,
+                "Upgrade prompt experiment",
+                [("control", 34), ("aggressive", 33), ("subtle", 33)],
+                self.upgrade_prompt_experiment_start - dt.timedelta(hours=1),
             )
-
-            # Retention nudge flag (draft)
-            retention_nudge_flag = FeatureFlag.objects.create(
-                team=team,
-                key=FLAG_RETENTION_NUDGE_EXPERIMENT,
-                name="Retention nudge",
-                filters={
-                    "groups": [{"properties": [], "rollout_percentage": None}],
-                    "multivariate": {
-                        "variants": [
-                            {"key": "control", "rollout_percentage": 50},
-                            {"key": "test", "rollout_percentage": 50},
-                        ]
-                    },
-                },
-                created_by=user,
-                created_at=self.now - dt.timedelta(days=2),
+            retention_nudge_flag = create_experiment_flag(
+                FLAG_RETENTION_NUDGE_EXPERIMENT,
+                "Retention nudge",
+                [("control", 50), ("test", 50)],
+                self.now - dt.timedelta(days=2),
             )
-
-            # Team collaboration boost flag (stopped early)
-            team_collab_flag = FeatureFlag.objects.create(
-                team=team,
-                key=FLAG_TEAM_COLLAB_EXPERIMENT,
-                name="Team collaboration boost",
-                filters={
-                    "groups": [{"properties": [], "rollout_percentage": None}],
-                    "multivariate": {
-                        "variants": [
-                            {"key": "control", "rollout_percentage": 50},
-                            {"key": "test", "rollout_percentage": 50},
-                        ]
-                    },
-                },
-                created_by=user,
-                created_at=self.team_collab_experiment_start - dt.timedelta(hours=1),
+            team_collab_flag = create_experiment_flag(
+                FLAG_TEAM_COLLAB_EXPERIMENT,
+                "Team collaboration boost",
+                [("control", 50), ("test", 50)],
+                self.team_collab_experiment_start - dt.timedelta(hours=1),
             )
         except IntegrityError:
             # Flags already exist, fetch them

--- a/posthog/demo/products/hedgebox/matrix.py
+++ b/posthog/demo/products/hedgebox/matrix.py
@@ -81,14 +81,14 @@ from .taxonomy import (
     EVENT_SIGNED_UP,
     EVENT_UPGRADED_PLAN,
     EVENT_UPLOADED_FILE,
-    FILE_ENGAGEMENT_FLAG_KEY,
-    FILE_PREVIEWS_FLAG_KEY,
-    ONBOARDING_EXPERIMENT_FLAG_KEY,
-    PRICING_PAGE_FLAG_KEY,
-    RETENTION_NUDGE_FLAG_KEY,
-    SHARING_INCENTIVE_FLAG_KEY,
-    TEAM_COLLAB_FLAG_KEY,
-    UPGRADE_PROMPT_FLAG_KEY,
+    FLAG_FILE_ENGAGEMENT_EXPERIMENT,
+    FLAG_FILE_PREVIEWS,
+    FLAG_ONBOARDING_EXPERIMENT,
+    FLAG_PRICING_PAGE_EXPERIMENT,
+    FLAG_RETENTION_NUDGE_EXPERIMENT,
+    FLAG_SHARING_INCENTIVE_EXPERIMENT,
+    FLAG_TEAM_COLLAB_EXPERIMENT,
+    FLAG_UPGRADE_PROMPT_EXPERIMENT,
     URL_HOME,
     URL_SIGNUP,
 )
@@ -882,7 +882,7 @@ class HedgeboxMatrix(Matrix):
         try:
             FeatureFlag.objects.create(
                 team=team,
-                key=FILE_PREVIEWS_FLAG_KEY,
+                key=FLAG_FILE_PREVIEWS,
                 name="File previews (ticket #2137). Work-in-progress, so only visible internally at the moment",
                 filters={
                     "groups": [
@@ -910,7 +910,7 @@ class HedgeboxMatrix(Matrix):
             # LEGACY Experiment feature flag
             onboarding_flag = FeatureFlag.objects.create(
                 team=team,
-                key=ONBOARDING_EXPERIMENT_FLAG_KEY,
+                key=FLAG_ONBOARDING_EXPERIMENT,
                 name="Onboarding flow test",
                 filters={
                     "groups": [{"properties": [], "rollout_percentage": None}],
@@ -929,7 +929,7 @@ class HedgeboxMatrix(Matrix):
             # Experiment feature flag
             file_engagement_flag = FeatureFlag.objects.create(
                 team=team,
-                key=FILE_ENGAGEMENT_FLAG_KEY,
+                key=FLAG_FILE_ENGAGEMENT_EXPERIMENT,
                 name="File engagement boost",
                 filters={
                     "groups": [{"properties": [], "rollout_percentage": None}],
@@ -948,7 +948,7 @@ class HedgeboxMatrix(Matrix):
             # Pricing page redesign flag (inconclusive)
             pricing_flag = FeatureFlag.objects.create(
                 team=team,
-                key=PRICING_PAGE_FLAG_KEY,
+                key=FLAG_PRICING_PAGE_EXPERIMENT,
                 name="Pricing page redesign",
                 filters={
                     "groups": [{"properties": [], "rollout_percentage": None}],
@@ -966,7 +966,7 @@ class HedgeboxMatrix(Matrix):
             # File sharing incentive flag (lost)
             sharing_flag = FeatureFlag.objects.create(
                 team=team,
-                key=SHARING_INCENTIVE_FLAG_KEY,
+                key=FLAG_SHARING_INCENTIVE_EXPERIMENT,
                 name="File sharing incentive",
                 filters={
                     "groups": [{"properties": [], "rollout_percentage": None}],
@@ -984,7 +984,7 @@ class HedgeboxMatrix(Matrix):
             # Upgrade prompt flag (running)
             upgrade_prompt_flag = FeatureFlag.objects.create(
                 team=team,
-                key=UPGRADE_PROMPT_FLAG_KEY,
+                key=FLAG_UPGRADE_PROMPT_EXPERIMENT,
                 name="Upgrade prompt experiment",
                 filters={
                     "groups": [{"properties": [], "rollout_percentage": None}],
@@ -1003,7 +1003,7 @@ class HedgeboxMatrix(Matrix):
             # Retention nudge flag (draft)
             retention_nudge_flag = FeatureFlag.objects.create(
                 team=team,
-                key=RETENTION_NUDGE_FLAG_KEY,
+                key=FLAG_RETENTION_NUDGE_EXPERIMENT,
                 name="Retention nudge",
                 filters={
                     "groups": [{"properties": [], "rollout_percentage": None}],
@@ -1021,7 +1021,7 @@ class HedgeboxMatrix(Matrix):
             # Team collaboration boost flag (stopped early)
             team_collab_flag = FeatureFlag.objects.create(
                 team=team,
-                key=TEAM_COLLAB_FLAG_KEY,
+                key=FLAG_TEAM_COLLAB_EXPERIMENT,
                 name="Team collaboration boost",
                 filters={
                     "groups": [{"properties": [], "rollout_percentage": None}],
@@ -1037,13 +1037,13 @@ class HedgeboxMatrix(Matrix):
             )
         except IntegrityError:
             # Flags already exist, fetch them
-            onboarding_flag = FeatureFlag.objects.get(team=team, key=ONBOARDING_EXPERIMENT_FLAG_KEY)
-            file_engagement_flag = FeatureFlag.objects.get(team=team, key=FILE_ENGAGEMENT_FLAG_KEY)
-            pricing_flag = FeatureFlag.objects.get(team=team, key=PRICING_PAGE_FLAG_KEY)
-            sharing_flag = FeatureFlag.objects.get(team=team, key=SHARING_INCENTIVE_FLAG_KEY)
-            upgrade_prompt_flag = FeatureFlag.objects.get(team=team, key=UPGRADE_PROMPT_FLAG_KEY)
-            retention_nudge_flag = FeatureFlag.objects.get(team=team, key=RETENTION_NUDGE_FLAG_KEY)
-            team_collab_flag = FeatureFlag.objects.get(team=team, key=TEAM_COLLAB_FLAG_KEY)
+            onboarding_flag = FeatureFlag.objects.get(team=team, key=FLAG_ONBOARDING_EXPERIMENT)
+            file_engagement_flag = FeatureFlag.objects.get(team=team, key=FLAG_FILE_ENGAGEMENT_EXPERIMENT)
+            pricing_flag = FeatureFlag.objects.get(team=team, key=FLAG_PRICING_PAGE_EXPERIMENT)
+            sharing_flag = FeatureFlag.objects.get(team=team, key=FLAG_SHARING_INCENTIVE_EXPERIMENT)
+            upgrade_prompt_flag = FeatureFlag.objects.get(team=team, key=FLAG_UPGRADE_PROMPT_EXPERIMENT)
+            retention_nudge_flag = FeatureFlag.objects.get(team=team, key=FLAG_RETENTION_NUDGE_EXPERIMENT)
+            team_collab_flag = FeatureFlag.objects.get(team=team, key=FLAG_TEAM_COLLAB_EXPERIMENT)
 
         # Experiments and shared metrics
 

--- a/posthog/demo/products/hedgebox/models.py
+++ b/posthog/demo/products/hedgebox/models.py
@@ -26,19 +26,19 @@ from .taxonomy import (
     EVENT_UPLOADED_FILE,
     FILE_ENGAGEMENT_BLUE_SHARE_MULTIPLIER,
     FILE_ENGAGEMENT_BLUE_UPLOAD_MULTIPLIER,
-    FILE_ENGAGEMENT_FLAG_KEY,
     FILE_ENGAGEMENT_RED_SHARE_MULTIPLIER,
     FILE_ENGAGEMENT_RED_UPLOAD_MULTIPLIER,
+    FLAG_FILE_ENGAGEMENT_EXPERIMENT,
+    FLAG_ONBOARDING_EXPERIMENT,
+    FLAG_PRICING_PAGE_EXPERIMENT,
+    FLAG_SHARING_INCENTIVE_EXPERIMENT,
+    FLAG_TEAM_COLLAB_EXPERIMENT,
+    FLAG_UPGRADE_PROMPT_EXPERIMENT,
     GROUP_TYPE_ACCOUNT,
     ONBOARDING_BLUE_RATE,
     ONBOARDING_CONTROL_RATE,
-    ONBOARDING_EXPERIMENT_FLAG_KEY,
     ONBOARDING_RED_RATE,
-    PRICING_PAGE_FLAG_KEY,
-    SHARING_INCENTIVE_FLAG_KEY,
     SIGNUP_SUCCESS_RATE_CONTROL,
-    TEAM_COLLAB_FLAG_KEY,
-    UPGRADE_PROMPT_FLAG_KEY,
     URL_ACCOUNT_BILLING,
     URL_ACCOUNT_SETTINGS,
     URL_ACCOUNT_TEAM,
@@ -311,37 +311,37 @@ class HedgeboxPerson(SimPerson):
 
         # Legacy experiment (complete): 30%-60% of simulation
         if m.onboarding_experiment_start <= t < m.onboarding_experiment_end:
-            flags[ONBOARDING_EXPERIMENT_FLAG_KEY] = self.onboarding_variant
+            flags[FLAG_ONBOARDING_EXPERIMENT] = self.onboarding_variant
 
         # File engagement (running): 70% onward
         if t >= m.file_engagement_experiment_start:
-            flags[FILE_ENGAGEMENT_FLAG_KEY] = self.file_engagement_variant
+            flags[FLAG_FILE_ENGAGEMENT_EXPERIMENT] = self.file_engagement_variant
 
         # Pricing page redesign (inconclusive): 15%-45%
         if m.pricing_experiment_start <= t < m.pricing_experiment_end:
-            flags[PRICING_PAGE_FLAG_KEY] = self.pricing_variant
+            flags[FLAG_PRICING_PAGE_EXPERIMENT] = self.pricing_variant
 
         # File sharing incentive (lost): 40%-65%
         if m.sharing_experiment_start <= t < m.sharing_experiment_end:
-            flags[SHARING_INCENTIVE_FLAG_KEY] = self.sharing_variant
+            flags[FLAG_SHARING_INCENTIVE_EXPERIMENT] = self.sharing_variant
 
         # Upgrade prompt (running): 90% onward
         if t >= m.upgrade_prompt_experiment_start:
-            flags[UPGRADE_PROMPT_FLAG_KEY] = self.upgrade_prompt_variant
+            flags[FLAG_UPGRADE_PROMPT_EXPERIMENT] = self.upgrade_prompt_variant
 
         # Team collab boost (stopped early): 50%-70%
         if m.team_collab_experiment_start <= t < m.team_collab_experiment_end:
-            flags[TEAM_COLLAB_FLAG_KEY] = self.team_collab_variant
+            flags[FLAG_TEAM_COLLAB_EXPERIMENT] = self.team_collab_variant
 
         return flags
 
     _EXPERIMENT_FLAG_KEYS = {
-        ONBOARDING_EXPERIMENT_FLAG_KEY,
-        FILE_ENGAGEMENT_FLAG_KEY,
-        PRICING_PAGE_FLAG_KEY,
-        SHARING_INCENTIVE_FLAG_KEY,
-        UPGRADE_PROMPT_FLAG_KEY,
-        TEAM_COLLAB_FLAG_KEY,
+        FLAG_ONBOARDING_EXPERIMENT,
+        FLAG_FILE_ENGAGEMENT_EXPERIMENT,
+        FLAG_PRICING_PAGE_EXPERIMENT,
+        FLAG_SHARING_INCENTIVE_EXPERIMENT,
+        FLAG_UPGRADE_PROMPT_EXPERIMENT,
+        FLAG_TEAM_COLLAB_EXPERIMENT,
     }
 
     def capture_feature_flag_exposures(self):
@@ -412,7 +412,7 @@ class HedgeboxPerson(SimPerson):
             file_count = len(self.account.files)
 
             # File engagement experiment: Apply multipliers to upload and share intents
-            variant = self.decide_feature_flags().get(FILE_ENGAGEMENT_FLAG_KEY)
+            variant = self.decide_feature_flags().get(FLAG_FILE_ENGAGEMENT_EXPERIMENT)
             upload_multiplier = 1.0
             share_multiplier = 1.0
             if variant == "red":
@@ -591,7 +591,7 @@ class HedgeboxPerson(SimPerson):
             return self.go_to_login()
 
         # Onboarding experiment: Different success rates per variant
-        variant = self.decide_feature_flags().get(ONBOARDING_EXPERIMENT_FLAG_KEY)
+        variant = self.decide_feature_flags().get(FLAG_ONBOARDING_EXPERIMENT)
         if variant == "red":
             success_rate = ONBOARDING_RED_RATE
             signup_duration = 120

--- a/posthog/demo/products/hedgebox/models.py
+++ b/posthog/demo/products/hedgebox/models.py
@@ -34,7 +34,11 @@ from .taxonomy import (
     ONBOARDING_CONTROL_RATE,
     ONBOARDING_EXPERIMENT_FLAG_KEY,
     ONBOARDING_RED_RATE,
+    PRICING_PAGE_FLAG_KEY,
+    SHARING_INCENTIVE_FLAG_KEY,
     SIGNUP_SUCCESS_RATE_CONTROL,
+    TEAM_COLLAB_FLAG_KEY,
+    UPGRADE_PROMPT_FLAG_KEY,
     URL_ACCOUNT_BILLING,
     URL_ACCOUNT_SETTINGS,
     URL_ACCOUNT_TEAM,
@@ -165,6 +169,10 @@ class HedgeboxPerson(SimPerson):
     affinity: float  # 0 roughly means they won't like Hedgebox, 1 means they will - affects need/satisfaction deltas
     onboarding_variant: str
     file_engagement_variant: str
+    pricing_variant: str
+    sharing_variant: str
+    upgrade_prompt_variant: str
+    team_collab_variant: str
     watches_marius_tech_tips: bool
 
     # Internal state - plain
@@ -205,6 +213,24 @@ class HedgeboxPerson(SimPerson):
             self.file_engagement_variant = "red"
         else:
             self.file_engagement_variant = "blue"
+
+        # Assign pricing page experiment variant (2-way)
+        self.pricing_variant = "control" if self.cluster.random.random() < 0.5 else "test"
+
+        # Assign sharing incentive experiment variant (2-way)
+        self.sharing_variant = "control" if self.cluster.random.random() < 0.5 else "test"
+
+        # Assign upgrade prompt experiment variant (3-way)
+        rand_val = self.cluster.random.random()
+        if rand_val < 0.34:
+            self.upgrade_prompt_variant = "control"
+        elif rand_val < 0.67:
+            self.upgrade_prompt_variant = "aggressive"
+        else:
+            self.upgrade_prompt_variant = "subtle"
+
+        # Assign team collab experiment variant (2-way)
+        self.team_collab_variant = "control" if self.cluster.random.random() < 0.5 else "test"
 
         self.watches_marius_tech_tips = self.cluster.random.random() < 0.04
         self.invite_to_use_id = None
@@ -280,19 +306,43 @@ class HedgeboxPerson(SimPerson):
 
     def decide_feature_flags(self) -> dict[str, Any]:
         flags = {}
+        t = self.cluster.simulation_time
+        m = self.cluster.matrix
 
-        # Legacy experiment (complete)
-        if (
-            self.cluster.simulation_time >= self.cluster.matrix.onboarding_experiment_start
-            and self.cluster.simulation_time < self.cluster.matrix.onboarding_experiment_end
-        ):
+        # Legacy experiment (complete): 30%-60% of simulation
+        if m.onboarding_experiment_start <= t < m.onboarding_experiment_end:
             flags[ONBOARDING_EXPERIMENT_FLAG_KEY] = self.onboarding_variant
 
-        # New experiment (running)
-        if self.cluster.simulation_time >= self.cluster.matrix.file_engagement_experiment_start:
+        # File engagement (running): 70% onward
+        if t >= m.file_engagement_experiment_start:
             flags[FILE_ENGAGEMENT_FLAG_KEY] = self.file_engagement_variant
 
+        # Pricing page redesign (inconclusive): 15%-45%
+        if m.pricing_experiment_start <= t < m.pricing_experiment_end:
+            flags[PRICING_PAGE_FLAG_KEY] = self.pricing_variant
+
+        # File sharing incentive (lost): 40%-65%
+        if m.sharing_experiment_start <= t < m.sharing_experiment_end:
+            flags[SHARING_INCENTIVE_FLAG_KEY] = self.sharing_variant
+
+        # Upgrade prompt (running): 90% onward
+        if t >= m.upgrade_prompt_experiment_start:
+            flags[UPGRADE_PROMPT_FLAG_KEY] = self.upgrade_prompt_variant
+
+        # Team collab boost (stopped early): 50%-70%
+        if m.team_collab_experiment_start <= t < m.team_collab_experiment_end:
+            flags[TEAM_COLLAB_FLAG_KEY] = self.team_collab_variant
+
         return flags
+
+    _EXPERIMENT_FLAG_KEYS = {
+        ONBOARDING_EXPERIMENT_FLAG_KEY,
+        FILE_ENGAGEMENT_FLAG_KEY,
+        PRICING_PAGE_FLAG_KEY,
+        SHARING_INCENTIVE_FLAG_KEY,
+        UPGRADE_PROMPT_FLAG_KEY,
+        TEAM_COLLAB_FLAG_KEY,
+    }
 
     def capture_feature_flag_exposures(self):
         """Capture $feature_flag_called exposure events for active experiment flags."""
@@ -300,7 +350,8 @@ class HedgeboxPerson(SimPerson):
 
         for flag_key, variant in active_flags.items():
             # Only capture exposures for experiment flags (not regular feature flags)
-            if flag_key in [ONBOARDING_EXPERIMENT_FLAG_KEY, FILE_ENGAGEMENT_FLAG_KEY]:
+            # (This check is defensive in case non-experiment flags are added to decide_feature_flags())
+            if flag_key in self._EXPERIMENT_FLAG_KEYS:
                 self.active_client.capture(
                     EVENT_FEATURE_FLAG_CALLED,
                     {

--- a/posthog/demo/products/hedgebox/models.py
+++ b/posthog/demo/products/hedgebox/models.py
@@ -196,41 +196,13 @@ class HedgeboxPerson(SimPerson):
             if self.active_client.browser != "Internet Explorer"
             else self.cluster.random.betavariate(1, 1.4)
         )
-        # Assign onboarding experiment variant
-        rand_val = self.cluster.random.random()
-        if rand_val < 0.34:
-            self.onboarding_variant = "control"
-        elif rand_val < 0.67:
-            self.onboarding_variant = "red"
-        else:
-            self.onboarding_variant = "blue"
-
-        # Assign file engagement experiment variant
-        rand_val = self.cluster.random.random()
-        if rand_val < 0.34:
-            self.file_engagement_variant = "control"
-        elif rand_val < 0.67:
-            self.file_engagement_variant = "red"
-        else:
-            self.file_engagement_variant = "blue"
-
-        # Assign pricing page experiment variant (2-way)
-        self.pricing_variant = "control" if self.cluster.random.random() < 0.5 else "test"
-
-        # Assign sharing incentive experiment variant (2-way)
-        self.sharing_variant = "control" if self.cluster.random.random() < 0.5 else "test"
-
-        # Assign upgrade prompt experiment variant (3-way)
-        rand_val = self.cluster.random.random()
-        if rand_val < 0.34:
-            self.upgrade_prompt_variant = "control"
-        elif rand_val < 0.67:
-            self.upgrade_prompt_variant = "aggressive"
-        else:
-            self.upgrade_prompt_variant = "subtle"
-
-        # Assign team collab experiment variant (2-way)
-        self.team_collab_variant = "control" if self.cluster.random.random() < 0.5 else "test"
+        # Assign experiment variants
+        self.onboarding_variant = self._pick_variant("control", "red", "blue")
+        self.file_engagement_variant = self._pick_variant("control", "red", "blue")
+        self.pricing_variant = self._pick_variant("control", "test")
+        self.sharing_variant = self._pick_variant("control", "test")
+        self.upgrade_prompt_variant = self._pick_variant("control", "aggressive", "subtle")
+        self.team_collab_variant = self._pick_variant("control", "test")
 
         self.watches_marius_tech_tips = self.cluster.random.random() < 0.04
         self.invite_to_use_id = None
@@ -301,6 +273,11 @@ class HedgeboxPerson(SimPerson):
     @property
     def has_signed_up(self) -> bool:
         return self.account is not None and self in self.account.team_members
+
+    # Helpers
+
+    def _pick_variant(self, *variants: str) -> str:
+        return self.cluster.random.choice(variants)
 
     # Abstract methods
 

--- a/posthog/demo/products/hedgebox/models.py
+++ b/posthog/demo/products/hedgebox/models.py
@@ -196,13 +196,9 @@ class HedgeboxPerson(SimPerson):
             if self.active_client.browser != "Internet Explorer"
             else self.cluster.random.betavariate(1, 1.4)
         )
-        # Assign experiment variants
+        # Assign original experiment variants (order matters for random seed stability)
         self.onboarding_variant = self._pick_variant("control", "red", "blue")
         self.file_engagement_variant = self._pick_variant("control", "red", "blue")
-        self.pricing_variant = self._pick_variant("control", "test")
-        self.sharing_variant = self._pick_variant("control", "test")
-        self.upgrade_prompt_variant = self._pick_variant("control", "aggressive", "subtle")
-        self.team_collab_variant = self._pick_variant("control", "test")
 
         self.watches_marius_tech_tips = self.cluster.random.random() < 0.04
         self.invite_to_use_id = None
@@ -237,6 +233,12 @@ class HedgeboxPerson(SimPerson):
                 continue
             else:
                 break
+
+        # New experiment variants — appended at end to preserve random seed stability
+        self.pricing_variant = self._pick_variant("control", "test")
+        self.sharing_variant = self._pick_variant("control", "test")
+        self.upgrade_prompt_variant = self._pick_variant("control", "aggressive", "subtle")
+        self.team_collab_variant = self._pick_variant("control", "test")
 
     def __str__(self) -> str:
         return f"{self.name} <{self.email}>"
@@ -277,7 +279,9 @@ class HedgeboxPerson(SimPerson):
     # Helpers
 
     def _pick_variant(self, *variants: str) -> str:
-        return self.cluster.random.choice(variants)
+        """Pick a variant using a single random() call to keep the random sequence stable."""
+        n = len(variants)
+        return variants[int(self.cluster.random.random() * n)]
 
     # Abstract methods
 

--- a/posthog/demo/products/hedgebox/taxonomy.py
+++ b/posthog/demo/products/hedgebox/taxonomy.py
@@ -46,37 +46,37 @@ GROUP_TYPE_ACCOUNT = "account"  # Properties: name, industry, used_mb, file_coun
 
 # Feature flags
 
-FILE_PREVIEWS_FLAG_KEY = "file-previews"
+FLAG_FILE_PREVIEWS = "file-previews"
 
 # Experiments
 
 # Completed experiment (won, legacy format)
-ONBOARDING_EXPERIMENT_FLAG_KEY = "onboarding-test-v1"
+FLAG_ONBOARDING_EXPERIMENT = "onboarding-test-v1"
 ONBOARDING_CONTROL_RATE = 0.487
 ONBOARDING_RED_RATE = 0.560
 ONBOARDING_BLUE_RATE = 0.516
 
 # Running experiment
-FILE_ENGAGEMENT_FLAG_KEY = "file-engagement-v2"
+FLAG_FILE_ENGAGEMENT_EXPERIMENT = "file-engagement-v2"
 FILE_ENGAGEMENT_RED_UPLOAD_MULTIPLIER = 1.25
 FILE_ENGAGEMENT_RED_SHARE_MULTIPLIER = 1.15
 FILE_ENGAGEMENT_BLUE_UPLOAD_MULTIPLIER = 1.18
 FILE_ENGAGEMENT_BLUE_SHARE_MULTIPLIER = 1.35
 
 # Completed experiment (inconclusive)
-PRICING_PAGE_FLAG_KEY = "pricing-page-v3"
+FLAG_PRICING_PAGE_EXPERIMENT = "pricing-page-v3"
 
 # Completed experiment (lost)
-SHARING_INCENTIVE_FLAG_KEY = "sharing-incentive-v1"
+FLAG_SHARING_INCENTIVE_EXPERIMENT = "sharing-incentive-v1"
 
 # Running experiment (recent)
-UPGRADE_PROMPT_FLAG_KEY = "upgrade-prompt-v1"
+FLAG_UPGRADE_PROMPT_EXPERIMENT = "upgrade-prompt-v1"
 
 # Draft experiment (not started)
-RETENTION_NUDGE_FLAG_KEY = "retention-nudge-v1"
+FLAG_RETENTION_NUDGE_EXPERIMENT = "retention-nudge-v1"
 
 # Completed experiment (stopped early)
-TEAM_COLLAB_FLAG_KEY = "team-collab-v1"
+FLAG_TEAM_COLLAB_EXPERIMENT = "team-collab-v1"
 
 # Fallback signup rate (used outside experiments)
 SIGNUP_SUCCESS_RATE_CONTROL = 0.4887

--- a/posthog/demo/products/hedgebox/taxonomy.py
+++ b/posthog/demo/products/hedgebox/taxonomy.py
@@ -48,18 +48,35 @@ GROUP_TYPE_ACCOUNT = "account"  # Properties: name, industry, used_mb, file_coun
 
 FILE_PREVIEWS_FLAG_KEY = "file-previews"
 
-# Legacy experiment (complete)
+# Experiments
+
+# Completed experiment (won, legacy format)
 ONBOARDING_EXPERIMENT_FLAG_KEY = "onboarding-test-v1"
 ONBOARDING_CONTROL_RATE = 0.487
 ONBOARDING_RED_RATE = 0.560
 ONBOARDING_BLUE_RATE = 0.516
 
-# New experiment (running)
+# Running experiment
 FILE_ENGAGEMENT_FLAG_KEY = "file-engagement-v2"
 FILE_ENGAGEMENT_RED_UPLOAD_MULTIPLIER = 1.25
 FILE_ENGAGEMENT_RED_SHARE_MULTIPLIER = 1.15
 FILE_ENGAGEMENT_BLUE_UPLOAD_MULTIPLIER = 1.18
 FILE_ENGAGEMENT_BLUE_SHARE_MULTIPLIER = 1.35
+
+# Completed experiment (inconclusive)
+PRICING_PAGE_FLAG_KEY = "pricing-page-v3"
+
+# Completed experiment (lost)
+SHARING_INCENTIVE_FLAG_KEY = "sharing-incentive-v1"
+
+# Running experiment (recent)
+UPGRADE_PROMPT_FLAG_KEY = "upgrade-prompt-v1"
+
+# Draft experiment (not started)
+RETENTION_NUDGE_FLAG_KEY = "retention-nudge-v1"
+
+# Completed experiment (stopped early)
+TEAM_COLLAB_FLAG_KEY = "team-collab-v1"
 
 # Fallback signup rate (used outside experiments)
 SIGNUP_SUCCESS_RATE_CONTROL = 0.4887


### PR DESCRIPTION
## Problem

Demo mode just had 2 experiments which is little for playing around. Especially for manual testing it would be convenient to have more experiments with metric data.

## Changes

- Setup demo mode with 7 experiments in various states
- Experiments have metric data
- Do so with existing events so that the generation script does not take longer to run

|Overview|Details|
|-|-|
|<img width="1330" height="539" alt="demo-experiments-overview" src="https://github.com/user-attachments/assets/322049da-17df-4891-ae07-d05699087199" />|<img width="1303" height="756" alt="demo-experiments-details" src="https://github.com/user-attachments/assets/ac594288-7023-4534-8e7d-f7e67c8aef2d" />|


## How did you test this code?

- Manually by running `generate-demo-data`

## Publish to changelog?

No