### PR TITLE
chore: improve AGENTS.md PR and automation guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,7 +109,7 @@ See [.agents/security.md](.agents/security.md) for SQL, HogQL, and semgrep secur
 
 ## Agent automation
 
-Prefer the most enforceable approach that fits the problem:
+When automating a convention, try these in order — only fall back to the next if the previous isn't suitable:
 
 1. **Linters** (ruff, oxlint, semgrep) — code pattern enforcement, always paired with CI
 2. **lint-staged / husky** — file-level validation or warnings at commit time

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,7 +57,10 @@ Examples:
 
 ### PR descriptions
 
-Follow the PR description template in `.github/pull_request_template.md` when creating or updating PR descriptions. Keep the descriptions of changes higher-level, focusing on key details for the human reviewer to evaluate the rationale for the approach, and the overall architecture.
+**Required:** Before creating any PR, read `.github/pull_request_template.md` and use its exact section structure.
+Do not invent a different format.
+Always uncomment and fill the `## LLM context` section for agent-authored PRs.
+Keep descriptions high-level, focusing on rationale and architecture for the human reviewer.
 
 ### Rules
 
@@ -106,12 +109,11 @@ See [.agents/security.md](.agents/security.md) for SQL, HogQL, and semgrep secur
 
 ## Agent automation
 
-Prefer these approaches in order:
+Prefer the most enforceable approach that fits the problem:
 
-1. **AGENTS.md / CLAUDE.md instructions** — try this first
-2. **Skills** (`.agents/skills/`) — scaffold with `hogli init:skill`
-3. **lint-staged / husky** — file-level validation at commit time
-4. **CI checks** — PR-level enforcement
-5. **Linters** (ruff, oxlint, semgrep) — code pattern enforcement
+1. **Linters** (ruff, oxlint, semgrep) — code pattern enforcement, always paired with CI
+2. **lint-staged / husky** — file-level validation or warnings at commit time
+3. **Skills** (`.agents/skills/`) — scaffold with `hogli init:skill`
+4. **AGENTS.md / CLAUDE.md instructions** — when automated enforcement isn't suitable
 
 Claude Code hooks are reserved for environment bootstrapping (`SessionStart` only) — do not add `PreToolUse`, `PostToolUse`, or `Notification` hooks as they add latency and are fragile. Changes to `.claude/hooks/` trigger a lint-staged warning; changes to `.claude/settings.json` are blocked outright.


### PR DESCRIPTION
## Problem

Agent-authored PRs don't reliably follow the repo's PR template, and the agent automation preference list in AGENTS.md had the wrong priority order — it encouraged reaching for AGENTS.md instructions first instead of automated enforcement.

Follows up on #52411 feedback.

## Changes

- **PR descriptions:** changed from soft "follow the template" to a required pre-step that reads `.github/pull_request_template.md` and uses its exact structure. Explicitly requires the `## LLM context` section for agent PRs.
- **Agent automation order:** inverted the preference list so the most enforceable approaches come first (linters + CI > lint-staged > skills > AGENTS.md).

## How did you test this code?

This is a documentation/instructions change — no runtime behavior affected.

## Publish to changelog?

no

## Docs update

n/a

## LLM context

Agent-authored PR. Changes are limited to AGENTS.md instructions.