### PR TITLE
fix: scrollable shadows content assumes parent height

### DIFF
--- a/frontend/src/lib/components/ScrollableShadows/ScrollableShadows.tsx
+++ b/frontend/src/lib/components/ScrollableShadows/ScrollableShadows.tsx
@@ -86,7 +86,7 @@ export const ScrollableShadows = React.forwardRef<HTMLDivElement, ScrollableShad
                           : undefined
                 }
             >
-                <ScrollArea.Content className="min-w-0">{children}</ScrollArea.Content>
+                <ScrollArea.Content className="min-w-0 h-full">{children}</ScrollArea.Content>
             </ScrollArea.Viewport>
         </ScrollArea.Root>
     )


### PR DESCRIPTION
## Summary
- Adds `h-full` to `ScrollArea.Content` so the content area fills the parent height
- Fixes cases where scrollable shadow containers didn't stretch to match their parent's height

## Test plan
- [ ] Check components using `ScrollableShadows` still render correctly
- [ ] Verify content fills the available height in the parent container


🤖 Generated with [Claude Code](https://claude.com/claude-code)