### PR TITLE
fix(phai): handle null action in trends formula results formatter

### DIFF
--- a/ee/hogai/context/insight/format/test/test_trends.py
+++ b/ee/hogai/context/insight/format/test/test_trends.py
@@ -165,6 +165,23 @@ class TestTrendsResultsFormatter(BaseTest):
             "Date range|Aggregated value for $pageview|Aggregated value for $pageleave\n2025-01-20 to 2025-01-22|993|1000",
         )
 
+    def test_trends_aggregated_value_with_null_action(self):
+        results = [
+            {
+                "data": None,
+                "days": [],
+                "count": 0,
+                "aggregated_value": 92.22,
+                "label": "Bounce rate",
+                "action": None,
+                "breakdown_value": ["/news-research"],
+            }
+        ]
+        self.assertEqual(
+            TrendsResultsFormatter(AssistantTrendsQuery(series=[]), results).format(),
+            "Date range|Aggregated value for Bounce rate breakdown for the value `/news-research`\nAll time|92.22",
+        )
+
     def test_trends_aggregated_values_with_comparison(self):
         results = [
             {

--- a/ee/hogai/context/insight/format/trends.py
+++ b/ee/hogai/context/insight/format/trends.py
@@ -49,7 +49,7 @@ class TrendsResultsFormatter:
     def _format_aggregated_values(self, results: list[dict[str, Any]]) -> str:
         # Get dates and series labels
         result = results[0]
-        dates = result.get("action", {}).get("days") or []
+        dates = (result.get("action") or {}).get("days") or []
         if len(dates) == 0:
             range = "All time"
         else:

--- a/posthog/models/resource_transfer/test/__snapshots__/test_visitor_field_snapshots.ambr
+++ b/posthog/models/resource_transfer/test/__snapshots__/test_visitor_field_snapshots.ambr
@@ -451,6 +451,7 @@
   list([
     'DoesNotExist',
     'MultipleObjectsReturned',
+    '__annotations__',
     '__doc__',
     '__module__',
     '__repr__',


### PR DESCRIPTION
## Problem

Formula-based trends queries (e.g. bounce rate = A/B*100) with aggregated displays (`ActionsBarValue`) return results where `action` is `null`. The trends formatter crashed with `AttributeError: 'NoneType' object has no attribute 'get'` because `result.get("action", {})` returns `None` when the key exists with a `None` value — the default `{}` only applies when the key is absent.

~96 occurrences: https://us.posthog.com/project/2/error_tracking/019b3195-2156-7803-bf15-bcace6387526

## Changes

- Fixed `_format_aggregated_values` to use `(result.get("action") or {})` instead of `result.get("action", {})`, correctly handling explicit `None` values.
- Added test for formula results with `action: None`.

## How did you test this code?

Added `test_trends_aggregated_value_with_null_action` which reproduces the exact crash scenario from the error report and verifies correct output.