### PR TITLE
fix(embed): escape eot

### DIFF
--- a/rust/common/types/src/embeddings.rs
+++ b/rust/common/types/src/embeddings.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::{borrow::Cow, collections::HashMap};
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
@@ -97,6 +97,19 @@ impl EmbeddingModel {
         match self {
             EmbeddingModel::OpenAITextEmbeddingSmall => 8192,
             EmbeddingModel::OpenAITextEmbeddingLarge => 8192,
+        }
+    }
+
+    /// Apply model-specific escaping/sanitisation to input text before tokenisation.
+    pub fn escape_input<'a>(&self, content: &'a str) -> std::borrow::Cow<'a, str> {
+        match self {
+            EmbeddingModel::OpenAITextEmbeddingSmall | EmbeddingModel::OpenAITextEmbeddingLarge => {
+                if content.contains("<|endoftext|>") {
+                    // Open AI's embedding endpoints 500 in the face of <|endoftext|> tokens
+                    return Cow::Owned(content.replace("<|endoftext|>", ">|endoftext|<"));
+                }
+                Cow::Borrowed(content)
+            }
         }
     }
 
@@ -222,5 +235,27 @@ impl From<EmbeddingResponse> for Vec<EmbeddingRecord> {
         }
 
         records
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_escape_input() {
+        let model = EmbeddingModel::default();
+
+        // Normal text passes through borrowed
+        let normal = "hello world";
+        let result = model.escape_input(normal);
+        assert!(matches!(result, std::borrow::Cow::Borrowed(_)));
+        assert_eq!(result, "hello world");
+
+        // endoftext token gets escaped
+        let bad = "foo <|endoftext|> bar";
+        let result = model.escape_input(bad);
+        assert!(matches!(result, std::borrow::Cow::Owned(_)));
+        assert_eq!(result, "foo >|endoftext|< bar");
     }
 }

--- a/rust/embedding-worker/src/lib.rs
+++ b/rust/embedding-worker/src/lib.rs
@@ -190,11 +190,12 @@ pub fn generate_embedding_text(
     model: &EmbeddingModel,
     labels: &RequestLabels,
 ) -> Result<(String, usize)> {
+    let content = model.escape_input(content);
     let (text, count) = match model {
         EmbeddingModel::OpenAITextEmbeddingSmall | EmbeddingModel::OpenAITextEmbeddingLarge => {
             let encoder = tiktoken_rs::cl100k_base()?;
             let mut tokens: Vec<_> = encoder
-                .encode_with_special_tokens(content)
+                .encode_with_special_tokens(&content)
                 .into_iter()
                 .take(model.model_input_window())
                 .collect();

--- a/rust/embedding-worker/src/lib.rs
+++ b/rust/embedding-worker/src/lib.rs
@@ -1,5 +1,5 @@
-use std::sync::Arc;
 use std::time::Duration;
+use std::{borrow::Cow, sync::Arc};
 
 use anyhow::Result;
 use common_kafka::kafka_consumer::Offset;
@@ -185,11 +185,11 @@ pub async fn generate_embedding(
 
 // This is here, rather than on the embedding model, to avoid taking a dep on tiktoken in common/types. We
 // can reconsider it later if we want
-pub fn generate_embedding_text(
-    content: &str,
+pub fn generate_embedding_text<'a>(
+    content: &'a str,
     model: &EmbeddingModel,
     labels: &RequestLabels,
-) -> Result<(String, usize)> {
+) -> Result<(Cow<'a, str>, usize)> {
     let content = model.escape_input(content);
     let (text, count) = match model {
         EmbeddingModel::OpenAITextEmbeddingSmall | EmbeddingModel::OpenAITextEmbeddingLarge => {
@@ -199,6 +199,11 @@ pub fn generate_embedding_text(
                 .into_iter()
                 .take(model.model_input_window())
                 .collect();
+
+            if tokens.len() < model.model_input_window() {
+                return Ok((content, tokens.len()));
+            }
+
             // Truncation can split a multi-byte character's token sequence,
             // producing bytes that aren't valid UTF-8 on decode. Drop trailing
             // tokens until we land on a clean boundary.
@@ -219,7 +224,7 @@ pub fn generate_embedding_text(
         counter!(MESSAGE_TRUNCATED, labels.render()).increment(1);
     }
 
-    Ok((text, count))
+    Ok((Cow::Owned(text), count))
 }
 
 pub fn construct_request(
@@ -261,6 +266,6 @@ mod tests {
 
         let (text, _count) =
             generate_embedding_text(&content, &model, &RequestLabels::default()).unwrap();
-        assert!(content.starts_with(&text));
+        assert!(content.starts_with(&*text));
     }
 }


### PR DESCRIPTION
Turns out oai's embedding endpoint returns a 500 if you send it text containing `<|endoftext|>`. We should stop doing that.