### PR TITLE
chore(dagster): extract ducklake partition migration and align log keys

### DIFF
--- a/posthog/dags/events_backfill_to_ducklake.py
+++ b/posthog/dags/events_backfill_to_ducklake.py
@@ -213,6 +213,12 @@ ORDER BY event_time DESC;
     return f"http://localhost:8123/play?user=default#{base64.b64encode(sql.encode('utf-8')).decode('utf-8')}"
 
 
+def _validate_identifier(identifier: str) -> None:
+    """Validate that an identifier is safe for SQL interpolation."""
+    if not identifier.replace("_", "").isalnum():
+        raise ValueError(f"Invalid SQL identifier: {identifier}")
+
+
 def _ensure_partition_columns_exist(
     conn: duckdb.DuckDBPyConnection,
     alias: str,
@@ -223,6 +229,9 @@ def _ensure_partition_columns_exist(
 
     Returns the current set of column names (including any newly added ones).
     """
+    _validate_identifier(alias)
+    _validate_identifier(table)
+
     result = conn.execute(f"DESCRIBE {alias}.posthog.{table}").fetchall()
     columns = {row[0] for row in result}
 

--- a/posthog/dags/events_backfill_to_ducklake.py
+++ b/posthog/dags/events_backfill_to_ducklake.py
@@ -213,6 +213,29 @@ ORDER BY event_time DESC;
     return f"http://localhost:8123/play?user=default#{base64.b64encode(sql.encode('utf-8')).decode('utf-8')}"
 
 
+def _ensure_partition_columns_exist(
+    conn: duckdb.DuckDBPyConnection,
+    alias: str,
+    table: str,
+    context: AssetExecutionContext,
+) -> set[str]:
+    """Add year/month/day partition columns to an existing table if missing.
+
+    Returns the current set of column names (including any newly added ones).
+    """
+    result = conn.execute(f"DESCRIBE {alias}.posthog.{table}").fetchall()
+    columns = {row[0] for row in result}
+
+    for col in ("year", "month", "day"):
+        if col not in columns:
+            context.log.info(f"Adding missing partition column '{col}' to {table} table")
+            conn.execute(f"ALTER TABLE {alias}.posthog.{table} ADD COLUMN {col} INTEGER")
+            columns.add(col)
+            logger.info("ducklake_partition_column_added", table=table, column=col)
+
+    return columns
+
+
 def validate_ducklake_schema(context: AssetExecutionContext) -> None:
     """Validate that the DuckLake events table schema matches our export columns.
 
@@ -234,18 +257,7 @@ def validate_ducklake_schema(context: AssetExecutionContext) -> None:
             if alias not in str(exc):
                 raise
 
-        result = conn.execute(f"DESCRIBE {alias}.posthog.events").fetchall()
-        ducklake_columns = {row[0] for row in result}
-
-        # Migrate existing tables: add partition columns if missing
-        partition_cols = {"year", "month", "day"}
-        missing_partition_cols = partition_cols - ducklake_columns
-        for col in ("year", "month", "day"):
-            if col in missing_partition_cols:
-                context.log.info(f"Adding missing partition column '{col}' to events table")
-                conn.execute(f"ALTER TABLE {alias}.posthog.events ADD COLUMN {col} INTEGER")
-                ducklake_columns.add(col)
-                logger.info("ducklake_partition_column_added", table="events", column=col)
+        ducklake_columns = _ensure_partition_columns_exist(conn, alias, "events", context)
 
         missing_in_ducklake = EXPECTED_DUCKLAKE_COLUMNS - ducklake_columns
         if missing_in_ducklake:

--- a/posthog/dags/events_backfill_to_duckling.py
+++ b/posthog/dags/events_backfill_to_duckling.py
@@ -491,7 +491,7 @@ def _ensure_partition_columns_exist(
             context.log.info(f"Adding missing partition column '{col}' to {table} table")
             conn.execute(f"ALTER TABLE {alias}.posthog.{table} ADD COLUMN {col} INTEGER")
             logger.info(
-                "duckling_partition_column_added",
+                "ducklake_partition_column_added",
                 team_id=team_id,
                 table=table,
                 column=col,

--- a/posthog/dags/tests/test_events_backfill_to_ducklake.py
+++ b/posthog/dags/tests/test_events_backfill_to_ducklake.py
@@ -8,6 +8,7 @@ from parameterized import parameterized
 from posthog.dags.events_backfill_to_ducklake import (
     EVENTS_COLUMNS,
     EXPECTED_DUCKLAKE_COLUMNS,
+    _ensure_partition_columns_exist,
     get_partition_where_clause,
     get_s3_function_args,
     get_s3_path_for_partition,
@@ -217,6 +218,42 @@ class TestEventsColumnsSchema:
             "day",
         }
         assert EXPECTED_DUCKLAKE_COLUMNS == export_columns
+
+
+class TestEnsurePartitionColumnsExist:
+    def test_adds_missing_columns_and_returns_updated_set(self):
+        conn = duckdb.connect()
+        conn.execute("INSTALL ducklake; LOAD ducklake;")
+        conn.execute("ATTACH ':memory:' AS test_catalog (TYPE DUCKLAKE, DATA_PATH ':memory:')")
+        conn.execute("CREATE SCHEMA test_catalog.posthog")
+        conn.execute("CREATE TABLE test_catalog.posthog.events (uuid VARCHAR, timestamp TIMESTAMP)")
+
+        mock_context = MagicMock()
+
+        columns = _ensure_partition_columns_exist(conn, "test_catalog", "events", mock_context)
+
+        assert {"year", "month", "day", "uuid", "timestamp"}.issubset(columns)
+        # Idempotent — calling again returns same result without ALTER TABLE
+        columns2 = _ensure_partition_columns_exist(conn, "test_catalog", "events", mock_context)
+        assert columns == columns2
+        conn.close()
+
+    def test_noop_when_columns_exist(self):
+        conn = duckdb.connect()
+        conn.execute("INSTALL ducklake; LOAD ducklake;")
+        conn.execute("ATTACH ':memory:' AS test_catalog (TYPE DUCKLAKE, DATA_PATH ':memory:')")
+        conn.execute("CREATE SCHEMA test_catalog.posthog")
+        conn.execute(
+            "CREATE TABLE test_catalog.posthog.events "
+            "(uuid VARCHAR, timestamp TIMESTAMP, year INTEGER, month INTEGER, day INTEGER)"
+        )
+
+        mock_context = MagicMock()
+        _ensure_partition_columns_exist(conn, "test_catalog", "events", mock_context)
+
+        for call in mock_context.log.info.call_args_list:
+            assert "Adding missing partition column" not in str(call)
+        conn.close()
 
 
 class TestValidateDucklakeSchemaAddsMissingPartitionColumns:


### PR DESCRIPTION
## Summary

Follow-up cleanup to #52679:

- Extract inline partition column migration logic in `validate_ducklake_schema()` into a reusable `_ensure_partition_columns_exist()` function, matching the pattern already used in the duckling pipeline
- Align structlog event key to `"ducklake_partition_column_added"` in both pipelines (duckling previously used `"duckling_partition_column_added"`)
- Add direct unit tests for the extracted function

## Test plan

- [x] New `TestEnsurePartitionColumnsExist` tests cover add-missing and noop-when-present cases
- [x] Existing `TestValidateDucklakeSchemaAddsMissingPartitionColumns` integration tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)