### PR TITLE
fix(flags): add fetch status to disambiguate person property cache misses

### DIFF
--- a/rust/feature-flags/src/flags/flag_matching.rs
+++ b/rust/feature-flags/src/flags/flag_matching.rs
@@ -129,19 +129,21 @@ impl FeatureFlagMatch {
     }
 }
 
-/// Tracks whether person properties were fetched from the database or intentionally skipped.
+/// Tracks person property state through the evaluation lifecycle.
 ///
-/// When request overrides cover all needed property keys, DB prep is skipped and `person_properties`
-/// stays `None`. This enum lets downstream code distinguish that expected case from an unexpected miss.
+/// Combines fetch status with property data so that impossible states (e.g. "fetched"
+/// but no properties) are unrepresentable. When request overrides cover all needed keys,
+/// DB prep is skipped and this stays `Skipped`. When DB prep runs, properties are stored
+/// directly in the `Fetched` variant.
 #[derive(Clone, Debug, Default)]
-pub(crate) enum PersonPropertyFetchStatus {
+pub(crate) enum PersonPropertyState {
     /// DB prep has not yet run (initial state)
     #[default]
     Pending,
     /// DB prep was skipped because request overrides covered all needed property keys
     Skipped,
-    /// DB prep ran and populated person_properties
-    Fetched,
+    /// DB prep ran and populated person properties
+    Fetched(HashMap<String, Value>),
 }
 
 /// This struct maintains evaluation state by caching database-sourced data during feature flag evaluation.
@@ -155,10 +157,8 @@ pub struct FlagEvaluationState {
     person_id: Option<PersonId>,
     /// The person UUID, needed for realtime cohort membership lookups
     person_uuid: Option<Uuid>,
-    /// Properties associated with the person, fetched from the database
-    pub(crate) person_properties: Option<HashMap<String, Value>>,
-    /// Whether person properties were fetched, skipped, or not yet attempted
-    pub(crate) person_property_fetch_status: PersonPropertyFetchStatus,
+    /// Person property fetch state: pending, skipped, or fetched (with property data)
+    person_property_state: PersonPropertyState,
     /// Properties for each group type involved in flag evaluation
     group_properties: HashMap<GroupTypeIndex, HashMap<String, Value>>,
     /// Cohorts for the current request
@@ -177,7 +177,10 @@ impl FlagEvaluationState {
     }
 
     pub fn get_person_properties(&self) -> Option<&HashMap<String, Value>> {
-        self.person_properties.as_ref()
+        match &self.person_property_state {
+            PersonPropertyState::Fetched(props) => Some(props),
+            _ => None,
+        }
     }
 
     pub fn get_group_properties(&self) -> &HashMap<GroupTypeIndex, HashMap<String, Value>> {
@@ -201,8 +204,11 @@ impl FlagEvaluationState {
     }
 
     pub fn set_person_properties(&mut self, properties: HashMap<String, Value>) {
-        self.person_properties = Some(properties);
-        self.person_property_fetch_status = PersonPropertyFetchStatus::Fetched;
+        self.person_property_state = PersonPropertyState::Fetched(properties);
+    }
+
+    pub fn skip_person_properties(&mut self) {
+        self.person_property_state = PersonPropertyState::Skipped;
     }
 
     pub fn set_cohorts(&mut self, cohorts: Vec<Cohort>) {
@@ -803,8 +809,7 @@ impl FeatureFlagMatcher {
         );
 
         if flags_requiring_db_preparation.is_empty() {
-            self.flag_evaluation_state.person_property_fetch_status =
-                PersonPropertyFetchStatus::Skipped;
+            self.flag_evaluation_state.skip_person_properties();
             return false;
         }
 
@@ -1637,9 +1642,10 @@ impl FeatureFlagMatcher {
         &self,
         property_overrides: Option<&HashMap<String, Value>>,
     ) -> Result<HashMap<String, Value>, FlagError> {
-        // Start with DB properties
+        // Start with DB properties (clone only when we need a mutable copy)
         let mut merged_properties = self
             .get_person_properties_from_evaluation_state()
+            .cloned()
             .unwrap_or_default();
 
         // Merge in overrides (overrides take precedence)
@@ -2134,61 +2140,42 @@ impl FeatureFlagMatcher {
         Ok(group_type_to_key)
     }
 
-    /// Get person properties from the `FlagEvaluationState` only, returning empty HashMap if not found.
+    /// Get person properties from the `FlagEvaluationState` only, returning a reference.
     fn get_person_properties_from_evaluation_state(
         &self,
-    ) -> Result<HashMap<String, Value>, FlagError> {
-        if let Some(properties) = self.flag_evaluation_state.get_person_properties() {
-            inc(
-                PROPERTY_CACHE_HITS_COUNTER,
-                &[("type".to_string(), "person_properties".to_string())],
-                1,
-            );
-            with_canonical_log(|log| log.eval.property_cache_hits += 1);
-            let mut result = HashMap::new();
-            result.clone_from(properties);
-            Ok(result)
-        } else {
-            match self.flag_evaluation_state.person_property_fetch_status {
-                PersonPropertyFetchStatus::Skipped => {
-                    tracing::debug!(
-                        "Person properties not in cache — DB prep was skipped (overrides cover all needed keys)"
-                    );
-                }
-                PersonPropertyFetchStatus::Fetched => {
-                    inc(
-                        PROPERTY_CACHE_MISSES_COUNTER,
-                        &[
-                            ("type".to_string(), "person_properties".to_string()),
-                            ("reason".to_string(), "fetched_but_missing".to_string()),
-                        ],
-                        1,
-                    );
-                    with_canonical_log(|log| {
-                        log.eval.property_cache_misses += 1;
-                        log.eval.person_properties_not_cached = true;
-                    });
-                    tracing::warn!(
-                        "Person properties not found in evaluation state cache despite DB prep running"
-                    );
-                }
-                PersonPropertyFetchStatus::Pending => {
-                    inc(
-                        PROPERTY_CACHE_MISSES_COUNTER,
-                        &[
-                            ("type".to_string(), "person_properties".to_string()),
-                            ("reason".to_string(), "db_prep_never_ran".to_string()),
-                        ],
-                        1,
-                    );
-                    with_canonical_log(|log| {
-                        log.eval.property_cache_misses += 1;
-                        log.eval.person_properties_not_cached = true;
-                    });
-                    tracing::error!("Person properties not found — DB prep never ran");
-                }
+    ) -> Result<&HashMap<String, Value>, FlagError> {
+        match &self.flag_evaluation_state.person_property_state {
+            PersonPropertyState::Fetched(properties) => {
+                inc(
+                    PROPERTY_CACHE_HITS_COUNTER,
+                    &[("type".to_string(), "person_properties".to_string())],
+                    1,
+                );
+                with_canonical_log(|log| log.eval.property_cache_hits += 1);
+                Ok(properties)
             }
-            Err(FlagError::PersonNotFound)
+            PersonPropertyState::Skipped => {
+                tracing::debug!(
+                    "Person properties not in cache — DB prep was skipped (overrides cover all needed keys)"
+                );
+                Err(FlagError::PersonNotFound)
+            }
+            PersonPropertyState::Pending => {
+                inc(
+                    PROPERTY_CACHE_MISSES_COUNTER,
+                    &[
+                        ("type".to_string(), "person_properties".to_string()),
+                        ("reason".to_string(), "db_prep_never_ran".to_string()),
+                    ],
+                    1,
+                );
+                with_canonical_log(|log| {
+                    log.eval.property_cache_misses += 1;
+                    log.eval.person_properties_not_cached = true;
+                });
+                tracing::error!("Person properties not found — DB prep never ran");
+                Err(FlagError::PersonNotFound)
+            }
         }
     }
 

--- a/rust/feature-flags/src/flags/flag_matching.rs
+++ b/rust/feature-flags/src/flags/flag_matching.rs
@@ -129,6 +129,21 @@ impl FeatureFlagMatch {
     }
 }
 
+/// Tracks whether person properties were fetched from the database or intentionally skipped.
+///
+/// When request overrides cover all needed property keys, DB prep is skipped and `person_properties`
+/// stays `None`. This enum lets downstream code distinguish that expected case from an unexpected miss.
+#[derive(Clone, Debug, Default)]
+pub(crate) enum PersonPropertyFetchStatus {
+    /// DB prep has not yet run (initial state)
+    #[default]
+    Pending,
+    /// DB prep was skipped because request overrides covered all needed property keys
+    Skipped,
+    /// DB prep ran and populated person_properties
+    Fetched,
+}
+
 /// This struct maintains evaluation state by caching database-sourced data during feature flag evaluation.
 /// It stores person IDs, properties, group properties, and cohort matches that are fetched from the database,
 /// allowing them to be reused across multiple flag evaluations within the same request without additional DB lookups.
@@ -142,6 +157,8 @@ pub struct FlagEvaluationState {
     person_uuid: Option<Uuid>,
     /// Properties associated with the person, fetched from the database
     pub(crate) person_properties: Option<HashMap<String, Value>>,
+    /// Whether person properties were fetched, skipped, or not yet attempted
+    pub(crate) person_property_fetch_status: PersonPropertyFetchStatus,
     /// Properties for each group type involved in flag evaluation
     group_properties: HashMap<GroupTypeIndex, HashMap<String, Value>>,
     /// Cohorts for the current request
@@ -185,6 +202,7 @@ impl FlagEvaluationState {
 
     pub fn set_person_properties(&mut self, properties: HashMap<String, Value>) {
         self.person_properties = Some(properties);
+        self.person_property_fetch_status = PersonPropertyFetchStatus::Fetched;
     }
 
     pub fn set_cohorts(&mut self, cohorts: Vec<Cohort>) {
@@ -785,6 +803,8 @@ impl FeatureFlagMatcher {
         );
 
         if flags_requiring_db_preparation.is_empty() {
+            self.flag_evaluation_state.person_property_fetch_status =
+                PersonPropertyFetchStatus::Skipped;
             return false;
         }
 
@@ -2129,23 +2149,45 @@ impl FeatureFlagMatcher {
             result.clone_from(properties);
             Ok(result)
         } else {
-            inc(
-                PROPERTY_CACHE_MISSES_COUNTER,
-                &[("type".to_string(), "person_properties".to_string())],
-                1,
-            );
-            with_canonical_log(|log| {
-                log.eval.property_cache_misses += 1;
-                log.eval.person_properties_not_cached = true;
-            });
-            // Return empty HashMap instead of error - no properties is a valid state
-            // TODO probably worth error modeling empty cache vs error.
-            // Maybe an error is fine?  Idk.  I feel like the idea is that there's no matching properties,
-            // so it's not an error, it's just an empty result.
-            // i just want to be able to differentiate between no properties because we fetched no properties,
-            // and no properties because we failed to fetch
-            // maybe I need a fetch indicator in the cache?
-            tracing::warn!("Person properties not found in evaluation state cache");
+            match self.flag_evaluation_state.person_property_fetch_status {
+                PersonPropertyFetchStatus::Skipped => {
+                    tracing::debug!(
+                        "Person properties not in cache — DB prep was skipped (overrides cover all needed keys)"
+                    );
+                }
+                PersonPropertyFetchStatus::Fetched => {
+                    inc(
+                        PROPERTY_CACHE_MISSES_COUNTER,
+                        &[
+                            ("type".to_string(), "person_properties".to_string()),
+                            ("reason".to_string(), "fetched_but_missing".to_string()),
+                        ],
+                        1,
+                    );
+                    with_canonical_log(|log| {
+                        log.eval.property_cache_misses += 1;
+                        log.eval.person_properties_not_cached = true;
+                    });
+                    tracing::warn!(
+                        "Person properties not found in evaluation state cache despite DB prep running"
+                    );
+                }
+                PersonPropertyFetchStatus::Pending => {
+                    inc(
+                        PROPERTY_CACHE_MISSES_COUNTER,
+                        &[
+                            ("type".to_string(), "person_properties".to_string()),
+                            ("reason".to_string(), "db_prep_never_ran".to_string()),
+                        ],
+                        1,
+                    );
+                    with_canonical_log(|log| {
+                        log.eval.property_cache_misses += 1;
+                        log.eval.person_properties_not_cached = true;
+                    });
+                    tracing::error!("Person properties not found — DB prep never ran");
+                }
+            }
             Err(FlagError::PersonNotFound)
         }
     }

--- a/rust/feature-flags/src/flags/test_flag_matching.rs
+++ b/rust/feature-flags/src/flags/test_flag_matching.rs
@@ -1813,7 +1813,7 @@ mod tests {
         );
 
         let cache = &matcher.flag_evaluation_state;
-        assert!(cache.person_properties.is_none());
+        assert!(cache.get_person_properties().is_none());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Problem

`get_person_properties_from_evaluation_state()` emits a `tracing::warn!` when person properties are `None` in the evaluation state cache. But `None` is ambiguous — it occurs both when DB prep was intentionally skipped (request overrides covered all needed property keys) and when something genuinely went wrong. This produces noisy WARN logs for teams whose SDKs send complete property overrides, even though flag evaluation succeeds correctly via the override path.

A TODO comment in the code explicitly called out this ambiguity: "i just want to be able to differentiate between no properties because we fetched no properties, and no properties because we failed to fetch."

## Changes

Replace the `Option<HashMap<String, Value>>` person properties field with a `PersonPropertyState` enum that combines fetch status and data into a single type, making impossible states unrepresentable:

- `Pending` — initial state before DB prep runs
- `Skipped` — DB prep was intentionally skipped because request overrides cover all needed property keys
- `Fetched(HashMap<String, Value>)` — DB prep ran and populated person properties

In the cache lookup path, log at the appropriate level based on state:
- `Skipped` → `debug!` (expected, overrides handle evaluation)
- `Pending` → `error!` + increment miss counter (DB prep never ran — invariant violation)

The `Fetched` variant always carries data, so there is no "fetched but missing" branch.

## How did you test this code?

- `cargo check -p feature-flags` — compiles clean
- `cargo test -p feature-flags` — all 1208 tests pass
- `cargo clippy -p feature-flags` — no warnings
 - Manual testing. created flag with email person property then made request supplying it and one without.
 
 <details>
 
 Skipped — overrides cover the needed property

 ```bash
 curl -s http://localhost:8010/flags/ \
  -H 'Content-Type: application/json' \
  -d '{
    "token": "phc_vqBecWHWj3zGJGhe2vImg1zNiJpq1L9JRpvMwraNK1e",
    "distinct_id": "test-user",
    "person_properties": {"email": "test@example.com"}
  }'
 ```

Fetched — no overrides, forces DB lookup:
 
 ```bash
 curl -s http://localhost:8010/flags/ \
  -H 'Content-Type: application/json' \
  -d '{
    "token": "phc_vqBecWHWj3zGJGhe2vImg1zNiJpq1L9JRpvMwraNK1e",
    "distinct_id": "test-user"
  }'
  ```
 
 </details>

## Docs update

skip-inkeep-docs

## LLM context

Agent-authored PR. Copilot review comments were evaluated — most were stale (from earlier revisions that used a separate status field). The `PersonPropertyState` enum design intentionally makes the "Fetched but no properties" state unrepresentable, which addressed several of the review concerns structurally.