### PR TITLE
chore(devex): speed up hogli start cold boot

### DIFF
--- a/bin/mprocs.yaml
+++ b/bin/mprocs.yaml
@@ -115,7 +115,7 @@ procs:
         ready_pattern: 'Launching Dagster services'
 
     docker-compose:
-        shell: 'docker compose -f docker-compose.dev.yml up --pull always -d && echo "docker-compose ready" && docker compose -f docker-compose.dev.yml logs --tail=100 -f'
+        shell: 'docker compose -f docker-compose.dev.yml up --pull ${DOCKER_PULL_POLICY:-always} -d && echo "docker-compose ready" && docker compose -f docker-compose.dev.yml logs --tail=100 -f'
         capability: core_infra
         ready_pattern: 'docker-compose ready'
 

--- a/bin/start
+++ b/bin/start
@@ -25,8 +25,18 @@ export DEBUG=${DEBUG:-1}
 export SKIP_SERVICE_VERSION_REQUIREMENTS=${SKIP_SERVICE_VERSION_REQUIREMENTS:-1}
 
 # Limit Rust parallel compilation jobs to reduce CPU contention when multiple
-# services start simultaneously via phrocs (they share a build lock anyway)
-export CARGO_BUILD_JOBS="${CARGO_BUILD_JOBS:-1}"
+# services start simultaneously via phrocs. The cargo file lock only serializes
+# the final link step — different crates within the dependency graph compile in
+# parallel, so allowing more than 1 job significantly speeds up recompilation.
+# Defaults to half the available cores, capped at 4 to avoid starving other
+# processes. Override with CARGO_BUILD_JOBS=N if needed.
+if [ -z "${CARGO_BUILD_JOBS:-}" ]; then
+    _ncpu=$(sysctl -n hw.ncpu 2>/dev/null || nproc 2>/dev/null || echo 4)
+    _half=$(( _ncpu / 2 ))
+    [ "$_half" -lt 1 ] && _half=1
+    [ "$_half" -gt 4 ] && _half=4
+    export CARGO_BUILD_JOBS="$_half"
+fi
 
 # Use sccache for Rust compilation caching (if available via flox or homebrew)
 if [[ -z "${RUSTC_WRAPPER:-}" ]] && command -v sccache &>/dev/null; then
@@ -67,6 +77,12 @@ if [[ "$*" == *"--tracing"* ]]; then
     echo "👉 Tracing enabled, see http://localhost:16686 for Jaeger UI"
 else
     export OTEL_SDK_DISABLED="true"
+fi
+
+# --no-pull: skip docker image pull checks (use --pull missing instead of --pull always)
+# Useful for faster restarts when images are already cached locally
+if [[ "$*" == *"--no-pull"* ]]; then
+    export DOCKER_PULL_POLICY="missing"
 fi
 
 if [ -f .env ]; then

--- a/common/hogli/devenv/generator.py
+++ b/common/hogli/devenv/generator.py
@@ -317,7 +317,8 @@ printf '  {gray}Run {reset}{blue}hogli dev:setup{reset}{gray} to tailor this to 
         else:
             message = "echo '▶ docker-compose: core services only (configure via: hogli dev:setup)' && "
 
