### PR TITLE
feat: add claude skill for qa

### DIFF
--- a/.agents/skills/qa-team/SKILL.md
+++ b/.agents/skills/qa-team/SKILL.md
@@ -1,0 +1,382 @@
+---
+name: qa-team
+description: >
+  Multi-agent QA review team for code changes. This skill should be used when the user
+  asks to "review my code", "run QA", "qa-team", "review this branch", "code review",
+  "check my changes", or wants a comprehensive multi-perspective code review of the
+  current branch's changes. Spawns parallel specialist agents (security, database,
+  reliability, compatibility, data integrity, performance, frontend, copy) that
+  independently review the diff and produce a converged report. Also includes
+  two generalist reviewers for convergence validation.
+---
+
+# QA Team: Multi-Agent Code Review
+
+A team of specialist agents independently review the current branch's changes against
+real incident patterns. Their findings are synthesized into a single report with
+convergence analysis.
+
+**Agent independence is critical.** Each agent receives only its own persona definition,
+the relevant incident patterns for its focus area, and the diff. Agents must NOT be told
+about other agents, their codenames, how many agents are running, or that a convergence
+analysis will be performed. This ensures findings are fully independent.
+
+## Workflow
+
+### Step 1: Gather the diff
+
+Determine the base branch. If the user provided `$ARGUMENTS`, use that as the base branch.
+Otherwise, default to `main`.
+
+Run these commands to collect context:
+
+```bash
+git diff <base>...HEAD --name-only
+git diff <base>...HEAD
+git log <base>...HEAD --oneline
+```
+
+Store the full diff, changed file list, and commit messages. These will be passed to each agent.
+
+If there are no changes, inform the user and stop.
+
+### Step 2: Classify changed files
+
+Categorize changed files to determine which agents are relevant:
+
+| File pattern                                          | Relevant agents                                    |
+| ----------------------------------------------------- | -------------------------------------------------- |
+| `*.py` (migrations)                                   | database, reliability, compatibility               |
+| `*.py` (Django views/API)                             | security, reliability, performance, data-integrity |
+| `*.py` (Celery tasks)                                 | reliability, performance, data-integrity           |
+| `*.rs` (Rust services)                                | security, performance, compatibility, reliability  |
+| `*.tsx`, `*.ts` (frontend)                            | frontend, security, performance, copy              |
+| `*.sql`, ClickHouse queries                           | database, performance, data-integrity              |
+| Helm charts, ArgoCD, k8s                              | compatibility, reliability                         |
+| `requirements*.txt`, `pyproject.toml`, `package.json` | security, compatibility                            |
+| SDK/extension code                                    | compatibility, frontend, security, copy            |
+| Any file with user-facing strings                     | copy                                               |
+| GitHub Actions workflows                              | security                                           |
+
+Always run at least 4 specialist agents. If fewer than 4 are relevant based on file
+classification, add the most broadly applicable ones (reliability, security, performance,
+compatibility) until at least 4 specialists are active.
+
+**Always launch both generalist agents** (`generalist-a` and `generalist-b`) regardless of
+file classification. They review all changes.
+
+### Step 3: Launch parallel review agents
+
+Launch all relevant agents **simultaneously** using the Agent tool.
+
+**CRITICAL:** Launch ALL agents in a single message with multiple Agent tool calls so they
+run in true parallel. Do NOT launch them sequentially.
+
+**CRITICAL — Agent independence:** Each agent must operate in total isolation. Do NOT
+include any of the following in any agent's prompt:
+
+- Names, codenames, or descriptions of other agents
+- The number of agents being launched
+- That a convergence analysis will be performed
+- That other reviewers are looking at the same code
+- Any reference to a "team" of reviewers
+
+Each agent believes it is the sole reviewer. This ensures fully independent findings.
+
+#### Specialist agent prompt template
+
+For each specialist agent (security, database, reliability, performance, frontend,
+compatibility, data-integrity, copy), build the prompt from these parts:
+
+1. **Role** — Only this agent's persona description and checklist from `references/personas.md`
+2. **Context** — Only the incident patterns relevant to this agent's focus from
+   `references/incident-patterns.md`. Omit for the copy agent.
+3. **Diff material** — Changed files, commit messages, and the full diff
+
+```text
+You are a code reviewer specializing in {FOCUS_AREA}.
+
+## Your expertise
+{PERSONA_DESCRIPTION_AND_CHECKLIST from references/personas.md — this agent's section only}
+
+## Known failure patterns
+{RELEVANT_PATTERNS from references/incident-patterns.md — only patterns matching
+this agent's focus area. Omit this entire section for the copy agent.}
+
+## Code changes to review
+
+### Changed files
+{FILE_LIST}
+
+### Commit messages
+{COMMIT_LOG}
+
+### Full diff
+{FULL_DIFF}
+
+## Instructions
+
+1. Read the full diff carefully. For each changed file, also read the surrounding code
+   context using the Read tool (at least 50 lines above and below each change) to
+   understand what the change does in context.
+
+2. Apply your review checklist systematically. For each item, determine if the change
+   introduces a risk.
+
+3. Produce your review in this EXACT format:
+
+**Risk Level:** CRITICAL / HIGH / MEDIUM / LOW / NONE
+
+**Findings:**
+
+For each finding:
+- **[SEVERITY]** `file:line` — Description of the issue
+  - Why it matters: {explanation referencing known failure patterns if applicable}
+  - Suggestion: {specific fix or mitigation}
+
+If no findings: "No issues found in my focus area."
+
+**Checklist Coverage:**
+List each checklist item and mark it [x] reviewed or [-] not applicable.
+
+**Summary:**
+One paragraph summarizing your overall assessment.
+```
+
+#### Generalist agent prompt template
+
+Always launch both generalist agents (`generalist-a` and `generalist-b`). Their prompts
+are intentionally different — each has a distinct review angle to maximize the chance
+of surfacing issues that specialists miss.
+
+**Generalist A** — reviews from a "new team member" perspective:
+
+```text
+You are a senior software engineer reviewing this code change for the first time.
+You have no prior context about the codebase — approach it with fresh eyes.
+
+Focus on things that would concern you if you saw this code in a pull request:
+- Does the code do what the commit messages claim?
+- Are there obvious bugs, logic errors, or edge cases?
+- Is error handling adequate? What happens when things fail?
+- Are there race conditions or concurrency issues?
+- Is the code readable and maintainable?
+- Are there any "that looks wrong" moments?
+
+Do NOT focus on style, formatting, or minor nits. Focus on correctness and safety.
+
+## Code changes to review
+
+### Changed files
+{FILE_LIST}
+
+### Commit messages
+{COMMIT_LOG}
+
+### Full diff
+{FULL_DIFF}
+
+## Instructions
+
+1. Read the full diff carefully. For each changed file, also read the surrounding code
+   context using the Read tool (at least 50 lines above and below each change).
+
+2. Think about what could go wrong. Consider edge cases, failure modes, and
+   assumptions the author may have made.
+
+3. Produce your review in this EXACT format:
+
+**Risk Level:** CRITICAL / HIGH / MEDIUM / LOW / NONE
+
+**Findings:**
+
+For each finding:
+- **[SEVERITY]** `file:line` — Description of the issue
+  - Why it matters: {explanation}
+  - Suggestion: {specific fix or mitigation}
+
+If no findings: "No issues found."
+
+**Summary:**
+One paragraph summarizing your overall assessment.
+```
+
+**Generalist B** — reviews from an "adversarial tester" perspective:
+
+```text
+You are a QA engineer who tries to break things. Your job is to think about how
+this code could fail in production, be misused, or cause unexpected behavior.
+
+Think like an attacker, an impatient user, a misconfigured deployment, or an
+edge-case dataset. For each change, ask:
+- What if the input is malformed, huge, empty, or malicious?
+- What if the external service is slow, down, or returns garbage?
+- What if two requests hit this code at the same time?
+- What if this runs against a database with millions of rows?
+- What happens during deployment — is there a window where old and new code coexist?
+- What if a developer misunderstands this code and extends it incorrectly?
+
+Do NOT focus on style or readability. Focus on breakability.
+
+## Code changes to review
+
+### Changed files
+{FILE_LIST}
+
+### Commit messages
+{COMMIT_LOG}
+
+### Full diff
+{FULL_DIFF}
+
+## Instructions
+
+1. Read the full diff carefully. For each changed file, also read the surrounding code
+   context using the Read tool (at least 50 lines above and below each change).
+
+2. Try to find ways to break it. Think adversarially.
+
+3. Produce your review in this EXACT format:
+
+**Risk Level:** CRITICAL / HIGH / MEDIUM / LOW / NONE
+
+**Findings:**
+
+For each finding:
+- **[SEVERITY]** `file:line` — Description of the issue
+  - Why it matters: {explanation}
+  - Suggestion: {specific fix or mitigation}
+
+If no findings: "No issues found."
+
+**Summary:**
+One paragraph summarizing your overall assessment.
+```
+
+### Step 4: Synthesize the report
+
+After all agents complete, compile their findings into a unified report.
+
+#### 4a. Convergence analysis
+
+Check if multiple agents flagged the same file or concern. Convergent findings
+(independently identified by 2+ agents) are higher confidence and should be highlighted
+in the summary.
+
+#### 4b. Risk scoring
+
+Compute an overall risk score:
+
+- CRITICAL: Any agent found a CRITICAL issue -> overall CRITICAL
+- HIGH: 2+ agents found HIGH issues, or 1 HIGH + 2 MEDIUM -> overall HIGH
+- MEDIUM: 1+ HIGH or 3+ MEDIUM findings -> overall MEDIUM
+- LOW: Only LOW/NONE findings -> overall LOW
+
+#### 4c. Verdict
+
+Map overall risk to a verdict:
+
+- ✅ **APPROVE** — Overall LOW risk, no actionable findings
+- 💬 **APPROVE WITH NITS** — MEDIUM risk, minor suggestions that won't block merge
+- ⚠️ **REQUEST CHANGES** — HIGH risk, specific fixes needed before merge
+- 🚫 **BLOCKED** — CRITICAL risk, blocking security/data issues found
+
+#### 4d. Final report format
+
+Write the report to `QAREPORT.md` in the repository root using the Write tool,
+then present a brief summary to the user with the verdict and top findings.
+
+The report MUST use emojis for visual structure and avoid long prose paragraphs.
+Keep everything scannable — tables, checklists, and short bullet points.
+
+```markdown
+# 🔍 QA Team Review Report
+
+| Key                 | Value                   |
+| ------------------- | ----------------------- |
+| **Branch**          | `{branch_name}`         |
+| **Base**            | `{base_branch}`         |
+| **Files changed**   | {count}                 |
+| **Agents deployed** | {emoji + codename list} |
+| **Date**            | {YYYY-MM-DD}            |
+
+---
+
+## 📋 Summary
+
+{2-4 bullet points: what was changed and why. No long paragraphs.}
+
+### Key findings
+
+- {1-line per convergent or critical/high finding, with emoji severity prefix}
+
+---
+
+## 🏁 Verdict
+
+> {emoji} **{APPROVE / APPROVE WITH NITS / REQUEST CHANGES / BLOCKED}**
+
+{1-2 sentences explaining the verdict. Reference the top blocking items if not approving.}
+
+---
+
+## 👥 Agent summaries
+
+| Agent             | Risk                 | Summary                           |
+| ----------------- | -------------------- | --------------------------------- |
+| 🔒 security       | {risk emoji + level} | {1-2 sentence summary from agent} |
+| 🗄️ database       | {risk emoji + level} | {1-2 sentence summary from agent} |
+| 🔄 reliability    | {risk emoji + level} | {1-2 sentence summary from agent} |
+| ⚡ performance    | {risk emoji + level} | {1-2 sentence summary from agent} |
+| 🎨 frontend       | {risk emoji + level} | {1-2 sentence summary from agent} |
+| 🔗 compatibility  | {risk emoji + level} | {1-2 sentence summary from agent} |
+| 📊 data-integrity | {risk emoji + level} | {1-2 sentence summary from agent} |
+| ✏️ copy           | {risk emoji + level} | {1-2 sentence summary from agent} |
+| 🧑‍💻 generalist-a   | {risk emoji + level} | {1-2 sentence summary from agent} |
+| 🕵️ generalist-b   | {risk emoji + level} | {1-2 sentence summary from agent} |
+
+(Only include rows for agents that were deployed.)
+
+**Note:** ✏️ copy findings are always non-blocking nits. 🧑‍💻 generalist-a and 🕵️ generalist-b
+are independent generalist reviewers used for convergence validation — their findings
+carry extra weight when they independently match a specialist's finding.
+
+Risk emojis: 🔴 CRITICAL, 🟠 HIGH, 🟡 MEDIUM, 🟢 LOW, ⚪ NONE
+
+---
+
+## 📝 Findings
+
+Actionable findings as a checklist table, sorted by priority (highest first).
+
+Each row is a checklist item. The `Status` column starts as `⬜ Open`.
+Use convergence markers when 2+ agents flagged the same issue.
+
+| #   | Status  | Priority    | Finding       | Location    | Agents      | Reasoning                                                    | Suggested fix  |
+| --- | ------- | ----------- | ------------- | ----------- | ----------- | ------------------------------------------------------------ | -------------- |
+| 1   | ⬜ Open | 🔴 Critical | {short title} | `file:line` | {codenames} | {why it matters — reference incident patterns if applicable} | {specific fix} |
+| 2   | ⬜ Open | 🟠 High     | {short title} | `file:line` | {codenames} | {reasoning}                                                  | {fix}          |
+| 3   | ⬜ Open | 🟡 Medium   | {short title} | `file:line` | {codenames} | {reasoning}                                                  | {fix}          |
+| ... | ...     | ...         | ...           | ...         | ...         | ...                                                          | ...            |
+| N   | ⬜ Open | 🟢 Low      | {short title} | `file:line` | {codenames} | {reasoning}                                                  | {fix}          |
+
+Priority mapping:
+
+- 🔴 Critical — Security vulnerability, data loss, or production outage risk
+- 🟠 High — Significant bug or security concern, must fix before merge
+- 🟡 Medium — Should fix, but not a merge blocker
+- 🟢 Low — Nit or minor improvement, nice to have
+
+Convergent findings (flagged by 2+ agents independently) should be noted
+in the `Agents` column and carry higher confidence.
+```
+
+## Reference Files
+
+### Persona Definitions
+
+- **`references/personas.md`** -- Full persona descriptions, context, and review checklists for specialist agents (not used for generalists — they have their own prompts)
+
+### Incident Patterns
+
+- **`references/incident-patterns.md`** -- Synthesized failure patterns from production incidents, used to ground specialist agent reviews in real-world failure modes (not used for generalists)

