### PR TITLE
chore(devex): Restrict dependabot to security-only updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,147 +4,21 @@ updates:
       directory: '/'
       schedule:
           interval: weekly
+      open-pull-requests-limit: 0
 
-    # npm dependencies - configured to only update from root to support pnpm workspaces
+    # Configured to only update from root to support pnpm workspaces
     # Without this, automatic security updates may try to update from subdirectories
     # which fails with "Updating workspaces from inside a workspace subdirectory is not supported"
     - package-ecosystem: 'npm'
       directory: '/'
       schedule:
           interval: weekly
-      open-pull-requests-limit: 5
-      groups:
-          npm-dependencies:
-              patterns:
-                  - '*'
-              update-types:
-                  - 'minor'
-                  - 'patch'
+      open-pull-requests-limit: 0
 
-    # Python dependencies for main PostHog application (uv updates both pyproject.toml and uv.lock)
+    # Python dependencies for main PostHog application
+    # uv updates both pyproject.toml and uv.lock
     - package-ecosystem: 'uv'
       directory: '/'
+      open-pull-requests-limit: 0
       schedule:
           interval: weekly
-      open-pull-requests-limit: 1
-      reviewers:
-          - 'PostHog/team-devex'
-      groups:
-          # Security and authentication packages
-          security-auth:
-              patterns:
-                  - 'cryptography'
-                  - 'certifi'
-                  - 'pyjwt'
-                  - 'python3-saml'
-                  - 'xmlsec'
-                  - 'django-two-factor-auth'
-                  - 'django-oauth-toolkit'
-                  - 'social-auth-*'
-                  - 'zxcvbn'
-              update-types:
-                  - 'minor'
-                  - 'patch'
-
-          # Django ecosystem packages (extensions, middleware, auth, etc)
-          django-ecosystem:
-              patterns:
-                  - 'django-*'
-                  - 'djangorestframework*'
-                  - 'drf-*'
-              update-types:
-                  - 'minor'
-                  - 'patch'
-
-          # Data and database layer packages
-          data-database:
-              patterns:
-                  - 'clickhouse-*'
-                  - 'psycopg*'
-                  - 'redis'
-                  - 'boto3'
-                  - 'aioboto*'
-                  - 's3fs'
-                  - 'pyarrow'
-                  - 'deltalake'
-              update-types:
-                  - 'minor'
-                  - 'patch'
-
-          # Data integration and ETL packages
-          data-integration-etl:
-              patterns:
-                  - 'dlt'
-                  - 'google-cloud-bigquery'
-                  - 'snowflake-connector-python'
-                  - 'databricks-sql-connector'
-                  - 'databricks-sdk'
-                  - 'simple-salesforce'
-                  - 'gspread'
-                  - 'google-ads'
-                  - 'pymssql'
-                  - 'pymysql'
-                  - 'pymongo'
-                  - 'pyodbc'
-              update-types:
-                  - 'minor'
-                  - 'patch'
-
-          # AI/ML packages (fast-moving, frequent releases)
-          ai-ml-packages:
-              patterns:
-                  - 'anthropic'
-                  - 'openai'
-                  - 'mistralai'
-                  - 'google-genai'
-                  - 'langchain*'
-                  - 'langgraph'
-                  - 'elevenlabs'
-                  - 'litellm'
-                  - 'azure-ai-*'
-              update-types:
-                  - 'minor'
-                  - 'patch'
-
-          # Workflow orchestration packages
-          dagster-workflow:
-              patterns:
-                  - 'dagster*'
-              update-types:
-                  - 'minor'
-                  - 'patch'
-
-          # Testing packages (pytest, mocking, fixtures) - include major since dev-only
-          testing:
-              patterns:
-                  - 'pytest*'
-                  - 'aioresponses'
-                  - 'faker'
-                  - 'fakeredis'
-                  - 'freezegun'
-                  - 'requests-mock'
-                  - 'responses'
-                  - 'syrupy'
-                  - 'flaky'
-                  - 'parameterized'
-                  - 'deepdiff'
-              update-types:
-                  - 'major'
-                  - 'minor'
-                  - 'patch'
-
-          # All other minor and patch updates
-          other-dependencies:
-              patterns:
-                  - '*'
-              update-types:
-                  - 'minor'
-                  - 'patch'
-
-      # Cooldown period - avoid packages released in last 7 days
-      cooldown:
-          default-days: 7
-
-      ignore:
-          # Exclude Django core from updates
-          - dependency-name: 'django'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,3 +22,13 @@ updates:
       open-pull-requests-limit: 0
       schedule:
           interval: weekly
+      reviewers:
+          - 'PostHog/team-devex'
+
+      # Cooldown period - avoid packages released in last 7 days (applies to version updates only)
+      cooldown:
+          default-days: 7
+
+      ignore:
+          # Exclude Django core from updates
+          - dependency-name: 'django'


### PR DESCRIPTION
## Changes

Set `open-pull-requests-limit: 0` on all ecosystems to disable version update PRs while still allowing security update PRs to be opened.

For the `uv` ecosystem, the following settings are preserved to ensure security PRs are properly routed:
- `reviewers: PostHog/team-devex` — ensures security PRs are assigned to the right team
- `cooldown: default-days: 7` — retained (applies to version updates only, no impact on security PRs)
- `ignore: django` — retained to continue excluding Django core from automated updates

The `groups` configuration was intentionally removed, as Dependabot ignores group rules for security update PRs (security updates always generate individual PRs regardless of grouping).

## How did you test this code?

This is a configuration-only change to `.github/dependabot.yml`. No automated tests apply; correctness was verified by reviewing the final config against GitHub's Dependabot documentation.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

no

## Docs update