### PR TITLE
fix(dagster): add year/month/day columns to duckling events table for Hive partition compatibility

### DIFF
--- a/mypy-baseline.txt
+++ b/mypy-baseline.txt
@@ -573,6 +573,7 @@ posthog/tasks/exports/test/test_image_exporter.py:0: error: Function is missing 
 posthog/tasks/exports/test/test_image_exporter.py:0: error: Function is missing a type annotation for one or more arguments  [no-untyped-def]
 posthog/tasks/exports/test/test_image_exporter.py:0: error: Function is missing a type annotation for one or more arguments  [no-untyped-def]
 posthog/tasks/exports/test/test_image_exporter.py:0: error: Function is missing a type annotation for one or more arguments  [no-untyped-def]
+posthog/tasks/process_scheduled_changes.py:0: error: Unused "type: ignore" comment  [unused-ignore]
 posthog/tasks/test/test_process_scheduled_changes.py:0: error: Item "None" of "Any | None" has no attribute "get"  [union-attr]
 posthog/tasks/test/test_process_scheduled_changes.py:0: error: Item "None" of "Any | None" has no attribute "get"  [union-attr]
 posthog/tasks/test/test_stop_surveys_reached_target.py:0: error: No overload variant of "__sub__" of "datetime" matches argument type "None"  [operator]

--- a/posthog/dags/events_backfill_to_ducklake.py
+++ b/posthog/dags/events_backfill_to_ducklake.py
@@ -217,7 +217,8 @@ def validate_ducklake_schema(context: AssetExecutionContext) -> None:
     """Validate that the DuckLake events table schema matches our export columns.
 
     This pre-flight check ensures we don't waste time exporting data that can't
-    be registered with DuckLake due to schema mismatches.
+    be registered with DuckLake due to schema mismatches. Also migrates existing
+    tables by adding missing partition columns (year, month, day) via ALTER TABLE.
     """
     ducklake_config = get_config()
     storage_config = DuckLakeStorageConfig.from_runtime()
@@ -235,6 +236,16 @@ def validate_ducklake_schema(context: AssetExecutionContext) -> None:
 
         result = conn.execute(f"DESCRIBE {alias}.posthog.events").fetchall()
         ducklake_columns = {row[0] for row in result}
+
+        # Migrate existing tables: add partition columns if missing
+        partition_cols = {"year", "month", "day"}
+        missing_partition_cols = partition_cols - ducklake_columns
+        for col in ("year", "month", "day"):
+            if col in missing_partition_cols:
+                context.log.info(f"Adding missing partition column '{col}' to events table")
+                conn.execute(f"ALTER TABLE {alias}.posthog.events ADD COLUMN {col} INTEGER")
+                ducklake_columns.add(col)
+                logger.info("ducklake_partition_column_added", table="events", column=col)
 
         missing_in_ducklake = EXPECTED_DUCKLAKE_COLUMNS - ducklake_columns
         if missing_in_ducklake:

--- a/posthog/dags/events_backfill_to_ducklake.py
+++ b/posthog/dags/events_backfill_to_ducklake.py
@@ -17,10 +17,8 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime
 from typing import Any
 
-from django.conf import settings as django_settings
-
-import duckdb
 import dagster
+import duckdb
 import structlog
 from clickhouse_driver import Client
 from clickhouse_driver.errors import Error as ClickHouseError
@@ -33,6 +31,7 @@ from dagster import (
     asset,
     define_asset_job,
 )
