### PR TITLE
chore(cdp): Add ghost run cleanup script

### DIFF
--- a/nodejs/src/cdp/scripts/cleanup-ghost-runs.test.ts
+++ b/nodejs/src/cdp/scripts/cleanup-ghost-runs.test.ts
@@ -1,0 +1,335 @@
+import { extractActionId, extractEventId, generateCleanupSQL, identifyGhostRuns, parseCSV } from './cleanup-ghost-runs'
+
+describe('cleanup-ghost-runs', () => {
+    describe('extractEventId', () => {
+        it('extracts event ID from a Resuming workflow message', () => {
+            const emailMessage =
+                '[Action:action_function_email_abc] Email sent to test@example.com on [Event:019d035d-56b0-7f2d-a109-f7bfef12c591|$pageview|2026-03-18T23:52:23.085Z]'
+            expect(extractEventId(emailMessage)).toBe('019d035d-56b0-7f2d-a109-f7bfef12c591')
+        })
+
+        it('extracts event ID from any message containing [Event:]', () => {
+            const message =
+                'Resuming workflow execution at [Action:action_conditional_branch_c0daca89] on [Event:019d035d-56b0-7f2d-a109-f7bfef12c591|$pageview|2026-03-18T23:52:23.085Z]'
+            expect(extractEventId(message)).toBe('019d035d-56b0-7f2d-a109-f7bfef12c591')
+        })
+
+        it('returns null for messages without an event', () => {
+            expect(extractEventId('Workflow completed')).toBeNull()
+        })
+
+        it('handles event IDs with different formats', () => {
+            const message =
+                'Resuming workflow execution at [Action:abc] on [Event:1bf394c3-9aea-464e-ab7a-0db8335bb6b2|user_signed_up|2026-03-20T11:57:25.249Z]'
+            expect(extractEventId(message)).toBe('1bf394c3-9aea-464e-ab7a-0db8335bb6b2')
+        })
+    })
+
+    describe('extractActionId', () => {
+        it('extracts action ID from a workflow message', () => {
+            const message =
+                'Resuming workflow execution at [Action:action_conditional_branch_c0daca89] on [Event:abc|test|2026-01-01]'
+            expect(extractActionId(message)).toBe('action_conditional_branch_c0daca89')
+        })
+
+        it('returns null for messages without an action', () => {
+            expect(extractActionId('Workflow completed')).toBeNull()
+        })
+    })
+
+    describe('identifyGhostRuns', () => {
+        it('identifies ghost runs when multiple runs share the same event', () => {
+            const entries = [
+                {
+                    team_id: '47337',
+                    workflow_id: 'wf-1',
+                    run_id: 'run-1',
+                    message: 'Resuming workflow execution at [Action:abc] on [Event:event-1|test|2026-01-01]',
+                    timestamp: '2026-03-19 01:52:28.000000',
+                },
+                {
+                    team_id: '47337',
+                    workflow_id: 'wf-1',
+                    run_id: 'run-2',
+                    message: 'Resuming workflow execution at [Action:abc] on [Event:event-1|test|2026-01-01]',
+                    timestamp: '2026-03-19 01:53:05.000000',
+                },
+                {
+                    team_id: '47337',
+                    workflow_id: 'wf-1',
+                    run_id: 'run-3',
+                    message: 'Resuming workflow execution at [Action:abc] on [Event:event-1|test|2026-01-01]',
+                    timestamp: '2026-03-19 01:53:45.000000',
+                },
+                {
+                    team_id: '47337',
+                    workflow_id: 'wf-1',
+                    run_id: 'run-4',
+                    message: 'Resuming workflow execution at [Action:abc] on [Event:event-1|test|2026-01-01]',
+                    timestamp: '2026-03-19 01:54:25.000000',
+                },
+            ]
+
+            const results = identifyGhostRuns(entries)
+
+            expect(results).toHaveLength(1)
+            expect(results[0].legitimateRunId).toBe('run-1')
+            expect(results[0].ghostRunIds).toEqual(['run-2', 'run-3', 'run-4'])
+            expect(results[0].totalRuns).toBe(4)
+            expect(results[0].teamId).toBe('47337')
+        })
+
+        it('does not flag single runs as ghosts', () => {
+            const entries = [
+                {
+                    team_id: '47337',
+                    workflow_id: 'wf-1',
+                    run_id: 'run-1',
+                    message: 'Resuming workflow execution at [Action:abc] on [Event:event-1|test|2026-01-01]',
+                    timestamp: '2026-03-19 01:52:28.000000',
+                },
+                {
+                    team_id: '47337',
+                    workflow_id: 'wf-1',
+                    run_id: 'run-2',
+                    message: 'Resuming workflow execution at [Action:abc] on [Event:event-2|test|2026-01-01]',
+                    timestamp: '2026-03-19 02:00:00.000000',
+                },
+            ]
+
+            const results = identifyGhostRuns(entries)
+            expect(results).toHaveLength(0)
+        })
+
+        it('handles multiple teams independently', () => {
+            const entries = [
+                {
+                    team_id: '47337',
+                    workflow_id: 'wf-1',
+                    run_id: 'run-1a',
+                    message: 'Resuming workflow execution at [Action:abc] on [Event:event-1|test|2026-01-01]',
+                    timestamp: '2026-03-19 01:52:28.000000',
+                },
+                {
+                    team_id: '47337',
+                    workflow_id: 'wf-1',
+                    run_id: 'run-1b',
+                    message: 'Resuming workflow execution at [Action:abc] on [Event:event-1|test|2026-01-01]',
+                    timestamp: '2026-03-19 01:53:05.000000',
+                },
+                {
+                    team_id: '281194',
+                    workflow_id: 'wf-2',
+                    run_id: 'run-2a',
+                    message: 'Resuming workflow execution at [Action:xyz] on [Event:event-2|test|2026-01-01]',
+                    timestamp: '2026-03-19 01:52:28.000000',
+                },
+                {
+                    team_id: '281194',
+                    workflow_id: 'wf-2',
+                    run_id: 'run-2b',
+                    message: 'Resuming workflow execution at [Action:xyz] on [Event:event-2|test|2026-01-01]',
+                    timestamp: '2026-03-19 01:53:05.000000',
+                },
+            ]
+
+            const results = identifyGhostRuns(entries)
+
+            expect(results).toHaveLength(2)
+
+            const team47337 = results.find((r) => r.teamId === '47337')!
+            expect(team47337.legitimateRunId).toBe('run-1a')
+            expect(team47337.ghostRunIds).toEqual(['run-1b'])
+
+            const team281194 = results.find((r) => r.teamId === '281194')!
+            expect(team281194.legitimateRunId).toBe('run-2a')
+            expect(team281194.ghostRunIds).toEqual(['run-2b'])
+        })
+
+        it('keeps earliest run as legitimate regardless of input order', () => {
+            const entries = [
+                {
+                    team_id: '47337',
+                    workflow_id: 'wf-1',
+                    run_id: 'run-late',
+                    message: 'Resuming workflow execution at [Action:abc] on [Event:event-1|test|2026-01-01]',
+                    timestamp: '2026-03-19 01:54:25.000000',
+                },
+                {
+                    team_id: '47337',
+                    workflow_id: 'wf-1',
+                    run_id: 'run-early',
+                    message: 'Resuming workflow execution at [Action:abc] on [Event:event-1|test|2026-01-01]',
+                    timestamp: '2026-03-19 01:52:28.000000',
+                },
+            ]
+
+            const results = identifyGhostRuns(entries)
+
+            expect(results[0].legitimateRunId).toBe('run-early')
+            expect(results[0].ghostRunIds).toEqual(['run-late'])
+        })
+
+        it('deduplicates run IDs that appear multiple times in log entries', () => {
+            const entries = [
+                {
+                    team_id: '47337',
+                    workflow_id: 'wf-1',
+                    run_id: 'run-1',
+                    message: 'Resuming workflow execution at [Action:abc] on [Event:event-1|test|2026-01-01]',
+                    timestamp: '2026-03-19 01:52:28.000000',
+                },
+                {
+                    team_id: '47337',
+                    workflow_id: 'wf-1',
+                    run_id: 'run-1',
+                    message: 'Resuming workflow execution at [Action:def] on [Event:event-1|test|2026-01-01]',
+                    timestamp: '2026-03-19 01:52:29.000000',
+                },
+                {
+                    team_id: '47337',
+                    workflow_id: 'wf-1',
+                    run_id: 'run-2',
+                    message: 'Resuming workflow execution at [Action:abc] on [Event:event-1|test|2026-01-01]',
+                    timestamp: '2026-03-19 01:53:05.000000',
+                },
+            ]
+
+            const results = identifyGhostRuns(entries)
+
+            expect(results).toHaveLength(1)
+            expect(results[0].legitimateRunId).toBe('run-1')
+            expect(results[0].ghostRunIds).toEqual(['run-2'])
+            expect(results[0].totalRuns).toBe(2)
+        })
+
+        it('handles different events for the same team correctly', () => {
+            const entries = [
+                {
+                    team_id: '47337',
+                    workflow_id: 'wf-1',
+                    run_id: 'run-1',
+                    message: 'Resuming workflow execution at [Action:abc] on [Event:event-A|test|2026-01-01]',
+                    timestamp: '2026-03-19 01:52:28.000000',
+                },
+                {
+                    team_id: '47337',
+                    workflow_id: 'wf-1',
+                    run_id: 'run-2',
+                    message: 'Resuming workflow execution at [Action:abc] on [Event:event-A|test|2026-01-01]',
+                    timestamp: '2026-03-19 01:53:05.000000',
+                },
+                {
+                    team_id: '47337',
+                    workflow_id: 'wf-1',
+                    run_id: 'run-3',
+                    message: 'Resuming workflow execution at [Action:abc] on [Event:event-B|test|2026-01-01]',
+                    timestamp: '2026-03-19 02:00:00.000000',
+                },
+            ]
+
+            const results = identifyGhostRuns(entries)
+
+            expect(results).toHaveLength(1)
+            expect(results[0].eventId).toBe('event-A')
+            expect(results[0].ghostRunIds).toEqual(['run-2'])
+        })
+
+        it('returns empty array for empty input', () => {
+            expect(identifyGhostRuns([])).toEqual([])
+        })
+
+        it('skips entries without event IDs', () => {
+            const entries = [
+                {
+                    team_id: '47337',
+                    workflow_id: 'wf-1',
+                    run_id: 'run-1',
+                    message: 'Some message without event',
+                    timestamp: '2026-03-19 01:52:28.000000',
+                },
+            ]
+
+            expect(identifyGhostRuns(entries)).toEqual([])
+        })
+
+        it('does not flag different workflows triggered by the same event as ghosts', () => {
+            const entries = [
+                {
+                    team_id: '47337',
+                    workflow_id: 'workflow-A',
+                    run_id: 'run-1',
+                    message: 'Resuming workflow execution at [Action:abc] on [Event:event-1|test|2026-01-01]',
+                    timestamp: '2026-03-19 01:52:28.000000',
+                },
+                {
+                    team_id: '47337',
+                    workflow_id: 'workflow-B',
+                    run_id: 'run-2',
+                    message: 'Resuming workflow execution at [Action:xyz] on [Event:event-1|test|2026-01-01]',
+                    timestamp: '2026-03-19 01:52:30.000000',
+                },
+            ]
+
+            const results = identifyGhostRuns(entries)
+            expect(results).toHaveLength(0)
+        })
+    })
+
+    describe('parseCSV', () => {
+        it('parses a simple CSV', () => {
+            const csv = `team_id,run_id,workflow_id,message,timestamp
+47337,run-1,wf-1,Resuming workflow at [Action:abc] on [Event:e1|test|2026],2026-03-19 01:00:00
+47337,run-2,wf-1,Resuming workflow at [Action:abc] on [Event:e1|test|2026],2026-03-19 01:01:00`
+
+            const entries = parseCSV(csv)
+
+            expect(entries).toHaveLength(2)
+            expect(entries[0].team_id).toBe('47337')
+            expect(entries[0].run_id).toBe('run-1')
+            expect(entries[0].workflow_id).toBe('wf-1')
+            expect(entries[1].run_id).toBe('run-2')
+        })
+
+        it('handles quoted fields with commas', () => {
+            const csv = `team_id,run_id,workflow_id,message,timestamp
+"47,337",run-1,wf-1,Resuming workflow,2026-03-19 01:00:00`
+
+            const entries = parseCSV(csv)
+
+            expect(entries).toHaveLength(1)
+            expect(entries[0].team_id).toBe('47337')
+        })
+
+        it('handles empty input', () => {
+            expect(parseCSV('')).toEqual([])
+        })
+
+        it('handles header only', () => {
+            expect(parseCSV('team_id,run_id,workflow_id,message,timestamp')).toEqual([])
+        })
+    })
+
+    describe('generateCleanupSQL', () => {
+        it('generates SQL for ghost run IDs', () => {
+            const sql = generateCleanupSQL(['run-1', 'run-2', 'run-3'])
+
+            expect(sql).toContain("'run-1'")
+            expect(sql).toContain("'run-2'")
+            expect(sql).toContain("'run-3'")
+            expect(sql).toContain("state = 'completed'")
+            expect(sql).toContain("AND state = 'available'")
+            expect(sql).toContain('Total ghost runs: 3')
+        })
+
+        it('returns comment for empty input', () => {
+            const sql = generateCleanupSQL([])
+            expect(sql).toBe('-- No ghost runs to clean up')
+        })
+
+        it('only updates available jobs', () => {
+            const sql = generateCleanupSQL(['run-1'])
+            expect(sql).toContain("AND state = 'available'")
+        })
+    })
+})

