### PR TITLE
fix(ws): reduce noise from Kafka commit warnings during rebalance

### DIFF
--- a/posthog/models/resource_transfer/test/__snapshots__/test_visitor_field_snapshots.ambr
+++ b/posthog/models/resource_transfer/test/__snapshots__/test_visitor_field_snapshots.ambr
@@ -451,6 +451,7 @@
   list([
     'DoesNotExist',
     'MultipleObjectsReturned',
+    '__annotations__',
     '__doc__',
     '__module__',
     '__repr__',

--- a/posthog/temporal/data_imports/pipelines/pipeline_v3/kafka/consumer.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline_v3/kafka/consumer.py
@@ -14,6 +14,7 @@ import posthoganalytics
 from confluent_kafka import (
     Consumer as ConfluentConsumer,
     KafkaError,
+    KafkaException,
 )
 
 from posthog.exceptions_capture import capture_exception
@@ -115,8 +116,14 @@ class KafkaConsumerService:
             )
         try:
             consumer.commit(asynchronous=False)
-        except Exception:
-            logger.warning("failed_to_commit_on_revoke")
+        except KafkaException as e:
+            kafka_error = e.args[0]
+            if hasattr(kafka_error, "code") and kafka_error.code() == KafkaError._NO_OFFSET:  # type: ignore[attr-defined]
+                logger.debug("no_offsets_to_commit_on_revoke")
+            else:
+                logger.warning("failed_to_commit_on_revoke", error=str(e))
+        except Exception as e:
+            logger.warning("failed_to_commit_on_revoke", error=str(e))
 
     def _get_dlq_producer(self) -> _KafkaProducer:
         if self._dlq_producer is None:

--- a/posthog/temporal/data_imports/pipelines/pipeline_v3/kafka/test_consumer.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline_v3/kafka/test_consumer.py
@@ -126,4 +126,31 @@ class TestKafkaConsumerServiceCallbacks:
         with patch("posthog.temporal.data_imports.pipelines.pipeline_v3.kafka.consumer.logger") as mock_logger:
             service._on_revoke(mock_consumer, [])
 
-            mock_logger.warning.assert_called_once_with("failed_to_commit_on_revoke")
+            mock_logger.warning.assert_called_once_with("failed_to_commit_on_revoke", error="commit failed")
+
+    def test_on_revoke_logs_debug_on_no_offset(self):
+        from confluent_kafka import KafkaError, KafkaException
+
+        service = _make_service()
+        mock_consumer = MagicMock()
+        kafka_error = KafkaError(KafkaError._NO_OFFSET)
+        mock_consumer.commit.side_effect = KafkaException(kafka_error)
+
+        with patch("posthog.temporal.data_imports.pipelines.pipeline_v3.kafka.consumer.logger") as mock_logger:
+            service._on_revoke(mock_consumer, [])
+
+            mock_logger.debug.assert_called_once_with("no_offsets_to_commit_on_revoke")
+            mock_logger.warning.assert_not_called()
+
+    def test_on_revoke_logs_warning_on_kafka_exception(self):
+        from confluent_kafka import KafkaError, KafkaException
+
+        service = _make_service()
+        mock_consumer = MagicMock()
+        kafka_error = KafkaError(KafkaError._FAIL)
+        mock_consumer.commit.side_effect = KafkaException(kafka_error)
+
+        with patch("posthog.temporal.data_imports.pipelines.pipeline_v3.kafka.consumer.logger") as mock_logger:
+            service._on_revoke(mock_consumer, [])
+
+            mock_logger.warning.assert_called_once()

--- a/posthog/temporal/data_imports/pipelines/pipeline_v3/kafka/test_consumer.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline_v3/kafka/test_consumer.py
@@ -133,7 +133,7 @@ class TestKafkaConsumerServiceCallbacks:
 
         service = _make_service()
         mock_consumer = MagicMock()
-        kafka_error = KafkaError(KafkaError._NO_OFFSET)
+        kafka_error = KafkaError(KafkaError._NO_OFFSET)  # type: ignore[attr-defined]
         mock_consumer.commit.side_effect = KafkaException(kafka_error)
 
         with patch("posthog.temporal.data_imports.pipelines.pipeline_v3.kafka.consumer.logger") as mock_logger:
@@ -147,7 +147,7 @@ class TestKafkaConsumerServiceCallbacks:
 
         service = _make_service()
         mock_consumer = MagicMock()
-        kafka_error = KafkaError(KafkaError._FAIL)
+        kafka_error = KafkaError(KafkaError._FAIL)  # type: ignore[attr-defined]
         mock_consumer.commit.side_effect = KafkaException(kafka_error)
 
         with patch("posthog.temporal.data_imports.pipelines.pipeline_v3.kafka.consumer.logger") as mock_logger:


### PR DESCRIPTION
## Problem

These warnings fire on every Kafka rebalance even when there are simply no offsets to commit

## Changes

  * Distinguished benign `_NO_OFFSET` Kafka exceptions (logged at `debug`) from real commit failures (logged at `warning` with error details)
  * Added `KafkaException` import from `confluent_kafka`
  * Included `error=str(e)` in warning logs for diagnosability
  * Added tests for the `_NO_OFFSET` and general `KafkaException` cases

## How did you test this code?

Test pass

## Publish to changelog?

NO
