### PR TITLE
chore(flags): Display flag name instead of id in feature flag release conditions

### DIFF
--- a/frontend/src/lib/components/PropertyFilters/utils.ts
+++ b/frontend/src/lib/components/PropertyFilters/utils.ts
@@ -155,15 +155,25 @@ export function formatPropertyLabel(
 
     const isSingleEmptyString = Array.isArray(value) && value.length === 1 && value[0] === ''
 
-    return resolvedType === PropertyFilterType.Cohort
-        ? `${capitalizeFirstLetter(cohortOperatorMap[resolvedOperator] || 'user in')} ` +
-              (cohortName || (typeof value === 'number' ? cohortsById[value]?.name : undefined) || `ID ${value}`)
-        : (getCoreFilterDefinition(key, taxonomicFilterGroupType)?.label || label || key) +
-              (isOperatorFlag(resolvedOperator)
-                  ? ` ${allOperatorsMapping[resolvedOperator]}`
-                  : ` ${(allOperatorsMapping[resolvedOperator] || '?').split(' ')[0]} ${
-                        isSingleEmptyString ? '(empty string)' : valueFormatter(value) || ''
-                    } `)
+    if (resolvedType === PropertyFilterType.Cohort) {
+        return (
+            `${capitalizeFirstLetter(cohortOperatorMap[resolvedOperator] || 'user in')} ` +
+            (cohortName || (typeof value === 'number' ? cohortsById[value]?.name : undefined) || `ID ${value}`)
+        )
+    }
+
+    if (resolvedType === PropertyFilterType.Flag) {
+        return `${label || key} ${allOperatorsMapping[resolvedOperator] || '?'} ${valueFormatter(value) || ''}`
+    }
+
+    return (
+        (getCoreFilterDefinition(key, taxonomicFilterGroupType)?.label || label || key) +
+        (isOperatorFlag(resolvedOperator)
+            ? ` ${allOperatorsMapping[resolvedOperator]}`
+            : ` ${(allOperatorsMapping[resolvedOperator] || '?').split(' ')[0]} ${
+                  isSingleEmptyString ? '(empty string)' : valueFormatter(value) || ''
+              } `)
+    )
 }
 
 /** Make sure unverified user property filter input has at least a "type" */

--- a/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditionsCollapsible.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditionsCollapsible.tsx
@@ -75,7 +75,14 @@ function summarizeProperties(properties: AnyPropertyFilter[], aggregationTargetN
     }
 
     const parts = properties.slice(0, 2).map((property) => {
-        const key = property.type === PropertyFilterType.Cohort ? 'Cohort' : property.key || 'property'
+        let key: string
+        if (property.type === PropertyFilterType.Cohort) {
+            key = 'Cohort'
+        } else if (property.type === PropertyFilterType.Flag) {
+            key = property.label || property.key || 'flag'
+        } else {
+            key = property.key || 'property'
+        }
         const operator = isPropertyFilterWithOperator(property) ? allOperatorsToHumanName(property.operator) : 'is'
         const groupKeyNames: Record<string, string> =
             property.key === '$group_key' && property.type === PropertyFilterType.Group && 'group_key_names' in property

--- a/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditionsReadonly.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditionsReadonly.tsx
@@ -1,6 +1,6 @@
 import { useValues } from 'kea'
 
-import { IconInfo } from '@posthog/icons'
+import { IconFlag, IconInfo } from '@posthog/icons'
 import { LemonButton, LemonDivider, LemonLabel, LemonSnack, LemonTag, Tooltip } from '@posthog/lemon-ui'
 
 import { allOperatorsToHumanName } from 'lib/components/DefinitionPopover/utils'
@@ -61,7 +61,7 @@ function PropertyValueDisplay({ property }: { property: AnyPropertyFilter }): JS
 
 function PropertyFilterRow({ property, isFirst }: { property: AnyPropertyFilter; isFirst: boolean }): JSX.Element {
     const propertyLabel =
-        property.type === PropertyFilterType.Cohort
+        property.type === PropertyFilterType.Cohort || property.type === PropertyFilterType.Flag
             ? null
             : getFilterLabel(
                   property.key,
@@ -80,7 +80,14 @@ function PropertyFilterRow({ property, isFirst }: { property: AnyPropertyFilter;
                 <LemonButton icon={<span className="text-xs font-medium">&</span>} size="small" noPadding />
             )}
             {propertyLabel && propertyLabel !== property.key && <span className="text-muted">{propertyLabel}</span>}
-            <LemonSnack>{property.type === PropertyFilterType.Cohort ? 'Cohort' : property.key}</LemonSnack>
+            {property.type === PropertyFilterType.Flag ? (
+                <LemonSnack>
+                    <IconFlag className="mr-1" />
+                    {property.label || property.key}
+                </LemonSnack>
+            ) : (
+                <LemonSnack>{property.type === PropertyFilterType.Cohort ? 'Cohort' : property.key}</LemonSnack>
+            )}
             <span className="text-muted">{operator}</span>
             <PropertyValueDisplay property={property} />
         </div>


### PR DESCRIPTION
## Problem
When selecting a feature flag for release condition, it displayed the id instead of the name.
<img width="779" height="70" alt="image" src="https://github.com/user-attachments/assets/456fc61b-4e01-440f-8b05-53d0eaf2fae9" />
<img width="779" height="156" alt="image" src="https://github.com/user-attachments/assets/9b499ad6-2d27-43f0-ab1d-ef4a70bcbdae" />


<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
<img width="1596" height="476" alt="image" src="https://github.com/user-attachments/assets/f54f1021-2b62-424c-b56c-a8443e277c94" />
<img width="779" height="96" alt="image" src="https://github.com/user-attachments/assets/5aaffc06-213a-430a-a85a-74e27f07822f" />

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
