### PR TITLE
feat(dashboard): increase dashboard templates table page size to 25

### DIFF
--- a/frontend/src/scenes/dashboard/dashboards/templates/DashboardTemplatesTable.tsx
+++ b/frontend/src/scenes/dashboard/dashboards/templates/DashboardTemplatesTable.tsx
@@ -156,7 +156,7 @@ export const DashboardTemplatesTable = (): JSX.Element | null => {
             <LemonTable
                 id="dashboard-templates"
                 data-attr="dashboards-template-table"
-                pagination={{ pageSize: 10 }}
+                pagination={{ pageSize: 25 }}
                 dataSource={Object.values(allTemplates)}
                 columns={columns}
                 loading={allTemplatesLoading}


### PR DESCRIPTION
## Problem

The dashboards **Templates** tab list used 10 rows per page, which made browsing many templates unnecessarily click-heavy.

## Changes

- Set `LemonTable` `pageSize` from 10 to 25 in `DashboardTemplatesTable`.

## How did you test this code?

Not run locally; trivial UI constant change. API list still uses default limit (100), so all fetched templates remain available across pages.

## Publish to changelog?

no

## Docs update

N/A

Made with [Cursor](https://cursor.com)