### PR TITLE
fix: Improve the SLO dashboard with events outside boundaries

### DIFF
--- a/posthog/slo/context.py
+++ b/posthog/slo/context.py
@@ -28,6 +28,7 @@ from os import sep
 from pathlib import Path
 from time import monotonic
 from typing import Any
+from uuid import uuid4
 
 from posthog.slo.events import emit_slo_completed, emit_slo_started
 from posthog.slo.types import SloArea, SloCompletedProperties, SloOperation, SloOutcome, SloStartedProperties
@@ -115,6 +116,7 @@ def slo_operation(
 
     handle = SloHandle()
     base_properties = dict(properties or {})
+    base_properties["correlation_id"] = str(uuid4())
     started_at = monotonic()
     token = _current_slo.set(handle)
 

--- a/posthog/slo/test/test_slo_context.py
+++ b/posthog/slo/test/test_slo_context.py
@@ -65,17 +65,19 @@ def test_slo_operation_emits_success_with_completion_properties(
         assert get_current_slo() is slo
         _tag_from_current_slo(alert_state="healthy", notifications_sent=2)
 
-    mock_emit_slo_started.assert_called_once_with(
-        distinct_id="alert-123",
-        properties=SloStartedProperties(
-            area=SloArea.ANALYTIC_PLATFORM,
-            operation=SloOperation.ALERT_CHECK,
-            team_id=123,
-            resource_id="alert-123",
-        ),
-        extra_properties={"calculation_interval": "hourly"},
-        capture=capture,
+    mock_emit_slo_started.assert_called_once()
+    started_kwargs = mock_emit_slo_started.call_args.kwargs
+    assert started_kwargs["distinct_id"] == "alert-123"
+    assert started_kwargs["properties"] == SloStartedProperties(
+        area=SloArea.ANALYTIC_PLATFORM,
+        operation=SloOperation.ALERT_CHECK,
+        team_id=123,
+        resource_id="alert-123",
     )
+    assert started_kwargs["capture"] is capture
+    assert "correlation_id" in started_kwargs["extra_properties"]
+    started_correlation_id = started_kwargs["extra_properties"].pop("correlation_id")
+    assert started_kwargs["extra_properties"] == {"calculation_interval": "hourly"}
 
     mock_emit_slo_completed.assert_called_once()
     completed_kwargs = mock_emit_slo_completed.call_args.kwargs
@@ -88,6 +90,9 @@ def test_slo_operation_emits_success_with_completion_properties(
         resource_id="alert-123",
         duration_ms=completed_kwargs["properties"].duration_ms,
     )
+    assert "correlation_id" in completed_kwargs["extra_properties"]
+    completed_correlation_id = completed_kwargs["extra_properties"].pop("correlation_id")
+    assert started_correlation_id == completed_correlation_id
     assert completed_kwargs["extra_properties"] == {
         "calculation_interval": "hourly",
         "alert_state": "healthy",
@@ -127,8 +132,13 @@ def test_slo_operation_emits_failure_with_automatic_error_properties(
 
     mock_emit_slo_started.assert_called_once()
     mock_emit_slo_completed.assert_called_once()
+    started_kwargs = mock_emit_slo_started.call_args.kwargs
     completed_kwargs = mock_emit_slo_completed.call_args.kwargs
     assert completed_kwargs["properties"].outcome == SloOutcome.FAILURE
+    assert (
+        started_kwargs["extra_properties"]["correlation_id"] == completed_kwargs["extra_properties"]["correlation_id"]
+    )
+    completed_kwargs["extra_properties"].pop("correlation_id")
     assert completed_kwargs["extra_properties"] == {
         "calculation_interval": "daily",
         "error_type": "RuntimeError",
@@ -208,8 +218,13 @@ def test_slo_operation_allows_no_exception_outcome_override(
 
     mock_emit_slo_started.assert_called_once()
     mock_emit_slo_completed.assert_called_once()
+    started_kwargs = mock_emit_slo_started.call_args.kwargs
     completed_kwargs = mock_emit_slo_completed.call_args.kwargs
     assert completed_kwargs["properties"].outcome == expected_outcome
+    assert (
+        started_kwargs["extra_properties"]["correlation_id"] == completed_kwargs["extra_properties"]["correlation_id"]
+    )
+    completed_kwargs["extra_properties"].pop("correlation_id")
     assert completed_kwargs["extra_properties"] == expected_extra_properties
 
 
@@ -255,4 +270,8 @@ async def test_slo_operation_contextvar_survives_await(
 
     mock_emit_slo_started.assert_called_once()
     mock_emit_slo_completed.assert_called_once()
-    assert mock_emit_slo_completed.call_args.kwargs["extra_properties"] == {"async_stage": "after_await"}
+    started_extra = mock_emit_slo_started.call_args.kwargs["extra_properties"]
+    completed_extra = mock_emit_slo_completed.call_args.kwargs["extra_properties"]
+    assert started_extra["correlation_id"] == completed_extra["correlation_id"]
+    completed_extra.pop("correlation_id")
+    assert completed_extra == {"async_stage": "after_await"}

--- a/posthog/slo/test/test_slo_context.py
+++ b/posthog/slo/test/test_slo_context.py
@@ -75,9 +75,8 @@ def test_slo_operation_emits_success_with_completion_properties(
         resource_id="alert-123",
     )
     assert started_kwargs["capture"] is capture
-    assert "correlation_id" in started_kwargs["extra_properties"]
-    started_correlation_id = started_kwargs["extra_properties"].pop("correlation_id")
-    assert started_kwargs["extra_properties"] == {"calculation_interval": "hourly"}
+    correlation_id = started_kwargs["extra_properties"]["correlation_id"]
+    assert started_kwargs["extra_properties"] == {"calculation_interval": "hourly", "correlation_id": correlation_id}
 
     mock_emit_slo_completed.assert_called_once()
     completed_kwargs = mock_emit_slo_completed.call_args.kwargs
@@ -90,11 +89,10 @@ def test_slo_operation_emits_success_with_completion_properties(
         resource_id="alert-123",
         duration_ms=completed_kwargs["properties"].duration_ms,
     )
-    assert "correlation_id" in completed_kwargs["extra_properties"]
-    completed_correlation_id = completed_kwargs["extra_properties"].pop("correlation_id")
-    assert started_correlation_id == completed_correlation_id
+    assert completed_kwargs["extra_properties"]["correlation_id"] == correlation_id
     assert completed_kwargs["extra_properties"] == {
         "calculation_interval": "hourly",
+        "correlation_id": correlation_id,
         "alert_state": "healthy",
         "notifications_sent": 2,
     }
@@ -135,12 +133,10 @@ def test_slo_operation_emits_failure_with_automatic_error_properties(
     started_kwargs = mock_emit_slo_started.call_args.kwargs
     completed_kwargs = mock_emit_slo_completed.call_args.kwargs
     assert completed_kwargs["properties"].outcome == SloOutcome.FAILURE
-    assert (
-        started_kwargs["extra_properties"]["correlation_id"] == completed_kwargs["extra_properties"]["correlation_id"]
-    )
-    completed_kwargs["extra_properties"].pop("correlation_id")
+    correlation_id = started_kwargs["extra_properties"]["correlation_id"]
     assert completed_kwargs["extra_properties"] == {
         "calculation_interval": "daily",
+        "correlation_id": correlation_id,
         "error_type": "RuntimeError",
         "error_message": "boom",
         "error_origin": _expected_origin_for(_raise_runtime_error),
@@ -221,11 +217,8 @@ def test_slo_operation_allows_no_exception_outcome_override(
     started_kwargs = mock_emit_slo_started.call_args.kwargs
     completed_kwargs = mock_emit_slo_completed.call_args.kwargs
     assert completed_kwargs["properties"].outcome == expected_outcome
-    assert (
-        started_kwargs["extra_properties"]["correlation_id"] == completed_kwargs["extra_properties"]["correlation_id"]
-    )
-    completed_kwargs["extra_properties"].pop("correlation_id")
-    assert completed_kwargs["extra_properties"] == expected_extra_properties
+    correlation_id = started_kwargs["extra_properties"]["correlation_id"]
+    assert completed_kwargs["extra_properties"] == {**expected_extra_properties, "correlation_id": correlation_id}
 
 
 @patch("posthog.slo.context.emit_slo_completed")
@@ -272,6 +265,5 @@ async def test_slo_operation_contextvar_survives_await(
     mock_emit_slo_completed.assert_called_once()
     started_extra = mock_emit_slo_started.call_args.kwargs["extra_properties"]
     completed_extra = mock_emit_slo_completed.call_args.kwargs["extra_properties"]
-    assert started_extra["correlation_id"] == completed_extra["correlation_id"]
-    completed_extra.pop("correlation_id")
-    assert completed_extra == {"async_stage": "after_await"}
+    correlation_id = started_extra["correlation_id"]
+    assert completed_extra == {"async_stage": "after_await", "correlation_id": correlation_id}

--- a/posthog/tasks/alerts/test/test_alert_checks.py
+++ b/posthog/tasks/alerts/test/test_alert_checks.py
@@ -1194,8 +1194,6 @@ class TestAlertCheckSloInstrumentation(APIBaseTest, ClickhouseDestroyTablesMixin
         else:
             check_alert_task(self.alert_id, self.team.id, calculation_interval, insight_id)
 
-        expected_base_properties = {"calculation_interval": calculation_interval, "insight_id": insight_id}
-
         mock_slo_started.assert_called_once()
         started_kwargs = mock_slo_started.call_args.kwargs
         assert started_kwargs["distinct_id"] == self.alert_id
@@ -1205,7 +1203,9 @@ class TestAlertCheckSloInstrumentation(APIBaseTest, ClickhouseDestroyTablesMixin
             team_id=self.team.id,
             resource_id=self.alert_id,
         )
-        assert started_kwargs["extra_properties"] == expected_base_properties
+        assert started_kwargs["extra_properties"]["calculation_interval"] == calculation_interval
+        assert started_kwargs["extra_properties"]["insight_id"] == insight_id
+        assert "correlation_id" in started_kwargs["extra_properties"]
         assert started_kwargs["capture"] is not None  # ph_scoped_capture callable
 
         mock_slo_completed.assert_called_once()
@@ -1219,6 +1219,10 @@ class TestAlertCheckSloInstrumentation(APIBaseTest, ClickhouseDestroyTablesMixin
             resource_id=self.alert_id,
             outcome=expected_outcome,
             duration_ms=completed_kwargs["properties"].duration_ms,
+        )
+        assert (
+            completed_kwargs["extra_properties"]["correlation_id"]
+            == started_kwargs["extra_properties"]["correlation_id"]
         )
         assert completed_kwargs["extra_properties"]["calculation_interval"] == calculation_interval
         assert completed_kwargs["extra_properties"]["insight_id"] == insight_id

--- a/posthog/temporal/common/slo_interceptor.py
+++ b/posthog/temporal/common/slo_interceptor.py
@@ -1,4 +1,5 @@
 from typing import Any
+from uuid import uuid4
 
 from django.conf import settings
 
@@ -23,6 +24,7 @@ class _SloWorkflowInterceptor(WorkflowInboundInterceptor):
         # Attach workflow identity for debugging and query-level deduplication.
         info = workflow.info()
         workflow_context = {
+            "correlation_id": str(uuid4()),
             "workflow_id": info.workflow_id,
             "workflow_run_id": info.run_id,
             "workflow_type": info.workflow_type,

--- a/posthog/temporal/common/slo_interceptor.py
+++ b/posthog/temporal/common/slo_interceptor.py
@@ -1,5 +1,4 @@
 from typing import Any
-from uuid import uuid4
 
 from django.conf import settings
 
@@ -24,9 +23,8 @@ class _SloWorkflowInterceptor(WorkflowInboundInterceptor):
         # Attach workflow identity for debugging and query-level deduplication.
         info = workflow.info()
         workflow_context = {
-            "correlation_id": str(uuid4()),
+            "correlation_id": info.run_id,
             "workflow_id": info.workflow_id,
-            "workflow_run_id": info.run_id,
             "workflow_type": info.workflow_type,
         }
 

--- a/posthog/temporal/tests/test_slo_interceptor.py
+++ b/posthog/temporal/tests/test_slo_interceptor.py
@@ -137,7 +137,6 @@ async def test_interceptor_emits_slo_events(
     assert started_props["operation"] == "export"
     assert started_props["resource_id"] == "42"
     assert started_props["correlation_id"] is not None
-    assert started_props["workflow_run_id"] is not None
     assert started_props["workflow_type"] == workflow_cls.__temporal_workflow_definition.name
 
     completed_calls = _get_slo_calls(mock_analytics, "slo_operation_completed")
@@ -146,7 +145,6 @@ async def test_interceptor_emits_slo_events(
     assert completed_props["outcome"] == expected_outcome
     assert completed_props["duration_ms"] is not None
     assert completed_props["correlation_id"] == started_props["correlation_id"]
-    assert completed_props["workflow_run_id"] == started_props["workflow_run_id"]
     for key, value in extra_completed_checks.items():
         assert completed_props[key] == value
 

--- a/posthog/temporal/tests/test_slo_interceptor.py
+++ b/posthog/temporal/tests/test_slo_interceptor.py
@@ -136,6 +136,7 @@ async def test_interceptor_emits_slo_events(
     started_props = started_calls[0].kwargs["properties"]
     assert started_props["operation"] == "export"
     assert started_props["resource_id"] == "42"
+    assert started_props["correlation_id"] is not None
     assert started_props["workflow_run_id"] is not None
     assert started_props["workflow_type"] == workflow_cls.__temporal_workflow_definition.name
 
@@ -144,6 +145,7 @@ async def test_interceptor_emits_slo_events(
     completed_props = completed_calls[0].kwargs["properties"]
     assert completed_props["outcome"] == expected_outcome
     assert completed_props["duration_ms"] is not None
+    assert completed_props["correlation_id"] == started_props["correlation_id"]
     assert completed_props["workflow_run_id"] == started_props["workflow_run_id"]
     for key, value in extra_completed_checks.items():
         assert completed_props[key] == value

--- a/terraform/us/project-2/team-analytics-platform/slo-monitoring/insights.tf
+++ b/terraform/us/project-2/team-analytics-platform/slo-monitoring/insights.tf
@@ -51,17 +51,62 @@ locals {
   # Placeholders: {{OPERATION}}, {{REGION}}, {{ERROR_BUDGET}}
   # ---------------------------------------------------------------------------
   slo_burn_rate_query = <<-SQL
-    WITH hourly AS (
+    -- Two paths: correlated (pairs started/completed by correlation_id, exact)
+    -- and uncorrelated (bucket-based with clamp, for SLOs without correlation_id).
+    WITH correlated AS (
         SELECT
-            toStartOfHour(timestamp) AS hour,
-            countIf(event = 'slo_operation_started') AS total,
-            countIf(event = 'slo_operation_started')
-              - countIf(event = 'slo_operation_completed' AND properties.outcome = 'success') AS failures
+            properties.correlation_id AS cid,
+            minIf(timestamp, event = 'slo_operation_started') AS started_at,
+            max(if(event = 'slo_operation_completed' AND properties.outcome = 'success', 1, 0)) AS succeeded
         FROM events
         WHERE event IN ('slo_operation_started', 'slo_operation_completed')
           AND properties.operation = '{{OPERATION}}'
           AND properties.region = '{{REGION}}'
+          AND properties.correlation_id IS NOT NULL
           AND timestamp >= now() - INTERVAL 35 DAY
+        GROUP BY cid
+    ),
+    correlated_hourly AS (
+        SELECT
+            toStartOfHour(started_at) AS hour,
+            count() AS total,
+            countIf(succeeded = 0) AS failures
+        FROM correlated
+        WHERE started_at IS NOT NULL
+        GROUP BY hour
+    ),
+    -- Clamped to 0: without correlation_id, started/completed events for the
+    -- same operation can land in different hourly buckets, producing negative
+    -- failure counts that are measurement artifacts, not real data.
+    uncorrelated_hourly AS (
+        SELECT
+            toStartOfHour(timestamp) AS hour,
+            countIf(event = 'slo_operation_started') AS total,
+            greatest(
+                countIf(event = 'slo_operation_started')
+                  - countIf(event = 'slo_operation_completed' AND properties.outcome = 'success'),
+                0
+            ) AS failures
+        FROM events
+        WHERE event IN ('slo_operation_started', 'slo_operation_completed')
+          AND properties.operation = '{{OPERATION}}'
+          AND properties.region = '{{REGION}}'
+          -- HogQL returns NULL for missing properties on materialized columns,
+          -- but empty string on non-materialized ones; handle both.
+          AND (properties.correlation_id IS NULL OR properties.correlation_id = '')
+          AND timestamp >= now() - INTERVAL 35 DAY
+        GROUP BY hour
+    ),
+    hourly AS (
+        SELECT
+            hour,
+            sum(total) AS total,
+            sum(failures) AS failures
+        FROM (
+            SELECT * FROM correlated_hourly
+            UNION ALL
+            SELECT * FROM uncorrelated_hourly
+        )
         GROUP BY hour
     ),
     hour_range AS (
@@ -265,17 +310,54 @@ resource "posthog_insight" "slo_success_rate" {
     source = {
       kind  = "HogQLQuery"
       query = <<-SQL
-        WITH daily AS (
+        -- Two paths: see burn rate query comment for rationale.
+        WITH correlated_ops AS (
+            SELECT
+                properties.correlation_id AS cid,
+                properties.operation AS operation,
+                minIf(timestamp, event = 'slo_operation_started') AS started_at,
+                max(if(event = 'slo_operation_completed' AND properties.outcome = 'success', 1, 0)) AS succeeded
+            FROM events
+            WHERE event IN ('slo_operation_started', 'slo_operation_completed')
+              AND properties.operation IN (${local.slo_operation_list})
+              AND properties.correlation_id IS NOT NULL
+              AND timestamp >= now() - INTERVAL 56 DAY
+            GROUP BY cid, operation
+        ),
+        correlated_daily AS (
+            SELECT
+                toDate(started_at) AS date,
+                operation,
+                count() AS total,
+                countIf(succeeded = 0) AS failures
+            FROM correlated_ops
+            WHERE started_at IS NOT NULL
+            GROUP BY date, operation
+        ),
+        uncorrelated_daily AS (
             SELECT
                 toDate(timestamp) AS date,
                 properties.operation AS operation,
                 countIf(event = 'slo_operation_started') AS total,
-                countIf(event = 'slo_operation_started')
-                  - countIf(event = 'slo_operation_completed' AND properties.outcome = 'success') AS failures
+                greatest(
+                    countIf(event = 'slo_operation_started')
+                      - countIf(event = 'slo_operation_completed' AND properties.outcome = 'success'),
+                    0
+                ) AS failures
             FROM events
             WHERE event IN ('slo_operation_started', 'slo_operation_completed')
               AND properties.operation IN (${local.slo_operation_list})
+              AND (properties.correlation_id IS NULL OR properties.correlation_id = '')
               AND timestamp >= now() - INTERVAL 56 DAY
+            GROUP BY date, operation
+        ),
+        daily AS (
+            SELECT date, operation, sum(total) AS total, sum(failures) AS failures
+            FROM (
+                SELECT * FROM correlated_daily
+                UNION ALL
+                SELECT * FROM uncorrelated_daily
+            )
             GROUP BY date, operation
         ),
         date_range AS (
@@ -347,28 +429,76 @@ resource "posthog_insight" "slo_volume" {
     source = {
       kind  = "HogQLQuery"
       query = <<-SQL
+        -- Two paths: see burn rate query comment for rationale.
+        WITH correlated_ops AS (
+            SELECT
+                properties.correlation_id AS cid,
+                properties.operation AS operation,
+                properties.region AS region,
+                countIf(event = 'slo_operation_started') AS starts,
+                max(if(event = 'slo_operation_completed' AND properties.outcome = 'success', 1, 0)) AS succeeded,
+                max(if(event = 'slo_operation_completed' AND properties.outcome = 'failure', 1, 0)) AS failed,
+                countIf(event = 'slo_operation_completed') AS completions
+            FROM events
+            WHERE event IN ('slo_operation_started', 'slo_operation_completed')
+              AND properties.correlation_id IS NOT NULL
+              AND timestamp >= now() - INTERVAL 28 DAY
+            GROUP BY cid, operation, region
+        ),
+        correlated_summary AS (
+            SELECT
+                operation,
+                region,
+                countIf(starts > 0) AS started,
+                countIf(succeeded = 1) AS successes,
+                countIf(failed = 1) AS failures,
+                countIf(starts > 0 AND completions = 0) AS never_completed
+            FROM correlated_ops
+            GROUP BY operation, region
+        ),
+        uncorrelated_summary AS (
+            SELECT
+                properties.operation AS operation,
+                properties.region AS region,
+                countIf(event = 'slo_operation_started') AS started,
+                countIf(event = 'slo_operation_completed' AND properties.outcome = 'success') AS successes,
+                countIf(event = 'slo_operation_completed' AND properties.outcome = 'failure') AS failures,
+                greatest(
+                    countIf(event = 'slo_operation_started')
+                      - countIf(event = 'slo_operation_completed'),
+                    0
+                ) AS never_completed
+            FROM events
+            WHERE event IN ('slo_operation_started', 'slo_operation_completed')
+              AND (properties.correlation_id IS NULL OR properties.correlation_id = '')
+              AND timestamp >= now() - INTERVAL 28 DAY
+            GROUP BY operation, region
+        ),
+        combined AS (
+            SELECT operation, region, started, successes, failures, never_completed
+            FROM correlated_summary
+            UNION ALL
+            SELECT operation, region, started, successes, failures, never_completed
+            FROM uncorrelated_summary
+        )
         SELECT
-            properties.operation AS operation,
+            operation,
             if(
-                count(properties.region) OVER (PARTITION BY properties.operation) = 1,
+                count(region) OVER (PARTITION BY operation) = 1,
                 'all*',
-                properties.region
+                region
             ) AS region,
-            countIf(event = 'slo_operation_started') AS started,
-            countIf(event = 'slo_operation_completed' AND properties.outcome = 'success') AS successes,
-            countIf(event = 'slo_operation_completed' AND properties.outcome = 'failure') AS failures,
-            countIf(event = 'slo_operation_started')
-              - countIf(event = 'slo_operation_completed') AS never_completed,
+            sum(started) AS started,
+            sum(successes) AS successes,
+            sum(failures) AS failures,
+            sum(never_completed) AS never_completed,
             if(
-                countIf(event = 'slo_operation_started') > 0,
-                round(countIf(event = 'slo_operation_completed' AND properties.outcome = 'success')
-                  / countIf(event = 'slo_operation_started') * 100, 2),
+                sum(started) > 0,
+                round(sum(successes) / sum(started) * 100, 2),
                 NULL
             ) AS success_rate
-        FROM events
-        WHERE event IN ('slo_operation_started', 'slo_operation_completed')
-          AND timestamp >= now() - INTERVAL 28 DAY
-        GROUP BY operation, properties.region
+        FROM combined
+        GROUP BY operation, region
         ORDER BY operation, region
       SQL
     }


### PR DESCRIPTION
## Problem

On the [slo monitoring](https://us.posthog.com/project/2/dashboard/1397132) dashboard, it's possible for the burn rate to go into the negative. This is due to the fact that it does a naive time based boundary comparison. In other words, if the `started` event is emitted at xx:58 and the `completed` event is emitted at xx:02, there weill be a negative value in those buckets, this as the correlation between the 2 has been lost.

Whilst this does not mattter much for the higher duration burn rates (as this evens out over time), it does make the 1hr burn rate a bit hard to read. As a result, I would like to add a `correlation_id` field to the SLO metrics so that the start can be correlated with the completed event (if present) to avoid those negative numbers. 

Additionally I've also updated the dashboard to query both the events with correlation id (comparing the "correlated" events) but also to retain functionality for the legacy bucket comparison. Eventually we might want to remove the latter, but I figured it couldn't hurt to keep them side by side for now, preferring the correlation approach; this so that if there are new flavours of the SLO metrics being implemented, we support both methods.

## Changes

- Added automatic `correlation_id` generation using UUID4 for all SLO operations to link started and completed events
- Enhanced SLO monitoring queries in Terraform to use two-path approach:
    - **Correlated path**: Exact pairing of started/completed events by correlation_id for precise measurements
    - **Uncorrelated path**: Legacy bucket-based approach with clamping to handle existing data without correlation_id
- Updated burn rate, success rate, and volume queries to combine both correlated and uncorrelated data
- Added correlation_id to Temporal workflow SLO context for distributed tracing
- Updated all test assertions to verify correlation_id presence and consistency between started/completed events

## How did you test this code?

The changes include comprehensive unit test updates that verify:

- Correlation IDs are automatically generated and included in both started and completed events
- The same correlation ID is used consistently across the lifecycle of an SLO operation
- All existing functionality continues to work with the new correlation_id field
- Test assertions properly handle the new field structure in event properties

## Publish to changelog?

No - this is an internal monitoring improvement that doesn't affect user-facing features.

## Docs update

No documentation updates needed as this is an internal SLO monitoring enhancement.