### PR TITLE
chore(endpoints): add team_id to endpoints_endpointversion

### DIFF
--- a/products/endpoints/backend/api.py
+++ b/products/endpoints/backend/api.py
@@ -635,6 +635,7 @@ class EndpointViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.Model
                 columns = None
             EndpointVersion.objects.create(
                 endpoint=endpoint,
+                team=self.team,
                 version=1,
                 query=query_dict,
                 description=data.description or "",

--- a/products/endpoints/backend/migrations/0021_add_team_to_endpointversion.py
+++ b/products/endpoints/backend/migrations/0021_add_team_to_endpointversion.py
@@ -1,0 +1,21 @@
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("endpoints", "0020_backfill_endpoint_edges"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="endpointversion",
+            name="team",
+            field=models.ForeignKey(
+                help_text="Team this version belongs to (denormalized from endpoint for HogQL system table access)",
+                null=True,
+                on_delete=django.db.models.deletion.CASCADE,
+                to="posthog.team",
+            ),
+        )
+    ]

--- a/products/endpoints/backend/migrations/max_migration.txt
+++ b/products/endpoints/backend/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0020_backfill_endpoint_edges
+0021_add_team_to_endpointversion

--- a/products/endpoints/backend/models.py
+++ b/products/endpoints/backend/models.py
@@ -97,6 +97,12 @@ class EndpointVersion(models.Model):
 
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     endpoint = models.ForeignKey("Endpoint", on_delete=models.CASCADE, related_name="versions")
+    team = models.ForeignKey(
+        Team,
+        on_delete=models.CASCADE,
+        null=True,
+        help_text="Team this version belongs to (denormalized from endpoint for HogQL system table access)",
+    )
     version = models.IntegerField()
     query = models.JSONField(help_text="Immutable query snapshot")
     description = models.TextField(blank=True, default="", help_text="Optional description for this endpoint version")
@@ -357,6 +363,7 @@ class Endpoint(CreatedMetaFields, UpdatedMetaFields, DeletedMetaFields, UUIDTMod
             columns = None
         version = EndpointVersion.objects.create(
             endpoint=self,
+            team=self.team,
             version=self.current_version,
             query=query,
             created_by=user,


### PR DESCRIPTION
## Problem

#52722 is not making it in easily

need team_id on endpoints_endpointversion so i can add it as a system table

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

## Changes

- adds team to the endpointVersion model

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

- ran it locally

<!-- Briefly describe the steps you took. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

no

## Docs update

no

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->