### PR TITLE
fix(MarkdownEditor): defer focus to avoid Safari ProseMirror transaction error

### DIFF
--- a/frontend/src/lib/components/MarkdownEditor/inline/InlineRichMarkdownEditor.tsx
+++ b/frontend/src/lib/components/MarkdownEditor/inline/InlineRichMarkdownEditor.tsx
@@ -160,9 +160,16 @@ export function InlineRichMarkdownEditor({
     const bubbleMenuSafeToMount = useBubbleMenuSafeToMount(editor)
 
     useEffect(() => {
-        if (editor && autoFocus && getTiptapEditorDom(editor)) {
-            editor.commands.focus()
+        if (!editor || !autoFocus || !getTiptapEditorDom(editor)) {
+            return
         }
+        // Match RichMarkdownEditor: defer focus so Safari does not race TipTap transactions.
+        const id = window.setTimeout(() => {
+            if (!editor.isDestroyed) {
+                editor.commands.focus()
+            }
+        }, 0)
+        return () => window.clearTimeout(id)
     }, [editor, autoFocus, editor?.isInitialized])
 
     useMarkdownEditorControlledAndFormEffects({

--- a/frontend/src/lib/components/MarkdownEditor/rich/RichMarkdownEditor.tsx
+++ b/frontend/src/lib/components/MarkdownEditor/rich/RichMarkdownEditor.tsx
@@ -80,9 +80,17 @@ export function RichMarkdownEditor({
     })
 
     useEffect(() => {
-        if (editor && autoFocus && getTiptapEditorDom(editor)) {
-            editor.commands.focus()
+        if (!editor || !autoFocus || !getTiptapEditorDom(editor)) {
+            return
         }
+        // Defer past TipTap init + same-tick React effects (e.g. controlled setContent). Safari often
+        // interleaves these in one turn; synchronous focus() can throw "Applying a mismatched transaction".
+        const id = window.setTimeout(() => {
+            if (!editor.isDestroyed) {
+                editor.commands.focus()
+            }
+        }, 0)
+        return () => window.clearTimeout(id)
     }, [editor, autoFocus, editor?.isInitialized])
 
     useMarkdownEditorControlledAndFormEffects({


### PR DESCRIPTION
## Problem

Safari could throw `RangeError: Applying a mismatched transaction` when opening the text card rich markdown editor (e.g. `RichMarkdownEditor` with `autoFocus`). Chrome/Firefox rarely hit the same race. Reported in #52693 and production error tracking (text tile + ProseMirror stack).

## Changes

- Defer `editor.commands.focus()` to the next macrotask (`setTimeout(..., 0)`) in `RichMarkdownEditor` and `InlineRichMarkdownEditor`, with cleanup and `isDestroyed` guard.
- Avoids the same JavaScript turn as TipTap init and the controlled `setContent` effect in `useMarkdownEditorControlledAndFormEffects`.

## How did you test this code?

- `pnpm --filter=@posthog/frontend jest` on `RichMarkdownEditor.test.tsx` and `InlineRichMarkdownEditor.test.tsx` (pass).
- Manual: reproduced the crash in Safari before the change when editing a text card; deferred focus addresses the race (author verified locally).

Closes #52693

## Publish to changelog?

no

## Docs update

N/A