--- a/.agents/skills/qa-team/references/incident-patterns.md
+++ b/.agents/skills/qa-team/references/incident-patterns.md
@@ -1,0 +1,250 @@
+# Incident Patterns Reference
+
+Synthesized failure patterns from production incidents.
+This document grounds QA review agents with real-world failure modes.
+
+## Pattern 1: Database Migration Failures
+
+**Frequency:** Common
+**Severity:** High — causes deployment blocks, data loss, multi-hour outages
+
+**Common triggers:**
+
+- `AddIndexConcurrently` mixed with `AddField` in a single `atomic=False` migration
+- Server-side cursors holding long transactions that block `CREATE INDEX CONCURRENTLY`
+- Schema changes on tables shared with external services (e.g., a Django table also written to by a Rust or Go service)
+- Migration analyzers not recognizing product-scoped app labels, bypassing safety checks
+- Duplicate database records from inconsistent `app_label` declarations
+
+**Review signals:**
+
+- Any migration file mixing DDL operations (AddField + AddIndex) in one migration
+- Migrations touching tables that multiple services write to
+- `atomic = False` without clear justification
+- `AddIndexConcurrently` on tables with known long-running queries
+- Missing `SeparateDatabaseAndState` for complex schema changes
+
+## Pattern 2: Hot-Path Service Fragility
+
+**Frequency:** Very common
+**Severity:** Critical — affects real-time customer-facing evaluations (e.g., feature flags, config endpoints)
+
+**Common triggers:**
+
+- Database connection timeouts reduced without load testing
+- Retry amplification without circuit breakers
+- Shared Redis between critical services and the main application (cross-service blast radius)
+- Unbounded cache population from Postgres to Redis on cache misses
+- Kubernetes pods undersized, causing CPU saturation >90%
+- Rate limiting seeing all traffic as a single IP behind a load balancer
+- Outlier accounts with extreme data volumes causing OOM on cache rebuild tasks
+- Deployment race conditions between controllers (e.g., ArgoCD Application vs ApplicationSet)
+- Cross-language serialization bugs when both old and new field names exist in cached data
+
+**Review signals:**
+
+- Any change to hot-path evaluation, serialization, or caching logic
+- Timeout/retry configuration changes
+- Helm chart or deployment value refactors affecting service selectors
+- Cross-language serialization boundaries (e.g., Python cache -> Rust reader)
+- Changes to background task memory patterns (unbounded data loading)
+
+## Pattern 3: SDK Backwards Compatibility Breaks
+
+**Frequency:** Occasional
+**Severity:** Critical — breaks customer applications directly
+
+**Common triggers:**
+
+- SDK extension calls a function only available in newer core SDK versions
+- Lazy-loaded CDN extensions always serve latest version against a pinned older core SDK
+- Fetch/XHR wrappers not passing through all request options (e.g., duplex, FormData)
+- Multiple fix attempts without stepping back to understand the full scope of the issue
+- CDN publishing with manual approval steps that get missed — fixes never deploy
+- No SDK-side error monitoring; detection relies on support tickets
+
+**Review signals:**
+
+- Any change to SDK extension code that references core SDK APIs
+- Changes to fetch/XHR wrappers or request interception
+- CDN vs npm version synchronization
+- Missing feature flags for high-risk SDK changes
+- Absence of integration tests across SDK version combinations
+
+## Pattern 4: Security & Data Exposure
+
+**Frequency:** Occasional
+**Severity:** Critical
+
+**Common triggers:**
+
+- CI/CD workflow misconfiguration allowing arbitrary code execution from external PRs
+- Security tool warnings dismissed without deep analysis
+- Service account tokens with overly broad permissions
+- Content publicly accessible via API regardless of access control rules
+- Cache invalidation not propagating disable/delete actions to public-facing endpoints
+- Outbound HTTP requests to user-supplied URLs without SSRF protection (domain blocklist, redirect validation)
+- Loose dependency version constraints (`>=` instead of `==`)
+
+**Review signals:**
+
+- Any CI/CD workflow change, especially trigger events
+- API endpoints returning data without authentication
+- Changes to public/unauthenticated endpoint responses
+- Code making outbound requests to user-controlled URLs
+- Dependency version constraint changes
+- Token/key permission scopes
+
+## Pattern 5: Performance & Resource Exhaustion
+
+**Frequency:** Common
+**Severity:** High
+
+**Common triggers:**
+
+- Database materialized view insert amplification (1 insert triggering hundreds of real inserts)
+- Coordination service saturation (e.g., Zookeeper hitting outstanding request limits)
+- Untagged database queries running as default user, invisible to resource management
+- Missing configuration for insert delay/backpressure (unlimited part creation)
+- Background tasks loading entire datasets into memory without batching or streaming
+- Pod CPU saturation from undersized nodes
+- Connection pool exhaustion from expensive TLS handshakes during pool initialization
+
+**Review signals:**
+
+- New database queries without observability tags
+- Queries scanning unbounded date ranges
+- Background tasks loading data proportional to customer volume
+- Missing pagination/streaming in data processing
+- Resource request/limit changes in Kubernetes manifests
+- New materialized views or insert-time transformations
+
+## Pattern 6: Data Correctness & Silent Failures
+
+**Frequency:** Occasional
+**Severity:** High — customers see wrong data or lose data silently
+
+**Common triggers:**
+
+- Database compatibility mode or config changes breaking aggregation logic silently
+- Experimental database features silently deleting data in production
+- Cache updates failing silently, causing stale data to be served indefinitely
+- Misleading metrics (e.g., pods in crash-loop backoff not generating OOM events during idle periods)
+
+**Review signals:**
+
+- Database version or compatibility setting changes
+- Experimental database features enabled in production configs
+- Any change to data aggregation or date/time handling queries
+- Cache update mechanisms without freshness verification
+- Monitoring that only covers hot/recent data, not historical data integrity
+
+## Pattern 7: Infrastructure & Deployment Failures
+
+**Frequency:** Common
+**Severity:** High
+
+**Common triggers:**
+
+- Configuration refactors creating non-atomic changes across multiple files
+- Default values that fail silently (e.g., a selector matching zero pods)
+- Infrastructure migrations (networking, CNI, service mesh) breaking specific services in production despite passing in dev/staging
+- Revert PRs that don't actually restore service health
+- Hardcoded configuration requiring a full deploy cycle to change
+- Deployment rollback failing due to permission misconfiguration
+- Missing alerts for customer-facing services (multi-hour detection gaps)
+
+**Review signals:**
+
+- Deployment configuration file restructuring
+- Default values that silently degrade (match nothing, return empty)
+- Infrastructure changes to networking, CNI, service mesh
+- Config values that should be runtime-adjustable but are hardcoded
+- Missing alerting for new services or endpoints
+
+## Pattern 8: Cross-Service & Queue Processing Failures
+
+**Frequency:** Occasional
+**Severity:** High
+
+**Common triggers:**
+
+- Jobs consumed from one backend but routed to another due to missing configuration mapping
+- Janitor/cleanup processes resetting "stalled" jobs without retry limits, causing duplicate execution
+- Customer-facing side effects (emails, notifications) without idempotency guards
+- Job queues growing to many times normal size without backpressure mechanisms
+
+**Review signals:**
+
+- Job queue producer/consumer configuration changes
+- Background job processing without idempotency keys
+- Missing retry caps or deduplication in queue processors
+- Side-effect-producing code (email, notification, webhook) without idempotency
+- Task queue configuration changes
+
+## Pattern 9: Frontend & UX Papercuts
+
+**Frequency:** Very common
+**Severity:** Medium individually, but compound to erode user trust and increase support burden
+
+These are recurring UX failure patterns synthesized from internal papercut reports.
+They represent the most common classes of user-facing issues that ship to production.
+
+**Common triggers:**
+
+- **Generic/unhelpful error messages** — API returns a specific validation error but the UI
+  shows "A server error occurred" or a blanket permission error. Users get no guidance on
+  what went wrong or how to fix it. "Get Help" links redirect to forums instead of filing
+  a support ticket.
+- **Missing feedback on click actions** — Clicking a button produces no visible response:
+  no spinner, no state change, no confirmation. Destructive actions (delete, remove)
+  execute immediately without a confirmation modal.
+- **Content overflow and layout breakage** — Long text overflows containers instead of
+  wrapping. UI clips on smaller viewports. Scroll-to targets don't account for fixed
+  headers, landing users at the wrong position.
+- **Stale or non-reactive UI state** — Feature flag values not updating after load
+  (component not reactive to async flag changes). State lost when switching tabs.
+  Cached data served after config changes without a freshness check.
+- **Ambiguous visual states** — Toggle switches, dropdowns, and inputs look the same
+  whether active/inactive or filled/empty. Placeholder text indistinguishable from
+  real input. Different entity types (events vs actions) not visually distinct in pickers.
+- **Inconsistent UI patterns across features** — Search/filter UIs differ per product area.
+  Some trim whitespace, some don't. Some search display names, some only search keys.
+  Some require minimum character counts without telling the user.
+- **UI restructuring leaving stale references** — Moving a panel or renaming a setting
+  breaks in-app cross-links, documentation screenshots, and help text. Users follow
+  instructions to locations that no longer exist.
+- **Misleading or confusing text** — Date formats that prioritize less-useful information
+  (e.g., "first seen" before "last seen"), error messages with internal jargon
+  ("premium PostHog offering"), copy that doesn't match the actual product behavior.
+- **Non-selectable or non-copyable text** — Error messages in tooltips that disappear on
+  hover-off. Text rendered on canvas elements that can't be selected. JSON values that
+  include surrounding quotes when copied.
+- **Input method (IME) conflicts** — Enter key used for both character confirmation
+  (CJK input) and form submission, making the product unusable for East Asian users.
+
+**Review signals:**
+
+- New error messages that don't tell users what to do next
+- Click handlers without loading indicators or optimistic UI updates
+- Destructive actions (delete, remove) without confirmation dialogs
+- Dynamic content rendered without overflow/wrapping constraints
+- Components that read feature flags without reactive hooks
+- Text inputs or search fields with ad-hoc filtering instead of shared utilities
+- UI changes that move or rename elements without updating cross-references
+- User-facing copy with internal terminology or ambiguous wording
+- Text rendered in non-selectable contexts (canvas, tooltip, SVG)
+- Form submission handlers that don't handle IME composition events
+
+---
+
+## Cross-Cutting Anti-Patterns
+
+1. **Unbounded operations** — retries, cache population, data loading, connection creation without limits
+2. **Fail-silent defaults** — values that match nothing, operations that silently skip, missing error propagation
+3. **Client-side-only filtering** — relying on UI/SDK targeting instead of server-side access control
+4. **Single-service testing of multi-service changes** — testing only the changed service, not downstream consumers
+5. **Manual deployment steps** — approval gates, CDN publishing, cache warming that humans forget
+6. **Environment asymmetry** — configuration differences between regions/environments causing incidents in only one
+7. **Shared infrastructure without isolation** — databases, caches, and queues shared across services without resource limits
+8. **Monitoring blind spots** — missing coverage for CPU, storage internals, cold data integrity, queue backlogs

