### PR TITLE
fix(ws): replace async log methods with sync in pipelinesV3 consumer path

### DIFF
--- a/posthog/temporal/data_imports/pipelines/pipeline_sync.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline_sync.py
@@ -130,7 +130,7 @@ async def validate_schema_and_update_table(
     logger = LOGGER.bind(team_id=team_id)
 
     if row_count == 0:
-        await logger.awarn("Skipping `validate_schema_and_update_table` due to `row_count` being 0")
+        logger.warning("Skipping `validate_schema_and_update_table` due to `row_count` being 0")
         return
 
     @database_sync_to_async_pool

--- a/posthog/temporal/data_imports/pipelines/pipeline_v3/load/processor.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline_v3/load/processor.py
@@ -116,17 +116,17 @@ async def _handle_partial_data_loading(
         new_file_uris = list(set(current_file_uris) - set(previous_file_uris))
         modified_files = set(previous_file_uris) - set(current_file_uris)
         if modified_files:
-            await logger.awarning(
+            logger.warning(
                 "Found modified files during first sync, skipping partial data loading",
                 modified_count=len(modified_files),
             )
             return
 
     if not new_file_uris:
-        await logger.adebug("No new files to make queryable")
+        logger.debug("No new files to make queryable")
         return
 
-    await logger.adebug(
+    logger.debug(
         "partial_data_loading",
         batch_index=export_signal.batch_index,
         new_file_count=len(new_file_uris),


### PR DESCRIPTION
## Problem

alog calls fail on warehouse source load consumer

## Changes

  * Fixed `pipeline_sync.py`: replaced `await logger.awarn(...)` with `logger.warning(...)` in `validate_schema_and_update_table` — the method `awarn` does not exist on structlog's `BoundLogger` used in the
  consumer context
  * Fixed `pipeline_v3/load/processor.py`: replaced `await logger.awarning(...)` and `await logger.adebug(...)` with sync equivalents in `_handle_partial_data_loading` — this function is only called from the
  consumer via `async_to_sync()`

## How did you test this code?

local run
test pass

## Publish to changelog?

NO
