### PR TITLE
fix(replay): rasterizer production hardening

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Misc stuff, should be categorized/explained in the future
 # This is sorted in ascending order, keep it that way if you wanna please
 # people's OCDs ^_^
+.cache
 .planning
 .pr-review-diff.patch
 __emails__

--- a/nodejs/src/session-replay/recording-rasterizer/__tests__/activities.test.ts
+++ b/nodejs/src/session-replay/recording-rasterizer/__tests__/activities.test.ts
@@ -141,7 +141,8 @@ describe('rasterizeRecordingActivity', () => {
             expect.any(String),
             'my-bucket',
             'exports/mp4/team-99/task-42',
-            expect.any(String)
+            expect.any(String),
+            expect.any(Function)
         )
     })
 

--- a/nodejs/src/session-replay/recording-rasterizer/__tests__/storage.test.ts
+++ b/nodejs/src/session-replay/recording-rasterizer/__tests__/storage.test.ts
@@ -1,25 +1,30 @@
 import { uploadToS3 } from '../storage'
 
-const sendMock = jest.fn().mockResolvedValue({})
+const mockDone = jest.fn().mockResolvedValue({})
+const mockOn = jest.fn()
 
-jest.mock('@aws-sdk/client-s3', () => {
-    return {
-        S3Client: jest.fn().mockImplementation(() => ({ send: sendMock })),
-        PutObjectCommand: jest.fn().mockImplementation((input) => input),
-    }
-})
+jest.mock('@aws-sdk/client-s3', () => ({
+    S3Client: jest.fn().mockImplementation(() => ({})),
+}))
+
+jest.mock('@aws-sdk/lib-storage', () => ({
+    Upload: jest.fn().mockImplementation(() => ({
+        done: mockDone,
+        on: mockOn,
+    })),
+}))
 
 jest.mock('fs', () => ({
     createReadStream: jest.fn().mockReturnValue('mock-stream'),
 }))
 
