### PR TITLE
fix(docker): amd64 support

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -471,6 +471,7 @@ services:
     duckgres:
         # DuckLake 0.4 + DuckDB 1.5.1 (posthog/duckgres@4b787d7)
         image: ghcr.io/posthog/duckgres:4b787d7a5c576cba92ff53d6e95f10c7b6464a39
+        platform: arm64
         restart: on-failure
         profiles: ['duckgres']
         ports:


### PR DESCRIPTION
## Problem

Can't run our dev stack on `amd64`

## Changes

Tell docker the ducklake container is `arm64`, so it could just virtualize it.

## How did you test this code?

The stack ran after this change.

## Publish to changelog?

no
## Docs update
no