### PR TITLE
fix: Remove top margin from NavPanelAdvertisement header

### DIFF
--- a/frontend/src/lib/components/NavPanelAdvertisement/NavPanelAdvertisement.tsx
+++ b/frontend/src/lib/components/NavPanelAdvertisement/NavPanelAdvertisement.tsx
@@ -192,7 +192,7 @@ function Content({
 
     return (
         <div className="border rounded-sm bg-primary text-xs *:flex *:gap-2 *:px-2 *:py-1">
-            <div className="flex justify-between mt-1">
+            <div className="flex justify-between">
                 <div className="flex items-center gap-2">
                     <strong>
                         <span role="img" aria-label={emojiLabel}>


### PR DESCRIPTION
## Problem

The NavPanelAdvertisement component has unnecessary top margin that affects the visual alignment of the advertisement content.

## Changes

Removed the `mt-1` class from the advertisement container div to eliminate unwanted top margin spacing.

## Publish to changelog?

No

## Docs update

No documentation update needed for this minor styling adjustment.