### PR TITLE
fix(signals): Send more heartbeats when doing multi turn agentic runs through sandboxes

### DIFF
--- a/products/tasks/backend/services/custom_prompt_multi_turn_runner.py
+++ b/products/tasks/backend/services/custom_prompt_multi_turn_runner.py
@@ -1,10 +1,17 @@
+from __future__ import annotations
+
 import logging
 from dataclasses import dataclass, field
-from typing import TypeVar
+from typing import TYPE_CHECKING, TypeVar
 
 from pydantic import BaseModel
 
 from products.tasks.backend.models import Task, TaskRun
+
+if TYPE_CHECKING:
+    from temporalio.client import WorkflowHandle
+from posthog.temporal.common.client import async_connect
+
 from products.tasks.backend.services.custom_prompt_executor import extract_json_from_text
 from products.tasks.backend.services.custom_prompt_runner import (
     CustomPromptSandboxContext,
@@ -12,6 +19,7 @@ from products.tasks.backend.services.custom_prompt_runner import (
     _create_task_and_trigger,
     _poll_for_turn,
 )
+from products.tasks.backend.temporal.process_task.workflow import ProcessTaskWorkflow
 
 logger = logging.getLogger(__name__)
 
@@ -26,6 +34,7 @@ class MultiTurnSession:
     printed_lines: int = 0
     verbose: bool = False
     output_fn: OutputFn = field(default=None)
+    _workflow_handle: WorkflowHandle | None = field(default=None, repr=False)
 
     @classmethod
     async def start(
@@ -38,20 +47,23 @@ class MultiTurnSession:
         step_name: str = "",
         verbose: bool = False,
         output_fn: OutputFn = None,
-    ) -> tuple["MultiTurnSession", _ModelT]:
+    ) -> tuple[MultiTurnSession, _ModelT]:
         """Start a multi-turn sandbox session and wait for the first response."""
         task, task_run = await _create_task_and_trigger(prompt, context, branch, step_name)
         logger.info("multi_turn: started task=%s run=%s step=%s", task.id, task_run.id, step_name or "unknown")
-
+        # Get session's parent workflow to send heartbeats to keep the agent alive while waiting for turns
+        workflow_id = TaskRun.get_workflow_id(task.id, task_run.id)
+        client = await async_connect()
+        workflow_handle = client.get_workflow_handle(workflow_id)
         session = cls(
             task=task,
             task_run=task_run,
             verbose=verbose,
             output_fn=output_fn,
+            _workflow_handle=workflow_handle,
         )
-
         last_message, _, session.log_lines_seen, session.printed_lines = await _poll_for_turn(
-            task_run, verbose=verbose, output_fn=output_fn
+            task_run, verbose=verbose, output_fn=output_fn, workflow_handle=workflow_handle
         )
         parsed = cls._parse_and_validate(last_message, model, label="initial turn")
         return session, parsed
@@ -64,22 +76,17 @@ class MultiTurnSession:
         label: str = "",
     ) -> _ModelT:
         """Send a follow-up message and wait for the agent's next response."""
-        from posthog.temporal.common.client import async_connect
-
-        from products.tasks.backend.temporal.process_task.workflow import ProcessTaskWorkflow
-
-        workflow_id = TaskRun.get_workflow_id(self.task.id, self.task_run.id)
-        client = await async_connect()
-        handle = client.get_workflow_handle(workflow_id)
-        await handle.signal(ProcessTaskWorkflow.send_followup_message, message)
+        if not self._workflow_handle:
+            raise RuntimeError("Workflow handle is not available in this session.")
+        await self._workflow_handle.signal(ProcessTaskWorkflow.send_followup_message, message)
         logger.info("multi_turn: sent followup run=%s label=%s", self.task_run.id, label)
-
         last_message, _, self.log_lines_seen, self.printed_lines = await _poll_for_turn(
             self.task_run,
             skip_lines=self.log_lines_seen,
             printed_lines=self.printed_lines,
             verbose=self.verbose,
             output_fn=self.output_fn,
+            workflow_handle=self._workflow_handle,
         )
         parsed = self._parse_and_validate(last_message, model, label=label or "followup")
         return parsed
@@ -92,15 +99,10 @@ class MultiTurnSession:
 
     async def end(self) -> None:
         """Signal the workflow to shut down cleanly."""
-        from posthog.temporal.common.client import async_connect
-
-        from products.tasks.backend.temporal.process_task.workflow import ProcessTaskWorkflow
-
-        workflow_id = TaskRun.get_workflow_id(self.task.id, self.task_run.id)
+        if not self._workflow_handle:
+            raise RuntimeError("Workflow handle is not available in this session.")
         try:
-            client = await async_connect()
-            handle = client.get_workflow_handle(workflow_id)
-            await handle.signal(ProcessTaskWorkflow.complete_task, args=["completed", None])
+            await self._workflow_handle.signal(ProcessTaskWorkflow.complete_task, args=["completed", None])
             logger.info("multi_turn: ended session run=%s", self.task_run.id)
         except Exception:
             logger.warning("multi_turn: failed to signal completion run=%s", self.task_run.id, exc_info=True)