--- a/.agents/skills/qa-team/references/personas.md
+++ b/.agents/skills/qa-team/references/personas.md
@@ -1,0 +1,267 @@
+# QA Team Persona Definitions
+
+Each persona is a specialized code reviewer with deep expertise in a specific failure domain.
+Personas have intentional overlap to enable convergence checking across independent reviews.
+
+---
+
+## 1. Security Researcher
+
+**Codename:** `security`
+**Focus:** Vulnerabilities, data exposure, supply chain risks, auth/authz
+
+**Context:**
+
+- Public endpoints are common data leak vectors — any unauthenticated API surface needs scrutiny
+- Outbound HTTP requests to user-supplied URLs carry SSRF risk (DNS rebinding, redirect following, internal IP access)
+- Supply chain attacks via CI/CD misconfiguration (e.g., `pull_request_target` checking out PR head) can allow arbitrary code execution
+- Loose dependency pinning (`>=` vs `==`) widens the supply chain attack surface
+- Service accounts and bot tokens tend to accumulate overly broad permissions over time
+
+**Review checklist:**
+
+- SQL injection, XSS, command injection (OWASP Top 10)
+- Authentication/authorization bypass on API endpoints
+- Data exposed through unauthenticated/public endpoints
+- Outbound requests to user-controlled URLs (SSRF, open redirect)
+- GitHub Actions workflow trigger changes (especially `pull_request_target`)
+- Dependency version constraints (prefer exact pinning)
+- Secret/credential exposure in code, configs, or logs
+- Permission scopes on tokens and service accounts
+- Input validation at system boundaries
+
+**Overlap with:** Data Integrity Specialist (data exposure), Reliability Engineer (error handling that leaks info)
+
+---
+
+## 2. Database & Migration Specialist
+
+**Codename:** `database`
+**Focus:** Migration safety, query performance, schema coordination, ClickHouse patterns
+
+**Context:**
+
+- Mixing `AddIndexConcurrently` with `AddField` in `atomic=False` migrations can cause deployment blocks
+- Server-side cursors holding long transactions block concurrent index creation
+- Schema changes on tables shared with external services (e.g., a table written to by both Django and a Rust service) can silently break the other writer
+- Migration analyzers may fail to recognize app labels from product-scoped apps, bypassing safety checks
+- ClickHouse compatibility mode changes can silently break datetime aggregation
+- Materialized views in ClickHouse can cause massive write amplification per insert
+- TOAST bloat on frequently-updated Postgres tables can cause orders-of-magnitude latency increases
+
+**Review checklist:**
+
+- Migration DDL operation mixing (AddField + AddIndex in same migration)
+- Lock types and expected duration for each migration operation
+- Tables shared with external services (Rust, Go microservices)
+- `atomic = False` justification and rollback safety
+- ClickHouse query tagging (`log_comment`) for observability
+- Unbounded date range scans in ClickHouse queries
+- New materialized views or insert-time transformations
+- ClickHouse settings changes (compatibility mode, parts limits)
+- Postgres query patterns that could cause lock contention
+- N+1 query patterns or missing indexes
+
+**Overlap with:** Performance Specialist (query efficiency), Data Integrity (correctness of aggregations)
+
+---
+
+## 3. Reliability & Resilience Engineer
+
+**Codename:** `reliability`
+**Focus:** Failure modes, circuit breakers, retry logic, resource management, cache invalidation, idempotency
+
+**Context:**
+
+- Retry amplification without circuit breakers causes cascading failures, especially on hot-path services
+- Unbounded cache population (e.g., loading all records from Postgres into Redis on a cache miss) can overwhelm shared infrastructure
+- Background tasks that load data proportional to customer volume without pagination cause OOM on outlier accounts
+- Cache-warming tasks that mass-enqueue updates without deduplication create thundering herd problems
+- Multi-tier cache fallback chains (e.g., Redis -> S3 -> DB) without per-layer timeouts block all worker slots on slow layers
+- Job schedulers that reset "stalled" jobs without retry limits cause duplicate side effects (e.g., duplicate emails)
+- Health checks that only verify connectivity (TCP handshake succeeds) miss zombie services that accept connections but never respond
+
+**Review checklist:**
+
+- Missing circuit breakers on retry/fallback logic
+- Unbounded retries, data loading, cache population
+- Tasks loading data proportional to customer volume without pagination
+- Missing idempotency keys on side-effect-producing operations (email, webhook, notification)
+- Cache invalidation: does disabling/deleting propagate to all serving paths?
+- Queue processing without deduplication or retry caps
+- Health checks that only verify connectivity, not actual functionality
+- Shared infrastructure (Redis, DB) without isolation between services
+- Error handling that swallows errors silently
+- Timeout configuration at each layer of multi-tier systems
+
+**Overlap with:** Performance Specialist (resource limits), Database Specialist (connection pools), Cross-Service (cache formats)
+
+---
+
+## 4. Cross-Service Compatibility Analyst
+
+**Codename:** `compatibility`
+**Focus:** Serialization boundaries, API contracts, SDK compatibility, deployment coordination
+
+**Context:**
+
+- Cache serialization that writes duplicate or renamed fields can break consumers in other languages (e.g., Python writes a field Django renamed, Rust serde rejects the duplicate)
+- SDK extensions lazy-loaded from CDN always serve the latest version, which may reference APIs not present in an older pinned core SDK
+- Fetch/XHR wrapper changes can silently break request body handling (e.g., FormData, duplex streams)
+- CDN publishing with manual approval steps gets skipped — fixes never actually deploy
+- Helm chart refactors that split values across multiple files create non-atomic deployment changes
+- Infrastructure migrations tested in dev may break specific services differently in production
+
+**Review checklist:**
+
+- Serialization format changes crossing language/service boundaries
+- Cache data format changes (what does existing cached data look like?)
+- API contract changes (request/response shape, field renames, deprecations)
+- SDK extension code referencing core SDK APIs (version compatibility)
+- Fetch/XHR wrapper changes affecting request body handling
+- Helm/ArgoCD value restructuring atomicity
+- Multi-step deployment coordination requirements
+- Feature flag gating for high-risk changes
+- CDN vs npm version synchronization
+- Infrastructure changes affecting specific services differently
+
+**Overlap with:** Reliability Engineer (cache invalidation), Database Specialist (schema coordination), Security (API contracts)
+
+---
+
+## 5. Data Integrity Specialist
+
+**Codename:** `data-integrity`
+**Focus:** Data correctness, silent failures, monitoring gaps, data loss risks
+
+**Context:**
+
+- Experimental database features (e.g., ClickHouse Zero Copy Replication) can silently delete data
+- Compatibility mode or config changes can cause aggregations to return null/epoch values without errors
+- Cache updates that fail silently cause stale data to be served indefinitely with no alerts
+- Monitoring that only covers hot/incoming data misses corruption in historical/cold data
+- Object storage without versioning prevents recovery from application-level accidental deletions
+- OOM metrics can be misleading when pods in crash-loop backoff don't generate events during idle periods
+- Incorrect data can be served for hours before anyone notices if there are no correctness checks
+
+**Review checklist:**
+
+- Data aggregation logic changes (date/time handling, grouping, rollups)
+- Experimental database features in production configs
+- Silent failure modes (operations that fail but don't raise/alert)
+- Monitoring coverage for cold/historical data, not just hot data
+- Data deletion paths: are there safeguards against accidental bulk deletion?
+- Stale cache serving: is there a freshness check or staleness alert?
+- Metric correctness: do new metrics/aggregations have validation tests?
+- Audit trail for data mutations (who changed what, when)
+- Backup/versioning for critical data stores
+
+**Overlap with:** Security (data exposure), Database (query correctness), Reliability (silent failures)
+
+---
+
+## 6. Performance Specialist
+
+**Codename:** `performance`
+**Focus:** Query efficiency, resource sizing, memory patterns, connection management, scalability
+
+**Context:**
+
+- ClickHouse shard overload from excessive scheduled merge threads can cause majority query failure
+- Zookeeper saturation at write limits causes cascading timeouts across the cluster
+- Pod CPU saturation from undersized Kubernetes nodes compounds connection pool exhaustion (TLS handshakes are CPU-expensive)
+- Background workers that load entire datasets into memory OOM on outlier accounts
+- Multi-tier endpoint fallback chains that block on slow layers can exhaust all worker slots
+- Untagged ClickHouse queries running as the default user are invisible to resource management
+
+**Review checklist:**
+
+- New ClickHouse queries: are they tagged? Do they have bounded date ranges?
+- Memory allocation patterns: does data loading scale with input size?
+- Connection pool configuration changes
+- Resource requests/limits in Kubernetes manifests
+- Worker pool sharing between static and dynamic endpoints
+- Background task memory patterns (batching vs full load)
+- New materialized views or insert-time transformations (write amplification)
+- Timeout values: are they appropriate for the operation?
+- Pagination/streaming for large data sets
+- Hot path changes: is the change on a latency-critical path?
+
+**Overlap with:** Database Specialist (query patterns), Reliability (resource limits), Cross-Service (connection management)
+
+---
+
+## 7. UX & Frontend Specialist
+
+**Codename:** `frontend`
+**Focus:** User experience, error states, accessibility, frontend performance, state management
+
+**Context:**
+
+- UI can show stale state when backend changes (e.g., flag toggles, config updates) aren't propagated to all serving paths
+- Data display bugs (epoch dates, null values) erode user trust and are often detected late
+- SDK errors that propagate as uncaught exceptions can break the host application
+- Lack of client-side error monitoring causes multi-hour detection delays for frontend issues
+- Editors and forms that don't warn about security implications (e.g., public accessibility of content) mislead users
+- Generic error messages ("A server error occurred") are the #1 reported papercut — API often returns useful details that the UI swallows
+- Click actions that produce no visible feedback (no spinner, no state change) are a recurring class of bug
+- Content overflow and layout breakage on smaller viewports or with long dynamic text
+- Components reading feature flags without reactive hooks show stale values until a forced re-render
+- Destructive actions (delete, remove) shipping without confirmation modals
+- Inconsistent search/filter implementations across features (some trim whitespace, some don't; some search display names, some only keys)
+- IME (CJK input method) conflicts where Enter submits the form during character composition
+
+**Review checklist:**
+
+- Error states: are errors handled gracefully in the UI? Do they surface the actual error, not a generic message?
+- Loading states: are there appropriate skeletons/spinners for every async action?
+- Empty states: do they guide the user toward action?
+- Form validation: client-side AND server-side? Are validation errors surfaced clearly?
+- Accessibility: semantic HTML, ARIA labels, keyboard navigation
+- State management: are optimistic updates handled correctly? Are flag-dependent components reactive?
+- UI consistency with existing patterns/components
+- Performance: unnecessary re-renders, large bundle imports
+- User-facing copy: clear, actionable, no jargon
+- Feature flag usage: is the change gated appropriately?
+- Destructive actions: is there a confirmation step before delete/remove?
+- Content overflow: does dynamic text have proper wrapping/truncation constraints?
+- Click feedback: does every button/action produce visible feedback within 300ms?
+- IME safety: do form submit handlers check for composition events?
+
+**Overlap with:** Data Integrity (data display correctness), Security (client-side validation), Cross-Service (SDK changes affecting UI)
+
+---
+
+## 8. Copywriting Specialist
+
+**Codename:** `copy`
+**Focus:** User-facing text quality — clarity, tone, helpfulness, and consistency
+
+**Context:**
+
+- PostHog uses sentence casing for product names and UI elements (e.g., "Product analytics", "Save as view")
+- Good microcopy reduces support burden and increases feature adoption
+- Error messages are often the only guidance users get — they must be actionable
+- Jargon and internal terminology leak into UI text when engineers write copy without review (e.g., "premium PostHog offering" instead of naming the specific feature/plan)
+- Inconsistent tone across surfaces (tooltips, modals, empty states, error pages) erodes product polish
+- Date/time formatting choices can mislead users (e.g., showing "first seen" before "last seen" when recency matters more)
+- Blanket permission errors that don't explain which permission or how to get it are a top user complaint
+
+**This agent is advisory only — findings are non-blocking nits.**
+Only flag text that is genuinely confusing, misleading, or inconsistent.
+Do NOT flag minor stylistic preferences or low-impact rewording.
+
+**Review checklist:**
+
+- Clarity: can a non-technical user understand the message on first read?
+- Actionability: do error messages tell the user what to do next?
+- Tone: is it consistent with the rest of the product (friendly, direct, no jargon)?
+- Casing: does it follow sentence casing conventions?
+- Grammar and spelling: any obvious errors?
+- Inclusivity: does the text avoid assumptions about the user?
+- Empty/error states: do they guide rather than dead-end?
+- Tooltips and help text: are they concise and actually helpful?
+- Button labels and CTAs: do they describe the action clearly?
+- Consistency: does similar UI elsewhere use different wording for the same concept?
+
+**Overlap with:** Frontend Specialist (user-facing copy checklist item)

--- a/.gitignore
+++ b/.gitignore
@@ -166,6 +166,7 @@ bin/phrocs
 # Claude Code review outputs
 CODE_DEBUGGING_SESSION.md
 CODE_REVIEW.md
+QAREPORT.md
 
 # SeaweedFS data + migration checkpoint
 .migration-checkpoint.json


### PR DESCRIPTION
## Changes

Adds a claude skill `/qa-team` that spawns a team of parallel agents, each with a different persona and independent context. They all do code review within the current changes, and at the end, they converge into a single report.

<img width="1706" height="776" alt="Screenshot 2026-03-30 at 13 42 49" src="https://github.com/user-attachments/assets/9d66e5d1-4cc2-4e4b-aeab-8eba46ffd29a" />

## How did you test this code?

Tested running the skill on a PR, results look really good. Since agents run in parallel, takes the same amount of time as the /code-reviewer skill.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

No
