### PR TITLE
feat: Improve SLO dashboard readability

### DIFF
--- a/terraform/us/project-2/team-analytics-platform/slo-monitoring/insights.tf
+++ b/terraform/us/project-2/team-analytics-platform/slo-monitoring/insights.tf
@@ -40,7 +40,7 @@ locals {
 
   # Row budgets for queries (with 2x margin for safety).
   slo_burn_rate_limit    = 168 * 4 * 2 # 7 days * 24h * 4 metrics * margin
-  slo_duration_limit     = 28 * 3 * 2  # 28 days * 3 percentiles * margin
+  slo_duration_limit     = 7 * 3 * 2   # 7 days * 3 percentiles * margin
   slo_success_rate_limit = length(local.slo_operations) * 28 * 2
 
   # Explicit operation list for the success rate query (avoids DISTINCT drift).
@@ -96,12 +96,16 @@ locals {
     FROM (
         SELECT
             hour,
+            if(t1h  > 0, round((f1h  / t1h)  / {{ERROR_BUDGET}}, 2), NULL) AS raw_1h,
+            if(t24h > 0, round((f24h / t24h) / {{ERROR_BUDGET}}, 2), NULL) AS raw_24h,
+            if(t7d  > 0, round((f7d  / t7d)  / {{ERROR_BUDGET}}, 2), NULL) AS raw_7d,
+            if(t28d > 0, round((f28d / t28d) / {{ERROR_BUDGET}}, 2), NULL) AS raw_28d,
             ['Burn rate 1h', 'Burn rate 24h', 'Burn rate 7d', 'Burn rate 28d'] AS metrics,
             [
-                if(t1h  > 0, round((f1h  / t1h)  / {{ERROR_BUDGET}}, 2), NULL),
-                if(t24h > 0, round((f24h / t24h) / {{ERROR_BUDGET}}, 2), NULL),
-                if(t7d  > 0, round((f7d  / t7d)  / {{ERROR_BUDGET}}, 2), NULL),
-                if(t28d > 0, round((f28d / t28d) / {{ERROR_BUDGET}}, 2), NULL)
+                sign(raw_1h)  * log10(1 + abs(raw_1h)),
+                sign(raw_24h) * log10(1 + abs(raw_24h)),
+                sign(raw_7d)  * log10(1 + abs(raw_7d)),
+                sign(raw_28d) * log10(1 + abs(raw_28d))
             ] AS vals
         FROM rolling
         WHERE hour >= now() - INTERVAL 7 DAY
@@ -127,11 +131,11 @@ locals {
           AND properties.operation = '{{OPERATION}}'
           AND properties.region = '{{REGION}}'
           AND properties.duration_ms IS NOT NULL
-          AND timestamp >= now() - INTERVAL 28 DAY
+          AND timestamp >= now() - INTERVAL 7 DAY
         GROUP BY date
     ),
     date_range AS (
-        SELECT toDate(now()) - number AS date FROM numbers(28)
+        SELECT toDate(now()) - number AS date FROM numbers(7)
     ),
     base AS (
         SELECT
@@ -192,7 +196,8 @@ resource "posthog_insight" "slo_burn_rate" {
       seriesBreakdownColumn = "metric"
       showLegend            = true
       goalLines = [
-        { label = "Budget rate", value = 1.0, position = "start" }
+        { label = "Budget rate", value = 0.30, position = "start" },
+        { label = "100x burn",   value = 2.00, position = "start" }
       ]
     }
     tableSettings = {

--- a/terraform/us/project-2/team-analytics-platform/slo-monitoring/layouts.tf
+++ b/terraform/us/project-2/team-analytics-platform/slo-monitoring/layouts.tf
@@ -22,7 +22,7 @@ resource "posthog_dashboard_layout" "slo_monitoring" {
         })
       },
       {
-        text_body = "**Success rate** is a 28-day rolling window showing the percentage of successful operations. **Burn rate** measures how fast you're consuming your error budget — 1.0 means you're spending at the sustainable rate, >1.0 means you'll exhaust it before the window ends. **Duration** shows p50/p95/p99 operation latency in seconds."
+        text_body = "**Success rate** is a 28-day rolling window showing the percentage of successful operations. **Burn rate** shows how fast you're consuming your error budget on a logarithmic scale — the Budget rate line marks sustainable consumption, crossing 100x burn indicates an active incident. **Duration** shows p50/p95/p99 operation latency in seconds."
         layouts_json = jsonencode({
           sm = {
             h = 1, i = "text", w = 12, x = 0, y = 5


### PR DESCRIPTION
## Problem

In the current [SLO monitoring dashboard](https://us.posthog.com/project/2/dashboard/1397132?highlightInsightId=0i3yPS24), reading the burn rates can be quite difficult if we've experienced spikes. This makes gaining insight at a glance dififcult and requires thorough viewing / reading of the dashboard to extract insights.

Additionally the duration graphs are based on the last 28d vs the last 7d which is what the burn rate measures. This can look confusing.  

## Changes

- Applied logarithmic scaling to burn rate metrics to improve visualization of extreme values (effectively it now will range from -5 to 5 in extreme cases, a 1000x burn rate violation has a value of 3)
- Reduced duration query window from 28 days to 7 days to align with burn rate.
- Added goal lines for "Budget rate" (0.30) and "100x burn" (2.00) thresholds on the burn rate chart
- Updated dashboard description to clarify that burn rate now uses logarithmic scale and explain the new threshold lines

## How did you test this code?

:white_check_mark: Speculative plan looks good

:white_check_mark: Ran the SQL query manually ([example](https://us.posthog.com/project/2/insights/0i3yPS24?dashboard=1397132&variables_override={}&filters_override={}&tile_filters_override={}))

## Publish to changelog?

No

## Docs update

No