### PR TITLE
feat: spark line drag selector

### DIFF
--- a/products/error_tracking/frontend/components/IssueMetadata.tsx
+++ b/products/error_tracking/frontend/components/IssueMetadata.tsx
@@ -1,5 +1,5 @@
-import { useValues } from 'kea'
-import { PropsWithChildren } from 'react'
+import { useActions, useValues } from 'kea'
+import { PropsWithChildren, useCallback } from 'react'
 import { match } from 'ts-pattern'
 
 import { IconChevronRight, IconTrending } from '@posthog/icons'
@@ -22,10 +22,21 @@ import { VolumeSparkline } from './VolumeSparkline/VolumeSparkline'
 export const Metadata = ({ children, className }: PropsWithChildren<{ className?: string }>): JSX.Element => {
     const { aggregations, summaryLoading, issueLoading, firstSeen, lastSeen, issueId } =
         useValues(errorTrackingIssueSceneLogic)
+    const { setDateRange } = useActions(errorTrackingIssueSceneLogic)
     const sparklineKey = issueId || 'issue-unknown'
     const { hoverSelection } = useValues(errorTrackingVolumeSparklineLogic({ sparklineKey }))
     const sparklineData = useSparklineDataIssueScene()
     const sparklineEvents = useSparklineEvents()
+
+    const handleRangeSelect = useCallback(
+        (startDate: Date, endDate: Date) => {
+            setDateRange({
+                date_from: startDate.toISOString(),
+                date_to: endDate.toISOString(),
+            })
+        },
+        [setDateRange]
+    )
 
     return (
         <div className={className}>
@@ -42,35 +53,31 @@ export const Metadata = ({ children, className }: PropsWithChildren<{ className?
                 </div>
                 <div className="flex justify-end items-center h-full">
                     {match(hoverSelection)
-                        .when(
-                            (data) => shouldRenderIssueMetrics(data),
-                            () => (
-                                <>
-                                    <TimeBoundary
-                                        time={firstSeen}
-                                        loading={issueLoading}
-                                        label="First Seen"
-                                        updateDateRange={(dateRange) => {
-                                            dateRange.date_from = firstSeen?.toISOString()
-                                            return dateRange
-                                        }}
-                                    />
-                                    <IconChevronRight />
-                                    <TimeBoundary
-                                        time={lastSeen}
-                                        loading={summaryLoading}
-                                        label="Last Seen"
-                                        updateDateRange={(dateRange) => {
-                                            dateRange.date_to = lastSeen?.endOf('minute').toISOString()
-                                            return dateRange
-                                        }}
-                                    />
-                                </>
-                            )
-                        )
                         .with({ kind: 'bin' }, (data) => renderDate(data.datum.date))
                         .with({ kind: 'event' }, (data) => renderDate(data.event.date))
-                        .otherwise(() => null)}
+                        .otherwise(() => (
+                            <>
+                                <TimeBoundary
+                                    time={firstSeen}
+                                    loading={issueLoading}
+                                    label="First Seen"
+                                    updateDateRange={(dateRange) => {
+                                        dateRange.date_from = firstSeen?.toISOString()
+                                        return dateRange
+                                    }}
+                                />
+                                <IconChevronRight />
+                                <TimeBoundary
+                                    time={lastSeen}
+                                    loading={summaryLoading}
+                                    label="Last Seen"
+                                    updateDateRange={(dateRange) => {
+                                        dateRange.date_to = lastSeen?.endOf('minute').toISOString()
+                                        return dateRange
+                                    }}
+                                />
+                            </>
+                        ))}
                 </div>
             </div>
             <div onClick={cancelEvent} className="relative w-full min-h-[160px] shrink-0 flex flex-col px-4">
@@ -81,6 +88,7 @@ export const Metadata = ({ children, className }: PropsWithChildren<{ className?
                     events={sparklineEvents}
                     sparklineKey={sparklineKey}
                     className="h-full min-h-[160px]"
+                    onRangeSelect={handleRangeSelect}
                 />
             </div>
             <div className="flex-1 min-h-0 overflow-y-auto">{children}</div>
@@ -124,7 +132,7 @@ function renderMetric(name: string, value: number | undefined, loading: boolean,
     return (
         <>
             {match([loading])
-                .with([true], () => <LemonSkeleton className="w-[80px] h-2" />)
+                .with([true], () => <LemonSkeleton className="w-[50px] h-2" />)
                 .with([false], () => (
                     <Tooltip title={tooltip} delayMs={0} placement="right">
                         <div className="flex items-center gap-1">

--- a/products/error_tracking/frontend/components/VolumeSparkline/VolumeSparkline.tsx
+++ b/products/error_tracking/frontend/components/VolumeSparkline/VolumeSparkline.tsx
@@ -25,6 +25,7 @@ export type VolumeSparklineProps = {
     xAxis?: VolumeSparklineXAxisMode
     className?: string
     events?: SparklineEvent<string>[]
+    onRangeSelect?: (startDate: Date, endDate: Date) => void
 }
 
 export function VolumeSparkline({
@@ -34,6 +35,7 @@ export function VolumeSparkline({
     xAxis = 'none',
     className,
     events = [],
+    onRangeSelect,
 }: VolumeSparklineProps): JSX.Element {
     const { setHoveredBin, setHoveredEvent } = useActions(errorTrackingVolumeSparklineLogic({ sparklineKey }))
     const svgRef = useRef<SVGSVGElement>(null)
@@ -77,7 +79,8 @@ export function VolumeSparkline({
             return
         }
 
-        renderVolumeSparkline(svg, {
+        const cleanup = renderVolumeSparkline(svg, {
+            sparklineKey,
             data,
             width,
             height,
@@ -95,7 +98,10 @@ export function VolumeSparkline({
             eventLabelPaddingX: chartStyle.eventLabelPaddingX,
             eventLabelPaddingY: chartStyle.eventLabelPaddingY,
             eventMinSpace: chartStyle.eventMinSpace,
+            onRangeSelect,
         })
+
+        return cleanup
     }, [
         data,
         width,
@@ -114,6 +120,8 @@ export function VolumeSparkline({
         onHoverChange,
         events,
         onEventHoverChange,
+        onRangeSelect,
+        sparklineKey,
     ])
 
     const paddingClass = match(layout)

--- a/products/error_tracking/frontend/components/VolumeSparkline/volumeSparklineRender.ts
+++ b/products/error_tracking/frontend/components/VolumeSparkline/volumeSparklineRender.ts
@@ -13,6 +13,8 @@ const VOLUME_SPARKLINE_EVENT_LABEL_BAR_GAP_PX = 10
 
 const STRIPE_CELL = 12
 
+const DRAG_MIN_DISTANCE_PX = 5
+
 export type VolumeSparklineRenderArgs = {
     data: SparklineData
     width: number
@@ -31,6 +33,9 @@ export type VolumeSparklineRenderArgs = {
     eventLabelPaddingX?: number
     eventLabelPaddingY?: number
     eventMinSpace?: number
+    onRangeSelect?: (startDate: Date, endDate: Date) => void
+    /** Used to namespace window-level d3 drag listeners so multiple sparklines do not clobber each other */
+    sparklineKey: string
 }
 
 function roundedTopBarBottomClipPx(borderRadius: number): number {
@@ -97,7 +102,7 @@ function createeStripePatterns(
     return (color: string) => idByColor.get(color) ?? hashColorId(color)
 }
 
-export function renderVolumeSparkline(svgEl: SVGSVGElement, args: VolumeSparklineRenderArgs): void {
+export function renderVolumeSparkline(svgEl: SVGSVGElement, args: VolumeSparklineRenderArgs): () => void {
     const {
         data,
         width,
@@ -116,14 +121,36 @@ export function renderVolumeSparkline(svgEl: SVGSVGElement, args: VolumeSparklin
         eventLabelPaddingX = 5,
         eventLabelPaddingY = 3,
         eventMinSpace = 2,
+        onRangeSelect,
+        sparklineKey,
     } = args
 
     const svg = d3.select(svgEl)
     svg.selectAll('*').remove()
 
     if (width <= 0 || height <= 0 || data.length < 2) {
-        return
+        return () => {}
     }
+
+    let isDragging = false
+
+    const gatedOnHoverChange = onHoverChange
+        ? (index: number | null, datum: SparklineDatum | null): void => {
+              if (isDragging) {
+                  return
+              }
+              onHoverChange(index, datum)
+          }
+        : undefined
+
+    const gatedOnEventHoverChange = onEventHoverChange
+        ? (event: SparklineEvent<string> | null): void => {
+              if (isDragging) {
+                  return
+              }
+              onEventHoverChange(event)
+          }
+        : undefined
 
     const axisReserve = VOLUME_SPARKLINE_X_AXIS_RESERVE_PX[xAxis]
     const chartHeight = Math.max(1, height - axisReserve)
@@ -174,7 +201,7 @@ export function renderVolumeSparkline(svgEl: SVGSVGElement, args: VolumeSparklin
         .data(occurrences)
         .join('g')
         .attr('class', 'volume-bar')
-        .style('cursor', 'default')
+        .style('cursor', onRangeSelect ? 'crosshair' : 'default')
 
     barGroups.each(function (d, i) {
         const g = d3.select(this)
@@ -227,8 +254,8 @@ export function renderVolumeSparkline(svgEl: SVGSVGElement, args: VolumeSparklin
             .style('pointer-events', 'all')
 
         g.on('mouseover', () => {
-            onEventHoverChange?.(null)
-            onHoverChange?.(i, d)
+            gatedOnEventHoverChange?.(null)
+            gatedOnHoverChange?.(i, d)
             if (showAxisHover) {
                 const axis = svg.select('.volume-sparkline-x-axis-hover')
                 if (d.value === 0) {
@@ -239,6 +266,9 @@ export function renderVolumeSparkline(svgEl: SVGSVGElement, args: VolumeSparklin
                     axis.attr('stroke-opacity', 0)
                 }
             }
+            if (isDragging) {
+                return
+            }
             if (d.animated && d.color) {
                 g.select('.bar-hover-overlay').style('fill', 'white').style('opacity', 0.22)
             } else {
@@ -247,6 +277,9 @@ export function renderVolumeSparkline(svgEl: SVGSVGElement, args: VolumeSparklin
         })
 
         g.on('mouseout', () => {
+            if (isDragging) {
+                return
+            }
             g.select('.bar-hover-overlay').style('opacity', 0).style('fill', 'black')
             g.select('.bar-main').style('fill', spikeBarFill(d, backgroundColor, patternIdFor))
         })
@@ -283,14 +316,40 @@ export function renderVolumeSparkline(svgEl: SVGSVGElement, args: VolumeSparklin
                 eventMinSpace,
                 borderRadius,
             },
-            onHoverChange,
-            onEventHoverChange
+            gatedOnHoverChange,
+            gatedOnEventHoverChange
         )
     }
 
+    // Hover cursor line (vertical indicator) – only for range-selectable charts
+    let hoverCursorLine: d3.Selection<SVGLineElement, unknown, null, undefined> | null = null
+    if (onRangeSelect) {
+        hoverCursorLine = svg
+            .append('line')
+            .attr('class', 'volume-sparkline-hover-cursor')
+            .attr('y1', barPlotTop)
+            .attr('y2', chartHeight)
+            .attr('stroke', 'rgba(128, 128, 128, 0.5)')
+            .attr('stroke-width', 1)
+            .attr('pointer-events', 'none')
+            .style('opacity', 0)
+
+        svg.on('mousemove.cursor', (event: MouseEvent) => {
+            if (isDragging) {
+                return
+            }
+            const [mx] = d3.pointer(event)
+            hoverCursorLine!.attr('x1', mx).attr('x2', mx).style('opacity', 1)
+        })
+    }
+
     svg.on('mouseleave', () => {
-        onEventHoverChange?.(null)
-        onHoverChange?.(null, null)
+        if (isDragging) {
+            return
+        }
+        hoverCursorLine?.style('opacity', 0)
+        gatedOnEventHoverChange?.(null)
+        gatedOnHoverChange?.(null, null)
         if (showAxisHover) {
             svg.select('.volume-sparkline-x-axis-hover').attr('stroke-opacity', 0)
         }
@@ -300,4 +359,153 @@ export function renderVolumeSparkline(svgEl: SVGSVGElement, args: VolumeSparklin
             g.select('.bar-main').style('fill', spikeBarFill(d, backgroundColor, patternIdFor))
         })
     })
+
+    // Drag-to-select range
+    if (onRangeSelect) {
+        let dragStartX = -1
+
+        const selectionOverlay = svg
+            .append('rect')
+            .attr('class', 'drag-selection-overlay')
+            .attr('y', barPlotTop)
+            .attr('height', chartHeight - barPlotTop)
+            .attr('rx', 0)
+            .attr('ry', 0)
+            .style('fill', 'rgba(128, 128, 128, 0.15)')
+            .style('stroke', 'none')
+            .style('pointer-events', 'none')
+            .style('opacity', 0)
+
+        function resetBarStyles(): void {
+            barGroups.each(function (d: SparklineDatum) {
+                const g = d3.select(this)
+                g.select('.bar-main')
+                    .style('fill', spikeBarFill(d, backgroundColor, patternIdFor))
+                    .style('opacity', null)
+                g.select('.bar-hover-overlay').style('opacity', 0).style('fill', 'black')
+            })
+        }
+
+        svg.on('mousedown', (event: MouseEvent) => {
+            if (event.button !== 0) {
+                return
+            }
+            event.preventDefault()
+
+            const [mx] = d3.pointer(event)
+            dragStartX = mx
+
+            onHoverChange?.(null, null)
+            onEventHoverChange?.(null)
+
+            isDragging = true
+
+            svg.style('cursor', 'col-resize')
+            hoverCursorLine?.style('opacity', 0)
+        })
+
+        const handleMouseMove = (event: MouseEvent): void => {
+            if (!isDragging) {
+                return
+            }
+
+            const [mx] = d3.pointer(event, svgEl)
+            const clampedX = Math.max(0, Math.min(mx, width))
+            const left = Math.min(dragStartX, clampedX)
+            const right = Math.max(dragStartX, clampedX)
+
+            selectionOverlay
+                .attr('x', left)
+                .attr('width', Math.max(0, right - left))
+                .style('opacity', 1)
+
+            for (let i = 0; i < occurrences.length; i++) {
+                const binLeft = xScale(occurrences[i].date)
+                if (clampedX >= binLeft && clampedX < binLeft + bandwidth) {
+                    onHoverChange?.(i, occurrences[i])
+                    break
+                }
+            }
+
+            // Highlight bars inside selection, dim bars outside
+            barGroups.each(function (d: SparklineDatum) {
+                const g = d3.select(this)
+                const binLeft = xScale(d.date)
+                const binCenter = binLeft + bandwidth / 2
+                const inSelection = binCenter >= left && binCenter <= right
+
+                if (inSelection) {
+                    g.select('.bar-main').style('opacity', null)
+                    if (d.animated && d.color) {
+                        g.select('.bar-hover-overlay').style('fill', 'white').style('opacity', 0.15)
+                    } else {
+                        g.select('.bar-main').style('fill', hoverBackgroundColor)
+                    }
+                } else {
+                    g.select('.bar-main')
+                        .style('fill', spikeBarFill(d, backgroundColor, patternIdFor))
+                        .style('opacity', 0.3)
+                    g.select('.bar-hover-overlay').style('opacity', 0)
+                }
+            })
+        }
+
+        const handleMouseUp = (event: MouseEvent): void => {
+            if (!isDragging) {
+                return
+            }
+            isDragging = false
+
+            svg.style('cursor', 'crosshair')
+
+            const [mx] = d3.pointer(event, svgEl)
+            const clampedX = Math.max(0, Math.min(mx, width))
+            const dragDist = Math.abs(clampedX - dragStartX)
+
+            selectionOverlay.style('opacity', 0)
+
+            resetBarStyles()
+
+            if (dragDist < DRAG_MIN_DISTANCE_PX) {
+                return
+            }
+
+            const left = Math.min(dragStartX, clampedX)
+            const right = Math.max(dragStartX, clampedX)
+
+            let startDate: Date | null = null
+            let endDate: Date | null = null
+
+            for (const d of occurrences) {
+                const binLeft = xScale(d.date)
+                const binCenter = binLeft + bandwidth / 2
+                if (binCenter >= left && binCenter <= right) {
+                    if (!startDate || d.date < startDate) {
+                        startDate = d.date
+                    }
+                    if (!endDate || d.date > endDate) {
+                        endDate = d.date
+                    }
+                }
+            }
+
+            if (startDate && endDate) {
+                onRangeSelect(startDate, new Date(endDate.getTime() + timeDiff))
+            }
+        }
+
+        const namespace = `sparkline-drag-${sparklineKey}`
+        d3.select(window as EventTarget as Window).on(`mousemove.${namespace}`, handleMouseMove)
+        d3.select(window as EventTarget as Window).on(`mouseup.${namespace}`, handleMouseUp)
+
+        return () => {
+            d3.select(window as EventTarget as Window).on(`mousemove.${namespace}`, null)
+            d3.select(window as EventTarget as Window).on(`mouseup.${namespace}`, null)
+            svg.on('mousemove.cursor', null)
+        }
+    }
+
+    return () => {
+        svg.on('mousemove.cursor', null)
+    }
 }

--- a/products/error_tracking/frontend/scenes/ErrorTrackingIssueScene/errorTrackingIssueSceneLogic.ts
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingIssueScene/errorTrackingIssueSceneLogic.ts
@@ -31,6 +31,7 @@ import { ActivityScope, Breadcrumb, IntegrationType, UniversalFiltersGroup } fro
 
 import { issueActionsLogic } from '../../components/IssueActions/issueActionsLogic'
 import {
+    DEFAULT_DATE_RANGE,
     issueFiltersLogic,
     triggerFilterActions,
     updateFilterSearchParams,
@@ -104,6 +105,7 @@ export const errorTrackingIssueSceneLogic = kea<errorTrackingIssueSceneLogicType
         updateName: (name: string) => ({ name }),
         updateDescription: (description: string) => ({ description }),
         setSimilarIssuesMaxDistance: (distance: number) => ({ distance }),
+        setListDateRange: (dateRange: DateRange) => ({ dateRange }),
     }),
 
     defaults({
@@ -117,6 +119,7 @@ export const errorTrackingIssueSceneLogic = kea<errorTrackingIssueSceneLogicType
         initialEventLoading: true as boolean,
         similarIssuesMaxDistance: 0.2 as number,
         similarIssuesError: null as string | null,
+        listDateRange: null as DateRange | null,
     }),
 
     reducers(({ values }) => ({
@@ -153,6 +156,9 @@ export const errorTrackingIssueSceneLogic = kea<errorTrackingIssueSceneLogicType
                 }
                 return event
             },
+        },
+        listDateRange: {
+            setListDateRange: (_, { dateRange }) => dateRange,
         },
     })),
 
@@ -301,20 +307,20 @@ export const errorTrackingIssueSceneLogic = kea<errorTrackingIssueSceneLogicType
 
     selectors(({ actions }) => ({
         breadcrumbs: [
-            (s) => [s.issue, s.dateRange, s.filterTestAccounts, s.filterGroup, s.searchQuery],
+            (s) => [s.issue, s.listDateRange, s.filterTestAccounts, s.filterGroup, s.searchQuery],
             (
                 issue: ErrorTrackingRelationalIssue | null,
-                dateRange: DateRange,
+                listDateRange: DateRange | null,
                 filterTestAccounts: boolean,
                 filterGroup: UniversalFiltersGroup,
                 searchQuery: string
             ): Breadcrumb[] => {
                 const exceptionType: string = issue?.name || 'Issue'
-                // We want to keep params in sync between listing and details views
+                // Use the original list date range for back navigation
                 const urlParams = updateFilterSearchParams(
                     {},
                     {
-                        dateRange,
+                        dateRange: listDateRange ?? DEFAULT_DATE_RANGE,
                         filterTestAccounts,
                         filterGroup,
                         searchQuery,
@@ -468,6 +474,9 @@ export const errorTrackingIssueSceneLogic = kea<errorTrackingIssueSceneLogicType
     urlToAction(({ actions, values }) => {
         return {
             '**/error_tracking/:id': (_, params) => {
+                if (values.listDateRange == null) {
+                    actions.setListDateRange(params.dateRange ?? DEFAULT_DATE_RANGE)
+                }
                 triggerFilterActions(params, values, actions)
                 const tab = params.tab as ErrorTrackingIssueSceneCategory | undefined
                 const category = tab && VALID_CATEGORIES.includes(tab) ? tab : DEFAULT_CATEGORY


### PR DESCRIPTION
Added an ability to click and drag to select a time range in issue details scene:
- when selecting a new time range in details scene, this date range only applies to that scene. Going back to list scene resets time range to what was set before or default time range if none was set before,
- we are now displaying a vertical indicator when hovering over detailed spark line and we are also updating hovered date even if we don't hover over a bar,

| New vertical line | Dragging |
|--------|--------|
| ![CleanShot 2026-03-31 at 14 11 32](https://github.com/user-attachments/assets/023f0c30-b821-4078-9af2-552e61df4309) | ![CleanShot 2026-03-31 at 14 12 07](https://github.com/user-attachments/assets/4b73f2c8-a086-48c5-be3b-a8198ca36d9b) | 

| Full cool demo | Going back (arrow back or browser button) |
|--------|--|
| ![CleanShot 2026-03-31 at 14 13 06](https://github.com/user-attachments/assets/190c374f-f2df-4d32-a691-61619371a997) | ![CleanShot 2026-03-31 at 14 14 49](https://github.com/user-attachments/assets/e6c512df-f1d4-448c-a9bf-3eebeec99a4e) |