### PR TITLE
fix(endpoints): remove date formatting from endpoints usage trends

### DIFF
--- a/products/endpoints/frontend/nodes/EndpointsUsageTrendsNode.tsx
+++ b/products/endpoints/frontend/nodes/EndpointsUsageTrendsNode.tsx
@@ -190,7 +190,7 @@ function transformDataForLineGraph(
                     label: 'Date',
                     dataIndex: 0,
                 },
-                data: dates.map(formatDate),
+                data: dates,
             },
             yData: breakdowns.map((breakdown, index) => {
                 const breakdownValues = dates.map((date) => dateGroups[date][breakdown] || 0)
@@ -225,7 +225,7 @@ function transformDataForLineGraph(
                 label: 'Date',
                 dataIndex: 0,
             },
-            data: results.map((r) => formatDate(r.date)),
+            data: results.map((r) => r.date),
         },
         yData: [
             {
@@ -239,15 +239,6 @@ function transformDataForLineGraph(
                 settings,
             },
         ],
-    }
-}
-
-function formatDate(dateStr: string): string {
-    try {
-        const date = new Date(dateStr)
-        return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
-    } catch {
-        return dateStr
     }
 }
 


### PR DESCRIPTION
## Problem

when split hourly - the Endpoints Usage tab was showing some weird stuff. we don't need to date format

## Changes

- Removed the `formatDate` function that was converting date strings to localized format (e.g., "Jan 1")
- Updated two call sites in `transformDataForLineGraph` to pass raw date strings instead of formatted dates:
  - Line 193: Changed `dates.map(formatDate)` to `dates`
  - Line 228: Changed `results.map((r) => formatDate(r.date))` to `results.map((r) => r.date)`

This change delegates date formatting responsibility elsewhere in the component hierarchy, likely to the charting library or a parent component.

## How did you test this code?
- locally

## Docs update

No documentation updates needed.
