### PR TITLE
fix(ux): fix scrolling insight table

### DIFF
--- a/frontend/src/lib/components/ScrollableShadows/ScrollableShadows.scss
+++ b/frontend/src/lib/components/ScrollableShadows/ScrollableShadows.scss
@@ -10,7 +10,7 @@
         position: absolute;
         top: var(--scrollable-shadows-offset-top);
         left: 0;
-        z-index: 5; // Bumped from 1 because in new scene layout we use scrollable shadows in around the main content, and some content has their own z-index > 1
+        z-index: 7; // Bumped from 1 to 7 so it goes above lemon table headers & because in new scene layout we use scrollable shadows in around the main content, and some content has their own z-index > 1
         width: 100%;
         height: 100%;
         pointer-events: none;

--- a/frontend/src/lib/components/ScrollableShadows/ScrollableShadows.tsx
+++ b/frontend/src/lib/components/ScrollableShadows/ScrollableShadows.tsx
@@ -6,7 +6,7 @@ import React, { CSSProperties, MutableRefObject } from 'react'
 
 export type ScrollableShadowsProps = {
     children: React.ReactNode
-    direction: 'horizontal' | 'vertical'
+    direction: 'horizontal' | 'vertical' | 'both'
     className?: string
     innerClassName?: string
     scrollRef?: MutableRefObject<HTMLDivElement | null>
@@ -55,7 +55,8 @@ export const ScrollableShadows = React.forwardRef<HTMLDivElement, ScrollableShad
             ref={ref}
             className={clsx(
                 'ScrollableShadows',
-                `ScrollableShadows--${direction}`,
+                (direction === 'horizontal' || direction === 'both') && 'ScrollableShadows--horizontal',
+                (direction === 'vertical' || direction === 'both') && 'ScrollableShadows--vertical',
                 hideShadows && 'ScrollableShadows--hide-shadows',
                 hideScrollbars && 'ScrollableShadows--hide-scrollbars',
                 className
@@ -78,12 +79,14 @@ export const ScrollableShadows = React.forwardRef<HTMLDivElement, ScrollableShad
                 style={
                     disableScroll
                         ? { overflow: 'hidden' }
-                        : constrainToDirection
-                          ? {
-                                overflowX: direction === 'horizontal' ? undefined : 'hidden',
-                                overflowY: direction === 'vertical' ? undefined : 'hidden',
-                            }
-                          : undefined
+                        : direction === 'both'
+                          ? undefined
+                          : constrainToDirection
+                            ? {
+                                  overflowX: direction === 'horizontal' ? undefined : 'hidden',
+                                  overflowY: direction === 'vertical' ? undefined : 'hidden',
+                              }
+                            : undefined
                 }
             >
                 <ScrollArea.Content className="min-w-0">{children}</ScrollArea.Content>

--- a/frontend/src/lib/lemon-ui/LemonTable/LemonTable.tsx
+++ b/frontend/src/lib/lemon-ui/LemonTable/LemonTable.tsx
@@ -280,8 +280,7 @@ export function LemonTable<T extends Record<string, any>>({
         >
             <ScrollableShadows
                 innerClassName={hideScrollbar ? 'hide-scrollbar' : undefined}
-                direction="horizontal"
-                constrainToDirection={!allowContentScroll}
+                direction={allowContentScroll ? 'both' : 'horizontal'}
                 scrollRef={scrollRef}
             >
                 <div className="LemonTable__content">

--- a/frontend/src/scenes/insights/views/InsightsTable/InsightsTable.tsx
+++ b/frontend/src/scenes/insights/views/InsightsTable/InsightsTable.tsx
@@ -512,9 +512,7 @@ export function InsightsTable({
             firstColumnSticky
             pinnedColumns={pinnedColumns}
             maxHeaderWidth="20rem"
-            // Allow vertical scrolling within the card so long tables
-            // inside dashboards remain scrollable without resizing tiles.
-            allowContentScroll={isInDashboardContext}
+            allowContentScroll
         />
     )
 }


### PR DESCRIPTION
## Problem
Insight table isn't scrolling

<img width="748" height="532" alt="image" src="https://github.com/user-attachments/assets/14c25224-299e-4638-9005-d791094a175b" />


## Changes
![2026-03-30 15 37 32](https://github.com/user-attachments/assets/cceb4669-89e6-4a13-9dbd-0a90e5a217b5)


## How did you test this code?
locally

## Publish to changelog?
No