### PR TITLE
fix: rewrite SLO queries to single-scan pattern to avoid timeouts

### DIFF
--- a/terraform/us/project-2/team-analytics-platform/slo-monitoring/insights.tf
+++ b/terraform/us/project-2/team-analytics-platform/slo-monitoring/insights.tf
@@ -60,7 +60,7 @@ locals {
             toStartOfHour(timestamp) AS event_hour,
             countIf(event = 'slo_operation_started') AS starts,
             countIf(event = 'slo_operation_completed' AND properties.outcome = 'success') AS successes,
-            minIf(timestamp, event = 'slo_operation_started') AS first_start
+            min(if(event = 'slo_operation_started', timestamp, NULL)) AS first_start
         FROM events
         WHERE event IN ('slo_operation_started', 'slo_operation_completed')
           AND properties.operation = '{{OPERATION}}'
@@ -77,7 +77,7 @@ locals {
                 starts AS total,
                 greatest(starts - successes, 0) AS failures
             FROM per_cid_hour
-            Where cid = ''
+            WHERE cid = ''
 
             UNION ALL
 

--- a/terraform/us/project-2/team-analytics-platform/slo-monitoring/insights.tf
+++ b/terraform/us/project-2/team-analytics-platform/slo-monitoring/insights.tf
@@ -51,61 +51,45 @@ locals {
   # Placeholders: {{OPERATION}}, {{REGION}}, {{ERROR_BUDGET}}
   # ---------------------------------------------------------------------------
   slo_burn_rate_query = <<-SQL
-    -- Two paths: correlated (pairs started/completed by correlation_id, exact)
-    -- and uncorrelated (bucket-based with clamp, for SLOs without correlation_id).
-    WITH correlated AS (
+    -- Single scan: GROUP BY (cid, hour) extracts correlation_id once per row.
+    -- Correlated events (cid != '') are paired by cid then attributed to start hour.
+    -- Uncorrelated events (cid = '') use bucket-based counting with clamp.
+    WITH per_cid_hour AS (
         SELECT
-            properties.correlation_id AS cid,
-            minIf(timestamp, event = 'slo_operation_started') AS started_at,
-            max(if(event = 'slo_operation_completed' AND properties.outcome = 'success', 1, 0)) AS succeeded
+            coalesce(nullIf(properties.correlation_id, ''), '') AS cid,
+            toStartOfHour(timestamp) AS event_hour,
+            countIf(event = 'slo_operation_started') AS starts,
+            countIf(event = 'slo_operation_completed' AND properties.outcome = 'success') AS successes,
+            minIf(timestamp, event = 'slo_operation_started') AS first_start
         FROM events
         WHERE event IN ('slo_operation_started', 'slo_operation_completed')
           AND properties.operation = '{{OPERATION}}'
           AND properties.region = '{{REGION}}'
-          AND properties.correlation_id IS NOT NULL
           AND timestamp >= now() - INTERVAL 35 DAY
-        GROUP BY cid
-    ),
-    correlated_hourly AS (
-        SELECT
-            toStartOfHour(started_at) AS hour,
-            count() AS total,
-            countIf(succeeded = 0) AS failures
-        FROM correlated
-        WHERE started_at IS NOT NULL
-        GROUP BY hour
-    ),
-    -- Clamped to 0: without correlation_id, started/completed events for the
-    -- same operation can land in different hourly buckets, producing negative
-    -- failure counts that are measurement artifacts, not real data.
-    uncorrelated_hourly AS (
-        SELECT
-            toStartOfHour(timestamp) AS hour,
-            countIf(event = 'slo_operation_started') AS total,
-            greatest(
-                countIf(event = 'slo_operation_started')
-                  - countIf(event = 'slo_operation_completed' AND properties.outcome = 'success'),
-                0
-            ) AS failures
-        FROM events
-        WHERE event IN ('slo_operation_started', 'slo_operation_completed')
-          AND properties.operation = '{{OPERATION}}'
-          AND properties.region = '{{REGION}}'
-          -- HogQL returns NULL for missing properties on materialized columns,
-          -- but empty string on non-materialized ones; handle both.
-          AND (properties.correlation_id IS NULL OR properties.correlation_id = '')
-          AND timestamp >= now() - INTERVAL 35 DAY
-        GROUP BY hour
+        GROUP BY cid, event_hour
     ),
     hourly AS (
-        SELECT
-            hour,
-            sum(total) AS total,
-            sum(failures) AS failures
+        SELECT hour, sum(total) AS total, sum(failures) AS failures
         FROM (
-            SELECT * FROM correlated_hourly
+            -- Uncorrelated: each row is one hour bucket, clamp failures to 0
+            SELECT
+                event_hour AS hour,
+                starts AS total,
+                greatest(starts - successes, 0) AS failures
+            FROM per_cid_hour
+            Where cid = ''
+
             UNION ALL
-            SELECT * FROM uncorrelated_hourly
+
+            -- Correlated: collapse across hours per cid, attribute to start hour
+            SELECT
+                toStartOfHour(min(first_start)) AS hour,
+                1 AS total,
+                if(max(successes) > 0, 0, 1) AS failures
+            FROM per_cid_hour
+            WHERE cid != ''
+            GROUP BY cid
+            HAVING hour IS NOT NULL
         )
         GROUP BY hour
     ),
@@ -310,31 +294,8 @@ resource "posthog_insight" "slo_success_rate" {
     source = {
       kind  = "HogQLQuery"
       query = <<-SQL
-        -- Two paths: see burn rate query comment for rationale.
-        WITH correlated_ops AS (
-            SELECT
-                properties.correlation_id AS cid,
-                properties.operation AS operation,
-                minIf(timestamp, event = 'slo_operation_started') AS started_at,
-                max(if(event = 'slo_operation_completed' AND properties.outcome = 'success', 1, 0)) AS succeeded
-            FROM events
-            WHERE event IN ('slo_operation_started', 'slo_operation_completed')
-              AND properties.operation IN (${local.slo_operation_list})
-              AND properties.correlation_id IS NOT NULL
-              AND timestamp >= now() - INTERVAL 56 DAY
-            GROUP BY cid, operation
-        ),
-        correlated_daily AS (
-            SELECT
-                toDate(started_at) AS date,
-                operation,
-                count() AS total,
-                countIf(succeeded = 0) AS failures
-            FROM correlated_ops
-            WHERE started_at IS NOT NULL
-            GROUP BY date, operation
-        ),
-        uncorrelated_daily AS (
+        -- No correlation_id needed: daily buckets have negligible cross-bucket issues.
+        WITH daily AS (
             SELECT
                 toDate(timestamp) AS date,
                 properties.operation AS operation,
@@ -347,17 +308,7 @@ resource "posthog_insight" "slo_success_rate" {
             FROM events
             WHERE event IN ('slo_operation_started', 'slo_operation_completed')
               AND properties.operation IN (${local.slo_operation_list})
-              AND (properties.correlation_id IS NULL OR properties.correlation_id = '')
               AND timestamp >= now() - INTERVAL 56 DAY
-            GROUP BY date, operation
-        ),
-        daily AS (
-            SELECT date, operation, sum(total) AS total, sum(failures) AS failures
-            FROM (
-                SELECT * FROM correlated_daily
-                UNION ALL
-                SELECT * FROM uncorrelated_daily
-            )
             GROUP BY date, operation
         ),
         date_range AS (
@@ -429,76 +380,32 @@ resource "posthog_insight" "slo_volume" {
     source = {
       kind  = "HogQLQuery"
       query = <<-SQL
-        -- Two paths: see burn rate query comment for rationale.
-        WITH correlated_ops AS (
-            SELECT
-                properties.correlation_id AS cid,
-                properties.operation AS operation,
-                properties.region AS region,
-                countIf(event = 'slo_operation_started') AS starts,
-                max(if(event = 'slo_operation_completed' AND properties.outcome = 'success', 1, 0)) AS succeeded,
-                max(if(event = 'slo_operation_completed' AND properties.outcome = 'failure', 1, 0)) AS failed,
-                countIf(event = 'slo_operation_completed') AS completions
-            FROM events
-            WHERE event IN ('slo_operation_started', 'slo_operation_completed')
-              AND properties.correlation_id IS NOT NULL
-              AND timestamp >= now() - INTERVAL 28 DAY
-            GROUP BY cid, operation, region
-        ),
-        correlated_summary AS (
-            SELECT
-                operation,
-                region,
-                countIf(starts > 0) AS started,
-                countIf(succeeded = 1) AS successes,
-                countIf(failed = 1) AS failures,
-                countIf(starts > 0 AND completions = 0) AS never_completed
-            FROM correlated_ops
-            GROUP BY operation, region
-        ),
-        uncorrelated_summary AS (
-            SELECT
-                properties.operation AS operation,
-                properties.region AS region,
-                countIf(event = 'slo_operation_started') AS started,
-                countIf(event = 'slo_operation_completed' AND properties.outcome = 'success') AS successes,
-                countIf(event = 'slo_operation_completed' AND properties.outcome = 'failure') AS failures,
-                greatest(
-                    countIf(event = 'slo_operation_started')
-                      - countIf(event = 'slo_operation_completed'),
-                    0
-                ) AS never_completed
-            FROM events
-            WHERE event IN ('slo_operation_started', 'slo_operation_completed')
-              AND (properties.correlation_id IS NULL OR properties.correlation_id = '')
-              AND timestamp >= now() - INTERVAL 28 DAY
-            GROUP BY operation, region
-        ),
-        combined AS (
-            SELECT operation, region, started, successes, failures, never_completed
-            FROM correlated_summary
-            UNION ALL
-            SELECT operation, region, started, successes, failures, never_completed
-            FROM uncorrelated_summary
-        )
+        -- No correlation_id needed: single 28-day bucket has no cross-bucket issue.
         SELECT
-            operation,
+            properties.operation AS operation,
             if(
-                count(region) OVER (PARTITION BY operation) = 1,
+                count(properties.region) OVER (PARTITION BY properties.operation) = 1,
                 'all*',
-                region
+                properties.region
             ) AS region,
-            sum(started) AS started,
-            sum(successes) AS successes,
-            sum(failures) AS failures,
-            sum(never_completed) AS never_completed,
+            countIf(event = 'slo_operation_started') AS started,
+            countIf(event = 'slo_operation_completed' AND properties.outcome = 'success') AS successes,
+            countIf(event = 'slo_operation_completed' AND properties.outcome = 'failure') AS failures,
+            greatest(
+                countIf(event = 'slo_operation_started')
+                  - countIf(event = 'slo_operation_completed'),
+                0
+            ) AS never_completed,
             if(
-                sum(started) > 0,
-                round(sum(successes) / sum(started) * 100, 2),
+                countIf(event = 'slo_operation_started') > 0,
+                round(countIf(event = 'slo_operation_completed' AND properties.outcome = 'success')
+                  / countIf(event = 'slo_operation_started') * 100, 2),
                 NULL
             ) AS success_rate
-        FROM combined
-        GROUP BY operation, region
+        FROM events
+        WHERE event IN ('slo_operation_started', 'slo_operation_completed')
+          AND timestamp >= now() - INTERVAL 28 DAY
+        GROUP BY operation, properties.region
         ORDER BY operation, region
       SQL
     }


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

The dual-scan approach extracted the non-materialized`properties.correlation_id` from JSON for every matching event row twice — once per path. This caused query timeouts on the SLO dashboard ([link](https://us.posthog.com/project/2/dashboard/1397132?highlightInsightId=br4I7zLe)). 

## Changes

Upon investigation, I think we only need the correlation ID checks on the burn rate segments of that dashboard, as those have the very sensitive hourly burn rates. In the total volume / success rates, the impact is negligible and can be kept at bay by using the clamp functionality, this as those queries span the last 28d, compared to the last hour. 

Thus for the burn rates: 

- Rewrites the query from dual-scan (one for correlated events, one for uncorrelated) to a single scan with `GROUP BY (cid, event_hour)`
- Extracts `properties.correlation_id` once per row, then splits into correlated/uncorrelated paths on the in-memory aggregated result

For the success and volume:

- Revert to the old query and clamp the values to >= 0 to avoid negative values during day end boundaries.

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

[Manually updated the queries on a few entries in the dashboard](https://us.posthog.com/project/2/dashboard/1397132)

<!-- Briefly describe the steps you took. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Publish to changelog?

No

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

No

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->