### PR TITLE
fix: dark mode in support

### DIFF
--- a/products/conversations/frontend/components/Editor/SupportMarkdown.scss
+++ b/products/conversations/frontend/components/Editor/SupportMarkdown.scss
@@ -26,7 +26,7 @@
     .SupportMarkdown__image-error {
         display: inline-block;
         padding: 0.5em;
-        background: var(--bg-light);
+        background: var(--color-bg-surface-secondary);
         border-radius: var(--radius);
     }
 }

--- a/products/conversations/frontend/components/SidePanel/TicketsList.tsx
+++ b/products/conversations/frontend/components/SidePanel/TicketsList.tsx
@@ -59,7 +59,7 @@ export function TicketsList(): JSX.Element {
                         <div
                             key={ticket.id}
                             className={`flex items-center justify-between p-3 rounded border cursor-pointer hover:bg-surface-light transition-colors ${
-                                (ticket.unread_count ?? 0) > 0 ? 'bg-primary-alt-highlight' : 'bg-white'
+                                (ticket.unread_count ?? 0) > 0 ? 'bg-primary-alt-highlight' : 'bg-surface-primary'
                             }`}
                             onClick={() => {
                                 setCurrentTicket(ticket)


### PR DESCRIPTION
Before
<img width="603" height="407" alt="Screenshot 2026-03-31 at 9 01 41" src="https://github.com/user-attachments/assets/86a5d7bf-d32d-41a3-9a9d-5d44ef66794b" />


After
<img width="579" height="493" alt="Screenshot 2026-03-31 at 9 02 47" src="https://github.com/user-attachments/assets/a5c984e8-9aa1-455c-a858-d4a1207a8713" />
