### PR TITLE
feat(kafka-assigner): add Deregister RPC for graceful consumer shutdown

### DIFF
--- a/proto/kafka_assigner/v1/service.proto
+++ b/proto/kafka_assigner/v1/service.proto
@@ -27,6 +27,18 @@ service KafkaAssigner {
   // PartitionReleased signals that the consumer has released a
   // partition after a handoff completion.
   rpc PartitionReleased(PartitionReleasedRequest) returns (PartitionReleasedResponse);
+
+  // Deregister signals that a consumer is shutting down gracefully.
+  //
+  // The coordinator transitions the consumer to Draining status,
+  // which excludes it from new partition assignments and triggers
+  // handoffs for its current partitions.
+  //
+  // The response tells the consumer whether to wait for all Release
+  // events to complete (WAIT_FOR_DRAIN) or to exit immediately
+  // (SHUTDOWN_NOW). For example, during a StatefulSet rollout the
+  // same pod name will come back, so waiting is unnecessary.
+  rpc Deregister(DeregisterRequest) returns (DeregisterResponse);
 }
 
 // ── Register ─────────────────────────────────────────────
@@ -97,3 +109,25 @@ message PartitionReleasedRequest {
 }
 
 message PartitionReleasedResponse {}
+
+// ── Deregister ──────────────────────────────────────────
+
+message DeregisterRequest {
+  // The consumer name that is shutting down.
+  string consumer_name = 1;
+}
+
+message DeregisterResponse {
+  DeregisterAction action = 1;
+}
+
+enum DeregisterAction {
+  // Exit immediately. Used when the coordinator expects the pod to
+  // come back under the same name (e.g., StatefulSet rollout) or
+  // when K8s awareness is unavailable.
+  SHUTDOWN_NOW = 0;
+  // Keep the gRPC stream open and wait for all Release events to
+  // complete before exiting. Used when partitions must be drained
+  // to other consumers (e.g., Deployment rollout or downscale).
+  WAIT_FOR_DRAIN = 1;
+}

--- a/proto/kafka_assigner/v1/service.proto
+++ b/proto/kafka_assigner/v1/service.proto
@@ -122,12 +122,14 @@ message DeregisterResponse {
 }
 
 enum DeregisterAction {
+  // Unspecified / default. Treated the same as SHUTDOWN_NOW.
+  DEREGISTER_ACTION_UNSPECIFIED = 0;
   // Exit immediately. Used when the coordinator expects the pod to
   // come back under the same name (e.g., StatefulSet rollout) or
   // when K8s awareness is unavailable.
-  SHUTDOWN_NOW = 0;
+  DEREGISTER_ACTION_SHUTDOWN_NOW = 1;
   // Keep the gRPC stream open and wait for all Release events to
   // complete before exiting. Used when partitions must be drained
   // to other consumers (e.g., Deployment rollout or downscale).
-  WAIT_FOR_DRAIN = 1;
+  DEREGISTER_ACTION_WAIT_FOR_DRAIN = 2;
 }

--- a/rust/kafka-assigner/ARCHITECTURE.md
+++ b/rust/kafka-assigner/ARCHITECTURE.md
@@ -66,7 +66,7 @@ rust/
 │   ├── consumer_registry.rs             In-memory local consumer tracking
 │   ├── error.rs                         Error types
 │   └── grpc/
-│       ├── server.rs                    Register / PartitionReady / PartitionReleased
+│       ├── server.rs                    Register / PartitionReady / PartitionReleased / Deregister
 │       ├── relay.rs                     Watch etcd → push events to consumers
 │       └── convert.rs                   Proto ↔ domain conversions
 │
@@ -106,6 +106,12 @@ rust/
      │                                                    │
      │─── PartitionReleased(topic, partition) ───────────►│
      │◄── PartitionReleasedResponse ──────────────────────│
