### PR TITLE
fix(phai): strip result from insight objects entering MaxContext system

### DIFF
--- a/frontend/src/scenes/max/maxTypes.ts
+++ b/frontend/src/scenes/max/maxTypes.ts
@@ -16,7 +16,8 @@ export enum MaxContextType {
     NOTEBOOK = 'notebook',
 }
 
-export type InsightWithQuery = Pick<Partial<QueryBasedInsightModel>, 'query'> & Partial<QueryBasedInsightModel>
+export type InsightWithQuery = Omit<Partial<QueryBasedInsightModel>, 'result'> &
+    Pick<Partial<QueryBasedInsightModel>, 'query'>
 
 export interface MaxInsightContext {
     type: MaxContextType.INSIGHT
@@ -156,7 +157,16 @@ export type MaxContextInput =
 export const createMaxContextHelpers = {
     dashboard: (dashboard: DashboardType<QueryBasedInsightModel>): MaxDashboardContextInput => ({
         type: MaxContextType.DASHBOARD,
-        data: dashboard,
+        data: {
+            ...dashboard,
+            tiles: dashboard.tiles.map((tile) => {
+                if (!tile.insight) {
+                    return tile
+                }
+                const { result: _, ...insightWithoutResult } = tile.insight
+                return { ...tile, insight: insightWithoutResult as QueryBasedInsightModel }
+            }),
+        },
     }),
 
     insight: (
@@ -170,13 +180,16 @@ export const createMaxContextHelpers = {
             variablesOverride?: Record<string, HogQLVariable>
             revenueAnalyticsQuery?: RevenueAnalyticsQuery
         } = {}
-    ): MaxInsightContextInput => ({
-        type: MaxContextType.INSIGHT,
-        data: insight,
-        filtersOverride,
-        variablesOverride,
-        revenueAnalyticsQuery,
-    }),
+    ): MaxInsightContextInput => {
+        const { result: _, ...insightWithoutResult } = insight as Partial<QueryBasedInsightModel>
+        return {
+            type: MaxContextType.INSIGHT,
+            data: insightWithoutResult as InsightWithQuery,
+            filtersOverride,
+            variablesOverride,
+            revenueAnalyticsQuery,
+        }
+    },
 
     event: (event: EventDefinition): MaxEventContextInput => ({
         type: MaxContextType.EVENT,

--- a/frontend/src/scenes/max/maxTypes.ts
+++ b/frontend/src/scenes/max/maxTypes.ts
@@ -16,8 +16,10 @@ export enum MaxContextType {
     NOTEBOOK = 'notebook',
 }
 
-export type InsightWithQuery = Omit<Partial<QueryBasedInsightModel>, 'result'> &
-    Pick<Partial<QueryBasedInsightModel>, 'query'>
+export type InsightWithQuery = Pick<
+    Partial<QueryBasedInsightModel>,
+    'query' | 'short_id' | 'name' | 'derived_name' | 'description' | 'id'
+>
 
 export interface MaxInsightContext {
     type: MaxContextType.INSIGHT
@@ -150,6 +152,17 @@ export type MaxContextInput =
     | MaxEvaluationContextInput
     | MaxNotebookContextInput
 
+function pickInsightFields(insight: Partial<QueryBasedInsightModel>): InsightWithQuery {
+    return {
+        id: insight.id,
+        short_id: insight.short_id,
+        name: insight.name,
+        derived_name: insight.derived_name,
+        description: insight.description,
+        query: insight.query,
+    }
+}
+
 /**
  * Helper functions to create maxContext items safely
  * These ensure proper typing and consistent patterns across scene logics
@@ -159,13 +172,10 @@ export const createMaxContextHelpers = {
         type: MaxContextType.DASHBOARD,
         data: {
             ...dashboard,
-            tiles: dashboard.tiles.map((tile) => {
-                if (!tile.insight) {
-                    return tile
-                }
-                const { result: _, ...insightWithoutResult } = tile.insight
-                return { ...tile, insight: insightWithoutResult as QueryBasedInsightModel }
-            }),
+            tiles: dashboard.tiles.map((tile) => ({
+                ...tile,
+                insight: tile.insight ? pickInsightFields(tile.insight) : tile.insight,
+            })),
         },
     }),
 
@@ -180,16 +190,13 @@ export const createMaxContextHelpers = {
             variablesOverride?: Record<string, HogQLVariable>
             revenueAnalyticsQuery?: RevenueAnalyticsQuery
         } = {}
-    ): MaxInsightContextInput => {
-        const { result: _, ...insightWithoutResult } = insight as Partial<QueryBasedInsightModel>
-        return {
-            type: MaxContextType.INSIGHT,
-            data: insightWithoutResult as InsightWithQuery,
-            filtersOverride,
-            variablesOverride,
-            revenueAnalyticsQuery,
-        }
-    },
+    ): MaxInsightContextInput => ({
+        type: MaxContextType.INSIGHT,
+        data: pickInsightFields(insight),
+        filtersOverride,
+        variablesOverride,
+        revenueAnalyticsQuery,
+    }),
 
     event: (event: EventDefinition): MaxEventContextInput => ({
         type: MaxContextType.EVENT,

--- a/frontend/src/scenes/max/maxTypes.ts
+++ b/frontend/src/scenes/max/maxTypes.ts
@@ -115,7 +115,7 @@ type MaxInsightContextInput = {
 }
 type MaxDashboardContextInput = {
     type: MaxContextType.DASHBOARD
-    data: DashboardType<QueryBasedInsightModel>
+    data: DashboardType<InsightWithQuery>
 }
 type MaxEventContextInput = {
     type: MaxContextType.EVENT

--- a/frontend/src/scenes/max/utils.ts
+++ b/frontend/src/scenes/max/utils.ts
@@ -40,6 +40,7 @@ import { Scene } from '../sceneTypes'
 import { MODE_DEFINITIONS } from './max-constants'
 import { SuggestionGroup } from './maxLogic'
 import {
+    InsightWithQuery,
     MaxActionContext,
     MaxContextType,
     MaxDashboardContext,
@@ -167,7 +168,7 @@ export const insightToMaxContext = (
     }
 }
 
-export const dashboardToMaxContext = (dashboard: DashboardType<QueryBasedInsightModel>): MaxDashboardContext => {
+export const dashboardToMaxContext = (dashboard: DashboardType<InsightWithQuery>): MaxDashboardContext => {
     return {
         type: MaxContextType.DASHBOARD,
         id: dashboard.id,


### PR DESCRIPTION
The `result` field from QueryBasedInsightModel was being carried through
the MaxContext intermediate data structures unnecessarily. While
`insightToMaxContext` already strips it before the API call, the full
insight objects (with potentially large result payloads) were held in kea
state via `rawSceneContext`.

- Update `InsightWithQuery` type to exclude `result`
- Strip `result` in `createMaxContextHelpers.insight()` before storing
- Strip `result` from dashboard tile insights in
  `createMaxContextHelpers.dashboard()`

https://claude.ai/code/session_01JjRyRgNw5sGjVjewrPxbkV