### PR TITLE
chore(): remove nodejs/src codeowners entry

### DIFF
--- a/.github/CODEOWNERS-soft
+++ b/.github/CODEOWNERS-soft
@@ -97,7 +97,6 @@ posthog/tests/test_product_tour.py @PostHog/team-surveys
 posthog/tests/test_product_tour.py @PostHog/team-surveys
 
 # Nodejs Services - ownership is split between ingestion and workflows teams
-nodejs/src/ @PostHog/team-ingestion @PostHog/team-workflows
 nodejs/tests/ @PostHog/team-ingestion
 nodejs/src/ingestion/ @PostHog/team-ingestion
 nodejs/src/cdp/ @PostHog/team-workflows


### PR DESCRIPTION
## Problem

- IMO this entry just causes too much noise in github notifications / emails, resulting in too many distractions + missing the actual team-relevant PRs
- PR authors will add the appropriate team(s) if the more specific entries did not do that for them automatically

## Changes

- Remove `nodejs/src/` from codeowners-soft

## Publish to changelog?

No