+     │                                                    │
+     │         ... graceful shutdown ...                  │
+     │                                                    │
+     │─── Deregister(consumer_name) ──────────────────────►│
+     │                                                    │  set status = Draining
+     │◄── DeregisterResponse { action } ──────────────────│  (SHUTDOWN_NOW or WAIT_FOR_DRAIN)
      │                                                    │
 ```
 
@@ -267,13 +273,23 @@ Target: 5 each = [5, 5]
    graceful    crash /
    shutdown    disconnect
         │         │
-        │         ▼
-        │    ┌───────────────────┐
-        │    │  Lease expires    │──── TTL provides a grace window for
-        │    │  via TTL          │     reconnection (e.g. rolling restart).
-        │    └────────┬──────────┘     If the consumer reconnects before
-        │             │                expiry, it re-registers with a fresh
-        ▼             ▼                lease — no rebalance occurs.
+        ▼         ▼
+    ┌───────────────────┐    ┌───────────────────┐
+    │  Deregister()     │    │  Lease expires    │──── TTL provides a grace window for
+    │  gRPC call        │    │  via TTL          │     reconnection (e.g. rolling restart).
+    └────────┬──────────┘    └────────┬──────────┘     If the consumer reconnects before
+             │                        │                expiry, it re-registers with a fresh
+             ▼                        │                lease — no rebalance occurs.
+    ┌───────────────────┐             │
+    │  Status: Draining │─────────    │
+    │                   │        │    │
+    │  Excluded from    │   partitions handed off
+    │  new assignments  │   to other consumers
+    │  Partitions drain │   via handoff protocol
+    │  via handoffs     │        │    │
+    └────────┬──────────┘        │    │
+             │                   │    │
+             ▼                   ▼    ▼
     ┌────────────────────┐
     │  Consumer removed  │
     │  from etcd         │

--- a/rust/kafka-assigner/ARCHITECTURE.md
+++ b/rust/kafka-assigner/ARCHITECTURE.md
@@ -111,7 +111,7 @@ rust/
      │                                                    │
      │─── Deregister(consumer_name) ──────────────────────►│
      │                                                    │  set status = Draining
-     │◄── DeregisterResponse { action } ──────────────────│  (SHUTDOWN_NOW or WAIT_FOR_DRAIN)
+     │◄── DeregisterResponse { action } ──────────────────│  (DEREGISTER_ACTION_SHUTDOWN_NOW or DEREGISTER_ACTION_WAIT_FOR_DRAIN)
      │                                                    │
 ```
 

--- a/rust/kafka-assigner/src/consumer_registry.rs
+++ b/rust/kafka-assigner/src/consumer_registry.rs
@@ -52,6 +52,11 @@ impl ConsumerRegistry {
             .map(|c| c.command_tx.clone())
     }
 
+    /// Get the etcd lease ID for a consumer, if connected.
+    pub fn get_lease_id(&self, consumer_name: &str) -> Option<i64> {
+        self.connections.get(consumer_name).map(|c| c.lease_id)
+    }
+
     /// Check if a consumer is connected to this instance.
     pub fn is_connected(&self, consumer_name: &str) -> bool {
         self.connections.contains_key(consumer_name)
@@ -100,6 +105,8 @@ mod tests {
         assert!(!registry.is_connected("c-1"));
         assert!(registry.get_sender("c-0").is_some());
         assert!(registry.get_sender("c-1").is_none());
+        assert_eq!(registry.get_lease_id("c-0"), Some(100));
+        assert_eq!(registry.get_lease_id("c-1"), None);
     }
 
     #[test]

--- a/rust/kafka-assigner/src/grpc/server.rs
+++ b/rust/kafka-assigner/src/grpc/server.rs
@@ -405,6 +405,50 @@ impl KafkaAssigner for KafkaAssignerService {
 
         Ok(Response::new(proto::PartitionReleasedResponse {}))
     }
+
+    async fn deregister(
+        &self,
+        request: Request<proto::DeregisterRequest>,
+    ) -> Result<Response<proto::DeregisterResponse>, Status> {
+        let req = request.into_inner();
+        let consumer_name = &req.consumer_name;
+
+        assignment_coordination::util::validate_identifier(consumer_name)
+            .map_err(|e| Status::invalid_argument(format!("invalid consumer_name: {e}")))?;
+
+        // Look up the consumer's lease ID from the local registry.
+        let lease_id = self
+            .registry
+            .get_lease_id(consumer_name)
+            .ok_or_else(|| Status::not_found(format!("consumer {consumer_name} not connected")))?;
+
+        // Transition the consumer to Draining in etcd. The assigner's
+        // consumer watch loop will see this change and exclude the consumer
+        // from new partition assignments. On the next rebalance (triggered
+        // when all in-flight handoffs complete), the consumer's partitions
+        // will be handed off to other Ready consumers.
+        self.store
+            .update_consumer_status(consumer_name, ConsumerStatus::Draining, lease_id)
+            .await
+            .map_err(|e| {
+                Status::internal(format!("failed to update consumer status to Draining: {e}"))
+            })?;
+
+        // For now, always return SHUTDOWN_NOW. Stage 3 will wire in K8s
+        // awareness to return WAIT_FOR_DRAIN when appropriate (Deployment
+        // rollouts and downscales).
+        let action = proto::DeregisterAction::ShutdownNow;
+
+        tracing::info!(
+            consumer = %consumer_name,
+            action = ?action,
+            "consumer deregistered via gRPC, status set to Draining"
+        );
+
+        Ok(Response::new(proto::DeregisterResponse {
+            action: action.into(),
+        }))
+    }
 }
 
 /// Double-checked locking: run `init_fn` at most once per key.

