### PR TITLE
feat(sql): show nulls as zero in breakdowns

### DIFF
--- a/frontend/src/queries/nodes/DataVisualization/Components/Charts/LineGraph.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Charts/LineGraph.tsx
@@ -110,7 +110,7 @@ const getYAxisSettings = (
 
 export type LineGraphProps = {
     xData: AxisSeries<string> | null
-    yData: AxisSeries<number | null>[] | AxisBreakdownSeries<number>[]
+    yData: AxisSeries<number | null>[] | AxisBreakdownSeries<number | null>[]
     visualizationType: ChartDisplayType
     chartSettings: ChartSettings
     presetChartHeight?: boolean

--- a/frontend/src/queries/nodes/DataVisualization/Components/SeriesTab.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/SeriesTab.tsx
@@ -505,7 +505,13 @@ export const SeriesBreakdownSelector = (): JSX.Element => {
     )
 }
 
-const BreakdownSeries = ({ series, index }: { series: AxisBreakdownSeries<number>; index: number }): JSX.Element => {
+const BreakdownSeries = ({
+    series,
+    index,
+}: {
+    series: AxisBreakdownSeries<number | null>
+    index: number
+}): JSX.Element => {
     const seriesColor = series.settings?.display?.color ?? getSeriesColor(index)
 
     return (

--- a/frontend/src/queries/nodes/DataVisualization/Components/seriesBreakdownLogic.test.ts
+++ b/frontend/src/queries/nodes/DataVisualization/Components/seriesBreakdownLogic.test.ts
@@ -12,7 +12,7 @@ import { seriesBreakdownLogic } from './seriesBreakdownLogic'
 
 const testUniqueKey = 'testUniqueKey'
 
-const initialQuery: DataVisualizationNode = {
+const makeInitialQuery = (): DataVisualizationNode => ({
     kind: NodeKind.DataVisualizationNode,
     source: {
         kind: NodeKind.HogQLQuery,
@@ -51,12 +51,12 @@ const initialQuery: DataVisualizationNode = {
         conditionalFormatting: [],
     },
     chartSettings: { goalLines: undefined },
-}
+})
 
 // globalQuery represents the query object that is passed into the data
 // visualization logic and series breakdown logic it is modified by calls to
 // setQuery so we want to ensure this is updated correctly
-let globalQuery: DataVisualizationNode = { ...initialQuery }
+let globalQuery: DataVisualizationNode = makeInitialQuery()
 
 const dummyDataVisualizationLogicProps: DataVisualizationLogicProps = {
     key: testUniqueKey,
@@ -97,7 +97,8 @@ describe('seriesBreakdownLogic', () => {
         featureFlagLogic.mount()
 
         // ensure we reset the globalQuery state before each test
-        globalQuery = { ...initialQuery }
+        globalQuery = makeInitialQuery()
+        dummyDataVisualizationLogicProps.query = globalQuery
 
         builtDataVizLogic = dataVisualizationLogic(dummyDataVisualizationLogicProps)
         builtDataVizLogic.mount()
@@ -118,7 +119,7 @@ describe('seriesBreakdownLogic', () => {
         })
 
         expect(globalQuery).toEqual({
-            ...initialQuery,
+            ...makeInitialQuery(),
             chartSettings: {
                 goalLines: undefined,
                 seriesBreakdownColumn: undefined,
@@ -142,7 +143,7 @@ describe('seriesBreakdownLogic', () => {
         })
 
         expect(globalQuery).toEqual({
-            ...initialQuery,
+            ...makeInitialQuery(),
             chartSettings: {
                 goalLines: undefined,
                 seriesBreakdownColumn: undefined,
@@ -162,7 +163,7 @@ describe('seriesBreakdownLogic', () => {
         })
 
         expect(globalQuery).toEqual({
-            ...initialQuery,
+            ...makeInitialQuery(),
             chartSettings: {
                 goalLines: undefined,
                 seriesBreakdownColumn: 'test_column',
@@ -171,13 +172,17 @@ describe('seriesBreakdownLogic', () => {
     })
 
     it('adds a series breakdown after mount if one already selected in query', async () => {
-        builtDataVizLogic.actions.setQuery((query) => ({
-            ...query,
+        builtDataVizLogic.unmount()
+        globalQuery = {
+            ...makeInitialQuery(),
             chartSettings: {
                 goalLines: undefined,
                 seriesBreakdownColumn: 'test_column',
             },
-        }))
+        }
+        dummyDataVisualizationLogicProps.query = globalQuery
+        builtDataVizLogic = dataVisualizationLogic(dummyDataVisualizationLogicProps)
+        builtDataVizLogic.mount()
 
         logic = seriesBreakdownLogic({ key: testUniqueKey })
         logic.mount()
@@ -188,7 +193,7 @@ describe('seriesBreakdownLogic', () => {
         })
 
         expect(globalQuery).toEqual({
-            ...initialQuery,
+            ...makeInitialQuery(),
             chartSettings: {
                 goalLines: undefined,
                 seriesBreakdownColumn: 'test_column',
@@ -209,7 +214,7 @@ describe('seriesBreakdownLogic', () => {
         })
 
         expect(globalQuery).toEqual({
-            ...initialQuery,
+            ...makeInitialQuery(),
             chartSettings: {
                 goalLines: undefined,
                 seriesBreakdownColumn: undefined,
@@ -230,7 +235,7 @@ describe('seriesBreakdownLogic', () => {
         })
 
         expect(globalQuery).toEqual({
-            ...initialQuery,
+            ...makeInitialQuery(),
             tableSettings: {
                 columns: [],
                 conditionalFormatting: [],
@@ -273,6 +278,7 @@ describe('seriesBreakdownLogic', () => {
             ],
         })
 
+        builtDataVizLogic.actions.clearAxis()
         builtDataVizLogic.actions.updateXSeries('event')
         builtDataVizLogic.actions.addYSeries('total_count')
 
@@ -310,6 +316,133 @@ describe('seriesBreakdownLogic', () => {
                     {
                         name: 'Chrome',
                         data: [59, 173, 2218],
+                        settings: {
+                            formatting: { prefix: '', suffix: '' },
+                            display: { displayType: undefined, yAxisPosition: undefined },
+                        },
+                    },
+                ],
+                isUnaggregated: false,
+            },
+        })
+    })
+
+    it('preserves missing breakdown buckets as null when showNullsAsZero is disabled', async () => {
+        logic = seriesBreakdownLogic({ key: testUniqueKey })
+        logic.mount()
+
+        const builtDataNodeLogic = dataNodeLogic({
+            key: testUniqueKey,
+            query: globalQuery.source,
+        })
+        builtDataNodeLogic.mount()
+        builtDataNodeLogic.actions.setResponse({
+            results: [
+                ['signed_up', 'Safari', 11],
+                ['logged_out', 'Safari', 32],
+                ['downloaded_file', 'Firefox', 820],
+            ],
+            columns: ['event', 'browser', 'total_count'],
+            types: [
+                ['event', 'String'],
+                ['browser', 'Nullable(String)'],
+                ['total_count', 'Nullable(UInt64)'],
+            ],
+        })
+
+        builtDataVizLogic.actions.clearAxis()
+        builtDataVizLogic.actions.updateXSeries('event')
+        builtDataVizLogic.actions.addYSeries('total_count')
+
+        logic.actions.addSeriesBreakdown('browser')
+
+        await expectLogic(logic).toMatchValues({
+            seriesBreakdownData: {
+                xData: {
+                    column: {
+                        name: 'event',
+                        type: { name: 'STRING', isNumerical: false },
+                        label: 'event - String',
+                        dataIndex: 0,
+                    },
+                    data: ['signed_up', 'logged_out', 'downloaded_file'],
+                },
+                seriesData: [
+                    {
+                        name: 'Safari',
+                        data: [11, 32, null],
+                        settings: {
+                            formatting: { prefix: '', suffix: '' },
+                            display: { displayType: undefined, yAxisPosition: undefined },
+                        },
+                    },
+                    {
+                        name: 'Firefox',
+                        data: [null, null, 820],
+                        settings: {
+                            formatting: { prefix: '', suffix: '' },
+                            display: { displayType: undefined, yAxisPosition: undefined },
+                        },
+                    },
+                ],
+                isUnaggregated: false,
+            },
+        })
+    })
+
+    it('renders breakdown nulls as zero when showNullsAsZero is enabled', async () => {
+        logic = seriesBreakdownLogic({ key: testUniqueKey })
+        logic.mount()
+
+        const builtDataNodeLogic = dataNodeLogic({
+            key: testUniqueKey,
+            query: globalQuery.source,
+        })
+        builtDataNodeLogic.mount()
+        builtDataNodeLogic.actions.setResponse({
+            results: [
+                ['signed_up', 'Safari', null],
+                ['logged_out', 'Safari', 32],
+                ['downloaded_file', 'Firefox', 820],
+            ],
+            columns: ['event', 'browser', 'total_count'],
+            types: [
+                ['event', 'String'],
+                ['browser', 'Nullable(String)'],
+                ['total_count', 'Nullable(UInt64)'],
+            ],
+        })
+
+        builtDataVizLogic.actions.updateChartSettings({ showNullsAsZero: true })
+        builtDataVizLogic.actions.clearAxis()
+        builtDataVizLogic.actions.updateXSeries('event')
+        builtDataVizLogic.actions.addYSeries('total_count')
+
+        logic.actions.addSeriesBreakdown('browser')
+
+        await expectLogic(logic).toMatchValues({
+            seriesBreakdownData: {
+                xData: {
+                    column: {
+                        name: 'event',
+                        type: { name: 'STRING', isNumerical: false },
+                        label: 'event - String',
+                        dataIndex: 0,
+                    },
+                    data: ['signed_up', 'logged_out', 'downloaded_file'],
+                },
+                seriesData: [
+                    {
+                        name: 'Safari',
+                        data: [0, 32, 0],
+                        settings: {
+                            formatting: { prefix: '', suffix: '' },
+                            display: { displayType: undefined, yAxisPosition: undefined },
+                        },
+                    },
+                    {
+                        name: 'Firefox',
+                        data: [0, 0, 820],
                         settings: {
                             formatting: { prefix: '', suffix: '' },
                             display: { displayType: undefined, yAxisPosition: undefined },

--- a/frontend/src/queries/nodes/DataVisualization/Components/seriesBreakdownLogic.ts
+++ b/frontend/src/queries/nodes/DataVisualization/Components/seriesBreakdownLogic.ts
@@ -16,7 +16,7 @@ export interface BreakdownSeriesData<T> {
     error?: string
 }
 
-export const EmptyBreakdownSeries: BreakdownSeriesData<number> = {
+export const EmptyBreakdownSeries: BreakdownSeriesData<number | null> = {
     xData: {
         column: {
             name: 'None',
@@ -32,10 +32,34 @@ export const EmptyBreakdownSeries: BreakdownSeriesData<number> = {
     seriesData: [],
 }
 
-const createEmptyBreakdownSeriesWithError = (error: string): BreakdownSeriesData<number> => {
+const createEmptyBreakdownSeriesWithError = (error: string): BreakdownSeriesData<number | null> => {
     return {
         ...EmptyBreakdownSeries,
         error,
+    }
+}
+
+const parseBreakdownSeriesValue = (value: unknown, selectedYAxis: SelectedYAxis): number | null => {
+    if (value === undefined || value === null || Number.isNaN(value)) {
+        return null
+    }
+
+    try {
+        const multiplier = selectedYAxis.settings.formatting?.style === 'percent' ? 100 : 1
+
+        if (selectedYAxis.settings.formatting?.decimalPlaces) {
+            const parsed = parseFloat(
+                (parseFloat(String(value)) * multiplier).toFixed(selectedYAxis.settings.formatting.decimalPlaces)
+            )
+            return Number.isNaN(parsed) ? null : parsed
+        }
+
+        const parsed = Number.isInteger(value)
+            ? parseInt(String(value), 10) * multiplier
+            : parseFloat(String(value)) * multiplier
+        return Number.isNaN(parsed) ? null : parsed
+    } catch {
+        return null
     }
 }
 
@@ -49,7 +73,10 @@ export const seriesBreakdownLogic = kea<seriesBreakdownLogicType>([
     props({ key: '' } as SeriesBreakdownLogicProps),
     connect(() => ({
         actions: [dataVisualizationLogic, ['clearAxis', 'setQuery']],
-        values: [dataVisualizationLogic, ['query', 'response', 'columns', 'selectedXAxis', 'selectedYAxis']],
+        values: [
+            dataVisualizationLogic,
+            ['query', 'response', 'columns', 'selectedXAxis', 'selectedYAxis', 'chartSettings'],
+        ],
     })),
     actions(({ values }) => ({
         addSeriesBreakdown: (columnName: string | null) => ({ columnName, response: values.response }),
@@ -92,6 +119,7 @@ export const seriesBreakdownLogic = kea<seriesBreakdownLogicType>([
                 s.selectedXAxis,
                 s.response,
                 s.columns,
+                s.chartSettings,
             ],
             (
                 selectedBreakdownColumn,
@@ -99,8 +127,9 @@ export const seriesBreakdownLogic = kea<seriesBreakdownLogicType>([
                 ySeries,
                 xSeries,
                 response,
-                columns
-            ): BreakdownSeriesData<number> => {
+                columns,
+                chartSettings
+            ): BreakdownSeriesData<number | null> => {
                 if (
                     !response ||
                     !selectedBreakdownColumn ||
@@ -145,14 +174,15 @@ export const seriesBreakdownLogic = kea<seriesBreakdownLogicType>([
                 let isUnaggregated = false
 
                 const multipleYSeries = yAxis.length > 1
+                const showNullsAsZero = chartSettings.showNullsAsZero ?? false
 
-                const seriesData: AxisBreakdownSeries<number>[] = yAxis.flatMap((selectedYAxis) => {
+                const seriesData: AxisBreakdownSeries<number | null>[] = yAxis.flatMap((selectedYAxis) => {
                     const yColumn = columns.find((n) => n.name === selectedYAxis.name)
                     if (!yColumn) {
                         return []
                     }
 
-                    return breakdownColumnValues.map<AxisBreakdownSeries<number>>((value) => {
+                    return breakdownColumnValues.map<AxisBreakdownSeries<number | null>>((value) => {
                         const seriesName = multipleYSeries
                             ? `${selectedYAxis.name} - ${value || '[No value]'}`
                             : value || '[No value]'
@@ -176,32 +206,19 @@ export const seriesBreakdownLogic = kea<seriesBreakdownLogicType>([
                             }
                         }
 
-                        // sum y values for each x value, setting to 0 if no corresponding y value
+                        // Missing buckets should remain null unless the chart explicitly
+                        // requests zero-filling, matching the non-breakdown series path.
                         const dataset = xData.map((xValue) => {
-                            const yValue = filteredData
+                            const numericValues = filteredData
                                 .filter((n) => n[xColumn.dataIndex] === xValue)
-                                .map((n) => {
-                                    try {
-                                        const value = n[yColumn.dataIndex]
-                                        const multiplier =
-                                            selectedYAxis.settings.formatting?.style === 'percent' ? 100 : 1
+                                .map((n) => parseBreakdownSeriesValue(n[yColumn.dataIndex], selectedYAxis))
+                                .filter((value): value is number => value !== null)
 
-                                        if (selectedYAxis.settings.formatting?.decimalPlaces) {
-                                            return parseFloat(
-                                                (parseFloat(value) * multiplier).toFixed(
-                                                    selectedYAxis.settings.formatting.decimalPlaces
-                                                )
-                                            )
-                                        }
+                            if (numericValues.length === 0) {
+                                return showNullsAsZero ? 0 : null
+                            }
 
-                                        const isInt = Number.isInteger(value)
-                                        return isInt ? parseInt(value) * multiplier : parseFloat(value) * multiplier
-                                    } catch {
-                                        return 0
-                                    }
-                                })
-                                .reduce((a, b) => a + b, 0)
-                            return yValue
+                            return numericValues.reduce((a, b) => a + b, 0)
                         })
 
                         return {


### PR DESCRIPTION
## Problem

The "nulls as zeros" toggle didn't work in the SQL editor when you had a breakdown

## Changes

Works now:

![2026-03-30 14 47 53](https://github.com/user-attachments/assets/dbcd965f-7d8e-49a7-baf0-2dcfebe9b0a0)

## How did you test this code?

In the UI with this query

```sql
WITH base AS (
    SELECT
        i,
        CASE CAST(floor(random() * 4) AS BIGINT)
            WHEN 0 THEN 'A'
            WHEN 1 THEN 'B'
            WHEN 2 THEN 'C'
            ELSE 'D'
        END AS breakdown,
        'id_' || CAST(floor(random() * 100) AS BIGINT) AS x_id,
        random() AS r
    FROM range(100) t(i)
)
SELECT
    breakdown,
    x_id,
    CASE
        WHEN r < 1.0 / 3 THEN NULL
        ELSE round(r * 100, 2)
    END AS y_value
FROM base;
```

Added jest tests as well.

## Publish to changelog?

nah

## Docs update

nah