### PR TITLE
fix: insight legend now shows it can scroll

### DIFF
--- a/frontend/src/lib/components/InsightLegend/InsightLegend.tsx
+++ b/frontend/src/lib/components/InsightLegend/InsightLegend.tsx
@@ -6,6 +6,7 @@ import { useValues } from 'kea'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { trendsDataLogic } from 'scenes/trends/trendsDataLogic'
 
+import { ScrollableShadows } from '../ScrollableShadows/ScrollableShadows'
 import { InsightLegendRow } from './InsightLegendRow'
 
 export interface InsightLegendProps {
@@ -19,7 +20,8 @@ export function InsightLegend({ horizontal, inCardView, readOnly = false }: Insi
     const { indexedResults, hasLegend } = useValues(trendsDataLogic(insightProps))
 
     return hasLegend ? (
-        <div
+        <ScrollableShadows
+            direction="horizontal"
             className={clsx('InsightLegendMenu', 'flex overflow-auto border rounded', {
                 'InsightLegendMenu--horizontal': horizontal,
                 'InsightLegendMenu--readonly': readOnly,
@@ -30,6 +32,6 @@ export function InsightLegend({ horizontal, inCardView, readOnly = false }: Insi
                 {indexedResults &&
                     indexedResults.map((item) => <InsightLegendRow key={item.id} item={item} readOnly={readOnly} />)}
             </div>
-        </div>
+        </ScrollableShadows>
     ) : null
 }


### PR DESCRIPTION
## Summary
- Wraps the insight legend in a `ScrollableShadows` component with horizontal direction, replacing the plain `div` wrapper
- This adds visual scroll indicators (shadow gradients) so users can see there's more legend content to scroll to

## Test plan
- [ ] Open an insight with many series (enough to overflow the legend)
- [ ] Verify shadow indicators appear at the edges when content overflows
- [ ] Verify scrolling works as before


🤖 Generated with [Claude Code](https://claude.com/claude-code)