-const { PutObjectCommand } = require('@aws-sdk/client-s3')
+const { Upload } = require('@aws-sdk/lib-storage')
 const fsModule = require('fs')
 
 describe('uploadToS3', () => {
     beforeEach(() => {
         jest.clearAllMocks()
-        sendMock.mockResolvedValue({})
+        mockDone.mockResolvedValue({})
     })
 
     it('uses the provided id for the S3 key', async () => {
@@ -40,20 +45,37 @@ describe('uploadToS3', () => {
         expect(key1).toBe(key2)
     })
 
-    it('sends PutObjectCommand with correct bucket, key, content type, and file stream', async () => {
+    it('creates Upload with correct bucket, key, content type, and file stream', async () => {
         await uploadToS3('/tmp/video.mp4', 'my-bucket', 'exports/team-1', 'abc-123')
 
         expect(fsModule.createReadStream).toHaveBeenCalledWith('/tmp/video.mp4')
-        expect(PutObjectCommand).toHaveBeenCalledWith({
-            Bucket: 'my-bucket',
-            Key: 'exports/team-1/abc-123.mp4',
-            Body: 'mock-stream',
-            ContentType: 'video/mp4',
-        })
+        expect(Upload).toHaveBeenCalledWith(
+            expect.objectContaining({
+                params: {
+                    Bucket: 'my-bucket',
+                    Key: 'exports/team-1/abc-123.mp4',
+                    Body: 'mock-stream',
+                    ContentType: 'video/mp4',
+                },
+            })
+        )
     })
 
-    it('propagates S3 send errors', async () => {
-        sendMock.mockRejectedValue(new Error('AccessDenied'))
+    it('registers httpUploadProgress listener when onProgress is provided', async () => {
+        const onProgress = jest.fn()
+        await uploadToS3('/tmp/video.mp4', 'my-bucket', 'exports/team-1', 'abc-123', onProgress)
+
+        expect(mockOn).toHaveBeenCalledWith('httpUploadProgress', expect.any(Function))
+    })
+
+    it('does not register httpUploadProgress listener when onProgress is omitted', async () => {
+        await uploadToS3('/tmp/video.mp4', 'my-bucket', 'exports/team-1', 'abc-123')
+
+        expect(mockOn).not.toHaveBeenCalled()
+    })
+
+    it('propagates upload errors', async () => {
+        mockDone.mockRejectedValue(new Error('AccessDenied'))
         await expect(uploadToS3('/tmp/v.mp4', 'bucket', 'prefix', 'id')).rejects.toThrow('AccessDenied')
     })
 })

--- a/nodejs/src/session-replay/recording-rasterizer/capture/capture.ts
+++ b/nodejs/src/session-replay/recording-rasterizer/capture/capture.ts
@@ -64,8 +64,8 @@ export async function capturePlayback(
     let captureAborted: Error | null = null
     let captureAbortReject: ((err: Error) => void) | null = null
     recorder.on('captureStopped', () => {
-        log.error({ stderr: ffmpegStderr.slice(-20), frames: frameCount }, 'ffmpeg process exited unexpectedly')
-        const err = new RasterizationError('capture stopped unexpectedly (ffmpeg crashed)', true, 'CAPTURE_ABORTED')
+        log.error({ stderr: ffmpegStderr.slice(-20), frames: frameCount }, 'capture stopped unexpectedly')
+        const err = new RasterizationError('capture stopped unexpectedly', true, 'CAPTURE_ABORTED')
         captureAborted = err
         captureAbortReject?.(err)
     })

--- a/nodejs/src/session-replay/recording-rasterizer/storage.ts
+++ b/nodejs/src/session-replay/recording-rasterizer/storage.ts
@@ -1,4 +1,5 @@
-import { PutObjectCommand, S3Client } from '@aws-sdk/client-s3'
+import { S3Client } from '@aws-sdk/client-s3'
+import { Upload } from '@aws-sdk/lib-storage'
 import * as fs from 'fs'
 
 import { config } from './config'
@@ -15,17 +16,30 @@ function getS3Client(): S3Client {
     return s3Client
 }
 
-export async function uploadToS3(localPath: string, bucket: string, keyPrefix: string, id: string): Promise<string> {
+export async function uploadToS3(
+    localPath: string,
+    bucket: string,
+    keyPrefix: string,
+    id: string,
+    onProgress?: () => void
+): Promise<string> {
     const key = `${keyPrefix}/${id}.mp4`
 
-    await getS3Client().send(
-        new PutObjectCommand({
+    const upload = new Upload({
+        client: getS3Client(),
+        params: {
             Bucket: bucket,
             Key: key,
             Body: fs.createReadStream(localPath),
             ContentType: 'video/mp4',
-        })
-    )
+        },
+    })
+
+    if (onProgress) {
+        upload.on('httpUploadProgress', () => onProgress())
+    }
+
+    await upload.done()
 
     return `s3://${bucket}/${key}`
 }

--- a/nodejs/src/session-replay/recording-rasterizer/temporal/activities.ts
+++ b/nodejs/src/session-replay/recording-rasterizer/temporal/activities.ts
@@ -57,7 +57,7 @@ async function rasterizeRecordingActivity(
         const periods = computeVideoTimestamps(result.inactivity_periods)
 
         const uploadStart = process.hrtime()
-        const s3Uri = await uploadToS3(outputPath, input.s3_bucket, input.s3_key_prefix, id)
+        const s3Uri = await uploadToS3(outputPath, input.s3_bucket, input.s3_key_prefix, id, onProgress)
         timings.upload_s = elapsed(uploadStart)
         RasterizationMetrics.observeUpload('success', timings.upload_s)
 

--- a/nodejs/src/session-replay/recording-rasterizer/temporal/worker.ts
+++ b/nodejs/src/session-replay/recording-rasterizer/temporal/worker.ts
@@ -82,7 +82,7 @@ function startMetricsServer(): http.Server {
     const app = express()
     app.get(['/_health'], (_, res) => res.status(200).send('ok'))
     app.get(['/_ready'], (_, res) => res.status(ready ? 200 : 503).send(ready ? 'ok' : 'not ready'))
-    app.get(['/metrics', '/_metrics'], async (_, res) => {
+    app.get('/_metrics', async (_, res) => {
         try {
             res.set('Content-Type', prometheus.register.contentType)
             res.end(await prometheus.register.metrics())

--- a/posthog/models/resource_transfer/test/__snapshots__/test_visitor_field_snapshots.ambr
+++ b/posthog/models/resource_transfer/test/__snapshots__/test_visitor_field_snapshots.ambr
@@ -451,6 +451,7 @@
   list([
     'DoesNotExist',
     'MultipleObjectsReturned',
+    '__annotations__',
     '__doc__',
     '__module__',
     '__repr__',

--- a/posthog/temporal/session_replay/rasterize_recording/workflow.py
+++ b/posthog/temporal/session_replay/rasterize_recording/workflow.py
@@ -44,7 +44,7 @@ class RasterizeRecordingWorkflow(PostHogWorkflow):
             activity_input.model_dump(exclude_none=True),
             task_queue=settings.RASTERIZATION_TASK_QUEUE,
             start_to_close_timeout=dt.timedelta(minutes=30),
-            heartbeat_timeout=dt.timedelta(minutes=2),
+            heartbeat_timeout=dt.timedelta(seconds=30),
             retry_policy=common.RetryPolicy(maximum_attempts=2),
         )
 


### PR DESCRIPTION
## Summary

- Reduce rasterizer heartbeat timeout from 2min to 30s — stalled captures now fail fast instead of hanging until Temporal kills the activity
- Fix misleading "ffmpeg crashed" error message on `captureStopped` — the event fires for any reason (including activity cancellation), not just ffmpeg crashes
- Remove duplicate `/metrics` endpoint on the rasterizer worker, keep only `/_metrics`
- Add `.cache` to `.gitignore`

## Context

When rrweb encounters massive DOM mutation storms (3k-5k node adds in a single mutation), `HeadlessExperimental.beginFrame` hangs indefinitely. No frames are produced, no heartbeats are sent, and the activity previously waited 2 full minutes before Temporal killed it. 30s is generous — normal frame production heartbeats every ~0.4s.

## Test plan

- [x] Verify rasterizer tests pass
- [ ] Deploy and confirm stalled sessions fail within ~30s instead of ~2min
- [ ] Confirm metrics are still scraped on `/_metrics`