### PR TITLE
feat: add testing steps to PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,6 +16,10 @@
 <!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
 <!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->
 
+## How can other people test this code?
+
+<!-- Describe what is the expected behavior of these changes, and the steps other reviewers must take to get there. -->
+
 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
 
 ## Publish to changelog?

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,7 +12,7 @@
 
 ## How did you test this code?
 
-<!-- Briefly describe the steps you took, and what steps reviewers must take to get to where changes are, and what is the expceted behavior. -->
+<!-- Briefly describe the steps you took, and what steps reviewers must take to get to where changes are, and what is the expected behavior. -->
 <!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
 <!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,13 +12,9 @@
 
 ## How did you test this code?
 
-<!-- Briefly describe the steps you took. -->
+<!-- Briefly describe the steps you took, and what steps reviewers must take to get to where changes are, and what is the expceted behavior. -->
 <!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
 <!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->
-
-## How can other people test this code?
-
-<!-- Describe what is the expected behavior of these changes, and the steps other reviewers must take to get there. -->
 
 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
 


### PR DESCRIPTION
## Problem

When reviewing PRs, depending on the changes made, it is very difficult to understand the steps you should take to get to where the changes are, specially in backend changes.

## Changes

This extends our pull_request_template.md with a section "How can other people test this code?" which asks PR authors to describe all the steps you should take to see the changes for yourself, and what is expected to happen.

## Publish to changelog?

No, this is devex only.