### PR TITLE
fix(dagster): use correct Hive partition keys in duckling backfill S3 paths

### DIFF
--- a/posthog/dags/events_backfill_to_ducklake.py
+++ b/posthog/dags/events_backfill_to_ducklake.py
@@ -534,8 +534,7 @@ def register_files_with_ducklake(
                 context.log.info(f"Registering file with DuckLake: {s3_path}")
                 # Use escape() to prevent SQL injection
                 conn.execute(
-                    f"CALL ducklake_add_data_files('{alias}', 'events', '{escape(s3_path)}',"
-                    f" schema => 'posthog')"
+                    f"CALL ducklake_add_data_files('{alias}', 'events', '{escape(s3_path)}', schema => 'posthog')"
                 )
                 registered_count += 1
                 context.log.info(f"Successfully registered: {s3_path}")

--- a/posthog/dags/events_backfill_to_ducklake.py
+++ b/posthog/dags/events_backfill_to_ducklake.py
@@ -8,9 +8,6 @@ The job is partitioned by date to allow incremental backfilling of historical da
 Within each date partition, events are further chunked by team_id to keep file sizes manageable.
 
 S3 path structure: s3://{bucket}/backfill/events/{team_id}/{year}/{month}/{day}/
-
-Uses plain directory segments (not Hive-style key=value) to avoid DuckLake
-interpreting them as partition columns during ducklake_add_data_files.
 """
 
 import base64
@@ -298,9 +295,6 @@ def get_s3_path_for_partition(
     """Build S3 path for a partition file.
 
     Path structure: s3://{bucket}/backfill/events/{team_id}/{year}/{month}/{day}/{chunk_id}.parquet
-
-    Uses plain directory segments (not Hive-style key=value) to avoid DuckLake
-    interpreting them as partition columns during ducklake_add_data_files.
     """
     year = date.strftime("%Y")
     month = date.strftime("%m")
@@ -533,7 +527,7 @@ def register_files_with_ducklake(
                 # Use escape() to prevent SQL injection
                 conn.execute(
                     f"CALL ducklake_add_data_files('{alias}', 'events', '{escape(s3_path)}',"
-                    f" schema => 'posthog', hive_partitioning => false)"
+                    f" schema => 'posthog')"
                 )
                 registered_count += 1
                 context.log.info(f"Successfully registered: {s3_path}")

--- a/posthog/dags/events_backfill_to_ducklake.py
+++ b/posthog/dags/events_backfill_to_ducklake.py
@@ -295,6 +295,14 @@ def get_s3_path_for_partition(
     """Build S3 path for a partition file.
 
     Path structure: s3://{bucket}/backfill/events/{team_id}/{year}/{month}/{day}/{chunk_id}.parquet
+
+    TODO: These paths use plain segments, not Hive-style key=value. This means
+    ducklake_add_data_files will fail on partitioned tables (0 Hive keys vs N
+    partition fields). Fixing this requires restructuring the chunking strategy:
+    the table partitions by team_id (IDENTITY) but each file contains data from
+    multiple team_ids (team_id % total_chunks = chunk), so a single file can't
+    map to one team_id partition. Either remove team_id from the partition
+    expression or export one file per team_id instead of modular chunks.
     """
     year = date.strftime("%Y")
     month = date.strftime("%m")

--- a/posthog/dags/events_backfill_to_duckling.py
+++ b/posthog/dags/events_backfill_to_duckling.py
@@ -1184,10 +1184,7 @@ def register_file_with_duckling(
             attach_catalog(conn, catalog_config, alias=alias)
 
             context.log.info(f"Registering file with DuckLake: {s3_path}")
-            conn.execute(
-                f"CALL ducklake_add_data_files('{alias}', 'events', '{escape(s3_path)}',"
-                f" schema => 'posthog')"
-            )
+            conn.execute(f"CALL ducklake_add_data_files('{alias}', 'events', '{escape(s3_path)}', schema => 'posthog')")
 
             context.log.info(f"Successfully registered: {s3_path}")
             logger.info("duckling_file_registered", s3_path=s3_path, team_id=catalog.team_id)
@@ -1409,8 +1406,7 @@ def register_persons_file_with_duckling(
 
             context.log.info(f"Registering persons file with DuckLake: {s3_path}")
             conn.execute(
-                f"CALL ducklake_add_data_files('{alias}', 'persons', '{escape(s3_path)}',"
-                f" schema => 'posthog')"
+                f"CALL ducklake_add_data_files('{alias}', 'persons', '{escape(s3_path)}', schema => 'posthog')"
             )
 
             context.log.info(f"Successfully registered persons: {s3_path}")

--- a/posthog/dags/events_backfill_to_duckling.py
+++ b/posthog/dags/events_backfill_to_duckling.py
@@ -1092,7 +1092,7 @@ def export_events_to_duckling_s3(
     date_str = date.strftime("%Y-%m-%d")
 
     # Path without s3:// scheme for the HTTPS URL
-    path_without_scheme = f"{BACKFILL_EVENTS_S3_PREFIX}/{team_id}/{year}/{month}/{day}/{run_id}.parquet"
+    path_without_scheme = f"{BACKFILL_EVENTS_S3_PREFIX}/{team_id}/year={year}/month={month}/day={day}/{run_id}.parquet"
 
     # ClickHouse needs HTTPS URL format for cross-account S3 access
     s3_url = get_s3_url_for_clickhouse(catalog.bucket, catalog.bucket_region, path_without_scheme)
@@ -1186,7 +1186,7 @@ def register_file_with_duckling(
             context.log.info(f"Registering file with DuckLake: {s3_path}")
             conn.execute(
                 f"CALL ducklake_add_data_files('{alias}', 'events', '{escape(s3_path)}',"
-                f" schema => 'posthog', hive_partitioning => false)"
+                f" schema => 'posthog')"
             )
 
             context.log.info(f"Successfully registered: {s3_path}")
@@ -1254,7 +1254,7 @@ def export_persons_to_duckling_s3(
     day = date.strftime("%d")
     date_str = date.strftime("%Y-%m-%d")
 
-    path_without_scheme = f"{BACKFILL_PERSONS_S3_PREFIX}/{team_id}/{year}/{month}/{day}/{run_id}.parquet"
+    path_without_scheme = f"{BACKFILL_PERSONS_S3_PREFIX}/{team_id}/year={year}/month={month}/{run_id}.parquet"
     s3_url = get_s3_url_for_clickhouse(catalog.bucket, catalog.bucket_region, path_without_scheme)
     s3_path = f"s3://{catalog.bucket}/{path_without_scheme}"
 
@@ -1411,7 +1411,7 @@ def register_persons_file_with_duckling(
             context.log.info(f"Registering persons file with DuckLake: {s3_path}")
             conn.execute(
                 f"CALL ducklake_add_data_files('{alias}', 'persons', '{escape(s3_path)}',"
-                f" schema => 'posthog', hive_partitioning => false)"
+                f" schema => 'posthog')"
             )
 
             context.log.info(f"Successfully registered persons: {s3_path}")

--- a/posthog/dags/events_backfill_to_duckling.py
+++ b/posthog/dags/events_backfill_to_duckling.py
@@ -1251,7 +1251,6 @@ def export_persons_to_duckling_s3(
     """
     year = date.strftime("%Y")
     month = date.strftime("%m")
-    day = date.strftime("%d")
     date_str = date.strftime("%Y-%m-%d")
 
     path_without_scheme = f"{BACKFILL_PERSONS_S3_PREFIX}/{team_id}/year={year}/month={month}/{run_id}.parquet"

--- a/posthog/dags/test_events_backfill_to_duckling.py
+++ b/posthog/dags/test_events_backfill_to_duckling.py
@@ -1,3 +1,5 @@
+import os
+import tempfile
 from datetime import date, datetime, timedelta
 
 import pytest
@@ -832,3 +834,145 @@ class TestGetClusterRetry:
             _get_cluster()
 
         assert mock_get_cluster.call_count == 3
+
+
+class TestDuckLakeAddDataFilesPartitioning:
+    """Integration tests proving that ducklake_add_data_files succeeds/fails
+    based on whether the S3 path Hive keys match the table's partition fields.
+
+    These tests use a real DuckLake catalog (local DuckDB file) to exercise
+    the exact code path that produces the "invalid partition value" error.
+    """
+
+    @pytest.fixture
+    def ducklake_env(self, tmp_path):
+        """Create a DuckLake catalog with a partitioned events table and a sample parquet file."""
+        catalog_path = str(tmp_path / "test.ducklake")
+        data_path = str(tmp_path / "data")
+        os.makedirs(data_path)
+
+        conn = duckdb.connect()
+        conn.execute("INSTALL ducklake")
+        conn.execute("LOAD ducklake")
+        conn.execute(
+            f"ATTACH 'ducklake:{catalog_path}' AS test_lake (DATA_PATH '{data_path}')"
+        )
+        conn.execute("CREATE SCHEMA IF NOT EXISTS test_lake.posthog")
+        conn.execute(EVENTS_TABLE_DDL.format(catalog="test_lake"))
+        conn.execute(
+            "ALTER TABLE test_lake.posthog.events "
+            "SET PARTITIONED BY (year(timestamp), month(timestamp), day(timestamp))"
+        )
+
+        # Write a minimal parquet file with the same columns as the events table
+        parquet_dir = str(tmp_path / "parquet")
+        os.makedirs(parquet_dir)
+        conn.execute(f"""
+            COPY (
+                SELECT
+                    'abc-123'::VARCHAR AS uuid,
+                    '$pageview'::VARCHAR AS event,
+                    '{{}}'::VARCHAR AS properties,
+                    '2026-03-30 12:00:00+00'::TIMESTAMPTZ AS timestamp,
+                    2::BIGINT AS team_id,
+                    2::BIGINT AS project_id,
+                    'user1'::VARCHAR AS distinct_id,
+                    ''::VARCHAR AS elements_chain,
+                    '2026-03-30 12:00:00+00'::TIMESTAMPTZ AS created_at,
+                    'person-1'::VARCHAR AS person_id,
+                    '2026-03-30 12:00:00+00'::TIMESTAMPTZ AS person_created_at,
+                    '{{}}'::VARCHAR AS person_properties,
+                    '{{}}'::VARCHAR AS group0_properties,
+                    '{{}}'::VARCHAR AS group1_properties,
+                    '{{}}'::VARCHAR AS group2_properties,
+                    '{{}}'::VARCHAR AS group3_properties,
+                    '{{}}'::VARCHAR AS group4_properties,
+                    '2026-03-30 12:00:00+00'::TIMESTAMPTZ AS group0_created_at,
+                    '2026-03-30 12:00:00+00'::TIMESTAMPTZ AS group1_created_at,
+                    '2026-03-30 12:00:00+00'::TIMESTAMPTZ AS group2_created_at,
+                    '2026-03-30 12:00:00+00'::TIMESTAMPTZ AS group3_created_at,
+                    '2026-03-30 12:00:00+00'::TIMESTAMPTZ AS group4_created_at,
+                    'full'::VARCHAR AS person_mode,
+                    false::BOOLEAN AS historical_migration,
+                    '2026-03-30 12:00:00+00'::TIMESTAMPTZ AS _inserted_at
+            ) TO '{parquet_dir}/events.parquet' (FORMAT PARQUET)
+        """)
+
+        yield conn, parquet_dir
+
+        conn.close()
+
+    def test_new_path_format_succeeds(self, ducklake_env):
+        """Path with plain team_id + Hive year/month/day keys: 3 partition values = 3 fields."""
+        conn, parquet_dir = ducklake_env
+
+        # Simulate the new path format: {team_id}/year={year}/month={month}/day={day}/
+        dest = os.path.join(parquet_dir, "2", "year=2026", "month=03", "day=30")
+        os.makedirs(dest)
+        os.link(
+            os.path.join(parquet_dir, "events.parquet"),
+            os.path.join(dest, "run1.parquet"),
+        )
+
+        path = os.path.join(dest, "run1.parquet")
+        conn.execute(
+            f"CALL ducklake_add_data_files('test_lake', 'events', '{path}', schema => 'posthog')"
+        )
+
+        # Verify the data is queryable
+        result = conn.execute("SELECT count(*) FROM test_lake.posthog.events").fetchone()
+        assert result[0] == 1
+
+    def test_old_path_format_with_hive_team_id_fails(self, ducklake_env):
+        """Path with Hive team_id=X: 4 partition values vs 3 fields -> error."""
+        conn, parquet_dir = ducklake_env
+
+        # Simulate the old path format: team_id={team_id}/year={year}/month={month}/day={day}/
+        dest = os.path.join(parquet_dir, "team_id=2", "year=2026", "month=03", "day=30")
+        os.makedirs(dest)
+        os.link(
+            os.path.join(parquet_dir, "events.parquet"),
+            os.path.join(dest, "run1.parquet"),
+        )
+
+        path = os.path.join(dest, "run1.parquet")
+        with pytest.raises(duckdb.InvalidInputException, match="invalid partition value"):
+            conn.execute(
+                f"CALL ducklake_add_data_files('test_lake', 'events', '{path}', schema => 'posthog')"
+            )
+
+    def test_plain_path_no_hive_keys_fails(self, ducklake_env):
+        """Path with no Hive keys at all: 0 partition values vs 3 fields -> error."""
+        conn, parquet_dir = ducklake_env
+
+        # Simulate the intermediate "fix" path format: {team_id}/{year}/{month}/{day}/
+        dest = os.path.join(parquet_dir, "2", "2026", "03", "30")
+        os.makedirs(dest)
+        os.link(
+            os.path.join(parquet_dir, "events.parquet"),
+            os.path.join(dest, "run1.parquet"),
+        )
+
+        path = os.path.join(dest, "run1.parquet")
+        with pytest.raises(duckdb.InvalidInputException, match="invalid partition value"):
+            conn.execute(
+                f"CALL ducklake_add_data_files('test_lake', 'events', '{path}', schema => 'posthog')"
+            )
+
+    def test_hive_partitioning_false_with_plain_path_still_fails(self, ducklake_env):
+        """hive_partitioning => false skips parsing entirely: 0 partition values vs 3 fields -> error."""
+        conn, parquet_dir = ducklake_env
+
+        dest = os.path.join(parquet_dir, "2", "2026", "03", "30")
+        os.makedirs(dest, exist_ok=True)
+        os.link(
+            os.path.join(parquet_dir, "events.parquet"),
+            os.path.join(dest, "run2.parquet"),
+        )
+
+        path = os.path.join(dest, "run2.parquet")
+        with pytest.raises(duckdb.InvalidInputException, match="invalid partition value"):
+            conn.execute(
+                f"CALL ducklake_add_data_files('test_lake', 'events', '{path}',"
+                f" schema => 'posthog', hive_partitioning => false)"
+            )

--- a/posthog/dags/test_events_backfill_to_duckling.py
+++ b/posthog/dags/test_events_backfill_to_duckling.py
@@ -1,5 +1,4 @@
 import os
-import tempfile
 from datetime import date, datetime, timedelta
 
 import pytest

--- a/posthog/dags/test_events_backfill_to_duckling.py
+++ b/posthog/dags/test_events_backfill_to_duckling.py
@@ -853,9 +853,7 @@ class TestDuckLakeAddDataFilesPartitioning:
         conn = duckdb.connect()
         conn.execute("INSTALL ducklake")
         conn.execute("LOAD ducklake")
-        conn.execute(
-            f"ATTACH 'ducklake:{catalog_path}' AS test_lake (DATA_PATH '{data_path}')"
-        )
+        conn.execute(f"ATTACH 'ducklake:{catalog_path}' AS test_lake (DATA_PATH '{data_path}')")
         conn.execute("CREATE SCHEMA IF NOT EXISTS test_lake.posthog")
         conn.execute(EVENTS_TABLE_DDL.format(catalog="test_lake"))
         conn.execute(
@@ -914,9 +912,7 @@ class TestDuckLakeAddDataFilesPartitioning:
         )
 
         path = os.path.join(dest, "run1.parquet")
-        conn.execute(
-            f"CALL ducklake_add_data_files('test_lake', 'events', '{path}', schema => 'posthog')"
-        )
+        conn.execute(f"CALL ducklake_add_data_files('test_lake', 'events', '{path}', schema => 'posthog')")
 
         # Verify the data is queryable
         result = conn.execute("SELECT count(*) FROM test_lake.posthog.events").fetchone()
@@ -936,9 +932,7 @@ class TestDuckLakeAddDataFilesPartitioning:
 
         path = os.path.join(dest, "run1.parquet")
         with pytest.raises(duckdb.InvalidInputException, match="invalid partition value"):
-            conn.execute(
-                f"CALL ducklake_add_data_files('test_lake', 'events', '{path}', schema => 'posthog')"
-            )
+            conn.execute(f"CALL ducklake_add_data_files('test_lake', 'events', '{path}', schema => 'posthog')")
 
     def test_plain_path_no_hive_keys_fails(self, ducklake_env):
         """Path with no Hive keys at all: 0 partition values vs 3 fields -> error."""
@@ -954,9 +948,7 @@ class TestDuckLakeAddDataFilesPartitioning:
 
         path = os.path.join(dest, "run1.parquet")
         with pytest.raises(duckdb.InvalidInputException, match="invalid partition value"):
-            conn.execute(
-                f"CALL ducklake_add_data_files('test_lake', 'events', '{path}', schema => 'posthog')"
-            )
+            conn.execute(f"CALL ducklake_add_data_files('test_lake', 'events', '{path}', schema => 'posthog')")
 
     def test_hive_partitioning_false_with_plain_path_still_fails(self, ducklake_env):
         """hive_partitioning => false skips parsing entirely: 0 partition values vs 3 fields -> error."""


### PR DESCRIPTION
## Summary

Fixes the `ducklake_add_data_files` error: `"invalid partition value for the table configuration"`.

Root cause traced through [DuckLake source code](https://github.com/duckdb/ducklake/blob/main/src/functions/ducklake_add_data_files.cpp):

- The events table is partitioned by `year(timestamp), month(timestamp), day(timestamp)` — **3 partition fields**
- DuckLake resolves partition values by parsing Hive-style `key=value` segments from the file path, then checks that the count matches the table's partition field count exactly
- `GetPartitionKeyName` generates the expected Hive keys: `year`, `month`, `day`

**Why every previous attempt failed:**

| Path format | Hive keys parsed | Partition fields | Result |
|---|---|---|---|
| `team_id=2/year=2026/month=03/day=30/` (original) | 4 (`team_id`, `year`, `month`, `day`) | 3 | **4 ≠ 3 → error** |
| `2/2026/03/30/` (PR #52677) | 0 | 3 | **0 ≠ 3 → error** |
| `2/2026/03/30/` + `hive_partitioning => false` (PR #52813) | 0 (parsing skipped) | 3 | **0 ≠ 3 → error** |

**Fix:** `{team_id}/year={year}/month={month}/day={day}/` — `team_id` as a plain segment (invisible to Hive parser), only the 3 partition keys as Hive `key=value` pairs.

- Removes invalid `hive_partitioning => false` param from all `ducklake_add_data_files` calls (it's a valid param per source, but setting it to `false` disables ALL Hive parsing which is the opposite of what we want)
- Applies same fix to persons paths (2 partition fields: `year`, `month`)

## Test plan

- [x] Integration tests against a real DuckLake catalog proving all 4 path formats (91 tests pass)
- [ ] Deploy and verify duckling events backfill completes without partition errors
- [ ] Verify duckling persons daily backfill completes without partition errors

**Note:** The persons full export path (`/{team_id}/full/{run_id}.parquet`) still lacks Hive keys — this is a pre-existing issue since full exports span multiple year/month values and can't map to a single partition. Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)