### PR TITLE
fix: add horizontal padding to sidepanel recent chats

### DIFF
--- a/frontend/src/scenes/max/HistoryPreview.tsx
+++ b/frontend/src/scenes/max/HistoryPreview.tsx
@@ -23,7 +23,7 @@ export function HistoryPreview({ sidePanel = false }: HistoryPreviewProps): JSX.
     }
 
     return (
-        <div className="max-w-120 w-full self-center flex flex-col gap-2">
+        <div className="max-w-120 w-full self-center flex flex-col gap-2 px-2">
             <div className="flex items-center justify-between gap-2 -mr-2">
                 <h3 className="text-sm font-medium text-secondary mb-0">Recent chats</h3>
                 <LemonButton

--- a/frontend/src/scenes/max/HistoryPreview.tsx
+++ b/frontend/src/scenes/max/HistoryPreview.tsx
@@ -24,7 +24,7 @@ export function HistoryPreview({ sidePanel = false }: HistoryPreviewProps): JSX.
 
     return (
         <div className="max-w-120 w-full self-center flex flex-col gap-2 px-2">
-            <div className="flex items-center justify-between gap-2 -mr-2">
+            <div className="flex items-center justify-between gap-2">
                 <h3 className="text-sm font-medium text-secondary mb-0">Recent chats</h3>
                 <LemonButton
                     size="small"


### PR DESCRIPTION
## Summary
- Adds `px-2` horizontal padding to the recent chats list in `HistoryPreview` so items don't touch the edges of the sidepanel

## Test plan
- [ ] Open the sidepanel chat view with recent conversations
- [ ] Verify the recent chats list has proper horizontal padding


🤖 Generated with [Claude Code](https://claude.com/claude-code)