### PR TITLE
chore: allow joining in PostgresTable to allow team_id guard

### DIFF
--- a/posthog/hogql/database/postgres_table.py
+++ b/posthog/hogql/database/postgres_table.py
@@ -67,6 +67,13 @@ class PostgresTable(FunctionCallTable):
     access_scope: Optional[APIScopeObject] = None
     predicates: list[Expr] = []
 
+    # FK-based team_id: for tables that inherit team_id through a foreign key
+    # to a parent table. When set, to_printed_clickhouse() returns a subquery
+    # joining with the parent to surface team_id, so the standard guard works.
+    team_id_parent_postgres_table_name: Optional[str] = None
+    team_id_parent_fk_field: Optional[str] = None
+    team_id_parent_pk_field: str = "id"
+
     def get_predicates(self) -> list[Expr]:
         return self.predicates
 
@@ -74,4 +81,13 @@ class PostgresTable(FunctionCallTable):
         return escape_hogql_identifier(self.name)
 
     def to_printed_clickhouse(self, context):
+        if self.team_id_parent_postgres_table_name and self.team_id_parent_fk_field:
+            child_sql = build_function_call(self.postgres_table_name, context)
+            parent_sql = build_function_call(self.team_id_parent_postgres_table_name, context)
+            return (
+                f"(SELECT child.*, parent.team_id"
+                f" FROM {child_sql} AS child"
+                f" INNER JOIN {parent_sql} AS parent"
+                f" ON child.{self.team_id_parent_fk_field} = parent.{self.team_id_parent_pk_field})"
+            )
         return build_function_call(self.postgres_table_name, context)

--- a/posthog/hogql/database/test/test_postgres_table.py
+++ b/posthog/hogql/database/test/test_postgres_table.py
@@ -321,3 +321,65 @@ class TestPostgresTable(BaseTest):
             self._select("SELECT id FROM postgres_table LIMIT 10"),
             f"SELECT postgres_table.id AS id FROM postgresql(%(hogql_val_1_sensitive)s, %(hogql_val_2_sensitive)s, %(hogql_val_0_sensitive)s, %(hogql_val_3_sensitive)s, %(hogql_val_4_sensitive)s) AS postgres_table WHERE and(equals(postgres_table.team_id, {self.team.pk}), ifNull(notEquals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(postgres_table.properties, %(hogql_val_15)s), ''), 'null'), '^\"|\"$', ''), %(hogql_val_16)s), 1)) LIMIT 10",
         )
+
+    def test_fk_guarded_team_id(self):
+        self.database = Database.create_for(team=self.team)
+        self.database.tables.add_child(
+            TableNode(
+                name="child_table",
+                table=PostgresTable(
+                    name="child_table",
+                    postgres_table_name="child_pg_table",
+                    team_id_parent_postgres_table_name="parent_pg_table",
+                    team_id_parent_fk_field="parent_id",
+                    fields={
+                        "id": IntegerDatabaseField(name="id"),
+                        "team_id": IntegerDatabaseField(name="team_id"),
+                        "parent_id": IntegerDatabaseField(name="parent_id"),
+                        "name": StringDatabaseField(name="name"),
+                    },
+                ),
+            )
+        )
+        self.context = HogQLContext(
+            team_id=self.team.pk,
+            enable_select_queries=True,
+            database=self.database,
+            modifiers=create_default_modifiers_for_team(self.team),
+        )
+
+        result = self._select("SELECT name FROM child_table LIMIT 10")
+        assert "(SELECT child.*, parent.team_id FROM postgresql(" in result
+        assert "INNER JOIN postgresql(" in result
+        assert "ON child.parent_id = parent.id)" in result
+        assert f"equals(child_table.team_id, {self.team.pk})" in result
+
+    def test_fk_guarded_team_id_custom_pk(self):
+        self.database = Database.create_for(team=self.team)
+        self.database.tables.add_child(
+            TableNode(
+                name="child_table",
+                table=PostgresTable(
+                    name="child_table",
+                    postgres_table_name="child_pg_table",
+                    team_id_parent_postgres_table_name="parent_pg_table",
+                    team_id_parent_fk_field="parent_id",
+                    team_id_parent_pk_field="uuid",
+                    fields={
+                        "id": IntegerDatabaseField(name="id"),
+                        "team_id": IntegerDatabaseField(name="team_id"),
+                        "parent_id": IntegerDatabaseField(name="parent_id"),
+                        "name": StringDatabaseField(name="name"),
+                    },
+                ),
+            )
+        )
+        self.context = HogQLContext(
+            team_id=self.team.pk,
+            enable_select_queries=True,
+            database=self.database,
+            modifiers=create_default_modifiers_for_team(self.team),
+        )
+
+        result = self._select("SELECT name FROM child_table LIMIT 10")
+        assert "ON child.parent_id = parent.uuid)" in result

--- a/posthog/models/resource_transfer/test/__snapshots__/test_visitor_field_snapshots.ambr
+++ b/posthog/models/resource_transfer/test/__snapshots__/test_visitor_field_snapshots.ambr
@@ -451,6 +451,7 @@
   list([
     'DoesNotExist',
     'MultipleObjectsReturned',
+    '__annotations__',
     '__doc__',
     '__module__',
     '__repr__',


### PR DESCRIPTION
## Problem

some tables are normalized and don't have team_id field. we can either add team_id on them all so that we can expose them as system tables, or do this

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

## Changes

- allow connecting a parent table in PostgresTable, to bring in the team_id field

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

- locally with the endpoints table (not in there yet)

<!-- Briefly describe the steps you took. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->