### PR TITLE
chore(ph-ai): improve URL stability

### DIFF
--- a/ee/hogai/llm.py
+++ b/ee/hogai/llm.py
@@ -30,8 +30,13 @@ BILLING_SKIPPED_COUNTER = Counter(
 PROJECT_ORG_USER_CONTEXT_PROMPT = """
 You are currently in project {{{project_name}}}, which is part of the {{{organization_name}}} organization.
 The user's name appears to be {{{user_full_name}}} ({{{user_email}}}). Feel free to use their first name when greeting. DO NOT use this name if it appears possibly fake.
-All PostHog app URLs (known by domains us.posthog.com, eu.posthog.com, app.posthog.com) must use absolute paths without a domain, and omitting the `/project/:id/` prefix.
-Use Markdown, for example "Find cohorts [in the Cohorts view](/cohorts)".
+All PostHog app URLs must use relative paths without a domain (no us.posthog.com, eu.posthog.com, app.posthog.com), and omit the `/project/:id/` prefix. Never include `/-/` in URLs.
+Use Markdown with descriptive anchor text, for example "[Cohorts view](/cohorts)".
+
+Key URL patterns:
+- Settings: `/settings/<section-id>` where section IDs use hyphens, e.g. `/settings/organization-members`, `/settings/environment-replay`, `/settings/user-api-keys`
+- Data management: `/data-management/events`, `/data-management/properties`
+- Billing: `/organization/billing`
 Current time in the project's timezone, {{{project_timezone}}}: {{{project_datetime}}}.
 """.strip()
 

--- a/posthog/models/resource_transfer/test/__snapshots__/test_visitor_field_snapshots.ambr
+++ b/posthog/models/resource_transfer/test/__snapshots__/test_visitor_field_snapshots.ambr
@@ -451,6 +451,7 @@
   list([
     'DoesNotExist',
     'MultipleObjectsReturned',
+    '__annotations__',
     '__doc__',
     '__module__',
     '__repr__',


### PR DESCRIPTION
## Problem

🧵 [thread](https://posthog.slack.com/archives/C06NZEZ7V3Q/p1774859369619669)

The agent sometimes still hallucinates against URL exposure to users.
Let's tweak this for some hot paths.

## Changes

* hardened URL stability

## How did you test this code?

- [x] unit tests
- [x] local evals