--- a/rust/kafka-assigner/src/grpc/server.rs
+++ b/rust/kafka-assigner/src/grpc/server.rs
@@ -434,10 +434,11 @@ impl KafkaAssigner for KafkaAssignerService {
                 Status::internal(format!("failed to update consumer status to Draining: {e}"))
             })?;
 
-        // For now, always return SHUTDOWN_NOW. Stage 3 will wire in K8s
-        // awareness to return WAIT_FOR_DRAIN when appropriate (Deployment
-        // rollouts and downscales).
-        let action = proto::DeregisterAction::ShutdownNow;
+        // Always return WAIT_FOR_DRAIN so the consumer stays alive to
+        // complete handoffs via the handoff protocol.
+        // TODO: Wire in K8s awareness to return SHUTDOWN_NOW when the same
+        // pod name will come back (e.g. StatefulSet rollouts).
+        let action = proto::DeregisterAction::WaitForDrain;
 
         tracing::info!(
             consumer = %consumer_name,

--- a/rust/kafka-assigner/tests/grpc_integration.rs
+++ b/rust/kafka-assigner/tests/grpc_integration.rs
@@ -12,7 +12,7 @@ use common::{
     create_grpc_client, create_kafka_topic, start_assigner, start_grpc_server, test_store,
     wait_for_condition, NUM_PARTITIONS, POLL_INTERVAL, WAIT_TIMEOUT,
 };
-use kafka_assigner::types::HandoffPhase;
+use kafka_assigner::types::{ConsumerStatus, HandoffPhase};
 use kafka_assigner_proto::kafka_assigner::v1 as proto;
 use kafka_assigner_proto::kafka_assigner::v1::kafka_assigner_client::KafkaAssignerClient;
 use proto::assignment_command::Command;
@@ -597,6 +597,99 @@ async fn grpc_sequential_crashes_converge() {
         }
     })
     .await;
+
+    cancel.cancel();
+}
+
+// ── Deregister / Draining scenarios ─────────────────────────────
+
+#[tokio::test]
+async fn grpc_deregister_transitions_to_draining_and_drains() {
+    let store = test_store("grpc-deregister").await;
+    let cancel = CancellationToken::new();
+    let topic = test_topic("grpc-deregister");
+
+    create_kafka_topic(&topic, NUM_PARTITIONS as i32).await;
+    let _assigner = start_assigner(Arc::clone(&store), cancel.clone());
+    let server = start_grpc_server(Arc::clone(&store), cancel.clone()).await;
+
+    let c0 = SimulatedConsumer::connect(server.addr, "c-0", &topic).await;
+    let _c0_driver = spawn_consumer_driver(c0, Duration::ZERO);
+    let c1 = SimulatedConsumer::connect(server.addr, "c-1", &topic).await;
+    let _c1_driver = spawn_consumer_driver(c1, Duration::ZERO);
+
+    // Wait for balanced 2-way assignment.
+    let check_store = Arc::clone(&store);
+    wait_for_condition(Duration::from_secs(15), POLL_INTERVAL, || {
+        let store = Arc::clone(&check_store);
+        async move {
+            let handoffs = store.list_handoffs().await.unwrap_or_default();
+            let assignments = store.list_assignments().await.unwrap_or_default();
+            handoffs.is_empty()
+                && assignments.len() == NUM_PARTITIONS as usize
+                && assignments.iter().any(|a| a.owner == "c-0")
+                && assignments.iter().any(|a| a.owner == "c-1")
+        }
+    })
+    .await;
+
+    // Call the Deregister RPC for c-0.
+    let mut client = create_grpc_client(server.addr).await;
+    let response = client
+        .deregister(proto::DeregisterRequest {
+            consumer_name: "c-0".to_string(),
+        })
+        .await
+        .expect("deregister RPC failed");
+    let action = response.into_inner().action();
+    assert_eq!(action, proto::DeregisterAction::ShutdownNow);
+
+    // Verify c-0 is now Draining in the store.
+    let consumers = store.list_consumers().await.unwrap();
+    let c0_consumer = consumers
+        .iter()
+        .find(|c| c.consumer_name == "c-0")
+        .expect("c-0 should still be registered");
+    assert_eq!(c0_consumer.status, ConsumerStatus::Draining);
+
+    // The assigner should move all c-0 partitions to c-1 via handoffs.
+    let check_store = Arc::clone(&store);
+    wait_for_condition(Duration::from_secs(15), POLL_INTERVAL, || {
+        let store = Arc::clone(&check_store);
+        async move {
+            let handoffs = store.list_handoffs().await.unwrap_or_default();
+            let assignments = store.list_assignments().await.unwrap_or_default();
+            handoffs.is_empty()
+                && assignments.len() == NUM_PARTITIONS as usize
+                && assignments.iter().all(|a| a.owner == "c-1")
+        }
+    })
+    .await;
+
+    let assignments = store.list_assignments().await.unwrap();
+    assert_eq!(assignments.len(), NUM_PARTITIONS as usize);
+    assert!(assignments.iter().all(|a| a.owner == "c-1"));
+
+    cancel.cancel();
+}
+
+#[tokio::test]
+async fn grpc_deregister_unknown_consumer_returns_not_found() {
+    let store = test_store("grpc-dereg-404").await;
+    let cancel = CancellationToken::new();
+
+    let server = start_grpc_server(Arc::clone(&store), cancel.clone()).await;
+
+    let mut client = create_grpc_client(server.addr).await;
+    let result = client
+        .deregister(proto::DeregisterRequest {
+            consumer_name: "nonexistent".to_string(),
+        })
+        .await;
+
+    assert!(result.is_err());
+    let status = result.unwrap_err();
+    assert_eq!(status.code(), tonic::Code::NotFound);
 
     cancel.cancel();
 }

