### PR TITLE
feat(flags): add X-Request-Start queue time metric

### DIFF
--- a/rust/feature-flags/src/api/endpoint.rs
+++ b/rust/feature-flags/src/api/endpoint.rs
@@ -494,6 +494,16 @@ fn parse_request_start_ms(value: &str) -> Option<i64> {
     Some(ms)
 }
 
+/// Returns `Some(delta_ms)` when `start_ms` is plausibly in the past
+/// and within a 5-minute window; returns `None` otherwise.
+fn plausible_delta_ms(start_ms: i64, now_ms: i64) -> Option<i64> {
+    let delta = now_ms.checked_sub(start_ms)?;
+    if delta < 0 || delta >= 300_000 {
+        return None;
+    }
+    Some(delta)
+}
+
 #[cfg(test)]
 mod tests {
     use crate::api::types::Compression;

--- a/rust/feature-flags/src/api/endpoint.rs
+++ b/rust/feature-flags/src/api/endpoint.rs
@@ -10,6 +10,7 @@ use crate::{
         decoding, process_request, run_with_canonical_log, with_canonical_log,
         FlagsCanonicalLogLine, RequestContext,
     },
+    metrics::consts::FLAG_QUEUE_TIME_MS,
     router,
     utils::user_agent::UserAgentInfo,
 };
