### PR TITLE
fix: update funnel significance highlight text color to use design tokens

### DIFF
--- a/frontend/src/queries/nodes/InsightViz/InsightViz.scss
+++ b/frontend/src/queries/nodes/InsightViz/InsightViz.scss
@@ -195,11 +195,11 @@
 
 .funnel-significance-highlight {
     display: inline-flex;
-    color: var(--color-bg-surface-primary);
+    color: var(--text-3000-light);
     background: var(--color-accent);
 
     .LemonIcon {
-        color: var(--color-bg-surface-primary);
+        color: var(--text-3000-light);
     }
 }
 


### PR DESCRIPTION
## Problem

The funnel significance highlight component was using a hardcoded CSS variable (`--color-bg-surface-primary`) for text color, which doesn't align with the design system's text color tokens.

## Changes

Updated the `.funnel-significance-highlight` class and its nested `.LemonIcon` to use `--text-3000-light` instead of `--color-bg-surface-primary` for the text color. This ensures the component uses proper text color tokens from the design system.

## How did you test this code?

No testing needed. This is a straightforward CSS variable substitution that aligns the component with design system conventions.

## Docs update

No docs update needed.

https://claude.ai/code/session_01DSaMQePfcpUa4ybvKcxnqe