### PR TITLE
fix(dashboard): fixes mobile responsiveness for filters on dashboard

### DIFF
--- a/frontend/src/scenes/dashboard/DashboardEditBar.tsx
+++ b/frontend/src/scenes/dashboard/DashboardEditBar.tsx
@@ -58,7 +58,7 @@ export function DashboardEditBar({ showDateFilter = true, className }: Dashboard
             }
         >
             {showDateFilter && (
-                <div className={clsx('content-end', { 'h-[61px]': hasVariables })}>
+                <div className={clsx('content-end min-w-0', { 'h-[61px]': hasVariables })}>
                     <AppShortcut
                         name="DashboardDateFilter"
                         keybind={[keyBinds.dateFilter]}

--- a/frontend/src/scenes/dashboard/DashboardFilters.tsx
+++ b/frontend/src/scenes/dashboard/DashboardFilters.tsx
@@ -31,7 +31,7 @@ export function DashboardPrimaryFilters(): JSX.Element {
 
     return (
         <>
-            <div className={clsx('content-end', { 'h-[61px]': hasVariables })}>
+            <div className={clsx('content-end min-w-0', { 'h-[61px]': hasVariables })}>
                 <AppShortcut
                     name="DashboardDateFilter"
                     keybind={[keyBinds.dateFilter]}
@@ -160,7 +160,7 @@ export function DashboardFilterBar({ backTo }: DashboardFilterBarProps): JSX.Ele
 
     return (
         <div className="flex min-w-0 flex-1 flex-col gap-2">
-            <div className="flex gap-2 justify-between">
+            <div className="flex flex-wrap gap-x-2 gap-y-2 justify-between items-start">
                 <div className="flex min-w-0 flex-1 flex-col gap-2 md:flex-row md:justify-between items-start lg:items-center">
                     {![
                         DashboardPlacement.Public,
@@ -176,7 +176,8 @@ export function DashboardFilterBar({ backTo }: DashboardFilterBarProps): JSX.Ele
                 {![DashboardPlacement.Export, DashboardPlacement.Builtin].includes(placement) && (
                     <div
                         className={clsx(
-                            'flex flex-col lg:flex-row items-end lg:items-center shrink-0 gap-4 dashoard-items-actions ml-auto',
+                            'flex flex-col lg:flex-row items-end lg:items-center gap-4 dashoard-items-actions',
+                            'min-w-0 max-lg:basis-full max-lg:w-full max-lg:ml-0 shrink-0 lg:ml-auto',
                             {
                                 'mt-7': hasVariables,
                             }

--- a/frontend/src/scenes/dashboard/DashboardReloadAction.tsx
+++ b/frontend/src/scenes/dashboard/DashboardReloadAction.tsx
@@ -92,7 +92,7 @@ export function DashboardReloadAction(): JSX.Element {
     })
 
     return (
-        <div className="relative flex items-center gap-2">
+        <div className="relative flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1 sm:flex-nowrap">
             {/* Status text */}
             <span className="text-muted text-sm whitespace-nowrap">
                 {itemsLoading ? (


### PR DESCRIPTION
## Problem

smoosh smoosh on small screens.

## Changes

Before:
<img width="932" height="1772" alt="CleanShot 2026-03-30 at 13 06 23@2x" src="https://github.com/user-attachments/assets/40dae7ea-afbe-465f-a940-dbe77cae9256" />


After:
<img width="1142" height="1852" alt="CleanShot 2026-03-30 at 13 05 55@2x" src="https://github.com/user-attachments/assets/e6ba10d6-6c60-4cf1-b994-9e361865b78c" />


## How did you test this code?

Locally.
## Publish to changelog?

No/