--- a/products/tasks/backend/services/custom_prompt_runner.py
+++ b/products/tasks/backend/services/custom_prompt_runner.py
@@ -127,6 +127,7 @@ async def _poll_for_turn(
 
     elapsed = 0
     consecutive_storage_errors = 0
+    last_new_lines_at = 0  # elapsed time when we last saw new log lines
     while elapsed < MAX_POLL_SECONDS:
         await asyncio.sleep(POLL_INTERVAL_SECONDS)
         elapsed += POLL_INTERVAL_SECONDS
@@ -152,6 +153,17 @@ async def _poll_for_turn(
             continue
         consecutive_storage_errors = 0
 
+        if total_lines > skip_lines:
+            last_new_lines_at = elapsed
+        stale_seconds = elapsed - last_new_lines_at
+        if stale_seconds >= 60 and stale_seconds % 60 < POLL_INTERVAL_SECONDS:
+            logger.warning(
+                "custom_prompt - poll_for_turn: no new S3 log lines for %ds, run=%s, total_lines=%d",
+                stale_seconds,
+                task_run.id,
+                total_lines,
+            )
+
         printed_lines = _stream_new_lines(full_log, printed_lines, verbose=verbose, output_fn=output_fn)
         if finished and last_message:
             return last_message, full_log, total_lines, printed_lines
@@ -163,6 +175,16 @@ async def _poll_for_turn(
             TaskRun.Status.FAILED,
             TaskRun.Status.CANCELLED,
         }:
+            logger.warning(
+                "custom_prompt - poll_for_turn: TaskRun reached terminal status=%s, error_message=%s, "
+                "run=%s, elapsed=%ds, stale_for=%ds, total_lines=%d",
+                refreshed.status,
+                refreshed.error_message,
+                task_run.id,
+                elapsed,
+                elapsed - last_new_lines_at,
+                total_lines,
+            )
             # Terminal status — one final log read with retries.
             final_message = None
             final_log = None

--- a/products/tasks/backend/services/custom_prompt_runner.py
+++ b/products/tasks/backend/services/custom_prompt_runner.py
@@ -118,12 +118,9 @@ async def _poll_for_turn(
     printed_lines: int = 0,
     verbose: bool = False,
     output_fn: OutputFn = None,
+    workflow_handle=None,
 ) -> tuple[str, str | None, int, int]:
-    """Poll S3 logs until the agent finishes a turn.
-
-    Returns (last_message, full_log, new_skip_lines, new_printed_lines).
-    Raises RuntimeError on timeout or terminal status without a message.
-    """
+    """Poll S3 logs until the agent finishes a turn."""
     from posthog.storage.object_storage import ObjectStorageError
 
     from products.tasks.backend.models import TaskRun
@@ -133,7 +130,13 @@ async def _poll_for_turn(
     while elapsed < MAX_POLL_SECONDS:
         await asyncio.sleep(POLL_INTERVAL_SECONDS)
         elapsed += POLL_INTERVAL_SECONDS
-
+        # Send heartbeat signals to the ProcessTaskWorkflow on each poll cycle to prevent
+        # the workflow's inactivity timeout from firing while the agent is still working
+        if workflow_handle is not None:
+            try:
+                await workflow_handle.signal("heartbeat")
+            except Exception:
+                logger.warning("custom_prompt - poll_for_turn: failed to send workflow heartbeat", exc_info=True)
         try:
             finished, last_message, full_log, total_lines = await sync_to_async(_check_logs)(task_run, skip_lines)
         except ObjectStorageError:

--- a/products/tasks/backend/services/custom_prompt_runner.py
+++ b/products/tasks/backend/services/custom_prompt_runner.py
@@ -1,10 +1,16 @@
+from __future__ import annotations
+
 import json
 import asyncio
 import logging
 from collections.abc import Callable
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
 from asgiref.sync import sync_to_async
+
+if TYPE_CHECKING:
+    from temporalio.client import WorkflowHandle
 
 logger = logging.getLogger(__name__)
 
@@ -118,7 +124,7 @@ async def _poll_for_turn(
     printed_lines: int = 0,
     verbose: bool = False,
     output_fn: OutputFn = None,
-    workflow_handle=None,
+    workflow_handle: WorkflowHandle | None = None,
 ) -> tuple[str, str | None, int, int]:
     """Poll S3 logs until the agent finishes a turn."""
     from posthog.storage.object_storage import ObjectStorageError


### PR DESCRIPTION
## Problem
- Tasks timeout without providing meaningful results

<img width="1015" height="782" alt="image" src="https://github.com/user-attachments/assets/b896dafa-1e92-4d99-b3c3-7d1fdcda23ae" />


<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
- Push more heartbeats + add logs to get better picture on what's happening

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
