### PR TITLE
fix: Update Products panel root from custom-products:// to products://

### DIFF
--- a/frontend/src/layout/panel-layout/ai-first/Nav.tsx
+++ b/frontend/src/layout/panel-layout/ai-first/Nav.tsx
@@ -314,9 +314,7 @@ export function Nav(): JSX.Element {
                     showRecents
                 />
             )}
-            {activePanelIdentifier === 'Products' && (
-                <ProjectTree root="custom-products://" searchPlaceholder="Search apps" />
-            )}
+            {activePanelIdentifier === 'Products' && <ProjectTree root="products://" searchPlaceholder="Search apps" />}
             {activePanelIdentifier === 'Shortcuts' && (
                 <ProjectTree root="shortcuts://" searchPlaceholder="Search starred items" />
             )}


### PR DESCRIPTION
## Problem

The Products panel in the navigation was using an incorrect root path that prevented proper functionality. The `custom-products://` root was not the correct protocol for accessing product data.

## Changes

Updated the ProjectTree component in the Products panel to use the correct `products://` root path instead of `custom-products://`. This ensures the Products panel can properly load and display product data.

## How did you test this code?

As an AI agent, I have not manually tested this code. The change should be verified by:
- Opening the Products panel in the navigation
- Confirming that products load correctly with the new `products://` root path
- Testing the search functionality with the "Search apps" placeholder

## Publish to changelog?

No

## Docs update

No documentation update required for this internal path correction.