### PR TITLE
feat(dagster): add team_id to ducklake events table partitioning

### DIFF
--- a/posthog/dags/events_backfill_to_ducklake.py
+++ b/posthog/dags/events_backfill_to_ducklake.py
@@ -207,11 +207,17 @@ ORDER BY event_time DESC;
     return f"http://localhost:8123/play?user=default#{base64.b64encode(sql.encode('utf-8')).decode('utf-8')}"
 
 
+# The shared DuckLake table should be partitioned by team_id first (most
+# selective predicate — every query filters by it) then by date.
+DUCKLAKE_EVENTS_PARTITION_EXPR = "team_id, year(timestamp), month(timestamp), day(timestamp)"
+
+
 def validate_ducklake_schema(context: AssetExecutionContext) -> None:
     """Validate that the DuckLake events table schema matches our export columns.
 
     This pre-flight check ensures we don't waste time exporting data that can't
-    be registered with DuckLake due to schema mismatches.
+    be registered with DuckLake due to schema mismatches. Also ensures the table
+    is partitioned by (team_id, year, month, day) for efficient pruning.
     """
     ducklake_config = get_config()
     storage_config = DuckLakeStorageConfig.from_runtime()
@@ -257,6 +263,18 @@ def validate_ducklake_schema(context: AssetExecutionContext) -> None:
             ducklake_columns=len(ducklake_columns),
             export_columns=len(EXPECTED_DUCKLAKE_COLUMNS),
         )
+
+        # Ensure partitioning includes team_id for efficient pruning (idempotent).
+        try:
+            conn.execute(f"ALTER TABLE {alias}.posthog.events SET PARTITIONED BY ({DUCKLAKE_EVENTS_PARTITION_EXPR})")
+            context.log.info(f"Partitioning set: {DUCKLAKE_EVENTS_PARTITION_EXPR}")
+        except Exception as exc:
+            context.log.warning(f"Failed to set partitioning (non-fatal): {exc}")
+            logger.warning(
+                "ducklake_partitioning_failed",
+                error=str(exc),
+                partition_expr=DUCKLAKE_EVENTS_PARTITION_EXPR,
+            )
 
     finally:
         conn.close()


### PR DESCRIPTION
## Summary

The shared DuckLake events table is partitioned by `year(timestamp), month(timestamp), day(timestamp)` — missing `team_id`. Since every query filters by `team_id` first, this means DuckLake must scan partition metadata for all teams even when querying a single team's data.

This adds an idempotent `SET PARTITIONED BY` call in `validate_ducklake_schema` (the pre-flight check that runs before every backfill) to ensure the table is partitioned by:

```sql
PARTITIONED BY (team_id, year(timestamp), month(timestamp), day(timestamp))
```

The call is non-fatal — if it fails (e.g. permissions), the backfill proceeds with existing partitioning and logs a warning.

Follow-up to #52677.

## Test plan

- [ ] Verify backfill job runs successfully and logs "Partitioning set: ..."
- [ ] Verify queries filtering by `team_id` show improved partition pruning in EXPLAIN

🤖 Generated with [Claude Code](https://claude.com/claude-code)