### PR TITLE
fix(viz): heights, scrolling shadows

### DIFF
--- a/frontend/src/lib/components/InsightLegend/InsightLegend.tsx
+++ b/frontend/src/lib/components/InsightLegend/InsightLegend.tsx
@@ -6,6 +6,7 @@ import { useValues } from 'kea'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { trendsDataLogic } from 'scenes/trends/trendsDataLogic'
 
+import { ScrollableShadows } from '../ScrollableShadows/ScrollableShadows'
 import { InsightLegendRow } from './InsightLegendRow'
 
 export interface InsightLegendProps {
@@ -19,7 +20,8 @@ export function InsightLegend({ horizontal, inCardView, readOnly = false }: Insi
     const { indexedResults, hasLegend } = useValues(trendsDataLogic(insightProps))
 
     return hasLegend ? (
-        <div
+        <ScrollableShadows
+            direction="horizontal"
             className={clsx('InsightLegendMenu', 'flex overflow-auto border rounded', {
                 'InsightLegendMenu--horizontal': horizontal,
                 'InsightLegendMenu--readonly': readOnly,
@@ -30,6 +32,6 @@ export function InsightLegend({ horizontal, inCardView, readOnly = false }: Insi
                 {indexedResults &&
                     indexedResults.map((item) => <InsightLegendRow key={item.id} item={item} readOnly={readOnly} />)}
             </div>
-        </div>
+        </ScrollableShadows>
     ) : null
 }

--- a/frontend/src/lib/components/ScrollableShadows/ScrollableShadows.tsx
+++ b/frontend/src/lib/components/ScrollableShadows/ScrollableShadows.tsx
@@ -86,7 +86,7 @@ export const ScrollableShadows = React.forwardRef<HTMLDivElement, ScrollableShad
                           : undefined
                 }
             >
-                <ScrollArea.Content className="min-w-0">{children}</ScrollArea.Content>
+                <ScrollArea.Content className="min-w-0 h-full">{children}</ScrollArea.Content>
             </ScrollArea.Viewport>
         </ScrollArea.Root>
     )

--- a/frontend/src/lib/lemon-ui/LemonMarkdown/LemonMarkdown.scss
+++ b/frontend/src/lib/lemon-ui/LemonMarkdown/LemonMarkdown.scss
@@ -85,6 +85,7 @@
 
     // Table styling - minimal approach
     table {
+        width: 100%;
         margin: 1em 0;
         overflow: auto;
         border-spacing: 0;

--- a/frontend/src/queries/nodes/DataTable/DataTable.scss
+++ b/frontend/src/queries/nodes/DataTable/DataTable.scss
@@ -50,6 +50,9 @@
 }
 
 .DataVisualizationTable {
+    border: 0;
+    border-radius: 0;
+
     th {
         max-width: 15rem;
         overflow: visible;

--- a/frontend/src/queries/nodes/InsightViz/InsightViz.scss
+++ b/frontend/src/queries/nodes/InsightViz/InsightViz.scss
@@ -70,6 +70,14 @@
             flex-direction: row;
         }
 
+        .thread & {
+            padding: 0;
+
+            .LineGraph {
+                padding: 0;
+            }
+        }
+
         .InsightVizDisplay__content__left {
             position: relative;
             display: flex;

--- a/frontend/src/scenes/max/HistoryPreview.tsx
+++ b/frontend/src/scenes/max/HistoryPreview.tsx
@@ -23,7 +23,7 @@ export function HistoryPreview({ sidePanel = false }: HistoryPreviewProps): JSX.
     }
 
     return (
-        <div className="max-w-120 w-full self-center flex flex-col gap-2">
+        <div className="max-w-120 w-full self-center flex flex-col gap-2 px-2">
             <div className="flex items-center justify-between gap-2 -mr-2">
                 <h3 className="text-sm font-medium text-secondary mb-0">Recent chats</h3>
                 <LemonButton

--- a/frontend/src/scenes/max/Thread.tsx
+++ b/frontend/src/scenes/max/Thread.tsx
@@ -133,7 +133,7 @@ export function Thread({ className }: { className?: string }): JSX.Element | nul
     return (
         <div
             className={cn(
-                '@container/thread flex flex-col items-stretch w-full max-w-180 self-center gap-1.5 grow mx-auto',
+                'thread @container/thread flex flex-col items-stretch w-full max-w-180 self-center gap-1.5 grow mx-auto',
                 className
             )}
         >

--- a/frontend/src/scenes/max/messages/VisualizationArtifactAnswer.tsx
+++ b/frontend/src/scenes/max/messages/VisualizationArtifactAnswer.tsx
@@ -26,7 +26,7 @@ import {
 import { DataVisualizationNode, InsightVizNode } from '~/queries/schema/schema-general'
 import { QueryContext } from '~/queries/types'
 import { isFunnelsQuery, isHogQLQuery, isInsightVizNode } from '~/queries/utils'
-import { InsightShortId } from '~/types'
+import { ChartDisplayType, InsightShortId } from '~/types'
 
 import { MessageStatus } from '../maxLogic'
 import { visualizationTypeToQuery } from '../utils'
@@ -91,8 +91,10 @@ export const VisualizationArtifactAnswer = React.memo(function VisualizationArti
         return visualizationTypeToQuery(content)
     }, [content])
 
-    // Get the raw query for height calculation
     const rawQuery = content.query
+    const isTableDisplay =
+        isHogQLQuery(rawQuery) ||
+        ('trendsFilter' in rawQuery && rawQuery.trendsFilter?.display === ChartDisplayType.ActionsTable)
 
     if (status !== 'completed') {
         return null
@@ -117,7 +119,12 @@ export const VisualizationArtifactAnswer = React.memo(function VisualizationArti
     return (
         <MessageTemplate type="ai" className="w-full" wrapperClassName="w-full" boxClassName="flex flex-col w-full">
             {!isCollapsed && (
-                <div className={clsx('flex flex-col overflow-auto', isFunnelsQuery(rawQuery) ? 'h-[580px]' : 'h-96')}>
+                <div
+                    className={clsx(
+                        'flex flex-col',
+                        isFunnelsQuery(rawQuery) ? 'max-h-[580px]' : isTableDisplay && 'max-h-96'
+                    )}
+                >
                     <Query query={query} readOnly embedded context={QUERY_CONTEXT_POSTHOG_AI} />
                 </div>
             )}


### PR DESCRIPTION
## Problem
Some issues i've found in viz stuff, specifically in chat interface

> Insights height fixed...
<img width="748" height="1464" alt="image" src="https://github.com/user-attachments/assets/fbb3d57f-db00-419f-b836-8a9aea13a615" />

> Legends not clear on being scrolled 

> Scroll recent chats padding X too small
<img width="389" height="753" alt="Screenshot 2026-03-30 at 12 03 14" src="https://github.com/user-attachments/assets/a8679c6a-0d3a-4403-8f29-535188651b22" />


## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
