### PR TITLE
fix(notebooks): skip ScrollableShadows for insight viz nodes to fix height chain

### DIFF
--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodeQuery.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodeQuery.tsx
@@ -119,31 +119,36 @@ const Component = ({
         return null
     }
 
+    const isInsightViz = isInsightVizNode(modifiedQuery) || isSavedInsightNode(modifiedQuery)
+
+    const queryComponent = (
+        <Query
+            uniqueKey={nodeId + '-component'}
+            query={modifiedQuery}
+            attachTo={notebookLogic}
+            setQuery={(t) => {
+                updateAttributes({
+                    query: {
+                        ...attributes.query,
+                        source: (t as DataTableNode | InsightVizNode).source,
+                    } as QuerySchema,
+                })
+            }}
+            embedded
+            readOnly
+        />
+    )
+
     return (
         <div className="flex flex-1 flex-col h-full" data-attr="notebook-node-query">
             <BindLogic logic={insightLogic} props={insightLogicProps}>
-                <ScrollableShadows
-                    direction="vertical"
-                    className="flex-1"
-                    hideScrollbars={isInsightVizNode(modifiedQuery) || isSavedInsightNode(modifiedQuery)}
-                >
-                    <Query
-                        // use separate keys for the settings and visualization to avoid conflicts with insightProps
-                        uniqueKey={nodeId + '-component'}
-                        query={modifiedQuery}
-                        attachTo={notebookLogic}
-                        setQuery={(t) => {
-                            updateAttributes({
-                                query: {
-                                    ...attributes.query,
-                                    source: (t as DataTableNode | InsightVizNode).source,
-                                } as QuerySchema,
-                            })
-                        }}
-                        embedded
-                        readOnly
-                    />
-                </ScrollableShadows>
+                {isInsightViz ? (
+                    <div className="flex flex-1 flex-col overflow-hidden">{queryComponent}</div>
+                ) : (
+                    <ScrollableShadows direction="vertical" className="flex-1">
+                        {queryComponent}
+                    </ScrollableShadows>
+                )}
             </BindLogic>
         </div>
     )


### PR DESCRIPTION
## Problem

Insight viz nodes in notebooks render at ~50% height, leaving a large empty white space below the chart. Caused by #49149 which migrated `ScrollableShadows` to `@base-ui/react/scroll-area` — `ScrollArea.Viewport` sizes to content rather than viewport, breaking the `height: 100%` chain that chart components depend on.

## Changes

- For insight viz and saved insight nodes, bypass `ScrollableShadows` and use a simple flex container that preserves height propagation
- Data table nodes continue using `ScrollableShadows` for scroll behavior

## How did you test this code?

- 0 automated tests added — this is a CSS layout fix; verified by visual inspection that insight nodes fill their notebook pane


## Publish to changelog?

no