--- a/nodejs/src/cdp/scripts/cleanup-ghost-runs.test.ts
+++ b/nodejs/src/cdp/scripts/cleanup-ghost-runs.test.ts
@@ -311,12 +311,16 @@ describe('cleanup-ghost-runs', () => {
     })
 
     describe('generateCleanupSQL', () => {
-        it('generates SQL for ghost run IDs', () => {
-            const sql = generateCleanupSQL(['run-1', 'run-2', 'run-3'])
+        const uuid1 = '019d0523-b5a4-0000-fff1-1a73f4b71910'
+        const uuid2 = '019d0581-c0a6-0000-dac3-748c0751c5e0'
+        const uuid3 = '019d0430-c587-0000-31ef-c4204a48748a'
 
-            expect(sql).toContain("'run-1'")
-            expect(sql).toContain("'run-2'")
-            expect(sql).toContain("'run-3'")
+        it('generates SQL for ghost run IDs', () => {
+            const sql = generateCleanupSQL([uuid1, uuid2, uuid3])
+
+            expect(sql).toContain(`'${uuid1}'`)
+            expect(sql).toContain(`'${uuid2}'`)
+            expect(sql).toContain(`'${uuid3}'`)
             expect(sql).toContain("state = 'completed'")
             expect(sql).toContain("AND state = 'available'")
             expect(sql).toContain('Total ghost runs: 3')
@@ -328,8 +332,12 @@ describe('cleanup-ghost-runs', () => {
         })
 
         it('only updates available jobs', () => {
-            const sql = generateCleanupSQL(['run-1'])
+            const sql = generateCleanupSQL([uuid1])
             expect(sql).toContain("AND state = 'available'")
+        })
+
+        it('rejects non-UUID IDs', () => {
+            expect(() => generateCleanupSQL(['not-a-uuid'])).toThrow('Non-UUID ghost run IDs detected')
         })
     })
 })

--- a/nodejs/src/cdp/scripts/cleanup-ghost-runs.ts
+++ b/nodejs/src/cdp/scripts/cleanup-ghost-runs.ts
@@ -156,6 +156,12 @@ export function generateCleanupSQL(ghostRunIds: string[]): string {
         return '-- No ghost runs to clean up'
     }
 
+    const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+    const invalid = ghostRunIds.filter((id) => !uuidRegex.test(id))
+    if (invalid.length > 0) {
+        throw new Error(`Non-UUID ghost run IDs detected, refusing to generate SQL: ${invalid.slice(0, 5).join(', ')}`)
+    }
+
     // Batch into chunks of 1000 to avoid overly large IN clauses
     const chunks: string[][] = []
     for (let i = 0; i < ghostRunIds.length; i += 1000) {
@@ -202,6 +208,19 @@ export function parseCSV(csv: string): LogEntry[] {
         return []
     }
 
+    const expectedColumns = ['team_id', 'run_id', 'workflow_id', 'message', 'timestamp']
+    const headerColumns = header.split(',').map((h) => h.trim().toLowerCase())
+    for (const col of expectedColumns) {
+        if (!headerColumns.includes(col)) {
+            throw new Error(`CSV header missing required column '${col}'. Found: ${headerColumns.join(', ')}`)
+        }
+    }
+
+    const colIdx = Object.fromEntries(expectedColumns.map((col) => [col, headerColumns.indexOf(col)])) as Record<
+        string,
+        number
+    >
+
     const entries: LogEntry[] = []
 
     for (let i = 1; i < lines.length; i++) {
@@ -227,13 +246,13 @@ export function parseCSV(csv: string): LogEntry[] {
         }
         fields.push(current.trim())
 
-        if (fields.length >= 5) {
+        if (fields.length >= expectedColumns.length) {
             entries.push({
-                team_id: fields[0].replace(/,/g, ''),
-                run_id: fields[1],
-                workflow_id: fields[2],
-                message: fields[3],
-                timestamp: fields[4],
+                team_id: fields[colIdx['team_id']].replace(/,/g, ''),
+                run_id: fields[colIdx['run_id']],
+                workflow_id: fields[colIdx['workflow_id']],
+                message: fields[colIdx['message']],
+                timestamp: fields[colIdx['timestamp']],
             })
         }
     }
@@ -297,17 +316,16 @@ if (require.main === module) {
     const csvPath = args.find((a) => !a.startsWith('--') && !(teamsIdx !== -1 && a === args[teamsIdx + 1]))
 
     if (!csvPath) {
-        console.log('Usage: npx ts-node cleanup-ghost-runs.ts <csv-file> [--dry-run] [--teams 79155,110739]')
+        console.log('Usage: npx ts-node cleanup-ghost-runs.ts <csv-file> [--dry-run] [--teams <ids>]')
         console.log('')
         console.log('Options:')
         console.log('  --dry-run           Print summary only, do not write SQL files')
         console.log('  --teams 1,2,3       Only process specific team IDs from the CSV')
         console.log('')
-        console.log('Step 1: Run the ClickHouse query to get the data:')
+        console.log('Step 1: Run the ClickHouse query to get the data (all teams):')
         console.log(getClickHouseQuery())
         console.log('')
-        console.log('  Or for specific teams:')
-        console.log(getClickHouseQuery([79155, 110739]))
+        console.log('  Or for specific teams: pass team IDs to getClickHouseQuery([team1, team2])')
         console.log('')
         console.log('Step 2: Save the result as CSV and run this script with the path')
         process.exit(1)

--- a/nodejs/src/cdp/scripts/cleanup-ghost-runs.ts
+++ b/nodejs/src/cdp/scripts/cleanup-ghost-runs.ts
@@ -48,8 +48,8 @@ interface GhostRunResult {
  * Returns the ClickHouse query to extract workflow trigger/resume data
  * for the incident window. Run this on ClickHouse and save the result as CSV.
  */
-export function getClickHouseQuery(teamIds: number[]): string {
-    const teamIdList = teamIds.join(', ')
+export function getClickHouseQuery(teamIds?: number[]): string {
+    const teamFilter = teamIds?.length ? `  AND team_id IN (${teamIds.join(', ')})` : ''
     return `
 SELECT
     team_id,
@@ -61,7 +61,7 @@ FROM log_entries
 WHERE timestamp BETWEEN '2026-03-18 00:00:00' AND '2026-03-31 00:00:00'
   AND log_source = 'hog_flow'
   AND message LIKE '%[Event:%'
-  AND team_id IN (${teamIdList})
+${teamFilter}
 ORDER BY team_id, message, instance_id
 `
 }
@@ -244,14 +244,21 @@ export function parseCSV(csv: string): LogEntry[] {
 /**
  * Main cleanup function. Takes a CSV file path and outputs cleanup SQL.
  */
-export function processCleanup(csvPath: string): {
+export function processCleanup(
+    csvPath: string,
+    filterTeamIds?: number[]
+): {
     results: GhostRunResult[]
     allGhostRunIds: string[]
     sql: string
     summary: string
 } {
     const csv = fs.readFileSync(csvPath, 'utf-8')
-    const entries = parseCSV(csv)
+    let entries = parseCSV(csv)
+    if (filterTeamIds?.length) {
+        const teamSet = new Set(filterTeamIds.map(String))
+        entries = entries.filter((e) => teamSet.has(e.team_id))
+    }
     const results = identifyGhostRuns(entries)
 
     const allGhostRunIds = results.flatMap((r) => r.ghostRunIds)
@@ -283,26 +290,38 @@ export function processCleanup(csvPath: string): {
 
 // CLI entrypoint
 if (require.main === module) {
-    const csvPath = process.argv[2]
+    const args = process.argv.slice(2)
+    const dryRun = args.includes('--dry-run')
+    const teamsIdx = args.indexOf('--teams')
+    const teamIds = teamsIdx !== -1 ? args[teamsIdx + 1]?.split(',').map(Number) : undefined
+    const csvPath = args.find((a) => !a.startsWith('--') && !(teamsIdx !== -1 && a === args[teamsIdx + 1]))
+
     if (!csvPath) {
-        console.log('Usage: npx ts-node cleanup-ghost-runs.ts <csv-file>')
+        console.log('Usage: npx ts-node cleanup-ghost-runs.ts <csv-file> [--dry-run] [--teams 79155,110739]')
+        console.log('')
+        console.log('Options:')
+        console.log('  --dry-run           Print summary only, do not write SQL files')
+        console.log('  --teams 1,2,3       Only process specific team IDs from the CSV')
         console.log('')
         console.log('Step 1: Run the ClickHouse query to get the data:')
-        console.log(
-            getClickHouseQuery([
-                277932, 281194, 240217, 243819, 78051, 47337, 110739, 262324, 70616, 103207, 73108, 122682, 118319,
-                81505, 163576, 76160, 127158, 189310, 106363, 105711, 224119, 121623,
-            ])
-        )
+        console.log(getClickHouseQuery())
+        console.log('')
+        console.log('  Or for specific teams:')
+        console.log(getClickHouseQuery([79155, 110739]))
         console.log('')
         console.log('Step 2: Save the result as CSV and run this script with the path')
         process.exit(1)
     }
 
-    const { summary, sql, allGhostRunIds } = processCleanup(csvPath)
+    const { summary, sql, allGhostRunIds } = processCleanup(csvPath, teamIds)
 
     console.log(summary)
     console.log('')
+
+    if (dryRun) {
+        console.log('Dry run - no files written.')
+        process.exit(0)
+    }
 
     // Write SQL to file
     const sqlPath = path.join(path.dirname(csvPath), 'ghost-run-cleanup.sql')

--- a/nodejs/src/cdp/scripts/cleanup-ghost-runs.ts
+++ b/nodejs/src/cdp/scripts/cleanup-ghost-runs.ts
@@ -1,0 +1,316 @@
+/**
+ * Ghost Run Cleanup Script
+ *
+ * Context: During the March 18-19, 2026 incident, a cross-routing bug in the
+ * Cyclotron job queue caused workflow invocations to be executed multiple times
+ * per trigger event. The bug created 4 parallel execution paths per event (1
+ * legitimate + 3 from janitor resets). Each path has its own Cyclotron job ID
+ * but shares the same trigger event UUID. These ghost runs are still alive in
+ * the Cyclotron database, progressing through delay steps and sending duplicate
+ * emails/notifications at each action step.
+ *
+ * Key insight: Cyclotron job ID = ClickHouse instance_id. The same job ID
+ * persists through delay steps (retry in place, not recreated).
+ *
+ * This script:
+ * 1. Takes a ClickHouse CSV export of all log entries containing [Event:] during
+ *    the incident window (uses any log message, not just "Resuming workflow")
+ * 2. Groups runs by (team_id, workflow_id, event_uuid)
+ * 3. For each group with multiple instance_ids, keeps the earliest and marks the rest as ghosts
+ * 4. Outputs ghost run IDs that can be marked as 'completed' in the Cyclotron DB
+ *    (the IDs match Cyclotron job IDs directly)
+ *
+ * Usage:
+ *   Step 1: Export ClickHouse data to CSV using the query in getClickHouseQuery()
+ *   Step 2: Run this script with the CSV to get ghost run IDs
+ *   Step 3: Use the generated SQL to clean up the Cyclotron DB
+ */
+import * as fs from 'fs'
+import * as path from 'path'
+
+interface LogEntry {
+    team_id: string
+    run_id: string
+    workflow_id: string
+    message: string
+    timestamp: string
+}
+
+interface GhostRunResult {
+    teamId: string
+    ghostRunIds: string[]
+    legitimateRunId: string
+    eventId: string
+    totalRuns: number
+}
+
+/**
+ * Returns the ClickHouse query to extract workflow trigger/resume data
+ * for the incident window. Run this on ClickHouse and save the result as CSV.
+ */
+export function getClickHouseQuery(teamIds: number[]): string {
+    const teamIdList = teamIds.join(', ')
+    return `
+SELECT
+    team_id,
+    instance_id AS run_id,
+    log_source_id AS workflow_id,
+    message,
+    toString(timestamp) AS timestamp
+FROM log_entries
+WHERE timestamp BETWEEN '2026-03-18 00:00:00' AND '2026-03-31 00:00:00'
+  AND log_source = 'hog_flow'
+  AND message LIKE '%[Event:%'
+  AND team_id IN (${teamIdList})
+ORDER BY team_id, message, instance_id
+`
+}
+
+/**
+ * Extracts the event ID from a workflow log message.
+ * Messages contain: [Event:EVENT_ID|event_name|timestamp]
+ */
+export function extractEventId(message: string): string | null {
+    const match = message.match(/\[Event:([^|]+)\|/)
+    return match ? match[1] : null
+}
+
+/**
+ * Extracts the action ID from a workflow log message.
+ * Messages look like: "Resuming workflow execution at [Action:ACTION_ID] on [Event:...]"
+ */
+export function extractActionId(message: string): string | null {
+    const match = message.match(/\[Action:([^\]]+)\]/)
+    return match ? match[1] : null
+}
+
+/**
+ * Parses CSV data and identifies ghost runs.
+ *
+ * Groups runs by (team_id, workflow_id, event_id). Within each group,
+ * the earliest run (by timestamp) is kept as legitimate, and the rest
+ * are marked as ghosts.
+ */
+export function identifyGhostRuns(entries: LogEntry[]): GhostRunResult[] {
+    // Group by team_id + workflow_id + event_id
+    const groups = new Map<string, { runId: string; timestamp: string }[]>()
+
+    for (const entry of entries) {
+        const eventId = extractEventId(entry.message)
+        if (!eventId) {
+            continue
+        }
+
+        const key = `${entry.team_id}:${entry.workflow_id}:${eventId}`
+
+        if (!groups.has(key)) {
+            groups.set(key, [])
+        }
+
+        const group = groups.get(key)!
+        // Only add each run_id once per group
+        if (!group.some((r) => r.runId === entry.run_id)) {
+            group.push({ runId: entry.run_id, timestamp: entry.timestamp })
+        }
+    }
+
+    // For each group with duplicates, identify ghost runs
+    const results: GhostRunResult[] = []
+
+    for (const [key, runs] of groups) {
+        if (runs.length <= 1) {
+            continue
+        }
+
+        const parts = key.split(':')
+        const teamId = parts[0]
+        const eventId = parts.slice(2).join(':')
+
+        // Sort by timestamp, keep the earliest as legitimate
+        runs.sort((a, b) => a.timestamp.localeCompare(b.timestamp))
+
+        const legitimateRun = runs[0]
+        const ghostRuns = runs.slice(1)
+
+        results.push({
+            teamId,
+            ghostRunIds: ghostRuns.map((r) => r.runId),
+            legitimateRunId: legitimateRun.runId,
+            eventId,
+            totalRuns: runs.length,
+        })
+    }
+
+    return results
+}
+
+/**
+ * Generates SQL to mark ghost runs as completed in the Cyclotron DB.
+ * Only updates jobs that are currently in 'available' state (safe to update).
+ *
+ * The old Cyclotron DB (Rust) uses column 'state' for the status enum.
+ * Production ghost runs are in the old DB.
+ */
+export function generateCleanupSQL(ghostRunIds: string[]): string {
+    if (ghostRunIds.length === 0) {
+        return '-- No ghost runs to clean up'
+    }
+
+    // Batch into chunks of 1000 to avoid overly large IN clauses
+    const chunks: string[][] = []
+    for (let i = 0; i < ghostRunIds.length; i += 1000) {
+        chunks.push(ghostRunIds.slice(i, i + 1000))
+    }
+
+    let sql = `-- Ghost run cleanup: mark duplicate workflow runs as completed
+-- Generated by cleanup-ghost-runs script
+-- Total ghost runs: ${ghostRunIds.length}
+-- Batched into ${chunks.length} statements of up to 1000 IDs each
+--
+-- IMPORTANT: Only updates jobs in 'available' state (not currently running).
+-- Run against the old Cyclotron DB (uses 'state' column for status).
+`
+
+    for (let i = 0; i < chunks.length; i++) {
+        const idList = chunks[i].map((id) => `'${id}'`).join(',\n    ')
+        sql += `
+-- Batch ${i + 1}/${chunks.length} (${chunks[i].length} IDs)
+UPDATE cyclotron_jobs
+SET state = 'completed',
+    lock_id = NULL,
+    last_heartbeat = NULL,
+    last_transition = NOW(),
+    transition_count = transition_count + 1
+WHERE id IN (
+    ${idList}
+)
+AND state = 'available';
+`
+    }
+
+    return sql
+}
+
+/**
+ * Parses a CSV string into LogEntry objects.
+ * Handles quoted fields with commas.
+ */
+export function parseCSV(csv: string): LogEntry[] {
+    const lines = csv.trim().split('\n')
+    const header = lines[0]
+    if (!header) {
+        return []
+    }
+
+    const entries: LogEntry[] = []
+
+    for (let i = 1; i < lines.length; i++) {
+        const line = lines[i]
+        if (!line.trim()) {
+            continue
+        }
+
+        // Simple CSV parsing: split by comma but respect quoted fields
+        const fields: string[] = []
+        let current = ''
+        let inQuotes = false
+
+        for (const char of line) {
+            if (char === '"') {
+                inQuotes = !inQuotes
+            } else if (char === ',' && !inQuotes) {
+                fields.push(current.trim())
+                current = ''
+            } else {
+                current += char
+            }
+        }
+        fields.push(current.trim())
+
+        if (fields.length >= 5) {
+            entries.push({
+                team_id: fields[0].replace(/,/g, ''),
+                run_id: fields[1],
+                workflow_id: fields[2],
+                message: fields[3],
+                timestamp: fields[4],
+            })
+        }
+    }
+
+    return entries
+}
+
+/**
+ * Main cleanup function. Takes a CSV file path and outputs cleanup SQL.
+ */
+export function processCleanup(csvPath: string): {
+    results: GhostRunResult[]
+    allGhostRunIds: string[]
+    sql: string
+    summary: string
+} {
+    const csv = fs.readFileSync(csvPath, 'utf-8')
+    const entries = parseCSV(csv)
+    const results = identifyGhostRuns(entries)
+
+    const allGhostRunIds = results.flatMap((r) => r.ghostRunIds)
+
+    // Summary per team
+    const teamSummary = new Map<string, { ghostRuns: number; affectedEvents: number }>()
+    for (const result of results) {
+        const existing = teamSummary.get(result.teamId) || { ghostRuns: 0, affectedEvents: 0 }
+        existing.ghostRuns += result.ghostRunIds.length
+        existing.affectedEvents += 1
+        teamSummary.set(result.teamId, existing)
+    }
+
+    let summary = `Ghost Run Cleanup Summary\n`
+    summary += `========================\n`
+    summary += `Total ghost runs: ${allGhostRunIds.length}\n`
+    summary += `Total affected events: ${results.length}\n`
+    summary += `Total affected teams: ${teamSummary.size}\n\n`
+    summary += `Per team:\n`
+
+    for (const [teamId, stats] of teamSummary) {
+        summary += `  Team ${teamId}: ${stats.ghostRuns} ghost runs across ${stats.affectedEvents} events\n`
+    }
+
+    const sql = generateCleanupSQL(allGhostRunIds)
+
+    return { results, allGhostRunIds, sql, summary }
+}
+
+// CLI entrypoint
+if (require.main === module) {
+    const csvPath = process.argv[2]
+    if (!csvPath) {
+        console.log('Usage: npx ts-node cleanup-ghost-runs.ts <csv-file>')
+        console.log('')
+        console.log('Step 1: Run the ClickHouse query to get the data:')
+        console.log(
+            getClickHouseQuery([
+                277932, 281194, 240217, 243819, 78051, 47337, 110739, 262324, 70616, 103207, 73108, 122682, 118319,
+                81505, 163576, 76160, 127158, 189310, 106363, 105711, 224119, 121623,
+            ])
+        )
+        console.log('')
+        console.log('Step 2: Save the result as CSV and run this script with the path')
+        process.exit(1)
+    }
+
+    const { summary, sql, allGhostRunIds } = processCleanup(csvPath)
+
+    console.log(summary)
+    console.log('')
+
+    // Write SQL to file
+    const sqlPath = path.join(path.dirname(csvPath), 'ghost-run-cleanup.sql')
+    fs.writeFileSync(sqlPath, sql)
+    console.log(`SQL written to: ${sqlPath}`)
+
+    // Write ghost IDs to file
+    const idsPath = path.join(path.dirname(csvPath), 'ghost-run-ids.txt')
+    fs.writeFileSync(idsPath, allGhostRunIds.join('\n'))
+    console.log(`Ghost run IDs written to: ${idsPath}`)
+}


### PR DESCRIPTION
## Problem

The March 18-19 Cyclotron cross-routing incident created ghost workflow runs. These are duplicate invocations that share the same trigger event but have different Cyclotron job IDs. They progress through delay steps independently and send duplicate emails/notifications each time they reach an action step.

Customers are actively receiving duplicate emails from ghost runs still progressing through workflow delay steps.

## Changes

Adds a script to identify ghost run Cyclotron job IDs from ClickHouse logs and generate cleanup SQL.

The identification logic:
1. Query ClickHouse for all log entries containing `[Event:]` during the incident window (March 18-31)
2. Group by (team_id, workflow_id, event_uuid)
3. Groups with multiple distinct instance_ids are duplicates (typically count=4, matching the janitor maxTouchCount pattern)
4. Keep the earliest instance_id as legitimate, the rest are ghosts
5. Ghost instance_ids = Cyclotron job IDs (verified: same ID persists through delay steps)
6. Generate batched `UPDATE cyclotron_jobs SET state = 'completed' WHERE id IN (...) AND state = 'available'`

Usage:
```
# Step 1: Export ClickHouse data to CSV using the query from getClickHouseQuery()
# Step 2: Run the script
npx ts-node cleanup-ghost-runs.ts <csv-file>
# Step 3: Review the generated SQL, then run against the Cyclotron DB
```

## How did you test this code?

Unit tests covering:
- Event UUID extraction from various log message formats
- Ghost run identification (grouping, deduplication, multi-team, ordering)
- CSV parsing with quoted fields
- SQL generation with batching

Cross-referenced against production data: matched on US and EU Cyclotron DBs by joining ClickHouse ghost instance_ids with Cyclotron available job IDs.

## Publish to changelog?

No