### PR TITLE
fix(phai): strip large spend_history from billing context before temporal workflows

### DIFF
--- a/ee/api/conversation.py
+++ b/ee/api/conversation.py
@@ -123,6 +123,8 @@ class MessageSerializer(MessageMinimalSerializer):
         if billing_context:
             try:
                 billing_context = MaxBillingContext.model_validate(billing_context)
+                if billing_context.spend_history and len(billing_context.spend_history) > 20:
+                    billing_context.spend_history = None
                 data["billing_context"] = billing_context
             except pydantic.ValidationError as e:
                 capture_exception(e)
@@ -159,6 +161,8 @@ class QueueMessageSerializer(serializers.Serializer):
         if billing_context:
             try:
                 parsed_context = MaxBillingContext.model_validate(billing_context)
+                if parsed_context.spend_history and len(parsed_context.spend_history) > 20:
+                    parsed_context.spend_history = None
                 data["billing_context"] = parsed_context.model_dump()
             except pydantic.ValidationError as e:
                 capture_exception(e)

--- a/ee/api/conversation.py
+++ b/ee/api/conversation.py
@@ -123,6 +123,7 @@ class MessageSerializer(MessageMinimalSerializer):
         if billing_context:
             try:
                 billing_context = MaxBillingContext.model_validate(billing_context)
+                # Large spend histories can exceed Temporal's 2MB payload limit
                 if billing_context.spend_history and len(billing_context.spend_history) > 20:
                     billing_context.spend_history = None
                 data["billing_context"] = billing_context
@@ -161,6 +162,7 @@ class QueueMessageSerializer(serializers.Serializer):
         if billing_context:
             try:
                 parsed_context = MaxBillingContext.model_validate(billing_context)
+                # Large spend histories can exceed Temporal's 2MB payload limit
                 if parsed_context.spend_history and len(parsed_context.spend_history) > 20:
                     parsed_context.spend_history = None
                 data["billing_context"] = parsed_context.model_dump()

--- a/ee/api/conversation.py
+++ b/ee/api/conversation.py
@@ -81,6 +81,13 @@ class MessageMinimalSerializer(serializers.Serializer):
     content = serializers.CharField(required=True, max_length=10000)
 
 
+def _strip_large_spend_history(billing_context: MaxBillingContext, threshold: int = 20) -> MaxBillingContext:
+    """Large spend histories can exceed Temporal's 2MB payload limit."""
+    if billing_context.spend_history and len(billing_context.spend_history) > threshold:
+        billing_context.spend_history = None
+    return billing_context
+
+
 class MessageSerializer(MessageMinimalSerializer):
     content = serializers.CharField(
         required=True,
@@ -122,10 +129,7 @@ class MessageSerializer(MessageMinimalSerializer):
         billing_context = data.get("billing_context")
         if billing_context:
             try:
-                billing_context = MaxBillingContext.model_validate(billing_context)
-                # Large spend histories can exceed Temporal's 2MB payload limit
-                if billing_context.spend_history and len(billing_context.spend_history) > 20:
-                    billing_context.spend_history = None
+                billing_context = _strip_large_spend_history(MaxBillingContext.model_validate(billing_context))
                 data["billing_context"] = billing_context
             except pydantic.ValidationError as e:
                 capture_exception(e)
@@ -161,10 +165,7 @@ class QueueMessageSerializer(serializers.Serializer):
         billing_context = data.get("billing_context")
         if billing_context:
             try:
-                parsed_context = MaxBillingContext.model_validate(billing_context)
-                # Large spend histories can exceed Temporal's 2MB payload limit
-                if parsed_context.spend_history and len(parsed_context.spend_history) > 20:
-                    parsed_context.spend_history = None
+                parsed_context = _strip_large_spend_history(MaxBillingContext.model_validate(billing_context))
                 data["billing_context"] = parsed_context.model_dump()
             except pydantic.ValidationError as e:
                 capture_exception(e)

--- a/ee/api/test/test_conversation.py
+++ b/ee/api/test/test_conversation.py
@@ -21,6 +21,7 @@ from posthog.schema import (
     MaxBillingContextSubscriptionLevel,
     MaxBillingContextTrial,
     MaxProductInfo,
+    SpendHistoryItem,
 )
 
 from posthog.models.team.team import Team
@@ -1087,3 +1088,57 @@ class TestConversation(APIBaseTest):
 
                 # Verify agent_mode is passed for chat mode
                 self.assertEqual(workflow_inputs.agent_mode, AgentMode.SQL)
+
+    def _make_spend_history(self, count: int) -> list[dict]:
+        return [
+            SpendHistoryItem(
+                id=i,
+                label=f"item_{i}",
+                data=[float(i)],
+                dates=["2023-01-01"],
+            ).model_dump()
+            for i in range(count)
+        ]
+
+    def test_billing_context_strips_large_spend_history(self):
+        with patch(
+            "ee.hogai.core.executor.AgentExecutor.astream",
+            return_value=_async_generator(),
+        ) as mock_astream:
+            with patch("ee.api.conversation.StreamingHttpResponse", side_effect=self._create_mock_streaming_response):
+                billing_data = self.billing_context.model_dump()
+                billing_data["spend_history"] = self._make_spend_history(21)
+                response = self.client.post(
+                    f"/api/environments/{self.team.id}/conversations/",
+                    {
+                        "content": "test query",
+                        "trace_id": str(uuid.uuid4()),
+                        "conversation": str(uuid.uuid4()),
+                        "billing_context": billing_data,
+                    },
+                )
+                self.assertEqual(response.status_code, status.HTTP_200_OK)
+                workflow_inputs = mock_astream.call_args[0][1]
+                self.assertIsNone(workflow_inputs.billing_context.spend_history)
+
+    def test_billing_context_keeps_small_spend_history(self):
+        with patch(
+            "ee.hogai.core.executor.AgentExecutor.astream",
+            return_value=_async_generator(),
+        ) as mock_astream:
+            with patch("ee.api.conversation.StreamingHttpResponse", side_effect=self._create_mock_streaming_response):
+                billing_data = self.billing_context.model_dump()
+                billing_data["spend_history"] = self._make_spend_history(20)
+                response = self.client.post(
+                    f"/api/environments/{self.team.id}/conversations/",
+                    {
+                        "content": "test query",
+                        "trace_id": str(uuid.uuid4()),
+                        "conversation": str(uuid.uuid4()),
+                        "billing_context": billing_data,
+                    },
+                )
+                self.assertEqual(response.status_code, status.HTTP_200_OK)
+                workflow_inputs = mock_astream.call_args[0][1]
+                self.assertIsNotNone(workflow_inputs.billing_context.spend_history)
+                self.assertEqual(len(workflow_inputs.billing_context.spend_history), 20)


### PR DESCRIPTION
## Problem

The `spend_history` field in billing context can exceed 2MB, which hits Temporal workflow payload limits and causes failures. This is a temporary measure until we migrate large payloads to S3.

## Changes

- Strip `spend_history` from billing context in both `MessageSerializer` and `QueueMessageSerializer` when it exceeds 20 rows
- Small spend histories (<=20 rows) are preserved for use by the billing tool

## How did you test this code?

Added two unit tests:
- `test_billing_context_strips_large_spend_history` — verifies 21+ items are stripped
- `test_billing_context_keeps_small_spend_history` — verifies <=20 items pass through

## Publish to changelog?

no