### PR TITLE
fix(signup): handle Turnstile challenge in social signup org confirmation flow

### DIFF
--- a/frontend/src/scenes/organization/ConfirmOrganization/ConfirmOrganization.tsx
+++ b/frontend/src/scenes/organization/ConfirmOrganization/ConfirmOrganization.tsx
@@ -11,6 +11,7 @@ import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { LemonDivider } from 'lib/lemon-ui/LemonDivider'
 import { LemonField } from 'lib/lemon-ui/LemonField'
 import { LemonInput } from 'lib/lemon-ui/LemonInput/LemonInput'
+import { TurnstileChallenge } from 'scenes/authentication/signup/signupForm/TurnstileChallenge'
 import { organizationLogic } from 'scenes/organizationLogic'
 import { SceneExport } from 'scenes/sceneTypes'
 
@@ -22,8 +23,15 @@ export const scene: SceneExport = {
 }
 
 export function ConfirmOrganization(): JSX.Element {
-    const { isConfirmOrganizationSubmitting, email, showNewOrgWarning } = useValues(confirmOrganizationLogic)
-    const { setShowNewOrgWarning } = useActions(confirmOrganizationLogic)
+    const {
+        isConfirmOrganizationSubmitting,
+        email,
+        showNewOrgWarning,
+        challengeRequired,
+        turnstileSiteKey,
+        turnstileToken,
+    } = useValues(confirmOrganizationLogic)
+    const { setShowNewOrgWarning, setTurnstileToken } = useActions(confirmOrganizationLogic)
 
     return (
         <BridgePage view="org-creation-confirmation" hedgehog>
@@ -83,15 +91,24 @@ export function ConfirmOrganization(): JSX.Element {
                 <SignupRoleSelect />
                 <SignupReferralSource disabled={isConfirmOrganizationSubmitting} />
 
-                <LemonButton
-                    htmlType="submit"
-                    fullWidth
-                    center
-                    type="primary"
-                    loading={isConfirmOrganizationSubmitting}
-                >
-                    Create organization
-                </LemonButton>
+                {challengeRequired && turnstileSiteKey ? (
+                    <TurnstileChallenge
+                        siteKey={turnstileSiteKey}
+                        onSuccess={setTurnstileToken}
+                        tokenReceived={!!turnstileToken}
+                        email={email}
+                    />
+                ) : (
+                    <LemonButton
+                        htmlType="submit"
+                        fullWidth
+                        center
+                        type="primary"
+                        loading={isConfirmOrganizationSubmitting}
+                    >
+                        Create organization
+                    </LemonButton>
+                )}
             </Form>
 
             <div className="text-center terms-and-conditions-text mt-4 text-secondary">

--- a/frontend/src/scenes/organization/ConfirmOrganization/confirmOrganizationLogic.ts
+++ b/frontend/src/scenes/organization/ConfirmOrganization/confirmOrganizationLogic.ts
@@ -1,4 +1,4 @@
-import { actions, kea, path, reducers } from 'kea'
+import { actions, kea, listeners, path, reducers } from 'kea'
 import { forms } from 'kea-forms'
 import { urlToAction } from 'kea-router'
 
@@ -24,6 +24,11 @@ export const confirmOrganizationLogic = kea<confirmOrganizationLogicType>([
             email,
         }),
         setShowNewOrgWarning: (show: boolean) => ({ show }),
+        setChallengeRequired: (required: boolean) => ({ required }),
+        setChallengeNonce: (nonce: string | null) => ({ nonce }),
+        setTurnstileSiteKey: (siteKey: string | null) => ({ siteKey }),
+        setTurnstileToken: (token: string | null) => ({ token }),
+        resetChallenge: true,
     }),
 
     reducers({
@@ -39,9 +44,36 @@ export const confirmOrganizationLogic = kea<confirmOrganizationLogicType>([
                 setEmail: (_, { email }) => email,
             },
         ],
+        challengeRequired: [
+            false,
+            {
+                setChallengeRequired: (_, { required }) => required,
+                resetChallenge: () => false,
+            },
+        ],
+        challengeNonce: [
+            null as string | null,
+            {
+                setChallengeNonce: (_, { nonce }) => nonce,
+                resetChallenge: () => null,
+            },
+        ],
+        turnstileSiteKey: [
+            null as string | null,
+            {
+                setTurnstileSiteKey: (_, { siteKey }) => siteKey,
+            },
+        ],
+        turnstileToken: [
+            null as string | null,
+            {
+                setTurnstileToken: (_, { token }) => token,
+                resetChallenge: () => null,
+            },
+        ],
     }),
 
-    forms(() => ({
+    forms(({ actions, values }) => ({
         confirmOrganization: {
             defaults: {} as ConfirmOrganizationFormValues,
             errors: ({ organization_name, first_name }) => ({
@@ -50,10 +82,15 @@ export const confirmOrganizationLogic = kea<confirmOrganizationLogicType>([
             }),
 
             submit: async (formValues) => {
+                const submitData: Record<string, any> = { ...formValues }
+
+                if (values.turnstileToken && values.challengeNonce) {
+                    submitData.turnstile_token = values.turnstileToken
+                    submitData.challenge_nonce = values.challengeNonce
+                }
+
                 await api
-                    .create('api/social_signup/', {
-                        ...formValues,
-                    })
+                    .create('api/social_signup/', submitData)
                     .then(() => {
                         const nextUrl = getRelativeNextPath(new URLSearchParams(location.search).get('next'), location)
 
@@ -62,10 +99,27 @@ export const confirmOrganizationLogic = kea<confirmOrganizationLogicType>([
                         location.href = nextUrl || '/'
                     })
                     .catch((error: any) => {
+                        if (error.code === 'challenge_required') {
+                            actions.setTurnstileToken(null)
+                            actions.setChallengeNonce(error.data?.extra?.challenge_nonce)
+                            actions.setTurnstileSiteKey(error.data?.extra?.turnstile_site_key)
+                            actions.setChallengeRequired(true)
+                            return
+                        }
+
+                        actions.resetChallenge()
                         console.error('error', error)
                         lemonToast.error(error.detail || 'Failed to create organization')
                     })
             },
+        },
+    })),
+
+    listeners(({ actions, values }) => ({
+        setTurnstileToken: ({ token }) => {
+            if (token && values.challengeNonce) {
+                actions.submitConfirmOrganization()
+            }
         },
     })),
 

--- a/posthog/api/signup.py
+++ b/posthog/api/signup.py
@@ -572,6 +572,8 @@ class SocialSignupSerializer(serializers.Serializer):
     referral_source_ai_prompt: serializers.Field = serializers.CharField(
         max_length=1000, required=False, allow_blank=True, default=""
     )
+    turnstile_token: serializers.Field = serializers.CharField(required=False, default="")
+    challenge_nonce: serializers.Field = serializers.CharField(required=False, default="")
 
     def create(self, validated_data, **kwargs):
         request = self.context["request"]
@@ -587,6 +589,8 @@ class SocialSignupSerializer(serializers.Serializer):
         referral_source = validated_data.get("referral_source", "")
         referral_source_ai_prompt = validated_data.get("referral_source_ai_prompt", "")
         first_name = validated_data["first_name"]
+        turnstile_token = validated_data.get("turnstile_token", "")
+        challenge_nonce = validated_data.get("challenge_nonce", "")
 
         serializer = SignupSerializer(
             data={
@@ -597,6 +601,8 @@ class SocialSignupSerializer(serializers.Serializer):
                 "role_at_organization": role_at_organization,
                 "referral_source": referral_source,
                 "referral_source_ai_prompt": referral_source_ai_prompt,
+                "turnstile_token": turnstile_token,
+                "challenge_nonce": challenge_nonce,
             },
             context={"request": request},
         )


### PR DESCRIPTION
## Problem

Users signing up via Google OAuth who get a Radar CHALLENGE verdict see a toast saying "Additional verification is required to complete signup." with no way to complete the challenge. The `/organization/confirm-creation` page (`confirmOrganizationLogic`) has no `challenge_required` error handling — the 428 response falls through to a generic `lemonToast.error`.

## Changes

- Add challenge state (actions, reducers, listener) to `confirmOrganizationLogic`
- Handle `challenge_required` error in the form submit catch block, show Turnstile widget instead of toasting
- Auto-resubmit the form when Turnstile token is received
- Add `turnstile_token` and `challenge_nonce` fields to `SocialSignupSerializer` and pass them through to the underlying `SignupSerializer`
- Render `TurnstileChallenge` in place of the submit button on `ConfirmOrganization.tsx` when challenged

## How did you test this code?

- Manually verified with hardcoded CHALLENGE verdict and Turnstile always-pass test keys on both invite and social signup flows via Playwright
- Existing backend API tests cover the `SignupSerializer` challenge flow which `SocialSignupSerializer` delegates to

## Publish to changelog?

no