### PR TITLE
fix(funnels): hide correlation feedback form until data loads

### DIFF
--- a/frontend/src/scenes/funnels/funnelCorrelationFeedbackLogic.ts
+++ b/frontend/src/scenes/funnels/funnelCorrelationFeedbackLogic.ts
@@ -19,9 +19,9 @@ export const funnelCorrelationFeedbackLogic = kea<funnelCorrelationFeedbackLogic
     connect((props: InsightLogicProps) => ({
         actions: [
             funnelCorrelationLogic(props),
-            ['loadEventCorrelations'],
+            ['loadEventCorrelationsSuccess'],
             funnelPropertyCorrelationLogic(props),
-            ['loadPropertyCorrelations'],
+            ['loadPropertyCorrelationsSuccess'],
         ],
     })),
 
@@ -36,9 +36,9 @@ export const funnelCorrelationFeedbackLogic = kea<funnelCorrelationFeedbackLogic
         correlationFeedbackHidden: [
             true,
             {
-                // don't load the feedback form until after some results were loaded
-                loadEventCorrelations: () => false,
-                loadPropertyCorrelations: () => false,
+                // don't show the feedback form until after results have loaded
+                loadEventCorrelationsSuccess: () => false,
+                loadPropertyCorrelationsSuccess: () => false,
                 sendCorrelationAnalysisFeedback: () => true,
                 hideCorrelationAnalysisFeedback: () => true,
             },

--- a/frontend/src/scenes/insights/views/Funnels/FunnelCorrelationFeedbackForm.tsx
+++ b/frontend/src/scenes/insights/views/Funnels/FunnelCorrelationFeedbackForm.tsx
@@ -5,12 +5,10 @@ import { IconComment, IconX } from '@posthog/icons'
 import { LemonButton, LemonTextArea } from '@posthog/lemon-ui'
 
 import { funnelCorrelationFeedbackLogic } from 'scenes/funnels/funnelCorrelationFeedbackLogic'
-import { funnelCorrelationLogic } from 'scenes/funnels/funnelCorrelationLogic'
 import { insightLogic } from 'scenes/insights/insightLogic'
 
 export const FunnelCorrelationFeedbackForm = (): JSX.Element | null => {
     const { insightProps } = useValues(insightLogic)
-    const { loadedEventCorrelationsTableOnce } = useValues(funnelCorrelationLogic(insightProps))
     const { correlationFeedbackHidden, correlationDetailedFeedbackVisible, correlationFeedbackRating } = useValues(
         funnelCorrelationFeedbackLogic(insightProps)
     )
@@ -23,7 +21,7 @@ export const FunnelCorrelationFeedbackForm = (): JSX.Element | null => {
 
     const detailedFeedbackRef = useRef<HTMLTextAreaElement>(null)
 
-    if (correlationFeedbackHidden || !loadedEventCorrelationsTableOnce) {
+    if (correlationFeedbackHidden) {
         return null
     }
 

--- a/frontend/src/scenes/insights/views/Funnels/FunnelCorrelationFeedbackForm.tsx
+++ b/frontend/src/scenes/insights/views/Funnels/FunnelCorrelationFeedbackForm.tsx
@@ -5,10 +5,12 @@ import { IconComment, IconX } from '@posthog/icons'
 import { LemonButton, LemonTextArea } from '@posthog/lemon-ui'
 
 import { funnelCorrelationFeedbackLogic } from 'scenes/funnels/funnelCorrelationFeedbackLogic'
+import { funnelCorrelationLogic } from 'scenes/funnels/funnelCorrelationLogic'
 import { insightLogic } from 'scenes/insights/insightLogic'
 
 export const FunnelCorrelationFeedbackForm = (): JSX.Element | null => {
     const { insightProps } = useValues(insightLogic)
+    const { loadedEventCorrelationsTableOnce } = useValues(funnelCorrelationLogic(insightProps))
     const { correlationFeedbackHidden, correlationDetailedFeedbackVisible, correlationFeedbackRating } = useValues(
         funnelCorrelationFeedbackLogic(insightProps)
     )
@@ -21,7 +23,7 @@ export const FunnelCorrelationFeedbackForm = (): JSX.Element | null => {
 
     const detailedFeedbackRef = useRef<HTMLTextAreaElement>(null)
 
-    if (correlationFeedbackHidden) {
+    if (correlationFeedbackHidden || !loadedEventCorrelationsTableOnce) {
         return null
     }
 


### PR DESCRIPTION
Don't show the "was this correlation analysis report useful" banner before the correlation events have actually loaded.

Slack thread: https://posthog.slack.com/archives/C0ACRAMJUAG/p1774952467343209?thread_ts=1774640678.729209&cid=C0ACRAMJUAG

https://claude.ai/code/session_01EvHbLyRUmKsG1PmJSGH94x