-        up_cmd = build_docker_compose_command(profiles, "up --pull always -d")
+        # DOCKER_PULL_POLICY defaults to "always"; bin/start --no-pull sets it to "missing"
+        up_cmd = build_docker_compose_command(profiles, "up --pull ${DOCKER_PULL_POLICY:-always} -d")
         logs_cmd = build_docker_compose_command(profiles, "logs --tail=100 -f")
 
         return {

--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -14,8 +14,8 @@
         "start:dist": "node dist/index.js",
         "start:dev": "NODE_ENV=dev tsx watch src/index.ts",
         "start:devNoWatch": "NODE_ENV=dev tsx src/index.ts",
-        "prestart:dev": "pnpm build:cyclotron",
-        "prestart:devNoWatch": "pnpm build:cyclotron",
+        "prestart:dev": "pnpm build:cyclotron:if-needed",
+        "prestart:devNoWatch": "pnpm build:cyclotron:if-needed",
         "build": "pnpm clean && pnpm typescript:compile && pnpm typescript:compile-cleanup",
         "clean": "rm -rf dist/*",
         "typescript:compile": "tsc -b && tsc-alias",
@@ -40,6 +40,7 @@
         "services:clean": "cd .. && docker compose -f docker-compose.dev.yml rm -v",
         "services": "pnpm services:stop && pnpm services:clean && pnpm services:start",
         "build:cyclotron": "pnpm --filter=@posthog/cyclotron package",
+        "build:cyclotron:if-needed": "pnpm --filter=@posthog/cyclotron package:if-needed",
         "update-ai-costs": "ts-node src/ingestion/ai/costs/scripts/update-ai-costs.ts",
         "sync-segment-icons": "DATABASE_URL=something ts-node src/cdp/segment/sync-segment-icons.ts",
         "start:recording-rasterizer": "node dist/session-replay/recording-rasterizer/index.js"

--- a/rust/cyclotron-node/build-if-needed.sh
+++ b/rust/cyclotron-node/build-if-needed.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Skip cyclotron cargo build when index.node is already up-to-date.
+# Compares index.node mtime against source files, Cargo.toml, and Cargo.lock.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+INDEX_NODE="$SCRIPT_DIR/index.node"
+
+if [ ! -f "$INDEX_NODE" ]; then
+    echo "cyclotron: index.node missing, building..."
+    exec pnpm --filter=@posthog/cyclotron package
+fi
+
+# Find the newest source file across cyclotron-node and cyclotron-core
+RUST_DIR="$(dirname "$SCRIPT_DIR")"
+NEWEST_SOURCE=$(find \
+    "$SCRIPT_DIR/src" \
+    "$RUST_DIR/cyclotron-core/src" \
+    "$SCRIPT_DIR/Cargo.toml" \
+    "$RUST_DIR/cyclotron-core/Cargo.toml" \
+    "$RUST_DIR/Cargo.toml" \
+    "$RUST_DIR/Cargo.lock" \
+    -type f \( -name '*.rs' -o -name 'Cargo.toml' -o -name 'Cargo.lock' \) \
+    -newer "$INDEX_NODE" \
+    -print -quit 2>/dev/null || true)
+
+if [ -n "$NEWEST_SOURCE" ]; then
+    echo "cyclotron: source changed ($NEWEST_SOURCE), rebuilding..."
+    exec pnpm --filter=@posthog/cyclotron package
+fi
+
+echo "cyclotron: up to date, skipping build"

--- a/rust/cyclotron-node/package.json
+++ b/rust/cyclotron-node/package.json
@@ -13,7 +13,8 @@
         "build:cross": "cross build --message-format=json > cross.log",
         "build:typescript": "tsc",
         "clean": "rm -rf index.node",
-        "package": "NODE_ENV=development pnpm --filter=@posthog/cyclotron run build"
+        "package": "NODE_ENV=development pnpm --filter=@posthog/cyclotron run build",
+        "package:if-needed": "bash build-if-needed.sh"
     },
     "author": "",
     "license": "MIT",


### PR DESCRIPTION
## Problem

`hogli start` cold boot is slow. The ingestion/nodejs processes pay ~30s for an unconditional `cargo build --release` of cyclotron (which rarely changes), Rust compilation is limited to 1 CPU core, and docker images are checked against the registry on every start.

## Changes

- **Cyclotron build skip**: `prestart:dev` now checks if `index.node` is newer than source files before running `cargo build --release`. Skips in ~0.3s when up to date (vs ~30s before).
- **CARGO_BUILD_JOBS**: Default increased from 1 to `ncpu/2` (capped at 4). The cargo file lock only serializes linking, not per-crate compilation.
- **`--no-pull` flag**: `bin/start --no-pull` uses `--pull missing` instead of `--pull always` for docker-compose. Default behavior unchanged.

## How did you test this code?

- Verified cyclotron skip: `pnpm build:cyclotron:if-needed` prints "up to date" and completes in 0.3s when no source changes; correctly rebuilds when a `.rs` file is touched or `index.node` is missing
- Verified CARGO_BUILD_JOBS calculation: 12 cores -> 4 jobs
- Verified generated mprocs.yaml contains `${DOCKER_PULL_POLICY:-always}` shell substitution
- All 202 hogli tests pass

## Publish to changelog?

No