### PR TITLE
revert(flags): remove sent_at delta metric for client-to-server transit time

### DIFF
--- a/rust/feature-flags/src/api/endpoint.rs
+++ b/rust/feature-flags/src/api/endpoint.rs
@@ -10,7 +10,6 @@ use crate::{
         decoding, process_request, run_with_canonical_log, with_canonical_log,
         FlagsCanonicalLogLine, RequestContext,
     },
-    metrics::consts::FLAG_SENT_AT_DELTA_MS,
     router,
     utils::user_agent::UserAgentInfo,
 };
@@ -262,10 +261,6 @@ pub async fn flags(
     let user_agent = headers.get("user-agent").and_then(|v| v.to_str().ok());
     let ua_info = UserAgentInfo::parse(user_agent);
 
-    let sent_at_delta_ms: Option<i64> = query_params
-        .sent_at
-        .and_then(|sent_at| compute_sent_at_delta(sent_at, chrono::Utc::now().timestamp_millis()));
-
     // Initialize canonical log with all upfront request metadata.
     // Fields discovered during processing (team_id, flags_evaluated, etc.) are set via with_canonical_log().
     let canonical_log = FlagsCanonicalLogLine {
@@ -276,7 +271,6 @@ pub async fn flags(
         // Browser SDK sends ver= query param, server SDKs send version in User-Agent
         lib_version: query_params.lib_version.clone().or(ua_info.sdk_version),
         api_version: query_params.version.clone(),
-        sent_at_delta_ms,
         ..Default::default()
     };
 
@@ -374,11 +368,6 @@ pub async fn flags(
     // Emit DB operations metrics before the canonical log
     log.emit_db_operations_metrics();
 
-    // Emit sent_at delta histogram for transit time dashboards
-    if let Some(delta) = log.sent_at_delta_ms {
-        common_metrics::histogram(FLAG_SENT_AT_DELTA_MS, &[], delta as f64);
-    }
-
     match result {
         Ok(response) => {
             // Determine the response format based on whether request is from decide and version
@@ -441,19 +430,6 @@ fn create_request_span(
         sent_at = %query_params.sent_at.unwrap_or(0).to_string(),
         request_id = %request_id
     )
-}
-
-/// Compute client-to-server transit time from a `sent_at` timestamp.
-/// Returns `None` if the delta is outside [0, 5min) — negative means client
-/// clock ahead, very large means stale/garbage timestamp.
-fn compute_sent_at_delta(sent_at_ms: i64, now_ms: i64) -> Option<i64> {
-    const MAX_PLAUSIBLE_TRANSIT_MS: i64 = 300_000; // 5 minutes
-    let delta = now_ms - sent_at_ms;
-    if (0..MAX_PLAUSIBLE_TRANSIT_MS).contains(&delta) {
-        Some(delta)
-    } else {
-        None
-    }
 }
 
 #[cfg(test)]
@@ -694,30 +670,5 @@ mod tests {
         // Two calls without header should generate different UUIDs
         let extracted_id_empty2 = extract_request_id(&empty_headers);
         assert_ne!(extracted_id_empty, extracted_id_empty2);
-    }
-
-    #[test]
-    fn test_compute_sent_at_delta() {
-        use super::compute_sent_at_delta;
-
-        let now = 1_700_000_000_000i64;
-
-        // Normal transit time (100ms)
-        assert_eq!(compute_sent_at_delta(now - 100, now), Some(100));
-
-        // Zero delta (sent_at == now)
-        assert_eq!(compute_sent_at_delta(now, now), Some(0));
-
-        // Just below 5min threshold
-        assert_eq!(compute_sent_at_delta(now - 299_999, now), Some(299_999));
-
-        // Exactly 5min — excluded
-        assert_eq!(compute_sent_at_delta(now - 300_000, now), None);
-
-        // Large delta (stale timestamp)
-        assert_eq!(compute_sent_at_delta(now - 600_000, now), None);
-
-        // Negative delta (client clock ahead)
-        assert_eq!(compute_sent_at_delta(now + 1000, now), None);
     }
 }

--- a/rust/feature-flags/src/handler/canonical_log.rs
+++ b/rust/feature-flags/src/handler/canonical_log.rs
@@ -250,12 +250,6 @@ pub struct FlagsCanonicalLogLine {
     /// True when a rate limit warn threshold was exceeded but the request was still allowed.
     pub rate_limit_warned: bool,
 
-    // Transit time
-    /// Client-to-server transit time in milliseconds (server_now - sent_at).
-    /// None when sent_at is missing or delta is outside [0, 5min) (negative = client clock
-    /// ahead, >= 5min = stale/garbage timestamp).
-    pub sent_at_delta_ms: Option<i64>,
-
     // Cache sources (populated during data fetching)
     /// Where team metadata was fetched from: "redis", "s3", "fallback", or None if not fetched
     pub team_cache_source: Option<&'static str>,
@@ -302,7 +296,6 @@ impl Default for FlagsCanonicalLogLine {
             evaluation_type: None,
             rate_limited: false,
             rate_limit_warned: false,
-            sent_at_delta_ms: None,
             team_cache_source: None,
             http_status: 200,
             error_code: None,
@@ -367,7 +360,6 @@ impl FlagsCanonicalLogLine {
             evaluation_type = self.evaluation_type.map(|t| t.as_str()),
             rate_limited = self.rate_limited,
             rate_limit_warned = self.rate_limit_warned,
-            sent_at_delta_ms = self.sent_at_delta_ms,
             team_cache_source = self.team_cache_source,
             error_code = self.error_code,
             "canonical_log_line"

--- a/rust/feature-flags/src/metrics/consts.rs
+++ b/rust/feature-flags/src/metrics/consts.rs
@@ -29,7 +29,6 @@ pub const DB_PERSON_AND_GROUP_PROPERTIES_READS_COUNTER: &str =
     "flags_db_person_and_group_properties_reads_total";
 pub const FLAG_REQUESTS_COUNTER: &str = "flags_requests_total";
 pub const FLAG_REQUESTS_LATENCY: &str = "flags_requests_duration_ms";
-pub const FLAG_SENT_AT_DELTA_MS: &str = "flags_sent_at_delta_ms";
 pub const FLAG_REQUEST_FAULTS_COUNTER: &str = "flags_request_faults_total";
 
 // Performance monitoring


### PR DESCRIPTION
Reverts PostHog/posthog#52648

## Problem

The `sent_at` delta metric added in #52648 doesn't work as intended — only a couple of clients send the `sent_at` field, and they send it in different formats. It's not the right field to measure client-to-server transit time.

Reverting while we come up with a better approach.

## Changes

Removes all code added in #52648 across 3 files:
- `rust/feature-flags/src/api/endpoint.rs` — removes `compute_sent_at_delta` function, its call site, histogram emission, and tests
- `rust/feature-flags/src/handler/canonical_log.rs` — removes `sent_at_delta_ms` field from canonical log struct
- `rust/feature-flags/src/metrics/consts.rs` — removes `FLAG_SENT_AT_DELTA_MS` constant

## How did you test this code?

This is a clean revert of #52648. The removed code had no dependents.

## Publish to changelog?

No

## Docs update

No docs changes needed.