### PR TITLE
fix(flags): preserve multivariate payloads on distribution update

### DIFF
--- a/frontend/src/scenes/feature-flags/featureFlagLogic.test.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagLogic.test.ts
@@ -10,9 +10,11 @@ import { FeatureFlagFilters } from '~/types'
 import { detectFeatureFlagChanges } from './featureFlagConfirmationLogic'
 import {
     NEW_FLAG,
+    convertIndexBasedPayloadsToVariantKeys,
     featureFlagLogic,
     hasMultipleVariantsActive,
     hasZeroRollout,
+    indexToVariantKeyFeatureFlagPayloads,
     slugifyFeatureFlagKey,
     validateFeatureFlagKey,
 } from './featureFlagLogic'
@@ -40,6 +42,75 @@ const MOCK_DEPENDENT_FLAGS = [
     { id: 10, key: 'dependent-flag-1', name: 'Dependent Flag 1' },
     { id: 11, key: 'dependent-flag-2', name: 'Dependent Flag 2' },
 ]
+
+describe('payload conversion helpers', () => {
+    const variants = [
+        { key: 'control', rollout_percentage: 50 },
+        { key: 'test', rollout_percentage: 50 },
+    ]
+
+    it.each([
+        [
+            'already keyed by variant key',
+            {
+                control: '{"color":"red"}',
+                test: '{"color":"blue"}',
+            },
+            {
+                control: '{"color":"red"}',
+                test: '{"color":"blue"}',
+            },
+        ],
+        [
+            'keyed by variant index',
+            {
+                0: '{"color":"red"}',
+                1: '{"color":"blue"}',
+            },
+            {
+                control: '{"color":"red"}',
+                test: '{"color":"blue"}',
+            },
+        ],
+        [
+            'with mixed keys while preferring explicit variant keys',
+            {
+                control: '{"color":"red"}',
+                0: '{"color":"green"}',
+                1: '{"color":"blue"}',
+            },
+            {
+                control: '{"color":"red"}',
+                test: '{"color":"blue"}',
+            },
+        ],
+    ])('converts multivariate payloads %s', (_label, payloads, expected) => {
+        expect(convertIndexBasedPayloadsToVariantKeys(variants, payloads)).toEqual(expected)
+    })
+
+    it('keeps boolean flag payload handling unchanged', () => {
+        expect(
+            indexToVariantKeyFeatureFlagPayloads({
+                filters: {
+                    groups: [{ properties: [], rollout_percentage: 100, variant: null }],
+                    multivariate: null,
+                    payloads: {
+                        true: '{"enabled":true}',
+                        false: '{"enabled":false}',
+                    },
+                },
+            } as FeatureFlagType)
+        ).toEqual({
+            filters: {
+                groups: [{ properties: [], rollout_percentage: 100, variant: null }],
+                multivariate: null,
+                payloads: {
+                    true: '{"enabled":true}',
+                },
+            },
+        })
+    })
+})
 
 describe('featureFlagLogic', () => {
     let logic: ReturnType<typeof featureFlagLogic.build>

--- a/frontend/src/scenes/feature-flags/featureFlagLogic.test.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagLogic.test.ts
@@ -99,7 +99,7 @@ describe('payload conversion helpers', () => {
                         false: '{"enabled":false}',
                     },
                 },
-            } as FeatureFlagType)
+            } as unknown as FeatureFlagType)
         ).toEqual({
             filters: {
                 groups: [{ properties: [], rollout_percentage: 100, variant: null }],

--- a/frontend/src/scenes/feature-flags/featureFlagLogic.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagLogic.ts
@@ -275,11 +275,25 @@ export const convertIndexBasedPayloadsToVariantKeys = (
     payloads?: Record<string | number, JsonType>
 ): Record<string, JsonType> => {
     const newPayloads: Record<string, JsonType> = {}
-    variants.forEach(({ key }, index) => {
-        if (payloads?.[index] !== undefined) {
-            newPayloads[key] = payloads[index]
+    const variantKeys = new Set(variants.map(({ key }) => key))
+
+    Object.entries(payloads || {}).forEach(([payloadKey, payloadValue]) => {
+        if (variantKeys.has(payloadKey)) {
+            newPayloads[payloadKey] = payloadValue
+            return
+        }
+
+        const payloadIndex = Number(payloadKey)
+        if (!Number.isInteger(payloadIndex) || String(payloadIndex) !== payloadKey) {
+            return
+        }
+
+        const variantKey = variants[payloadIndex]?.key
+        if (variantKey && newPayloads[variantKey] === undefined) {
+            newPayloads[variantKey] = payloadValue
         }
     })
+
     return newPayloads
 }
 


### PR DESCRIPTION
## Problem

Adjusting experiment distribution can remove payloads from the linked multivariate feature flag.

This happens because the frontend save path runs the flag through a helper that assumes payloads are keyed by variant index. In the experiment flow, payloads are already keyed by variant key, so the conversion drops them.

Closes #52773

## Changes

Made the multivariate payload conversion helper shape-aware.

It now:
- preserves payloads that are already keyed by variant key
- still converts index-keyed payloads for feature flag form flows
- leaves boolean flag payload handling unchanged

Also added focused regression tests for these cases.

## How did you test this code?

Ran:

`pnpm --filter=@posthog/frontend jest frontend/src/scenes/feature-flags/featureFlagLogic.test.ts --runInBand`

## Publish to changelog?

no

## Docs update

No docs update needed.