### PR TITLE
fix(replay): restore recording filters for all insight types in persons modal

### DIFF
--- a/frontend/src/scenes/trends/persons-modal/personsModalLogic.test.ts
+++ b/frontend/src/scenes/trends/persons-modal/personsModalLogic.test.ts
@@ -3,7 +3,7 @@ import { expectLogic } from 'kea-test-utils'
 import { useMocks } from '~/mocks/jest'
 import { NodeKind } from '~/queries/schema/schema-general'
 import { initKeaTests } from '~/test/init'
-import { PersonActorType } from '~/types'
+import { FilterLogicalOperator, PersonActorType } from '~/types'
 
 import { personsModalLogic } from './personsModalLogic'
 
@@ -130,6 +130,105 @@ describe('personsModalLogic', () => {
             expectLogic(logic).toMatchValues({
                 sessionIdsFromLoadedActors: [],
             })
+        })
+    })
+
+    describe('recordingFilters', () => {
+        it('uses session IDs for InsightActorsQuery when available', () => {
+            logic = personsModalLogic({
+                query: {
+                    kind: NodeKind.InsightActorsQuery,
+                    source: {
+                        kind: NodeKind.TrendsQuery,
+                        series: [{ kind: NodeKind.EventsNode, event: '$pageview' }],
+                    },
+                    includeRecordings: true,
+                } as any,
+                url: '/api/environments/1/persons?',
+                additionalSelect: { matched_recordings: 'matched_recordings' },
+            })
+            logic.mount()
+
+            logic.actions.loadActorsSuccess({
+                results: [
+                    {
+                        count: 1,
+                        people: [
+                            {
+                                type: 'person',
+                                id: 'person-1',
+                                distinct_ids: ['user-1'],
+                                is_identified: true,
+                                properties: {},
+                                created_at: '2024-01-01',
+                                matched_recordings: [{ session_id: 'session-1', events: [] }],
+                                value_at_data_point: null,
+                            },
+                        ],
+                    },
+                ],
+                missing_persons: 0,
+            })
+
+            expectLogic(logic).toMatchValues({
+                recordingFilters: {
+                    session_ids: ['session-1'],
+                    filter_group: {
+                        type: FilterLogicalOperator.And,
+                        values: [{ type: FilterLogicalOperator.And, values: [] }],
+                    },
+                    duration: [],
+                },
+            })
+        })
+
+        it('falls back to event filters when no session IDs are available', () => {
+            logic = personsModalLogic({
+                query: {
+                    kind: NodeKind.InsightActorsQuery,
+                    source: {
+                        kind: NodeKind.TrendsQuery,
+                        series: [
+                            { kind: NodeKind.EventsNode, event: '$pageview' },
+                            { kind: NodeKind.EventsNode, event: 'sign_up' },
+                        ],
+                    },
+                    includeRecordings: true,
+                } as any,
+                url: '/api/environments/1/persons?',
+                additionalSelect: { matched_recordings: 'matched_recordings' },
+            })
+            logic.mount()
+
+            logic.actions.loadActorsSuccess({
+                results: [
+                    {
+                        count: 1,
+                        people: [
+                            {
+                                type: 'person',
+                                id: 'person-1',
+                                distinct_ids: ['user-1'],
+                                is_identified: true,
+                                properties: {},
+                                created_at: '2024-01-01',
+                                matched_recordings: [],
+                                value_at_data_point: null,
+                            },
+                        ],
+                    },
+                ],
+                missing_persons: 0,
+            })
+
+            const filters = logic.values.recordingFilters
+            const innerValues = (filters.filter_group as any)?.values?.[0]?.values
+            expect(innerValues).toEqual(
+                expect.arrayContaining([
+                    expect.objectContaining({ id: '$pageview', type: 'events' }),
+                    expect.objectContaining({ id: 'sign_up', type: 'events' }),
+                ])
+            )
         })
     })
 })

--- a/frontend/src/scenes/trends/persons-modal/personsModalLogic.ts
+++ b/frontend/src/scenes/trends/persons-modal/personsModalLogic.ts
@@ -479,9 +479,9 @@ export const personsModalLogic = kea<personsModalLogicType>([
 
                 const source = actorsQuery.source
 
-                // For FunnelsActorsQuery with session IDs, use ONLY session IDs for efficient lookup
+                // If we have session IDs from matched_recordings, use them directly for efficient lookup
                 // No need for additional event/property filters since we already have the exact list of sessions
-                if (source.kind === 'FunnelsActorsQuery' && sessionIds.length > 0) {
+                if (sessionIds.length > 0) {
                     return {
                         session_ids: sessionIds,
                         // Use minimal valid structure required by conversion functions
@@ -496,10 +496,31 @@ export const personsModalLogic = kea<personsModalLogicType>([
                 // For non-funnel queries or funnels without session IDs, use filter-based approach
                 const filters: UniversalFilterValue[] = []
 
-                // For FunnelsActorsQuery, the actual query is nested at source.source
+                // The actual insight query (with series, properties, etc.) is nested at source.source
                 let insightQuery = source
-                if (source.kind === 'FunnelsActorsQuery' && 'source' in source && source.source) {
+                if ('source' in source && source.source) {
                     insightQuery = source.source as any
+                }
+
+                // Extract events from the insight query series
+                if ('series' in insightQuery && Array.isArray(insightQuery.series)) {
+                    insightQuery.series.forEach((series) => {
+                        if ('event' in series && series.event) {
+                            const eventFilter: any = {
+                                id: series.event,
+                                name: series.event,
+                                type: 'events',
+                            }
+                            if (
+                                'properties' in series &&
+                                Array.isArray(series.properties) &&
+                                series.properties.length > 0
+                            ) {
+                                eventFilter.properties = series.properties
+                            }
+                            filters.push(eventFilter)
+                        }
+                    })
                 }
 
                 // Add breakdown filters if present


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->
The "View recordings" button in the persons modal navigates to Session Replay with nearly empty filters, showing a generic unfiltered page instead of relevant recordings.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->
- Remove the `FunnelsActorsQuery` gate from the session ID path so all insight types benefit from exact session ID matching when `matched_recordings` data is available
- Broaden the insight query unwrap so `source.source` is resolved for all query types, not just funnels
- Restore the event extraction from insight series as a fallback when session IDs are unavailable (server-side events, expired
  replays, etc.)

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->
- Added tests for both the session ID path and event filter fallback with `InsightActorsQuery`

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
