### PR TITLE
fix(experiments): Truncate long metric names in timeseries modal title

### DIFF
--- a/frontend/src/scenes/experiments/MetricsView/new/TimeseriesModal.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/TimeseriesModal.tsx
@@ -77,16 +77,16 @@ export function TimeseriesModal({
             onClose={onClose}
             width={1000}
             title={
-                <div className="flex items-center gap-2 text-sm">
-                    <div className="flex items-center">
+                <div className="flex items-center gap-2 text-sm min-w-0">
+                    <div className="flex items-center shrink-0">
                         <span>Time series</span>
                     </div>
-                    <LemonDivider vertical className="h-4 self-stretch" />
-                    <div className="flex items-center">
+                    <LemonDivider vertical className="h-4 self-stretch shrink-0" />
+                    <div className="min-w-0 [&_span]:!line-clamp-1">
                         <MetricTitle metric={metric} />
                     </div>
-                    <LemonDivider vertical className="h-4 self-stretch" />
-                    <div className="flex items-center">
+                    <LemonDivider vertical className="h-4 self-stretch shrink-0" />
+                    <div className="flex items-center shrink-0">
                         <VariantTag variantKey={variantResult.key} />
                     </div>
                 </div>

--- a/frontend/src/scenes/experiments/MetricsView/shared/MetricTitle.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/shared/MetricTitle.tsx
@@ -6,13 +6,24 @@ import { InsightType } from '~/types'
 
 import { getDefaultMetricTitle } from './utils'
 
-export const MetricTitle = ({ metric, metricType }: { metric: any; metricType?: InsightType }): JSX.Element => {
+export const MetricTitle = ({
+    metric,
+    metricType,
+    singleLine,
+}: {
+    metric: any
+    metricType?: InsightType
+    singleLine?: boolean
+}): JSX.Element => {
     const shouldShowTooltip = (text: string): boolean => {
         // Show tooltip for longer text that might be clamped
         return text.length > 50
     }
 
     const getTextClassName = (text: string): string => {
+        if (singleLine) {
+            return 'truncate block'
+        }
         // Use break-words for text with spaces, break-all for underscore-separated text
         const breakClass = text.includes(' ') ? 'break-words' : 'break-all'
         return `line-clamp-3 ${breakClass}`


### PR DESCRIPTION
## Problem
Long metric names in the timeseries modal title wrap to a new line, breaking the layout.

## Changes
Truncate the metric name with an ellipsis, keeping the other title elements fixed.

## How did you test this code?
|Before|After|
|----|----|
|<img width="991" height="65" alt="image" src="https://github.com/user-attachments/assets/e367fe71-a644-43b2-a70e-533a6909fbd0" />|<img width="997" height="51" alt="image" src="https://github.com/user-attachments/assets/f12a0cbe-26bc-400e-bf16-b9cf0ce67989" />|