### PR TITLE
fix(cdp): Add action deduplication to prevent duplicate workflow executions from ghost runs

### DIFF
--- a/nodejs/src/cdp/cdp-services.ts
+++ b/nodejs/src/cdp/cdp-services.ts
@@ -167,7 +167,7 @@ export function createCdpCoreServices(
 
     const recipientsManager = new RecipientsManagerService(deps.postgres)
     const recipientPreferencesService = new RecipientPreferencesService(recipientsManager)
-    const hogFlowExecutor = new HogFlowExecutorService(hogFlowFunctionsService, recipientPreferencesService)
+    const hogFlowExecutor = new HogFlowExecutorService(hogFlowFunctionsService, recipientPreferencesService, redis)
 
     const hogFunctionMonitoringService = new HogFunctionMonitoringService(
         deps.kafkaProducer,

--- a/nodejs/src/cdp/services/hogflows/hogflow-executor.service.test.ts
+++ b/nodejs/src/cdp/services/hogflows/hogflow-executor.service.test.ts
@@ -1787,4 +1787,485 @@ describe('Hogflow Executor', () => {
             expect(emailBilling).toHaveLength(2)
         })
     })
+
+    describe('ghost run reproduction - March 18-19 incident', () => {
+        // This test reproduces the exact production scenario from the March 18-19
+        // Cyclotron cross-routing incident. A workflow with trigger -> function -> delay
+        // -> function -> exit receives 4 invocations for the same event (1 legitimate
+        // + 3 ghost runs from janitor resets). Each invocation has a different ID but
+        // carries the same event UUID.
+
+        let hogFlow: HogFlow
+
+        beforeEach(async () => {
+            hogFlow = new FixtureHogFlowBuilder()
+                .withWorkflow({
+                    actions: {
+                        trigger: {
+                            type: 'trigger',
+                            config: {
+                                type: 'event',
+                                filters: HOG_FILTERS_EXAMPLES.no_filters.filters ?? {},
+                            },
+                        },
+                        send_welcome_email: {
+                            type: 'function',
+                            config: {
+                                template_id: 'template-test-hogflow-executor',
+                                inputs: {
+                                    name: {
+                                        value: `Mr {event?.properties?.name}`,
+                                        bytecode: await compileHog(`return f'Mr {event?.properties?.name}'`),
+                                    },
+                                },
+                            },
+                        },
+                        wait_2_days: {
+                            type: 'delay',
+                            config: { delay_duration: '2d' },
+                        },
+                        send_followup_email: {
+                            type: 'function',
+                            config: {
+                                template_id: 'template-test-hogflow-executor',
+                                inputs: {
+                                    name: {
+                                        value: `Mr {event?.properties?.name}`,
+                                        bytecode: await compileHog(`return f'Mr {event?.properties?.name}'`),
+                                    },
+                                },
+                            },
+                        },
+                        exit: {
+                            type: 'exit',
+                            config: {},
+                        },
+                    },
+                    edges: [
+                        { from: 'trigger', to: 'send_welcome_email', type: 'continue' },
+                        { from: 'send_welcome_email', to: 'wait_2_days', type: 'continue' },
+                        { from: 'wait_2_days', to: 'send_followup_email', type: 'continue' },
+                        { from: 'send_followup_email', to: 'exit', type: 'continue' },
+                    ],
+                })
+                .build()
+        })
+
+        it('without dedup: all 4 invocations execute the function action (the bug)', async () => {
+            // Executor without Redis - no deduplication
+            const executorWithoutDedup = new HogFlowExecutorService(
+                new HogFlowFunctionsService(
+                    hub.SITE_URL,
+                    new HogFunctionTemplateManagerService(hub.postgres),
+                    new HogExecutorService(
+                        {
+                            hogCostTimingUpperMs: hub.CDP_WATCHER_HOG_COST_TIMING_UPPER_MS,
+                            googleAdwordsDeveloperToken: hub.CDP_GOOGLE_ADWORDS_DEVELOPER_TOKEN,
+                            fetchRetries: hub.CDP_FETCH_RETRIES,
+                            fetchBackoffBaseMs: hub.CDP_FETCH_BACKOFF_BASE_MS,
+                            fetchBackoffMaxMs: hub.CDP_FETCH_BACKOFF_MAX_MS,
+                        },
+                        { teamManager: hub.teamManager, siteUrl: hub.SITE_URL },
+                        new HogInputsService(hub.integrationManager, hub.ENCRYPTION_SALT_KEYS, hub.SITE_URL),
+                        new EmailService(
+                            {
+                                sesAccessKeyId: hub.SES_ACCESS_KEY_ID,
+                                sesSecretAccessKey: hub.SES_SECRET_ACCESS_KEY,
+                                sesRegion: hub.SES_REGION,
+                                sesEndpoint: hub.SES_ENDPOINT,
+                            },
+                            hub.integrationManager,
+                            hub.ENCRYPTION_SALT_KEYS,
+                            hub.SITE_URL
+                        ),
+                        new RecipientTokensService(hub.ENCRYPTION_SALT_KEYS, hub.SITE_URL)
+                    )
+                ),
+                new RecipientPreferencesService(new RecipientsManagerService(hub.postgres))
+                // No Redis - dedup disabled
+            )
+
+            const sharedEvent = { ...createHogExecutionGlobals().event, uuid: 'user-signup-event-001' }
+
+            // Simulate 4 invocations created by the cross-routing bug
+            // Each has a different invocation ID but the same trigger event
+            const invocations = Array.from({ length: 4 }, () =>
+                createExampleHogFlowInvocation(hogFlow, { event: sharedEvent })
+            )
+
+            let fetchCallCount = 0
+            for (const invocation of invocations) {
+                const beforeFetch = mockFetch.mock.calls.length
+                const result = await executorWithoutDedup.execute(invocation)
+
+                // Each invocation reaches the delay step (not finished, scheduled)
+                expect(result.invocation.queueScheduledAt).toBeDefined()
+
+                const fetchCalls = mockFetch.mock.calls.length - beforeFetch
+                fetchCallCount += fetchCalls
+            }
+
+            // BUG: All 4 invocations executed the function, making 4 fetch calls
+            // This is the duplicate execution that caused 4x emails in production
+            expect(fetchCallCount).toBe(4)
+        })
+
+        it('with dedup: only the first invocation executes, ghosts are blocked', async () => {
+            const redisStore = new Map<string, { value: string; expiry: number }>()
+            const mockRedis = {
+                useClient: jest.fn(async (_opts: any, callback: (client: any) => Promise<any>) => {
+                    const mockClient = {
+                        set: jest.fn((key: string, value: string, _ex: string, ttl: number, _nx: string) => {
+                            if (redisStore.has(key)) {
+                                return Promise.resolve(null)
+                            }
+                            redisStore.set(key, { value, expiry: Date.now() + ttl * 1000 })
+                            return Promise.resolve('OK')
+                        }),
+                        get: jest.fn((key: string) => {
+                            const entry = redisStore.get(key)
+                            return Promise.resolve(entry ? entry.value : null)
+                        }),
+                    }
+                    return callback(mockClient)
+                }),
+            }
+
+            const executorWithDedup = new HogFlowExecutorService(
+                new HogFlowFunctionsService(
+                    hub.SITE_URL,
+                    new HogFunctionTemplateManagerService(hub.postgres),
+                    new HogExecutorService(
+                        {
+                            hogCostTimingUpperMs: hub.CDP_WATCHER_HOG_COST_TIMING_UPPER_MS,
+                            googleAdwordsDeveloperToken: hub.CDP_GOOGLE_ADWORDS_DEVELOPER_TOKEN,
+                            fetchRetries: hub.CDP_FETCH_RETRIES,
+                            fetchBackoffBaseMs: hub.CDP_FETCH_BACKOFF_BASE_MS,
+                            fetchBackoffMaxMs: hub.CDP_FETCH_BACKOFF_MAX_MS,
+                        },
+                        { teamManager: hub.teamManager, siteUrl: hub.SITE_URL },
+                        new HogInputsService(hub.integrationManager, hub.ENCRYPTION_SALT_KEYS, hub.SITE_URL),
+                        new EmailService(
+                            {
+                                sesAccessKeyId: hub.SES_ACCESS_KEY_ID,
+                                sesSecretAccessKey: hub.SES_SECRET_ACCESS_KEY,
+                                sesRegion: hub.SES_REGION,
+                                sesEndpoint: hub.SES_ENDPOINT,
+                            },
+                            hub.integrationManager,
+                            hub.ENCRYPTION_SALT_KEYS,
+                            hub.SITE_URL
+                        ),
+                        new RecipientTokensService(hub.ENCRYPTION_SALT_KEYS, hub.SITE_URL)
+                    )
+                ),
+                new RecipientPreferencesService(new RecipientsManagerService(hub.postgres)),
+                mockRedis as any
+            )
+
+            const sharedEvent = { ...createHogExecutionGlobals().event, uuid: 'user-signup-event-002' }
+
+            const invocations = Array.from({ length: 4 }, () =>
+                createExampleHogFlowInvocation(hogFlow, { event: sharedEvent })
+            )
+
+            let fetchCallCount = 0
+            let blockedCount = 0
+            for (const invocation of invocations) {
+                const beforeFetch = mockFetch.mock.calls.length
+                const result = await executorWithDedup.execute(invocation)
+
+                const fetchCalls = mockFetch.mock.calls.length - beforeFetch
+                fetchCallCount += fetchCalls
+
+                const logMessages = result.logs.map((l) => l.message)
+                if (logMessages.some((m) => m.includes('duplicate execution detected'))) {
+                    blockedCount++
+                    // Blocked invocations must not have executed any action
+                    expect(logMessages).not.toContainEqual(expect.stringContaining('Executing action'))
+                    expect(fetchCalls).toBe(0)
+                }
+            }
+
+            // FIX: Only 1 invocation executed the function, 3 were blocked
+            expect(fetchCallCount).toBe(1)
+            expect(blockedCount).toBe(3)
+        })
+    })
+
+    describe('action deduplication', () => {
+        let hogFlow: HogFlow
+        let redisStore: Map<string, { value: string; expiry: number }>
+        let mockRedis: any
+
+        beforeEach(async () => {
+            redisStore = new Map()
+
+            mockRedis = {
+                useClient: jest.fn(async (_opts: any, callback: (client: any) => Promise<any>) => {
+                    const mockClient = {
+                        set: jest.fn((key: string, value: string, _exFlag: string, ttl: number, _nxFlag: string) => {
+                            if (redisStore.has(key)) {
+                                return Promise.resolve(null) // NX: key already exists
+                            }
+                            redisStore.set(key, { value, expiry: Date.now() + ttl * 1000 })
+                            return Promise.resolve('OK')
+                        }),
+                        get: jest.fn((key: string) => {
+                            const entry = redisStore.get(key)
+                            return Promise.resolve(entry ? entry.value : null)
+                        }),
+                    }
+                    return callback(mockClient)
+                }),
+            }
+
+            hogFlow = new FixtureHogFlowBuilder()
+                .withWorkflow({
+                    actions: {
+                        trigger: {
+                            type: 'trigger',
+                            config: {
+                                type: 'event',
+                                filters: HOG_FILTERS_EXAMPLES.no_filters.filters ?? {},
+                            },
+                        },
+                        function_id_1: {
+                            type: 'function',
+                            config: {
+                                template_id: 'template-test-hogflow-executor',
+                                inputs: {
+                                    name: {
+                                        value: `Mr {event?.properties?.name}`,
+                                        bytecode: await compileHog(`return f'Mr {event?.properties?.name}'`),
+                                    },
+                                },
+                            },
+                        },
+                        exit: {
+                            type: 'exit',
+                            config: {},
+                        },
+                    },
+                    edges: [
+                        { from: 'trigger', to: 'function_id_1', type: 'continue' },
+                        { from: 'function_id_1', to: 'exit', type: 'continue' },
+                    ],
+                })
+                .build()
+
+            executor = new HogFlowExecutorService(
+                new HogFlowFunctionsService(
+                    hub.SITE_URL,
+                    new HogFunctionTemplateManagerService(hub.postgres),
+                    new HogExecutorService(
+                        {
+                            hogCostTimingUpperMs: hub.CDP_WATCHER_HOG_COST_TIMING_UPPER_MS,
+                            googleAdwordsDeveloperToken: hub.CDP_GOOGLE_ADWORDS_DEVELOPER_TOKEN,
+                            fetchRetries: hub.CDP_FETCH_RETRIES,
+                            fetchBackoffBaseMs: hub.CDP_FETCH_BACKOFF_BASE_MS,
+                            fetchBackoffMaxMs: hub.CDP_FETCH_BACKOFF_MAX_MS,
+                        },
+                        { teamManager: hub.teamManager, siteUrl: hub.SITE_URL },
+                        new HogInputsService(hub.integrationManager, hub.ENCRYPTION_SALT_KEYS, hub.SITE_URL),
+                        new EmailService(
+                            {
+                                sesAccessKeyId: hub.SES_ACCESS_KEY_ID,
+                                sesSecretAccessKey: hub.SES_SECRET_ACCESS_KEY,
+                                sesRegion: hub.SES_REGION,
+                                sesEndpoint: hub.SES_ENDPOINT,
+                            },
+                            hub.integrationManager,
+                            hub.ENCRYPTION_SALT_KEYS,
+                            hub.SITE_URL
+                        ),
+                        new RecipientTokensService(hub.ENCRYPTION_SALT_KEYS, hub.SITE_URL)
+                    )
+                ),
+                new RecipientPreferencesService(new RecipientsManagerService(hub.postgres)),
+                mockRedis
+            )
+        })
+
+        it('allows the first invocation to execute', async () => {
+            const invocation = createExampleHogFlowInvocation(hogFlow, {
+                event: { ...createHogExecutionGlobals().event, uuid: 'event-123' },
+            })
+
+            const result = await executor.execute(invocation)
+
+            expect(result.finished).toBe(true)
+            expect(result.error).toBeUndefined()
+            expect(mockRedis.useClient).toHaveBeenCalled()
+            // Dedup keys set for each action in the workflow (function + exit)
+            expect(redisStore.size).toBeGreaterThanOrEqual(1)
+        })
+
+        it('blocks a different invocation for the same event and action', async () => {
+            // First invocation executes successfully
+            const firstInvocation = createExampleHogFlowInvocation(hogFlow, {
+                event: { ...createHogExecutionGlobals().event, uuid: 'event-456' },
+            })
+            await executor.execute(firstInvocation)
+            const fetchCallsAfterFirst = mockFetch.mock.calls.length
+
+            // Second invocation with different ID but same event
+            const secondInvocation = createExampleHogFlowInvocation(hogFlow, {
+                event: { ...createHogExecutionGlobals().event, uuid: 'event-456' },
+            })
+
+            const result = await executor.execute(secondInvocation)
+
+            expect(result.finished).toBe(true)
+            const logMessages = result.logs.map((l) => l.message)
+            expect(logMessages).toContainEqual(expect.stringContaining('duplicate execution detected'))
+            // The handler must NOT have executed
+            expect(logMessages).not.toContainEqual(expect.stringContaining('Executing action'))
+            // No fetch calls were made (the hog function template uses fetch)
+            expect(mockFetch.mock.calls.length).toBe(fetchCallsAfterFirst)
+        })
+
+        it('blocks all 4 ghost runs from the cross-routing incident pattern', async () => {
+            const eventUuid = 'event-incident-pattern'
+            const invocations = Array.from({ length: 4 }, () =>
+                createExampleHogFlowInvocation(hogFlow, {
+                    event: { ...createHogExecutionGlobals().event, uuid: eventUuid },
+                })
+            )
+
+            // First invocation (legitimate) executes successfully
+            const firstResult = await executor.execute(invocations[0])
+            expect(firstResult.finished).toBe(true)
+            expect(firstResult.error).toBeUndefined()
+
+            // Remaining 3 (ghost runs from janitor resets) are all blocked
+            for (let i = 1; i < 4; i++) {
+                const result = await executor.execute(invocations[i])
+                expect(result.finished).toBe(true)
+                const logMessages = result.logs.map((l) => l.message)
+                expect(logMessages).toContainEqual(expect.stringContaining('duplicate execution detected'))
+                expect(logMessages).not.toContainEqual(expect.stringContaining('Executing action'))
+            }
+        })
+
+        it('first ghost run wins if legitimate invocation already passed before deployment', async () => {
+            const eventUuid = 'event-pre-deploy'
+
+            // Simulate: legit invocation already executed before deployment (no Redis key exists)
+            // First ghost run arrives after deployment -- it "wins" the key
+            const ghostA = createExampleHogFlowInvocation(hogFlow, {
+                event: { ...createHogExecutionGlobals().event, uuid: eventUuid },
+            })
+            const resultA = await executor.execute(ghostA)
+            expect(resultA.finished).toBe(true)
+            expect(resultA.error).toBeUndefined() // Ghost A gets through (unavoidable)
+
+            // Subsequent ghosts are blocked
+            const ghostB = createExampleHogFlowInvocation(hogFlow, {
+                event: { ...createHogExecutionGlobals().event, uuid: eventUuid },
+            })
+            const resultB = await executor.execute(ghostB)
+            expect(resultB.finished).toBe(true)
+            const logMessages = resultB.logs.map((l) => l.message)
+            expect(logMessages).toContainEqual(expect.stringContaining('duplicate execution detected'))
+        })
+
+        it('allows a legitimate retry (same invocation ID)', async () => {
+            const invocation = createExampleHogFlowInvocation(hogFlow, {
+                event: { ...createHogExecutionGlobals().event, uuid: 'event-789' },
+            })
+
+            // First execution
+            await executor.execute(invocation)
+
+            // Retry with same invocation ID (simulates janitor retry)
+            const retryInvocation = { ...invocation }
+            retryInvocation.state = {
+                ...invocation.state,
+                actionStepCount: 0,
+                currentAction: undefined,
+            }
+
+            const result = await executor.execute(retryInvocation)
+
+            expect(result.finished).toBe(true)
+            expect(result.error).toBeUndefined()
+            const logMessages = result.logs.map((l) => l.message)
+            expect(logMessages).not.toContainEqual(expect.stringContaining('duplicate execution detected'))
+        })
+
+        it('allows different events to execute independently', async () => {
+            const firstInvocation = createExampleHogFlowInvocation(hogFlow, {
+                event: { ...createHogExecutionGlobals().event, uuid: 'event-aaa' },
+            })
+            await executor.execute(firstInvocation)
+
+            const secondInvocation = createExampleHogFlowInvocation(hogFlow, {
+                event: { ...createHogExecutionGlobals().event, uuid: 'event-bbb' },
+            })
+            const result = await executor.execute(secondInvocation)
+
+            expect(result.finished).toBe(true)
+            expect(result.error).toBeUndefined()
+            const logMessages = result.logs.map((l) => l.message)
+            expect(logMessages).not.toContainEqual(expect.stringContaining('duplicate execution detected'))
+        })
+
+        it('also deduplicates non-side-effect actions like delays', async () => {
+            const delayFlow: HogFlow = new FixtureHogFlowBuilder()
+                .withWorkflow({
+                    actions: {
+                        trigger: {
+                            type: 'trigger',
+                            config: {
+                                type: 'event',
+                                filters: HOG_FILTERS_EXAMPLES.no_filters.filters ?? {},
+                            },
+                        },
+                        delay_1: {
+                            type: 'delay',
+                            config: { delay_duration: '1h' },
+                        },
+                        exit: {
+                            type: 'exit',
+                            config: {},
+                        },
+                    },
+                    edges: [
+                        { from: 'trigger', to: 'delay_1', type: 'continue' },
+                        { from: 'delay_1', to: 'exit', type: 'continue' },
+                    ],
+                })
+                .build()
+
+            // First invocation hits the delay
+            const firstInvocation = createExampleHogFlowInvocation(delayFlow, {
+                event: { ...createHogExecutionGlobals().event, uuid: 'event-delay' },
+            })
+            await executor.execute(firstInvocation)
+            expect(redisStore.size).toBe(1)
+
+            // Ghost run with same event is blocked at the delay step
+            const ghostInvocation = createExampleHogFlowInvocation(delayFlow, {
+                event: { ...createHogExecutionGlobals().event, uuid: 'event-delay' },
+            })
+            const result = await executor.execute(ghostInvocation)
+            expect(result.finished).toBe(true)
+            const logMessages = result.logs.map((l) => l.message)
+            expect(logMessages).toContainEqual(expect.stringContaining('duplicate execution detected'))
+        })
+
+        it('proceeds when Redis is unavailable', async () => {
+            mockRedis.useClient.mockRejectedValue(new Error('Redis connection failed'))
+
+            const invocation = createExampleHogFlowInvocation(hogFlow, {
+                event: { ...createHogExecutionGlobals().event, uuid: 'event-redis-fail' },
+            })
+
+            const result = await executor.execute(invocation)
+
+            expect(result.finished).toBe(true)
+            expect(result.error).toBeUndefined()
+        })
+    })
 })

