### PR TITLE
feat(experiments): gate matured users filter behind feature flag

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -281,6 +281,7 @@ export const FEATURE_FLAGS = {
     EVENT_MEDIA_PREVIEWS: 'event-media-previews', // owner: @alexlider
     EXPERIMENT_AI_ANALYSIS_TAB: 'experiment-ai-analysis-tab', // owner: @rodrigoi #team-experiments
     EXPERIMENT_FUNNEL_DWH_SUPPORT: 'experiment-funnel-dwh-support', // owner: @rodrigoi #team-experiments
+    EXPERIMENTS_MATURED_USERS_FILTER: 'experiments-matured-users-filter', // owner: @jurajmajerik #team-experiments
     EXPERIMENT_SESSION_REPLAYS_SKILL: 'experiment-session-replays-skill', // owner: @rodrigoi #team-experiments
     EXPERIMENT_SIGNIFICANCE_ALERTS: 'experiment-significance-alerts', // owner: @jurajmajerik #team-experiments
     EXPERIMENT_QUERY_PREAGGREGATION: 'experiment-query-preaggregation', // owner: @jurajmajerik #team-experiments

--- a/frontend/src/scenes/experiments/ExperimentMetricConversionWindowFilter.tsx
+++ b/frontend/src/scenes/experiments/ExperimentMetricConversionWindowFilter.tsx
@@ -1,5 +1,6 @@
 import { LemonCheckbox } from '@posthog/lemon-ui'
 
+import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { LemonInput } from 'lib/lemon-ui/LemonInput'
 import { LemonRadio } from 'lib/lemon-ui/LemonRadio'
 import { LemonSelect, LemonSelectOption } from 'lib/lemon-ui/LemonSelect'
@@ -17,6 +18,8 @@ export function ExperimentMetricConversionWindowFilter({
     metric: ExperimentMetric
     handleSetMetric: (newMetric: ExperimentMetric) => void
 }): JSX.Element {
+    const showMaturedUsersOption = useFeatureFlag('EXPERIMENTS_MATURED_USERS_FILTER')
+
     const options: LemonSelectOption<FunnelConversionWindowTimeUnit>[] = Object.keys(TIME_INTERVAL_BOUNDS).map(
         (unit) => ({
             label: capitalizeFirstLetter(pluralize(metric.conversion_window ?? 72, unit, `${unit}s`, false)),
@@ -93,21 +96,23 @@ export function ExperimentMetricConversionWindowFilter({
                                 options={options}
                             />
                         </div>
-                        <div className="flex items-center gap-2">
-                            <LemonCheckbox
-                                label="Only count matured users"
-                                checked={metric.only_count_matured_users ?? false}
-                                onChange={(checked) =>
-                                    handleSetMetric({
-                                        ...metric,
-                                        only_count_matured_users: checked || undefined,
-                                    })
-                                }
-                            />
-                            <span className="text-muted text-xs">
-                                Exclude users from calculations until their full conversion window has elapsed.
-                            </span>
-                        </div>
+                        {showMaturedUsersOption && (
+                            <div className="flex items-center gap-2">
+                                <LemonCheckbox
+                                    label="Only count matured users"
+                                    checked={metric.only_count_matured_users ?? false}
+                                    onChange={(checked) =>
+                                        handleSetMetric({
+                                            ...metric,
+                                            only_count_matured_users: checked || undefined,
+                                        })
+                                    }
+                                />
+                                <span className="text-muted text-xs">
+                                    Exclude users from calculations until their full conversion window has elapsed.
+                                </span>
+                            </div>
+                        )}
                     </>
                 )}
             </div>


### PR DESCRIPTION
## Changes

Gate the checkbox behind `experiments-matured-users-filter` feature flag, while I'm still collecting early feedback.

## How did you test this code?
👀 