### PR TITLE
feat(ci): add checks and trigger for logs alerting temporal worker deployment

### DIFF
--- a/.github/workflows/container-images-cd.yml
+++ b/.github/workflows/container-images-cd.yml
@@ -496,12 +496,20 @@ jobs:
                       }
 
             - name: Check for changes that affect logs alerting temporal worker
+              uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
               id: check_changes_logs_alerting_temporal_worker
-              run: |
-                  echo "changed=$((git diff --name-only HEAD^ HEAD | grep -qE '^posthog/temporal/logs_alerting|^products/logs/backend|^posthog/temporal/common|^posthog/management/commands/start_temporal_worker.py$|^pyproject.toml$|^bin/temporal-django-worker$' && echo true) || echo false)" >> $GITHUB_OUTPUT
+              with:
+                  filters: |
+                      shouldRun:
+                        - 'posthog/temporal/logs_alerting/**'
+                        - 'products/logs/backend/**'
+                        - 'posthog/temporal/common/**'
+                        - 'posthog/management/commands/start_temporal_worker.py'
+                        - pyproject.toml
+                        - bin/temporal-django-worker
 
             - name: Trigger Logs Alerting Temporal Worker Cloud deployment
-              if: steps.check_changes_logs_alerting_temporal_worker.outputs.changed == 'true'
+              if: steps.check_changes_logs_alerting_temporal_worker.outputs.shouldRun == 'true'
               uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4.0.1
               with:
                   token: ${{ steps.deployer.outputs.token }}

--- a/.github/workflows/container-images-cd.yml
+++ b/.github/workflows/container-images-cd.yml
@@ -495,6 +495,32 @@ jobs:
                         "timestamp": "${{ github.event.head_commit.timestamp }}"
                       }
 
+            - name: Check for changes that affect logs alerting temporal worker
+              id: check_changes_logs_alerting_temporal_worker
+              run: |
+                  echo "changed=$((git diff --name-only HEAD^ HEAD | grep -qE '^posthog/temporal/logs_alerting|^products/logs/backend|^posthog/temporal/common|^posthog/management/commands/start_temporal_worker.py$|^pyproject.toml$|^bin/temporal-django-worker$' && echo true) || echo false)" >> $GITHUB_OUTPUT
+
+            - name: Trigger Logs Alerting Temporal Worker Cloud deployment
+              if: steps.check_changes_logs_alerting_temporal_worker.outputs.changed == 'true'
+              uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4.0.1
+              with:
+                  token: ${{ steps.deployer.outputs.token }}
+                  repository: PostHog/charts
+                  event-type: commit_state_update
+                  client-payload: |
+                      {
+                        "values": {
+                          "image": {
+                            "sha": "${{ github.sha }}@${{ steps.build.outputs.digest }}"
+                          }
+                        },
+                        "release": "temporal-worker-logs-alerting",
+                        "commit": ${{ toJson(github.event.head_commit) }},
+                        "repository": ${{ toJson(github.repository) }},
+                        "labels": ${{ steps.labels.outputs.labels }},
+                        "timestamp": "${{ github.event.head_commit.timestamp }}"
+                      }
+
             - name: Check for changes that affect ducklake temporal worker
               id: check_changes_ducklake_temporal_worker
               run: |


### PR DESCRIPTION
## Problem

The logs alerting temporal worker needs automated deployment when code changes are made

## Changes

Added automated deployment trigger for the logs alerting temporal worker that:

- Detects changes in logs alerting temporal worker paths, common temporal code, worker management commands, and configuration files
- Triggers deployment to the `temporal-worker-logs-alerting` release when relevant changes are detected
- Passes the built image SHA and commit metadata to the deployment system

## How did you test this code?

Follows the same pattern as existing temporal worker deployments in the workflow.

## Publish to changelog?

No