### PR TITLE
fix(insights): allow table scrolling in embedded contexts (like thread)

### DIFF
--- a/frontend/src/lib/components/ScrollableShadows/ScrollableShadows.scss
+++ b/frontend/src/lib/components/ScrollableShadows/ScrollableShadows.scss
@@ -3,21 +3,9 @@
 
     position: relative;
     display: flex;
+    width: 100%;
+    height: 100%;
     overflow: hidden;
-
-    &::before,
-    &::after {
-        position: absolute;
-        top: var(--scrollable-shadows-offset-top);
-        left: 0;
-        z-index: 5; // Bumped from 1 because in new scene layout we use scrollable shadows in around the main content, and some content has their own z-index > 1
-        width: 100%;
-        height: 100%;
-        pointer-events: none;
-        content: '';
-        opacity: 0;
-        transition: opacity 200ms ease;
-    }
 
     // Base UI ScrollArea injects `.base-ui-disable-scrollbar` on the Viewport
     // which hides native scrollbars. Restore them unless explicitly hidden.
@@ -35,67 +23,67 @@
         flex: 1;
     }
 
-    &.ScrollableShadows--horizontal {
-        height: 100%;
-
-        &::before {
-            box-shadow: 16px 0 16px -16px rgb(0 0 0 / 25%) inset;
-        }
-
-        &::after {
-            box-shadow: -16px 0 16px -16px rgb(0 0 0 / 25%) inset;
-        }
-
-        [theme='dark'] & {
-            &::before {
-                box-shadow: 16px 0 16px -16px rgb(0 0 0 / 100%) inset;
-            }
-
-            &::after {
-                box-shadow: -16px 0 16px -16px rgb(0 0 0 / 100%) inset;
-            }
-        }
-    }
-
-    &.ScrollableShadows--vertical {
+    // Shadow pseudo-elements driven by Base UI's data-overflow-* attributes.
+    // ::before handles start shadows (left + top), ::after handles end shadows (right + bottom).
+    // Each shadow is independently toggled via CSS custom properties.
+    &::before,
+    &::after {
+        position: absolute;
+        top: var(--scrollable-shadows-offset-top);
+        left: 0;
+        z-index: 8; // 8 because we want it over lemon table headers/rows & other stuff
         width: 100%;
+        height: 100%;
+        pointer-events: none;
+        content: '';
+        transition: box-shadow 200ms ease;
+    }
 
+    &:not(.ScrollableShadows--hide-shadows) {
         &::before {
-            box-shadow: 0 16px 16px -16px rgb(0 0 0 / 25%) inset;
+            box-shadow:
+                var(--shadow-x-start, 0 0 0 0 transparent) inset,
+                var(--shadow-y-start, 0 0 0 0 transparent) inset;
         }
 
         &::after {
-            box-shadow: 0 -16px 16px -16px rgb(0 0 0 / 25%) inset;
+            box-shadow:
+                var(--shadow-x-end, 0 0 0 0 transparent) inset,
+                var(--shadow-y-end, 0 0 0 0 transparent) inset;
+        }
+
+        &[data-overflow-x-start] {
+            --shadow-x-start: 16px 0 16px -16px rgb(0 0 0 / 25%);
+        }
+
+        &[data-overflow-x-end] {
+            --shadow-x-end: -16px 0 16px -16px rgb(0 0 0 / 25%);
+        }
+
+        &[data-overflow-y-start] {
+            --shadow-y-start: 0 16px 16px -16px rgb(0 0 0 / 25%);
+        }
+
+        &[data-overflow-y-end] {
+            --shadow-y-end: 0 -16px 16px -16px rgb(0 0 0 / 25%);
         }
 
         [theme='dark'] & {
-            &::before {
-                box-shadow: 0 16px 16px -16px rgb(0 0 0 / 100%) inset;
+            &[data-overflow-x-start] {
+                --shadow-x-start: 16px 0 16px -16px rgb(0 0 0 / 100%);
             }
 
-            &::after {
-                box-shadow: 0 -16px 16px -16px rgb(0 0 0 / 100%) inset;
+            &[data-overflow-x-end] {
+                --shadow-x-end: -16px 0 16px -16px rgb(0 0 0 / 100%);
             }
-        }
-    }
 
-    &.ScrollableShadows--horizontal:not(.ScrollableShadows--hide-shadows) {
-        &[data-overflow-x-start]::before {
-            opacity: 1;
-        }
+            &[data-overflow-y-start] {
+                --shadow-y-start: 0 16px 16px -16px rgb(0 0 0 / 100%);
+            }
 
-        &[data-overflow-x-end]::after {
-            opacity: 1;
-        }
-    }
-
-    &.ScrollableShadows--vertical:not(.ScrollableShadows--hide-shadows) {
-        &[data-overflow-y-start]::before {
-            opacity: 1;
-        }
-
-        &[data-overflow-y-end]::after {
-            opacity: 1;
+            &[data-overflow-y-end] {
+                --shadow-y-end: 0 -16px 16px -16px rgb(0 0 0 / 100%);
+            }
         }
     }
 

--- a/frontend/src/lib/components/ScrollableShadows/ScrollableShadows.scss
+++ b/frontend/src/lib/components/ScrollableShadows/ScrollableShadows.scss
@@ -1,6 +1,13 @@
 .ScrollableShadows {
     --scrollable-shadows-offset-top: 0px;
 
+    // Reset shadow custom properties so nested ScrollableShadows don't inherit
+    // the parent's shadow values via CSS custom property inheritance.
+    --shadow-x-start: 0 0 0 0 transparent;
+    --shadow-x-end: 0 0 0 0 transparent;
+    --shadow-y-start: 0 0 0 0 transparent;
+    --shadow-y-end: 0 0 0 0 transparent;
+
     position: relative;
     display: flex;
     width: 100%;

--- a/frontend/src/lib/components/ScrollableShadows/ScrollableShadows.tsx
+++ b/frontend/src/lib/components/ScrollableShadows/ScrollableShadows.tsx
@@ -6,7 +6,11 @@ import React, { CSSProperties, MutableRefObject } from 'react'
 
 export type ScrollableShadowsProps = {
     children: React.ReactNode
-    direction: 'horizontal' | 'vertical'
+    /**
+     * Which axis to scroll and show shadows for.
+     * When omitted, both axes can scroll and shadows appear on whichever axis overflows.
+     */
+    direction?: 'horizontal' | 'vertical'
     className?: string
     innerClassName?: string
     contentClassName?: string
@@ -21,13 +25,6 @@ export type ScrollableShadowsProps = {
     style?: CSSProperties
     /** Whether to disable scrolling. */
     disableScroll?: boolean
-    /**
-     * Whether scrolling should be constrained to the given direction.
-     * When false, both axes are allowed to scroll.
-     * Defaults to true for backwards compatibility.
-     * Should be used in conjunction with direction
-     */
-    constrainToDirection?: boolean
     /** Whether to hide the scrollable shadows. */
     hideShadows?: boolean
     /** Whether to hide the scrollbars. */
@@ -44,7 +41,6 @@ export const ScrollableShadows = React.forwardRef<HTMLDivElement, ScrollableShad
         scrollRef,
         styledScrollbars = false,
         disableScroll = false,
-        constrainToDirection = true,
         hideShadows = false,
         hideScrollbars = false,
         style,
@@ -57,7 +53,6 @@ export const ScrollableShadows = React.forwardRef<HTMLDivElement, ScrollableShad
             ref={ref}
             className={clsx(
                 'ScrollableShadows',
-                `ScrollableShadows--${direction}`,
                 hideShadows && 'ScrollableShadows--hide-shadows',
                 hideScrollbars && 'ScrollableShadows--hide-scrollbars',
                 className
@@ -80,7 +75,7 @@ export const ScrollableShadows = React.forwardRef<HTMLDivElement, ScrollableShad
                 style={
                     disableScroll
                         ? { overflow: 'hidden' }
-                        : constrainToDirection
+                        : direction
                           ? {
                                 overflowX: direction === 'horizontal' ? undefined : 'hidden',
                                 overflowY: direction === 'vertical' ? undefined : 'hidden',

--- a/frontend/src/lib/lemon-ui/LemonTable/LemonTable.stories.tsx
+++ b/frontend/src/lib/lemon-ui/LemonTable/LemonTable.stories.tsx
@@ -493,8 +493,8 @@ export const WithHorizontalOverflow: Story = {
 export const WithVerticalOverflow: Story = {
     render: () => {
         return (
-            <div className="max-h-60 flex flex-col overflow-auto">
-                <LemonTable columns={WIDE_COLUMNS.slice(0, 2)} dataSource={MANY_PEOPLE} />
+            <div className="h-60 flex flex-col">
+                <LemonTable columns={WIDE_COLUMNS.slice(0, 2)} dataSource={MANY_PEOPLE} allowContentScroll />
             </div>
         )
     },
@@ -503,8 +503,8 @@ export const WithVerticalOverflow: Story = {
 export const WithHorizontalAndVerticalOverflow: Story = {
     render: () => {
         return (
-            <div className="max-w-120 max-h-60 flex flex-col overflow-auto">
-                <LemonTable columns={WIDE_COLUMNS} dataSource={MANY_PEOPLE} />
+            <div className="max-w-120 h-80 flex flex-col">
+                <LemonTable columns={WIDE_COLUMNS} dataSource={MANY_PEOPLE} allowContentScroll />
             </div>
         )
     },

--- a/frontend/src/lib/lemon-ui/LemonTable/LemonTable.tsx
+++ b/frontend/src/lib/lemon-ui/LemonTable/LemonTable.tsx
@@ -272,6 +272,7 @@ export function LemonTable<T extends Record<string, any>>({
                 rowRibbonColor !== undefined && `LemonTable--with-ribbon`,
                 stealth && 'LemonTable--stealth',
                 !uppercaseHeader && 'LemonTable--lowercase-header',
+                allowContentScroll && 'h-full overflow-hidden',
                 className
             )}
             // eslint-disable-next-line react/forbid-dom-props

--- a/frontend/src/lib/lemon-ui/LemonTable/LemonTable.tsx
+++ b/frontend/src/lib/lemon-ui/LemonTable/LemonTable.tsx
@@ -280,8 +280,7 @@ export function LemonTable<T extends Record<string, any>>({
         >
             <ScrollableShadows
                 innerClassName={hideScrollbar ? 'hide-scrollbar' : undefined}
-                direction="horizontal"
-                constrainToDirection={!allowContentScroll}
+                direction={allowContentScroll ? undefined : 'horizontal'}
                 scrollRef={scrollRef}
             >
                 <div className="LemonTable__content">

--- a/frontend/src/queries/nodes/InsightViz/InsightVizDisplay.tsx
+++ b/frontend/src/queries/nodes/InsightViz/InsightVizDisplay.tsx
@@ -351,6 +351,7 @@ export function InsightVizDisplay({
                     <InsightsTable
                         // Do not show ribbons for world map insight table. All ribbons are nuances of blue, and do not bring any UX value
                         isLegend={display !== ChartDisplayType.WorldMap}
+                        embedded={embedded}
                         editMode={editMode}
                         filterKey={keyForInsightLogicProps('new')(insightProps)}
                         canEditSeriesNameInline={!hasFormula && editMode}

--- a/frontend/src/queries/nodes/InsightViz/InsightVizDisplay.tsx
+++ b/frontend/src/queries/nodes/InsightViz/InsightVizDisplay.tsx
@@ -441,7 +441,7 @@ export function InsightVizDisplay({
                             ) : supportsDisplay && showLegend ? (
                                 <>
                                     <div className="InsightVizDisplay__content__left">{renderActiveView()}</div>
-                                    <div className="InsightVizDisplay__content__right">
+                                    <div className="InsightVizDisplay__content__right empty:hidden">
                                         {display === ChartDisplayType.BoxPlot ? <BoxPlotLegend /> : <InsightLegend />}
                                     </div>
                                 </>

--- a/frontend/src/scenes/insights/views/InsightsTable/InsightsTable.tsx
+++ b/frontend/src/scenes/insights/views/InsightsTable/InsightsTable.tsx
@@ -512,9 +512,9 @@ export function InsightsTable({
             firstColumnSticky
             pinnedColumns={pinnedColumns}
             maxHeaderWidth="20rem"
-            // Allow vertical scrolling within the card so long tables
-            // inside dashboards remain scrollable without resizing tiles.
-            allowContentScroll={isInDashboardContext}
+            // Allow vertical scrolling so long tables inside constrained
+            // containers (dashboards, embedded views) remain scrollable.
+            allowContentScroll={isInDashboardContext || embedded}
         />
     )
 }


### PR DESCRIPTION

## Problem
Insights tables displayed as table visualizations (e.g.trends with "Table" display) inside embedded contexts like the Max AI thread don't scroll vertically. The table content overflows its container but ScrollableShadows sets overflow-y: 
hidden, clipping the content. The outer h-96 scroll container in VisualizationArtifactAnswer can't scroll because the overflow  is absorbed internally.    

bonus:  `InsightVizDisplay__content__right` can be empty but take up space in DOM flow
<img width="827" height="531" alt="image" src="https://github.com/user-attachments/assets/dd1a2483-ad34-429b-b83f-b990415c4f7d" />
     

<img width="737" height="515" alt="image" src="https://github.com/user-attachments/assets/846d74a6-c46c-404e-9529-a996f61b0db0" />

## Changes
- ScrollableShadows - Refactored to be data-attribute driven. direction is now optional — when omitted, both axes scroll an shadows appear independently on whichever axis overflows, using CSS custom properties toggled by Base UI's data-overflow- attributes. Removed constrainToDirection prop.                 
- LemonTable - When allowContentScroll is true, omit direction (enabling both-axis scrolling) and add h-full overflow-hidden so  the table respects its parent's height constraint  
- InsightVizDisplay - Pass embedded prop through to InsightsTable (was available but not forwarded) 
- InsightsTable - Enable allowContentScroll when embedded, no just on dashboards.


![2026-03-30 20 59 32](https://github.com/user-attachments/assets/ea8943a0-be65-4ebf-967e-d3a628e22045)


> Just some other scrollable containers working as expected
![2026-03-30 21 13 10](https://github.com/user-attachments/assets/6d1ee3ba-98c6-45bc-b074-8029fbc76ddc)


## How did you test this code?
Locally

## Publish to changelog?
No

## Docs update
No