### PR TITLE
fix(dev): portable rdkafka for worktrees, remove sandbox infra

### DIFF
--- a/bin/fix-rdkafka-paths
+++ b/bin/fix-rdkafka-paths
@@ -29,8 +29,12 @@ cd "$ROOT_DIR"
 
 # Find node-rdkafka build directory
 candidates=(node_modules/.pnpm/node-rdkafka@*/node_modules/node-rdkafka/build)
-if [[ ${#candidates[@]} -ne 1 || ! -d "${candidates[0]}" ]]; then
-    # No match or multiple versions — nothing to fix
+if [[ ${#candidates[@]} -eq 0 || ! -d "${candidates[0]}" ]]; then
+    # No match — nothing to fix
+    exit 0
+fi
+if [[ ${#candidates[@]} -ne 1 ]]; then
+    print_color yellow "Warning: multiple node-rdkafka versions found; skipping dylib path fix. Run pnpm install to deduplicate."
     exit 0
 fi
 build_dir="${candidates[0]}"

--- a/bin/fix-rdkafka-paths
+++ b/bin/fix-rdkafka-paths
@@ -1,0 +1,110 @@
+#!/bin/bash
+
+# Fix node-rdkafka dylib paths to use @loader_path for portability across git worktrees.
+# macOS only. Idempotent — safe to run multiple times.
+#
+# On macOS, node-gyp bakes absolute paths into the .node binary when linking against
+# bundled dylibs. This breaks when node_modules is CoW-cloned to a different worktree.
+# We rewrite them to @loader_path-relative references so the binary works at any path.
+
+set -e
+
+# Exit silently on non-macOS — Linux already uses $ORIGIN-relative rpaths
+[[ "$(uname -s)" == "Darwin" ]] || exit 0
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# Source helpers if available (standalone invocation)
+if [[ -f "$SCRIPT_DIR/helpers/_utils.sh" ]]; then
+    source "$SCRIPT_DIR/helpers/_utils.sh"
+else
+    # Minimal fallback for when helpers aren't available
+    print_color() { echo "$2"; }
+    success() { echo "✓ $*"; }
+    error() { echo "Error: $*" >&2; }
+fi
+
+cd "$ROOT_DIR"
+
+# Find node-rdkafka build directory
+candidates=(node_modules/.pnpm/node-rdkafka@*/node_modules/node-rdkafka/build)
+if [[ ${#candidates[@]} -ne 1 || ! -d "${candidates[0]}" ]]; then
+    # No match or multiple versions — nothing to fix
+    exit 0
+fi
+build_dir="${candidates[0]}"
+node_file="$build_dir/Release/node-librdkafka.node"
+deps_dir="$build_dir/deps"
+
+if [[ ! -f "$node_file" ]]; then
+    # node-rdkafka not built yet — nothing to fix
+    exit 0
+fi
+
+# Cache otool output (dependency lines start with a tab, skip the filename header)
+otool_deps=$(otool -L "$node_file" | grep $'^\t')
+
+# Check if fix is already applied: look for absolute paths to rdkafka deps
+abs_refs=$(echo "$otool_deps" | grep 'librdkafka' | grep -v '@loader_path' || true)
+if [[ -z "$abs_refs" ]]; then
+    print_color blue "node-rdkafka dylib paths already portable"
+    exit 0
+fi
+
+# Extract the absolute path prefix from the cached otool output
+# e.g., "/Users/foo/repo/node_modules/.pnpm/node-rdkafka@3.6.1/node_modules/node-rdkafka/build/deps/"
+old_prefix=$(echo "$otool_deps" | grep 'librdkafka\.1\.dylib' | grep -v '@loader_path' | head -1 | awk '{print $1}' | sed 's|librdkafka\.1\.dylib$||')
+
+if [[ -z "$old_prefix" ]]; then
+    error "Could not extract absolute path prefix from $node_file"
+    exit 1
+fi
+
+old_rdkafka="${old_prefix}librdkafka.1.dylib"
+old_rdkafkapp="${old_prefix}librdkafka++.1.dylib"
+
+print_color blue "Fixing node-rdkafka dylib paths for worktree portability…"
+print_color blue "  Replacing: ${old_prefix}"
+print_color blue "  With:      @loader_path-relative references"
+
+# Fix librdkafka.1.dylib install name
+install_name_tool -id @loader_path/librdkafka.1.dylib "$deps_dir/librdkafka.1.dylib"
+
+# Fix librdkafka++.1.dylib install name and its reference to librdkafka
+install_name_tool -id @loader_path/librdkafka++.1.dylib "$deps_dir/librdkafka++.1.dylib"
+install_name_tool -change "$old_rdkafka" @loader_path/librdkafka.1.dylib "$deps_dir/librdkafka++.1.dylib"
+
+# Fix unversioned dylibs (separate Mach-O files, not symlinks)
+if [[ -f "$deps_dir/librdkafka.dylib" ]]; then
+    install_name_tool -id @loader_path/librdkafka.1.dylib "$deps_dir/librdkafka.dylib"
+fi
+if [[ -f "$deps_dir/librdkafka++.dylib" ]]; then
+    install_name_tool -id @loader_path/librdkafka++.1.dylib "$deps_dir/librdkafka++.dylib"
+    install_name_tool -change "$old_rdkafka" @loader_path/librdkafka.1.dylib "$deps_dir/librdkafka++.dylib"
+fi
+
+# Fix the main .node binary
+install_name_tool -change "$old_rdkafka" @loader_path/../deps/librdkafka.1.dylib "$node_file"
+install_name_tool -change "$old_rdkafkapp" @loader_path/../deps/librdkafka++.1.dylib "$node_file"
+
+# Re-sign ad-hoc (required on Apple Silicon after modifying binaries)
+codesign --force --sign - "$deps_dir/librdkafka.1.dylib" 2>/dev/null || true
+codesign --force --sign - "$deps_dir/librdkafka++.1.dylib" 2>/dev/null || true
+codesign --force --sign - "$node_file" 2>/dev/null || true
+if [[ -f "$deps_dir/librdkafka.dylib" ]]; then
+    codesign --force --sign - "$deps_dir/librdkafka.dylib" 2>/dev/null || true
+fi
+if [[ -f "$deps_dir/librdkafka++.dylib" ]]; then
+    codesign --force --sign - "$deps_dir/librdkafka++.dylib" 2>/dev/null || true
+fi
+
+# Verify
+remaining=$(otool -L "$node_file" | grep $'^\t' | grep 'librdkafka' | grep -v '@loader_path' || true)
+if [[ -n "$remaining" ]]; then
+    error "Some absolute paths remain after fix:"
+    echo "$remaining"
+    exit 1
+fi
+
+success "node-rdkafka dylib paths are now portable across worktrees"

--- a/bin/posthog-worktree
+++ b/bin/posthog-worktree
@@ -320,6 +320,11 @@ setup_worktree_environment() {
         fi
     fi
 
+    # Fix rdkafka dylib paths for worktree portability (macOS only)
+    if [[ "$(uname -s)" == "Darwin" && -d "${worktree_path}/node_modules" ]]; then
+        (cd "${worktree_path}" && bin/fix-rdkafka-paths)
+    fi
+
     # Initialize Flox in the new worktree
     cd "${worktree_path}"
     print_color blue "Initializing Flox environment (this will share packages from cache)…"

--- a/common/hogli/manifest.yaml
+++ b/common/hogli/manifest.yaml
@@ -743,5 +743,5 @@ environment:
         hidden: true
     fix:rdkafka:paths:
         bin_script: fix-rdkafka-paths
-        description: 'TODO: add description for fix-rdkafka-paths'
+        description: 'Rewrite node-rdkafka dylib paths to use @loader_path on macOS for worktree portability'
         hidden: true

--- a/common/hogli/manifest.yaml
+++ b/common/hogli/manifest.yaml
@@ -741,3 +741,7 @@ environment:
         bin_script: start-stripe-mock
         description: 'Start the local Stripe mock API server'
         hidden: true
+    fix:rdkafka:paths:
+        bin_script: fix-rdkafka-paths
+        description: 'TODO: add description for fix-rdkafka-paths'
+        hidden: true

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
         "storybook": "pnpm turbo --filter=@posthog/storybook start",
         "// DEPRECATED - use hogli start instead": "",
         "start": "./bin/start",
-        "postinstall": "git config --get blame.ignoreRevsFile > /dev/null 2>&1 || git config blame.ignoreRevsFile .git-blame-ignore-revs > /dev/null 2>&1 || true; bin/fix-rdkafka-paths",
+        "postinstall": "git config --get blame.ignoreRevsFile > /dev/null 2>&1 || git config blame.ignoreRevsFile .git-blame-ignore-revs > /dev/null 2>&1 || true; [ ! -f bin/fix-rdkafka-paths ] || bin/fix-rdkafka-paths",
         "lint": "pnpm lint:js && pnpm lint:css",
         "lint:js": "oxlint --quiet",
         "lint:css": "stylelint \"(frontend|products)/**/*.{css,scss}\"",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
         "storybook": "pnpm turbo --filter=@posthog/storybook start",
         "// DEPRECATED - use hogli start instead": "",
         "start": "./bin/start",
-        "postinstall": "git config --get blame.ignoreRevsFile > /dev/null 2>&1 || git config blame.ignoreRevsFile .git-blame-ignore-revs > /dev/null 2>&1 || true",
+        "postinstall": "git config --get blame.ignoreRevsFile > /dev/null 2>&1 || git config blame.ignoreRevsFile .git-blame-ignore-revs > /dev/null 2>&1 || true; bin/fix-rdkafka-paths",
         "lint": "pnpm lint:js && pnpm lint:css",
         "lint:js": "oxlint --quiet",
         "lint:css": "stylelint \"(frontend|products)/**/*.{css,scss}\"",


### PR DESCRIPTION
## Problem

On macOS, `node-gyp` bakes absolute paths into the `node-rdkafka` `.node` binary when linking against bundled dylibs. When `node_modules` is CoW-cloned to a different git worktree, the binary breaks because the paths no longer exist.

Separately, the sandbox infrastructure (`bin/sandbox`, `Dockerfile.sandbox`, `docker-compose.sandbox.yml`) adds complexity and maintenance burden without active use. Service hostname defaults (e.g. `db`, `redis7`, `objectstorage`) assumed a Docker-internal network, which doesn't match the standard local dev setup.

## Changes

- Add `bin/fix-rdkafka-paths` script that rewrites dylib load commands to `@loader_path`-relative references on macOS, making the binary portable across worktree locations
- Run the fix automatically via `postinstall` and when creating worktrees via `posthog-worktree`
- Register `fix:rdkafka:paths` as a hogli command
- Remove sandbox infrastructure: `bin/sandbox`, `bin/sandbox-entrypoint.py`, `Dockerfile.sandbox`, `docker-compose.sandbox.yml`, `dev-services.env`, and related configs
- Simplify service hostname defaults to `localhost` across Python settings, startup scripts, CI workflows, and Vite config
- Inline environment variables into `docker-compose.base.yml` (hobby deploy) instead of referencing the removed `dev-services.env`
- Simplify `.claude/hooks/setup-flox.sh` by removing manifest-hash caching
- Remove unused `cleanup_stale_worktree` function from `posthog-worktree`

## How did you test this code?

- Verified `bin/fix-rdkafka-paths` correctly rewrites dylib paths on macOS using `otool -L` before and after
- Created a git worktree and confirmed the Node.js service starts without rdkafka load errors
- Confirmed `pnpm install` triggers the fix via postinstall hook
- Verified dev environment starts correctly with localhost defaults

## Publish to changelog?

No

## Docs update

No docs changes needed.