### PR TITLE
fix(signup): skip Radar evaluation and Turnstile challenge for SSO signups

### DIFF
--- a/posthog/api/signup.py
+++ b/posthog/api/signup.py
@@ -179,15 +179,16 @@ class SignupSerializer(serializers.Serializer):
         request = self.context["request"]
         passkey_credential = request.session.get(WEBAUTHN_SIGNUP_CREDENTIAL_KEY)
 
-        auth_method = RadarAuthMethod.PASSKEY if passkey_credential else RadarAuthMethod.PASSWORD
-        evaluate_auth_attempt(
-            request=request._request,
-            email=validated_data["email"],
-            action=RadarAction.SIGNUP,
-            auth_method=auth_method,
-            turnstile_token=validated_data.get("turnstile_token", ""),
-            challenge_nonce=validated_data.get("challenge_nonce", ""),
-        )
+        if not self.is_social_signup:
+            auth_method = RadarAuthMethod.PASSKEY if passkey_credential else RadarAuthMethod.PASSWORD
+            evaluate_auth_attempt(
+                request=request._request,
+                email=validated_data["email"],
+                action=RadarAction.SIGNUP,
+                auth_method=auth_method,
+                turnstile_token=validated_data.get("turnstile_token", ""),
+                challenge_nonce=validated_data.get("challenge_nonce", ""),
+            )
 
         is_instance_first_user: bool = not User.objects.exists()
 

--- a/posthog/api/test/test_signup.py
+++ b/posthog/api/test/test_signup.py
@@ -1339,6 +1339,32 @@ class TestSignupChallengeAPI(APIBaseTest):
         user = User.objects.get(email="challenge@posthog.com")
         self.assertEqual(user.first_name, "John")
 
+    @pytest.mark.skip_on_multitenancy
+    @patch("posthog.workos_radar._call_radar_api")
+    @patch("posthoganalytics.capture")
+    @override_settings(
+        WORKOS_RADAR_ENABLED=True,
+        WORKOS_RADAR_API_KEY="test_key",
+        CLOUDFLARE_TURNSTILE_SITE_KEY="site_key_123",
+    )
+    def test_social_signup_skips_radar_evaluation(self, mock_capture, mock_call_api):
+        session = self.client.session
+        session["backend"] = "google-oauth2"
+        session["email"] = "social@posthog.com"
+        session["user_name"] = "Social User"
+        session.save()
+
+        response = self.client.post(
+            "/api/social_signup/",
+            {
+                "first_name": "Social",
+                "organization_name": "Social Org",
+            },
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        mock_call_api.assert_not_called()
+
 
 class TestInviteSignupChallengeAPI(APIBaseTest):
     CONFIG_EMAIL = None


### PR DESCRIPTION
## Problem

SSO signups (Google OAuth, SAML) that go through `SocialSignupSerializer` → `SignupSerializer` were being evaluated by WorkOS Radar. When Radar returned a CHALLENGE verdict, users saw a toast saying "Additional verification is required to complete signup." with no way to resolve it, since the `/organization/confirm-creation` page had no Turnstile challenge handling.

SSO signups are already authenticated by the identity provider, so Radar evaluation adds no value and creates a broken UX.

## Changes

- Skip `evaluate_auth_attempt` in `SignupSerializer.create()` when `self.is_social_signup` is `True`
- Add test verifying `_call_radar_api` is not called during social signup

## How did you test this code?

- 1 integration test added (`test_social_signup_skips_radar_evaluation`)

## Publish to changelog?

no