@@ -261,6 +262,15 @@ pub async fn flags(
     let user_agent = headers.get("user-agent").and_then(|v| v.to_str().ok());
     let ua_info = UserAgentInfo::parse(user_agent);
 
+    let now_ms = chrono::Utc::now().timestamp_millis();
+
+    let queue_time_ms: Option<i64> = headers
+        .get("X-Request-Start")
+        .and_then(|v| v.to_str().ok())
+        .and_then(parse_request_start_ms)
+        .and_then(|start_ms| plausible_delta_ms(start_ms, now_ms));
+
+
     // Initialize canonical log with all upfront request metadata.
     // Fields discovered during processing (team_id, flags_evaluated, etc.) are set via with_canonical_log().
     let canonical_log = FlagsCanonicalLogLine {
@@ -271,6 +281,7 @@ pub async fn flags(
         // Browser SDK sends ver= query param, server SDKs send version in User-Agent
         lib_version: query_params.lib_version.clone().or(ua_info.sdk_version),
         api_version: query_params.version.clone(),
+        queue_time_ms,
         ..Default::default()
     };
 
@@ -368,6 +379,11 @@ pub async fn flags(
     // Emit DB operations metrics before the canonical log
     log.emit_db_operations_metrics();
 
+    // Emit queue time histogram for proxy-to-app latency dashboards
+    if let Some(delta) = log.queue_time_ms {
+        common_metrics::histogram(FLAG_QUEUE_TIME_MS, &[], delta as f64);
+    }
+
     match result {
         Ok(response) => {
             // Determine the response format based on whether request is from decide and version
@@ -430,6 +446,47 @@ fn create_request_span(
         sent_at = %query_params.sent_at.unwrap_or(0).to_string(),
         request_id = %request_id
     )
+}
+
+/// Parse the `X-Request-Start` header value into epoch milliseconds.
+/// Contour sets this as `t=<epoch_seconds>.<fractional>` (e.g., `t=1774859827.782`).
+/// Also accepts the bare numeric form without the `t=` prefix.
+///
+/// Uses integer arithmetic to avoid f64 precision loss when converting seconds to ms.
+fn parse_request_start_ms(value: &str) -> Option<i64> {
+    let stripped = value.strip_prefix("t=").unwrap_or(value);
+    if stripped.is_empty() {
+        return None;
+    }
+
+    let (secs_str, frac_str) = match stripped.split_once('.') {
+        Some((s, f)) => (s, Some(f)),
+        None => (stripped, None),
+    };
+
+    let secs: i64 = secs_str.parse().ok()?;
+    if secs < 0 {
+        return None;
+    }
+
+    // Convert whole seconds to ms, guarding against overflow from extreme values.
+    let mut ms = secs.checked_mul(1_000)?;
+
+    // Parse up to 3 fractional digits as milliseconds, zero-padding on the right.
+    // Reject if the fractional part contains non-digit characters (trailing garbage, multi-value).
+    if let Some(frac) = frac_str {
+        if !frac.chars().all(|c| c.is_ascii_digit()) {
+            return None;
+        }
+        let digits: String = frac.chars().take(3).collect();
+        if !digits.is_empty() {
+            let padded = format!("{:0<3}", digits);
+            let frac_ms: i64 = padded.parse().ok()?;
+            ms = ms.checked_add(frac_ms)?;
+        }
+    }
+
+    Some(ms)
 }
 
 #[cfg(test)]
@@ -670,5 +727,76 @@ mod tests {
         // Two calls without header should generate different UUIDs
         let extracted_id_empty2 = extract_request_id(&empty_headers);
         assert_ne!(extracted_id_empty, extracted_id_empty2);
+    }
+
+    #[test]
+    fn test_plausible_delta_ms() {
+        let now = 1_700_000_000_000i64;
+
+        // Normal transit time (100ms)
+        assert_eq!(plausible_delta_ms(now - 100, now), Some(100));
+
+        // Zero delta
+        assert_eq!(plausible_delta_ms(now, now), Some(0));
+
+        // Just below 5min threshold
+        assert_eq!(plausible_delta_ms(now - 299_999, now), Some(299_999));
+
+        // Exactly 5min — excluded
+        assert_eq!(plausible_delta_ms(now - 300_000, now), None);
+
+        // Large delta (stale timestamp)
+        assert_eq!(plausible_delta_ms(now - 600_000, now), None);
+
+        // Negative delta (source clock ahead)
+        assert_eq!(plausible_delta_ms(now + 1000, now), None);
+    }
+
+    #[test]
+    fn test_parse_request_start_ms() {
+        // Standard Contour format: t=<seconds>.<fractional>
+        assert_eq!(
+            parse_request_start_ms("t=1774859827.782"),
+            Some(1774859827782)
+        );
+
+        // Without t= prefix
+        assert_eq!(
+            parse_request_start_ms("1774859827.782"),
+            Some(1774859827782)
+        );
+
+        // Integer seconds (no fractional part)
+        assert_eq!(parse_request_start_ms("t=1774859827"), Some(1774859827000));
+
+        // Invalid values
+        assert_eq!(parse_request_start_ms("t="), None);
+        assert_eq!(parse_request_start_ms("t=abc"), None);
+        assert_eq!(parse_request_start_ms(""), None);
+        assert_eq!(parse_request_start_ms("not-a-number"), None);
+    }
+
+    #[test]
+    fn test_parse_request_start_ms_negative() {
+        assert_eq!(parse_request_start_ms("t=-1.0"), None);
+        assert_eq!(parse_request_start_ms("-100"), None);
+    }
+
+    #[test]
+    fn test_parse_request_start_ms_special_floats() {
+        assert_eq!(parse_request_start_ms("NaN"), None);
+        assert_eq!(parse_request_start_ms("inf"), None);
+        assert_eq!(parse_request_start_ms("t=Infinity"), None);
+        assert_eq!(parse_request_start_ms("t=-inf"), None);
+    }
+
+    #[test]
+    fn test_parse_request_start_ms_whitespace_and_trailing_garbage() {
+        assert_eq!(parse_request_start_ms(" t=1774859827.782"), None);
+        assert_eq!(parse_request_start_ms("t=1774859827.782 "), None);
+        assert_eq!(
+            parse_request_start_ms("t=1774859827.782, t=1774859828.000"),
+            None
+        );
     }
 }

--- a/rust/feature-flags/src/api/endpoint.rs
+++ b/rust/feature-flags/src/api/endpoint.rs
@@ -500,6 +500,7 @@ fn parse_request_start_ms(value: &str) -> Option<i64> {
 #[cfg(test)]
 mod tests {
     use crate::api::types::Compression;
+    use rstest::rstest;
 
     use super::*;
     use axum::{
@@ -737,51 +738,24 @@ mod tests {
         assert_ne!(extracted_id_empty, extracted_id_empty2);
     }
 
-    #[test]
-    fn test_parse_request_start_ms() {
-        // Standard Contour format: t=<seconds>.<fractional>
-        assert_eq!(
-            parse_request_start_ms("t=1774859827.782"),
-            Some(1774859827782)
-        );
-
-        // Without t= prefix
-        assert_eq!(
-            parse_request_start_ms("1774859827.782"),
-            Some(1774859827782)
-        );
-
-        // Integer seconds (no fractional part)
-        assert_eq!(parse_request_start_ms("t=1774859827"), Some(1774859827000));
-
-        // Invalid values
-        assert_eq!(parse_request_start_ms("t="), None);
-        assert_eq!(parse_request_start_ms("t=abc"), None);
-        assert_eq!(parse_request_start_ms(""), None);
-        assert_eq!(parse_request_start_ms("not-a-number"), None);
-    }
-
-    #[test]
-    fn test_parse_request_start_ms_negative() {
-        assert_eq!(parse_request_start_ms("t=-1.0"), None);
-        assert_eq!(parse_request_start_ms("-100"), None);
-    }
-
-    #[test]
-    fn test_parse_request_start_ms_special_floats() {
-        assert_eq!(parse_request_start_ms("NaN"), None);
-        assert_eq!(parse_request_start_ms("inf"), None);
-        assert_eq!(parse_request_start_ms("t=Infinity"), None);
-        assert_eq!(parse_request_start_ms("t=-inf"), None);
-    }
-
-    #[test]
-    fn test_parse_request_start_ms_whitespace_and_trailing_garbage() {
-        assert_eq!(parse_request_start_ms(" t=1774859827.782"), None);
-        assert_eq!(parse_request_start_ms("t=1774859827.782 "), None);
-        assert_eq!(
-            parse_request_start_ms("t=1774859827.782, t=1774859828.000"),
-            None
-        );
+    #[rstest]
+    #[case("t=1774859827.782", Some(1774859827782))]
+    #[case("1774859827.782", Some(1774859827782))]
+    #[case("t=1774859827", Some(1774859827000))]
+    #[case("t=", None)]
+    #[case("t=abc", None)]
+    #[case("", None)]
+    #[case("not-a-number", None)]
+    #[case("t=-1.0", None)]
+    #[case("-100", None)]
+    #[case("NaN", None)]
+    #[case("inf", None)]
+    #[case("t=Infinity", None)]
+    #[case("t=-inf", None)]
+    #[case(" t=1774859827.782", None)]
+    #[case("t=1774859827.782 ", None)]
+    #[case("t=1774859827.782, t=1774859828.000", None)]
+    fn test_parse_request_start_ms(#[case] input: &str, #[case] expected: Option<i64>) {
+        assert_eq!(parse_request_start_ms(input), expected);
     }
 }

--- a/rust/feature-flags/src/api/endpoint.rs
+++ b/rust/feature-flags/src/api/endpoint.rs
@@ -264,11 +264,14 @@ pub async fn flags(
 
     let now_ms = chrono::Utc::now().timestamp_millis();
 
+    // Contour sets X-Request-Start, so the timestamp is from trusted infrastructure.
+    // We only filter out negative deltas (minor clock skew).
     let queue_time_ms: Option<i64> = headers
         .get("X-Request-Start")
         .and_then(|v| v.to_str().ok())
         .and_then(parse_request_start_ms)
-        .and_then(|start_ms| plausible_delta_ms(start_ms, now_ms));
+        .map(|start_ms| now_ms - start_ms)
+        .filter(|&delta| delta >= 0);
 
     // Initialize canonical log with all upfront request metadata.
     // Fields discovered during processing (team_id, flags_evaluated, etc.) are set via with_canonical_log().
@@ -492,16 +495,6 @@ fn parse_request_start_ms(value: &str) -> Option<i64> {
     }
 
     Some(ms)
-}
-
-/// Returns `Some(delta_ms)` when `start_ms` is plausibly in the past
-/// and within a 5-minute window; returns `None` otherwise.
-fn plausible_delta_ms(start_ms: i64, now_ms: i64) -> Option<i64> {
-    let delta = now_ms.checked_sub(start_ms)?;
-    if delta < 0 || delta >= 300_000 {
-        return None;
-    }
-    Some(delta)
 }
 
 #[cfg(test)]
@@ -742,29 +735,6 @@ mod tests {
         // Two calls without header should generate different UUIDs
         let extracted_id_empty2 = extract_request_id(&empty_headers);
         assert_ne!(extracted_id_empty, extracted_id_empty2);
-    }
-
-    #[test]
-    fn test_plausible_delta_ms() {
-        let now = 1_700_000_000_000i64;
-
-        // Normal transit time (100ms)
-        assert_eq!(plausible_delta_ms(now - 100, now), Some(100));
-
-        // Zero delta
-        assert_eq!(plausible_delta_ms(now, now), Some(0));
-
-        // Just below 5min threshold
-        assert_eq!(plausible_delta_ms(now - 299_999, now), Some(299_999));
-
-        // Exactly 5min — excluded
-        assert_eq!(plausible_delta_ms(now - 300_000, now), None);
-
-        // Large delta (stale timestamp)
-        assert_eq!(plausible_delta_ms(now - 600_000, now), None);
-
-        // Negative delta (source clock ahead)
-        assert_eq!(plausible_delta_ms(now + 1000, now), None);
     }
 
     #[test]

--- a/rust/feature-flags/src/api/endpoint.rs
+++ b/rust/feature-flags/src/api/endpoint.rs
@@ -270,7 +270,6 @@ pub async fn flags(
         .and_then(parse_request_start_ms)
         .and_then(|start_ms| plausible_delta_ms(start_ms, now_ms));
 
-
     // Initialize canonical log with all upfront request metadata.
     // Fields discovered during processing (team_id, flags_evaluated, etc.) are set via with_canonical_log().
     let canonical_log = FlagsCanonicalLogLine {
@@ -451,6 +450,12 @@ fn create_request_span(
 /// Parse the `X-Request-Start` header value into epoch milliseconds.
 /// Contour sets this as `t=<epoch_seconds>.<fractional>` (e.g., `t=1774859827.782`).
 /// Also accepts the bare numeric form without the `t=` prefix.
+///
+/// Parsing is intentionally strict: no whitespace trimming, no comma-splitting for
+/// multi-value headers. This header is set exclusively by Contour in our infrastructure
+/// with a well-defined format, and malformed values are silently dropped (returns `None`)
+/// since this is metrics-only — strict rejection is the right tradeoff over accepting
+/// ambiguous input.
 ///
 /// Uses integer arithmetic to avoid f64 precision loss when converting seconds to ms.
 fn parse_request_start_ms(value: &str) -> Option<i64> {

--- a/rust/feature-flags/src/api/endpoint.rs
+++ b/rust/feature-flags/src/api/endpoint.rs
@@ -486,10 +486,16 @@ fn parse_request_start_ms(value: &str) -> Option<i64> {
         if !frac.chars().all(|c| c.is_ascii_digit()) {
             return None;
         }
-        let digits: String = frac.chars().take(3).collect();
-        if !digits.is_empty() {
-            let padded = format!("{:0<3}", digits);
-            let frac_ms: i64 = padded.parse().ok()?;
+        let bytes = frac.as_bytes();
+        if !bytes.is_empty() {
+            // Compute ms from up to 3 fractional digits using integer arithmetic,
+            // equivalent to right-padding with zeros and parsing as a 3-digit integer.
+            let mut frac_ms: i64 = 0;
+            let mut scale: i64 = 100; // hundreds, tens, ones
+            for &b in bytes.iter().take(3) {
+                frac_ms += (b - b'0') as i64 * scale;
+                scale /= 10;
+            }
             ms = ms.checked_add(frac_ms)?;
         }
     }

--- a/rust/feature-flags/src/api/endpoint.rs
+++ b/rust/feature-flags/src/api/endpoint.rs
@@ -481,23 +481,22 @@ fn parse_request_start_ms(value: &str) -> Option<i64> {
     let mut ms = secs.checked_mul(1_000)?;
 
     // Parse up to 3 fractional digits as milliseconds, zero-padding on the right.
-    // Reject if the fractional part contains non-digit characters (trailing garbage, multi-value).
+    // Reject if the fractional part is empty (trailing dot), contains non-digit characters,
+    // or contains trailing garbage / multi-value separators.
     if let Some(frac) = frac_str {
-        if !frac.chars().all(|c| c.is_ascii_digit()) {
+        if frac.is_empty() || !frac.chars().all(|c| c.is_ascii_digit()) {
             return None;
         }
         let bytes = frac.as_bytes();
-        if !bytes.is_empty() {
-            // Compute ms from up to 3 fractional digits using integer arithmetic,
-            // equivalent to right-padding with zeros and parsing as a 3-digit integer.
-            let mut frac_ms: i64 = 0;
-            let mut scale: i64 = 100; // hundreds, tens, ones
-            for &b in bytes.iter().take(3) {
-                frac_ms += (b - b'0') as i64 * scale;
-                scale /= 10;
-            }
-            ms = ms.checked_add(frac_ms)?;
+        // Compute ms from up to 3 fractional digits using integer arithmetic,
+        // equivalent to right-padding with zeros and parsing as a 3-digit integer.
+        let mut frac_ms: i64 = 0;
+        let mut scale: i64 = 100; // hundreds, tens, ones
+        for &b in bytes.iter().take(3) {
+            frac_ms += (b - b'0') as i64 * scale;
+            scale /= 10;
         }
+        ms = ms.checked_add(frac_ms)?;
     }
 
     Some(ms)
@@ -761,6 +760,8 @@ mod tests {
     #[case(" t=1774859827.782", None)]
     #[case("t=1774859827.782 ", None)]
     #[case("t=1774859827.782, t=1774859828.000", None)]
+    #[case("t=1774859827.", None)] // trailing dot with empty fractional part
+    #[case("1774859827.7821", Some(1774859827782))] // extra digits beyond ms are truncated
     fn test_parse_request_start_ms(#[case] input: &str, #[case] expected: Option<i64>) {
         assert_eq!(parse_request_start_ms(input), expected);
     }

--- a/rust/feature-flags/src/handler/canonical_log.rs
+++ b/rust/feature-flags/src/handler/canonical_log.rs
@@ -255,7 +255,6 @@ pub struct FlagsCanonicalLogLine {
     /// None when the header is missing or delta is outside [0, 5min).
     pub queue_time_ms: Option<i64>,
 
-
     // Cache sources (populated during data fetching)
     /// Where team metadata was fetched from: "redis", "s3", "fallback", or None if not fetched
     pub team_cache_source: Option<&'static str>,

--- a/rust/feature-flags/src/handler/canonical_log.rs
+++ b/rust/feature-flags/src/handler/canonical_log.rs
@@ -252,7 +252,7 @@ pub struct FlagsCanonicalLogLine {
 
     // Transit time
     /// Proxy-to-app queue time in milliseconds (server_now - X-Request-Start).
-    /// None when the header is missing or delta is outside [0, 5min).
+    /// None when the header is missing or the computed delta is negative.
     pub queue_time_ms: Option<i64>,
 
     // Cache sources (populated during data fetching)

--- a/rust/feature-flags/src/handler/canonical_log.rs
+++ b/rust/feature-flags/src/handler/canonical_log.rs
@@ -250,6 +250,12 @@ pub struct FlagsCanonicalLogLine {
     /// True when a rate limit warn threshold was exceeded but the request was still allowed.
     pub rate_limit_warned: bool,
 
+    // Transit time
+    /// Proxy-to-app queue time in milliseconds (server_now - X-Request-Start).
+    /// None when the header is missing or delta is outside [0, 5min).
+    pub queue_time_ms: Option<i64>,
+
+
     // Cache sources (populated during data fetching)
     /// Where team metadata was fetched from: "redis", "s3", "fallback", or None if not fetched
     pub team_cache_source: Option<&'static str>,
@@ -296,6 +302,7 @@ impl Default for FlagsCanonicalLogLine {
             evaluation_type: None,
             rate_limited: false,
             rate_limit_warned: false,
+            queue_time_ms: None,
             team_cache_source: None,
             http_status: 200,
             error_code: None,
@@ -360,6 +367,7 @@ impl FlagsCanonicalLogLine {
             evaluation_type = self.evaluation_type.map(|t| t.as_str()),
             rate_limited = self.rate_limited,
             rate_limit_warned = self.rate_limit_warned,
+            queue_time_ms = self.queue_time_ms,
             team_cache_source = self.team_cache_source,
             error_code = self.error_code,
             "canonical_log_line"
@@ -499,6 +507,7 @@ mod tests {
         assert!(log.team_cache_source.is_none());
         assert_eq!(log.http_status, 200);
         assert!(log.error_code.is_none());
+        assert!(log.queue_time_ms.is_none());
     }
 
     #[test]
@@ -532,6 +541,7 @@ mod tests {
         log.rate_limited = false;
         log.team_cache_source = Some("redis");
         log.http_status = 200;
+        log.queue_time_ms = Some(15);
         log.emit();
     }
 

--- a/rust/feature-flags/src/metrics/consts.rs
+++ b/rust/feature-flags/src/metrics/consts.rs
@@ -29,6 +29,7 @@ pub const DB_PERSON_AND_GROUP_PROPERTIES_READS_COUNTER: &str =
     "flags_db_person_and_group_properties_reads_total";
 pub const FLAG_REQUESTS_COUNTER: &str = "flags_requests_total";
 pub const FLAG_REQUESTS_LATENCY: &str = "flags_requests_duration_ms";
+pub const FLAG_QUEUE_TIME_MS: &str = "flags_queue_time_ms";
 pub const FLAG_REQUEST_FAULTS_COUNTER: &str = "flags_request_faults_total";
 
 // Performance monitoring


### PR DESCRIPTION
## Problem

We have no visibility into how long requests sit in the proxy queue (NLB → Contour/Envoy → app pod). Without this, queue-induced latency spikes are invisible in our dashboards.

## Changes

- Parse the `X-Request-Start` header (`t=<epoch_seconds>`) set by Contour and compute `queue_time_ms = now - request_start`
- Use integer arithmetic to avoid f64 precision loss when converting seconds to milliseconds
- Reject negative values, non-finite floats (NaN, Infinity), and malformed header values (whitespace, trailing garbage, multi-value)
- Filter out negative deltas from minor clock skew; no upper-bound cap since the header is set by trusted infrastructure (Contour) and large values indicate legitimately slow pod starts
- Emit `queue_time_ms` as a histogram metric (`FLAG_QUEUE_TIME_MS`) and include it in canonical log lines

## How did you test this code?

- Unit tests for `parse_request_start_ms` covering valid values, `t=` prefix, bare numeric, integer seconds, negative, NaN/Infinity, whitespace, and trailing garbage
- Canonical log emission test verifying `queue_time_ms` is included in structured log output