### PR TITLE
feat: Simplify the export workflow and also expose the export type

### DIFF
--- a/mypy-baseline.txt
+++ b/mypy-baseline.txt
@@ -575,7 +575,6 @@ posthog/tasks/exports/test/test_image_exporter.py:0: error: Function is missing 
 posthog/tasks/exports/test/test_image_exporter.py:0: error: Function is missing a type annotation for one or more arguments  [no-untyped-def]
 posthog/tasks/exports/test/test_image_exporter.py:0: error: Function is missing a type annotation for one or more arguments  [no-untyped-def]
 posthog/tasks/exports/test/test_image_exporter.py:0: error: Function is missing a type annotation for one or more arguments  [no-untyped-def]
-posthog/tasks/process_scheduled_changes.py:0: error: Library stubs not installed for "croniter"  [import-untyped]
 posthog/tasks/test/test_process_scheduled_changes.py:0: error: Item "None" of "Any | None" has no attribute "get"  [union-attr]
 posthog/tasks/test/test_process_scheduled_changes.py:0: error: Item "None" of "Any | None" has no attribute "get"  [union-attr]
 posthog/tasks/test/test_stop_surveys_reached_target.py:0: error: No overload variant of "__sub__" of "datetime" matches argument type "None"  [operator]

--- a/posthog/api/exports.py
+++ b/posthog/api/exports.py
@@ -296,7 +296,6 @@ class ExportedAssetSerializer(serializers.ModelSerializer):
             exported_asset_id=instance.id,
             team_id=team.id,
             distinct_id=distinct_id,
-            export_format=instance.export_format,
             slo=SloConfig(
                 operation=SloOperation.EXPORT,
                 area=SloArea.ANALYTIC_PLATFORM,
@@ -305,6 +304,12 @@ class ExportedAssetSerializer(serializers.ModelSerializer):
                 distinct_id=distinct_id,
                 start_properties={
                     "export_format": instance.export_format,
+                    "export_type": instance.export_type,
+                    "source": source,
+                },
+                completion_properties={
+                    "export_format": instance.export_format,
+                    "export_type": instance.export_type,
                     "source": source,
                 },
             ),

--- a/posthog/models/exported_asset.py
+++ b/posthog/models/exported_asset.py
@@ -150,6 +150,19 @@ class ExportedAsset(models.Model):
     def file_ext(self):
         return self.export_format.split("/")[1]
 
+    @property
+    def export_type(self) -> str:
+        if self.insight_id is not None:
+            return "insight"
+        if self.dashboard_id is not None:
+            return "dashboard"
+        ctx = self.export_context or {}
+        if ctx.get("session_recording_id"):
+            return "recording"
+        if ctx.get("heatmap_url"):
+            return "heatmap"
+        return "unknown"
+
     def get_analytics_metadata(self):
         return {
             "asset_id": self.id,

--- a/posthog/temporal/exports/workflows.py
+++ b/posthog/temporal/exports/workflows.py
@@ -2,7 +2,6 @@ import json
 import traceback
 import dataclasses
 from datetime import timedelta
-from typing import Optional
 
 import temporalio.workflow as wf
 
@@ -19,7 +18,6 @@ class ExportAssetWorkflowInputs:
     exported_asset_id: int
     team_id: int
     distinct_id: str = ""
-    export_format: Optional[str] = None
     slo: SloConfig | None = None
 
 
@@ -34,9 +32,6 @@ class ExportAssetWorkflow(PostHogWorkflow):
 
     @wf.run
     async def run(self, inputs: ExportAssetWorkflowInputs) -> None:
-        if inputs.slo:
-            inputs.slo.completion_properties["export_format"] = inputs.export_format or ""
-
         try:
             await wf.execute_activity(
                 export_asset_activity,

--- a/posthog/temporal/tests/test_export_workflow.py
+++ b/posthog/temporal/tests/test_export_workflow.py
@@ -41,18 +41,35 @@ async def _run_export_workflow(env, asset, team, mock_exporter, fake_export):
             ExportAssetWorkflowInputs(
                 exported_asset_id=asset.id,
                 team_id=team.id,
-                export_format=EXPORT_FORMAT,
                 slo=SloConfig(
                     operation=SloOperation.EXPORT,
                     area=SloArea.ANALYTIC_PLATFORM,
                     team_id=team.id,
                     resource_id=str(asset.id),
                     distinct_id=str(team.id),
+                    start_properties={
+                        "export_format": EXPORT_FORMAT,
+                        "export_type": "insight",
+                        "source": "insight",
+                    },
+                    completion_properties={
+                        "export_format": EXPORT_FORMAT,
+                        "export_type": "insight",
+                        "source": "insight",
+                    },
                 ),
             ),
             id=f"export-asset-{asset.id}",
             task_queue=settings.TEMPORAL_TASK_QUEUE,
         )
+
+
+def _get_slo_started_props(mock_analytics) -> dict:
+    started_calls = [
+        c for c in mock_analytics.capture.call_args_list if c.kwargs.get("event") == "slo_operation_started"
+    ]
+    assert len(started_calls) == 1
+    return started_calls[0].kwargs["properties"]
 
 
 def _get_slo_completed_props(mock_analytics) -> dict:
@@ -83,11 +100,19 @@ async def test_successful_export(
     await sync_to_async(asset.refresh_from_db)()
     assert asset.has_content
 
+    started_props = _get_slo_started_props(mock_analytics)
+    assert started_props["operation"] == "export"
+    assert started_props["export_format"] == EXPORT_FORMAT
+    assert started_props["export_type"] == "insight"
+    assert started_props["source"] == "insight"
+
     props = _get_slo_completed_props(mock_analytics)
     assert props["outcome"] == SloOutcome.SUCCESS
     assert props["operation"] == "export"
     assert props["resource_id"] == str(asset.id)
     assert props["export_format"] == EXPORT_FORMAT
+    assert props["export_type"] == "insight"
+    assert props["source"] == "insight"
     assert "error" not in props
 
 


### PR DESCRIPTION
## Problem

Whilst investigating the drop in our export reliability ([notebook](https://us.posthog.com/project/2/notebooks/9FeZ)), I was looking into why the session replay exports would be broken. During this investigation I found out that, now that we have interceptors, we can make do with some improvements here to simplify the slo properties.

The actual fix has been done in: https://github.com/PostHog/posthog/pull/52953 (thanks to the Session Replay team for helping out here)

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

## Changes

Small QoL improvements in order to centralise the SLO properties.

Add an export type meta data property to the SLO so that the AI can better investigate / reason about certain anomalies.

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

:white_check_mark: Tests are passing

<!-- Briefly describe the steps you took. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Publish to changelog?

No

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

No

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->