+from django.conf import settings as django_settings
 from tenacity import (
     retry,
     retry_if_exception_type,

--- a/posthog/dags/events_backfill_to_ducklake.py
+++ b/posthog/dags/events_backfill_to_ducklake.py
@@ -17,8 +17,10 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime
 from typing import Any
 
-import dagster
+from django.conf import settings as django_settings
+
 import duckdb
+import dagster
 import structlog
 from clickhouse_driver import Client
 from clickhouse_driver.errors import Error as ClickHouseError
@@ -31,23 +33,13 @@ from dagster import (
     asset,
     define_asset_job,
 )
-from django.conf import settings as django_settings
-from tenacity import (
-    retry,
-    retry_if_exception_type,
-    stop_after_attempt,
-    wait_exponential,
-)
+from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential
 
 from posthog.clickhouse.client.connection import NodeRole, Workload
 from posthog.clickhouse.cluster import get_cluster
 from posthog.clickhouse.query_tagging import tags_context
 from posthog.cloud_utils import is_cloud
-from posthog.dags.common.common import (
-    JobOwners,
-    dagster_tags,
-    settings_with_log_comment,
-)
+from posthog.dags.common.common import JobOwners, dagster_tags, settings_with_log_comment
 from posthog.ducklake.common import attach_catalog, escape, get_config
 from posthog.ducklake.storage import DuckLakeStorageConfig, configure_connection
 from posthog.settings.base_variables import DEBUG
@@ -260,9 +252,7 @@ def validate_ducklake_schema(context: AssetExecutionContext) -> None:
         if extra_in_ducklake:
             # Extra columns in DuckLake are fine - they might come from streaming
             # (e.g., _kafka_* metadata columns)
-            context.log.info(
-                f"DuckLake has additional columns not in our export: {extra_in_ducklake}"
-            )
+            context.log.info(f"DuckLake has additional columns not in our export: {extra_in_ducklake}")
 
         context.log.info(
             f"Schema validation passed. DuckLake has {len(ducklake_columns)} columns, "
@@ -278,9 +268,7 @@ def validate_ducklake_schema(context: AssetExecutionContext) -> None:
         conn.close()
 
 
-def get_partition_where_clause(
-    context: AssetExecutionContext, timestamp_field: str = "timestamp"
-) -> str:
+def get_partition_where_clause(context: AssetExecutionContext, timestamp_field: str = "timestamp") -> str:
     start_incl = context.partition_time_window.start.strftime("%Y-%m-%d")
     end_excl = context.partition_time_window.end.strftime("%Y-%m-%d")
     return f"toDate({timestamp_field}) >= '{start_incl}' AND toDate({timestamp_field}) < '{end_excl}'"
@@ -405,9 +393,7 @@ def export_events_to_s3(
     WHERE {chunk_where}
     SETTINGS s3_truncate_on_insert=1, use_hive_partitioning=0
     """
-        context.log.info(
-            f"[DRY RUN] Would export chunk {chunk_info} with SQL: {safe_sql[:800]}..."
-        )
+        context.log.info(f"[DRY RUN] Would export chunk {chunk_info} with SQL: {safe_sql[:800]}...")
         return []
 
     context.log.info(f"Exporting events chunk {chunk_info} to {s3_path}")
@@ -422,17 +408,11 @@ def export_events_to_s3(
     try:
         _execute_export_with_retry(client, export_sql, settings, chunk_info)
         context.log.info(f"Successfully exported chunk {chunk_info}")
-        logger.info(
-            "export_chunk_success", chunk=team_id_chunk, total_chunks=total_chunks
-        )
+        logger.info("export_chunk_success", chunk=team_id_chunk, total_chunks=total_chunks)
         return [s3_path]
     except Exception:
-        context.log.exception(
-            f"Failed to export chunk {chunk_info} after {MAX_RETRY_ATTEMPTS} attempts"
-        )
-        logger.exception(
-            "export_chunk_failed", chunk=team_id_chunk, total_chunks=total_chunks
-        )
+        context.log.exception(f"Failed to export chunk {chunk_info} after {MAX_RETRY_ATTEMPTS} attempts")
+        logger.exception("export_chunk_failed", chunk=team_id_chunk, total_chunks=total_chunks)
         raise
 
 
@@ -502,9 +482,7 @@ def register_files_with_ducklake(
     Returns the number of files successfully registered.
     """
     if config.skip_ducklake_registration:
-        context.log.info(
-            "Skipping DuckLake registration (skip_ducklake_registration=True)"
-        )
+        context.log.info("Skipping DuckLake registration (skip_ducklake_registration=True)")
         return 0
 
     if not s3_paths:
@@ -512,9 +490,7 @@ def register_files_with_ducklake(
         return 0
 
     if config.dry_run:
-        context.log.info(
-            f"[DRY RUN] Would register {len(s3_paths)} files with DuckLake"
-        )
+        context.log.info(f"[DRY RUN] Would register {len(s3_paths)} files with DuckLake")
         return 0
 
     ducklake_config = get_config()
@@ -529,10 +505,7 @@ def register_files_with_ducklake(
 
         # Check if the DuckLake catalog is already attached in a robust way by querying DuckDB
         existing_catalogs = {
-            row[0]
-            for row in conn.execute(
-                "SELECT catalog_name FROM duckdb_catalog.get_catalogs()"
-            ).fetchall()
+            row[0] for row in conn.execute("SELECT catalog_name FROM duckdb_catalog.get_catalogs()").fetchall()
         }
 
         if alias in existing_catalogs:
@@ -558,9 +531,7 @@ def register_files_with_ducklake(
     finally:
         conn.close()
 
-    context.log.info(
-        f"Registered {registered_count}/{len(s3_paths)} files with DuckLake"
-    )
+    context.log.info(f"Registered {registered_count}/{len(s3_paths)} files with DuckLake")
     logger.info(
         "ducklake_registration_complete",
         registered=registered_count,
@@ -579,14 +550,10 @@ events_backfill_partitioned_config = PartitionedConfig(
 @asset(
     partitions_def=daily_partitions,
     name="events_ducklake_backfill",
-    backfill_policy=BackfillPolicy.multi_run(
-        max_partitions_per_run=MAX_PARTITIONS_PER_RUN
-    ),
+    backfill_policy=BackfillPolicy.multi_run(max_partitions_per_run=MAX_PARTITIONS_PER_RUN),
     tags={"owner": JobOwners.TEAM_DATA_STACK.value, **CONCURRENCY_TAG},
 )
-def events_ducklake_backfill(
-    context: AssetExecutionContext, config: EventsBackfillConfig
-) -> None:
+def events_ducklake_backfill(context: AssetExecutionContext, config: EventsBackfillConfig) -> None:
     """Backfill events from ClickHouse to DuckLake.
 
     This asset:
@@ -631,9 +598,7 @@ def events_ducklake_backfill(
     merged_settings.update(settings_with_log_comment(context))
     if config.clickhouse_settings:
         merged_settings.update(config.clickhouse_settings)
-        context.log.info(
-            f"Using custom ClickHouse settings: {config.clickhouse_settings}"
-        )
+        context.log.info(f"Using custom ClickHouse settings: {config.clickhouse_settings}")
 
     team_id_chunks = max(1, config.team_id_chunks)
     parallel_chunks = min(max(1, config.parallel_chunks), team_id_chunks)
@@ -679,14 +644,9 @@ def events_ducklake_backfill(
         ).result()
 
     if parallel_chunks > 1:
-        context.log.info(
-            f"Exporting {team_id_chunks} chunks with {parallel_chunks} parallel workers"
-        )
+        context.log.info(f"Exporting {team_id_chunks} chunks with {parallel_chunks} parallel workers")
         with ThreadPoolExecutor(max_workers=parallel_chunks) as executor:
-            futures = {
-                executor.submit(export_single_chunk, i): i
-                for i in range(team_id_chunks)
-            }
+            futures = {executor.submit(export_single_chunk, i): i for i in range(team_id_chunks)}
             for future in as_completed(futures):
                 chunk_i = futures[future]
                 try:
@@ -694,9 +654,7 @@ def events_ducklake_backfill(
                     all_s3_paths.extend(paths)
                     context.log.info(f"Completed chunk {chunk_i + 1}/{team_id_chunks}")
                 except Exception:
-                    context.log.exception(
-                        f"Chunk {chunk_i + 1}/{team_id_chunks} failed"
-                    )
+                    context.log.exception(f"Chunk {chunk_i + 1}/{team_id_chunks} failed")
                     raise
     else:
         for chunk_i in range(team_id_chunks):

--- a/posthog/dags/events_backfill_to_ducklake.py
+++ b/posthog/dags/events_backfill_to_ducklake.py
@@ -33,13 +33,22 @@ from dagster import (
     asset,
     define_asset_job,
 )
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential
+from tenacity import (
+    retry,
+    retry_if_exception_type,
+    stop_after_attempt,
+    wait_exponential,
+)
 
 from posthog.clickhouse.client.connection import NodeRole, Workload
 from posthog.clickhouse.cluster import get_cluster
 from posthog.clickhouse.query_tagging import tags_context
 from posthog.cloud_utils import is_cloud
-from posthog.dags.common.common import JobOwners, dagster_tags, settings_with_log_comment
+from posthog.dags.common.common import (
+    JobOwners,
+    dagster_tags,
+    settings_with_log_comment,
+)
 from posthog.ducklake.common import attach_catalog, escape, get_config
 from posthog.ducklake.storage import DuckLakeStorageConfig, configure_connection
 from posthog.settings.base_variables import DEBUG
@@ -252,7 +261,9 @@ def validate_ducklake_schema(context: AssetExecutionContext) -> None:
         if extra_in_ducklake:
             # Extra columns in DuckLake are fine - they might come from streaming
             # (e.g., _kafka_* metadata columns)
-            context.log.info(f"DuckLake has additional columns not in our export: {extra_in_ducklake}")
+            context.log.info(
+                f"DuckLake has additional columns not in our export: {extra_in_ducklake}"
+            )
 
         context.log.info(
             f"Schema validation passed. DuckLake has {len(ducklake_columns)} columns, "
@@ -268,7 +279,9 @@ def validate_ducklake_schema(context: AssetExecutionContext) -> None:
         conn.close()
 
 
-def get_partition_where_clause(context: AssetExecutionContext, timestamp_field: str = "timestamp") -> str:
+def get_partition_where_clause(
+    context: AssetExecutionContext, timestamp_field: str = "timestamp"
+) -> str:
     start_incl = context.partition_time_window.start.strftime("%Y-%m-%d")
     end_excl = context.partition_time_window.end.strftime("%Y-%m-%d")
     return f"toDate({timestamp_field}) >= '{start_incl}' AND toDate({timestamp_field}) < '{end_excl}'"
@@ -393,7 +406,9 @@ def export_events_to_s3(
     WHERE {chunk_where}
     SETTINGS s3_truncate_on_insert=1, use_hive_partitioning=0
     """
-        context.log.info(f"[DRY RUN] Would export chunk {chunk_info} with SQL: {safe_sql[:800]}...")
+        context.log.info(
+            f"[DRY RUN] Would export chunk {chunk_info} with SQL: {safe_sql[:800]}..."
+        )
         return []
 
     context.log.info(f"Exporting events chunk {chunk_info} to {s3_path}")
@@ -408,11 +423,17 @@ def export_events_to_s3(
     try:
         _execute_export_with_retry(client, export_sql, settings, chunk_info)
         context.log.info(f"Successfully exported chunk {chunk_info}")
-        logger.info("export_chunk_success", chunk=team_id_chunk, total_chunks=total_chunks)
+        logger.info(
+            "export_chunk_success", chunk=team_id_chunk, total_chunks=total_chunks
+        )
         return [s3_path]
     except Exception:
-        context.log.exception(f"Failed to export chunk {chunk_info} after {MAX_RETRY_ATTEMPTS} attempts")
-        logger.exception("export_chunk_failed", chunk=team_id_chunk, total_chunks=total_chunks)
+        context.log.exception(
+            f"Failed to export chunk {chunk_info} after {MAX_RETRY_ATTEMPTS} attempts"
+        )
+        logger.exception(
+            "export_chunk_failed", chunk=team_id_chunk, total_chunks=total_chunks
+        )
         raise
 
 
@@ -463,7 +484,11 @@ def cleanup_prior_run_files(
 
     if deleted_count > 0:
         context.log.info(f"Cleaned up {deleted_count} orphaned files from prior runs")
-        logger.info("cleanup_complete", deleted_count=deleted_count, partition_date=partition_date.isoformat())
+        logger.info(
+            "cleanup_complete",
+            deleted_count=deleted_count,
+            partition_date=partition_date.isoformat(),
+        )
 
     return deleted_count
 
@@ -478,7 +503,9 @@ def register_files_with_ducklake(
     Returns the number of files successfully registered.
     """
     if config.skip_ducklake_registration:
-        context.log.info("Skipping DuckLake registration (skip_ducklake_registration=True)")
+        context.log.info(
+            "Skipping DuckLake registration (skip_ducklake_registration=True)"
+        )
         return 0
 
     if not s3_paths:
@@ -486,7 +513,9 @@ def register_files_with_ducklake(
         return 0
 
     if config.dry_run:
-        context.log.info(f"[DRY RUN] Would register {len(s3_paths)} files with DuckLake")
+        context.log.info(
+            f"[DRY RUN] Would register {len(s3_paths)} files with DuckLake"
+        )
         return 0
 
     ducklake_config = get_config()
@@ -501,7 +530,10 @@ def register_files_with_ducklake(
 
         # Check if the DuckLake catalog is already attached in a robust way by querying DuckDB
         existing_catalogs = {
-            row[0] for row in conn.execute("SELECT catalog_name FROM duckdb_catalog.get_catalogs()").fetchall()
+            row[0]
+            for row in conn.execute(
+                "SELECT catalog_name FROM duckdb_catalog.get_catalogs()"
+            ).fetchall()
         }
 
         if alias in existing_catalogs:
@@ -527,8 +559,14 @@ def register_files_with_ducklake(
     finally:
         conn.close()
 
-    context.log.info(f"Registered {registered_count}/{len(s3_paths)} files with DuckLake")
-    logger.info("ducklake_registration_complete", registered=registered_count, total=len(s3_paths))
+    context.log.info(
+        f"Registered {registered_count}/{len(s3_paths)} files with DuckLake"
+    )
+    logger.info(
+        "ducklake_registration_complete",
+        registered=registered_count,
+        total=len(s3_paths),
+    )
     return registered_count
 
 
@@ -542,10 +580,14 @@ events_backfill_partitioned_config = PartitionedConfig(
 @asset(
     partitions_def=daily_partitions,
     name="events_ducklake_backfill",
-    backfill_policy=BackfillPolicy.multi_run(max_partitions_per_run=MAX_PARTITIONS_PER_RUN),
+    backfill_policy=BackfillPolicy.multi_run(
+        max_partitions_per_run=MAX_PARTITIONS_PER_RUN
+    ),
     tags={"owner": JobOwners.TEAM_DATA_STACK.value, **CONCURRENCY_TAG},
 )
-def events_ducklake_backfill(context: AssetExecutionContext, config: EventsBackfillConfig) -> None:
+def events_ducklake_backfill(
+    context: AssetExecutionContext, config: EventsBackfillConfig
+) -> None:
     """Backfill events from ClickHouse to DuckLake.
 
     This asset:
@@ -590,7 +632,9 @@ def events_ducklake_backfill(context: AssetExecutionContext, config: EventsBackf
     merged_settings.update(settings_with_log_comment(context))
     if config.clickhouse_settings:
         merged_settings.update(config.clickhouse_settings)
-        context.log.info(f"Using custom ClickHouse settings: {config.clickhouse_settings}")
+        context.log.info(
+            f"Using custom ClickHouse settings: {config.clickhouse_settings}"
+        )
 
     team_id_chunks = max(1, config.team_id_chunks)
     parallel_chunks = min(max(1, config.parallel_chunks), team_id_chunks)
@@ -636,9 +680,14 @@ def events_ducklake_backfill(context: AssetExecutionContext, config: EventsBackf
         ).result()
 
     if parallel_chunks > 1:
-        context.log.info(f"Exporting {team_id_chunks} chunks with {parallel_chunks} parallel workers")
+        context.log.info(
+            f"Exporting {team_id_chunks} chunks with {parallel_chunks} parallel workers"
+        )
         with ThreadPoolExecutor(max_workers=parallel_chunks) as executor:
-            futures = {executor.submit(export_single_chunk, i): i for i in range(team_id_chunks)}
+            futures = {
+                executor.submit(export_single_chunk, i): i
+                for i in range(team_id_chunks)
+            }
             for future in as_completed(futures):
                 chunk_i = futures[future]
                 try:
@@ -646,7 +695,9 @@ def events_ducklake_backfill(context: AssetExecutionContext, config: EventsBackf
                     all_s3_paths.extend(paths)
                     context.log.info(f"Completed chunk {chunk_i + 1}/{team_id_chunks}")
                 except Exception:
-                    context.log.exception(f"Chunk {chunk_i + 1}/{team_id_chunks} failed")
+                    context.log.exception(
+                        f"Chunk {chunk_i + 1}/{team_id_chunks} failed"
+                    )
                     raise
     else:
         for chunk_i in range(team_id_chunks):

--- a/posthog/dags/events_backfill_to_ducklake.py
+++ b/posthog/dags/events_backfill_to_ducklake.py
@@ -130,7 +130,10 @@ EVENTS_COLUMNS = """
     group4_created_at,
     person_mode,
     historical_migration,
-    NOW() as _inserted_at
+    NOW() as _inserted_at,
+    toYear(timestamp) as year,
+    toMonth(timestamp) as month,
+    toDayOfMonth(timestamp) as day
 """
 
 # Expected columns in the DuckLake events table (for schema validation)
@@ -160,6 +163,9 @@ EXPECTED_DUCKLAKE_COLUMNS = {
     "person_mode",
     "historical_migration",
     "_inserted_at",
+    "year",
+    "month",
+    "day",
 }
 
 

--- a/posthog/dags/events_backfill_to_duckling.py
+++ b/posthog/dags/events_backfill_to_duckling.py
@@ -933,16 +933,19 @@ def delete_events_partition_data(
     alias = "ducklake"
     date_str = partition_date.strftime("%Y-%m-%d")
 
-    # Range predicate enables DuckLake partition pruning.
-    # The table is partitioned by year(timestamp), month(timestamp), day(timestamp).
-    # A half-open range [start_of_day, start_of_next_day) allows DuckDB to prune
-    # to a single day's partition instead of scanning all data files.
+    # The table is partitioned by explicit year, month, day columns.
+    # Include partition column predicates so DuckLake can prune partitions,
+    # plus a timestamp range for correctness on any legacy rows without
+    # partition columns populated.
     next_date_str = (partition_date + timedelta(days=1)).strftime("%Y-%m-%d")
     delete_sql = f"""
     DELETE FROM {alias}.posthog.events
     WHERE team_id = $1
-      AND timestamp >= $2
-      AND timestamp < $3
+      AND year = $2
+      AND month = $3
+      AND day = $4
+      AND timestamp >= $5
+      AND timestamp < $6
     """
 
     last_exception: Exception | None = None
@@ -952,7 +955,10 @@ def delete_events_partition_data(
             configure_cross_account_connection(conn, destinations=[destination])
             attach_catalog(conn, catalog_config, alias=alias)
 
-            result = conn.execute(delete_sql, [team_id, date_str, next_date_str]).fetchone()
+            result = conn.execute(
+                delete_sql,
+                [team_id, partition_date.year, partition_date.month, partition_date.day, date_str, next_date_str],
+            ).fetchone()
             deleted_count = result[0] if result else 0
 
             if deleted_count > 0:
@@ -1037,10 +1043,20 @@ def delete_persons_partition_data(
         delete_sql = f"""
         DELETE FROM {alias}.posthog.persons
         WHERE team_id = $1
-          AND _timestamp >= $2
-          AND _timestamp < $3
+          AND year = $2
+          AND month = $3
+          AND day = $4
+          AND _timestamp >= $5
+          AND _timestamp < $6
         """
-        delete_params = [team_id, date_str, next_date_str]
+        delete_params = [
+            team_id,
+            partition_date.year,
+            partition_date.month,
+            partition_date.day,
+            date_str,
+            next_date_str,
+        ]
 
     last_exception: Exception | None = None
     for attempt in range(MAX_RETRY_ATTEMPTS):

--- a/posthog/dags/events_backfill_to_duckling.py
+++ b/posthog/dags/events_backfill_to_duckling.py
@@ -30,13 +30,11 @@ Partition Strategy:
     - date is the partition date (YYYY-MM-DD)
 """
 
+import calendar
 import json
 import time
-import calendar
 from datetime import date, datetime, timedelta
 from typing import Any
-
-from django.utils import timezone
 
 import duckdb
 import structlog
@@ -56,6 +54,7 @@ from dagster import (
     define_asset_job,
     sensor,
 )
+from django.utils import timezone
 from tenacity import (
     retry,
     retry_if_exception_type,

--- a/posthog/dags/events_backfill_to_duckling.py
+++ b/posthog/dags/events_backfill_to_duckling.py
@@ -30,11 +30,13 @@ Partition Strategy:
     - date is the partition date (YYYY-MM-DD)
 """
 
-import calendar
 import json
 import time
+import calendar
 from datetime import date, datetime, timedelta
 from typing import Any
+
+from django.utils import timezone
 
 import duckdb
 import structlog
@@ -54,35 +56,19 @@ from dagster import (
     define_asset_job,
     sensor,
 )
-from django.utils import timezone
-from tenacity import (
-    retry,
-    retry_if_exception_type,
-    stop_after_attempt,
-    wait_exponential,
-    wait_fixed,
-)
+from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential, wait_fixed
 
 from posthog.clickhouse.client.connection import NodeRole, Workload
 from posthog.clickhouse.cluster import ClickhouseCluster, get_cluster
 from posthog.clickhouse.query_tagging import tags_context
 from posthog.cloud_utils import is_cloud
-from posthog.dags.common.common import (
-    JobOwners,
-    dagster_tags,
-    settings_with_log_comment,
-)
+from posthog.dags.common.common import JobOwners, dagster_tags, settings_with_log_comment
 from posthog.dags.events_backfill_to_ducklake import (
     DEFAULT_CLICKHOUSE_SETTINGS,
     EXPECTED_DUCKLAKE_COLUMNS,
     MAX_RETRY_ATTEMPTS,
 )
-from posthog.ducklake.common import (
-    attach_catalog,
-    escape,
-    get_ducklake_catalog_for_team,
-    get_team_config,
-)
+from posthog.ducklake.common import attach_catalog, escape, get_ducklake_catalog_for_team, get_team_config
 from posthog.ducklake.models import DuckLakeCatalog
 from posthog.ducklake.storage import configure_cross_account_connection
 
@@ -195,12 +181,8 @@ EXPECTED_DUCKLAKE_PERSONS_COLUMNS = {
     "_inserted_at",
 }
 
-duckling_events_partitions_def = DynamicPartitionsDefinition(
-    name="duckling_events_backfill"
-)
-duckling_persons_partitions_def = DynamicPartitionsDefinition(
-    name="duckling_persons_backfill"
-)
+duckling_events_partitions_def = DynamicPartitionsDefinition(name="duckling_events_backfill")
+duckling_persons_partitions_def = DynamicPartitionsDefinition(name="duckling_persons_backfill")
 
 # SQL for creating the events table in DuckLake if it doesn't exist
 # Uses TIMESTAMPTZ because ClickHouse exports DateTime64 as TIMESTAMP WITH TIME ZONE in Parquet.
@@ -262,9 +244,7 @@ class DucklingBackfillConfig(Config):
     clickhouse_settings: dict[str, Any] | None = None
     skip_ducklake_registration: bool = False
     skip_schema_validation: bool = False
-    cleanup_existing_partition_data: bool = (
-        True  # Delete existing DuckLake data for partition before registering
-    )
+    cleanup_existing_partition_data: bool = True  # Delete existing DuckLake data for partition before registering
     create_tables_if_missing: bool = True
     delete_tables: bool = False  # Danger: drops and recreates tables, losing all data
     dry_run: bool = False
@@ -285,9 +265,7 @@ def parse_partition_key(key: str) -> tuple[int, str]:
     """
     parts = key.rsplit("_", 1)
     if len(parts) != 2:
-        raise ValueError(
-            f"Invalid partition key format: {key}. Expected 'team_id_YYYY-MM-DD' or 'team_id_YYYY-MM'"
-        )
+        raise ValueError(f"Invalid partition key format: {key}. Expected 'team_id_YYYY-MM-DD' or 'team_id_YYYY-MM'")
 
     team_id_str, date_str = parts
 
@@ -303,9 +281,7 @@ def parse_partition_key(key: str) -> tuple[int, str]:
         try:
             datetime.strptime(date_str, "%Y-%m")
         except ValueError as e:
-            raise ValueError(
-                f"Invalid date in partition key: {date_str}. Expected YYYY-MM-DD or YYYY-MM"
-            ) from e
+            raise ValueError(f"Invalid date in partition key: {date_str}. Expected YYYY-MM-DD or YYYY-MM") from e
 
     return team_id, date_str
 
@@ -354,9 +330,7 @@ def is_full_export_partition(key: str) -> bool:
     return key.isdigit()
 
 
-def get_s3_url_for_clickhouse(
-    bucket: str, region: str, path_without_scheme: str
-) -> str:
+def get_s3_url_for_clickhouse(bucket: str, region: str, path_without_scheme: str) -> str:
     """Build S3 URL in the format ClickHouse expects for cross-account access.
 
     ClickHouse uses the EC2 instance role for authentication. The duckling bucket
@@ -513,9 +487,7 @@ def _set_table_partitioning(
 
     context.log.info(f"Setting partitioning on {table} table...")
     try:
-        conn.execute(
-            f"ALTER TABLE {alias}.posthog.{table} SET PARTITIONED BY ({partition_expr})"
-        )
+        conn.execute(f"ALTER TABLE {alias}.posthog.{table} SET PARTITIONED BY ({partition_expr})")
         context.log.info(f"Successfully set partitioning on {table} table")
         logger.info(
             "duckling_table_partitioning_set",
@@ -563,9 +535,7 @@ def ensure_events_table_exists(
         if table_exists(conn, alias, "posthog", "events"):
             context.log.info("Events table already exists in duckling catalog")
             # Ensure partitioning is set even on existing tables (idempotent)
-            _set_table_partitioning(
-                conn, alias, "events", "year, month, day", context, catalog.team_id
-            )
+            _set_table_partitioning(conn, alias, "events", "year, month, day", context, catalog.team_id)
             return False
 
         context.log.info("Creating posthog schema if it doesn't exist...")
@@ -580,9 +550,7 @@ def ensure_events_table_exists(
             if table_exists(conn, alias, "posthog", "events"):
                 context.log.info("Events table was created by another worker")
                 # Ensure partitioning is set even when another worker created the table
-                _set_table_partitioning(
-                    conn, alias, "events", "year, month, day", context, catalog.team_id
-                )
+                _set_table_partitioning(conn, alias, "events", "year, month, day", context, catalog.team_id)
                 return False
             # Real error - log and re-raise
             context.log.exception(f"Failed to create events table: {exc}")
@@ -591,9 +559,7 @@ def ensure_events_table_exists(
         context.log.info("Successfully created events table")
 
         # Set partitioning by year/month/day for efficient querying
-        _set_table_partitioning(
-            conn, alias, "events", "year, month, day", context, catalog.team_id
-        )
+        _set_table_partitioning(conn, alias, "events", "year, month, day", context, catalog.team_id)
 
         logger.info(
             "duckling_events_table_created",
@@ -802,9 +768,7 @@ def validate_duckling_schema(
 
         extra_in_ducklake = ducklake_columns - EXPECTED_DUCKLAKE_COLUMNS
         if extra_in_ducklake:
-            context.log.info(
-                f"Duckling has additional columns not in our export: {extra_in_ducklake}"
-            )
+            context.log.info(f"Duckling has additional columns not in our export: {extra_in_ducklake}")
 
         context.log.info(
             f"Schema validation passed. Duckling has {len(ducklake_columns)} columns, "
@@ -853,9 +817,7 @@ def validate_duckling_persons_schema(
 
         extra_in_ducklake = ducklake_columns - EXPECTED_DUCKLAKE_PERSONS_COLUMNS
         if extra_in_ducklake:
-            context.log.info(
-                f"Duckling persons has additional columns not in our export: {extra_in_ducklake}"
-            )
+            context.log.info(f"Duckling persons has additional columns not in our export: {extra_in_ducklake}")
 
         context.log.info(
             f"Persons schema validation passed. Duckling has {len(ducklake_columns)} columns, "
@@ -899,9 +861,7 @@ def _execute_export_with_retry(
 
 def _is_transaction_conflict(exc: BaseException) -> bool:
     """Check if exception is a DuckLake transaction conflict (retryable)."""
-    return isinstance(
-        exc, duckdb.TransactionException
-    ) and "Transaction conflict" in str(exc)
+    return isinstance(exc, duckdb.TransactionException) and "Transaction conflict" in str(exc)
 
 
 def delete_events_partition_data(
@@ -944,15 +904,11 @@ def delete_events_partition_data(
             configure_cross_account_connection(conn, destinations=[destination])
             attach_catalog(conn, catalog_config, alias=alias)
 
-            result = conn.execute(
-                delete_sql, [team_id, date_str, next_date_str]
-            ).fetchone()
+            result = conn.execute(delete_sql, [team_id, date_str, next_date_str]).fetchone()
             deleted_count = result[0] if result else 0
 
             if deleted_count > 0:
-                context.log.info(
-                    f"Deleted {deleted_count} existing events for team_id={team_id}, date={date_str}"
-                )
+                context.log.info(f"Deleted {deleted_count} existing events for team_id={team_id}, date={date_str}")
                 logger.info(
                     "duckling_events_partition_deleted",
                     team_id=team_id,
@@ -984,9 +940,7 @@ def delete_events_partition_data(
                 time.sleep(wait_time)
                 continue
 
-            context.log.exception(
-                f"Failed to delete events for team_id={team_id}, date={date_str}"
-            )
+            context.log.exception(f"Failed to delete events for team_id={team_id}, date={date_str}")
             logger.exception(
                 "duckling_events_delete_failed",
                 team_id=team_id,
@@ -1053,9 +1007,7 @@ def delete_persons_partition_data(
             deleted_count = result[0] if result else 0
 
             if deleted_count > 0:
-                context.log.info(
-                    f"Deleted {deleted_count} existing persons for team_id={team_id}, date={date_label}"
-                )
+                context.log.info(f"Deleted {deleted_count} existing persons for team_id={team_id}, date={date_label}")
                 logger.info(
                     "duckling_persons_partition_deleted",
                     team_id=team_id,
@@ -1065,9 +1017,7 @@ def delete_persons_partition_data(
             return deleted_count
 
         except duckdb.CatalogException:
-            context.log.debug(
-                f"Persons table doesn't exist yet, nothing to delete for team_id={team_id}"
-            )
+            context.log.debug(f"Persons table doesn't exist yet, nothing to delete for team_id={team_id}")
             return 0
 
         except Exception as e:
@@ -1087,9 +1037,7 @@ def delete_persons_partition_data(
                 time.sleep(wait_time)
                 continue
 
-            context.log.exception(
-                f"Failed to delete persons for team_id={team_id}, date={date_label}"
-            )
+            context.log.exception(f"Failed to delete persons for team_id={team_id}, date={date_label}")
             logger.exception(
                 "duckling_persons_delete_failed",
                 team_id=team_id,
@@ -1129,12 +1077,12 @@ def export_events_to_duckling_s3(
     date_str = date.strftime("%Y-%m-%d")
 
     # Path without s3:// scheme for the HTTPS URL
-    path_without_scheme = f"{BACKFILL_EVENTS_S3_PREFIX}/team_id={team_id}/year={year}/month={month}/day={day}/{run_id}.parquet"
+    path_without_scheme = (
+        f"{BACKFILL_EVENTS_S3_PREFIX}/team_id={team_id}/year={year}/month={month}/day={day}/{run_id}.parquet"
+    )
 
     # ClickHouse needs HTTPS URL format for cross-account S3 access
-    s3_url = get_s3_url_for_clickhouse(
-        catalog.bucket, catalog.bucket_region, path_without_scheme
-    )
+    s3_url = get_s3_url_for_clickhouse(catalog.bucket, catalog.bucket_region, path_without_scheme)
 
     # S3 path with scheme for DuckLake registration
     s3_path = f"s3://{catalog.bucket}/{path_without_scheme}"
@@ -1175,9 +1123,7 @@ def export_events_to_duckling_s3(
         logger.info("duckling_export_success", team_id=team_id, date=date_str)
         return s3_path
     except Exception:
-        context.log.exception(
-            f"Failed to export events for {info} after {MAX_RETRY_ATTEMPTS} attempts"
-        )
+        context.log.exception(f"Failed to export events for {info} after {MAX_RETRY_ATTEMPTS} attempts")
         logger.exception("duckling_export_failed", team_id=team_id, date=date_str)
         raise
 
@@ -1206,15 +1152,11 @@ def register_file_with_duckling(
         True if registration succeeded, False otherwise.
     """
     if config.skip_ducklake_registration:
-        context.log.info(
-            "Skipping DuckLake registration (skip_ducklake_registration=True)"
-        )
+        context.log.info("Skipping DuckLake registration (skip_ducklake_registration=True)")
         return False
 
     if config.dry_run:
-        context.log.info(
-            f"[DRY RUN] Would register {s3_path} with DuckLake at {catalog.db_host}"
-        )
+        context.log.info(f"[DRY RUN] Would register {s3_path} with DuckLake at {catalog.db_host}")
         return False
 
     destination = catalog.to_cross_account_destination()
@@ -1229,22 +1171,16 @@ def register_file_with_duckling(
             attach_catalog(conn, catalog_config, alias=alias)
 
             context.log.info(f"Registering file with DuckLake: {s3_path}")
-            conn.execute(
-                f"CALL ducklake_add_data_files('{alias}', 'events', '{escape(s3_path)}', schema => 'posthog')"
-            )
+            conn.execute(f"CALL ducklake_add_data_files('{alias}', 'events', '{escape(s3_path)}', schema => 'posthog')")
 
             context.log.info(f"Successfully registered: {s3_path}")
-            logger.info(
-                "duckling_file_registered", s3_path=s3_path, team_id=catalog.team_id
-            )
+            logger.info("duckling_file_registered", s3_path=s3_path, team_id=catalog.team_id)
             return True
 
         except Exception as e:
             last_exception = e
             if _is_transaction_conflict(e) and attempt < MAX_RETRY_ATTEMPTS - 1:
-                wait_time = min(
-                    4 * (2**attempt), 60
-                )  # Exponential backoff: 4, 8, 16, ... capped at 60s
+                wait_time = min(4 * (2**attempt), 60)  # Exponential backoff: 4, 8, 16, ... capped at 60s
                 context.log.warning(
                     f"DuckLake transaction conflict on attempt {attempt + 1}, retrying in {wait_time}s..."
                 )
@@ -1302,10 +1238,10 @@ def export_persons_to_duckling_s3(
     day = date.strftime("%d")
     date_str = date.strftime("%Y-%m-%d")
 
-    path_without_scheme = f"{BACKFILL_PERSONS_S3_PREFIX}/team_id={team_id}/year={year}/month={month}/day={day}/{run_id}.parquet"
-    s3_url = get_s3_url_for_clickhouse(
-        catalog.bucket, catalog.bucket_region, path_without_scheme
+    path_without_scheme = (
+        f"{BACKFILL_PERSONS_S3_PREFIX}/team_id={team_id}/year={year}/month={month}/day={day}/{run_id}.parquet"
     )
+    s3_url = get_s3_url_for_clickhouse(catalog.bucket, catalog.bucket_region, path_without_scheme)
     s3_path = f"s3://{catalog.bucket}/{path_without_scheme}"
 
     # Join person with person_distinct_id2 to get distinct_ids
@@ -1331,9 +1267,7 @@ def export_persons_to_duckling_s3(
     info = f"team_id={team_id}, date={date_str}"
 
     if config.dry_run:
-        context.log.info(
-            f"[DRY RUN] Would export persons with SQL: {export_sql[:800]}..."
-        )
+        context.log.info(f"[DRY RUN] Would export persons with SQL: {export_sql[:800]}...")
         return None
 
     context.log.info(f"Exporting persons for {info} to {s3_path}")
@@ -1350,12 +1284,8 @@ def export_persons_to_duckling_s3(
         logger.info("duckling_persons_export_success", team_id=team_id, date=date_str)
         return s3_path
     except Exception:
-        context.log.exception(
-            f"Failed to export persons for {info} after {MAX_RETRY_ATTEMPTS} attempts"
-        )
-        logger.exception(
-            "duckling_persons_export_failed", team_id=team_id, date=date_str
-        )
+        context.log.exception(f"Failed to export persons for {info} after {MAX_RETRY_ATTEMPTS} attempts")
+        logger.exception("duckling_persons_export_failed", team_id=team_id, date=date_str)
         raise
 
 
@@ -1377,12 +1307,8 @@ def export_persons_full_to_duckling_s3(
     Returns:
         S3 path that was written, or None if dry_run.
     """
-    path_without_scheme = (
-        f"{BACKFILL_PERSONS_S3_PREFIX}/team_id={team_id}/full/{run_id}.parquet"
-    )
-    s3_url = get_s3_url_for_clickhouse(
-        catalog.bucket, catalog.bucket_region, path_without_scheme
-    )
+    path_without_scheme = f"{BACKFILL_PERSONS_S3_PREFIX}/team_id={team_id}/full/{run_id}.parquet"
+    s3_url = get_s3_url_for_clickhouse(catalog.bucket, catalog.bucket_region, path_without_scheme)
     s3_path = f"s3://{catalog.bucket}/{path_without_scheme}"
 
     # Join person with person_distinct_id2 to get distinct_ids
@@ -1394,10 +1320,7 @@ def export_persons_full_to_duckling_s3(
     full_export_settings.update(
         {
             "max_memory_usage": 100 * 1024 * 1024 * 1024,  # 100GB for full exports
-            "max_bytes_before_external_sort": 50
-            * 1024
-            * 1024
-            * 1024,  # Spill to disk after 50GB
+            "max_bytes_before_external_sort": 50 * 1024 * 1024 * 1024,  # Spill to disk after 50GB
         }
     )
 
@@ -1420,9 +1343,7 @@ def export_persons_full_to_duckling_s3(
     info = f"team_id={team_id}, full_export"
 
     if config.dry_run:
-        context.log.info(
-            f"[DRY RUN] Would export persons (full) with SQL: {export_sql[:800]}..."
-        )
+        context.log.info(f"[DRY RUN] Would export persons (full) with SQL: {export_sql[:800]}...")
         return None
 
     context.log.info(f"Exporting all persons for {info} to {s3_path}")
@@ -1438,9 +1359,7 @@ def export_persons_full_to_duckling_s3(
         logger.info("duckling_persons_full_export_success", team_id=team_id)
         return s3_path
     except Exception:
-        context.log.exception(
-            f"Failed to export persons (full) for {info} after {MAX_RETRY_ATTEMPTS} attempts"
-        )
+        context.log.exception(f"Failed to export persons (full) for {info} after {MAX_RETRY_ATTEMPTS} attempts")
         logger.exception("duckling_persons_full_export_failed", team_id=team_id)
         raise
 
@@ -1457,15 +1376,11 @@ def register_persons_file_with_duckling(
     multiple concurrent jobs attempt to register files with the same table.
     """
     if config.skip_ducklake_registration:
-        context.log.info(
-            "Skipping DuckLake registration (skip_ducklake_registration=True)"
-        )
+        context.log.info("Skipping DuckLake registration (skip_ducklake_registration=True)")
         return False
 
     if config.dry_run:
-        context.log.info(
-            f"[DRY RUN] Would register {s3_path} with DuckLake at {catalog.db_host}"
-        )
+        context.log.info(f"[DRY RUN] Would register {s3_path} with DuckLake at {catalog.db_host}")
         return False
 
     destination = catalog.to_cross_account_destination()
@@ -1530,9 +1445,7 @@ def register_persons_file_with_duckling(
     name="duckling_events_backfill",
     tags={"owner": JobOwners.TEAM_DATA_STACK.value, **EVENTS_CONCURRENCY_TAG},
 )
-def duckling_events_backfill(
-    context: AssetExecutionContext, config: DucklingBackfillConfig
-) -> None:
+def duckling_events_backfill(context: AssetExecutionContext, config: DucklingBackfillConfig) -> None:
     """Backfill events from ClickHouse to a customer's duckling.
 
     Supports both daily (YYYY-MM-DD) and monthly (YYYY-MM) partition keys.
@@ -1551,9 +1464,7 @@ def duckling_events_backfill(
     team_id, dates = parse_partition_key_dates(context.partition_key)
     run_id = context.run.run_id[:8]
 
-    context.log.info(
-        f"Starting duckling backfill for team_id={team_id}, dates={len(dates)} day(s)"
-    )
+    context.log.info(f"Starting duckling backfill for team_id={team_id}, dates={len(dates)} day(s)")
     logger.info(
         "duckling_backfill_start",
         team_id=team_id,
@@ -1566,34 +1477,20 @@ def duckling_events_backfill(
     if catalog is None:
         raise ValueError(f"No DuckLakeCatalog found for team_id={team_id}")
 
-    context.log.info(
-        f"Found DuckLakeCatalog: bucket={catalog.bucket}, db_host={catalog.db_host}"
-    )
+    context.log.info(f"Found DuckLakeCatalog: bucket={catalog.bucket}, db_host={catalog.db_host}")
 
     # Delete events table if requested (dangerous - loses all data)
-    if (
-        config.delete_tables
-        and not config.dry_run
-        and not config.skip_ducklake_registration
-    ):
+    if config.delete_tables and not config.dry_run and not config.skip_ducklake_registration:
         context.log.warning("delete_tables=True: Deleting events table...")
         delete_events_table(context, catalog)
 
     # Create events table if it doesn't exist
-    if (
-        config.create_tables_if_missing
-        and not config.dry_run
-        and not config.skip_ducklake_registration
-    ):
+    if config.create_tables_if_missing and not config.dry_run and not config.skip_ducklake_registration:
         context.log.info("Ensuring events table exists in duckling catalog...")
         ensure_events_table_exists(context, catalog)
 
     # Validate schema before starting export (skip if dry_run or skip_ducklake_registration)
-    if (
-        not config.dry_run
-        and not config.skip_ducklake_registration
-        and not config.skip_schema_validation
-    ):
+    if not config.dry_run and not config.skip_ducklake_registration and not config.skip_schema_validation:
         context.log.info("Validating duckling schema compatibility...")
         validate_duckling_schema(context, catalog)
 
@@ -1602,9 +1499,7 @@ def duckling_events_backfill(
     merged_settings.update(settings_with_log_comment(context))
     if config.clickhouse_settings:
         merged_settings.update(config.clickhouse_settings)
-        context.log.info(
-            f"Using custom ClickHouse settings: {config.clickhouse_settings}"
-        )
+        context.log.info(f"Using custom ClickHouse settings: {config.clickhouse_settings}")
 
     cluster = _get_cluster()
     tags = dagster_tags(context)
@@ -1620,11 +1515,7 @@ def duckling_events_backfill(
         context.log.info(f"Processing date {date_str}...")
 
         # Delete existing DuckLake data for this partition before re-processing
-        if (
-            config.cleanup_existing_partition_data
-            and not config.dry_run
-            and not config.skip_ducklake_registration
-        ):
+        if config.cleanup_existing_partition_data and not config.dry_run and not config.skip_ducklake_registration:
             delete_events_partition_data(context, catalog, team_id, partition_date)
 
         def do_export(client: Client, date: datetime = partition_date) -> str | None:
@@ -1682,9 +1573,7 @@ def duckling_events_backfill(
     name="duckling_persons_backfill",
     tags={"owner": JobOwners.TEAM_DATA_STACK.value, **PERSONS_CONCURRENCY_TAG},
 )
-def duckling_persons_backfill(
-    context: AssetExecutionContext, config: DucklingBackfillConfig
-) -> None:
+def duckling_persons_backfill(context: AssetExecutionContext, config: DucklingBackfillConfig) -> None:
     """Backfill persons from ClickHouse to a customer's duckling.
 
     Supports two partition formats with different export strategies:
@@ -1714,9 +1603,7 @@ def duckling_persons_backfill(
         team_id, dates = parse_partition_key_dates(partition_key)
         export_mode = "daily"
 
-    context.log.info(
-        f"Starting duckling persons backfill for team_id={team_id}, mode={export_mode}"
-    )
+    context.log.info(f"Starting duckling persons backfill for team_id={team_id}, mode={export_mode}")
     logger.info(
         "duckling_persons_backfill_start",
         team_id=team_id,
@@ -1728,33 +1615,19 @@ def duckling_persons_backfill(
     if catalog is None:
         raise ValueError(f"No DuckLakeCatalog found for team_id={team_id}")
 
-    context.log.info(
-        f"Found DuckLakeCatalog: bucket={catalog.bucket}, db_host={catalog.db_host}"
-    )
+    context.log.info(f"Found DuckLakeCatalog: bucket={catalog.bucket}, db_host={catalog.db_host}")
 
     # Delete persons table if requested (dangerous - loses all data)
-    if (
-        config.delete_tables
-        and not config.dry_run
-        and not config.skip_ducklake_registration
-    ):
+    if config.delete_tables and not config.dry_run and not config.skip_ducklake_registration:
         context.log.warning("delete_tables=True: Deleting persons table...")
         delete_persons_table(context, catalog)
 
     # Create persons table if it doesn't exist
-    if (
-        config.create_tables_if_missing
-        and not config.dry_run
-        and not config.skip_ducklake_registration
-    ):
+    if config.create_tables_if_missing and not config.dry_run and not config.skip_ducklake_registration:
         context.log.info("Ensuring persons table exists in duckling catalog...")
         ensure_persons_table_exists(context, catalog)
 
-    if (
-        not config.dry_run
-        and not config.skip_ducklake_registration
-        and not config.skip_schema_validation
-    ):
+    if not config.dry_run and not config.skip_ducklake_registration and not config.skip_schema_validation:
         context.log.info("Validating duckling persons schema compatibility...")
         validate_duckling_persons_schema(context, catalog)
 
@@ -1762,9 +1635,7 @@ def duckling_persons_backfill(
     merged_settings.update(settings_with_log_comment(context))
     if config.clickhouse_settings:
         merged_settings.update(config.clickhouse_settings)
-        context.log.info(
-            f"Using custom ClickHouse settings: {config.clickhouse_settings}"
-        )
+        context.log.info(f"Using custom ClickHouse settings: {config.clickhouse_settings}")
 
     cluster = _get_cluster()
     tags = dagster_tags(context)
@@ -1772,19 +1643,11 @@ def duckling_persons_backfill(
 
     if is_full:
         # FULL EXPORT MODE - single query for all persons
-        context.log.info(
-            f"Full export mode: exporting all persons for team_id={team_id}"
-        )
+        context.log.info(f"Full export mode: exporting all persons for team_id={team_id}")
 
         # Delete all existing persons data for this team before full re-export
-        if (
-            config.cleanup_existing_partition_data
-            and not config.dry_run
-            and not config.skip_ducklake_registration
-        ):
-            delete_persons_partition_data(
-                context, catalog, team_id, partition_date=None
-            )
+        if config.cleanup_existing_partition_data and not config.dry_run and not config.skip_ducklake_registration:
+            delete_persons_partition_data(context, catalog, team_id, partition_date=None)
 
         def do_full_export(client: Client) -> str | None:
             with tags_context(kind="dagster", dagster=tags):
@@ -1842,16 +1705,10 @@ def duckling_persons_backfill(
             context.log.info(f"Processing persons for date {date_str}...")
 
             # Delete existing DuckLake data for this partition before re-processing
-            if (
-                config.cleanup_existing_partition_data
-                and not config.dry_run
-                and not config.skip_ducklake_registration
-            ):
+            if config.cleanup_existing_partition_data and not config.dry_run and not config.skip_ducklake_registration:
                 delete_persons_partition_data(context, catalog, team_id, partition_date)
 
-            def do_export(
-                client: Client, date: datetime = partition_date
-            ) -> str | None:
+            def do_export(client: Client, date: datetime = partition_date) -> str | None:
                 with tags_context(kind="dagster", dagster=tags):
                     return export_persons_to_duckling_s3(
                         context=context,
@@ -1872,9 +1729,7 @@ def duckling_persons_backfill(
 
             if s3_path:
                 total_exported += 1
-                if register_persons_file_with_duckling(
-                    context, catalog, s3_path, config
-                ):
+                if register_persons_file_with_duckling(context, catalog, s3_path, config):
                     total_registered += 1
 
         context.add_output_metadata(
@@ -1940,9 +1795,7 @@ def duckling_events_daily_backfill_sensor(
                     run_key=f"{partition_key}_new",
                 )
             )
-            context.log.info(
-                f"Creating partition for team_id={catalog.team_id}, date={yesterday}"
-            )
+            context.log.info(f"Creating partition for team_id={catalog.team_id}, date={yesterday}")
         else:
             # Existing partition - check if the last run failed and needs retry
             # Query for runs with this partition key (stored in dagster/partition tag)
@@ -2000,9 +1853,7 @@ def duckling_events_daily_backfill_sensor(
 
     return SensorResult(
         run_requests=run_requests,
-        dynamic_partitions_requests=[
-            duckling_events_partitions_def.build_add_request(new_partitions)
-        ]
+        dynamic_partitions_requests=[duckling_events_partitions_def.build_add_request(new_partitions)]
         if new_partitions
         else [],
     )
@@ -2086,16 +1937,12 @@ def duckling_events_full_backfill_sensor(
 
     new_partitions: list[str] = []
     run_requests: list[RunRequest] = []
-    existing_partitions = set(
-        context.instance.get_dynamic_partitions("duckling_events_backfill")
-    )
+    existing_partitions = set(context.instance.get_dynamic_partitions("duckling_events_backfill"))
 
     # Process catalogs starting from where we left off
     for catalog_idx, catalog in enumerate(catalogs[start_idx:], start=start_idx):
         if len(new_partitions) >= BACKFILL_MONTHS_PER_TICK:
-            context.log.info(
-                f"Batch limit reached, will continue from team {catalog.team_id}"
-            )
+            context.log.info(f"Batch limit reached, will continue from team {catalog.team_id}")
             break
 
         team_id = catalog.team_id
@@ -2116,9 +1963,7 @@ def duckling_events_full_backfill_sensor(
 
         # Generate monthly partitions for this team
         end_month = yesterday.strftime("%Y-%m")
-        all_months = get_months_in_range(
-            datetime.strptime(current_month, "%Y-%m").date(), yesterday
-        )
+        all_months = get_months_in_range(datetime.strptime(current_month, "%Y-%m").date(), yesterday)
 
         for month in all_months:
             if len(new_partitions) >= BACKFILL_MONTHS_PER_TICK:
@@ -2164,10 +2009,7 @@ def duckling_events_full_backfill_sensor(
                 cursor_data = {"completed": timezone.now().date().isoformat()}
 
     # Check if we're in "completed" state and should skip until new data
-    if (
-        cursor_data.get("completed") == timezone.now().date().isoformat()
-        and not new_partitions
-    ):
+    if cursor_data.get("completed") == timezone.now().date().isoformat() and not new_partitions:
         context.log.debug("Full backfill complete for today")
         return SensorResult(run_requests=[], cursor=json.dumps(cursor_data))
 
@@ -2181,9 +2023,7 @@ def duckling_events_full_backfill_sensor(
 
     return SensorResult(
         run_requests=run_requests,
-        dynamic_partitions_requests=[
-            duckling_events_partitions_def.build_add_request(new_partitions)
-        ]
+        dynamic_partitions_requests=[duckling_events_partitions_def.build_add_request(new_partitions)]
         if new_partitions
         else [],
         cursor=json.dumps(cursor_data),
@@ -2232,9 +2072,7 @@ def duckling_persons_daily_backfill_sensor(
                     run_key=f"{partition_key}_persons_new",
                 )
             )
-            context.log.info(
-                f"Creating persons partition for team_id={catalog.team_id}, date={yesterday}"
-            )
+            context.log.info(f"Creating persons partition for team_id={catalog.team_id}, date={yesterday}")
         else:
             runs = context.instance.get_runs(
                 filters=RunsFilter(
@@ -2253,9 +2091,7 @@ def duckling_persons_daily_backfill_sensor(
                             run_key=f"{partition_key}_persons_retry_{latest_run.run_id[:8]}",
                         )
                     )
-                    context.log.info(
-                        f"Retrying failed persons partition team_id={catalog.team_id}, date={yesterday}"
-                    )
+                    context.log.info(f"Retrying failed persons partition team_id={catalog.team_id}, date={yesterday}")
                     logger.info(
                         "duckling_persons_sensor_retry_failed_partition",
                         team_id=catalog.team_id,
@@ -2271,9 +2107,7 @@ def duckling_persons_daily_backfill_sensor(
                     )
 
     if new_partitions:
-        context.log.info(
-            f"Discovered {len(new_partitions)} new persons partitions to backfill"
-        )
+        context.log.info(f"Discovered {len(new_partitions)} new persons partitions to backfill")
         logger.info(
             "duckling_persons_sensor_discovered_partitions",
             count=len(new_partitions),
@@ -2290,9 +2124,7 @@ def duckling_persons_daily_backfill_sensor(
 
     return SensorResult(
         run_requests=run_requests,
-        dynamic_partitions_requests=[
-            duckling_persons_partitions_def.build_add_request(new_partitions)
-        ]
+        dynamic_partitions_requests=[duckling_persons_partitions_def.build_add_request(new_partitions)]
         if new_partitions
         else [],
     )
@@ -2326,9 +2158,7 @@ def duckling_persons_full_backfill_sensor(
         return SensorResult(run_requests=[])
 
     # Check existing partitions
-    existing_partitions = set(
-        context.instance.get_dynamic_partitions("duckling_persons_backfill")
-    )
+    existing_partitions = set(context.instance.get_dynamic_partitions("duckling_persons_backfill"))
 
     new_partitions: list[str] = []
     run_requests: list[RunRequest] = []
@@ -2350,9 +2180,7 @@ def duckling_persons_full_backfill_sensor(
                     partition_key=partition_key,
                 )
             )
-            context.log.info(
-                f"Creating full persons backfill partition for team_id={team_id}"
-            )
+            context.log.info(f"Creating full persons backfill partition for team_id={team_id}")
         else:
             # Partition exists - check if we need to retry a failed run
             runs = context.instance.get_runs(
@@ -2372,9 +2200,7 @@ def duckling_persons_full_backfill_sensor(
                             run_key=f"{partition_key}_persons_full_retry_{latest_run.run_id[:8]}",
                         )
                     )
-                    context.log.info(
-                        f"Retrying failed full persons backfill for team_id={team_id}"
-                    )
+                    context.log.info(f"Retrying failed full persons backfill for team_id={team_id}")
                     logger.info(
                         "duckling_persons_full_backfill_retry",
                         team_id=team_id,
@@ -2387,9 +2213,7 @@ def duckling_persons_full_backfill_sensor(
                     context.log.debug(f"Skipping team_id={team_id} - run in progress")
 
     if new_partitions:
-        context.log.info(
-            f"Creating {len(new_partitions)} full persons backfill partitions"
-        )
+        context.log.info(f"Creating {len(new_partitions)} full persons backfill partitions")
         logger.info(
             "duckling_persons_full_backfill_batch",
             partition_count=len(new_partitions),
@@ -2406,9 +2230,7 @@ def duckling_persons_full_backfill_sensor(
 
     return SensorResult(
         run_requests=run_requests,
-        dynamic_partitions_requests=[
-            duckling_persons_partitions_def.build_add_request(new_partitions)
-        ]
+        dynamic_partitions_requests=[duckling_persons_partitions_def.build_add_request(new_partitions)]
         if new_partitions
         else [],
     )

--- a/posthog/dags/events_backfill_to_duckling.py
+++ b/posthog/dags/events_backfill_to_duckling.py
@@ -472,6 +472,7 @@ def _ensure_partition_columns_exist(
     alias: str,
     table: str,
     context: AssetExecutionContext,
+    team_id: int,
 ) -> None:
     """Add year/month/day partition columns to an existing table if missing.
 
@@ -491,6 +492,7 @@ def _ensure_partition_columns_exist(
             conn.execute(f"ALTER TABLE {alias}.posthog.{table} ADD COLUMN {col} INTEGER")
             logger.info(
                 "duckling_partition_column_added",
+                team_id=team_id,
                 table=table,
                 column=col,
             )
@@ -573,7 +575,7 @@ def ensure_events_table_exists(
         if table_exists(conn, alias, "posthog", "events"):
             context.log.info("Events table already exists in duckling catalog")
             # Existing tables may lack year/month/day columns — add them if missing
-            _ensure_partition_columns_exist(conn, alias, "events", context)
+            _ensure_partition_columns_exist(conn, alias, "events", context, catalog.team_id)
             # Ensure partitioning is set even on existing tables (idempotent)
             _set_table_partitioning(conn, alias, "events", "year, month, day", context, catalog.team_id)
             return False
@@ -590,7 +592,7 @@ def ensure_events_table_exists(
             if table_exists(conn, alias, "posthog", "events"):
                 context.log.info("Events table was created by another worker")
                 # Existing tables may lack year/month/day columns — add them if missing
-                _ensure_partition_columns_exist(conn, alias, "events", context)
+                _ensure_partition_columns_exist(conn, alias, "events", context, catalog.team_id)
                 # Ensure partitioning is set even when another worker created the table
                 _set_table_partitioning(conn, alias, "events", "year, month, day", context, catalog.team_id)
                 return False
@@ -640,7 +642,7 @@ def ensure_persons_table_exists(
         if table_exists(conn, alias, "posthog", "persons"):
             context.log.info("Persons table already exists in duckling catalog")
             # Existing tables may lack year/month/day columns — add them if missing
-            _ensure_partition_columns_exist(conn, alias, "persons", context)
+            _ensure_partition_columns_exist(conn, alias, "persons", context, catalog.team_id)
             # Ensure partitioning is set even on existing tables (idempotent)
             _set_table_partitioning(
                 conn,
@@ -664,7 +666,7 @@ def ensure_persons_table_exists(
             if table_exists(conn, alias, "posthog", "persons"):
                 context.log.info("Persons table was created by another worker")
                 # Existing tables may lack year/month/day columns — add them if missing
-                _ensure_partition_columns_exist(conn, alias, "persons", context)
+                _ensure_partition_columns_exist(conn, alias, "persons", context, catalog.team_id)
                 # Ensure partitioning is set even when another worker created the table
                 _set_table_partitioning(
                     conn,
@@ -681,7 +683,7 @@ def ensure_persons_table_exists(
 
         context.log.info("Successfully created persons table")
 
-        # Set partitioning by year/month of _timestamp for efficient querying
+        # Set partitioning by year/month/day for efficient querying
         _set_table_partitioning(
             conn,
             alias,

--- a/posthog/dags/events_backfill_to_duckling.py
+++ b/posthog/dags/events_backfill_to_duckling.py
@@ -56,19 +56,34 @@ from dagster import (
     define_asset_job,
     sensor,
 )
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential, wait_fixed
+from tenacity import (
+    retry,
+    retry_if_exception_type,
+    stop_after_attempt,
+    wait_exponential,
+    wait_fixed,
+)
 
 from posthog.clickhouse.client.connection import NodeRole, Workload
 from posthog.clickhouse.cluster import ClickhouseCluster, get_cluster
 from posthog.clickhouse.query_tagging import tags_context
 from posthog.cloud_utils import is_cloud
-from posthog.dags.common.common import JobOwners, dagster_tags, settings_with_log_comment
+from posthog.dags.common.common import (
+    JobOwners,
+    dagster_tags,
+    settings_with_log_comment,
+)
 from posthog.dags.events_backfill_to_ducklake import (
     DEFAULT_CLICKHOUSE_SETTINGS,
     EXPECTED_DUCKLAKE_COLUMNS,
     MAX_RETRY_ATTEMPTS,
 )
-from posthog.ducklake.common import attach_catalog, escape, get_ducklake_catalog_for_team, get_team_config
+from posthog.ducklake.common import (
+    attach_catalog,
+    escape,
+    get_ducklake_catalog_for_team,
+    get_team_config,
+)
 from posthog.ducklake.models import DuckLakeCatalog
 from posthog.ducklake.storage import configure_cross_account_connection
 
@@ -181,8 +196,12 @@ EXPECTED_DUCKLAKE_PERSONS_COLUMNS = {
     "_inserted_at",
 }
 
-duckling_events_partitions_def = DynamicPartitionsDefinition(name="duckling_events_backfill")
-duckling_persons_partitions_def = DynamicPartitionsDefinition(name="duckling_persons_backfill")
+duckling_events_partitions_def = DynamicPartitionsDefinition(
+    name="duckling_events_backfill"
+)
+duckling_persons_partitions_def = DynamicPartitionsDefinition(
+    name="duckling_persons_backfill"
+)
 
 # SQL for creating the events table in DuckLake if it doesn't exist
 # Uses TIMESTAMPTZ because ClickHouse exports DateTime64 as TIMESTAMP WITH TIME ZONE in Parquet.
@@ -244,7 +263,9 @@ class DucklingBackfillConfig(Config):
     clickhouse_settings: dict[str, Any] | None = None
     skip_ducklake_registration: bool = False
     skip_schema_validation: bool = False
-    cleanup_existing_partition_data: bool = True  # Delete existing DuckLake data for partition before registering
+    cleanup_existing_partition_data: bool = (
+        True  # Delete existing DuckLake data for partition before registering
+    )
     create_tables_if_missing: bool = True
     delete_tables: bool = False  # Danger: drops and recreates tables, losing all data
     dry_run: bool = False
@@ -265,7 +286,9 @@ def parse_partition_key(key: str) -> tuple[int, str]:
     """
     parts = key.rsplit("_", 1)
     if len(parts) != 2:
-        raise ValueError(f"Invalid partition key format: {key}. Expected 'team_id_YYYY-MM-DD' or 'team_id_YYYY-MM'")
+        raise ValueError(
+            f"Invalid partition key format: {key}. Expected 'team_id_YYYY-MM-DD' or 'team_id_YYYY-MM'"
+        )
 
     team_id_str, date_str = parts
 
@@ -281,7 +304,9 @@ def parse_partition_key(key: str) -> tuple[int, str]:
         try:
             datetime.strptime(date_str, "%Y-%m")
         except ValueError as e:
-            raise ValueError(f"Invalid date in partition key: {date_str}. Expected YYYY-MM-DD or YYYY-MM") from e
+            raise ValueError(
+                f"Invalid date in partition key: {date_str}. Expected YYYY-MM-DD or YYYY-MM"
+            ) from e
 
     return team_id, date_str
 
@@ -330,7 +355,9 @@ def is_full_export_partition(key: str) -> bool:
     return key.isdigit()
 
 
-def get_s3_url_for_clickhouse(bucket: str, region: str, path_without_scheme: str) -> str:
+def get_s3_url_for_clickhouse(
+    bucket: str, region: str, path_without_scheme: str
+) -> str:
     """Build S3 URL in the format ClickHouse expects for cross-account access.
 
     ClickHouse uses the EC2 instance role for authentication. The duckling bucket
@@ -487,7 +514,9 @@ def _set_table_partitioning(
 
     context.log.info(f"Setting partitioning on {table} table...")
     try:
-        conn.execute(f"ALTER TABLE {alias}.posthog.{table} SET PARTITIONED BY ({partition_expr})")
+        conn.execute(
+            f"ALTER TABLE {alias}.posthog.{table} SET PARTITIONED BY ({partition_expr})"
+        )
         context.log.info(f"Successfully set partitioning on {table} table")
         logger.info(
             "duckling_table_partitioning_set",
@@ -605,7 +634,12 @@ def ensure_persons_table_exists(
             context.log.info("Persons table already exists in duckling catalog")
             # Ensure partitioning is set even on existing tables (idempotent)
             _set_table_partitioning(
-                conn, alias, "persons", "year(_timestamp), month(_timestamp)", context, catalog.team_id
+                conn,
+                alias,
+                "persons",
+                "year(_timestamp), month(_timestamp)",
+                context,
+                catalog.team_id,
             )
             return False
 
@@ -622,7 +656,12 @@ def ensure_persons_table_exists(
                 context.log.info("Persons table was created by another worker")
                 # Ensure partitioning is set even when another worker created the table
                 _set_table_partitioning(
-                    conn, alias, "persons", "year(_timestamp), month(_timestamp)", context, catalog.team_id
+                    conn,
+                    alias,
+                    "persons",
+                    "year(_timestamp), month(_timestamp)",
+                    context,
+                    catalog.team_id,
                 )
                 return False
             # Real error - log and re-raise
@@ -632,7 +671,14 @@ def ensure_persons_table_exists(
         context.log.info("Successfully created persons table")
 
         # Set partitioning by year/month of _timestamp for efficient querying
-        _set_table_partitioning(conn, alias, "persons", "year(_timestamp), month(_timestamp)", context, catalog.team_id)
+        _set_table_partitioning(
+            conn,
+            alias,
+            "persons",
+            "year(_timestamp), month(_timestamp)",
+            context,
+            catalog.team_id,
+        )
 
         logger.info(
             "duckling_persons_table_created",
@@ -757,7 +803,9 @@ def validate_duckling_schema(
 
         extra_in_ducklake = ducklake_columns - EXPECTED_DUCKLAKE_COLUMNS
         if extra_in_ducklake:
-            context.log.info(f"Duckling has additional columns not in our export: {extra_in_ducklake}")
+            context.log.info(
+                f"Duckling has additional columns not in our export: {extra_in_ducklake}"
+            )
 
         context.log.info(
             f"Schema validation passed. Duckling has {len(ducklake_columns)} columns, "
@@ -806,7 +854,9 @@ def validate_duckling_persons_schema(
 
         extra_in_ducklake = ducklake_columns - EXPECTED_DUCKLAKE_PERSONS_COLUMNS
         if extra_in_ducklake:
-            context.log.info(f"Duckling persons has additional columns not in our export: {extra_in_ducklake}")
+            context.log.info(
+                f"Duckling persons has additional columns not in our export: {extra_in_ducklake}"
+            )
 
         context.log.info(
             f"Persons schema validation passed. Duckling has {len(ducklake_columns)} columns, "
@@ -850,7 +900,9 @@ def _execute_export_with_retry(
 
 def _is_transaction_conflict(exc: BaseException) -> bool:
     """Check if exception is a DuckLake transaction conflict (retryable)."""
-    return isinstance(exc, duckdb.TransactionException) and "Transaction conflict" in str(exc)
+    return isinstance(
+        exc, duckdb.TransactionException
+    ) and "Transaction conflict" in str(exc)
 
 
 def delete_events_partition_data(
@@ -893,11 +945,15 @@ def delete_events_partition_data(
             configure_cross_account_connection(conn, destinations=[destination])
             attach_catalog(conn, catalog_config, alias=alias)
 
-            result = conn.execute(delete_sql, [team_id, date_str, next_date_str]).fetchone()
+            result = conn.execute(
+                delete_sql, [team_id, date_str, next_date_str]
+            ).fetchone()
             deleted_count = result[0] if result else 0
 
             if deleted_count > 0:
-                context.log.info(f"Deleted {deleted_count} existing events for team_id={team_id}, date={date_str}")
+                context.log.info(
+                    f"Deleted {deleted_count} existing events for team_id={team_id}, date={date_str}"
+                )
                 logger.info(
                     "duckling_events_partition_deleted",
                     team_id=team_id,
@@ -929,7 +985,9 @@ def delete_events_partition_data(
                 time.sleep(wait_time)
                 continue
 
-            context.log.exception(f"Failed to delete events for team_id={team_id}, date={date_str}")
+            context.log.exception(
+                f"Failed to delete events for team_id={team_id}, date={date_str}"
+            )
             logger.exception(
                 "duckling_events_delete_failed",
                 team_id=team_id,
@@ -996,7 +1054,9 @@ def delete_persons_partition_data(
             deleted_count = result[0] if result else 0
 
             if deleted_count > 0:
-                context.log.info(f"Deleted {deleted_count} existing persons for team_id={team_id}, date={date_label}")
+                context.log.info(
+                    f"Deleted {deleted_count} existing persons for team_id={team_id}, date={date_label}"
+                )
                 logger.info(
                     "duckling_persons_partition_deleted",
                     team_id=team_id,
@@ -1006,7 +1066,9 @@ def delete_persons_partition_data(
             return deleted_count
 
         except duckdb.CatalogException:
-            context.log.debug(f"Persons table doesn't exist yet, nothing to delete for team_id={team_id}")
+            context.log.debug(
+                f"Persons table doesn't exist yet, nothing to delete for team_id={team_id}"
+            )
             return 0
 
         except Exception as e:
@@ -1026,7 +1088,9 @@ def delete_persons_partition_data(
                 time.sleep(wait_time)
                 continue
 
-            context.log.exception(f"Failed to delete persons for team_id={team_id}, date={date_label}")
+            context.log.exception(
+                f"Failed to delete persons for team_id={team_id}, date={date_label}"
+            )
             logger.exception(
                 "duckling_persons_delete_failed",
                 team_id=team_id,
@@ -1066,12 +1130,12 @@ def export_events_to_duckling_s3(
     date_str = date.strftime("%Y-%m-%d")
 
     # Path without s3:// scheme for the HTTPS URL
-    path_without_scheme = (
-        f"{BACKFILL_EVENTS_S3_PREFIX}/team_id={team_id}/year={year}/month={month}/day={day}/{run_id}.parquet"
-    )
+    path_without_scheme = f"{BACKFILL_EVENTS_S3_PREFIX}/team_id={team_id}/year={year}/month={month}/day={day}/{run_id}.parquet"
 
     # ClickHouse needs HTTPS URL format for cross-account S3 access
-    s3_url = get_s3_url_for_clickhouse(catalog.bucket, catalog.bucket_region, path_without_scheme)
+    s3_url = get_s3_url_for_clickhouse(
+        catalog.bucket, catalog.bucket_region, path_without_scheme
+    )
 
     # S3 path with scheme for DuckLake registration
     s3_path = f"s3://{catalog.bucket}/{path_without_scheme}"
@@ -1112,7 +1176,9 @@ def export_events_to_duckling_s3(
         logger.info("duckling_export_success", team_id=team_id, date=date_str)
         return s3_path
     except Exception:
-        context.log.exception(f"Failed to export events for {info} after {MAX_RETRY_ATTEMPTS} attempts")
+        context.log.exception(
+            f"Failed to export events for {info} after {MAX_RETRY_ATTEMPTS} attempts"
+        )
         logger.exception("duckling_export_failed", team_id=team_id, date=date_str)
         raise
 
@@ -1141,11 +1207,15 @@ def register_file_with_duckling(
         True if registration succeeded, False otherwise.
     """
     if config.skip_ducklake_registration:
-        context.log.info("Skipping DuckLake registration (skip_ducklake_registration=True)")
+        context.log.info(
+            "Skipping DuckLake registration (skip_ducklake_registration=True)"
+        )
         return False
 
     if config.dry_run:
-        context.log.info(f"[DRY RUN] Would register {s3_path} with DuckLake at {catalog.db_host}")
+        context.log.info(
+            f"[DRY RUN] Would register {s3_path} with DuckLake at {catalog.db_host}"
+        )
         return False
 
     destination = catalog.to_cross_account_destination()
@@ -1160,16 +1230,22 @@ def register_file_with_duckling(
             attach_catalog(conn, catalog_config, alias=alias)
 
             context.log.info(f"Registering file with DuckLake: {s3_path}")
-            conn.execute(f"CALL ducklake_add_data_files('{alias}', 'events', '{escape(s3_path)}', schema => 'posthog')")
+            conn.execute(
+                f"CALL ducklake_add_data_files('{alias}', 'events', '{escape(s3_path)}', schema => 'posthog')"
+            )
 
             context.log.info(f"Successfully registered: {s3_path}")
-            logger.info("duckling_file_registered", s3_path=s3_path, team_id=catalog.team_id)
+            logger.info(
+                "duckling_file_registered", s3_path=s3_path, team_id=catalog.team_id
+            )
             return True
 
         except Exception as e:
             last_exception = e
             if _is_transaction_conflict(e) and attempt < MAX_RETRY_ATTEMPTS - 1:
-                wait_time = min(4 * (2**attempt), 60)  # Exponential backoff: 4, 8, 16, ... capped at 60s
+                wait_time = min(
+                    4 * (2**attempt), 60
+                )  # Exponential backoff: 4, 8, 16, ... capped at 60s
                 context.log.warning(
                     f"DuckLake transaction conflict on attempt {attempt + 1}, retrying in {wait_time}s..."
                 )
@@ -1184,7 +1260,11 @@ def register_file_with_duckling(
                 continue
 
             context.log.exception(f"Failed to register file {s3_path}")
-            logger.exception("duckling_file_registration_failed", s3_path=s3_path, team_id=catalog.team_id)
+            logger.exception(
+                "duckling_file_registration_failed",
+                s3_path=s3_path,
+                team_id=catalog.team_id,
+            )
             raise
 
         finally:
@@ -1223,10 +1303,10 @@ def export_persons_to_duckling_s3(
     day = date.strftime("%d")
     date_str = date.strftime("%Y-%m-%d")
 
-    path_without_scheme = (
-        f"{BACKFILL_PERSONS_S3_PREFIX}/team_id={team_id}/year={year}/month={month}/day={day}/{run_id}.parquet"
+    path_without_scheme = f"{BACKFILL_PERSONS_S3_PREFIX}/team_id={team_id}/year={year}/month={month}/day={day}/{run_id}.parquet"
+    s3_url = get_s3_url_for_clickhouse(
+        catalog.bucket, catalog.bucket_region, path_without_scheme
     )
-    s3_url = get_s3_url_for_clickhouse(catalog.bucket, catalog.bucket_region, path_without_scheme)
     s3_path = f"s3://{catalog.bucket}/{path_without_scheme}"
 
     # Join person with person_distinct_id2 to get distinct_ids
@@ -1252,7 +1332,9 @@ def export_persons_to_duckling_s3(
     info = f"team_id={team_id}, date={date_str}"
 
     if config.dry_run:
-        context.log.info(f"[DRY RUN] Would export persons with SQL: {export_sql[:800]}...")
+        context.log.info(
+            f"[DRY RUN] Would export persons with SQL: {export_sql[:800]}..."
+        )
         return None
 
     context.log.info(f"Exporting persons for {info} to {s3_path}")
@@ -1269,8 +1351,12 @@ def export_persons_to_duckling_s3(
         logger.info("duckling_persons_export_success", team_id=team_id, date=date_str)
         return s3_path
     except Exception:
-        context.log.exception(f"Failed to export persons for {info} after {MAX_RETRY_ATTEMPTS} attempts")
-        logger.exception("duckling_persons_export_failed", team_id=team_id, date=date_str)
+        context.log.exception(
+            f"Failed to export persons for {info} after {MAX_RETRY_ATTEMPTS} attempts"
+        )
+        logger.exception(
+            "duckling_persons_export_failed", team_id=team_id, date=date_str
+        )
         raise
 
 
@@ -1292,8 +1378,12 @@ def export_persons_full_to_duckling_s3(
     Returns:
         S3 path that was written, or None if dry_run.
     """
-    path_without_scheme = f"{BACKFILL_PERSONS_S3_PREFIX}/team_id={team_id}/full/{run_id}.parquet"
-    s3_url = get_s3_url_for_clickhouse(catalog.bucket, catalog.bucket_region, path_without_scheme)
+    path_without_scheme = (
+        f"{BACKFILL_PERSONS_S3_PREFIX}/team_id={team_id}/full/{run_id}.parquet"
+    )
+    s3_url = get_s3_url_for_clickhouse(
+        catalog.bucket, catalog.bucket_region, path_without_scheme
+    )
     s3_path = f"s3://{catalog.bucket}/{path_without_scheme}"
 
     # Join person with person_distinct_id2 to get distinct_ids
@@ -1305,7 +1395,10 @@ def export_persons_full_to_duckling_s3(
     full_export_settings.update(
         {
             "max_memory_usage": 100 * 1024 * 1024 * 1024,  # 100GB for full exports
-            "max_bytes_before_external_sort": 50 * 1024 * 1024 * 1024,  # Spill to disk after 50GB
+            "max_bytes_before_external_sort": 50
+            * 1024
+            * 1024
+            * 1024,  # Spill to disk after 50GB
         }
     )
 
@@ -1328,7 +1421,9 @@ def export_persons_full_to_duckling_s3(
     info = f"team_id={team_id}, full_export"
 
     if config.dry_run:
-        context.log.info(f"[DRY RUN] Would export persons (full) with SQL: {export_sql[:800]}...")
+        context.log.info(
+            f"[DRY RUN] Would export persons (full) with SQL: {export_sql[:800]}..."
+        )
         return None
 
     context.log.info(f"Exporting all persons for {info} to {s3_path}")
@@ -1344,7 +1439,9 @@ def export_persons_full_to_duckling_s3(
         logger.info("duckling_persons_full_export_success", team_id=team_id)
         return s3_path
     except Exception:
-        context.log.exception(f"Failed to export persons (full) for {info} after {MAX_RETRY_ATTEMPTS} attempts")
+        context.log.exception(
+            f"Failed to export persons (full) for {info} after {MAX_RETRY_ATTEMPTS} attempts"
+        )
         logger.exception("duckling_persons_full_export_failed", team_id=team_id)
         raise
 
@@ -1361,11 +1458,15 @@ def register_persons_file_with_duckling(
     multiple concurrent jobs attempt to register files with the same table.
     """
     if config.skip_ducklake_registration:
-        context.log.info("Skipping DuckLake registration (skip_ducklake_registration=True)")
+        context.log.info(
+            "Skipping DuckLake registration (skip_ducklake_registration=True)"
+        )
         return False
 
     if config.dry_run:
-        context.log.info(f"[DRY RUN] Would register {s3_path} with DuckLake at {catalog.db_host}")
+        context.log.info(
+            f"[DRY RUN] Would register {s3_path} with DuckLake at {catalog.db_host}"
+        )
         return False
 
     destination = catalog.to_cross_account_destination()
@@ -1385,7 +1486,11 @@ def register_persons_file_with_duckling(
             )
 
             context.log.info(f"Successfully registered persons: {s3_path}")
-            logger.info("duckling_persons_file_registered", s3_path=s3_path, team_id=catalog.team_id)
+            logger.info(
+                "duckling_persons_file_registered",
+                s3_path=s3_path,
+                team_id=catalog.team_id,
+            )
             return True
 
         except Exception as e:
@@ -1406,7 +1511,11 @@ def register_persons_file_with_duckling(
                 continue
 
             context.log.exception(f"Failed to register persons file {s3_path}")
-            logger.exception("duckling_persons_file_registration_failed", s3_path=s3_path, team_id=catalog.team_id)
+            logger.exception(
+                "duckling_persons_file_registration_failed",
+                s3_path=s3_path,
+                team_id=catalog.team_id,
+            )
             raise
 
         finally:
@@ -1422,7 +1531,9 @@ def register_persons_file_with_duckling(
     name="duckling_events_backfill",
     tags={"owner": JobOwners.TEAM_DATA_STACK.value, **EVENTS_CONCURRENCY_TAG},
 )
-def duckling_events_backfill(context: AssetExecutionContext, config: DucklingBackfillConfig) -> None:
+def duckling_events_backfill(
+    context: AssetExecutionContext, config: DucklingBackfillConfig
+) -> None:
     """Backfill events from ClickHouse to a customer's duckling.
 
     Supports both daily (YYYY-MM-DD) and monthly (YYYY-MM) partition keys.
@@ -1441,7 +1552,9 @@ def duckling_events_backfill(context: AssetExecutionContext, config: DucklingBac
     team_id, dates = parse_partition_key_dates(context.partition_key)
     run_id = context.run.run_id[:8]
 
-    context.log.info(f"Starting duckling backfill for team_id={team_id}, dates={len(dates)} day(s)")
+    context.log.info(
+        f"Starting duckling backfill for team_id={team_id}, dates={len(dates)} day(s)"
+    )
     logger.info(
         "duckling_backfill_start",
         team_id=team_id,
@@ -1454,20 +1567,34 @@ def duckling_events_backfill(context: AssetExecutionContext, config: DucklingBac
     if catalog is None:
         raise ValueError(f"No DuckLakeCatalog found for team_id={team_id}")
 
-    context.log.info(f"Found DuckLakeCatalog: bucket={catalog.bucket}, db_host={catalog.db_host}")
+    context.log.info(
+        f"Found DuckLakeCatalog: bucket={catalog.bucket}, db_host={catalog.db_host}"
+    )
 
     # Delete events table if requested (dangerous - loses all data)
-    if config.delete_tables and not config.dry_run and not config.skip_ducklake_registration:
+    if (
+        config.delete_tables
+        and not config.dry_run
+        and not config.skip_ducklake_registration
+    ):
         context.log.warning("delete_tables=True: Deleting events table...")
         delete_events_table(context, catalog)
 
     # Create events table if it doesn't exist
-    if config.create_tables_if_missing and not config.dry_run and not config.skip_ducklake_registration:
+    if (
+        config.create_tables_if_missing
+        and not config.dry_run
+        and not config.skip_ducklake_registration
+    ):
         context.log.info("Ensuring events table exists in duckling catalog...")
         ensure_events_table_exists(context, catalog)
 
     # Validate schema before starting export (skip if dry_run or skip_ducklake_registration)
-    if not config.dry_run and not config.skip_ducklake_registration and not config.skip_schema_validation:
+    if (
+        not config.dry_run
+        and not config.skip_ducklake_registration
+        and not config.skip_schema_validation
+    ):
         context.log.info("Validating duckling schema compatibility...")
         validate_duckling_schema(context, catalog)
 
@@ -1476,7 +1603,9 @@ def duckling_events_backfill(context: AssetExecutionContext, config: DucklingBac
     merged_settings.update(settings_with_log_comment(context))
     if config.clickhouse_settings:
         merged_settings.update(config.clickhouse_settings)
-        context.log.info(f"Using custom ClickHouse settings: {config.clickhouse_settings}")
+        context.log.info(
+            f"Using custom ClickHouse settings: {config.clickhouse_settings}"
+        )
 
     cluster = _get_cluster()
     tags = dagster_tags(context)
@@ -1492,7 +1621,11 @@ def duckling_events_backfill(context: AssetExecutionContext, config: DucklingBac
         context.log.info(f"Processing date {date_str}...")
 
         # Delete existing DuckLake data for this partition before re-processing
-        if config.cleanup_existing_partition_data and not config.dry_run and not config.skip_ducklake_registration:
+        if (
+            config.cleanup_existing_partition_data
+            and not config.dry_run
+            and not config.skip_ducklake_registration
+        ):
             delete_events_partition_data(context, catalog, team_id, partition_date)
 
         def do_export(client: Client, date: datetime = partition_date) -> str | None:
@@ -1550,7 +1683,9 @@ def duckling_events_backfill(context: AssetExecutionContext, config: DucklingBac
     name="duckling_persons_backfill",
     tags={"owner": JobOwners.TEAM_DATA_STACK.value, **PERSONS_CONCURRENCY_TAG},
 )
-def duckling_persons_backfill(context: AssetExecutionContext, config: DucklingBackfillConfig) -> None:
+def duckling_persons_backfill(
+    context: AssetExecutionContext, config: DucklingBackfillConfig
+) -> None:
     """Backfill persons from ClickHouse to a customer's duckling.
 
     Supports two partition formats with different export strategies:
@@ -1580,7 +1715,9 @@ def duckling_persons_backfill(context: AssetExecutionContext, config: DucklingBa
         team_id, dates = parse_partition_key_dates(partition_key)
         export_mode = "daily"
 
-    context.log.info(f"Starting duckling persons backfill for team_id={team_id}, mode={export_mode}")
+    context.log.info(
+        f"Starting duckling persons backfill for team_id={team_id}, mode={export_mode}"
+    )
     logger.info(
         "duckling_persons_backfill_start",
         team_id=team_id,
@@ -1592,19 +1729,33 @@ def duckling_persons_backfill(context: AssetExecutionContext, config: DucklingBa
     if catalog is None:
         raise ValueError(f"No DuckLakeCatalog found for team_id={team_id}")
 
-    context.log.info(f"Found DuckLakeCatalog: bucket={catalog.bucket}, db_host={catalog.db_host}")
+    context.log.info(
+        f"Found DuckLakeCatalog: bucket={catalog.bucket}, db_host={catalog.db_host}"
+    )
 
     # Delete persons table if requested (dangerous - loses all data)
-    if config.delete_tables and not config.dry_run and not config.skip_ducklake_registration:
+    if (
+        config.delete_tables
+        and not config.dry_run
+        and not config.skip_ducklake_registration
+    ):
         context.log.warning("delete_tables=True: Deleting persons table...")
         delete_persons_table(context, catalog)
 
     # Create persons table if it doesn't exist
-    if config.create_tables_if_missing and not config.dry_run and not config.skip_ducklake_registration:
+    if (
+        config.create_tables_if_missing
+        and not config.dry_run
+        and not config.skip_ducklake_registration
+    ):
         context.log.info("Ensuring persons table exists in duckling catalog...")
         ensure_persons_table_exists(context, catalog)
 
-    if not config.dry_run and not config.skip_ducklake_registration and not config.skip_schema_validation:
+    if (
+        not config.dry_run
+        and not config.skip_ducklake_registration
+        and not config.skip_schema_validation
+    ):
         context.log.info("Validating duckling persons schema compatibility...")
         validate_duckling_persons_schema(context, catalog)
 
@@ -1612,7 +1763,9 @@ def duckling_persons_backfill(context: AssetExecutionContext, config: DucklingBa
     merged_settings.update(settings_with_log_comment(context))
     if config.clickhouse_settings:
         merged_settings.update(config.clickhouse_settings)
-        context.log.info(f"Using custom ClickHouse settings: {config.clickhouse_settings}")
+        context.log.info(
+            f"Using custom ClickHouse settings: {config.clickhouse_settings}"
+        )
 
     cluster = _get_cluster()
     tags = dagster_tags(context)
@@ -1620,11 +1773,19 @@ def duckling_persons_backfill(context: AssetExecutionContext, config: DucklingBa
 
     if is_full:
         # FULL EXPORT MODE - single query for all persons
-        context.log.info(f"Full export mode: exporting all persons for team_id={team_id}")
+        context.log.info(
+            f"Full export mode: exporting all persons for team_id={team_id}"
+        )
 
         # Delete all existing persons data for this team before full re-export
-        if config.cleanup_existing_partition_data and not config.dry_run and not config.skip_ducklake_registration:
-            delete_persons_partition_data(context, catalog, team_id, partition_date=None)
+        if (
+            config.cleanup_existing_partition_data
+            and not config.dry_run
+            and not config.skip_ducklake_registration
+        ):
+            delete_persons_partition_data(
+                context, catalog, team_id, partition_date=None
+            )
 
         def do_full_export(client: Client) -> str | None:
             with tags_context(kind="dagster", dagster=tags):
@@ -1682,10 +1843,16 @@ def duckling_persons_backfill(context: AssetExecutionContext, config: DucklingBa
             context.log.info(f"Processing persons for date {date_str}...")
 
             # Delete existing DuckLake data for this partition before re-processing
-            if config.cleanup_existing_partition_data and not config.dry_run and not config.skip_ducklake_registration:
+            if (
+                config.cleanup_existing_partition_data
+                and not config.dry_run
+                and not config.skip_ducklake_registration
+            ):
                 delete_persons_partition_data(context, catalog, team_id, partition_date)
 
-            def do_export(client: Client, date: datetime = partition_date) -> str | None:
+            def do_export(
+                client: Client, date: datetime = partition_date
+            ) -> str | None:
                 with tags_context(kind="dagster", dagster=tags):
                     return export_persons_to_duckling_s3(
                         context=context,
@@ -1706,7 +1873,9 @@ def duckling_persons_backfill(context: AssetExecutionContext, config: DucklingBa
 
             if s3_path:
                 total_exported += 1
-                if register_persons_file_with_duckling(context, catalog, s3_path, config):
+                if register_persons_file_with_duckling(
+                    context, catalog, s3_path, config
+                ):
                     total_registered += 1
 
         context.add_output_metadata(
@@ -1740,7 +1909,9 @@ def duckling_persons_backfill(context: AssetExecutionContext, config: DucklingBa
     minimum_interval_seconds=3600,  # Run hourly
     job_name="duckling_events_backfill_job",
 )
-def duckling_events_daily_backfill_sensor(context: SensorEvaluationContext) -> SensorResult:
+def duckling_events_daily_backfill_sensor(
+    context: SensorEvaluationContext,
+) -> SensorResult:
     """Discover teams with DuckLakeCatalog entries and create daily backfill partitions.
 
     This sensor runs periodically to:
@@ -1770,7 +1941,9 @@ def duckling_events_daily_backfill_sensor(context: SensorEvaluationContext) -> S
                     run_key=f"{partition_key}_new",
                 )
             )
-            context.log.info(f"Creating partition for team_id={catalog.team_id}, date={yesterday}")
+            context.log.info(
+                f"Creating partition for team_id={catalog.team_id}, date={yesterday}"
+            )
         else:
             # Existing partition - check if the last run failed and needs retry
             # Query for runs with this partition key (stored in dagster/partition tag)
@@ -1802,7 +1975,10 @@ def duckling_events_daily_backfill_sensor(context: SensorEvaluationContext) -> S
                         date=yesterday,
                         previous_run_id=latest_run.run_id,
                     )
-                elif latest_run.status in (DagsterRunStatus.STARTED, DagsterRunStatus.QUEUED):
+                elif latest_run.status in (
+                    DagsterRunStatus.STARTED,
+                    DagsterRunStatus.QUEUED,
+                ):
                     context.log.debug(
                         f"Skipping partition team_id={catalog.team_id}, date={yesterday} - run in progress"
                     )
@@ -1825,7 +2001,9 @@ def duckling_events_daily_backfill_sensor(context: SensorEvaluationContext) -> S
 
     return SensorResult(
         run_requests=run_requests,
-        dynamic_partitions_requests=[duckling_events_partitions_def.build_add_request(new_partitions)]
+        dynamic_partitions_requests=[
+            duckling_events_partitions_def.build_add_request(new_partitions)
+        ]
         if new_partitions
         else [],
     )
@@ -1861,7 +2039,9 @@ def get_months_in_range(start_date: date, end_date: date) -> list[str]:
     job_name="duckling_events_backfill_job",
     default_status=DefaultSensorStatus.RUNNING,
 )
-def duckling_events_full_backfill_sensor(context: SensorEvaluationContext) -> SensorResult:
+def duckling_events_full_backfill_sensor(
+    context: SensorEvaluationContext,
+) -> SensorResult:
     """Full historical backfill sensor - creates MONTHLY partitions for efficiency.
 
     Uses monthly partitions (YYYY-MM) instead of daily to reduce partition count.
@@ -1907,12 +2087,16 @@ def duckling_events_full_backfill_sensor(context: SensorEvaluationContext) -> Se
 
     new_partitions: list[str] = []
     run_requests: list[RunRequest] = []
-    existing_partitions = set(context.instance.get_dynamic_partitions("duckling_events_backfill"))
+    existing_partitions = set(
+        context.instance.get_dynamic_partitions("duckling_events_backfill")
+    )
 
     # Process catalogs starting from where we left off
     for catalog_idx, catalog in enumerate(catalogs[start_idx:], start=start_idx):
         if len(new_partitions) >= BACKFILL_MONTHS_PER_TICK:
-            context.log.info(f"Batch limit reached, will continue from team {catalog.team_id}")
+            context.log.info(
+                f"Batch limit reached, will continue from team {catalog.team_id}"
+            )
             break
 
         team_id = catalog.team_id
@@ -1933,7 +2117,9 @@ def duckling_events_full_backfill_sensor(context: SensorEvaluationContext) -> Se
 
         # Generate monthly partitions for this team
         end_month = yesterday.strftime("%Y-%m")
-        all_months = get_months_in_range(datetime.strptime(current_month, "%Y-%m").date(), yesterday)
+        all_months = get_months_in_range(
+            datetime.strptime(current_month, "%Y-%m").date(), yesterday
+        )
 
         for month in all_months:
             if len(new_partitions) >= BACKFILL_MONTHS_PER_TICK:
@@ -1979,7 +2165,10 @@ def duckling_events_full_backfill_sensor(context: SensorEvaluationContext) -> Se
                 cursor_data = {"completed": timezone.now().date().isoformat()}
 
     # Check if we're in "completed" state and should skip until new data
-    if cursor_data.get("completed") == timezone.now().date().isoformat() and not new_partitions:
+    if (
+        cursor_data.get("completed") == timezone.now().date().isoformat()
+        and not new_partitions
+    ):
         context.log.debug("Full backfill complete for today")
         return SensorResult(run_requests=[], cursor=json.dumps(cursor_data))
 
@@ -1993,7 +2182,9 @@ def duckling_events_full_backfill_sensor(context: SensorEvaluationContext) -> Se
 
     return SensorResult(
         run_requests=run_requests,
-        dynamic_partitions_requests=[duckling_events_partitions_def.build_add_request(new_partitions)]
+        dynamic_partitions_requests=[
+            duckling_events_partitions_def.build_add_request(new_partitions)
+        ]
         if new_partitions
         else [],
         cursor=json.dumps(cursor_data),
@@ -2016,7 +2207,9 @@ duckling_events_backfill_job = define_asset_job(
     minimum_interval_seconds=3600,  # Run hourly
     job_name="duckling_persons_backfill_job",
 )
-def duckling_persons_daily_backfill_sensor(context: SensorEvaluationContext) -> SensorResult:
+def duckling_persons_daily_backfill_sensor(
+    context: SensorEvaluationContext,
+) -> SensorResult:
     """Discover teams with DuckLakeCatalog entries and create daily persons partitions.
 
     Similar to duckling_events_daily_backfill_sensor but for persons data.
@@ -2040,7 +2233,9 @@ def duckling_persons_daily_backfill_sensor(context: SensorEvaluationContext) -> 
                     run_key=f"{partition_key}_persons_new",
                 )
             )
-            context.log.info(f"Creating persons partition for team_id={catalog.team_id}, date={yesterday}")
+            context.log.info(
+                f"Creating persons partition for team_id={catalog.team_id}, date={yesterday}"
+            )
         else:
             runs = context.instance.get_runs(
                 filters=RunsFilter(
@@ -2059,20 +2254,27 @@ def duckling_persons_daily_backfill_sensor(context: SensorEvaluationContext) -> 
                             run_key=f"{partition_key}_persons_retry_{latest_run.run_id[:8]}",
                         )
                     )
-                    context.log.info(f"Retrying failed persons partition team_id={catalog.team_id}, date={yesterday}")
+                    context.log.info(
+                        f"Retrying failed persons partition team_id={catalog.team_id}, date={yesterday}"
+                    )
                     logger.info(
                         "duckling_persons_sensor_retry_failed_partition",
                         team_id=catalog.team_id,
                         date=yesterday,
                         previous_run_id=latest_run.run_id,
                     )
-                elif latest_run.status in (DagsterRunStatus.STARTED, DagsterRunStatus.QUEUED):
+                elif latest_run.status in (
+                    DagsterRunStatus.STARTED,
+                    DagsterRunStatus.QUEUED,
+                ):
                     context.log.debug(
                         f"Skipping persons partition team_id={catalog.team_id}, date={yesterday} - run in progress"
                     )
 
     if new_partitions:
-        context.log.info(f"Discovered {len(new_partitions)} new persons partitions to backfill")
+        context.log.info(
+            f"Discovered {len(new_partitions)} new persons partitions to backfill"
+        )
         logger.info(
             "duckling_persons_sensor_discovered_partitions",
             count=len(new_partitions),
@@ -2089,7 +2291,9 @@ def duckling_persons_daily_backfill_sensor(context: SensorEvaluationContext) -> 
 
     return SensorResult(
         run_requests=run_requests,
-        dynamic_partitions_requests=[duckling_persons_partitions_def.build_add_request(new_partitions)]
+        dynamic_partitions_requests=[
+            duckling_persons_partitions_def.build_add_request(new_partitions)
+        ]
         if new_partitions
         else [],
     )
@@ -2101,7 +2305,9 @@ def duckling_persons_daily_backfill_sensor(context: SensorEvaluationContext) -> 
     job_name="duckling_persons_backfill_job",
     default_status=DefaultSensorStatus.RUNNING,
 )
-def duckling_persons_full_backfill_sensor(context: SensorEvaluationContext) -> SensorResult:
+def duckling_persons_full_backfill_sensor(
+    context: SensorEvaluationContext,
+) -> SensorResult:
     """Full persons backfill sensor - one partition per team.
 
     Creates a single partition per team for efficient full export. Uses a single
@@ -2121,7 +2327,9 @@ def duckling_persons_full_backfill_sensor(context: SensorEvaluationContext) -> S
         return SensorResult(run_requests=[])
 
     # Check existing partitions
-    existing_partitions = set(context.instance.get_dynamic_partitions("duckling_persons_backfill"))
+    existing_partitions = set(
+        context.instance.get_dynamic_partitions("duckling_persons_backfill")
+    )
 
     new_partitions: list[str] = []
     run_requests: list[RunRequest] = []
@@ -2143,7 +2351,9 @@ def duckling_persons_full_backfill_sensor(context: SensorEvaluationContext) -> S
                     partition_key=partition_key,
                 )
             )
-            context.log.info(f"Creating full persons backfill partition for team_id={team_id}")
+            context.log.info(
+                f"Creating full persons backfill partition for team_id={team_id}"
+            )
         else:
             # Partition exists - check if we need to retry a failed run
             runs = context.instance.get_runs(
@@ -2163,17 +2373,24 @@ def duckling_persons_full_backfill_sensor(context: SensorEvaluationContext) -> S
                             run_key=f"{partition_key}_persons_full_retry_{latest_run.run_id[:8]}",
                         )
                     )
-                    context.log.info(f"Retrying failed full persons backfill for team_id={team_id}")
+                    context.log.info(
+                        f"Retrying failed full persons backfill for team_id={team_id}"
+                    )
                     logger.info(
                         "duckling_persons_full_backfill_retry",
                         team_id=team_id,
                         previous_run_id=latest_run.run_id,
                     )
-                elif latest_run.status in (DagsterRunStatus.STARTED, DagsterRunStatus.QUEUED):
+                elif latest_run.status in (
+                    DagsterRunStatus.STARTED,
+                    DagsterRunStatus.QUEUED,
+                ):
                     context.log.debug(f"Skipping team_id={team_id} - run in progress")
 
     if new_partitions:
-        context.log.info(f"Creating {len(new_partitions)} full persons backfill partitions")
+        context.log.info(
+            f"Creating {len(new_partitions)} full persons backfill partitions"
+        )
         logger.info(
             "duckling_persons_full_backfill_batch",
             partition_count=len(new_partitions),
@@ -2190,7 +2407,9 @@ def duckling_persons_full_backfill_sensor(context: SensorEvaluationContext) -> S
 
     return SensorResult(
         run_requests=run_requests,
-        dynamic_partitions_requests=[duckling_persons_partitions_def.build_add_request(new_partitions)]
+        dynamic_partitions_requests=[
+            duckling_persons_partitions_def.build_add_request(new_partitions)
+        ]
         if new_partitions
         else [],
     )

--- a/posthog/dags/events_backfill_to_duckling.py
+++ b/posthog/dags/events_backfill_to_duckling.py
@@ -164,7 +164,10 @@ PERSONS_COLUMNS = """
     pd.version AS person_distinct_id_version,
     p.version AS person_version,
     toDateTime64(p._timestamp, 6) AS _timestamp,
-    now64(6) AS _inserted_at
+    now64(6) AS _inserted_at,
+    toYear(p._timestamp) AS year,
+    toMonth(p._timestamp) AS month,
+    toDayOfMonth(p._timestamp) AS day
 """
 
 # Expected columns in the duckling's persons table for schema validation
@@ -179,6 +182,9 @@ EXPECTED_DUCKLAKE_PERSONS_COLUMNS = {
     "person_version",
     "_timestamp",
     "_inserted_at",
+    "year",
+    "month",
+    "day",
 }
 
 duckling_events_partitions_def = DynamicPartitionsDefinition(name="duckling_events_backfill")
@@ -233,7 +239,10 @@ CREATE TABLE IF NOT EXISTS {catalog}.posthog.persons (
     person_distinct_id_version BIGINT,
     person_version UBIGINT,
     _timestamp TIMESTAMPTZ,
-    _inserted_at TIMESTAMPTZ
+    _inserted_at TIMESTAMPTZ,
+    year INTEGER,
+    month INTEGER,
+    day INTEGER
 )
 """
 
@@ -458,6 +467,35 @@ def table_exists(
         return False
 
 
+def _ensure_partition_columns_exist(
+    conn: duckdb.DuckDBPyConnection,
+    alias: str,
+    table: str,
+    context: AssetExecutionContext,
+) -> None:
+    """Add year/month/day partition columns to an existing table if missing.
+
+    Existing tables created before partition columns were added to the DDL
+    will lack these columns. This adds them via ALTER TABLE so that
+    column-based partitioning (year, month, day) can be set.
+    """
+    _validate_identifier(alias)
+    _validate_identifier(table)
+
+    result = conn.execute(f"DESCRIBE {alias}.posthog.{table}").fetchall()
+    existing_columns = {row[0] for row in result}
+
+    for col in ("year", "month", "day"):
+        if col not in existing_columns:
+            context.log.info(f"Adding missing partition column '{col}' to {table} table")
+            conn.execute(f"ALTER TABLE {alias}.posthog.{table} ADD COLUMN {col} INTEGER")
+            logger.info(
+                "duckling_partition_column_added",
+                table=table,
+                column=col,
+            )
+
+
 def _set_table_partitioning(
     conn: duckdb.DuckDBPyConnection,
     alias: str,
@@ -534,6 +572,8 @@ def ensure_events_table_exists(
 
         if table_exists(conn, alias, "posthog", "events"):
             context.log.info("Events table already exists in duckling catalog")
+            # Existing tables may lack year/month/day columns — add them if missing
+            _ensure_partition_columns_exist(conn, alias, "events", context)
             # Ensure partitioning is set even on existing tables (idempotent)
             _set_table_partitioning(conn, alias, "events", "year, month, day", context, catalog.team_id)
             return False
@@ -549,6 +589,8 @@ def ensure_events_table_exists(
             # Check if this was a race condition (another worker created the table)
             if table_exists(conn, alias, "posthog", "events"):
                 context.log.info("Events table was created by another worker")
+                # Existing tables may lack year/month/day columns — add them if missing
+                _ensure_partition_columns_exist(conn, alias, "events", context)
                 # Ensure partitioning is set even when another worker created the table
                 _set_table_partitioning(conn, alias, "events", "year, month, day", context, catalog.team_id)
                 return False
@@ -597,12 +639,14 @@ def ensure_persons_table_exists(
 
         if table_exists(conn, alias, "posthog", "persons"):
             context.log.info("Persons table already exists in duckling catalog")
+            # Existing tables may lack year/month/day columns — add them if missing
+            _ensure_partition_columns_exist(conn, alias, "persons", context)
             # Ensure partitioning is set even on existing tables (idempotent)
             _set_table_partitioning(
                 conn,
                 alias,
                 "persons",
-                "year(_timestamp), month(_timestamp)",
+                "year, month, day",
                 context,
                 catalog.team_id,
             )
@@ -619,12 +663,14 @@ def ensure_persons_table_exists(
             # Check if this was a race condition (another worker created the table)
             if table_exists(conn, alias, "posthog", "persons"):
                 context.log.info("Persons table was created by another worker")
+                # Existing tables may lack year/month/day columns — add them if missing
+                _ensure_partition_columns_exist(conn, alias, "persons", context)
                 # Ensure partitioning is set even when another worker created the table
                 _set_table_partitioning(
                     conn,
                     alias,
                     "persons",
-                    "year(_timestamp), month(_timestamp)",
+                    "year, month, day",
                     context,
                     catalog.team_id,
                 )
@@ -640,7 +686,7 @@ def ensure_persons_table_exists(
             conn,
             alias,
             "persons",
-            "year(_timestamp), month(_timestamp)",
+            "year, month, day",
             context,
             catalog.team_id,
         )

--- a/posthog/dags/events_backfill_to_duckling.py
+++ b/posthog/dags/events_backfill_to_duckling.py
@@ -131,7 +131,10 @@ EVENTS_COLUMNS = """
     group4_created_at,
     person_mode,
     historical_migration,
-    now64(6) as _inserted_at
+    now64(6) as _inserted_at,
+    toYear(timestamp) as year,
+    toMonth(timestamp) as month,
+    toDayOfMonth(timestamp) as day
 """
 
 BACKFILL_EVENTS_S3_PREFIX = "backfill/events"
@@ -209,7 +212,10 @@ CREATE TABLE IF NOT EXISTS {catalog}.posthog.events (
     group4_created_at TIMESTAMPTZ,
     person_mode VARCHAR,
     historical_migration BOOLEAN,
-    _inserted_at TIMESTAMPTZ
+    _inserted_at TIMESTAMPTZ,
+    year INTEGER,
+    month INTEGER,
+    day INTEGER
 )
 """
 
@@ -469,7 +475,7 @@ def _set_table_partitioning(
         conn: DuckDB connection with catalog attached.
         alias: Catalog alias.
         table: Table name (must be alphanumeric/underscore only).
-        partition_expr: Partition expression (e.g., "year(timestamp), month(timestamp), day(timestamp)").
+        partition_expr: Partition expression (e.g., "year, month, day").
         context: Dagster asset execution context.
         team_id: Team ID for logging.
 
@@ -530,7 +536,7 @@ def ensure_events_table_exists(
             context.log.info("Events table already exists in duckling catalog")
             # Ensure partitioning is set even on existing tables (idempotent)
             _set_table_partitioning(
-                conn, alias, "events", "year(timestamp), month(timestamp), day(timestamp)", context, catalog.team_id
+                conn, alias, "events", "year, month, day", context, catalog.team_id
             )
             return False
 
@@ -547,7 +553,7 @@ def ensure_events_table_exists(
                 context.log.info("Events table was created by another worker")
                 # Ensure partitioning is set even when another worker created the table
                 _set_table_partitioning(
-                    conn, alias, "events", "year(timestamp), month(timestamp), day(timestamp)", context, catalog.team_id
+                    conn, alias, "events", "year, month, day", context, catalog.team_id
                 )
                 return False
             # Real error - log and re-raise
@@ -558,7 +564,7 @@ def ensure_events_table_exists(
 
         # Set partitioning by year/month/day for efficient querying
         _set_table_partitioning(
-            conn, alias, "events", "year(timestamp), month(timestamp), day(timestamp)", context, catalog.team_id
+            conn, alias, "events", "year, month, day", context, catalog.team_id
         )
 
         logger.info(

--- a/posthog/dags/test_events_backfill_to_duckling.py
+++ b/posthog/dags/test_events_backfill_to_duckling.py
@@ -16,6 +16,7 @@ from posthog.dags.events_backfill_to_duckling import (
     PERSONS_COLUMNS,
     PERSONS_TABLE_DDL,
     _connect_duckdb,
+    _ensure_partition_columns_exist,
     _get_cluster,
     _is_transaction_conflict,
     _set_table_partitioning,
@@ -309,41 +310,23 @@ class TestSetTablePartitioning:
         conn.execute("INSTALL ducklake; LOAD ducklake;")
         conn.execute("ATTACH ':memory:' AS test_catalog (TYPE DUCKLAKE, DATA_PATH ':memory:')")
         conn.execute("CREATE SCHEMA test_catalog.posthog")
-        conn.execute("CREATE TABLE test_catalog.posthog.events (timestamp TIMESTAMP, event VARCHAR)")
+        conn.execute(
+            "CREATE TABLE test_catalog.posthog.events "
+            "(timestamp TIMESTAMP, event VARCHAR, year INTEGER, month INTEGER, day INTEGER)"
+        )
 
         mock_context = MagicMock()
 
         # First call should succeed
-        result1 = _set_table_partitioning(
-            conn,
-            "test_catalog",
-            "events",
-            "year(timestamp), month(timestamp)",
-            mock_context,
-            team_id=123,
-        )
+        result1 = _set_table_partitioning(conn, "test_catalog", "events", "year, month, day", mock_context, team_id=123)
         assert result1 is True
 
         # Second call with same keys should also succeed (idempotent)
-        result2 = _set_table_partitioning(
-            conn,
-            "test_catalog",
-            "events",
-            "year(timestamp), month(timestamp)",
-            mock_context,
-            team_id=123,
-        )
+        result2 = _set_table_partitioning(conn, "test_catalog", "events", "year, month, day", mock_context, team_id=123)
         assert result2 is True
 
         # Third call should also succeed
-        result3 = _set_table_partitioning(
-            conn,
-            "test_catalog",
-            "events",
-            "year(timestamp), month(timestamp)",
-            mock_context,
-            team_id=123,
-        )
+        result3 = _set_table_partitioning(conn, "test_catalog", "events", "year, month, day", mock_context, team_id=123)
         assert result3 is True
 
         conn.close()
@@ -354,18 +337,14 @@ class TestSetTablePartitioning:
         conn.execute("INSTALL ducklake; LOAD ducklake;")
         conn.execute("ATTACH ':memory:' AS test_catalog (TYPE DUCKLAKE, DATA_PATH ':memory:')")
         conn.execute("CREATE SCHEMA test_catalog.posthog")
-        conn.execute("CREATE TABLE test_catalog.posthog.events (timestamp TIMESTAMP, event VARCHAR)")
+        conn.execute(
+            "CREATE TABLE test_catalog.posthog.events "
+            "(timestamp TIMESTAMP, event VARCHAR, year INTEGER, month INTEGER, day INTEGER)"
+        )
 
         mock_context = MagicMock()
 
-        result = _set_table_partitioning(
-            conn,
-            "test_catalog",
-            "events",
-            "year(timestamp), month(timestamp)",
-            mock_context,
-            team_id=123,
-        )
+        result = _set_table_partitioning(conn, "test_catalog", "events", "year, month, day", mock_context, team_id=123)
 
         assert result is True
         mock_context.log.info.assert_any_call("Setting partitioning on events table...")
@@ -377,19 +356,14 @@ class TestSetTablePartitioning:
         conn = duckdb.connect()
         # Don't load ducklake - table won't support SET PARTITIONED BY
         conn.execute("CREATE SCHEMA posthog")
-        conn.execute("CREATE TABLE posthog.events (timestamp TIMESTAMP, event VARCHAR)")
+        conn.execute(
+            "CREATE TABLE posthog.events (timestamp TIMESTAMP, event VARCHAR, year INTEGER, month INTEGER, day INTEGER)"
+        )
 
         mock_context = MagicMock()
 
         # This should fail because regular DuckDB tables don't support SET PARTITIONED BY
-        result = _set_table_partitioning(
-            conn,
-            "memory",
-            "events",
-            "year(timestamp), month(timestamp)",
-            mock_context,
-            team_id=123,
-        )
+        result = _set_table_partitioning(conn, "memory", "events", "year, month, day", mock_context, team_id=123)
 
         assert result is False
         mock_context.log.warning.assert_called()
@@ -401,26 +375,56 @@ class TestSetTablePartitioning:
         mock_context = MagicMock()
 
         with pytest.raises(ValueError) as exc_info:
-            _set_table_partitioning(
-                conn,
-                "test; DROP TABLE",
-                "events",
-                "year(timestamp)",
-                mock_context,
-                team_id=123,
-            )
+            _set_table_partitioning(conn, "test; DROP TABLE", "events", "year, month, day", mock_context, team_id=123)
         assert "Invalid SQL identifier" in str(exc_info.value)
 
         with pytest.raises(ValueError) as exc_info:
-            _set_table_partitioning(
-                conn,
-                "test_catalog",
-                "events'; --",
-                "year(timestamp)",
-                mock_context,
-                team_id=123,
-            )
+            _set_table_partitioning(conn, "test_catalog", "events'; --", "year, month, day", mock_context, team_id=123)
         assert "Invalid SQL identifier" in str(exc_info.value)
+
+        conn.close()
+
+
+class TestEnsurePartitionColumnsExist:
+    def test_adds_missing_columns(self):
+        conn = duckdb.connect()
+        conn.execute("INSTALL ducklake; LOAD ducklake;")
+        conn.execute("ATTACH ':memory:' AS test_catalog (TYPE DUCKLAKE, DATA_PATH ':memory:')")
+        conn.execute("CREATE SCHEMA test_catalog.posthog")
+        conn.execute("CREATE TABLE test_catalog.posthog.events (timestamp TIMESTAMP, event VARCHAR)")
+
+        mock_context = MagicMock()
+
+        # Table starts without year/month/day columns
+        cols_before = {row[0] for row in conn.execute("DESCRIBE test_catalog.posthog.events").fetchall()}
+        assert "year" not in cols_before
+
+        _ensure_partition_columns_exist(conn, "test_catalog", "events", mock_context)
+
+        cols_after = {row[0] for row in conn.execute("DESCRIBE test_catalog.posthog.events").fetchall()}
+        assert {"year", "month", "day"}.issubset(cols_after)
+
+        # Calling again is safe (columns already exist)
+        _ensure_partition_columns_exist(conn, "test_catalog", "events", mock_context)
+        conn.close()
+
+    def test_noop_when_columns_exist(self):
+        conn = duckdb.connect()
+        conn.execute("INSTALL ducklake; LOAD ducklake;")
+        conn.execute("ATTACH ':memory:' AS test_catalog (TYPE DUCKLAKE, DATA_PATH ':memory:')")
+        conn.execute("CREATE SCHEMA test_catalog.posthog")
+        conn.execute(
+            "CREATE TABLE test_catalog.posthog.events "
+            "(timestamp TIMESTAMP, event VARCHAR, year INTEGER, month INTEGER, day INTEGER)"
+        )
+
+        mock_context = MagicMock()
+
+        _ensure_partition_columns_exist(conn, "test_catalog", "events", mock_context)
+
+        # No ALTER TABLE should have been logged
+        for call in mock_context.log.info.call_args_list:
+            assert "Adding missing partition column" not in str(call)
 
         conn.close()
 

--- a/posthog/dags/test_events_backfill_to_duckling.py
+++ b/posthog/dags/test_events_backfill_to_duckling.py
@@ -399,13 +399,13 @@ class TestEnsurePartitionColumnsExist:
         cols_before = {row[0] for row in conn.execute("DESCRIBE test_catalog.posthog.events").fetchall()}
         assert "year" not in cols_before
 
-        _ensure_partition_columns_exist(conn, "test_catalog", "events", mock_context)
+        _ensure_partition_columns_exist(conn, "test_catalog", "events", mock_context, team_id=123)
 
         cols_after = {row[0] for row in conn.execute("DESCRIBE test_catalog.posthog.events").fetchall()}
         assert {"year", "month", "day"}.issubset(cols_after)
 
         # Calling again is safe (columns already exist)
-        _ensure_partition_columns_exist(conn, "test_catalog", "events", mock_context)
+        _ensure_partition_columns_exist(conn, "test_catalog", "events", mock_context, team_id=123)
         conn.close()
 
     def test_noop_when_columns_exist(self):
@@ -420,7 +420,7 @@ class TestEnsurePartitionColumnsExist:
 
         mock_context = MagicMock()
 
-        _ensure_partition_columns_exist(conn, "test_catalog", "events", mock_context)
+        _ensure_partition_columns_exist(conn, "test_catalog", "events", mock_context, team_id=123)
 
         # No ALTER TABLE should have been logged
         for call in mock_context.log.info.call_args_list:

--- a/posthog/dags/test_events_backfill_to_duckling.py
+++ b/posthog/dags/test_events_backfill_to_duckling.py
@@ -533,16 +533,26 @@ class TestDeleteRangePredicate:
     def test_range_predicate_deletes_correct_rows(self, timestamps, target_date, expected_deleted, expected_remaining):
         conn = duckdb.connect()
         try:
-            conn.execute("CREATE TABLE events (team_id INTEGER, timestamp TIMESTAMPTZ)")
+            conn.execute(
+                "CREATE TABLE events (team_id INTEGER, timestamp TIMESTAMPTZ, year INTEGER, month INTEGER, day INTEGER)"
+            )
             for ts in timestamps:
-                conn.execute("INSERT INTO events VALUES (1, ?)", [ts])
+                dt = (
+                    datetime.strptime(ts, "%Y-%m-%d %H:%M:%S.%f")
+                    if "." in ts
+                    else datetime.strptime(ts, "%Y-%m-%d %H:%M:%S")
+                )
+                conn.execute(
+                    "INSERT INTO events VALUES (1, ?, ?, ?, ?)",
+                    [ts, dt.year, dt.month, dt.day],
+                )
 
-            date_str = target_date
-            next_date_str = (datetime.strptime(target_date, "%Y-%m-%d") + timedelta(days=1)).strftime("%Y-%m-%d")
+            target_dt = datetime.strptime(target_date, "%Y-%m-%d")
+            next_date_str = (target_dt + timedelta(days=1)).strftime("%Y-%m-%d")
 
             result = conn.execute(
-                "DELETE FROM events WHERE team_id = $1 AND timestamp >= $2 AND timestamp < $3",
-                [1, date_str, next_date_str],
+                "DELETE FROM events WHERE team_id = $1 AND year = $2 AND month = $3 AND day = $4 AND timestamp >= $5 AND timestamp < $6",
+                [1, target_dt.year, target_dt.month, target_dt.day, target_date, next_date_str],
             ).fetchone()
 
             deleted = result[0] if result else 0

--- a/posthog/dags/test_events_backfill_to_duckling.py
+++ b/posthog/dags/test_events_backfill_to_duckling.py
@@ -64,7 +64,12 @@ class TestParsePartitionKey:
 class TestGetS3UrlForClickhouse:
     @parameterized.expand(
         [
-            ("bucket", "us-east-1", "path/file.parquet", "https://bucket.s3.us-east-1.amazonaws.com/path/file.parquet"),
+            (
+                "bucket",
+                "us-east-1",
+                "path/file.parquet",
+                "https://bucket.s3.us-east-1.amazonaws.com/path/file.parquet",
+            ),
             (
                 "my-bucket",
                 "eu-west-1",
@@ -259,7 +264,11 @@ class TestGetMonthsInRange:
         [
             (date(2024, 1, 15), date(2024, 1, 20), ["2024-01"]),
             (date(2024, 1, 1), date(2024, 3, 15), ["2024-01", "2024-02", "2024-03"]),
-            (date(2023, 11, 1), date(2024, 2, 15), ["2023-11", "2023-12", "2024-01", "2024-02"]),
+            (
+                date(2023, 11, 1),
+                date(2024, 2, 15),
+                ["2023-11", "2023-12", "2024-01", "2024-02"],
+            ),
             (
                 date(2022, 6, 1),
                 date(2024, 2, 15),
@@ -298,27 +307,46 @@ class TestSetTablePartitioning:
         """Verify that SET PARTITIONED BY can be called multiple times safely."""
         conn = duckdb.connect()
         conn.execute("INSTALL ducklake; LOAD ducklake;")
-        conn.execute("ATTACH ':memory:' AS test_catalog (TYPE DUCKLAKE, DATA_PATH ':memory:')")
+        conn.execute(
+            "ATTACH ':memory:' AS test_catalog (TYPE DUCKLAKE, DATA_PATH ':memory:')"
+        )
         conn.execute("CREATE SCHEMA test_catalog.posthog")
-        conn.execute("CREATE TABLE test_catalog.posthog.events (timestamp TIMESTAMP, event VARCHAR)")
+        conn.execute(
+            "CREATE TABLE test_catalog.posthog.events (timestamp TIMESTAMP, event VARCHAR)"
+        )
 
         mock_context = MagicMock()
 
         # First call should succeed
         result1 = _set_table_partitioning(
-            conn, "test_catalog", "events", "year(timestamp), month(timestamp)", mock_context, team_id=123
+            conn,
+            "test_catalog",
+            "events",
+            "year(timestamp), month(timestamp)",
+            mock_context,
+            team_id=123,
         )
         assert result1 is True
 
         # Second call with same keys should also succeed (idempotent)
         result2 = _set_table_partitioning(
-            conn, "test_catalog", "events", "year(timestamp), month(timestamp)", mock_context, team_id=123
+            conn,
+            "test_catalog",
+            "events",
+            "year(timestamp), month(timestamp)",
+            mock_context,
+            team_id=123,
         )
         assert result2 is True
 
         # Third call should also succeed
         result3 = _set_table_partitioning(
-            conn, "test_catalog", "events", "year(timestamp), month(timestamp)", mock_context, team_id=123
+            conn,
+            "test_catalog",
+            "events",
+            "year(timestamp), month(timestamp)",
+            mock_context,
+            team_id=123,
         )
         assert result3 is True
 
@@ -328,19 +356,30 @@ class TestSetTablePartitioning:
         """Verify that successful partitioning logs appropriately."""
         conn = duckdb.connect()
         conn.execute("INSTALL ducklake; LOAD ducklake;")
-        conn.execute("ATTACH ':memory:' AS test_catalog (TYPE DUCKLAKE, DATA_PATH ':memory:')")
+        conn.execute(
+            "ATTACH ':memory:' AS test_catalog (TYPE DUCKLAKE, DATA_PATH ':memory:')"
+        )
         conn.execute("CREATE SCHEMA test_catalog.posthog")
-        conn.execute("CREATE TABLE test_catalog.posthog.events (timestamp TIMESTAMP, event VARCHAR)")
+        conn.execute(
+            "CREATE TABLE test_catalog.posthog.events (timestamp TIMESTAMP, event VARCHAR)"
+        )
 
         mock_context = MagicMock()
 
         result = _set_table_partitioning(
-            conn, "test_catalog", "events", "year(timestamp), month(timestamp)", mock_context, team_id=123
+            conn,
+            "test_catalog",
+            "events",
+            "year(timestamp), month(timestamp)",
+            mock_context,
+            team_id=123,
         )
 
         assert result is True
         mock_context.log.info.assert_any_call("Setting partitioning on events table...")
-        mock_context.log.info.assert_any_call("Successfully set partitioning on events table")
+        mock_context.log.info.assert_any_call(
+            "Successfully set partitioning on events table"
+        )
         conn.close()
 
     def test_partitioning_handles_failure_gracefully(self):
@@ -354,7 +393,12 @@ class TestSetTablePartitioning:
 
         # This should fail because regular DuckDB tables don't support SET PARTITIONED BY
         result = _set_table_partitioning(
-            conn, "memory", "events", "year(timestamp), month(timestamp)", mock_context, team_id=123
+            conn,
+            "memory",
+            "events",
+            "year(timestamp), month(timestamp)",
+            mock_context,
+            team_id=123,
         )
 
         assert result is False
@@ -367,11 +411,25 @@ class TestSetTablePartitioning:
         mock_context = MagicMock()
 
         with pytest.raises(ValueError) as exc_info:
-            _set_table_partitioning(conn, "test; DROP TABLE", "events", "year(timestamp)", mock_context, team_id=123)
+            _set_table_partitioning(
+                conn,
+                "test; DROP TABLE",
+                "events",
+                "year(timestamp)",
+                mock_context,
+                team_id=123,
+            )
         assert "Invalid SQL identifier" in str(exc_info.value)
 
         with pytest.raises(ValueError) as exc_info:
-            _set_table_partitioning(conn, "test_catalog", "events'; --", "year(timestamp)", mock_context, team_id=123)
+            _set_table_partitioning(
+                conn,
+                "test_catalog",
+                "events'; --",
+                "year(timestamp)",
+                mock_context,
+                team_id=123,
+            )
         assert "Invalid SQL identifier" in str(exc_info.value)
 
         conn.close()
@@ -405,7 +463,10 @@ class TestIsFullExportPartition:
             ("12345_2024-01-15", False),
             ("12345_2024-01", False),
             ("1_2020-12-31", False),
-            ("12345-2024-01", False),  # Invalid format with hyphen instead of underscore
+            (
+                "12345-2024-01",
+                False,
+            ),  # Invalid format with hyphen instead of underscore
             ("abc", False),  # Non-numeric
             ("", False),  # Empty string
         ]
@@ -444,26 +505,40 @@ class TestDeleteRangePredicate:
         [
             # (timestamps_to_insert, target_date, expected_deleted, expected_remaining)
             (
-                ["2024-01-15 00:00:00", "2024-01-15 12:30:00", "2024-01-15 23:59:59.999999"],
+                [
+                    "2024-01-15 00:00:00",
+                    "2024-01-15 12:30:00",
+                    "2024-01-15 23:59:59.999999",
+                ],
                 "2024-01-15",
                 3,
                 0,
             ),
             (
-                ["2024-01-14 23:59:59.999999", "2024-01-15 00:00:00", "2024-01-16 00:00:00"],
+                [
+                    "2024-01-14 23:59:59.999999",
+                    "2024-01-15 00:00:00",
+                    "2024-01-16 00:00:00",
+                ],
                 "2024-01-15",
                 1,
                 2,
             ),
             (
-                ["2024-02-29 00:00:00", "2024-02-29 23:59:59.999999", "2024-03-01 00:00:00"],
+                [
+                    "2024-02-29 00:00:00",
+                    "2024-02-29 23:59:59.999999",
+                    "2024-03-01 00:00:00",
+                ],
                 "2024-02-29",
                 2,
                 1,
             ),
         ]
     )
-    def test_range_predicate_deletes_correct_rows(self, timestamps, target_date, expected_deleted, expected_remaining):
+    def test_range_predicate_deletes_correct_rows(
+        self, timestamps, target_date, expected_deleted, expected_remaining
+    ):
         conn = duckdb.connect()
         try:
             conn.execute("CREATE TABLE events (team_id INTEGER, timestamp TIMESTAMPTZ)")
@@ -471,7 +546,9 @@ class TestDeleteRangePredicate:
                 conn.execute("INSERT INTO events VALUES (1, ?)", [ts])
 
             date_str = target_date
-            next_date_str = (datetime.strptime(target_date, "%Y-%m-%d") + timedelta(days=1)).strftime("%Y-%m-%d")
+            next_date_str = (
+                datetime.strptime(target_date, "%Y-%m-%d") + timedelta(days=1)
+            ).strftime("%Y-%m-%d")
 
             result = conn.execute(
                 "DELETE FROM events WHERE team_id = $1 AND timestamp >= $2 AND timestamp < $3",
@@ -505,10 +582,14 @@ class TestIsTransactionConflict:
 class TestDeleteEventsRetry:
     @patch("posthog.dags.events_backfill_to_duckling.time.sleep")
     @patch("posthog.dags.events_backfill_to_duckling.attach_catalog")
-    @patch("posthog.dags.events_backfill_to_duckling.configure_cross_account_connection")
+    @patch(
+        "posthog.dags.events_backfill_to_duckling.configure_cross_account_connection"
+    )
     @patch("posthog.dags.events_backfill_to_duckling._connect_duckdb")
     @patch("posthog.dags.events_backfill_to_duckling.get_team_config")
-    def test_retries_on_transaction_conflict(self, mock_config, mock_connect, mock_cross, mock_attach, mock_sleep):
+    def test_retries_on_transaction_conflict(
+        self, mock_config, mock_connect, mock_cross, mock_attach, mock_sleep
+    ):
         mock_config.return_value = {}
         mock_catalog = MagicMock()
         mock_catalog.team_id = 1
@@ -516,12 +597,16 @@ class TestDeleteEventsRetry:
         mock_context = MagicMock()
 
         conflict_conn = MagicMock()
-        conflict_conn.execute.side_effect = duckdb.TransactionException("Transaction conflict: write-write")
+        conflict_conn.execute.side_effect = duckdb.TransactionException(
+            "Transaction conflict: write-write"
+        )
         success_conn = MagicMock()
         success_conn.execute.return_value.fetchone.return_value = (5,)
         mock_connect.side_effect = [conflict_conn, success_conn]
 
-        result = delete_events_partition_data(mock_context, mock_catalog, 1, datetime(2024, 1, 15))
+        result = delete_events_partition_data(
+            mock_context, mock_catalog, 1, datetime(2024, 1, 15)
+        )
 
         assert result == 5
         assert mock_connect.call_count == 2
@@ -531,10 +616,14 @@ class TestDeleteEventsRetry:
 
     @patch("posthog.dags.events_backfill_to_duckling.time.sleep")
     @patch("posthog.dags.events_backfill_to_duckling.attach_catalog")
-    @patch("posthog.dags.events_backfill_to_duckling.configure_cross_account_connection")
+    @patch(
+        "posthog.dags.events_backfill_to_duckling.configure_cross_account_connection"
+    )
     @patch("posthog.dags.events_backfill_to_duckling._connect_duckdb")
     @patch("posthog.dags.events_backfill_to_duckling.get_team_config")
-    def test_raises_non_conflict_exception(self, mock_config, mock_connect, mock_cross, mock_attach, mock_sleep):
+    def test_raises_non_conflict_exception(
+        self, mock_config, mock_connect, mock_cross, mock_attach, mock_sleep
+    ):
         mock_config.return_value = {}
         mock_catalog = MagicMock()
         mock_catalog.team_id = 1
@@ -546,17 +635,23 @@ class TestDeleteEventsRetry:
         mock_connect.return_value = conn
 
         with pytest.raises(RuntimeError, match="Connection failed"):
-            delete_events_partition_data(mock_context, mock_catalog, 1, datetime(2024, 1, 15))
+            delete_events_partition_data(
+                mock_context, mock_catalog, 1, datetime(2024, 1, 15)
+            )
 
         assert mock_connect.call_count == 1
         mock_sleep.assert_not_called()
 
     @patch("posthog.dags.events_backfill_to_duckling.time.sleep")
     @patch("posthog.dags.events_backfill_to_duckling.attach_catalog")
-    @patch("posthog.dags.events_backfill_to_duckling.configure_cross_account_connection")
+    @patch(
+        "posthog.dags.events_backfill_to_duckling.configure_cross_account_connection"
+    )
     @patch("posthog.dags.events_backfill_to_duckling._connect_duckdb")
     @patch("posthog.dags.events_backfill_to_duckling.get_team_config")
-    def test_raises_after_max_retries(self, mock_config, mock_connect, mock_cross, mock_attach, mock_sleep):
+    def test_raises_after_max_retries(
+        self, mock_config, mock_connect, mock_cross, mock_attach, mock_sleep
+    ):
         mock_config.return_value = {}
         mock_catalog = MagicMock()
         mock_catalog.team_id = 1
@@ -564,20 +659,28 @@ class TestDeleteEventsRetry:
         mock_context = MagicMock()
 
         conn = MagicMock()
-        conn.execute.side_effect = duckdb.TransactionException("Transaction conflict: write-write")
+        conn.execute.side_effect = duckdb.TransactionException(
+            "Transaction conflict: write-write"
+        )
         mock_connect.return_value = conn
 
         with pytest.raises(duckdb.TransactionException, match="Transaction conflict"):
-            delete_events_partition_data(mock_context, mock_catalog, 1, datetime(2024, 1, 15))
+            delete_events_partition_data(
+                mock_context, mock_catalog, 1, datetime(2024, 1, 15)
+            )
 
         assert mock_connect.call_count == MAX_RETRY_ATTEMPTS
         assert mock_sleep.call_count == MAX_RETRY_ATTEMPTS - 1
 
     @patch("posthog.dags.events_backfill_to_duckling.attach_catalog")
-    @patch("posthog.dags.events_backfill_to_duckling.configure_cross_account_connection")
+    @patch(
+        "posthog.dags.events_backfill_to_duckling.configure_cross_account_connection"
+    )
     @patch("posthog.dags.events_backfill_to_duckling._connect_duckdb")
     @patch("posthog.dags.events_backfill_to_duckling.get_team_config")
-    def test_returns_zero_on_catalog_exception(self, mock_config, mock_connect, mock_cross, mock_attach):
+    def test_returns_zero_on_catalog_exception(
+        self, mock_config, mock_connect, mock_cross, mock_attach
+    ):
         mock_config.return_value = {}
         mock_catalog = MagicMock()
         mock_catalog.team_id = 1
@@ -588,17 +691,23 @@ class TestDeleteEventsRetry:
         conn.execute.side_effect = duckdb.CatalogException("Table does not exist")
         mock_connect.return_value = conn
 
-        result = delete_events_partition_data(mock_context, mock_catalog, 1, datetime(2024, 1, 15))
+        result = delete_events_partition_data(
+            mock_context, mock_catalog, 1, datetime(2024, 1, 15)
+        )
         assert result == 0
 
 
 class TestDeletePersonsRetry:
     @patch("posthog.dags.events_backfill_to_duckling.time.sleep")
     @patch("posthog.dags.events_backfill_to_duckling.attach_catalog")
-    @patch("posthog.dags.events_backfill_to_duckling.configure_cross_account_connection")
+    @patch(
+        "posthog.dags.events_backfill_to_duckling.configure_cross_account_connection"
+    )
     @patch("posthog.dags.events_backfill_to_duckling._connect_duckdb")
     @patch("posthog.dags.events_backfill_to_duckling.get_team_config")
-    def test_retries_on_transaction_conflict(self, mock_config, mock_connect, mock_cross, mock_attach, mock_sleep):
+    def test_retries_on_transaction_conflict(
+        self, mock_config, mock_connect, mock_cross, mock_attach, mock_sleep
+    ):
         mock_config.return_value = {}
         mock_catalog = MagicMock()
         mock_catalog.team_id = 1
@@ -606,12 +715,16 @@ class TestDeletePersonsRetry:
         mock_context = MagicMock()
 
         conflict_conn = MagicMock()
-        conflict_conn.execute.side_effect = duckdb.TransactionException("Transaction conflict: write-write")
+        conflict_conn.execute.side_effect = duckdb.TransactionException(
+            "Transaction conflict: write-write"
+        )
         success_conn = MagicMock()
         success_conn.execute.return_value.fetchone.return_value = (3,)
         mock_connect.side_effect = [conflict_conn, success_conn]
 
-        result = delete_persons_partition_data(mock_context, mock_catalog, 1, datetime(2024, 1, 15))
+        result = delete_persons_partition_data(
+            mock_context, mock_catalog, 1, datetime(2024, 1, 15)
+        )
 
         assert result == 3
         assert mock_connect.call_count == 2
@@ -619,10 +732,14 @@ class TestDeletePersonsRetry:
 
     @patch("posthog.dags.events_backfill_to_duckling.time.sleep")
     @patch("posthog.dags.events_backfill_to_duckling.attach_catalog")
-    @patch("posthog.dags.events_backfill_to_duckling.configure_cross_account_connection")
+    @patch(
+        "posthog.dags.events_backfill_to_duckling.configure_cross_account_connection"
+    )
     @patch("posthog.dags.events_backfill_to_duckling._connect_duckdb")
     @patch("posthog.dags.events_backfill_to_duckling.get_team_config")
-    def test_retries_on_full_export_conflict(self, mock_config, mock_connect, mock_cross, mock_attach, mock_sleep):
+    def test_retries_on_full_export_conflict(
+        self, mock_config, mock_connect, mock_cross, mock_attach, mock_sleep
+    ):
         mock_config.return_value = {}
         mock_catalog = MagicMock()
         mock_catalog.team_id = 1
@@ -630,12 +747,16 @@ class TestDeletePersonsRetry:
         mock_context = MagicMock()
 
         conflict_conn = MagicMock()
-        conflict_conn.execute.side_effect = duckdb.TransactionException("Transaction conflict: write-write")
+        conflict_conn.execute.side_effect = duckdb.TransactionException(
+            "Transaction conflict: write-write"
+        )
         success_conn = MagicMock()
         success_conn.execute.return_value.fetchone.return_value = (10,)
         mock_connect.side_effect = [conflict_conn, success_conn]
 
-        result = delete_persons_partition_data(mock_context, mock_catalog, 1, partition_date=None)
+        result = delete_persons_partition_data(
+            mock_context, mock_catalog, 1, partition_date=None
+        )
 
         assert result == 10
         assert mock_connect.call_count == 2
@@ -643,10 +764,14 @@ class TestDeletePersonsRetry:
 
     @patch("posthog.dags.events_backfill_to_duckling.time.sleep")
     @patch("posthog.dags.events_backfill_to_duckling.attach_catalog")
-    @patch("posthog.dags.events_backfill_to_duckling.configure_cross_account_connection")
+    @patch(
+        "posthog.dags.events_backfill_to_duckling.configure_cross_account_connection"
+    )
     @patch("posthog.dags.events_backfill_to_duckling._connect_duckdb")
     @patch("posthog.dags.events_backfill_to_duckling.get_team_config")
-    def test_exponential_backoff(self, mock_config, mock_connect, mock_cross, mock_attach, mock_sleep):
+    def test_exponential_backoff(
+        self, mock_config, mock_connect, mock_cross, mock_attach, mock_sleep
+    ):
         mock_config.return_value = {}
         mock_catalog = MagicMock()
         mock_catalog.team_id = 1
@@ -654,13 +779,17 @@ class TestDeletePersonsRetry:
         mock_context = MagicMock()
 
         conflict_conn = MagicMock()
-        conflict_conn.execute.side_effect = duckdb.TransactionException("Transaction conflict: write-write")
+        conflict_conn.execute.side_effect = duckdb.TransactionException(
+            "Transaction conflict: write-write"
+        )
         success_conn = MagicMock()
         success_conn.execute.return_value.fetchone.return_value = (0,)
         # MAX_RETRY_ATTEMPTS=3: attempts 0,1 conflict and retry, attempt 2 succeeds
         mock_connect.side_effect = [conflict_conn, conflict_conn, success_conn]
 
-        delete_persons_partition_data(mock_context, mock_catalog, 1, datetime(2024, 1, 15))
+        delete_persons_partition_data(
+            mock_context, mock_catalog, 1, datetime(2024, 1, 15)
+        )
 
         # Backoff: min(4 * 2^attempt, 60) -> 4, 8
         assert mock_sleep.call_args_list == [
@@ -682,7 +811,13 @@ class TestFullBackfillSensorEarliestDate:
     @patch("posthog.dags.events_backfill_to_duckling.DuckLakeCatalog")
     @patch("posthog.dags.events_backfill_to_duckling.timezone")
     def test_earliest_date_clamped(
-        self, _name, earliest_dt, expected_first_month, mock_tz, mock_catalog_cls, mock_get_earliest
+        self,
+        _name,
+        earliest_dt,
+        expected_first_month,
+        mock_tz,
+        mock_catalog_cls,
+        mock_get_earliest,
     ):
         from dagster import DagsterInstance, SensorResult, build_sensor_context
 
@@ -706,7 +841,9 @@ class TestFullBackfillSensorEarliestDate:
     @patch("posthog.dags.events_backfill_to_duckling.get_earliest_event_date_for_team")
     @patch("posthog.dags.events_backfill_to_duckling.DuckLakeCatalog")
     @patch("posthog.dags.events_backfill_to_duckling.timezone")
-    def test_no_events_returns_empty(self, mock_tz, mock_catalog_cls, mock_get_earliest):
+    def test_no_events_returns_empty(
+        self, mock_tz, mock_catalog_cls, mock_get_earliest
+    ):
         from dagster import DagsterInstance, SensorResult, build_sensor_context
 
         mock_tz.now.return_value = datetime(2025, 2, 10, 12, 0, 0)
@@ -733,7 +870,11 @@ class TestGetClusterRetry:
     @patch("posthog.dags.events_backfill_to_duckling.get_cluster")
     def test_retries_on_timeout_then_succeeds(self, mock_get_cluster, mock_sleep):
         mock_cluster = MagicMock()
-        mock_get_cluster.side_effect = [TimeoutError("timed out"), TimeoutError("timed out"), mock_cluster]
+        mock_get_cluster.side_effect = [
+            TimeoutError("timed out"),
+            TimeoutError("timed out"),
+            mock_cluster,
+        ]
 
         result = _get_cluster()
 
@@ -742,7 +883,9 @@ class TestGetClusterRetry:
 
     @patch("tenacity.nap.time.sleep")
     @patch("posthog.dags.events_backfill_to_duckling.get_cluster")
-    def test_raises_non_retryable_exception_immediately(self, mock_get_cluster, mock_sleep):
+    def test_raises_non_retryable_exception_immediately(
+        self, mock_get_cluster, mock_sleep
+    ):
         mock_get_cluster.side_effect = ValueError("bad config")
 
         with pytest.raises(ValueError, match="bad config"):

--- a/posthog/dags/test_events_backfill_to_duckling.py
+++ b/posthog/dags/test_events_backfill_to_duckling.py
@@ -307,13 +307,9 @@ class TestSetTablePartitioning:
         """Verify that SET PARTITIONED BY can be called multiple times safely."""
         conn = duckdb.connect()
         conn.execute("INSTALL ducklake; LOAD ducklake;")
-        conn.execute(
-            "ATTACH ':memory:' AS test_catalog (TYPE DUCKLAKE, DATA_PATH ':memory:')"
-        )
+        conn.execute("ATTACH ':memory:' AS test_catalog (TYPE DUCKLAKE, DATA_PATH ':memory:')")
         conn.execute("CREATE SCHEMA test_catalog.posthog")
-        conn.execute(
-            "CREATE TABLE test_catalog.posthog.events (timestamp TIMESTAMP, event VARCHAR)"
-        )
+        conn.execute("CREATE TABLE test_catalog.posthog.events (timestamp TIMESTAMP, event VARCHAR)")
 
         mock_context = MagicMock()
 
@@ -356,13 +352,9 @@ class TestSetTablePartitioning:
         """Verify that successful partitioning logs appropriately."""
         conn = duckdb.connect()
         conn.execute("INSTALL ducklake; LOAD ducklake;")
-        conn.execute(
-            "ATTACH ':memory:' AS test_catalog (TYPE DUCKLAKE, DATA_PATH ':memory:')"
-        )
+        conn.execute("ATTACH ':memory:' AS test_catalog (TYPE DUCKLAKE, DATA_PATH ':memory:')")
         conn.execute("CREATE SCHEMA test_catalog.posthog")
-        conn.execute(
-            "CREATE TABLE test_catalog.posthog.events (timestamp TIMESTAMP, event VARCHAR)"
-        )
+        conn.execute("CREATE TABLE test_catalog.posthog.events (timestamp TIMESTAMP, event VARCHAR)")
 
         mock_context = MagicMock()
 
@@ -377,9 +369,7 @@ class TestSetTablePartitioning:
 
         assert result is True
         mock_context.log.info.assert_any_call("Setting partitioning on events table...")
-        mock_context.log.info.assert_any_call(
-            "Successfully set partitioning on events table"
-        )
+        mock_context.log.info.assert_any_call("Successfully set partitioning on events table")
         conn.close()
 
     def test_partitioning_handles_failure_gracefully(self):
@@ -536,9 +526,7 @@ class TestDeleteRangePredicate:
             ),
         ]
     )
-    def test_range_predicate_deletes_correct_rows(
-        self, timestamps, target_date, expected_deleted, expected_remaining
-    ):
+    def test_range_predicate_deletes_correct_rows(self, timestamps, target_date, expected_deleted, expected_remaining):
         conn = duckdb.connect()
         try:
             conn.execute("CREATE TABLE events (team_id INTEGER, timestamp TIMESTAMPTZ)")
@@ -546,9 +534,7 @@ class TestDeleteRangePredicate:
                 conn.execute("INSERT INTO events VALUES (1, ?)", [ts])
 
             date_str = target_date
-            next_date_str = (
-                datetime.strptime(target_date, "%Y-%m-%d") + timedelta(days=1)
-            ).strftime("%Y-%m-%d")
+            next_date_str = (datetime.strptime(target_date, "%Y-%m-%d") + timedelta(days=1)).strftime("%Y-%m-%d")
 
             result = conn.execute(
                 "DELETE FROM events WHERE team_id = $1 AND timestamp >= $2 AND timestamp < $3",
@@ -582,14 +568,10 @@ class TestIsTransactionConflict:
 class TestDeleteEventsRetry:
     @patch("posthog.dags.events_backfill_to_duckling.time.sleep")
     @patch("posthog.dags.events_backfill_to_duckling.attach_catalog")
-    @patch(
-        "posthog.dags.events_backfill_to_duckling.configure_cross_account_connection"
-    )
+    @patch("posthog.dags.events_backfill_to_duckling.configure_cross_account_connection")
     @patch("posthog.dags.events_backfill_to_duckling._connect_duckdb")
     @patch("posthog.dags.events_backfill_to_duckling.get_team_config")
-    def test_retries_on_transaction_conflict(
-        self, mock_config, mock_connect, mock_cross, mock_attach, mock_sleep
-    ):
+    def test_retries_on_transaction_conflict(self, mock_config, mock_connect, mock_cross, mock_attach, mock_sleep):
         mock_config.return_value = {}
         mock_catalog = MagicMock()
         mock_catalog.team_id = 1
@@ -597,16 +579,12 @@ class TestDeleteEventsRetry:
         mock_context = MagicMock()
 
         conflict_conn = MagicMock()
-        conflict_conn.execute.side_effect = duckdb.TransactionException(
-            "Transaction conflict: write-write"
-        )
+        conflict_conn.execute.side_effect = duckdb.TransactionException("Transaction conflict: write-write")
         success_conn = MagicMock()
         success_conn.execute.return_value.fetchone.return_value = (5,)
         mock_connect.side_effect = [conflict_conn, success_conn]
 
-        result = delete_events_partition_data(
-            mock_context, mock_catalog, 1, datetime(2024, 1, 15)
-        )
+        result = delete_events_partition_data(mock_context, mock_catalog, 1, datetime(2024, 1, 15))
 
         assert result == 5
         assert mock_connect.call_count == 2
@@ -616,14 +594,10 @@ class TestDeleteEventsRetry:
 
     @patch("posthog.dags.events_backfill_to_duckling.time.sleep")
     @patch("posthog.dags.events_backfill_to_duckling.attach_catalog")
-    @patch(
-        "posthog.dags.events_backfill_to_duckling.configure_cross_account_connection"
-    )
+    @patch("posthog.dags.events_backfill_to_duckling.configure_cross_account_connection")
     @patch("posthog.dags.events_backfill_to_duckling._connect_duckdb")
     @patch("posthog.dags.events_backfill_to_duckling.get_team_config")
-    def test_raises_non_conflict_exception(
-        self, mock_config, mock_connect, mock_cross, mock_attach, mock_sleep
-    ):
+    def test_raises_non_conflict_exception(self, mock_config, mock_connect, mock_cross, mock_attach, mock_sleep):
         mock_config.return_value = {}
         mock_catalog = MagicMock()
         mock_catalog.team_id = 1
@@ -635,23 +609,17 @@ class TestDeleteEventsRetry:
         mock_connect.return_value = conn
 
         with pytest.raises(RuntimeError, match="Connection failed"):
-            delete_events_partition_data(
-                mock_context, mock_catalog, 1, datetime(2024, 1, 15)
-            )
+            delete_events_partition_data(mock_context, mock_catalog, 1, datetime(2024, 1, 15))
 
         assert mock_connect.call_count == 1
         mock_sleep.assert_not_called()
 
     @patch("posthog.dags.events_backfill_to_duckling.time.sleep")
     @patch("posthog.dags.events_backfill_to_duckling.attach_catalog")
-    @patch(
-        "posthog.dags.events_backfill_to_duckling.configure_cross_account_connection"
-    )
+    @patch("posthog.dags.events_backfill_to_duckling.configure_cross_account_connection")
     @patch("posthog.dags.events_backfill_to_duckling._connect_duckdb")
     @patch("posthog.dags.events_backfill_to_duckling.get_team_config")
-    def test_raises_after_max_retries(
-        self, mock_config, mock_connect, mock_cross, mock_attach, mock_sleep
-    ):
+    def test_raises_after_max_retries(self, mock_config, mock_connect, mock_cross, mock_attach, mock_sleep):
         mock_config.return_value = {}
         mock_catalog = MagicMock()
         mock_catalog.team_id = 1
@@ -659,28 +627,20 @@ class TestDeleteEventsRetry:
         mock_context = MagicMock()
 
         conn = MagicMock()
-        conn.execute.side_effect = duckdb.TransactionException(
-            "Transaction conflict: write-write"
-        )
+        conn.execute.side_effect = duckdb.TransactionException("Transaction conflict: write-write")
         mock_connect.return_value = conn
 
         with pytest.raises(duckdb.TransactionException, match="Transaction conflict"):
-            delete_events_partition_data(
-                mock_context, mock_catalog, 1, datetime(2024, 1, 15)
-            )
+            delete_events_partition_data(mock_context, mock_catalog, 1, datetime(2024, 1, 15))
 
         assert mock_connect.call_count == MAX_RETRY_ATTEMPTS
         assert mock_sleep.call_count == MAX_RETRY_ATTEMPTS - 1
 
     @patch("posthog.dags.events_backfill_to_duckling.attach_catalog")
-    @patch(
-        "posthog.dags.events_backfill_to_duckling.configure_cross_account_connection"
-    )
+    @patch("posthog.dags.events_backfill_to_duckling.configure_cross_account_connection")
     @patch("posthog.dags.events_backfill_to_duckling._connect_duckdb")
     @patch("posthog.dags.events_backfill_to_duckling.get_team_config")
-    def test_returns_zero_on_catalog_exception(
-        self, mock_config, mock_connect, mock_cross, mock_attach
-    ):
+    def test_returns_zero_on_catalog_exception(self, mock_config, mock_connect, mock_cross, mock_attach):
         mock_config.return_value = {}
         mock_catalog = MagicMock()
         mock_catalog.team_id = 1
@@ -691,23 +651,17 @@ class TestDeleteEventsRetry:
         conn.execute.side_effect = duckdb.CatalogException("Table does not exist")
         mock_connect.return_value = conn
 
-        result = delete_events_partition_data(
-            mock_context, mock_catalog, 1, datetime(2024, 1, 15)
-        )
+        result = delete_events_partition_data(mock_context, mock_catalog, 1, datetime(2024, 1, 15))
         assert result == 0
 
 
 class TestDeletePersonsRetry:
     @patch("posthog.dags.events_backfill_to_duckling.time.sleep")
     @patch("posthog.dags.events_backfill_to_duckling.attach_catalog")
-    @patch(
-        "posthog.dags.events_backfill_to_duckling.configure_cross_account_connection"
-    )
+    @patch("posthog.dags.events_backfill_to_duckling.configure_cross_account_connection")
     @patch("posthog.dags.events_backfill_to_duckling._connect_duckdb")
     @patch("posthog.dags.events_backfill_to_duckling.get_team_config")
-    def test_retries_on_transaction_conflict(
-        self, mock_config, mock_connect, mock_cross, mock_attach, mock_sleep
-    ):
+    def test_retries_on_transaction_conflict(self, mock_config, mock_connect, mock_cross, mock_attach, mock_sleep):
         mock_config.return_value = {}
         mock_catalog = MagicMock()
         mock_catalog.team_id = 1
@@ -715,16 +669,12 @@ class TestDeletePersonsRetry:
         mock_context = MagicMock()
 
         conflict_conn = MagicMock()
-        conflict_conn.execute.side_effect = duckdb.TransactionException(
-            "Transaction conflict: write-write"
-        )
+        conflict_conn.execute.side_effect = duckdb.TransactionException("Transaction conflict: write-write")
         success_conn = MagicMock()
         success_conn.execute.return_value.fetchone.return_value = (3,)
         mock_connect.side_effect = [conflict_conn, success_conn]
 
-        result = delete_persons_partition_data(
-            mock_context, mock_catalog, 1, datetime(2024, 1, 15)
-        )
+        result = delete_persons_partition_data(mock_context, mock_catalog, 1, datetime(2024, 1, 15))
 
         assert result == 3
         assert mock_connect.call_count == 2
@@ -732,14 +682,10 @@ class TestDeletePersonsRetry:
 
     @patch("posthog.dags.events_backfill_to_duckling.time.sleep")
     @patch("posthog.dags.events_backfill_to_duckling.attach_catalog")
-    @patch(
-        "posthog.dags.events_backfill_to_duckling.configure_cross_account_connection"
-    )
+    @patch("posthog.dags.events_backfill_to_duckling.configure_cross_account_connection")
     @patch("posthog.dags.events_backfill_to_duckling._connect_duckdb")
     @patch("posthog.dags.events_backfill_to_duckling.get_team_config")
-    def test_retries_on_full_export_conflict(
-        self, mock_config, mock_connect, mock_cross, mock_attach, mock_sleep
-    ):
+    def test_retries_on_full_export_conflict(self, mock_config, mock_connect, mock_cross, mock_attach, mock_sleep):
         mock_config.return_value = {}
         mock_catalog = MagicMock()
         mock_catalog.team_id = 1
@@ -747,16 +693,12 @@ class TestDeletePersonsRetry:
         mock_context = MagicMock()
 
         conflict_conn = MagicMock()
-        conflict_conn.execute.side_effect = duckdb.TransactionException(
-            "Transaction conflict: write-write"
-        )
+        conflict_conn.execute.side_effect = duckdb.TransactionException("Transaction conflict: write-write")
         success_conn = MagicMock()
         success_conn.execute.return_value.fetchone.return_value = (10,)
         mock_connect.side_effect = [conflict_conn, success_conn]
 
-        result = delete_persons_partition_data(
-            mock_context, mock_catalog, 1, partition_date=None
-        )
+        result = delete_persons_partition_data(mock_context, mock_catalog, 1, partition_date=None)
 
         assert result == 10
         assert mock_connect.call_count == 2
@@ -764,14 +706,10 @@ class TestDeletePersonsRetry:
 
     @patch("posthog.dags.events_backfill_to_duckling.time.sleep")
     @patch("posthog.dags.events_backfill_to_duckling.attach_catalog")
-    @patch(
-        "posthog.dags.events_backfill_to_duckling.configure_cross_account_connection"
-    )
+    @patch("posthog.dags.events_backfill_to_duckling.configure_cross_account_connection")
     @patch("posthog.dags.events_backfill_to_duckling._connect_duckdb")
     @patch("posthog.dags.events_backfill_to_duckling.get_team_config")
-    def test_exponential_backoff(
-        self, mock_config, mock_connect, mock_cross, mock_attach, mock_sleep
-    ):
+    def test_exponential_backoff(self, mock_config, mock_connect, mock_cross, mock_attach, mock_sleep):
         mock_config.return_value = {}
         mock_catalog = MagicMock()
         mock_catalog.team_id = 1
@@ -779,17 +717,13 @@ class TestDeletePersonsRetry:
         mock_context = MagicMock()
 
         conflict_conn = MagicMock()
-        conflict_conn.execute.side_effect = duckdb.TransactionException(
-            "Transaction conflict: write-write"
-        )
+        conflict_conn.execute.side_effect = duckdb.TransactionException("Transaction conflict: write-write")
         success_conn = MagicMock()
         success_conn.execute.return_value.fetchone.return_value = (0,)
         # MAX_RETRY_ATTEMPTS=3: attempts 0,1 conflict and retry, attempt 2 succeeds
         mock_connect.side_effect = [conflict_conn, conflict_conn, success_conn]
 
-        delete_persons_partition_data(
-            mock_context, mock_catalog, 1, datetime(2024, 1, 15)
-        )
+        delete_persons_partition_data(mock_context, mock_catalog, 1, datetime(2024, 1, 15))
 
         # Backoff: min(4 * 2^attempt, 60) -> 4, 8
         assert mock_sleep.call_args_list == [
@@ -841,9 +775,7 @@ class TestFullBackfillSensorEarliestDate:
     @patch("posthog.dags.events_backfill_to_duckling.get_earliest_event_date_for_team")
     @patch("posthog.dags.events_backfill_to_duckling.DuckLakeCatalog")
     @patch("posthog.dags.events_backfill_to_duckling.timezone")
-    def test_no_events_returns_empty(
-        self, mock_tz, mock_catalog_cls, mock_get_earliest
-    ):
+    def test_no_events_returns_empty(self, mock_tz, mock_catalog_cls, mock_get_earliest):
         from dagster import DagsterInstance, SensorResult, build_sensor_context
 
         mock_tz.now.return_value = datetime(2025, 2, 10, 12, 0, 0)
@@ -883,9 +815,7 @@ class TestGetClusterRetry:
 
     @patch("tenacity.nap.time.sleep")
     @patch("posthog.dags.events_backfill_to_duckling.get_cluster")
-    def test_raises_non_retryable_exception_immediately(
-        self, mock_get_cluster, mock_sleep
-    ):
+    def test_raises_non_retryable_exception_immediately(self, mock_get_cluster, mock_sleep):
         mock_get_cluster.side_effect = ValueError("bad config")
 
         with pytest.raises(ValueError, match="bad config"):

--- a/posthog/dags/tests/test_events_backfill_to_ducklake.py
+++ b/posthog/dags/tests/test_events_backfill_to_ducklake.py
@@ -96,7 +96,10 @@ class TestGetS3FunctionArgs:
             "https://bucket.s3.us-east-1.amazonaws.com/path/file.parquet",
             is_local=False,
         )
-        assert args == "'https://bucket.s3.us-east-1.amazonaws.com/path/file.parquet', 'Parquet'"
+        assert (
+            args
+            == "'https://bucket.s3.us-east-1.amazonaws.com/path/file.parquet', 'Parquet'"
+        )
         assert safe_args == args
 
     def test_local_mode_redacts_credentials(self):
@@ -127,7 +130,10 @@ class TestGetPartitionWhereClause:
 
         result = get_partition_where_clause(mock_context)
 
-        assert result == "toDate(timestamp) >= '2025-01-15' AND toDate(timestamp) < '2025-01-16'"
+        assert (
+            result
+            == "toDate(timestamp) >= '2025-01-15' AND toDate(timestamp) < '2025-01-16'"
+        )
 
     def test_custom_timestamp_field(self):
         mock_context = MagicMock()
@@ -136,7 +142,10 @@ class TestGetPartitionWhereClause:
 
         result = get_partition_where_clause(mock_context, timestamp_field="created_at")
 
-        assert result == "toDate(created_at) >= '2025-01-15' AND toDate(created_at) < '2025-01-16'"
+        assert (
+            result
+            == "toDate(created_at) >= '2025-01-15' AND toDate(created_at) < '2025-01-16'"
+        )
 
 
 class TestEventsColumnsSchema:
@@ -191,5 +200,8 @@ class TestEventsColumnsSchema:
             "person_mode",
             "historical_migration",
             "_inserted_at",
+            "year",
+            "month",
+            "day",
         }
         assert EXPECTED_DUCKLAKE_COLUMNS == export_columns

--- a/posthog/dags/tests/test_events_backfill_to_ducklake.py
+++ b/posthog/dags/tests/test_events_backfill_to_ducklake.py
@@ -16,6 +16,25 @@ from posthog.dags.events_backfill_to_ducklake import (
 )
 
 
+class _NonClosingProxy:
+    """Proxy that delegates all calls to the wrapped DuckDB connection but ignores close().
+
+    DuckDB connections are C extension objects whose close() attribute is read-only,
+    so we can't patch it directly. This proxy is used in tests to prevent
+    validate_ducklake_schema's finally block from closing a connection that the
+    test still needs.
+    """
+
+    def __init__(self, conn: duckdb.DuckDBPyConnection):
+        self._conn = conn
+
+    def close(self) -> None:
+        pass
+
+    def __getattr__(self, name: str):
+        return getattr(self._conn, name)
+
+
 class TestTagsForEventsPartition:
     @parameterized.expand(
         [
@@ -217,21 +236,23 @@ class TestValidateDucklakeSchemaAddsMissingPartitionColumns:
 
         mock_context = MagicMock()
 
-        # Patch duckdb.connect to return our pre-configured connection
-        with patch("posthog.dags.events_backfill_to_ducklake.duckdb.connect", return_value=conn):
-            validate_ducklake_schema(mock_context)
+        # Use proxy so validate_ducklake_schema's finally block doesn't close our conn
+        proxy = _NonClosingProxy(conn)
+        try:
+            with patch("posthog.dags.events_backfill_to_ducklake.duckdb.connect", return_value=proxy):
+                validate_ducklake_schema(mock_context)
 
-        # Verify columns were added
-        cols = {row[0] for row in conn.execute("DESCRIBE ducklake.posthog.events").fetchall()}
-        assert {"year", "month", "day"}.issubset(cols)
+            # Verify columns were added (conn is still open)
+            cols = {row[0] for row in conn.execute("DESCRIBE ducklake.posthog.events").fetchall()}
+            assert {"year", "month", "day"}.issubset(cols)
 
-        # Verify migration was logged
-        info_messages = [str(call) for call in mock_context.log.info.call_args_list]
-        assert any("Adding missing partition column 'year'" in msg for msg in info_messages)
-        assert any("Adding missing partition column 'month'" in msg for msg in info_messages)
-        assert any("Adding missing partition column 'day'" in msg for msg in info_messages)
-
-        conn.close()
+            # Verify migration was logged
+            info_messages = [str(call) for call in mock_context.log.info.call_args_list]
+            assert any("Adding missing partition column 'year'" in msg for msg in info_messages)
+            assert any("Adding missing partition column 'month'" in msg for msg in info_messages)
+            assert any("Adding missing partition column 'day'" in msg for msg in info_messages)
+        finally:
+            conn.close()
 
     @patch("posthog.dags.events_backfill_to_ducklake.DuckLakeStorageConfig")
     @patch("posthog.dags.events_backfill_to_ducklake.get_config")
@@ -249,11 +270,13 @@ class TestValidateDucklakeSchemaAddsMissingPartitionColumns:
 
         mock_context = MagicMock()
 
-        with patch("posthog.dags.events_backfill_to_ducklake.duckdb.connect", return_value=conn):
-            validate_ducklake_schema(mock_context)
+        proxy = _NonClosingProxy(conn)
+        try:
+            with patch("posthog.dags.events_backfill_to_ducklake.duckdb.connect", return_value=proxy):
+                validate_ducklake_schema(mock_context)
 
-        # No migration messages should be logged
-        info_messages = [str(call) for call in mock_context.log.info.call_args_list]
-        assert not any("Adding missing partition column" in msg for msg in info_messages)
-
-        conn.close()
+            # No migration messages should be logged
+            info_messages = [str(call) for call in mock_context.log.info.call_args_list]
+            assert not any("Adding missing partition column" in msg for msg in info_messages)
+        finally:
+            conn.close()

--- a/posthog/dags/tests/test_events_backfill_to_ducklake.py
+++ b/posthog/dags/tests/test_events_backfill_to_ducklake.py
@@ -96,10 +96,7 @@ class TestGetS3FunctionArgs:
             "https://bucket.s3.us-east-1.amazonaws.com/path/file.parquet",
             is_local=False,
         )
-        assert (
-            args
-            == "'https://bucket.s3.us-east-1.amazonaws.com/path/file.parquet', 'Parquet'"
-        )
+        assert args == "'https://bucket.s3.us-east-1.amazonaws.com/path/file.parquet', 'Parquet'"
         assert safe_args == args
 
     def test_local_mode_redacts_credentials(self):
@@ -130,10 +127,7 @@ class TestGetPartitionWhereClause:
 
         result = get_partition_where_clause(mock_context)
 
-        assert (
-            result
-            == "toDate(timestamp) >= '2025-01-15' AND toDate(timestamp) < '2025-01-16'"
-        )
+        assert result == "toDate(timestamp) >= '2025-01-15' AND toDate(timestamp) < '2025-01-16'"
 
     def test_custom_timestamp_field(self):
         mock_context = MagicMock()
@@ -142,10 +136,7 @@ class TestGetPartitionWhereClause:
 
         result = get_partition_where_clause(mock_context, timestamp_field="created_at")
 
-        assert (
-            result
-            == "toDate(created_at) >= '2025-01-15' AND toDate(created_at) < '2025-01-16'"
-        )
+        assert result == "toDate(created_at) >= '2025-01-15' AND toDate(created_at) < '2025-01-16'"
 
 
 class TestEventsColumnsSchema:

--- a/posthog/dags/tests/test_events_backfill_to_ducklake.py
+++ b/posthog/dags/tests/test_events_backfill_to_ducklake.py
@@ -2,6 +2,7 @@ from datetime import datetime
 
 from unittest.mock import MagicMock, patch
 
+import duckdb
 from parameterized import parameterized
 
 from posthog.dags.events_backfill_to_ducklake import (
@@ -11,6 +12,7 @@ from posthog.dags.events_backfill_to_ducklake import (
     get_s3_function_args,
     get_s3_path_for_partition,
     tags_for_events_partition,
+    validate_ducklake_schema,
 )
 
 
@@ -196,3 +198,62 @@ class TestEventsColumnsSchema:
             "day",
         }
         assert EXPECTED_DUCKLAKE_COLUMNS == export_columns
+
+
+class TestValidateDucklakeSchemaAddsMissingPartitionColumns:
+    @patch("posthog.dags.events_backfill_to_ducklake.DuckLakeStorageConfig")
+    @patch("posthog.dags.events_backfill_to_ducklake.get_config")
+    @patch("posthog.dags.events_backfill_to_ducklake.configure_connection")
+    @patch("posthog.dags.events_backfill_to_ducklake.attach_catalog")
+    def test_adds_partition_columns_to_existing_table(
+        self, mock_attach, mock_configure, mock_get_config, mock_storage_cls
+    ):
+        conn = duckdb.connect()
+        conn.execute("INSTALL ducklake; LOAD ducklake;")
+        conn.execute("ATTACH ':memory:' AS ducklake (TYPE DUCKLAKE, DATA_PATH ':memory:')")
+        conn.execute("CREATE SCHEMA ducklake.posthog")
+        # Create table WITHOUT year/month/day — simulates pre-migration state
+        conn.execute("CREATE TABLE ducklake.posthog.events (uuid VARCHAR, event VARCHAR, timestamp TIMESTAMP)")
+
+        mock_context = MagicMock()
+
+        # Patch duckdb.connect to return our pre-configured connection
+        with patch("posthog.dags.events_backfill_to_ducklake.duckdb.connect", return_value=conn):
+            validate_ducklake_schema(mock_context)
+
+        # Verify columns were added
+        cols = {row[0] for row in conn.execute("DESCRIBE ducklake.posthog.events").fetchall()}
+        assert {"year", "month", "day"}.issubset(cols)
+
+        # Verify migration was logged
+        info_messages = [str(call) for call in mock_context.log.info.call_args_list]
+        assert any("Adding missing partition column 'year'" in msg for msg in info_messages)
+        assert any("Adding missing partition column 'month'" in msg for msg in info_messages)
+        assert any("Adding missing partition column 'day'" in msg for msg in info_messages)
+
+        conn.close()
+
+    @patch("posthog.dags.events_backfill_to_ducklake.DuckLakeStorageConfig")
+    @patch("posthog.dags.events_backfill_to_ducklake.get_config")
+    @patch("posthog.dags.events_backfill_to_ducklake.configure_connection")
+    @patch("posthog.dags.events_backfill_to_ducklake.attach_catalog")
+    def test_skips_migration_when_columns_exist(self, mock_attach, mock_configure, mock_get_config, mock_storage_cls):
+        conn = duckdb.connect()
+        conn.execute("INSTALL ducklake; LOAD ducklake;")
+        conn.execute("ATTACH ':memory:' AS ducklake (TYPE DUCKLAKE, DATA_PATH ':memory:')")
+        conn.execute("CREATE SCHEMA ducklake.posthog")
+        conn.execute(
+            "CREATE TABLE ducklake.posthog.events "
+            "(uuid VARCHAR, event VARCHAR, timestamp TIMESTAMP, year INTEGER, month INTEGER, day INTEGER)"
+        )
+
+        mock_context = MagicMock()
+
+        with patch("posthog.dags.events_backfill_to_ducklake.duckdb.connect", return_value=conn):
+            validate_ducklake_schema(mock_context)
+
+        # No migration messages should be logged
+        info_messages = [str(call) for call in mock_context.log.info.call_args_list]
+        assert not any("Adding missing partition column" in msg for msg in info_messages)
+
+        conn.close()

--- a/posthog/tasks/process_scheduled_changes.py
+++ b/posthog/tasks/process_scheduled_changes.py
@@ -9,7 +9,7 @@ from django.utils import timezone
 
 import structlog
 from celery import current_task
-from croniter import croniter
+from croniter import croniter  # type: ignore[import-untyped]
 from dateutil.relativedelta import relativedelta
 from prometheus_client import Counter
 

--- a/posthog/tasks/process_scheduled_changes.py
+++ b/posthog/tasks/process_scheduled_changes.py
@@ -9,7 +9,7 @@ from django.utils import timezone
 
 import structlog
 from celery import current_task
-from croniter import croniter  # type: ignore[import-untyped]
+from croniter import croniter
 from dateutil.relativedelta import relativedelta
 from prometheus_client import Counter
 


### PR DESCRIPTION
## Summary

Alternative approach to #52677 for fixing the `InvalidInputError: invalid partition value for the table configuration` error in duckling backfill.

- Add explicit `year INTEGER`, `month INTEGER`, `day INTEGER` columns to the DuckLake events table DDL
- Add `toYear(timestamp)`, `toMonth(timestamp)`, `toDayOfMonth(timestamp)` to the ClickHouse export query so Parquet files include these columns
- Change partition expression from `year(timestamp), month(timestamp), day(timestamp)` to `year, month, day` (reference explicit columns instead of expressions)
- Add `year`, `month`, `day` to `EXPECTED_DUCKLAKE_COLUMNS` for schema validation

## Tradeoffs vs #52677

This approach keeps the Hive-style `key=value` path format but has more operational burden:
- **Existing tables** need `ALTER TABLE ADD COLUMN` for `year`, `month`, `day`, or recreation with `delete_tables=True`
- ~~**Known DuckLake issue** [#791](https://github.com/duckdb/ducklake/issues/791): columns present in both the Parquet file and Hive path can cause `ducklake_add_data_files` failures~~ — **Fixed upstream** in [duckdb/ducklake#798](https://github.com/duckdb/ducklake/pull/798) (merged). DuckLake now skips partition columns found in Parquet files when using Hive paths, so having `year`/`month`/`day` in both the Parquet data and the `year=`/`month=`/`day=` path segments is safe.
- Adds redundant data (`year`/`month`/`day` are derivable from `timestamp`)

## Test plan

- [ ] Recreate duckling events table (with `delete_tables=True`) and verify backfill succeeds
- [ ] Verify partition pruning works with the new `year, month, day` column-based partitioning

🤖 Generated with [Claude Code](https://claude.com/claude-code)