### PR TITLE
feat(personhog): add graceful drain protocol for pod shutdown

### DIFF
--- a/rust/personhog-coordination/src/pod.rs
+++ b/rust/personhog-coordination/src/pod.rs
@@ -34,6 +34,10 @@ pub struct PodConfig {
     pub generation: String,
     pub lease_ttl: i64,
     pub heartbeat_interval: Duration,
+    /// How long to wait for partitions to drain before shutting down.
+    /// Should be less than K8s terminationGracePeriodSeconds to allow
+    /// time for lease revocation before SIGKILL.
+    pub drain_timeout: Duration,
 }
 
 impl Default for PodConfig {
@@ -43,6 +47,7 @@ impl Default for PodConfig {
             generation: "blue".to_string(),
             lease_ttl: 30,
             heartbeat_interval: Duration::from_secs(10),
+            drain_timeout: Duration::from_secs(30),
         }
     }
 }
@@ -73,19 +78,45 @@ impl PodHandle {
     ///
     /// 1. Register with etcd (creates lease + key)
     /// 2. Start heartbeat loop
-    /// 3. Watch for handoff events
+    /// 3. Watch for handoff and assignment events
+    /// 4. On cancellation (SIGTERM): transition to Draining, wait for
+    ///    partition handoffs to complete, then revoke lease and exit
     pub async fn run(&self, cancel: CancellationToken) -> Result<()> {
         let lease_id = self.store.grant_lease(self.config.lease_ttl).await?;
         self.register(lease_id).await?;
 
         tracing::info!(pod = %self.config.pod_name, "registered with etcd");
 
-        let result = self.run_loops(lease_id, cancel.clone()).await;
+        // Heartbeat runs for the entire pod lifetime, including drain phase.
+        // This keeps the lease alive so the coordinator sees a Draining pod
+        // (not a crashed one with an expired lease).
+        let heartbeat_cancel = CancellationToken::new();
+        let heartbeat_handle = {
+            let store = Arc::clone(&self.store);
+            let interval = self.config.heartbeat_interval;
+            let token = heartbeat_cancel.child_token();
+            tokio::spawn(async move {
+                util::run_lease_keepalive(store, lease_id, interval, token).await
+            })
+        };
 
-        // Best-effort unregister on shutdown
-        if !cancel.is_cancelled() {
-            drop(self.store.revoke_lease(lease_id).await);
+        // Phase 1: Normal operation - watch handoffs and assignments until cancelled
+        let result = tokio::select! {
+            r = self.watch_handoff_loop(cancel.clone()) => r,
+            r = self.watch_assignment_loop(cancel.clone()) => r,
+        };
+
+        // Phase 2: If cancelled externally (SIGTERM), drain gracefully
+        if cancel.is_cancelled() {
+            if let Err(e) = self.drain(lease_id).await {
+                tracing::warn!(pod = %self.config.pod_name, error = %e, "drain failed");
+            }
         }
+
+        // Cleanup: stop heartbeat and revoke lease
+        heartbeat_cancel.cancel();
+        drop(heartbeat_handle.await);
+        drop(self.store.revoke_lease(lease_id).await);
 
         result
     }
@@ -102,27 +133,60 @@ impl PodHandle {
         self.store.register_pod(&pod, lease_id).await
     }
 
-    async fn run_loops(&self, lease_id: i64, cancel: CancellationToken) -> Result<()> {
-        let heartbeat_cancel = cancel.child_token();
-        let heartbeat_handle = {
-            let store = Arc::clone(&self.store);
-            let interval = self.config.heartbeat_interval;
-            let token = heartbeat_cancel.clone();
-            tokio::spawn(async move {
-                util::run_lease_keepalive(store, lease_id, interval, token).await
-            })
-        };
+    /// Graceful drain: set status to Draining, then keep processing handoff
+    /// events until all owned partitions have been released or timeout.
+    ///
+    /// The coordinator sees the Draining status, excludes this pod from
+    /// active assignments, and creates handoffs for its partitions. This pod
+    /// continues watching for handoff Complete events to release partitions.
+    async fn drain(&self, lease_id: i64) -> Result<()> {
+        self.store
+            .update_pod_status(&self.config.pod_name, PodStatus::Draining, lease_id)
+            .await?;
 
-        // Run handoff and assignment watches concurrently
-        let result = tokio::select! {
-            r = self.watch_handoff_loop(cancel.clone()) => r,
-            r = self.watch_assignment_loop(cancel.clone()) => r,
-        };
+        tracing::info!(
+            pod = %self.config.pod_name,
+            "set status to Draining, waiting for partition handoffs"
+        );
 
-        heartbeat_cancel.cancel();
-        drop(heartbeat_handle.await);
+        if self.owned_partitions.lock().await.is_empty() {
+            tracing::info!(pod = %self.config.pod_name, "no partitions to drain");
+            return Ok(());
+        }
 
-        result
+        // Keep watching handoffs during drain so we can release partitions
+        // when the coordinator completes them.
+        let drain_cancel = CancellationToken::new();
+
+        tokio::select! {
+            r = self.watch_handoff_loop(drain_cancel.clone()) => {
+                r?;
+            },
+            _ = self.wait_for_drain() => {
+                tracing::info!(pod = %self.config.pod_name, "all partitions drained successfully");
+            },
+            _ = tokio::time::sleep(self.config.drain_timeout) => {
+                let remaining = self.owned_partitions.lock().await.len();
+                tracing::warn!(
+                    pod = %self.config.pod_name,
+                    remaining_partitions = remaining,
+                    "drain timeout exceeded, shutting down"
+                );
+            }
+        }
+
+        drain_cancel.cancel();
+        Ok(())
+    }
+
+    /// Poll until all owned partitions have been released via handoffs.
+    async fn wait_for_drain(&self) {
+        loop {
+            if self.owned_partitions.lock().await.is_empty() {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
     }
 
     async fn watch_handoff_loop(&self, cancel: CancellationToken) -> Result<()> {

--- a/rust/personhog-coordination/src/pod.rs
+++ b/rust/personhog-coordination/src/pod.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 
 use async_trait::async_trait;
 use etcd_client::EventType;
-use tokio::sync::Mutex;
+use tokio::sync::{Mutex, Notify};
 use tokio_util::sync::CancellationToken;
 
 use assignment_coordination::store::parse_watch_value;
@@ -58,6 +58,8 @@ pub struct PodHandle {
     handler: Arc<dyn HandoffHandler>,
     /// Partitions this pod has warmed. Used to avoid re-warming on assignment watches.
     owned_partitions: Mutex<HashSet<u32>>,
+    /// Signalled when a partition is released, waking `drain()` without polling.
+    drain_notify: Notify,
 }
 
 impl PodHandle {
@@ -71,6 +73,7 @@ impl PodHandle {
             config,
             handler,
             owned_partitions: Mutex::new(HashSet::new()),
+            drain_notify: Notify::new(),
         }
     }
 
@@ -179,13 +182,14 @@ impl PodHandle {
         Ok(())
     }
 
-    /// Poll until all owned partitions have been released via handoffs.
+    /// Wait until all owned partitions have been released via handoffs.
+    /// Woken reactively by `drain_notify` each time a partition is released.
     async fn wait_for_drain(&self) {
         loop {
             if self.owned_partitions.lock().await.is_empty() {
                 return;
             }
-            tokio::time::sleep(Duration::from_millis(100)).await;
+            self.drain_notify.notified().await;
         }
     }
 
@@ -243,6 +247,7 @@ impl PodHandle {
                 .lock()
                 .await
                 .remove(&handoff.partition);
+            self.drain_notify.notify_one();
         }
 
         Ok(())

--- a/rust/personhog-coordination/src/store.rs
+++ b/rust/personhog-coordination/src/store.rs
@@ -82,6 +82,11 @@ impl PersonhogStore {
         Ok(self.inner.get(&key).await?)
     }
 
+    pub async fn delete_pod(&self, pod_name: &str) -> Result<()> {
+        let key = self.key(StoreKey::Pod(pod_name));
+        Ok(self.inner.delete(&key).await?)
+    }
+
     pub async fn list_pods(&self) -> Result<Vec<RegisteredPod>> {
         let key = self.key(StoreKey::PodsPrefix);
         Ok(self.inner.list(&key).await?)

--- a/rust/personhog-coordination/tests/common/mod.rs
+++ b/rust/personhog-coordination/tests/common/mod.rs
@@ -81,6 +81,7 @@ pub fn start_coordinator_named(
 
 pub struct PodHandles {
     pub events: Arc<Mutex<Vec<HandoffEvent>>>,
+    pub join_handle: Option<JoinHandle<Result<()>>>,
 }
 
 pub fn start_pod(store: Arc<PersonhogStore>, name: &str, cancel: CancellationToken) -> PodHandles {
@@ -106,8 +107,11 @@ pub fn start_pod_with_lease_ttl(
         Arc::new(handler),
     );
     let token = cancel.child_token();
-    tokio::spawn(async move { pod.run(token).await });
-    PodHandles { events }
+    let join_handle = tokio::spawn(async move { pod.run(token).await });
+    PodHandles {
+        events,
+        join_handle: Some(join_handle),
+    }
 }
 
 /// Start a pod whose warm_partition blocks forever. Useful for testing
@@ -131,8 +135,11 @@ pub fn start_pod_blocking(
         Arc::new(handler),
     );
     let token = cancel.child_token();
-    tokio::spawn(async move { pod.run(token).await });
-    PodHandles { events }
+    let join_handle = tokio::spawn(async move { pod.run(token).await });
+    PodHandles {
+        events,
+        join_handle: Some(join_handle),
+    }
 }
 
 pub fn start_coordinator_with_debounce(
@@ -169,8 +176,11 @@ pub fn start_pod_slow(
         Arc::new(handler),
     );
     let token = cancel.child_token();
-    tokio::spawn(async move { pod.run(token).await });
-    PodHandles { events }
+    let join_handle = tokio::spawn(async move { pod.run(token).await });
+    PodHandles {
+        events,
+        join_handle: Some(join_handle),
+    }
 }
 
 pub struct RouterHandles {

--- a/rust/personhog-coordination/tests/integration.rs
+++ b/rust/personhog-coordination/tests/integration.rs
@@ -71,6 +71,7 @@ strategy_tests! {
     rolling_update,
     coordinator_starts_after_pods,
     debounce_batches_rapid_pod_changes,
+    graceful_drain_transfers_partitions,
 }
 
 async fn single_pod_gets_all_partitions(
@@ -1047,4 +1048,105 @@ async fn debounce_batches_rapid_pod_changes(
     }
 
     cancel.cancel();
+}
+
+/// Verify that a pod going through graceful drain (SIGTERM) hands off its
+/// partitions to surviving pods before exiting.
+///
+/// Flow:
+/// 1. Two pods share partitions.
+/// 2. Pod-0 receives cancel (simulating SIGTERM) → sets status to Draining.
+/// 3. Coordinator sees Draining, creates handoffs to pod-1.
+/// 4. Pod-0 releases partitions after handoff completes.
+/// 5. Pod-1 ends up owning all partitions.
+async fn graceful_drain_transfers_partitions(
+    test_name: &str,
+    strategy: Arc<dyn AssignmentStrategy>,
+    _evenly_distributed: bool,
+) {
+    let store = test_store(test_name).await;
+    store.set_total_partitions(NUM_PARTITIONS).await.unwrap();
+
+    let coord_cancel = CancellationToken::new();
+    let _coord = start_coordinator(
+        Arc::clone(&store),
+        Arc::clone(&strategy),
+        coord_cancel.clone(),
+    );
+    let _router = start_router(Arc::clone(&store), "router-0", coord_cancel.clone());
+
+    // Start two pods, each with its own cancel token
+    let pod0_cancel = CancellationToken::new();
+    let pod0 = start_pod(Arc::clone(&store), "writer-0", pod0_cancel.clone());
+    let _pod1 = start_pod(Arc::clone(&store), "writer-1", coord_cancel.clone());
+
+    // Wait for both pods to have partitions assigned
+    let check_store = Arc::clone(&store);
+    wait_for_condition(WAIT_TIMEOUT, POLL_INTERVAL, || {
+        let store = Arc::clone(&check_store);
+        async move {
+            let assignments = store.list_assignments().await.unwrap_or_default();
+            let handoffs = store.list_handoffs().await.unwrap_or_default();
+            assignments.len() == NUM_PARTITIONS as usize
+                && assignments.iter().any(|a| a.owner == "writer-0")
+                && assignments.iter().any(|a| a.owner == "writer-1")
+                && handoffs.is_empty()
+        }
+    })
+    .await;
+
+    // Cancel pod-0 (simulates SIGTERM) — it should drain gracefully
+    pod0_cancel.cancel();
+
+    // Wait for pod-0 to transition away from Ready
+    let check_store = Arc::clone(&store);
+    wait_for_condition(WAIT_TIMEOUT, POLL_INTERVAL, || {
+        let store = Arc::clone(&check_store);
+        async move {
+            let pods = store.list_pods().await.unwrap_or_default();
+            !pods.iter().any(|p| {
+                p.pod_name == "writer-0"
+                    && p.status == personhog_coordination::types::PodStatus::Ready
+            })
+        }
+    })
+    .await;
+
+    // Wait for all partitions to be owned by pod-1 (handoffs complete)
+    let check_store = Arc::clone(&store);
+    wait_for_condition(WAIT_TIMEOUT, POLL_INTERVAL, || {
+        let store = Arc::clone(&check_store);
+        async move {
+            let assignments = store.list_assignments().await.unwrap_or_default();
+            let handoffs = store.list_handoffs().await.unwrap_or_default();
+            assignments.len() == NUM_PARTITIONS as usize
+                && assignments.iter().all(|a| a.owner == "writer-1")
+                && handoffs.is_empty()
+        }
+    })
+    .await;
+
+    // Verify pod-0 released its partitions (check events)
+    let events = pod0.events.lock().await;
+    let released: Vec<_> = events
+        .iter()
+        .filter(|e| matches!(e, HandoffEvent::Released(_)))
+        .collect();
+    assert!(
+        !released.is_empty(),
+        "pod-0 should have released partitions during drain"
+    );
+
+    // Verify all partitions belong to pod-1
+    let assignments = store.list_assignments().await.unwrap();
+    assert_eq!(assignments.len(), NUM_PARTITIONS as usize);
+    for a in &assignments {
+        assert_eq!(
+            a.owner, "writer-1",
+            "partition {} should be owned by writer-1",
+            a.partition
+        );
+    }
+
+    coord_cancel.cancel();
 }

--- a/rust/personhog-coordination/tests/integration.rs
+++ b/rust/personhog-coordination/tests/integration.rs
@@ -1201,7 +1201,10 @@ async fn drain_status_write_failure_exits_cleanly() {
         .expect("pod should exit within 5s, not hang")
         .expect("pod task should not panic");
     // drain() failure is logged as a warning, run() still returns Ok
-    assert!(result.is_ok(), "pod should exit cleanly despite drain failure");
+    assert!(
+        result.is_ok(),
+        "pod should exit cleanly despite drain failure"
+    );
 
     coord_cancel.cancel();
 }

--- a/rust/personhog-coordination/tests/integration.rs
+++ b/rust/personhog-coordination/tests/integration.rs
@@ -1126,16 +1126,19 @@ async fn graceful_drain_transfers_partitions(
     })
     .await;
 
-    // Verify pod-0 released its partitions (check events)
-    let events = pod0.events.lock().await;
-    let released: Vec<_> = events
-        .iter()
-        .filter(|e| matches!(e, HandoffEvent::Released(_)))
-        .collect();
-    assert!(
-        !released.is_empty(),
-        "pod-0 should have released partitions during drain"
-    );
+    // Wait for pod-0 to record Released events (may lag behind handoff deletion)
+    let check_events = Arc::clone(&pod0.events);
+    wait_for_condition(WAIT_TIMEOUT, POLL_INTERVAL, || {
+        let events = Arc::clone(&check_events);
+        async move {
+            events
+                .lock()
+                .await
+                .iter()
+                .any(|e| matches!(e, HandoffEvent::Released(_)))
+        }
+    })
+    .await;
 
     // Verify all partitions belong to pod-1
     let assignments = store.list_assignments().await.unwrap();

--- a/rust/personhog-coordination/tests/integration.rs
+++ b/rust/personhog-coordination/tests/integration.rs
@@ -1153,3 +1153,55 @@ async fn graceful_drain_transfers_partitions(
 
     coord_cancel.cancel();
 }
+
+/// Verify that when the drain status write to etcd fails (e.g. pod key was
+/// already deleted), the pod exits cleanly without hanging or panicking.
+/// It falls back to lease-based cleanup.
+#[tokio::test]
+async fn drain_status_write_failure_exits_cleanly() {
+    let store = test_store("drain-write-fail").await;
+    store.set_total_partitions(NUM_PARTITIONS).await.unwrap();
+
+    let coord_cancel = CancellationToken::new();
+    let strategy: Arc<dyn AssignmentStrategy> = Arc::new(StickyBalancedStrategy);
+    let _coord = start_coordinator(
+        Arc::clone(&store),
+        Arc::clone(&strategy),
+        coord_cancel.clone(),
+    );
+    let _router = start_router(Arc::clone(&store), "router-0", coord_cancel.clone());
+
+    let pod0_cancel = CancellationToken::new();
+    let pod0 = start_pod(Arc::clone(&store), "writer-0", pod0_cancel.clone());
+
+    // Wait for pod-0 to get all partitions
+    let check_store = Arc::clone(&store);
+    wait_for_condition(WAIT_TIMEOUT, POLL_INTERVAL, || {
+        let store = Arc::clone(&check_store);
+        async move {
+            let assignments = store.list_assignments().await.unwrap_or_default();
+            assignments.len() == NUM_PARTITIONS as usize
+                && assignments.iter().all(|a| a.owner == "writer-0")
+        }
+    })
+    .await;
+
+    // Delete the pod's key from etcd before cancelling. This simulates
+    // the lease expiring or etcd state being lost. When drain() tries
+    // update_pod_status(), it will fail with NotFound.
+    store.delete_pod("writer-0").await.unwrap();
+
+    // Cancel pod-0 (simulates SIGTERM)
+    pod0_cancel.cancel();
+
+    // The pod should exit cleanly within a reasonable time, not hang.
+    let join_handle = pod0.join_handle.unwrap();
+    let result = tokio::time::timeout(Duration::from_secs(5), join_handle)
+        .await
+        .expect("pod should exit within 5s, not hang")
+        .expect("pod task should not panic");
+    // drain() failure is logged as a warning, run() still returns Ok
+    assert!(result.is_ok(), "pod should exit cleanly despite drain failure");
+
+    coord_cancel.cancel();
+}


### PR DESCRIPTION
## Problem

When a personhog pod receives a SIGTERM (e.g. during a rollout or downscale), it revokes its lease and exits immediately. This causes the coordinator to treat it as a crash, and partitions sit unassigned until the next rebalance cycle detects the missing pod.

## Changes

- Add a `drain_timeout` field to `PodConfig` (default 30s) that controls how long a pod waits for partitions to drain before force-exiting
- Restructure `PodHandle::run()` into two phases: normal operation (watch handoffs/assignments) and drain (on cancellation, transition to `Draining` status and keep processing handoff events)
- Keep the heartbeat alive during drain so the coordinator sees a `Draining` pod rather than a crashed one with an expired lease
- Add a `graceful_drain_transfers_partitions` integration test that simulates SIGTERM on a pod and verifies all partitions are handed off to the surviving pod before exit

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
