### PR TITLE
chore(modeling): don't let failed matview syncs report rows_materialized

### DIFF
--- a/posthog/temporal/data_modeling/activities/fail_materialization.py
+++ b/posthog/temporal/data_modeling/activities/fail_materialization.py
@@ -50,6 +50,7 @@ def _fail_node_and_data_modeling_job(inputs: FailMaterializationInputs):
         return node, job
 
     job.status = DataModelingJobStatus.CANCELLED if inputs.cancelled else DataModelingJobStatus.FAILED
+    job.rows_materialized = 0
     job.error = sanitized_error
     job.save()
 

--- a/posthog/temporal/data_modeling/activities/preempt_dag_run.py
+++ b/posthog/temporal/data_modeling/activities/preempt_dag_run.py
@@ -1,0 +1,85 @@
+import dataclasses
+
+from structlog import get_logger
+from structlog.contextvars import bind_contextvars
+from temporalio import activity
+
+from posthog.exceptions_capture import capture_exception
+from posthog.sync import database_sync_to_async
+from posthog.temporal.common.client import async_connect
+
+from products.data_warehouse.backend.models import DataModelingJob
+from products.data_warehouse.backend.models.data_modeling_job import DataModelingJobStatus
+
+LOGGER = get_logger(__name__)
+
+PREEMPTED_ERROR = "Preempted: a new DAG run started before this job completed"
+
+
+@dataclasses.dataclass
+class PreemptDAGRunInputs:
+    team_id: int
+    dag_id: str
+
+
+@database_sync_to_async
+def _get_running_jobs_for_dag(team_id: int, dag_id: str) -> list[DataModelingJob]:
+    """Find RUNNING DataModelingJob records belonging to a previous run of this DAG.
+
+    Child workflow IDs follow the pattern `materialize-view-{dag_id}-{node_id}-{timestamp}`,
+    so we can match jobs by their workflow_id prefix.
+    """
+    return list(
+        DataModelingJob.objects.filter(
+            team_id=team_id,
+            status=DataModelingJobStatus.RUNNING,
+            workflow_id__startswith=f"materialize-view-{dag_id}-",
+        )
+    )
+
+
+@database_sync_to_async
+def _mark_jobs_as_preempted(job_ids: list[str]) -> int:
+    return DataModelingJob.objects.filter(id__in=job_ids, status=DataModelingJobStatus.RUNNING).update(
+        status=DataModelingJobStatus.FAILED,
+        rows_materialized=0,
+        error=PREEMPTED_ERROR,
+    )
+
+
+@activity.defn
+async def preempt_dag_run_activity(inputs: PreemptDAGRunInputs) -> None:
+    """Preempt a previous run of the same DAG by cancelling its child workflows and marking jobs as failed."""
+    bind_contextvars(team_id=inputs.team_id)
+    logger = LOGGER.bind()
+
+    running_jobs = await _get_running_jobs_for_dag(inputs.team_id, inputs.dag_id)
+    if not running_jobs:
+        await logger.adebug("No previous DAG run to preempt")
+        return
+
+    await logger.ainfo(
+        f"Preempting previous DAG run: found {len(running_jobs)} running jobs",
+        dag_id=inputs.dag_id,
+    )
+    # collect unique workflow IDs to cancel
+    workflow_ids_to_cancel = {job.workflow_id for job in running_jobs if job.workflow_id}
+    job_ids = [str(job.id) for job in running_jobs]
+    # mark all running jobs as preempted
+    updated_count = await _mark_jobs_as_preempted(job_ids)
+    await logger.ainfo(f"Marked {updated_count} jobs as preempted", dag_id=inputs.dag_id)
+    # request cancellation of child workflows
+    if workflow_ids_to_cancel:
+        try:
+            temporal = await async_connect()
+            for workflow_id in workflow_ids_to_cancel:
+                try:
+                    handle = temporal.get_workflow_handle(workflow_id)
+                    await handle.cancel()
+                    await logger.ainfo(f"Requested cancellation of workflow {workflow_id}")
+                except Exception as e:
+                    # workflow may have already completed — that's fine
+                    await logger.awarning(f"Could not cancel workflow {workflow_id}: {str(e)}")
+        except Exception as e:
+            capture_exception(e)
+            await logger.aexception(f"Failed to connect to Temporal for workflow cancellation: {str(e)}")

