### PR TITLE
fix(customer-journeys): Event name overflow in journey builder

### DIFF
--- a/frontend/src/scenes/funnels/FunnelFlowGraph/BuilderStepNode.tsx
+++ b/frontend/src/scenes/funnels/FunnelFlowGraph/BuilderStepNode.tsx
@@ -169,7 +169,7 @@ export const BuilderStepNode = React.memo(function BuilderStepNode({
                         }}
                         renderValue={
                             hasEvent
-                                ? () => <EntityFilterInfo filter={getActionFilterFromFunnelStep(step)} allowWrap />
+                                ? () => <EntityFilterInfo filter={getActionFilterFromFunnelStep(step)} />
                                 : undefined
                         }
                         type="secondary"

--- a/frontend/src/scenes/funnels/FunnelFlowGraph/BuilderStepNode.tsx
+++ b/frontend/src/scenes/funnels/FunnelFlowGraph/BuilderStepNode.tsx
@@ -159,22 +159,26 @@ export const BuilderStepNode = React.memo(function BuilderStepNode({
                 </>
             }
             eventDisplay={
-                <TaxonomicPopover
-                    groupType={TaxonomicFilterGroupType.Events}
-                    groupTypes={taxonomicGroupTypes}
-                    value={hasEvent ? (step.action_id as string) : undefined}
-                    onChange={(value, groupType, item) => {
-                        updateStepEvent(stepIndex, value as string, groupType, item)
-                    }}
-                    renderValue={
-                        hasEvent
-                            ? () => <EntityFilterInfo filter={getActionFilterFromFunnelStep(step)} allowWrap />
-                            : undefined
-                    }
-                    type={hasEvent ? 'tertiary' : 'secondary'}
-                    size="small"
-                    placeholder="Select event or action"
-                />
+                <div className="flex flex-1 min-w-0 overflow-hidden">
+                    <TaxonomicPopover
+                        groupType={TaxonomicFilterGroupType.Events}
+                        groupTypes={taxonomicGroupTypes}
+                        value={hasEvent ? (step.action_id as string) : undefined}
+                        onChange={(value, groupType, item) => {
+                            updateStepEvent(stepIndex, value as string, groupType, item)
+                        }}
+                        renderValue={
+                            hasEvent
+                                ? () => <EntityFilterInfo filter={getActionFilterFromFunnelStep(step)} allowWrap />
+                                : undefined
+                        }
+                        type="secondary"
+                        size="small"
+                        fullWidth
+                        truncate
+                        placeholder="Select event or action"
+                    />
+                </div>
             }
             headerAction={
                 canRemove ? (
@@ -184,6 +188,7 @@ export const BuilderStepNode = React.memo(function BuilderStepNode({
                         onClick={() => removeStep(stepIndex)}
                         tooltip="Remove step"
                         noPadding
+                        className="ml-1"
                     />
                 ) : (
                     <></>

--- a/frontend/src/scenes/funnels/FunnelFlowGraph/StepNodeShell.tsx
+++ b/frontend/src/scenes/funnels/FunnelFlowGraph/StepNodeShell.tsx
@@ -71,9 +71,9 @@ export function StepNodeShell({
 
             <div className="flex flex-col justify-between px-2.5 py-2 h-full">
                 <div>
-                    <div className="flex justify-between min-h-10">
-                        <div className="flex flex-col items-start">
-                            <div className="flex items-center gap-1.5">
+                    <div className="flex justify-between min-h-10 min-w-0">
+                        <div className="flex flex-col items-start min-w-0">
+                            <div className="flex items-center gap-1.5 min-w-0 max-w-full">
                                 <Lettermark name={stepIndex + 1} color={LettermarkColor.Gray} />
                                 {eventDisplay}
                             </div>


### PR DESCRIPTION
## Problem
Long events name would overflow in journey builder node
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
Also changed the component variant to make it clearer that it is editable
### Before
<img width="370" height="193" alt="image" src="https://github.com/user-attachments/assets/29c00ad0-79b7-4967-9ef3-71e4a02e9137" />

### After
<img width="507" height="317" alt="image" src="https://github.com/user-attachments/assets/b425ce39-8178-4fe6-9941-5ebd8679f199" />

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Manually
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
no
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update
no
<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
