### PR TITLE
chore(endpoints): add refresh button to usage dashboard

### DIFF
--- a/products/endpoints/frontend/Endpoints.tsx
+++ b/products/endpoints/frontend/Endpoints.tsx
@@ -77,7 +77,7 @@ export const EndpointsTable = ({ tabId }: EndpointsTableProps): JSX.Element => {
 
     const handleDuplicate = (endpoint: EndpointType): void => {
         if (isHogQLQuery(endpoint.query)) {
-            router.actions.push(urls.sqlEditor({ query: endpoint.query.query }))
+            router.actions.push(urls.sqlEditor({ query: endpoint.query.query, source: 'endpoint' }))
         } else {
             setDuplicateEndpoint(endpoint)
         }

--- a/products/endpoints/frontend/EndpointsUsage.tsx
+++ b/products/endpoints/frontend/EndpointsUsage.tsx
@@ -21,6 +21,7 @@ export function EndpointsUsage({ tabId }: { tabId: string }): JSX.Element {
         queryDurationTrendsQuery,
         errorRateTrendsQuery,
         endpointTableQuery,
+        refreshKey,
     } = useValues(endpointsUsageLogic({ tabId }))
 
     const tableContext: QueryContext<DataTableNode> = useMemo(
@@ -66,39 +67,40 @@ export function EndpointsUsage({ tabId }: { tabId: string }): JSX.Element {
             <div className="mt-4 grid grid-cols-1 md:grid-cols-4 gap-x-4 gap-y-8">
                 <div className="col-span-1 md:col-span-4 flex flex-col">
                     <h2 className="mb-3">Overview</h2>
-                    <Query query={overviewQuery} readOnly />
+                    <Query key={`overview-${refreshKey}`} query={overviewQuery} readOnly />
                 </div>
 
                 {/* Row 1: Executions, Error rate, Query duration */}
                 <div className="col-span-1 md:col-span-4 grid grid-cols-1 md:grid-cols-3 gap-4">
                     <div className="flex flex-col">
                         <h2 className="mb-3">Executions over time</h2>
-                        <Query query={requestsTrendsQuery} readOnly />
+                        <Query key={`requests-${refreshKey}`} query={requestsTrendsQuery} readOnly />
                     </div>
                     <div className="flex flex-col">
                         <h2 className="mb-3">Error rate over time</h2>
-                        <Query query={errorRateTrendsQuery} readOnly />
+                        <Query key={`error-rate-${refreshKey}`} query={errorRateTrendsQuery} readOnly />
                     </div>
                     <div className="flex flex-col">
                         <h2 className="mb-3">Query duration over time</h2>
-                        <Query query={queryDurationTrendsQuery} readOnly />
+                        <Query key={`query-duration-${refreshKey}`} query={queryDurationTrendsQuery} readOnly />
                     </div>
                 </div>
 
                 {/* Row 2: CPU time, Bytes read */}
                 <div className="col-span-1 md:col-span-2 flex flex-col">
                     <h2 className="mb-3">CPU time over time</h2>
-                    <Query query={cpuSecondsTrendsQuery} readOnly />
+                    <Query key={`cpu-seconds-${refreshKey}`} query={cpuSecondsTrendsQuery} readOnly />
                 </div>
 
                 <div className="col-span-1 md:col-span-2 flex flex-col">
                     <h2 className="mb-3">Bytes read over time</h2>
-                    <Query query={bytesReadTrendsQuery} readOnly />
+                    <Query key={`bytes-read-${refreshKey}`} query={bytesReadTrendsQuery} readOnly />
                 </div>
 
                 <div className="col-span-1 md:col-span-4 flex flex-col">
                     <h2 className="mb-3">Endpoints breakdown</h2>
                     <Query
+                        key={`table-${refreshKey}`}
                         query={
                             {
                                 kind: NodeKind.DataTableNode,

--- a/products/endpoints/frontend/EndpointsUsageFilters.tsx
+++ b/products/endpoints/frontend/EndpointsUsageFilters.tsx
@@ -1,7 +1,7 @@
 import { useActions, useValues } from 'kea'
 
 import { IconRefresh } from '@posthog/icons'
-import { LemonButton, LemonInputSelect, LemonSelect, Tooltip } from '@posthog/lemon-ui'
+import { LemonButton, LemonInputSelect, LemonSelect } from '@posthog/lemon-ui'
 
 import { DateFilter } from 'lib/components/DateFilter/DateFilter'
 import { FilterBar } from 'lib/components/FilterBar'
@@ -159,22 +159,21 @@ const RefreshButton = ({ tabId }: { tabId: string }): JSX.Element => {
     const { refresh } = useActions(endpointsUsageLogic({ tabId }))
 
     return (
-        <Tooltip
-            title={
-                canRefresh
-                    ? 'Refresh data. Note: usage data may be delayed by a few minutes and is not realtime.'
-                    : 'Refresh available every 15 minutes. Usage data may be delayed by a few minutes and is not realtime.'
+        <LemonButton
+            icon={<IconRefresh />}
+            size="small"
+            type="secondary"
+            tooltip="Refresh usage data."
+            disabledReason={
+                !canRefresh
+                    ? 'You can refresh once every 15 minutes. Note that it is not realtime, and may be delayed a few minutes.'
+                    : undefined
             }
+            onClick={refresh}
+            aria-label="Refresh usage data"
         >
-            <LemonButton
-                icon={<IconRefresh />}
-                size="small"
-                type="secondary"
-                disabledReason={!canRefresh ? 'You can refresh once every 15 minutes' : undefined}
-                onClick={refresh}
-                aria-label="Refresh usage data"
-            />
-        </Tooltip>
+            Refresh
+        </LemonButton>
     )
 }
 
@@ -199,10 +198,10 @@ export const EndpointsUsageFilters = ({ tabId }: { tabId: string }): JSX.Element
             }
             right={
                 <>
+                    <RefreshButton tabId={tabId} />
                     <MaterializationTypeFilter tabId={tabId} />
                     <IntervalFilter tabId={tabId} />
                     <BreakdownFilter tabId={tabId} />
-                    <RefreshButton tabId={tabId} />
                 </>
             }
         />

--- a/products/endpoints/frontend/EndpointsUsageFilters.tsx
+++ b/products/endpoints/frontend/EndpointsUsageFilters.tsx
@@ -1,6 +1,7 @@
 import { useActions, useValues } from 'kea'
 
-import { LemonInputSelect, LemonSelect } from '@posthog/lemon-ui'
+import { IconRefresh } from '@posthog/icons'
+import { LemonButton, LemonInputSelect, LemonSelect, Tooltip } from '@posthog/lemon-ui'
 
 import { DateFilter } from 'lib/components/DateFilter/DateFilter'
 import { FilterBar } from 'lib/components/FilterBar'
@@ -153,6 +154,30 @@ const BreakdownFilter = ({ tabId }: { tabId: string }): JSX.Element => {
     )
 }
 
+const RefreshButton = ({ tabId }: { tabId: string }): JSX.Element => {
+    const { canRefresh } = useValues(endpointsUsageLogic({ tabId }))
+    const { refresh } = useActions(endpointsUsageLogic({ tabId }))
+
+    return (
+        <Tooltip
+            title={
+                canRefresh
+                    ? 'Refresh data. Note: usage data may be delayed by a few minutes and is not realtime.'
+                    : 'Refresh available every 15 minutes. Usage data may be delayed by a few minutes and is not realtime.'
+            }
+        >
+            <LemonButton
+                icon={<IconRefresh />}
+                size="small"
+                type="secondary"
+                disabledReason={!canRefresh ? 'You can refresh once every 15 minutes' : undefined}
+                onClick={refresh}
+                aria-label="Refresh usage data"
+            />
+        </Tooltip>
+    )
+}
+
 export const EndpointsUsageFilters = ({ tabId }: { tabId: string }): JSX.Element => {
     const { dateFilter } = useValues(endpointsUsageLogic({ tabId }))
     const { setDates } = useActions(endpointsUsageLogic({ tabId }))
@@ -177,6 +202,7 @@ export const EndpointsUsageFilters = ({ tabId }: { tabId: string }): JSX.Element
                     <MaterializationTypeFilter tabId={tabId} />
                     <IntervalFilter tabId={tabId} />
                     <BreakdownFilter tabId={tabId} />
+                    <RefreshButton tabId={tabId} />
                 </>
             }
         />

--- a/products/endpoints/frontend/endpointsUsageLogic.tsx
+++ b/products/endpoints/frontend/endpointsUsageLogic.tsx
@@ -41,6 +41,7 @@ export const endpointsUsageLogic = kea<endpointsUsageLogicType>([
         setMaterializationType: (materializationType: 'materialized' | 'inline' | null) => ({ materializationType }),
         setInterval: (interval: IntervalType) => ({ interval }),
         setBreakdownBy: (breakdownBy: EndpointsUsageBreakdown | null) => ({ breakdownBy }),
+        refresh: true,
     }),
 
     reducers({
@@ -77,6 +78,18 @@ export const endpointsUsageLogic = kea<endpointsUsageLogicType>([
                 setBreakdownBy: (_, { breakdownBy }) => breakdownBy,
             },
         ],
+        lastRefreshedAt: [
+            null as number | null,
+            {
+                refresh: () => Date.now(),
+            },
+        ],
+        refreshKey: [
+            0,
+            {
+                refresh: (state) => state + 1,
+            },
+        ],
     }),
 
     selectors({
@@ -89,6 +102,15 @@ export const endpointsUsageLogic = kea<endpointsUsageLogicType>([
                     .sort(),
         ],
         endpointNamesLoading: [(s) => [s.allEndpointsLoading], (loading: boolean): boolean => loading],
+        canRefresh: [
+            (s) => [s.lastRefreshedAt],
+            (lastRefreshedAt: number | null): boolean => {
+                if (lastRefreshedAt === null) {
+                    return true
+                }
+                return Date.now() - lastRefreshedAt >= 15 * 60 * 1000
+            },
+        ],
         dateRange: [
             (s) => [s.dateFilter],
             (dateFilter): { date_from: string | null; date_to: string | null } => {

--- a/products/endpoints/frontend/endpointsUsageLogic.tsx
+++ b/products/endpoints/frontend/endpointsUsageLogic.tsx
@@ -1,4 +1,4 @@
-import { actions, connect, kea, key, path, props, reducers, selectors } from 'kea'
+import { actions, connect, kea, key, listeners, path, props, reducers, selectors } from 'kea'
 import { router } from 'kea-router'
 
 import { dayjs } from 'lib/dayjs'
@@ -42,6 +42,7 @@ export const endpointsUsageLogic = kea<endpointsUsageLogicType>([
         setInterval: (interval: IntervalType) => ({ interval }),
         setBreakdownBy: (breakdownBy: EndpointsUsageBreakdown | null) => ({ breakdownBy }),
         refresh: true,
+        clearCooldown: true,
     }),
 
     reducers({
@@ -78,10 +79,11 @@ export const endpointsUsageLogic = kea<endpointsUsageLogicType>([
                 setBreakdownBy: (_, { breakdownBy }) => breakdownBy,
             },
         ],
-        lastRefreshedAt: [
-            null as number | null,
+        cooldownActive: [
+            false,
             {
-                refresh: () => Date.now(),
+                refresh: () => true,
+                clearCooldown: () => false,
             },
         ],
         refreshKey: [
@@ -102,15 +104,7 @@ export const endpointsUsageLogic = kea<endpointsUsageLogicType>([
                     .sort(),
         ],
         endpointNamesLoading: [(s) => [s.allEndpointsLoading], (loading: boolean): boolean => loading],
-        canRefresh: [
-            (s) => [s.lastRefreshedAt],
-            (lastRefreshedAt: number | null): boolean => {
-                if (lastRefreshedAt === null) {
-                    return true
-                }
-                return Date.now() - lastRefreshedAt >= 15 * 60 * 1000
-            },
-        ],
+        canRefresh: [(s) => [s.cooldownActive], (cooldownActive: boolean): boolean => !cooldownActive],
         dateRange: [
             (s) => [s.dateFilter],
             (dateFilter): { date_from: string | null; date_to: string | null } => {
@@ -213,6 +207,17 @@ export const endpointsUsageLogic = kea<endpointsUsageLogicType>([
             }),
         ],
     }),
+
+    listeners(({ actions }) => ({
+        refresh: () => {
+            setTimeout(
+                () => {
+                    actions.clearCooldown()
+                },
+                15 * 60 * 1000
+            )
+        },
+    })),
 
     tabAwareActionToUrl(({ values }) => {
         const actionToUrl = ({


### PR DESCRIPTION
## Problem

Users need a way to manually refresh the endpoints usage data without reloading the entire page. 

## Changes

<img width="567" height="206" alt="image" src="https://github.com/user-attachments/assets/9c1f5776-e0b0-46e8-95cb-aefeb00168e1" />

## How did you test this code?
- locally

## Publish to changelog?

no