--- a/posthog/temporal/data_modeling/run_workflow.py
+++ b/posthog/temporal/data_modeling/run_workflow.py
@@ -400,6 +400,7 @@ async def handle_error(
         await logger.ainfo("Marking job %s as failed", job.id)
         await logger.aerror(f"handle_error: error={error_str}. error_message={error_message}")
         job.status = DataModelingJob.Status.FAILED
+        job.rows_materialized = 0
         job.error = strip_hostname_from_error(error_str)
         await database_sync_to_async(job.save)()
     await queue.put(
@@ -419,6 +420,7 @@ async def handle_cancelled(
     if job:
         await logger.aerror(f"handle_cancelled: error={error_str}. error_message={error_message}")
         job.status = DataModelingJob.Status.CANCELLED
+        job.rows_materialized = 0
         job.error = strip_hostname_from_error(error_str)
         await database_sync_to_async(job.save)()
     await queue.put(
@@ -711,6 +713,7 @@ async def mark_job_as_failed(job: DataModelingJob, error_message: str, logger: F
     await logger.aerror(f"mark_job_as_failed: {error_message}")
     await logger.ainfo("Marking job %s as failed", job.id)
     job.status = DataModelingJob.Status.FAILED
+    job.rows_materialized = 0
     job.error = strip_hostname_from_error(error_message)
     await database_sync_to_async(job.save)()
 
@@ -1384,6 +1387,7 @@ async def cleanup_running_jobs_activity(inputs: CleanupRunningJobsActivityInputs
         ).update
     )(
         status=DataModelingJob.Status.FAILED,
+        rows_materialized=0,
         error="Job timed out",
         updated_at=dt.datetime.now(dt.UTC),
     )
@@ -1508,7 +1512,7 @@ async def cancel_jobs_activity(inputs: CancelJobsActivityInputs) -> None:
 
     await database_sync_to_async(
         DataModelingJob.objects.filter(workflow_id=inputs.workflow_id, workflow_run_id=inputs.workflow_run_id).update
-    )(status=DataModelingJob.Status.CANCELLED)
+    )(status=DataModelingJob.Status.CANCELLED, rows_materialized=0)
     await logger.ainfo(
         "Cancelled data modeling jobs", workflow_id=inputs.workflow_id, workflow_run_id=inputs.workflow_run_id
     )

--- a/posthog/temporal/tests/data_modeling/test_materialize_view_activities.py
+++ b/posthog/temporal/tests/data_modeling/test_materialize_view_activities.py
@@ -110,6 +110,7 @@ class TestFailMaterializationActivity:
         await activity_environment.run(fail_materialization_activity, inputs)
         await database_sync_to_async(ajob.refresh_from_db)()
         assert ajob.status == DataModelingJob.Status.FAILED
+        assert ajob.rows_materialized == 0
         assert ajob.error == "Test error message"
 
     async def test_updates_node_system_properties(self, activity_environment, ateam, anode, ajob, adag):

--- a/posthog/temporal/tests/data_modeling/test_run_workflow.py
+++ b/posthog/temporal/tests/data_modeling/test_run_workflow.py
@@ -917,6 +917,7 @@ async def test_run_workflow_with_minio_bucket_with_errors(
     job = await DataModelingJob.objects.aget(workflow_id=workflow_id)
     assert job is not None
     assert job.status == DataModelingJob.Status.FAILED
+    assert job.rows_materialized == 0
 
 
 async def test_run_workflow_revert_materialization(
@@ -973,6 +974,7 @@ async def test_run_workflow_revert_materialization(
     job = await DataModelingJob.objects.aget(workflow_id=workflow_id)
     assert job is not None
     assert job.status == DataModelingJob.Status.FAILED
+    assert job.rows_materialized == 0
 
     for query in saved_queries:
         await database_sync_to_async(query.refresh_from_db)()
@@ -1041,6 +1043,7 @@ async def test_run_workflow_timeout_exceeded(
     job = await DataModelingJob.objects.aget(workflow_id=workflow_id)
     assert job is not None
     assert job.status == DataModelingJob.Status.FAILED
+    assert job.rows_materialized == 0
 
     for query in saved_queries:
         await database_sync_to_async(query.refresh_from_db)()
@@ -1351,9 +1354,11 @@ async def test_cleanup_running_jobs_activity(activity_environment, ateam):
     await database_sync_to_async(completed_job.refresh_from_db)()
 
     assert old_job.status == DataModelingJob.Status.FAILED
+    assert old_job.rows_materialized == 0
     assert old_job.error is not None
     assert "Job timed out" in old_job.error
     assert recent_job.status == DataModelingJob.Status.FAILED
+    assert recent_job.rows_materialized == 0
     assert recent_job.error is not None
     assert "Job timed out" in recent_job.error
     assert completed_job.status == DataModelingJob.Status.COMPLETED
@@ -1377,6 +1382,7 @@ async def test_create_job_model_activity_cleans_up_running_jobs(activity_environ
 
     await database_sync_to_async(orphaned_job.refresh_from_db)()
     assert orphaned_job.status == DataModelingJob.Status.FAILED
+    assert orphaned_job.rows_materialized == 0
     assert orphaned_job.error is not None
     assert "Job timed out" in orphaned_job.error
 


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

failed jobs report rows materialized

## Changes

don't do that

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

unit tests

## Publish to changelog?

no

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->