### PR TITLE
fix(dagster): disable hive partition inference in ducklake_add_data_files

### DIFF
--- a/posthog/dags/events_backfill_to_ducklake.py
+++ b/posthog/dags/events_backfill_to_ducklake.py
@@ -508,7 +508,8 @@ def register_files_with_ducklake(
                 context.log.info(f"Registering file with DuckLake: {s3_path}")
                 # Use escape() to prevent SQL injection
                 conn.execute(
-                    f"CALL ducklake_add_data_files('{alias}', 'events', '{escape(s3_path)}', schema => 'posthog')"
+                    f"CALL ducklake_add_data_files('{alias}', 'events', '{escape(s3_path)}',"
+                    f" schema => 'posthog', hive_partitioning => false)"
                 )
                 registered_count += 1
                 context.log.info(f"Successfully registered: {s3_path}")

--- a/posthog/dags/events_backfill_to_duckling.py
+++ b/posthog/dags/events_backfill_to_duckling.py
@@ -1154,7 +1154,10 @@ def register_file_with_duckling(
             attach_catalog(conn, catalog_config, alias=alias)
 
             context.log.info(f"Registering file with DuckLake: {s3_path}")
-            conn.execute(f"CALL ducklake_add_data_files('{alias}', 'events', '{escape(s3_path)}', schema => 'posthog')")
+            conn.execute(
+                f"CALL ducklake_add_data_files('{alias}', 'events', '{escape(s3_path)}',"
+                f" schema => 'posthog', hive_partitioning => false)"
+            )
 
             context.log.info(f"Successfully registered: {s3_path}")
             logger.info("duckling_file_registered", s3_path=s3_path, team_id=catalog.team_id)
@@ -1375,7 +1378,8 @@ def register_persons_file_with_duckling(
 
             context.log.info(f"Registering persons file with DuckLake: {s3_path}")
             conn.execute(
-                f"CALL ducklake_add_data_files('{alias}', 'persons', '{escape(s3_path)}', schema => 'posthog')"
+                f"CALL ducklake_add_data_files('{alias}', 'persons', '{escape(s3_path)}',"
+                f" schema => 'posthog', hive_partitioning => false)"
             )
 
             context.log.info(f"Successfully registered persons: {s3_path}")


### PR DESCRIPTION
## Summary

Fixes the `InvalidInputError: invalid partition value for the table configuration` error in the duckling/ducklake backfill jobs.

**Root cause:** `ducklake_add_data_files` auto-infers partition columns from directory structure (both Hive-style `key=value` and positional segments). The S3 paths have segments like `team_id/year/month/day/` but the table uses expression-based partitioning (`year(timestamp), month(timestamp), day(timestamp)`), so DuckLake can't map the directory segments to partition expressions.

**Fix:** Add `hive_partitioning => false` to all `ducklake_add_data_files` calls. This disables path-based partition inference — DuckLake determines partition placement from the actual Parquet column data instead. Verified locally that this works with both Hive-style and plain directory paths.

Applied to:
- `events_backfill_to_ducklake.py` (shared pipeline, 1 call)
- `events_backfill_to_duckling.py` (per-team pipeline, 2 calls: events + persons)

## Test plan

- [x] Verified locally with DuckLake: `hive_partitioning => false` successfully registers files with both Hive and plain path formats
- [ ] Re-run `duckling_events_backfill` dagster job for team_id=2 and verify files register without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)