### PR TITLE
fix: add team_id scoping to embedding queries in ErrorTrackingSimilarIssuesQueryRunner

### DIFF
--- a/products/error_tracking/backend/hogql_queries/error_tracking_similar_issues_query_runner.py
+++ b/products/error_tracking/backend/hogql_queries/error_tracking_similar_issues_query_runner.py
@@ -257,6 +257,7 @@ class ErrorTrackingSimilarIssuesQueryRunner(AnalyticsQueryRunner[ErrorTrackingQu
             AND model_name = {model_name}
             AND document_id IN {fingerprints}
             AND product = 'error_tracking'
+            AND team_id = {team_id}
             AND timestamp >= {min_target_timestamp}
             AND timestamp <= {max_target_timestamp}
             """,
@@ -264,6 +265,7 @@ class ErrorTrackingSimilarIssuesQueryRunner(AnalyticsQueryRunner[ErrorTrackingQu
                 "fingerprints": ast.Constant(value=target_fingerprints),
                 "model_name": ast.Constant(value=self.model_name),
                 "rendering": ast.Constant(value=self.rendering),
+                "team_id": ast.Constant(value=self.team.pk),
                 "min_target_timestamp": ast.Constant(value=min_timestamp),
                 "max_target_timestamp": ast.Constant(value=max_timestamp),
             },
@@ -282,6 +284,7 @@ class ErrorTrackingSimilarIssuesQueryRunner(AnalyticsQueryRunner[ErrorTrackingQu
                 "avg_embedding": ast.Constant(value=avg_embedding),
                 "model_name": ast.Constant(value=self.model_name),
                 "rendering": ast.Constant(value=self.rendering),
+                "team_id": ast.Constant(value=self.team.pk),
                 "max_distance": ast.Constant(value=self.max_distance),
                 "limit": ast.Constant(value=self.query.limit),
             },
@@ -302,6 +305,7 @@ class ErrorTrackingSimilarIssuesQueryRunner(AnalyticsQueryRunner[ErrorTrackingQu
             AND model_name = {model_name}
             AND document_id NOT IN {fingerprints}
             AND product = 'error_tracking'
+            AND team_id = {team_id}
             ORDER BY distance ASC
         ) as subquery
         WHERE subquery.distance <= {max_distance}


### PR DESCRIPTION
## Problem

The two queries against `document_embeddings` in `ErrorTrackingSimilarIssuesQueryRunner.to_query()` were missing a `team_id` filter. While the downstream fingerprint join scoped results to the correct team, the initial cosine distance scan ran across **all teams' embeddings**, causing:

- **Performance degradation**: scanning embeddings from every team unnecessarily
- **Data isolation concern**: accessing other teams' embedding data in the query layer

## Changes

Added `AND team_id = {team_id}` to both embedding queries in `ErrorTrackingSimilarIssuesQueryRunner`:

1. **Average embedding query** — the query that computes `avgForEach(embedding)` for the target issue's fingerprints
2. **Similar fingerprints query** (`query_template`) — the query that finds nearby embeddings via `cosineDistance`

Both pass `self.team.pk` as the `team_id` placeholder.

## How did you test this code?

I am an agent and have not tested this manually. The change is a straightforward addition of a WHERE clause filter to two SQL query templates and their corresponding placeholder dictionaries. The file passes Python syntax validation.

## Publish to changelog?

no