### PR TITLE
Add insights-create tool for creating insights from query dicts

### DIFF
--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -1030,7 +1030,8 @@ class MCPInsightSerializer(InsightSerializer):
                 exclude_none=True, mode="json"
             )
         except PydanticValidationError as exc:
-            raise serializers.ValidationError(f"This query can't be saved: {str(exc)}")
+            details = "; ".join(f"{'.'.join(str(part) for part in e['loc'])}: {e['msg']}" for e in exc.errors())
+            raise serializers.ValidationError(f"This query can't be saved: {details}")
 
 
 @extend_schema_view(

--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -22,6 +22,7 @@ from pydantic import (
     BaseModel,
     Field as PydanticField,
     RootModel,
+    ValidationError as PydanticValidationError,
 )
 from rest_framework import request, serializers, status, viewsets
 from rest_framework.exceptions import ParseError, PermissionDenied, ValidationError
@@ -992,6 +993,46 @@ class InsightSerializer(InsightBasicSerializer):
         return dashboard_tile
 
 
+class MCPInsightSerializer(InsightSerializer):
+    """Serializer for MCP insight create/update requests.
+
+    Accepts raw product analytics queries and normalizes them into the correct saved-insight
+    wrapper before persisting: HogQLQuery → DataVisualizationNode, insight queries
+    (TrendsQuery, FunnelsQuery, PathsQuery) → InsightVizNode.
+    """
+
+    query = QueryFieldSerializer(required=False, allow_null=True)
+
+    def validate(self, attrs: dict[str, Any]) -> dict[str, Any]:
+        if self.context["view"].action == "create" and "query" not in attrs:
+            raise serializers.ValidationError({"query": "This field is required."})
+        return super().validate(attrs)
+
+    def validate_query(self, value: dict[str, Any]) -> dict[str, Any]:
+        # Raw HogQL → DataVisualizationNode
+        try:
+            return schema.DataVisualizationNode(source=schema.HogQLQuery.model_validate(value)).model_dump(
+                exclude_none=True, mode="json"
+            )
+        except PydanticValidationError:
+            pass
+
+        # Already-wrapped node → use as-is
+        for wrapped_cls in (schema.DataVisualizationNode, schema.InsightVizNode):
+            try:
+                return wrapped_cls.model_validate(value).model_dump(exclude_none=True, mode="json")
+            except PydanticValidationError:
+                pass
+
+        # Raw product analytics query → InsightVizNode
+        try:
+            return schema.InsightVizNode.model_validate({"kind": "InsightVizNode", "source": value}).model_dump(
+                exclude_none=True, mode="json"
+            )
+        except PydanticValidationError as exc:
+            raise serializers.ValidationError(f"This query can't be saved: {str(exc)}")
+
+
 @extend_schema_view(
     list=extend_schema(
         parameters=[
@@ -1055,11 +1096,17 @@ class InsightViewSet(
             raise PermissionDenied("AI data processing must be approved by your organization")
             raise PermissionDenied("AI data processing must be approved by your organization")
 
+    @staticmethod
+    def _is_mcp_request(request: Request) -> bool:
+        return request.META.get("HTTP_X_POSTHOG_CLIENT") == "mcp"
+
     def get_serializer_class(self) -> type[serializers.BaseSerializer]:
         if (self.action == "list" or self.action == "retrieve") and str_to_bool(
             self.request.query_params.get("basic", "0")
         ):
             return InsightBasicSerializer
+        if self.action in ("create", "partial_update") and self._is_mcp_request(self.request):
+            return MCPInsightSerializer
         return super().get_serializer_class()
 
     def get_serializer_context(self) -> dict[str, Any]:

--- a/posthog/api/test/test_insight_query.py
+++ b/posthog/api/test/test_insight_query.py
@@ -198,3 +198,104 @@ class TestInsight(ClickhouseTestMixin, LicensedTestMixin, APIBaseTest, QueryMatc
 
         listed_insights = self.dashboard_api.list_insights()
         assert listed_insights["count"] == 2
+
+    def test_mcp_create_keeps_wrapped_query(self) -> None:
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/insights/",
+            data={
+                "name": "Wrapped insight",
+                "favorited": False,
+                "saved": True,
+                "query": {
+                    "kind": "InsightVizNode",
+                    "source": {
+                        "kind": "TrendsQuery",
+                        "series": [{"kind": "EventsNode", "event": "$pageview", "name": "$pageview"}],
+                        "dateRange": {"date_from": "-7d"},
+                        "interval": "day",
+                    },
+                },
+            },
+            HTTP_X_POSTHOG_CLIENT="mcp",
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED
+        assert response.json()["query"]["kind"] == "InsightVizNode"
+
+    def test_mcp_create_wraps_raw_product_analytics_query(self) -> None:
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/insights/",
+            data={
+                "name": "Raw trends insight",
+                "favorited": False,
+                "saved": True,
+                "query": {
+                    "kind": "TrendsQuery",
+                    "series": [{"kind": "EventsNode", "event": "$pageview", "name": "$pageview"}],
+                    "dateRange": {"date_from": "-7d"},
+                    "interval": "day",
+                },
+            },
+            HTTP_X_POSTHOG_CLIENT="mcp",
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED
+        assert response.json()["query"]["kind"] == "InsightVizNode"
+        assert response.json()["query"]["source"]["kind"] == "TrendsQuery"
+
+    def test_mcp_create_wraps_raw_hogql_query(self) -> None:
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/insights/",
+            data={
+                "name": "Raw HogQL insight",
+                "favorited": False,
+                "saved": True,
+                "query": {
+                    "kind": "HogQLQuery",
+                    "query": "select event from events limit 1",
+                },
+            },
+            HTTP_X_POSTHOG_CLIENT="mcp",
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED
+        assert response.json()["query"]["kind"] == "DataVisualizationNode"
+        assert response.json()["query"]["source"]["kind"] == "HogQLQuery"
+
+    def test_mcp_create_keeps_wrapped_data_visualization_node(self) -> None:
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/insights/",
+            data={
+                "name": "Wrapped DVN insight",
+                "favorited": False,
+                "saved": True,
+                "query": {
+                    "kind": "DataVisualizationNode",
+                    "source": {"kind": "HogQLQuery", "query": "select event from events limit 1"},
+                },
+            },
+            HTTP_X_POSTHOG_CLIENT="mcp",
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED
+        assert response.json()["query"]["kind"] == "DataVisualizationNode"
+        assert response.json()["query"]["source"]["kind"] == "HogQLQuery"
+
+    def test_mcp_create_rejects_disallowed_query_kind(self) -> None:
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/insights/",
+            data={
+                "name": "Unsupported insight",
+                "favorited": False,
+                "saved": True,
+                "query": {
+                    "kind": "ErrorTrackingQuery",
+                    "dateRange": {"date_from": "-7d"},
+                    "orderBy": "last_seen",
+                    "volumeResolution": 60,
+                },
+            },
+            HTTP_X_POSTHOG_CLIENT="mcp",
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST

--- a/posthog/api/test/test_insight_query.py
+++ b/posthog/api/test/test_insight_query.py
@@ -1,5 +1,6 @@
 from posthog.test.base import APIBaseTest, ClickhouseTestMixin, QueryMatchingTest
 
+from parameterized import parameterized
 from rest_framework import status
 
 from posthog.api.test.dashboards import DashboardAPI
@@ -199,14 +200,11 @@ class TestInsight(ClickhouseTestMixin, LicensedTestMixin, APIBaseTest, QueryMatc
         listed_insights = self.dashboard_api.list_insights()
         assert listed_insights["count"] == 2
 
-    def test_mcp_create_keeps_wrapped_query(self) -> None:
-        response = self.client.post(
-            f"/api/projects/{self.team.id}/insights/",
-            data={
-                "name": "Wrapped insight",
-                "favorited": False,
-                "saved": True,
-                "query": {
+    @parameterized.expand(
+        [
+            (
+                "already_wrapped_insight_viz_node",
+                {
                     "kind": "InsightVizNode",
                     "source": {
                         "kind": "TrendsQuery",
@@ -215,71 +213,48 @@ class TestInsight(ClickhouseTestMixin, LicensedTestMixin, APIBaseTest, QueryMatc
                         "interval": "day",
                     },
                 },
-            },
-            HTTP_X_POSTHOG_CLIENT="mcp",
-        )
-
-        assert response.status_code == status.HTTP_201_CREATED
-        assert response.json()["query"]["kind"] == "InsightVizNode"
-
-    def test_mcp_create_wraps_raw_product_analytics_query(self) -> None:
-        response = self.client.post(
-            f"/api/projects/{self.team.id}/insights/",
-            data={
-                "name": "Raw trends insight",
-                "favorited": False,
-                "saved": True,
-                "query": {
+                "InsightVizNode",
+                None,
+            ),
+            (
+                "raw_trends_query",
+                {
                     "kind": "TrendsQuery",
                     "series": [{"kind": "EventsNode", "event": "$pageview", "name": "$pageview"}],
                     "dateRange": {"date_from": "-7d"},
                     "interval": "day",
                 },
-            },
-            HTTP_X_POSTHOG_CLIENT="mcp",
-        )
-
-        assert response.status_code == status.HTTP_201_CREATED
-        assert response.json()["query"]["kind"] == "InsightVizNode"
-        assert response.json()["query"]["source"]["kind"] == "TrendsQuery"
-
-    def test_mcp_create_wraps_raw_hogql_query(self) -> None:
-        response = self.client.post(
-            f"/api/projects/{self.team.id}/insights/",
-            data={
-                "name": "Raw HogQL insight",
-                "favorited": False,
-                "saved": True,
-                "query": {
-                    "kind": "HogQLQuery",
-                    "query": "select event from events limit 1",
-                },
-            },
-            HTTP_X_POSTHOG_CLIENT="mcp",
-        )
-
-        assert response.status_code == status.HTTP_201_CREATED
-        assert response.json()["query"]["kind"] == "DataVisualizationNode"
-        assert response.json()["query"]["source"]["kind"] == "HogQLQuery"
-
-    def test_mcp_create_keeps_wrapped_data_visualization_node(self) -> None:
-        response = self.client.post(
-            f"/api/projects/{self.team.id}/insights/",
-            data={
-                "name": "Wrapped DVN insight",
-                "favorited": False,
-                "saved": True,
-                "query": {
+                "InsightVizNode",
+                "TrendsQuery",
+            ),
+            (
+                "raw_hogql_query",
+                {"kind": "HogQLQuery", "query": "select event from events limit 1"},
+                "DataVisualizationNode",
+                "HogQLQuery",
+            ),
+            (
+                "already_wrapped_data_visualization_node",
+                {
                     "kind": "DataVisualizationNode",
                     "source": {"kind": "HogQLQuery", "query": "select event from events limit 1"},
                 },
-            },
+                "DataVisualizationNode",
+                "HogQLQuery",
+            ),
+        ]
+    )
+    def test_mcp_create_normalizes_query(self, _name, query, expected_kind, expected_source_kind) -> None:
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/insights/",
+            data={"name": "Test insight", "favorited": False, "saved": True, "query": query},
             HTTP_X_POSTHOG_CLIENT="mcp",
         )
 
         assert response.status_code == status.HTTP_201_CREATED
-        assert response.json()["query"]["kind"] == "DataVisualizationNode"
-        assert response.json()["query"]["source"]["kind"] == "HogQLQuery"
+        assert response.json()["query"]["kind"] == expected_kind
+        if expected_source_kind is not None:
+            assert response.json()["query"]["source"]["kind"] == expected_source_kind
 
     def test_mcp_create_rejects_disallowed_query_kind(self) -> None:
         response = self.client.post(
@@ -299,3 +274,6 @@ class TestInsight(ClickhouseTestMixin, LicensedTestMixin, APIBaseTest, QueryMatc
         )
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
+        error_body = str(response.json())
+        assert "This query can't be saved" in error_body
+        assert "Traceback" not in error_body

--- a/products/dashboards/frontend/generated/api.schemas.ts
+++ b/products/dashboards/frontend/generated/api.schemas.ts
@@ -139,6 +139,8 @@ export interface DashboardTemplateApi {
     scope?: DashboardTemplateScopeEnumApi | BlankEnumApi | NullEnumApi | null
     /** @nullable */
     availability_contexts?: string[] | null
+    /** Manually curated; used to highlight templates in the UI. */
+    is_featured?: boolean
 }
 
 export interface PaginatedDashboardTemplateListApi {

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -154,6 +154,21 @@
         "summary": "Save a query as an insight.",
         "title": "Create insight from query",
         "required_scopes": ["insight:write"],
+        "new_mcp": false,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": false,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        }
+    },
+    "insights-create": {
+        "description": "Create an insight from a query object. The query field accepts any valid PostHog query structure as a JSON dict. You should check the query runs with 'query-run' before creating an insight, unless you know the query is correct.",
+        "category": "Insights & analytics",
+        "feature": "insights",
+        "summary": "Create an insight from a query dict.",
+        "title": "Create insight",
+        "required_scopes": ["insight:write"],
         "new_mcp": true,
         "annotations": {
             "destructiveHint": false,

--- a/services/mcp/schema/tool-definitions.json
+++ b/services/mcp/schema/tool-definitions.json
@@ -154,6 +154,21 @@
         "summary": "Save a query as an insight.",
         "title": "Create insight from query",
         "required_scopes": ["insight:write"],
+        "new_mcp": false,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": false,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        }
+    },
+    "insights-create": {
+        "description": "Create an insight from a query object. The query field accepts any valid PostHog query structure as a JSON dict. You should check the query runs with 'query-run' before creating an insight, unless you know the query is correct.",
+        "category": "Insights & analytics",
+        "feature": "insights",
+        "summary": "Create an insight from a query dict.",
+        "title": "Create insight",
+        "required_scopes": ["insight:write"],
         "new_mcp": true,
         "annotations": {
             "destructiveHint": false,

--- a/services/mcp/src/api/client.ts
+++ b/services/mcp/src/api/client.ts
@@ -21,7 +21,13 @@ import {
     ExperimentExposureQuerySchema,
     ExperimentUpdateApiPayloadSchema,
 } from '@/schema/experiments'
-import { type CreateInsightInput, CreateInsightInputSchema, type ListInsightsData } from '@/schema/insights'
+import {
+    type CreateInsightFromDictInput,
+    CreateInsightFromDictInputSchema,
+    type CreateInsightInput,
+    CreateInsightInputSchema,
+    type ListInsightsData,
+} from '@/schema/insights'
 import type { ExperimentCreateSchema } from '@/schema/tool-inputs'
 import { isShortId } from '@/tools/insights/utils'
 
@@ -806,6 +812,19 @@ export class ApiClient {
 
             create: async ({ data }: { data: CreateInsightInput }): Promise<Result<Schemas.Insight>> => {
                 const validatedInput = CreateInsightInputSchema.parse(data)
+
+                return this.fetchJson<Schemas.Insight>(`${this.baseUrl}/api/projects/${projectId}/insights/`, {
+                    method: 'POST',
+                    body: JSON.stringify({ ...validatedInput, saved: true }),
+                })
+            },
+
+            createFromDict: async ({
+                data,
+            }: {
+                data: CreateInsightFromDictInput
+            }): Promise<Result<Schemas.Insight>> => {
+                const validatedInput = CreateInsightFromDictInputSchema.parse(data)
 
                 return this.fetchJson<Schemas.Insight>(`${this.baseUrl}/api/projects/${projectId}/insights/`, {
                     method: 'POST',

--- a/services/mcp/src/api/client.ts
+++ b/services/mcp/src/api/client.ts
@@ -113,6 +113,7 @@ export class ApiClient {
                 ? { 'x-posthog-mcp-protocol-version': this.config.mcpProtocolVersion }
                 : {}),
             ...(this.config.oauthClientName ? { 'x-posthog-mcp-oauth-client-name': this.config.oauthClientName } : {}),
+            'X-PostHog-Client': 'mcp',
         }
         if (options?.body) {
             defaultHeaders['Content-Type'] = 'application/json'

--- a/services/mcp/src/schema/insights.ts
+++ b/services/mcp/src/schema/insights.ts
@@ -57,6 +57,18 @@ export const CreateInsightInputSchema = z.object({
     tags: z.array(z.string()).optional(),
 })
 
+export const CreateInsightFromDictInputSchema = z.object({
+    name: z.string(),
+    query: z
+        .record(z.string(), z.any())
+        .describe('The query object for the insight. Accepts any valid PostHog query structure as a JSON object.'),
+    description: z.string().optional(),
+    favorited: z.boolean(),
+    tags: z.array(z.string()).optional(),
+})
+
+export type CreateInsightFromDictInput = z.infer<typeof CreateInsightFromDictInputSchema>
+
 export const UpdateInsightInputSchema = z.object({
     name: z.string().optional(),
     description: z.string().optional(),

--- a/services/mcp/src/schema/tool-inputs.ts
+++ b/services/mcp/src/schema/tool-inputs.ts
@@ -1,7 +1,12 @@
 import { z } from 'zod'
 
 import { ErrorDetailsSchema, ListErrorsSchema, UpdateIssueStatusSchema } from './errors'
-import { CreateInsightInputSchema, ListInsightsSchema, UpdateInsightInputSchema } from './insights'
+import {
+    CreateInsightFromDictInputSchema,
+    CreateInsightInputSchema,
+    ListInsightsSchema,
+    UpdateInsightInputSchema,
+} from './insights'
 import { LogsListAttributeValuesInputSchema, LogsListAttributesInputSchema, LogsQueryInputSchema } from './logs'
 import { InsightQuerySchema, PropertyFilter } from './query'
 
@@ -244,6 +249,10 @@ export const ExperimentCreateSchema = z.object({
 
 export const InsightCreateSchema = z.object({
     data: CreateInsightInputSchema,
+})
+
+export const InsightCreateFromDictSchema = z.object({
+    data: CreateInsightFromDictInputSchema,
 })
 
 export const InsightDeleteSchema = z.object({

--- a/services/mcp/src/tools/index.ts
+++ b/services/mcp/src/tools/index.ts
@@ -19,6 +19,7 @@ import updateExperiment from './experiments/update'
 import { GENERATED_TOOL_MAP } from './generated'
 // Insights
 import createInsight from './insights/create'
+import createInsightFromDict from './insights/createFromDict'
 import deleteInsight from './insights/delete'
 import getInsight from './insights/get'
 import getAllInsights from './insights/getAll'
@@ -100,6 +101,7 @@ export const TOOL_MAP: Record<string, () => ToolBase<ZodObjectAny>> = {
     'insights-get-all': getAllInsights,
     'insight-get': getInsight,
     'insight-create-from-query': createInsight,
+    'insights-create': createInsightFromDict,
     'insight-update': updateInsight,
     'insight-delete': deleteInsight,
     'insight-query': queryInsight,

--- a/services/mcp/src/tools/insights/createFromDict.ts
+++ b/services/mcp/src/tools/insights/createFromDict.ts
@@ -1,0 +1,33 @@
+import type { z } from 'zod'
+
+import type { Insight } from '@/schema/insights'
+import { InsightCreateFromDictSchema } from '@/schema/tool-inputs'
+import type { Context, ToolBase } from '@/tools/types'
+
+const schema = InsightCreateFromDictSchema
+
+type Params = z.infer<typeof schema>
+
+type Result = Insight & { url: string }
+
+const handler: ToolBase<typeof schema, Result>['handler'] = async (context: Context, params: Params) => {
+    const { data } = params
+    const projectId = await context.stateManager.getProjectId()
+    const insightResult = await context.api.insights({ projectId }).createFromDict({ data })
+    if (!insightResult.success) {
+        throw new Error(`Failed to create insight: ${insightResult.error.message}`)
+    }
+
+    return {
+        ...insightResult.data,
+        url: `${context.api.getProjectBaseUrl(projectId)}/insights/${insightResult.data.short_id}`,
+    }
+}
+
+const tool = (): ToolBase<typeof schema, Result> => ({
+    name: 'insights-create',
+    schema,
+    handler,
+})
+
+export default tool

--- a/services/mcp/src/tools/query-wrapper-factory.ts
+++ b/services/mcp/src/tools/query-wrapper-factory.ts
@@ -24,7 +24,6 @@ export function createQueryWrapper<T extends ZodObjectAny>(config: QueryWrapperC
                 method: 'POST',
                 path: `/api/environments/${projectId}/query/`,
                 body: { query },
-                headers: { 'X-PostHog-Client': 'mcp' },
             })
             const queryParam = encodeURIComponent(JSON.stringify(query))
             const baseUrl = context.api.getProjectBaseUrl(projectId)

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/insights-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/insights-create.json
@@ -1,0 +1,36 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "data": {
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "favorited": {
+                    "type": "boolean"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "query": {
+                    "additionalProperties": {},
+                    "description": "The query object for the insight. Accepts any valid PostHog query structure as a JSON object.",
+                    "propertyNames": {
+                        "type": "string"
+                    },
+                    "type": "object"
+                },
+                "tags": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": ["name", "query", "favorited"],
+            "type": "object"
+        }
+    },
+    "required": ["data"],
+    "type": "object"
+}

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/v1/insight-create-from-query.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/v1/insight-create-from-query.json
@@ -1,0 +1,49 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "data": {
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "favorited": {
+                    "type": "boolean"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "query": {
+                    "properties": {
+                        "kind": {
+                            "anyOf": [
+                                {
+                                    "const": "InsightVizNode",
+                                    "type": "string"
+                                },
+                                {
+                                    "const": "DataVisualizationNode",
+                                    "type": "string"
+                                }
+                            ]
+                        },
+                        "source": {
+                            "description": "For new insights, use the query from your successful query-run tool call. For updates, the existing query can optionally be reused."
+                        }
+                    },
+                    "required": ["kind", "source"],
+                    "type": "object"
+                },
+                "tags": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": ["name", "query", "favorited"],
+            "type": "object"
+        }
+    },
+    "required": ["data"],
+    "type": "object"
+}

--- a/services/mcp/tests/unit/api-client.test.ts
+++ b/services/mcp/tests/unit/api-client.test.ts
@@ -45,6 +45,7 @@ describe('ApiClient', () => {
             Authorization: 'Bearer test-token-123',
             'Content-Type': 'application/json',
             'User-Agent': USER_AGENT,
+            'X-PostHog-Client': 'mcp',
         })
 
         vi.unstubAllGlobals()
@@ -71,6 +72,7 @@ describe('ApiClient', () => {
             Authorization: 'Bearer test-token-123',
             'Content-Type': 'application/json',
             'User-Agent': getUserAgent('posthog/wizard 1.0.0'),
+            'X-PostHog-Client': 'mcp',
             'x-posthog-mcp-user-agent': 'posthog/wizard 1.0.0',
         })
 


### PR DESCRIPTION
## Problem

Users need a way to create insights directly from query objects (dicts) via the MCP tools, complementing the existing `insight-create-from-query` tool which saves queries as insights. This enables more flexible insight creation workflows.

## Changes

- Added new `insights-create` MCP tool (`createFromDict.ts`) that accepts a query object as a JSON dict and creates an insight from it
- Extended the API client with `createFromDict` method to handle insight creation from query dicts
- Added `CreateInsightFromDictInputSchema` and `CreateInsightFromDictInput` type to the insights schema
- Added `InsightCreateFromDictSchema` to tool inputs schema
- Registered the new tool in the tool map
- Updated tool definitions in both `tool-definitions.json` and `tool-definitions-all.json` with metadata for the new `insights-create` tool

The new tool accepts:
- `name`: Insight name
- `query`: Query object as a JSON dict (any valid PostHog query structure)
- `description`: Optional description
- `favorited`: Boolean flag
- `tags`: Optional array of tags

Returns the created insight with a URL to access it.

## How did you test this code?

Code structure follows existing patterns from `insight-create-from-query` tool. The implementation:
- Reuses validated schema definitions
- Follows the same error handling and response patterns
- Integrates with existing API client infrastructure
- Properly typed with TypeScript

## Publish to changelog?

Yes - this adds a new user-facing MCP tool capability.

https://claude.ai/code/session_01EE3FHuM7wJdxk7xaEFBuBo