### PR TITLE
fix: improve x-axis ticks on hourly charts

### DIFF
--- a/frontend/src/lib/charts/utils/dates.test.ts
+++ b/frontend/src/lib/charts/utils/dates.test.ts
@@ -163,6 +163,17 @@ describe('createXAxisTickCallback', () => {
             }),
         },
         {
+            scenario: 'hourly, multi-day (4 days) → day-start labels only, no intermediate time ticks',
+            interval: 'hour' as const,
+            allDays: hourlyDates('2025-02-15', 96),
+            expected: sparseLabels(96, {
+                0: 'Feb 15',
+                24: 'Feb 16',
+                48: 'Feb 17',
+                72: 'Feb 18',
+            }),
+        },
+        {
             scenario:
                 'hourly, multi-day sparse (5 days, 8am-10pm only) → date label at each day start, not just midnight',
             interval: 'hour' as const,
@@ -203,15 +214,10 @@ describe('createXAxisTickCallback', () => {
             ],
             expected: sparseLabels(28, {
                 0: 'Mar 24', // day 1 start
-                4: '12:00', // noon
                 10: 'Mar 25', // day 2 start
-                12: '12:00', // noon
                 16: 'Mar 26', // day 3 start
-                17: '12:00', // noon
                 20: 'Mar 27', // day 4 start
-                21: '12:00', // noon
                 24: 'Mar 28', // day 5 start
-                25: '12:00', // noon
             }),
         },
     ])('$scenario', ({ interval, allDays, expected }) => {

--- a/frontend/src/lib/charts/utils/dates.ts
+++ b/frontend/src/lib/charts/utils/dates.ts
@@ -95,7 +95,11 @@ function isTickVisible(mode: TickMode, date: Dayjs, index: number): boolean {
         case 'monthly':
             return mode.visibleBoundaries.has(index)
         case 'hourly-multi-day':
-            return mode.dayStartIndices.has(index) || date.hour() % mode.step === 0
+            if (mode.dayStartIndices.has(index)) {
+                return true
+            }
+            // Only show intermediate time ticks (e.g. 06:00, 12:00) when there are few days
+            return mode.dayStartIndices.size <= 3 && date.hour() % mode.step === 0
         default:
             return true
     }


### PR DESCRIPTION
## Problem

Showing time and dates on hourly-multi-day charts looks odd

## Changes

- Updated `isTickVisible` in `dates.ts` to only show intermediate time ticks when there are 3 or fewer day-start labels
- Refactored the condition into an early return for readability
- Updated the 'hourly, multi-day sparse' test to expect only day-start labels
- Added a 4-day boundary test case to cover the threshold where intermediates get hidden

Month:
<img width="1260" height="641" alt="Screenshot 2026-03-30 at 17 06 50" src="https://github.com/user-attachments/assets/234e9080-18cd-4b29-99d9-82f6e411880b" />

Week:
<img width="1247" height="545" alt="Screenshot 2026-03-30 at 17 07 07" src="https://github.com/user-attachments/assets/7eee51b9-a6cf-4258-bbd3-e37a50466384" />

2 days:
<img width="1270" height="662" alt="Screenshot 2026-03-30 at 17 07 35" src="https://github.com/user-attachments/assets/4c60e50f-b3ff-4861-9455-c84b64bd5830" />


## How did you test this code?
locally, tests

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
no