--- a/nodejs/src/cdp/services/hogflows/hogflow-executor.service.test.ts
+++ b/nodejs/src/cdp/services/hogflows/hogflow-executor.service.test.ts
@@ -1788,6 +1788,40 @@ describe('Hogflow Executor', () => {
         })
     })
 
+    function createTestExecutor(redis?: any): HogFlowExecutorService {
+        return new HogFlowExecutorService(
+            new HogFlowFunctionsService(
+                hub.SITE_URL,
+                new HogFunctionTemplateManagerService(hub.postgres),
+                new HogExecutorService(
+                    {
+                        hogCostTimingUpperMs: hub.CDP_WATCHER_HOG_COST_TIMING_UPPER_MS,
+                        googleAdwordsDeveloperToken: hub.CDP_GOOGLE_ADWORDS_DEVELOPER_TOKEN,
+                        fetchRetries: hub.CDP_FETCH_RETRIES,
+                        fetchBackoffBaseMs: hub.CDP_FETCH_BACKOFF_BASE_MS,
+                        fetchBackoffMaxMs: hub.CDP_FETCH_BACKOFF_MAX_MS,
+                    },
+                    { teamManager: hub.teamManager, siteUrl: hub.SITE_URL },
+                    new HogInputsService(hub.integrationManager, hub.ENCRYPTION_SALT_KEYS, hub.SITE_URL),
+                    new EmailService(
+                        {
+                            sesAccessKeyId: hub.SES_ACCESS_KEY_ID,
+                            sesSecretAccessKey: hub.SES_SECRET_ACCESS_KEY,
+                            sesRegion: hub.SES_REGION,
+                            sesEndpoint: hub.SES_ENDPOINT,
+                        },
+                        hub.integrationManager,
+                        hub.ENCRYPTION_SALT_KEYS,
+                        hub.SITE_URL
+                    ),
+                    new RecipientTokensService(hub.ENCRYPTION_SALT_KEYS, hub.SITE_URL)
+                )
+            ),
+            new RecipientPreferencesService(new RecipientsManagerService(hub.postgres)),
+            redis
+        )
+    }
+
     describe('ghost run reproduction - March 18-19 incident', () => {
         // This test reproduces the exact production scenario from the March 18-19
         // Cyclotron cross-routing incident. A workflow with trigger -> function -> delay
@@ -1852,38 +1886,7 @@ describe('Hogflow Executor', () => {
         })
 
         it('without dedup: all 4 invocations execute the function action (the bug)', async () => {
-            // Executor without Redis - no deduplication
-            const executorWithoutDedup = new HogFlowExecutorService(
-                new HogFlowFunctionsService(
-                    hub.SITE_URL,
-                    new HogFunctionTemplateManagerService(hub.postgres),
-                    new HogExecutorService(
-                        {
-                            hogCostTimingUpperMs: hub.CDP_WATCHER_HOG_COST_TIMING_UPPER_MS,
-                            googleAdwordsDeveloperToken: hub.CDP_GOOGLE_ADWORDS_DEVELOPER_TOKEN,
-                            fetchRetries: hub.CDP_FETCH_RETRIES,
-                            fetchBackoffBaseMs: hub.CDP_FETCH_BACKOFF_BASE_MS,
-                            fetchBackoffMaxMs: hub.CDP_FETCH_BACKOFF_MAX_MS,
-                        },
-                        { teamManager: hub.teamManager, siteUrl: hub.SITE_URL },
-                        new HogInputsService(hub.integrationManager, hub.ENCRYPTION_SALT_KEYS, hub.SITE_URL),
-                        new EmailService(
-                            {
-                                sesAccessKeyId: hub.SES_ACCESS_KEY_ID,
-                                sesSecretAccessKey: hub.SES_SECRET_ACCESS_KEY,
-                                sesRegion: hub.SES_REGION,
-                                sesEndpoint: hub.SES_ENDPOINT,
-                            },
-                            hub.integrationManager,
-                            hub.ENCRYPTION_SALT_KEYS,
-                            hub.SITE_URL
-                        ),
-                        new RecipientTokensService(hub.ENCRYPTION_SALT_KEYS, hub.SITE_URL)
-                    )
-                ),
-                new RecipientPreferencesService(new RecipientsManagerService(hub.postgres))
-                // No Redis - dedup disabled
-            )
+            const executorWithoutDedup = createTestExecutor()
 
             const sharedEvent = { ...createHogExecutionGlobals().event, uuid: 'user-signup-event-001' }
 
@@ -1931,37 +1934,7 @@ describe('Hogflow Executor', () => {
                 }),
             }
 
-            const executorWithDedup = new HogFlowExecutorService(
-                new HogFlowFunctionsService(
-                    hub.SITE_URL,
-                    new HogFunctionTemplateManagerService(hub.postgres),
-                    new HogExecutorService(
-                        {
-                            hogCostTimingUpperMs: hub.CDP_WATCHER_HOG_COST_TIMING_UPPER_MS,
-                            googleAdwordsDeveloperToken: hub.CDP_GOOGLE_ADWORDS_DEVELOPER_TOKEN,
-                            fetchRetries: hub.CDP_FETCH_RETRIES,
-                            fetchBackoffBaseMs: hub.CDP_FETCH_BACKOFF_BASE_MS,
-                            fetchBackoffMaxMs: hub.CDP_FETCH_BACKOFF_MAX_MS,
-                        },
-                        { teamManager: hub.teamManager, siteUrl: hub.SITE_URL },
-                        new HogInputsService(hub.integrationManager, hub.ENCRYPTION_SALT_KEYS, hub.SITE_URL),
-                        new EmailService(
-                            {
-                                sesAccessKeyId: hub.SES_ACCESS_KEY_ID,
-                                sesSecretAccessKey: hub.SES_SECRET_ACCESS_KEY,
-                                sesRegion: hub.SES_REGION,
-                                sesEndpoint: hub.SES_ENDPOINT,
-                            },
-                            hub.integrationManager,
-                            hub.ENCRYPTION_SALT_KEYS,
-                            hub.SITE_URL
-                        ),
-                        new RecipientTokensService(hub.ENCRYPTION_SALT_KEYS, hub.SITE_URL)
-                    )
-                ),
-                new RecipientPreferencesService(new RecipientsManagerService(hub.postgres)),
-                mockRedis as any
-            )
+            const executorWithDedup = createTestExecutor(mockRedis as any)
 
             const sharedEvent = { ...createHogExecutionGlobals().event, uuid: 'user-signup-event-002' }
 
@@ -2054,37 +2027,7 @@ describe('Hogflow Executor', () => {
                 })
                 .build()
 
-            executor = new HogFlowExecutorService(
-                new HogFlowFunctionsService(
-                    hub.SITE_URL,
-                    new HogFunctionTemplateManagerService(hub.postgres),
-                    new HogExecutorService(
-                        {
-                            hogCostTimingUpperMs: hub.CDP_WATCHER_HOG_COST_TIMING_UPPER_MS,
-                            googleAdwordsDeveloperToken: hub.CDP_GOOGLE_ADWORDS_DEVELOPER_TOKEN,
-                            fetchRetries: hub.CDP_FETCH_RETRIES,
-                            fetchBackoffBaseMs: hub.CDP_FETCH_BACKOFF_BASE_MS,
-                            fetchBackoffMaxMs: hub.CDP_FETCH_BACKOFF_MAX_MS,
-                        },
-                        { teamManager: hub.teamManager, siteUrl: hub.SITE_URL },
-                        new HogInputsService(hub.integrationManager, hub.ENCRYPTION_SALT_KEYS, hub.SITE_URL),
-                        new EmailService(
-                            {
-                                sesAccessKeyId: hub.SES_ACCESS_KEY_ID,
-                                sesSecretAccessKey: hub.SES_SECRET_ACCESS_KEY,
-                                sesRegion: hub.SES_REGION,
-                                sesEndpoint: hub.SES_ENDPOINT,
-                            },
-                            hub.integrationManager,
-                            hub.ENCRYPTION_SALT_KEYS,
-                            hub.SITE_URL
-                        ),
-                        new RecipientTokensService(hub.ENCRYPTION_SALT_KEYS, hub.SITE_URL)
-                    )
-                ),
-                new RecipientPreferencesService(new RecipientsManagerService(hub.postgres)),
-                mockRedis
-            )
+            executor = createTestExecutor(mockRedis)
         })
 
         it('allows the first invocation to execute', async () => {

--- a/nodejs/src/cdp/services/hogflows/hogflow-executor.service.test.ts
+++ b/nodejs/src/cdp/services/hogflows/hogflow-executor.service.test.ts
@@ -2154,6 +2154,49 @@ describe('Hogflow Executor', () => {
             expect(logMessages).not.toContainEqual(expect.stringContaining('duplicate execution detected'))
         })
 
+        it('allows execution when Redis key expires between SET NX and GET', async () => {
+            // Simulate: SET NX fails (key exists), but GET returns null (key expired)
+            const expiringRedisStore = new Map<string, { value: string; expiry: number }>()
+            const expiringMockRedis = {
+                useClient: jest.fn(async (_opts: any, callback: (client: any) => Promise<any>) => {
+                    const mockClient = {
+                        set: jest.fn((key: string, value: string, _ex: string, ttl: number, _nx: string) => {
+                            if (expiringRedisStore.has(key)) {
+                                return Promise.resolve(null)
+                            }
+                            expiringRedisStore.set(key, { value, expiry: Date.now() + ttl * 1000 })
+                            return Promise.resolve('OK')
+                        }),
+                        get: jest.fn((_key: string) => {
+                            // Always return null to simulate key expiring between SET and GET
+                            return Promise.resolve(null)
+                        }),
+                    }
+                    return callback(mockClient)
+                }),
+            }
+
+            const expiringExecutor = createTestExecutor(expiringMockRedis)
+
+            // First invocation sets the key
+            const firstInvocation = createExampleHogFlowInvocation(hogFlow, {
+                event: { ...createHogExecutionGlobals().event, uuid: 'event-expiring' },
+            })
+            await expiringExecutor.execute(firstInvocation)
+
+            // Second invocation: SET NX fails (key exists), GET returns null (expired)
+            // Should fail open and allow execution
+            const secondInvocation = createExampleHogFlowInvocation(hogFlow, {
+                event: { ...createHogExecutionGlobals().event, uuid: 'event-expiring' },
+            })
+            const result = await expiringExecutor.execute(secondInvocation)
+
+            expect(result.finished).toBe(true)
+            expect(result.error).toBeUndefined()
+            const logMessages = result.logs.map((l) => l.message)
+            expect(logMessages).not.toContainEqual(expect.stringContaining('duplicate execution detected'))
+        })
+
         it('also deduplicates non-side-effect actions like delays', async () => {
             const delayFlow: HogFlow = new FixtureHogFlowBuilder()
                 .withWorkflow({

--- a/nodejs/src/cdp/services/hogflows/hogflow-executor.service.ts
+++ b/nodejs/src/cdp/services/hogflows/hogflow-executor.service.ts
@@ -1,6 +1,8 @@
 import { get } from 'lodash'
 import { DateTime } from 'luxon'
 
+import { RedisV2 } from '~/common/redis/redis-v2'
+
 import { HogFlow, HogFlowAction } from '../../../schema/hogflow'
 import { logger } from '../../../utils/logger'
 import { UUIDT } from '../../../utils/utils'
@@ -38,6 +40,10 @@ import {
 } from './hogflow-utils'
 
 export const MAX_ACTION_STEPS_HARD_LIMIT = 1000
+
+// 21 days in seconds - keys expire around April 20, after all ghost runs have completed.
+// Remove this deduplication code after April 2026.
+const DEDUP_TTL_SECONDS = 21 * 24 * 60 * 60
 
 export function createHogFlowInvocation(
     globals: HogFunctionInvocationGlobals,
@@ -78,11 +84,14 @@ export function createHogFlowInvocation(
 
 export class HogFlowExecutorService {
     private readonly actionHandlers: Record<HogFlowAction['type'], ActionHandler>
+    private readonly redis: RedisV2 | null
 
     constructor(
         hogFlowFunctionsService: HogFlowFunctionsService,
-        recipientPreferencesService: RecipientPreferencesService
+        recipientPreferencesService: RecipientPreferencesService,
+        redis?: RedisV2
     ) {
+        this.redis = redis ?? null
         const hogFunctionHandler = new HogFunctionHandler(hogFlowFunctionsService, recipientPreferencesService, 'fetch')
         const hogFunctionEmailHandler = new HogFunctionHandler(
             hogFlowFunctionsService,
@@ -338,6 +347,11 @@ export class HogFlowExecutorService {
                 return result
             }
 
+            const dedupResult = await this.checkActionDeduplication(invocation, currentAction)
+            if (dedupResult) {
+                return dedupResult
+            }
+
             result.logs.push({
                 level: 'debug',
                 message: `Executing action ${actionIdForLogging(currentAction)}`,
@@ -405,6 +419,66 @@ export class HogFlowExecutorService {
         }
 
         return result
+    }
+
+    /**
+     * Prevents the same action from executing twice for the same event across
+     * different workflow invocations. This handles ghost runs from the March 18-19
+     * Cyclotron cross-routing incident where duplicate invocations were created.
+     *
+     * Returns a finished result if this is a duplicate execution, null otherwise.
+     * Legitimate retries (same invocation ID) are allowed through.
+     */
+    private async checkActionDeduplication(
+        invocation: CyclotronJobInvocationHogFlow,
+        currentAction: HogFlowAction
+    ): Promise<CyclotronJobInvocationResult<CyclotronJobInvocationHogFlow> | null> {
+        if (!this.redis) {
+            return null
+        }
+
+        const eventUuid = invocation.state?.event?.uuid
+        if (!eventUuid) {
+            return null
+        }
+
+        const dedupKey = `hogflow:dedup:${invocation.functionId}:${eventUuid}:${currentAction.id}`
+        const invocationId = invocation.id
+
+        try {
+            const isDuplicate = await this.redis.useClient(
+                { name: 'hogflow-dedup', failOpen: true },
+                async (client) => {
+                    // Atomically set the key only if it doesn't exist
+                    const wasSet = await client.set(dedupKey, invocationId, 'EX', DEDUP_TTL_SECONDS, 'NX')
+                    if (wasSet) {
+                        // We're the first invocation to reach this action for this event
+                        return false
+                    }
+
+                    // Key exists - check if it's our own invocation (legitimate retry)
+                    const existingId = await client.get(dedupKey)
+                    return existingId !== invocationId
+                }
+            )
+
+            if (isDuplicate) {
+                const dedupResult = createInvocationResult<CyclotronJobInvocationHogFlow>(invocation)
+                dedupResult.finished = true
+                this.logAction(
+                    dedupResult,
+                    currentAction,
+                    'warn',
+                    `Skipped: duplicate execution detected for event ${eventUuid}. Another invocation already executed this action.`
+                )
+                return dedupResult
+            }
+        } catch (error) {
+            // On Redis failure, allow execution to proceed rather than blocking legitimate runs
+            logger.warn('🦔', '[HogFlowExecutor] Action deduplication check failed, allowing execution', { error })
+        }
+
+        return null
     }
 
     private goToNextAction(

--- a/nodejs/src/cdp/services/hogflows/hogflow-executor.service.ts
+++ b/nodejs/src/cdp/services/hogflows/hogflow-executor.service.ts
@@ -41,9 +41,9 @@ import {
 
 export const MAX_ACTION_STEPS_HARD_LIMIT = 1000
 
-// 21 days in seconds - keys expire around April 20, after all ghost runs have completed.
-// Remove this deduplication code after April 2026.
-const DEDUP_TTL_SECONDS = 21 * 24 * 60 * 60
+// 1 day in seconds - ghost runs reach the same action step within minutes of each other,
+// so this TTL has large margin. Also covers potential Kafka at-least-once redelivery.
+const DEDUP_TTL_SECONDS = 24 * 60 * 60
 
 export function createHogFlowInvocation(
     globals: HogFunctionInvocationGlobals,

--- a/nodejs/src/cdp/services/hogflows/hogflow-executor.service.ts
+++ b/nodejs/src/cdp/services/hogflows/hogflow-executor.service.ts
@@ -458,6 +458,10 @@ export class HogFlowExecutorService {
 
                     // Key exists - check if it's our own invocation (legitimate retry)
                     const existingId = await client.get(dedupKey)
+                    if (existingId === null) {
+                        // Key expired between SET and GET - fail open
+                        return false
+                    }
                     return existingId !== invocationId
                 }
             )


### PR DESCRIPTION
## Problem

The March 18-19 Cyclotron cross-routing incident created ghost workflow runs. These are duplicate invocations that share the same trigger event but have different Cyclotron job IDs. They progress through delay steps independently and send duplicate emails/notifications each time they reach an action step.

Customers are actively receiving duplicate emails from ghost runs still progressing through workflow delay steps.

## Changes

Adds a Redis-based deduplication check in the hogflow executor to prevent the same action from executing twice for the same event across different workflow invocations.

- Before executing any action, checks Redis with key `hogflow:dedup:{workflowId}:{eventUuid}:{actionId}`
- Uses `SET NX EX` for atomic check-and-set, value is the invocation ID
- If key exists with a different invocation ID: ghost run detected, terminate the invocation
- If key exists with same invocation ID: legitimate retry, allow through
- If key expired between SET NX and GET: fail open (allow through)
- 1-day TTL (ghost runs reach the same action step within minutes of each other, so this has large margin)
- Fails open on Redis errors

This is what it looks like in logs afterwards:

<img width="1797" height="1434" alt="Screenshot 2026-03-30 at 22 32 30" src="https://github.com/user-attachments/assets/ade53121-ad8c-405e-b878-141dfb7116d6" />

## How did you test this code?

**Unit tests reproducing the exact incident pattern:**
- Reproduction without dedup: confirms all 4 invocations execute (the bug)
- Reproduction with dedup: confirms only 1 executes, 3 blocked
- Verifies handler is NOT called for blocked invocations (checks fetch call count, not just logs)
- Legitimate retries (same invocation ID) allowed through
- Different events execute independently (no false positives)
- Delays and branches also deduped (ghost runs killed early)
- Redis failure fails open
- SET NX / GET race condition (key expiry) fails open

**Manual testing on localhost:**
- Reproduced ghost runs by inserting duplicate Cyclotron jobs with same event UUID, different job IDs
- Without dedup: all 4 jobs executed (bug confirmed)
- With dedup: 1 executed, 3 blocked with "duplicate execution detected" (fix confirmed)
- [Workflow cycling via postHogCapture](https://github.com/PostHog/posthog/pull/46181) works correctly with dedup enabled (each cycle gets a fresh event UUID from the capture pipeline, verified by code trace through Node.js -> Rust capture -> uuid_v7())

## Publish to changelog?

No
