### PR TITLE
fix(flags): use events_recent for sync_feature_flag_last_called query

### DIFF
--- a/posthog/settings/feature_flags.py
+++ b/posthog/settings/feature_flags.py
@@ -27,8 +27,9 @@ FEATURE_FLAG_LAST_CALLED_AT_SYNC_BATCH_SIZE: int = get_from_env(
 FEATURE_FLAG_LAST_CALLED_AT_SYNC_CLICKHOUSE_LIMIT: int = get_from_env(
     "FEATURE_FLAG_LAST_CALLED_AT_SYNC_CLICKHOUSE_LIMIT", 100000, type_cast=int
 )
-FEATURE_FLAG_LAST_CALLED_AT_SYNC_LOOKBACK_DAYS: int = get_from_env(
-    "FEATURE_FLAG_LAST_CALLED_AT_SYNC_LOOKBACK_DAYS", 1, type_cast=int
+FEATURE_FLAG_LAST_CALLED_AT_SYNC_LOOKBACK_DAYS: int = min(
+    get_from_env("FEATURE_FLAG_LAST_CALLED_AT_SYNC_LOOKBACK_DAYS", 1, type_cast=int),
+    6,  # events_recent has 7-day TTL; cap with 1-day margin
 )
 
 # Feature flag cache refresh settings

--- a/posthog/tasks/tasks.py
+++ b/posthog/tasks/tasks.py
@@ -1249,6 +1249,7 @@ def sync_feature_flag_last_called(self: PushGatewayTask) -> None:
               AND inserted_at > %(last_sync_timestamp)s
               AND inserted_at <= %(current_sync_timestamp)s
             WHERE JSONExtractString(properties, '$feature_flag') != ''
+              AND timestamp <= %(current_sync_timestamp)s
             GROUP BY team_id, flag_key
             ORDER BY last_called_at DESC
             LIMIT %(limit)s

--- a/posthog/tasks/tasks.py
+++ b/posthog/tasks/tasks.py
@@ -1280,12 +1280,10 @@ def sync_feature_flag_last_called(self: PushGatewayTask) -> None:
         # Collect flags for bulk update
         flags_to_update = []
 
-        # Get latest timestamp for checkpoint, fallback to current if all None
-        checkpoint_timestamp = max((row[2] for row in result if row[2]), default=current_sync_timestamp)
-        # Ensure timestamp is timezone-aware (ClickHouse returns naive datetimes)
-        checkpoint_timestamp = (
-            checkpoint_timestamp if checkpoint_timestamp.tzinfo else timezone.make_aware(checkpoint_timestamp)
-        )
+        # Use current_sync_timestamp as the checkpoint since the sync window
+        # is defined by inserted_at, not timestamp. Using max(timestamp) would
+        # mix timelines and cause gaps or reprocessing with late-arriving events.
+        checkpoint_timestamp = current_sync_timestamp
 
         # Build lookup map of (team_id, key) -> timestamp from ClickHouse results
         flag_updates = {(row[0], row[1]): row[2] for row in result}

--- a/posthog/tasks/tasks.py
+++ b/posthog/tasks/tasks.py
@@ -1244,11 +1244,11 @@ def sync_feature_flag_last_called(self: PushGatewayTask) -> None:
                 JSONExtractString(properties, '$feature_flag') as flag_key,
                 max(timestamp) as last_called_at,
                 count() as call_count
-            FROM events
+            FROM events_recent
             PREWHERE event = '$feature_flag_called'
-            WHERE timestamp > %(last_sync_timestamp)s
-              AND timestamp <= %(current_sync_timestamp)s
-              AND JSONExtractString(properties, '$feature_flag') != ''
+              AND inserted_at > %(last_sync_timestamp)s
+              AND inserted_at <= %(current_sync_timestamp)s
+            WHERE JSONExtractString(properties, '$feature_flag') != ''
             GROUP BY team_id, flag_key
             ORDER BY last_called_at DESC
             LIMIT %(limit)s

--- a/posthog/tasks/test/test_feature_flag_sync.py
+++ b/posthog/tasks/test/test_feature_flag_sync.py
@@ -304,29 +304,26 @@ class TestSyncFeatureFlagLastCalled(BaseTest):
     @freeze_time("2024-06-15 12:00:00")
     @patch("posthog.clickhouse.client.sync_execute")
     @patch("posthog.tasks.tasks.get_client")
-    def test_checkpoint_updated_to_latest_timestamp(
+    def test_checkpoint_updated_to_current_sync_timestamp(
         self, mock_get_client: MagicMock, mock_sync_execute: MagicMock
     ) -> None:
-        """Checkpoint should be updated to the latest timestamp from results"""
+        """Checkpoint should be updated to the wall-clock time of the sync run, not max event timestamp"""
         redis_mock = mock_redis_client()
         mock_get_client.return_value = redis_mock
 
-        earliest_timestamp = tz.make_aware(datetime(2024, 6, 15, 10, 0, 0))
-        latest_timestamp = tz.make_aware(datetime(2024, 6, 15, 11, 59, 59))
-
         mock_sync_execute.return_value = [
-            (self.team.pk, self.flag1.key, earliest_timestamp, 10),
+            (self.team.pk, self.flag1.key, tz.make_aware(datetime(2024, 6, 15, 10, 0, 0)), 10),
             (self.team.pk, self.flag2.key, tz.make_aware(datetime(2024, 6, 15, 11, 30, 0)), 20),
-            (self.team.pk, self.flag3.key, latest_timestamp, 30),
+            (self.team.pk, self.flag3.key, tz.make_aware(datetime(2024, 6, 15, 11, 59, 59)), 30),
         ]
 
         sync_feature_flag_last_called()
 
-        # Checkpoint should be set to latest timestamp
+        # Checkpoint should be set to current_sync_timestamp (frozen at 2024-06-15T12:00:00Z)
         checkpoint_key = "posthog:feature_flag_last_called_sync:last_timestamp"
         stored_timestamp = redis_mock.storage.get(checkpoint_key)
         assert stored_timestamp is not None
-        assert latest_timestamp.isoformat() in stored_timestamp
+        assert "2024-06-15T12:00:00" in stored_timestamp
 
     @freeze_time("2024-06-15 12:00:00")
     @patch("posthog.clickhouse.client.sync_execute")


### PR DESCRIPTION
## Problem

The `sync_feature_flag_last_called` Celery task hits ClickHouse's 5 TiB read limit after ~34 seconds. The task queries the main `events` table (months/years of data, monthly partitions) for `$feature_flag_called` events across all teams. Without a leading `team_id` filter, the primary key `(team_id, toDate(timestamp), event, ...)` can't be used efficiently, resulting in near-full table scans.

## Changes

Switch the query from the `events` table to `events_recent` — a materialized view with a 7-day TTL and daily partitions. This is the same pattern already used by the `property_definitions` DAG for cross-team aggregation.

- **Table**: `events` → `events_recent` (7-day TTL, daily partitions vs months of data with monthly partitions)
- **Time filters**: `timestamp` → `inserted_at` (matches the table's partition/ordering key), moved into `PREWHERE` for efficient granule skipping
- **Lookback cap**: `FEATURE_FLAG_LAST_CALLED_AT_SYNC_LOOKBACK_DAYS` capped at 6 days to stay within the 7-day TTL with a 1-day margin
- `max(timestamp)` in SELECT still captures the actual event time for the Postgres `last_called_at` field

## How did you test this code?

- Existing unit tests pass (`pytest posthog/tasks/test/test_feature_flag_sync.py` — 14 tests)
- Ruff linter and formatter clean
- End to end test locally (Temporarily change schedule to run every minute.  Captured `$feature_flag_called` event for a flag. Confirmed it was updated)

## Publish to changelog?

no