### PR TITLE
fix: Clamp the requested timestamp also in the export flow

### DIFF
--- a/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.test.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.test.ts
@@ -326,6 +326,28 @@ describe('sessionRecordingPlayerLogic', () => {
             logic.unmount()
             expect(logic.cache.hasInitialized).toBeFalsy()
         })
+
+        it('clamps out-of-bounds ?t= param to recording end instead of hanging', async () => {
+            // Mock recording: start=1682952380877, end=1682952392745, durationMs=11868
+            const END = 1682952392745
+
+            // Wait for recording data to load first
+            await expectLogic(logic).toDispatchActions([
+                sessionRecordingDataCoordinatorLogic({ sessionRecordingId: '2' }).actionTypes.loadRecordingMetaSuccess,
+                'initializePlayerFromStart',
+            ])
+
+            // Simulate what happens when seekToTime is called with an out-of-bounds
+            // offset (e.g. ?t=999999 → 999,999,000ms). seekToTime clamps via
+            // clamp(start + ms, start, end) and dispatches seekToTimestamp(end).
+            await expectLogic(logic, () => {
+                logic.actions.seekToTime(999_999_000)
+            })
+                .toDispatchActions(['seekToTime', 'seekToTimestamp'])
+                .toFinishAllListeners()
+
+            expect(logic.values.currentTimestamp).toBe(END)
+        })
     })
 
     describe('delete session recording', () => {

--- a/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
@@ -1482,6 +1482,12 @@ export const sessionRecordingPlayerLogic = kea<sessionRecordingPlayerLogicType>(
         initializePlayerFromStart: () => {
             const initialSegment = values.sessionPlayerData?.segments[0]
             if (initialSegment) {
+                // Ensure currentTimestamp is set before any seek so seekToTime
+                // doesn't early-return due to undefined currentTimestamp
+                if (!values.currentTimestamp) {
+                    actions.setCurrentTimestamp(initialSegment.startTimestamp)
+                }
+
                 // Check for the "t" search param in the url on first load
                 if (!cache.hasInitialized) {
                     cache.hasInitialized = true
@@ -1498,10 +1504,6 @@ export const sessionRecordingPlayerLogic = kea<sessionRecordingPlayerLogicType>(
                     } else {
                         actions.setSkipToFirstMatchingEvent(true)
                     }
-                }
-
-                if (!values.currentTimestamp) {
-                    actions.setCurrentTimestamp(initialSegment.startTimestamp)
                 }
 
                 actions.setCurrentSegment(initialSegment)

--- a/posthog/tasks/exports/test/test_image_exporter.py
+++ b/posthog/tasks/exports/test/test_image_exporter.py
@@ -314,3 +314,88 @@ class TestImageExporter(APIBaseTest):
             assert call_kwargs["tile_filters_override"] == tile_filters, (
                 "tile_filters_override should match tile filters"
             )
+
+    def test_session_recording_screenshot_export_passes_correct_args(
+        self,
+        mock_remove: Any,
+        mock_open: Any,
+        mock_screenshot_asset: Any,
+    ) -> None:
+        exported_asset = ExportedAsset.objects.create(
+            team=self.team,
+            export_format=ExportedAsset.ExportFormat.PNG,
+            export_context={
+                "mode": "screenshot",
+                "session_recording_id": "test-session-abc",
+                "timestamp": 87776,
+                "width": 1400,
+                "height": 600,
+                "css_selector": ".replayer-wrapper",
+            },
+        )
+
+        with self.settings(OBJECT_STORAGE_ENABLED=False):
+            image_exporter.export_image(exported_asset)
+
+        assert mock_screenshot_asset.called
+        call_args = mock_screenshot_asset.call_args[0]
+        # call_args: (image_path, url_to_render, screenshot_width, wait_for_css_selector, screenshot_height, max_height_pixels)
+        url_to_render = call_args[1]
+        screenshot_width = call_args[2]
+        wait_for_css_selector = call_args[3]
+        screenshot_height = call_args[4]
+
+        assert "t=87776" in url_to_render
+        assert "fullscreen=true" in url_to_render
+        assert "token=" in url_to_render
+        assert wait_for_css_selector == ".replayer-wrapper"
+        assert screenshot_width == 1400
+        assert screenshot_height == 600
+
+    def test_session_recording_screenshot_export_uses_defaults_when_optional_fields_missing(
+        self,
+        mock_remove: Any,
+        mock_open: Any,
+        mock_screenshot_asset: Any,
+    ) -> None:
+        exported_asset = ExportedAsset.objects.create(
+            team=self.team,
+            export_format=ExportedAsset.ExportFormat.PNG,
+            export_context={
+                "session_recording_id": "test-session-def",
+            },
+        )
+
+        with self.settings(OBJECT_STORAGE_ENABLED=False):
+            image_exporter.export_image(exported_asset)
+
+        assert mock_screenshot_asset.called
+        call_args = mock_screenshot_asset.call_args[0]
+        url_to_render = call_args[1]
+        screenshot_width = call_args[2]
+        wait_for_css_selector = call_args[3]
+        screenshot_height = call_args[4]
+
+        assert "t=0" in url_to_render
+        assert wait_for_css_selector == ".replayer-wrapper"
+        assert screenshot_width == 1400
+        assert screenshot_height == 600
+
+    def test_session_recording_export_without_recording_id_raises(
+        self,
+        mock_remove: Any,
+        mock_open: Any,
+        mock_screenshot_asset: Any,
+    ) -> None:
+        exported_asset = ExportedAsset.objects.create(
+            team=self.team,
+            export_format=ExportedAsset.ExportFormat.PNG,
+            export_context={"mode": "screenshot"},
+        )
+
+        with self.settings(OBJECT_STORAGE_ENABLED=False):
+            with self.assertRaises(
+                Exception,
+                msg="Export is missing required dashboard, insight ID, or session_recording_id in export_context",
+            ):
+                image_exporter.export_image(exported_asset)


### PR DESCRIPTION
## Problem

Whilst investigating a drop in our export reliability (AI generated [notebook](https://us.posthog.com/project/2/notebooks/9FeZ)), I noticed that we received a spike in export failures in the US as we have a customer very frequently (every ~2.5m) requesting a PNG export for a session replay with a timestamp that is out of bounds. Whilst normal PNG session replay exports are working as expected (see notebook for a curl request), these exports time out if the user is requesting a timestamp that is out of bounds. The session replay will be stuck in "buffering" indefinitely. As a result, the Chromium driver never finds the respective CSS class and due to that it will raise a `TimeoutException` after ~40s (the defined timeout).

## Changes

**Frontend:**

- Fixed session recording player initialization order by setting `currentTimestamp` before processing URL parameters with timestamp offsets
- Added test case to verify that out-of-bounds `?t=` parameters are properly clamped to the recording end instead of causing the player to hang

**Backend:**

- Added comprehensive test coverage for session recording screenshot exports, including:
    - Verification that correct parameters (timestamp, dimensions, CSS selector) are passed to the screenshot function
    - Default value handling when optional fields are missing
    - Error handling when required session recording ID is not provided

## How did you test this code?

1. Create a massive session replay (I injected some javascript that would randomly click on a clickable thing every 2 minutes and let that run for ±1hr)
2. ![CleanShot 2026-03-31 at 16.01.39@2x.png](https://app.graphite.com/user-attachments/assets/0b8a1772-ad02-4bc9-b330-394780e19caa.png)

    Prepare 2 urls, 1 with a `t=<low value>` and one with `t=<high value>`
    1. http://localhost:8010/project/1/replay/019d43af-0003-7cb5-b7a3-3233e46fea7d?t=123
    2. http://localhost:8010/project/1/replay/019d43af-0003-7cb5-b7a3-3233e46fea7d?t=123123123123123
3. Compare the results on master vs this branch

### Master:

##### **Low** **value:**

##### High value:

### This branch:

##### Low value:

##### High value:



👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Publish to changelog?

No

## Docs update

No