### PR TITLE
fix: reload insight variables list after creating a new variable

### DIFF
--- a/frontend/src/queries/nodes/DataVisualization/Components/Variables/variableDataLogic.ts
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Variables/variableDataLogic.ts
@@ -1,5 +1,5 @@
-import { kea, path } from 'kea'
-import { lazyLoaders } from 'kea-loaders'
+import { afterMount, kea, path } from 'kea'
+import { loaders } from 'kea-loaders'
 
 import { lemonToast } from '@posthog/lemon-ui'
 
@@ -10,11 +10,11 @@ import type { variableDataLogicType } from './variableDataLogicType'
 
 export const variableDataLogic = kea<variableDataLogicType>([
     path(['queries', 'nodes', 'DataVisualization', 'Components', 'Variables', 'variableDataLogic']),
-    lazyLoaders(({ values }) => ({
+    loaders(({ values }) => ({
         variables: [
             [] as Variable[],
             {
-                getVariables: async () => {
+                loadVariables: async () => {
                     const insights = await api.insightVariables.list()
                     return insights.results
                 },
@@ -30,4 +30,7 @@ export const variableDataLogic = kea<variableDataLogicType>([
             },
         ],
     })),
+    afterMount(({ actions }) => {
+        actions.loadVariables()
+    }),
 ])

--- a/frontend/src/queries/nodes/DataVisualization/Components/Variables/variableModalLogic.ts
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Variables/variableModalLogic.ts
@@ -97,7 +97,7 @@ export const variableModalLogic = kea<variableModalLogicType>([
         values: [teamLogic, ['currentTeamId']],
         actions: [
             variableDataLogic,
-            ['getVariables'],
+            ['loadVariables'],
             variablesLogic,
             ['addVariable', 'updateInternalSelectedVariable'],
         ],
@@ -204,7 +204,7 @@ export const variableModalLogic = kea<variableModalLogicType>([
                         })
                     }
                 }
-                actions.getVariables()
+                actions.loadVariables()
                 actions.closeModal()
             } catch (e: any) {
                 const error = e as ApiError

--- a/frontend/src/queries/nodes/DataVisualization/Components/Variables/variablesLogic.ts
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Variables/variablesLogic.ts
@@ -45,7 +45,7 @@ export const variablesLogic = kea<variablesLogicType>([
     props({ key: '' } as VariablesLogicProps),
     key((props) => props.key),
     connect(() => ({
-        actions: [dataVisualizationLogic, ['setQuery', 'loadData'], variableDataLogic, ['getVariables']],
+        actions: [dataVisualizationLogic, ['setQuery', 'loadData'], variableDataLogic, ['loadVariables']],
         values: [dataVisualizationLogic, ['query'], variableDataLogic, ['variables', 'variablesLoading']],
     })),
     actions(({ values }) => ({

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -1700,11 +1700,11 @@ export const dashboardLogic = kea<dashboardLogicType>([
                         }
                     }
                     // Deferred — quick filters wait for quickFiltersUrlRestoreComplete,
-                    // variables wait for getVariablesSuccess. Explicitly trigger
-                    // the variable fetch since variableDataLogic uses lazyLoaders
-                    // and may not load until a component subscribes to its values.
+                    // variables wait for loadVariablesSuccess. Explicitly trigger
+                    // the variable fetch to ensure variables are loaded before
+                    // the dashboard loads.
                     if (hasVariablesInUrl) {
-                        variableDataLogic.actions.getVariables()
+                        variableDataLogic.actions.loadVariables()
                     } else {
                         // No URL variables to wait for — mark as loaded so the
                         // urlVariables selector is active for runtime overrides
@@ -2458,7 +2458,7 @@ export const dashboardLogic = kea<dashboardLogicType>([
             actions.setInitialQuickFiltersLoaded(true)
 
             // If variables are also in the URL and haven't loaded yet, let
-            // getVariablesSuccess trigger the load — by then filtersOverrideForLoad
+            // loadVariablesSuccess trigger the load — by then filtersOverrideForLoad
             // will already include the restored quick filter properties.
             if (SEARCH_PARAM_QUERY_VARIABLES_KEY in router.values.searchParams && !values.initialVariablesLoaded) {
                 return
@@ -2473,7 +2473,7 @@ export const dashboardLogic = kea<dashboardLogicType>([
                 }
             }
         },
-        [variableDataLogic.actionTypes.getVariablesSuccess]: () => {
+        [variableDataLogic.actionTypes.loadVariablesSuccess]: () => {
             // Only run this handler once on startup
             // This ensures variables are loaded before the dashboard is loaded and insights are refreshed
             if (values.initialVariablesLoaded) {


### PR DESCRIPTION
Changed variableDataLogic from lazyLoaders to loaders so the variables list is refreshed when loadVariables is called after creating a variable. Previously lazyLoaders would skip the reload since data was already loaded.

https://claude.ai/code/session_01FcHDcDbRP52nBxrhtdNUtQ
