### PR TITLE
feat(phai): results formatter for stickiness query

### DIFF
--- a/ee/hogai/context/insight/format/__init__.py
+++ b/ee/hogai/context/insight/format/__init__.py
@@ -7,6 +7,7 @@ from posthog.schema import (
     AssistantFunnelsQuery,
     AssistantHogQLQuery,
     AssistantRetentionQuery,
+    AssistantStickinessQuery,
     AssistantTrendsQuery,
     FunnelsQuery,
     HogQLQuery,
@@ -15,6 +16,7 @@ from posthog.schema import (
     RevenueAnalyticsMetricsQuery,
     RevenueAnalyticsMRRQuery,
     RevenueAnalyticsTopCustomersQuery,
+    StickinessQuery,
     TrendsQuery,
 )
 
@@ -27,6 +29,7 @@ from .revenue_analytics import (
     RevenueAnalyticsTopCustomersResultsFormatter,
 )
 from .sql import TRUNCATED_MARKER, SQLResultsFormatter
+from .stickiness import StickinessResultsFormatter
 from .trends import TrendsResultsFormatter
 
 if TYPE_CHECKING:
@@ -52,6 +55,8 @@ def format_query_results_for_llm(
         return TrendsResultsFormatter(query, response["results"]).format()
     elif isinstance(query, AssistantFunnelsQuery | FunnelsQuery):
         return FunnelResultsFormatter(query, response["results"], team, utc_now).format()
+    elif isinstance(query, AssistantStickinessQuery | StickinessQuery):
+        return StickinessResultsFormatter(query, response["results"]).format()
     elif isinstance(query, AssistantRetentionQuery | RetentionQuery):
         return RetentionResultsFormatter(query, response["results"]).format()
     elif isinstance(query, AssistantHogQLQuery | HogQLQuery):
@@ -72,6 +77,7 @@ __all__ = [
     "FunnelResultsFormatter",
     "RetentionResultsFormatter",
     "SQLResultsFormatter",
+    "StickinessResultsFormatter",
     "TrendsResultsFormatter",
     "RevenueAnalyticsGrossRevenueResultsFormatter",
     "RevenueAnalyticsMetricsResultsFormatter",

--- a/ee/hogai/context/insight/format/stickiness.py
+++ b/ee/hogai/context/insight/format/stickiness.py
@@ -1,0 +1,75 @@
+from typing import Any
+
+from posthog.schema import AssistantStickinessQuery, Compare, StickinessQuery
+
+from .utils import format_matrix, format_number
+
+
+class StickinessResultsFormatter:
+    """
+    Compresses and formats stickiness results into a LLM-friendly string.
+
+    Single/Multiple series:
+    ```
+    Interval|Series Label 1|Series Label 2
+    1 day|value1|value2
+    2 days|value1|value2
+    ```
+    """
+
+    def __init__(
+        self,
+        query: AssistantStickinessQuery | StickinessQuery,
+        results: list[dict[str, Any]],
+    ):
+        self._query = query
+        self._results = results
+
+    def format(self) -> str:
+        results = self._results
+        if len(results) == 0:
+            return "No data recorded for this time period."
+
+        current = []
+        previous = []
+
+        for result in results:
+            if result.get("compare_label") == Compare.CURRENT or result.get("compare_label") == "current":
+                current.append(result)
+            elif result.get("compare_label") == Compare.PREVIOUS or result.get("compare_label") == "previous":
+                previous.append(result)
+
+        if len(previous) > 0 and len(current) > 0:
+            return f"Previous period:\n{self._format_results(previous)}\n\nCurrent period:\n{self._format_results(current)}"
+
+        return self._format_results(results)
+
+    def _format_results(self, results: list[dict[str, Any]]) -> str:
+        result = results[0]
+        days = result["days"]
+        labels = result["labels"]
+
+        series_labels = []
+        for series in results:
+            series_labels.append(self._extract_series_label(series))
+
+        matrix: list[list[str]] = []
+        header = ["Interval", *series_labels]
+        matrix.append(header)
+
+        for i, _day in enumerate(days):
+            row = [labels[i]]
+            for series in results:
+                row.append(format_number(series["data"][i]))
+            matrix.append(row)
+
+        return format_matrix(matrix)
+
+    def _extract_series_label(self, series: dict[str, Any]) -> str:
+        action = series.get("action")
+        name = series["label"]
+        if isinstance(action, dict):
+            custom_name = action.get("custom_name")
+            if custom_name is not None:
+                name = custom_name
+        return name

--- a/ee/hogai/context/insight/format/test/test_stickiness.py
+++ b/ee/hogai/context/insight/format/test/test_stickiness.py
@@ -1,0 +1,160 @@
+from posthog.test.base import BaseTest
+
+from posthog.schema import AssistantStickinessQuery
+
+from .. import StickinessResultsFormatter
+
+
+class TestStickinessResultsFormatter(BaseTest):
+    def test_stickiness_single_series(self):
+        results = [
+            {
+                "count": 500,
+                "data": [200, 150, 100, 50],
+                "days": [1, 2, 3, 4],
+                "labels": ["1 day", "2 days", "3 days", "4 days"],
+                "label": "$pageview",
+                "action": {
+                    "order": 0,
+                    "type": "events",
+                    "name": "$pageview",
+                    "id": "$pageview",
+                    "custom_name": None,
+                },
+            }
+        ]
+
+        self.assertEqual(
+            StickinessResultsFormatter(AssistantStickinessQuery(series=[]), results).format(),
+            "Interval|$pageview\n1 day|200\n2 days|150\n3 days|100\n4 days|50",
+        )
+
+    def test_stickiness_multiple_series(self):
+        results = [
+            {
+                "count": 500,
+                "data": [200, 150, 100],
+                "days": [1, 2, 3],
+                "labels": ["1 day", "2 days", "3 days"],
+                "label": "$pageview",
+                "action": {
+                    "order": 0,
+                    "type": "events",
+                    "name": "$pageview",
+                    "id": "$pageview",
+                    "custom_name": None,
+                },
+            },
+            {
+                "count": 300,
+                "data": [100, 120, 80],
+                "days": [1, 2, 3],
+                "labels": ["1 day", "2 days", "3 days"],
+                "label": "signup",
+                "action": {
+                    "order": 1,
+                    "type": "events",
+                    "name": "signup",
+                    "id": "signup",
+                    "custom_name": None,
+                },
+            },
+        ]
+
+        self.assertEqual(
+            StickinessResultsFormatter(AssistantStickinessQuery(series=[]), results).format(),
+            "Interval|$pageview|signup\n1 day|200|100\n2 days|150|120\n3 days|100|80",
+        )
+
+    def test_stickiness_comparison(self):
+        results = [
+            {
+                "count": 400,
+                "data": [200, 150, 50],
+                "days": [1, 2, 3],
+                "labels": ["1 day", "2 days", "3 days"],
+                "label": "$pageview",
+                "compare": True,
+                "compare_label": "previous",
+                "action": {
+                    "order": 0,
+                    "type": "events",
+                    "name": "$pageview",
+                    "id": "$pageview",
+                    "custom_name": None,
+                },
+            },
+            {
+                "count": 500,
+                "data": [250, 150, 100],
+                "days": [1, 2, 3],
+                "labels": ["1 day", "2 days", "3 days"],
+                "label": "$pageview",
+                "compare": True,
+                "compare_label": "current",
+                "action": {
+                    "order": 0,
+                    "type": "events",
+                    "name": "$pageview",
+                    "id": "$pageview",
+                    "custom_name": None,
+                },
+            },
+        ]
+
+        self.assertEqual(
+            StickinessResultsFormatter(AssistantStickinessQuery(series=[]), results).format(),
+            "Previous period:\nInterval|$pageview\n1 day|200\n2 days|150\n3 days|50\n\nCurrent period:\nInterval|$pageview\n1 day|250\n2 days|150\n3 days|100",
+        )
+
+    def test_stickiness_empty_results(self):
+        self.assertEqual(
+            StickinessResultsFormatter(AssistantStickinessQuery(series=[]), []).format(),
+            "No data recorded for this time period.",
+        )
+
+    def test_stickiness_custom_name(self):
+        results = [
+            {
+                "count": 300,
+                "data": [100, 120, 80],
+                "days": [1, 2, 3],
+                "labels": ["1 day", "2 days", "3 days"],
+                "label": "$pageview",
+                "action": {
+                    "order": 0,
+                    "type": "events",
+                    "name": "$pageview",
+                    "id": "$pageview",
+                    "custom_name": "Page Views",
+                },
+            }
+        ]
+
+        self.assertEqual(
+            StickinessResultsFormatter(AssistantStickinessQuery(series=[]), results).format(),
+            "Interval|Page Views\n1 day|100\n2 days|120\n3 days|80",
+        )
+
+    def test_stickiness_cumulative_labels(self):
+        results = [
+            {
+                "count": 500,
+                "data": [500, 300, 150],
+                "days": [1, 2, 3],
+                "labels": ["1 day or more", "2 days or more", "3 days or more"],
+                "label": "$pageview",
+                "action": {
+                    "order": 0,
+                    "type": "events",
+                    "name": "$pageview",
+                    "id": "$pageview",
+                    "custom_name": None,
+                },
+            }
+        ]
+
+        self.assertEqual(
+            StickinessResultsFormatter(AssistantStickinessQuery(series=[]), results).format(),
+            "Interval|$pageview\n1 day or more|500\n2 days or more|300\n3 days or more|150",
+        )


### PR DESCRIPTION
## Problem

The HogAI context system needs to format stickiness query results into a human-readable format suitable for LLM consumption. Currently, there is no formatter for stickiness insights, leaving a gap in the insight formatting pipeline.

<img width="1048" height="802" alt="Screenshot 2026-03-30 at 16 02 29" src="https://github.com/user-attachments/assets/5ea37068-8633-46f0-b752-f8449e868266" />


## Changes

Added a new `StickinessResultsFormatter` class that:
- Formats stickiness query results into a pipe-delimited table format
- Supports single and multiple series visualization
- Handles comparison periods (previous vs current)
- Respects custom action names when available
- Returns a user-friendly message for empty result sets
- Integrates with the existing `format_query_results_for_llm` function to handle both `AssistantStickinessQuery` and `StickinessQuery` types

The formatter produces output like:
```
Interval|Series Label 1|Series Label 2
1 day|value1|value2
2 days|value1|value2
```

For comparisons, it separates periods with headers:
```
Previous period:
Interval|Series Label
...

Current period:
Interval|Series Label
...
```

## How did you test this code?

Added comprehensive unit tests covering:
- Single series formatting
- Multiple series formatting
- Comparison period handling
- Empty result sets
- Custom action names
- Cumulative interval labels

All tests pass and validate the formatter produces correctly formatted output for various stickiness query scenarios.

## Publish to changelog?

No

https://claude.ai/code/session_01VTKSUG7zLKQoeutDzgwAWQ