### PR TITLE
fix: Resolve missing distinct id reference in alert flow

### DIFF
--- a/posthog/tasks/alerts/checks.py
+++ b/posthog/tasks/alerts/checks.py
@@ -1,6 +1,5 @@
 import traceback
 from collections import defaultdict
-from collections.abc import Callable
 from datetime import UTC, datetime, timedelta
 from typing import cast
 
@@ -18,7 +17,7 @@ from posthog.schema import AlertCalculationInterval, AlertState, TrendsQuery
 from posthog.clickhouse.query_tagging import tag_queries
 from posthog.errors import CH_TRANSIENT_ERRORS
 from posthog.exceptions_capture import capture_exception
-from posthog.models import AlertConfiguration, User
+from posthog.models import AlertConfiguration
 from posthog.models.alert import AlertCheck
 from posthog.ph_client import ph_scoped_capture
 from posthog.schema_migrations.upgrade_manager import upgrade_query
@@ -163,7 +162,7 @@ def check_alerts_task() -> None:
         .filter(Q(snoozed_until__isnull=True) | Q(snoozed_until__lt=now))
         .filter(insight__deleted=False)
         .order_by(F("next_check_at").asc(nulls_first=True))
-        .only("id", "team", "calculation_interval")
+        .only("id", "team", "calculation_interval", "insight_id")
     )
 
     sorted_alerts = sorted(
@@ -173,16 +172,18 @@ def check_alerts_task() -> None:
         ),
     )
 
-    grouped_by_team: defaultdict[int, list[tuple[str, int, str | None]]] = defaultdict(list)
+    grouped_by_team: defaultdict[int, list[tuple[str, int, str | None, int]]] = defaultdict(list)
     for alert in sorted_alerts:
-        grouped_by_team[alert.team_id].append((str(alert.id), alert.team_id, alert.calculation_interval))
+        grouped_by_team[alert.team_id].append(
+            (str(alert.id), alert.team_id, alert.calculation_interval, alert.insight_id)
+        )
 
     for alert_data in grouped_by_team.values():
         # We chain the task execution to prevent queries *for a single team* running at the same time
         chain(
             *(
-                check_alert_task.si(alert_id, team_id, calculation_interval).set(expires=expire_after)
-                for alert_id, team_id, calculation_interval in alert_data
+                check_alert_task.si(alert_id, team_id, calculation_interval, insight_id).set(expires=expire_after)
+                for alert_id, team_id, calculation_interval, insight_id in alert_data
             )
         )()
 
@@ -193,7 +194,9 @@ def check_alerts_task() -> None:
     expires=60 * 60,
 )
 # @limit_concurrency(5)  Concurrency controlled by CeleryQueue.ALERTS for now