--- a/rust/kafka-assigner/tests/grpc_integration.rs
+++ b/rust/kafka-assigner/tests/grpc_integration.rs
@@ -642,7 +642,7 @@ async fn grpc_deregister_transitions_to_draining_and_drains() {
         .await
         .expect("deregister RPC failed");
     let action = response.into_inner().action();
-    assert_eq!(action, proto::DeregisterAction::ShutdownNow);
+    assert_eq!(action, proto::DeregisterAction::WaitForDrain);
 
     // Verify c-0 is now Draining in the store.
     let consumers = store.list_consumers().await.unwrap();

--- a/rust/kafka-assigner/tests/integration.rs
+++ b/rust/kafka-assigner/tests/integration.rs
@@ -12,6 +12,7 @@ use common::{
     NUM_PARTITIONS, POLL_INTERVAL, WAIT_TIMEOUT,
 };
 use kafka_assigner::assigner::AssignerConfig;
+use kafka_assigner::types::ConsumerStatus;
 use kafka_assigner::types::HandoffPhase;
 
 // ── Basic scenarios ─────────────────────────────────────────────
@@ -726,6 +727,130 @@ async fn rapid_scale_up_debounce() {
             "expected even distribution for {name}"
         );
     }
+
+    cancel.cancel();
+}
+
+// ── Deregister / Draining scenarios ─────────────────────────────
+
+#[tokio::test]
+async fn draining_consumer_partitions_are_handed_off() {
+    let store = test_store("draining-handoff").await;
+    let cancel = CancellationToken::new();
+
+    set_topic_config(&store, "events", NUM_PARTITIONS).await;
+    let _assigner = start_assigner(Arc::clone(&store), cancel.clone());
+
+    let c0 = register_consumer(&store, "c-0", 10).await;
+    let _c1 = register_consumer(&store, "c-1", 10).await;
+
+    // Wait for balanced 2-way assignment with handoffs driven to completion.
+    let check_store = Arc::clone(&store);
+    wait_for_condition(Duration::from_secs(15), POLL_INTERVAL, || {
+        let store = Arc::clone(&check_store);
+        async move {
+            let handoffs = store.list_handoffs().await.unwrap_or_default();
+            for h in &handoffs {
+                match h.phase {
+                    HandoffPhase::Warming => signal_ready(&store, &h.topic_partition()).await,
+                    HandoffPhase::Complete => signal_released(&store, &h.topic_partition()).await,
+                    HandoffPhase::Ready => {}
+                }
+            }
+            let assignments = store.list_assignments().await.unwrap_or_default();
+            assignments.len() == NUM_PARTITIONS as usize
+                && store.list_handoffs().await.unwrap_or_default().is_empty()
+                && assignments.iter().any(|a| a.owner == "c-0")
+                && assignments.iter().any(|a| a.owner == "c-1")
+        }
+    })
+    .await;
+
+    // Transition c-0 to Draining (what the Deregister handler does).
+    store
+        .update_consumer_status("c-0", ConsumerStatus::Draining, c0.lease_id)
+        .await
+        .unwrap();
+
+    // The assigner should rebalance: c-0 is excluded from new assignments,
+    // so all partitions should move to c-1 via handoffs.
+    let check_store = Arc::clone(&store);
+    wait_for_condition(Duration::from_secs(15), POLL_INTERVAL, || {
+        let store = Arc::clone(&check_store);
+        async move {
+            let handoffs = store.list_handoffs().await.unwrap_or_default();
+            for h in &handoffs {
+                match h.phase {
+                    HandoffPhase::Warming => signal_ready(&store, &h.topic_partition()).await,
+                    HandoffPhase::Complete => signal_released(&store, &h.topic_partition()).await,
+                    HandoffPhase::Ready => {}
+                }
+            }
+            let assignments = store.list_assignments().await.unwrap_or_default();
+            assignments.len() == NUM_PARTITIONS as usize
+                && store.list_handoffs().await.unwrap_or_default().is_empty()
+                && assignments.iter().all(|a| a.owner == "c-1")
+        }
+    })
+    .await;
+
+    // Verify: all partitions owned by c-1, none by c-0.
+    let assignments = store.list_assignments().await.unwrap();
+    assert_eq!(assignments.len(), NUM_PARTITIONS as usize);
+    assert!(assignments.iter().all(|a| a.owner == "c-1"));
+
+    cancel.cancel();
+}
+
+#[tokio::test]
+async fn draining_consumer_still_receives_handoffs_as_old_owner() {
+    let store = test_store("draining-old-owner").await;
+    let cancel = CancellationToken::new();
+
+    set_topic_config(&store, "events", NUM_PARTITIONS).await;
+    let _assigner = start_assigner(Arc::clone(&store), cancel.clone());
+
+    let c0 = register_consumer(&store, "c-0", 10).await;
+
+    // c-0 gets all partitions.
+    let check_store = Arc::clone(&store);
+    wait_for_condition(WAIT_TIMEOUT, POLL_INTERVAL, || {
+        let store = Arc::clone(&check_store);
+        async move {
+            let assignments = store.list_assignments().await.unwrap_or_default();
+            assignments.len() == NUM_PARTITIONS as usize
+                && assignments.iter().all(|a| a.owner == "c-0")
+        }
+    })
+    .await;
+
+    // Set c-0 to Draining, then add c-1.
+    store
+        .update_consumer_status("c-0", ConsumerStatus::Draining, c0.lease_id)
+        .await
+        .unwrap();
+    let _c1 = register_consumer(&store, "c-1", 10).await;
+
+    // Handoffs should be created with c-0 as old_owner (still alive/registered).
+    let check_store = Arc::clone(&store);
+    wait_for_condition(WAIT_TIMEOUT, POLL_INTERVAL, || {
+        let store = Arc::clone(&check_store);
+        async move {
+            let handoffs = store.list_handoffs().await.unwrap_or_default();
+            !handoffs.is_empty()
+                && handoffs
+                    .iter()
+                    .all(|h| h.old_owner == "c-0" && h.new_owner == "c-1")
+        }
+    })
+    .await;
+
+    // Drive handoffs to completion.
+    drive_handoffs_to_completion(&store).await;
+
+    // All partitions now owned by c-1.
+    let assignments = store.list_assignments().await.unwrap();
+    assert!(assignments.iter().all(|a| a.owner == "c-1"));
 
     cancel.cancel();
 }


### PR DESCRIPTION
## Problem

When a kafka-assigner consumer shuts down, it relies entirely on etcd lease expiry (TTL) to detect the departure. This means partitions sit unassigned for the full TTL window, causing unnecessary lag during planned operations like rollouts and downscales.

## Changes

- Add a `Deregister` gRPC RPC to the kafka-assigner proto that transitions a consumer to `Draining` status and returns an action hint (`SHUTDOWN_NOW` or `WAIT_FOR_DRAIN`)
- Implement the server-side handler that looks up the consumer's lease, updates its status to `Draining` in etcd, and currently defaults to `SHUTDOWN_NOW` (K8s-aware action selection comes in a follow-up)
- Add `get_lease_id()` to `ConsumerRegistry` so the Deregister handler can look up the lease without an extra etcd round-trip
- Add integration tests covering the full drain flow (partitions handed off to surviving consumer) and the not-found error case
- Add direct store-level tests for draining consumer behavior: partition handoff and continued handoff participation as old owner
- Update ARCHITECTURE.md with the new Deregister flow and draining lifecycle diagrams

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
