### PR TITLE
fix(batch-exports): add missing scene config for back button and side panel

### DIFF
--- a/frontend/src/scenes/data-pipelines/batch-exports/BatchExportScene.tsx
+++ b/frontend/src/scenes/data-pipelines/batch-exports/BatchExportScene.tsx
@@ -27,6 +27,7 @@ import { HogFunctionSkeleton } from 'scenes/hog-functions/misc/HogFunctionSkelet
 import { Scene, SceneExport } from 'scenes/sceneTypes'
 import { urls } from 'scenes/urls'
 
+import { SIDE_PANEL_CONTEXT_KEY, SidePanelSceneContext } from '~/layout/navigation-3000/sidepanel/types'
 import { SceneContent } from '~/layout/scenes/components/SceneContent'
 import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
 import { ActivityScope, BATCH_EXPORT_SERVICE_NAMES, BatchExportService, Breadcrumb } from '~/types'
@@ -79,6 +80,11 @@ export const batchExportSceneLogic = kea<batchExportSceneLogicType>([
                     },
                 ]
             },
+        ],
+        [SIDE_PANEL_CONTEXT_KEY]: [
+            () => [(_, props) => props],
+            (props: BatchExportConfigFormLogicProps): SidePanelSceneContext | null =>
+                props.id ? { activity_scope: ActivityScope.BATCH_EXPORT, activity_item_id: props.id } : null,
         ],
     }),
     actionToUrl(({ values }) => ({

--- a/frontend/src/scenes/scenes.ts
+++ b/frontend/src/scenes/scenes.ts
@@ -75,6 +75,21 @@ export const sceneConfigurations: Record<Scene | string, SceneConfig> = {
         defaultDocsPath: '/docs/cdp/apps',
         iconType: 'data_pipeline',
     },
+    [Scene.BatchExport]: {
+        projectBased: true,
+        name: 'Batch export',
+        activityScope: ActivityScope.BATCH_EXPORT,
+        iconType: 'data_pipeline',
+        defaultDocsPath: '/docs/cdp/batch-exports',
+        changelogTeamSlug: 'Batch Exports',
+    },
+    [Scene.BatchExportNew]: {
+        projectBased: true,
+        name: 'New batch export',
+        iconType: 'data_pipeline',
+        defaultDocsPath: '/docs/cdp/batch-exports',
+        changelogTeamSlug: 'Batch Exports',
+    },
     [Scene.BillingAuthorizationStatus]: {
         organizationBased: true,
         defaultDocsPath: '/pricing',


### PR DESCRIPTION
## Problem

There was no back button being shown on the batch exports scene.

## Changes

- **`frontend/src/scenes/scenes.ts`**: Added `Scene.BatchExport` and `Scene.BatchExportNew` to `sceneConfigurations` with `projectBased`, `activityScope`, `iconType`, `defaultDocsPath`, and `changelogTeamSlug`.
- **`frontend/src/scenes/data-pipelines/batch-exports/BatchExportScene.tsx`**: Added `[SIDE_PANEL_CONTEXT_KEY]` selector to `batchExportSceneLogic` that provides `activity_scope` and `activity_item_id` from props.

As a consequence, we now have additional information in the sidebar, such as Activity logs! (I think it's still nice to have the History tab, as the Activity logs are a bit hidden away in the sidebar.)

## Screenshots

### Before

<img width="531" height="247" alt="image" src="https://github.com/user-attachments/assets/7cd0827d-4b87-4994-9d72-d63b58c00467" />


### After

<img width="539" height="241" alt="image" src="https://github.com/user-attachments/assets/00b07b76-3e85-4ca4-a82b-da52efd654a6" />


## How did you test this code?

Manual testing of the UI.

## Publish to changelog?

No

## Docs update

No docs changes needed.