-def check_alert_task(alert_id: str, team_id: int = 0, calculation_interval: str | None = None) -> None:
+def check_alert_task(
+    alert_id: str, team_id: int = 0, calculation_interval: str | None = None, insight_id: int = 0
+) -> None:
     with ph_scoped_capture() as capture_ph_event:
         with slo_operation(
             spec=SloSpec(
@@ -203,10 +206,10 @@ def check_alert_task(alert_id: str, team_id: int = 0, calculation_interval: str 
                 team_id=team_id,
                 resource_id=alert_id,
             ),
-            properties={"calculation_interval": calculation_interval},
+            properties={"calculation_interval": calculation_interval, "insight_id": insight_id},
             capture=capture_ph_event,
         ):
-            check_alert(alert_id, capture_ph_event)
+            check_alert(alert_id)
 
 
 @retry(
@@ -220,7 +223,7 @@ def check_alert_task(alert_id: str, team_id: int = 0, calculation_interval: str 
     ),
     reraise=True,
 )
-def check_alert(alert_id: str, capture_ph_event: Callable = lambda *args, **kwargs: None) -> None:
+def check_alert(alert_id: str) -> None:
     try:
         alert = AlertConfiguration.objects.select_related("insight").get(id=alert_id, enabled=True)
     except AlertConfiguration.DoesNotExist:
@@ -291,22 +294,8 @@ def check_alert(alert_id: str, capture_ph_event: Callable = lambda *args, **kwar
     alert.save()
 
     try:
-        check_alert_and_notify_atomically(alert, capture_ph_event)
+        check_alert_and_notify_atomically(alert)
     except Exception as err:
-        user = cast(User, alert.created_by)
-
-        capture_ph_event(
-            distinct_id=user.distinct_id,
-            event="alert check failed",
-            properties={
-                "alert_id": alert.id,
-                "error": f"AlertCheckError: {err}",
-                "traceback": traceback.format_exc(),
-                "insight_id": alert.insight_id,
-                "team_id": alert.team_id,
-            },
-        )
-
         logger.exception(AlertCheckException(err))
         capture_exception(
             AlertCheckException(err),
@@ -331,7 +320,7 @@ def check_alert(alert_id: str, capture_ph_event: Callable = lambda *args, **kwar
 
 
 @transaction.atomic
-def check_alert_and_notify_atomically(alert: AlertConfiguration, capture_ph_event: Callable) -> None:
+def check_alert_and_notify_atomically(alert: AlertConfiguration) -> None:
     """
     Computes insight results, checks alert for breaches and notifies user.
     Only commits updates to alert state if all of the above complete successfully.
@@ -339,19 +328,6 @@ def check_alert_and_notify_atomically(alert: AlertConfiguration, capture_ph_even
         so we can retry notification without re-computing insight.
     """
     tag_queries(alert_config_id=str(alert.id))
-    user = cast(User, alert.created_by)
-
-    # Event to count alert checks
-    capture_ph_event(
-        distinct_id=user.distinct_id,
-        event="alert check",
-        properties={
-            "alert_id": alert.id,
-            "calculation_interval": alert.calculation_interval,
-            "insight_id": alert.insight_id,
-            "team_id": alert.team_id,
-        },
-    )
 
     value = breaches = error = None
     alert_evaluation_result = None
@@ -366,19 +342,6 @@ def check_alert_and_notify_atomically(alert: AlertConfiguration, capture_ph_even
         raise
     except Exception as err:
         error_message = f"Alert id = {alert.id}, failed to evaluate"
-
-        capture_ph_event(
-            distinct_id=user.distinct_id,
-            event="alert check failed",
-            properties={
-                "alert_id": alert.id,
-                "error": error_message,
-                "traceback": traceback.format_exc(),
-                "insight_id": alert.insight_id,
-                "team_id": alert.team_id,
-            },
-        )
-
         logger.exception(error_message, exc_info=err)
         capture_exception(AlertCheckException(err))
 

--- a/posthog/tasks/alerts/test/test_alert_checks.py
+++ b/posthog/tasks/alerts/test/test_alert_checks.py
@@ -1185,14 +1185,16 @@ class TestAlertCheckSloInstrumentation(APIBaseTest, ClickhouseDestroyTablesMixin
         mock_slo_started: MagicMock,
         mock_slo_completed: MagicMock,
     ) -> None:
-        mock_check_alert.return_value = None
         mock_check_alert.side_effect = side_effect
+        insight_id = 42
 
         if side_effect is not None:
             with pytest.raises(type(side_effect)):
-                check_alert_task(self.alert_id, self.team.id, calculation_interval)
+                check_alert_task(self.alert_id, self.team.id, calculation_interval, insight_id)
         else:
-            check_alert_task(self.alert_id, self.team.id, calculation_interval)
+            check_alert_task(self.alert_id, self.team.id, calculation_interval, insight_id)
+
+        expected_base_properties = {"calculation_interval": calculation_interval, "insight_id": insight_id}
 
         mock_slo_started.assert_called_once()
         started_kwargs = mock_slo_started.call_args.kwargs
@@ -1203,7 +1205,7 @@ class TestAlertCheckSloInstrumentation(APIBaseTest, ClickhouseDestroyTablesMixin
             team_id=self.team.id,
             resource_id=self.alert_id,
         )
-        assert started_kwargs["extra_properties"] == {"calculation_interval": calculation_interval}
+        assert started_kwargs["extra_properties"] == expected_base_properties
         assert started_kwargs["capture"] is not None  # ph_scoped_capture callable
 
         mock_slo_completed.assert_called_once()
@@ -1219,6 +1221,7 @@ class TestAlertCheckSloInstrumentation(APIBaseTest, ClickhouseDestroyTablesMixin
             duration_ms=completed_kwargs["properties"].duration_ms,
         )
         assert completed_kwargs["extra_properties"]["calculation_interval"] == calculation_interval
+        assert completed_kwargs["extra_properties"]["insight_id"] == insight_id
         for key, value in (expected_error_extra or {}).items():
             assert completed_kwargs["extra_properties"][key] == value
         if side_effect is not None:


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

Whilst monitoring our [SLO dashboard](https://us.posthog.com/project/2/dashboard/1397132), I noticed that the alert checks are currently still pretty far away from our desired reliability number. Upon a closer inspection ([notebook](https://us.posthog.com/project/2/notebooks/5Ds9)), it turned out that there are less then a handful (2 in this case) alerts being very noisey. This as they try to emit events but receive an `AttributeError` when trying to fetch the distinct id.

We currently do not (yet) emit the file path from the exception (will be fixed in the PR upstack of this one); but after checking the code it looks like it originates from the fact that the user might have been deleted / removed from an organisation, whilst the alert sticks around. As a result the code tries to emit the `alert check` and `alert check failed` events, for which it needs `distinct_ids`\- this then fails and causes the failure to be logged through the SLO events.

## Changes

As we really do not need those `alert check` and `alert check failed` events anymore now that we have the slo versions, we can just remove these events; This both tackles the issue and reduces the ingestion load. Additionally, ensures that the `insight_id` is also emitted on the SLO events.

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

:white_check_mark: CI is passing

:white_check_mark: Alerts still fire correctly

![CleanShot 2026-03-30 at 14.25.10.png](https://app.graphite.com/user-attachments/assets/529eb4aa-c62a-441c-84e7-3b960882e50d.png)



👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Publish to changelog?

No

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

No

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->