### PR TITLE
fix(ci): use merge-multiple for single-image digest collection

### DIFF
--- a/.github/workflows/_rust-build-images.yml
+++ b/.github/workflows/_rust-build-images.yml
@@ -180,13 +180,13 @@ jobs:
             - name: Container image digest
               env:
                   DIGEST: ${{ steps.docker_build.outputs.digest }}
-              run: echo "$DIGEST" > /tmp/digest.txt
+              run: echo "$DIGEST" > /tmp/digest-${{ matrix.image }}.txt
 
             - name: Upload digest
               uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
               with:
                   name: digest-${{ matrix.image }}
-                  path: /tmp/digest.txt
+                  path: /tmp/digest-${{ matrix.image }}.txt
                   retention-days: 1
 
     collect:
@@ -204,7 +204,7 @@ jobs:
               with:
                   pattern: digest-*
                   path: /tmp/digests
-                  merge-multiple: false
+                  merge-multiple: true
 
             - name: Aggregate digests
               id: aggregate
@@ -214,12 +214,13 @@ jobs:
                   ls -laR /tmp/digests/ 2>/dev/null || echo "/tmp/digests/ does not exist"
                   digests='{}'
                   found=0
-                  for dir in /tmp/digests/digest-*; do
+                  for file in /tmp/digests/digest-*.txt; do
                       found=1
-                      name="${dir##*/digest-}"
-                      digest=$(cat "$dir/digest.txt")
+                      name="${file##*/digest-}"
+                      name="${name%.txt}"
+                      digest=$(cat "$file")
                       if [ -z "$digest" ]; then
-                          echo "::error::Empty digest for $name (file: $dir/digest.txt)"
+                          echo "::error::Empty digest for $name (file: $file)"
                           exit 1
                       fi
                       digests=$(echo "$digests" | jq -c --arg k "$name" --arg v "$digest" '. + {($k): $v}')


### PR DESCRIPTION
## Problem

The `build-images / collect digests` job in the Rust smoke test CI fails when only a single image is built (e.g., `image-filter: capture`).

`actions/download-artifact@v7` with `merge-multiple: false` creates subdirectories for multiple artifacts (`/tmp/digests/digest-capture/digest.txt`) but extracts directly to the path for a single artifact (`/tmp/digests/digest.txt`) — no subdirectory. The aggregation script iterates over `digest-*` directories, finds none, and errors with "No digest artifacts found".

Production builds (14 images) are unaffected because they always have multiple artifacts.

## Changes

- Write digest to a uniquely named file (`digest-<image>.txt`) instead of a generic `digest.txt`
- Switch to `merge-multiple: true` so all files merge into a flat directory
- Iterate over `digest-*.txt` files instead of `digest-*` directories in the aggregation step

## How did you test this code?

- Push and re-run the smoke test CI (which builds only `capture`) — the `collect digests` job should now succeed
- Production builds (multiple images) also work since `merge-multiple: true` merges all uniquely-named files into `/tmp/digests/`