### PR TITLE
fix(experiments): disable edit legacy experiment or shared metrics

### DIFF
--- a/products/experiments/backend/experiment_saved_metric_service.py
+++ b/products/experiments/backend/experiment_saved_metric_service.py
@@ -20,13 +20,15 @@ from posthog.schema import (
 
 from posthog.models.team.team import Team
 
-from products.experiments.backend.models.experiment import ExperimentSavedMetric, saved_metric_has_legacy_query
+from products.experiments.backend.models.experiment import (
+    LEGACY_METRIC_KINDS,
+    ExperimentSavedMetric,
+    saved_metric_has_legacy_query,
+)
 
 
 class ExperimentSavedMetricService:
     """Single source of truth for experiment saved metric business logic."""
-
-    LEGACY_QUERY_KINDS = {"ExperimentTrendsQuery", "ExperimentFunnelsQuery"}
 
     def __init__(self, team: Team, user: Any):
         self.team = team
@@ -39,7 +41,7 @@ class ExperimentSavedMetricService:
             raise ValidationError("Query is required to create a saved metric")
 
         kind = query.get("kind")
-        if kind in cls.LEGACY_QUERY_KINDS:
+        if kind in LEGACY_METRIC_KINDS:
             raise ValidationError(
                 f"Legacy metric kind '{kind}' is no longer supported for new saved metrics. "
                 "Use 'ExperimentMetric' instead."

--- a/products/experiments/backend/experiment_saved_metric_service.py
+++ b/products/experiments/backend/experiment_saved_metric_service.py
@@ -20,7 +20,7 @@ from posthog.schema import (
 
 from posthog.models.team.team import Team
 
-from products.experiments.backend.models.experiment import ExperimentSavedMetric
+from products.experiments.backend.models.experiment import ExperimentSavedMetric, saved_metric_has_legacy_query
 
 
 class ExperimentSavedMetricService:
@@ -94,7 +94,7 @@ class ExperimentSavedMetricService:
     def update_saved_metric(self, saved_metric: ExperimentSavedMetric, update_data: dict) -> ExperimentSavedMetric:
         """Update a saved metric with full business-logic validation."""
         self._assert_team_ownership(saved_metric)
-        self._validate_update_payload(update_data)
+        self._validate_update_payload(update_data, saved_metric)
 
         if "query" in update_data:
             existing_uuid = saved_metric.query.get("uuid") if saved_metric.query else None
@@ -136,7 +136,14 @@ class ExperimentSavedMetricService:
         return normalized_query
 
     @staticmethod
-    def _validate_update_payload(update_data: dict) -> None:
+    def _validate_update_payload(update_data: dict, saved_metric: ExperimentSavedMetric) -> None:
+        # Block all updates to legacy saved metrics
+        if saved_metric_has_legacy_query(saved_metric):
+            raise ValidationError(
+                "This saved metric uses a legacy query format and cannot be updated. "
+                "Please create a new saved metric with the ExperimentMetric format instead."
+            )
+
         expected_keys = {
             "name",
             "description",

--- a/products/experiments/backend/experiment_service.py
+++ b/products/experiments/backend/experiment_service.py
@@ -35,6 +35,7 @@ from products.experiments.backend.models.experiment import (
     ExperimentMetricResult,
     ExperimentSavedMetric,
     ExperimentTimeseriesRecalculation,
+    experiment_has_legacy_metrics,
     holdout_filters_for_flag,
 )
 
@@ -1147,6 +1148,28 @@ class ExperimentService:
 
     def _validate_update_payload(self, experiment: Experiment, update_data: dict, feature_flag: FeatureFlag) -> None:
         """Validate update payload before any database mutations occur."""
+        # Check for legacy metrics first
+        if experiment_has_legacy_metrics(experiment):
+            allowed_fields = {"name", "description", "end_date"}
+            update_fields = set(update_data.keys())
+
+            # Remove internal fields that are handled separately
+            update_fields.discard("get_feature_flag_key")
+
+            disallowed_fields = update_fields - allowed_fields
+            if disallowed_fields:
+                raise ValidationError(
+                    f"This experiment uses legacy metric formats and can only have its name, description, or end_date updated. "
+                    f"Cannot update: {', '.join(sorted(disallowed_fields))}"
+                )
+
+            # Validate end_date if present
+            if "end_date" in update_data:
+                self.validate_experiment_date_range(experiment.start_date, update_data["end_date"])
+
+            # If only allowed fields are being updated, skip the rest of the validation
+            return
+
         if experiment.deleted and update_data.get("deleted") is False and feature_flag.deleted:
             raise ValidationError(
                 "Cannot restore experiment: the linked feature flag has been deleted. "

--- a/products/experiments/backend/experiment_service.py
+++ b/products/experiments/backend/experiment_service.py
@@ -30,6 +30,7 @@ from posthog.models.team.team import Team
 from posthog.utils import str_to_bool
 
 from products.experiments.backend.models.experiment import (
+    LEGACY_METRIC_KINDS,
     Experiment,
     ExperimentHoldout,
     ExperimentMetricResult,
@@ -65,8 +66,6 @@ class ExperimentQueryStatus(str, Enum):
 
 class ExperimentService:
     """Single source of truth for experiment business logic."""
-
-    LEGACY_METRIC_KINDS = {"ExperimentTrendsQuery", "ExperimentFunnelsQuery"}
 
     def __init__(self, team: Team, user: Any):
         self.team = team
@@ -129,7 +128,7 @@ class ExperimentService:
                 raise ValidationError(f"Invalid metric at index {i}: must be a dict")
 
             kind = metric.get("kind")
-            if kind in cls.LEGACY_METRIC_KINDS:
+            if kind in LEGACY_METRIC_KINDS:
                 raise ValidationError(
                     f"Invalid metric at index {i}: legacy metric kind '{kind}' is no longer supported for new experiments. "
                     "Use 'ExperimentMetric' instead."

--- a/products/experiments/backend/models/experiment.py
+++ b/products/experiments/backend/models/experiment.py
@@ -186,6 +186,28 @@ def holdout_filters_for_flag(holdout_id: int | None, filters: list | None) -> di
     }
 
 
+def experiment_has_legacy_metrics(experiment: "Experiment") -> bool:
+    """Check if experiment uses legacy metric formats."""
+    legacy_kinds = {"ExperimentTrendsQuery", "ExperimentFunnelsQuery"}
+
+    # Check inline metrics
+    all_metrics = (experiment.metrics or []) + (experiment.metrics_secondary or [])
+    if any(m.get("kind") in legacy_kinds for m in all_metrics):
+        return True
+
+    # Check saved metrics
+    if experiment.experimenttosavedmetric_set.filter(saved_metric__query__kind__in=legacy_kinds).exists():
+        return True
+
+    return False
+
+
+def saved_metric_has_legacy_query(saved_metric: "ExperimentSavedMetric") -> bool:
+    """Check if saved metric uses legacy query format."""
+    legacy_kinds = {"ExperimentTrendsQuery", "ExperimentFunnelsQuery"}
+    return saved_metric.query.get("kind") in legacy_kinds if saved_metric.query else False
+
+
 class ExperimentHoldout(ModelActivityMixin, RootTeamMixin, models.Model):
     name = models.CharField(max_length=400)
     description = models.CharField(max_length=400, null=True, blank=True)

--- a/products/experiments/backend/models/experiment.py
+++ b/products/experiments/backend/models/experiment.py
@@ -186,17 +186,18 @@ def holdout_filters_for_flag(holdout_id: int | None, filters: list | None) -> di
     }
 
 
+LEGACY_METRIC_KINDS: frozenset[str] = frozenset({"ExperimentTrendsQuery", "ExperimentFunnelsQuery"})
+
+
 def experiment_has_legacy_metrics(experiment: "Experiment") -> bool:
     """Check if experiment uses legacy metric formats."""
-    legacy_kinds = {"ExperimentTrendsQuery", "ExperimentFunnelsQuery"}
-
     # Check inline metrics
     all_metrics = (experiment.metrics or []) + (experiment.metrics_secondary or [])
-    if any(m.get("kind") in legacy_kinds for m in all_metrics):
+    if any(m.get("kind") in LEGACY_METRIC_KINDS for m in all_metrics):
         return True
 
     # Check saved metrics
-    if experiment.experimenttosavedmetric_set.filter(saved_metric__query__kind__in=legacy_kinds).exists():
+    if experiment.experimenttosavedmetric_set.filter(saved_metric__query__kind__in=LEGACY_METRIC_KINDS).exists():
         return True
 
     return False
@@ -204,8 +205,7 @@ def experiment_has_legacy_metrics(experiment: "Experiment") -> bool:
 
 def saved_metric_has_legacy_query(saved_metric: "ExperimentSavedMetric") -> bool:
     """Check if saved metric uses legacy query format."""
-    legacy_kinds = {"ExperimentTrendsQuery", "ExperimentFunnelsQuery"}
-    return saved_metric.query.get("kind") in legacy_kinds if saved_metric.query else False
+    return saved_metric.query.get("kind") in LEGACY_METRIC_KINDS if saved_metric.query else False
 
 
 class ExperimentHoldout(ModelActivityMixin, RootTeamMixin, models.Model):

--- a/products/experiments/backend/test/test_experiment_saved_metric_service.py
+++ b/products/experiments/backend/test/test_experiment_saved_metric_service.py
@@ -238,3 +238,69 @@ class TestExperimentSavedMetricService(APIBaseTest):
             self._service().update_saved_metric(saved_metric, {"query": {}})
 
         save_mock.assert_not_called()
+
+    # ------------------------------------------------------------------
+    # Legacy query update restrictions
+    # ------------------------------------------------------------------
+
+    @parameterized.expand(
+        [
+            ("trends_name", "ExperimentTrendsQuery", {"name": "Updated Name"}),
+            ("trends_description", "ExperimentTrendsQuery", {"description": "New description"}),
+            ("trends_query", "ExperimentTrendsQuery", {"query": {"kind": "ExperimentMetric"}}),
+            ("funnels_name", "ExperimentFunnelsQuery", {"name": "Updated Name"}),
+            ("funnels_description", "ExperimentFunnelsQuery", {"description": "New description"}),
+            ("funnels_query", "ExperimentFunnelsQuery", {"query": {"kind": "ExperimentMetric"}}),
+        ]
+    )
+    def test_update_saved_metric_with_legacy_query_is_blocked(
+        self, test_name: str, legacy_kind: str, update_data: dict
+    ) -> None:
+        """Test that saved metrics with legacy query formats cannot be updated."""
+        saved_metric = ExperimentSavedMetric.objects.create(
+            team=self.team,
+            created_by=self.user,
+            name=f"Legacy {legacy_kind} Metric",
+            query={"kind": legacy_kind, "count_query": {}},
+        )
+
+        with self.assertRaises(ValidationError) as ctx:
+            self._service().update_saved_metric(saved_metric, update_data)
+
+        self.assertIn("legacy query format", str(ctx.exception))
+        self.assertIn("cannot be updated", str(ctx.exception))
+
+    @parameterized.expand(
+        [
+            ("name", {"name": "Updated Modern Metric"}),
+            ("description", {"description": "Updated description"}),
+            (
+                "query",
+                {
+                    "query": {
+                        "kind": "ExperimentMetric",
+                        "metric_type": "mean",
+                        "source": {"kind": "EventsNode", "event": "$pageleave"},
+                    }
+                },
+            ),
+        ]
+    )
+    def test_update_saved_metric_with_experiment_metric_is_allowed(self, field_name: str, update_data: dict) -> None:
+        """Test that saved metrics with ExperimentMetric can be updated normally."""
+        saved_metric = ExperimentSavedMetric.objects.create(
+            team=self.team,
+            created_by=self.user,
+            name="Modern Metric",
+            description="Original description",
+            query=self._valid_experiment_metric(),
+        )
+
+        updated = self._service().update_saved_metric(saved_metric, update_data)
+
+        if field_name == "name":
+            assert updated.name == "Updated Modern Metric"
+        elif field_name == "description":
+            assert updated.description == "Updated description"
+        elif field_name == "query":
+            assert updated.query["source"]["event"] == "$pageleave"

--- a/products/experiments/backend/test/test_experiment_service.py
+++ b/products/experiments/backend/test/test_experiment_service.py
@@ -2386,3 +2386,175 @@ class TestExperimentService(APIBaseTest):
         assert result["launched_previous_30d"] == 3
         expected_change = round(((1 - 3) / 3) * 100, 1)
         assert result["percent_change"] == expected_change
+
+    # ------------------------------------------------------------------
+    # Legacy metrics update restrictions
+    # ------------------------------------------------------------------
+
+    @parameterized.expand(
+        [
+            ("name", {"name": "Updated Name"}),
+            ("description", {"description": "New hypothesis"}),
+            ("end_date", {"end_date": timezone.now() + timedelta(days=7)}),
+        ]
+    )
+    def test_update_experiment_with_legacy_metrics_allows_specific_fields(self, field_name: str, update_data: dict):
+        """Test that experiments with legacy metrics can update name, description, and end_date."""
+        service = self._service()
+        flag = self._create_flag(key=f"legacy-flag-{field_name}")
+
+        # Create experiment with legacy inline metrics directly in database
+        experiment = Experiment.objects.create(
+            team=self.team,
+            created_by=self.user,
+            feature_flag=flag,
+            name="Legacy Experiment",
+            metrics=[{"kind": "ExperimentTrendsQuery", "query": {}}],
+            start_date=timezone.now(),
+        )
+
+        # Should allow update
+        updated = service.update_experiment(experiment, update_data)
+        if field_name == "name":
+            assert updated.name == "Updated Name"
+        elif field_name == "description":
+            assert updated.description == "New hypothesis"
+        elif field_name == "end_date":
+            assert updated.end_date is not None
+
+    @parameterized.expand(
+        [
+            ("metrics", {"metrics": []}, "metrics"),
+            ("metrics_secondary", {"metrics_secondary": []}, "metrics_secondary"),
+            ("parameters", {"parameters": {"foo": "bar"}}, "parameters"),
+            ("filters", {"filters": {"foo": "bar"}}, "filters"),
+            ("exposure_criteria", {"exposure_criteria": {"foo": "bar"}}, "exposure_criteria"),
+            ("stats_config", {"stats_config": {"foo": "bar"}}, "stats_config"),
+            ("scheduling_config", {"scheduling_config": {"foo": "bar"}}, "scheduling_config"),
+            ("start_date", {"start_date": timezone.now()}, "start_date"),
+            ("archived", {"archived": True}, "archived"),
+            ("conclusion", {"conclusion": "won"}, "conclusion"),
+        ]
+    )
+    def test_update_experiment_with_legacy_metrics_blocks_disallowed_fields(
+        self, field_name: str, update_data: dict, expected_field_in_error: str
+    ):
+        """Test that experiments with legacy metrics cannot update disallowed fields."""
+        service = self._service()
+        flag = self._create_flag(key=f"legacy-block-{field_name}")
+
+        # Create experiment with legacy inline metrics
+        experiment = Experiment.objects.create(
+            team=self.team,
+            created_by=self.user,
+            feature_flag=flag,
+            name="Legacy Experiment",
+            metrics=[{"kind": "ExperimentTrendsQuery", "query": {}}],
+            start_date=timezone.now(),
+        )
+
+        # Should block update
+        with self.assertRaises(ValidationError) as cm:
+            service.update_experiment(experiment, update_data)
+        self.assertIn("legacy metric formats", str(cm.exception))
+        self.assertIn(f"Cannot update: {expected_field_in_error}", str(cm.exception))
+
+    @parameterized.expand(
+        [
+            ("inline_trends", {"kind": "ExperimentTrendsQuery", "query": {}}, None),
+            ("inline_funnels", {"kind": "ExperimentFunnelsQuery", "funnels_query": {}}, None),
+            (
+                "saved_trends",
+                None,
+                {"kind": "ExperimentTrendsQuery", "query": {}},
+            ),
+            (
+                "saved_funnels",
+                None,
+                {"kind": "ExperimentFunnelsQuery", "funnels_query": {}},
+            ),
+        ]
+    )
+    def test_update_experiment_detects_various_legacy_metric_types(
+        self, test_name: str, inline_metric: dict | None, saved_metric_query: dict | None
+    ):
+        """Test that legacy detection works for both inline and saved metrics, Trends and Funnels."""
+        from products.experiments.backend.models.experiment import ExperimentToSavedMetric
+
+        service = self._service()
+        flag = self._create_flag(key=f"legacy-detect-{test_name}")
+
+        if inline_metric:
+            # Create with inline legacy metric
+            experiment = Experiment.objects.create(
+                team=self.team,
+                created_by=self.user,
+                feature_flag=flag,
+                name="Legacy Experiment",
+                metrics=[inline_metric],
+                start_date=timezone.now(),
+            )
+        else:
+            # Create with saved legacy metric
+            saved_metric = ExperimentSavedMetric.objects.create(
+                team=self.team,
+                created_by=self.user,
+                name="Legacy Saved Metric",
+                query=saved_metric_query,
+            )
+
+            experiment = Experiment.objects.create(
+                team=self.team,
+                created_by=self.user,
+                feature_flag=flag,
+                name="Legacy Saved Experiment",
+                start_date=timezone.now(),
+            )
+
+            ExperimentToSavedMetric.objects.create(
+                experiment=experiment,
+                saved_metric=saved_metric,
+                metadata={"type": "primary"},
+            )
+
+        # All should be detected as legacy and block disallowed updates
+        with self.assertRaises(ValidationError) as cm:
+            service.update_experiment(experiment, {"metrics": []})
+        self.assertIn("legacy metric formats", str(cm.exception))
+
+    def test_update_experiment_without_legacy_metrics_allows_all_updates(self):
+        """Test that experiments without legacy metrics can be updated normally."""
+        service = self._service()
+        self._create_flag(key="normal-flag")
+
+        # Create experiment with new ExperimentMetric format
+        experiment = service.create_experiment(
+            name="Normal Experiment",
+            feature_flag_key="normal-flag",
+            metrics=[
+                {
+                    "kind": "ExperimentMetric",
+                    "metric_type": "mean",
+                    "source": {"kind": "EventsNode", "event": "test_event"},
+                }
+            ],
+            start_date=timezone.now(),
+        )
+
+        # Should allow updating metrics
+        new_metrics = [
+            {
+                "kind": "ExperimentMetric",
+                "metric_type": "mean",
+                "source": {"kind": "EventsNode", "event": "another_event"},
+            }
+        ]
+        updated = service.update_experiment(experiment, {"metrics": new_metrics})
+        assert updated.metrics
+        assert updated.metrics[0]["source"]["event"] == "another_event"
+
+        # Should allow updating parameters (when draft)
+        experiment.start_date = None
+        experiment.save()
+        updated = service.update_experiment(experiment, {"parameters": {"minimum_detectable_effect": 0.05}})
+        assert updated.parameters == {"minimum_detectable_effect": 0.05}


### PR DESCRIPTION
## Problem

This is the backend version of #52671, where we disable edit legacy experiments. We still allow editing over the API.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Updating the experiment and shared metrics serializers to check for the existence of legacy metrics. For experiments, we allow editing the _name_, _description_, and _end date_, while for shared metrics, we disable all edits.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

```bash
pnpm turbo run backend:test --filter=@posthog/products-experiments
```

![cat-type](https://github.com/user-attachments/assets/56e2ea60-6388-4da7-8226-3d4e48a5bb26)


<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
