### PR TITLE
fix(visual): Fix visual review run counts to use writer DB during completion

### DIFF
--- a/products/visual_review/backend/logic.py
+++ b/products/visual_review/backend/logic.py
@@ -470,18 +470,14 @@ def _register_snapshots(
 
 def _update_run_counts(run: Run, using: str | None = None) -> None:
     """Recalculate result counts from RunSnapshot rows."""
-    db_alias = using or run._state.db or WRITER_DB
+    db_alias = using or WRITER_DB
     counts = RunSnapshot.objects.using(db_alias).filter(run_id=run.id).values("result").annotate(n=Count("id"))
     by_result = {row["result"]: row["n"] for row in counts}
 
     run.changed_count = by_result.get(SnapshotResult.CHANGED, 0)
     run.new_count = by_result.get(SnapshotResult.NEW, 0)
     run.removed_count = by_result.get(SnapshotResult.REMOVED, 0)
-    Run.objects.using(db_alias).filter(id=run.id).update(
-        changed_count=run.changed_count,
-        new_count=run.new_count,
-        removed_count=run.removed_count,
-    )
+    run.save(using=db_alias, update_fields=["changed_count", "new_count", "removed_count"])
 
 
 @transaction.atomic(using=WRITER_DB)

--- a/products/visual_review/backend/logic.py
+++ b/products/visual_review/backend/logic.py
@@ -336,7 +336,7 @@ def create_run(
     # requires the slot to be free before the insert. A new CI push always
     # replaces the previous run — approved and clean runs still show up in
     # their respective UI filters via REVIEW_STATE_FILTERS.
-    supersede_filter = Run.objects.filter(
+    supersede_filter = Run.objects.using(WRITER_DB).filter(
         repo_id=repo_id,
         branch=branch,
         run_type=run_type,
@@ -347,7 +347,7 @@ def create_run(
     if superseded_ids:
         from django.db.models import F
 
-        Run.objects.filter(id__in=superseded_ids, team_id=team_id).update(superseded_by=F("id"))
+        Run.objects.using(WRITER_DB).filter(id__in=superseded_ids, team_id=team_id).update(superseded_by=F("id"))
 
     removed = removed_identifiers or []
     total = len(snapshots) + unchanged_count
@@ -366,10 +366,10 @@ def create_run(
 
     # Fix up the sentinel pointers to reference the actual new run
     if superseded_ids:
-        Run.objects.filter(id__in=superseded_ids, team_id=team_id).update(superseded_by=run)
+        Run.objects.using(WRITER_DB).filter(id__in=superseded_ids, team_id=team_id).update(superseded_by=run)
 
     _added, uploads = _register_snapshots(run, repo, snapshots, verified_baselines, removed)
-    _update_run_counts(run)
+    _update_run_counts(run, using=WRITER_DB)
 
     transaction.on_commit(
         lambda: _post_commit_status(run, repo, "pending", "Visual review in progress"), using=WRITER_DB
@@ -468,15 +468,20 @@ def _register_snapshots(
     return added_count, uploads
 
 
-def _update_run_counts(run: Run) -> None:
+def _update_run_counts(run: Run, using: str | None = None) -> None:
     """Recalculate result counts from RunSnapshot rows."""
-    counts = run.snapshots.values("result").annotate(n=Count("id"))
+    db_alias = using or run._state.db or WRITER_DB
+    counts = RunSnapshot.objects.using(db_alias).filter(run_id=run.id).values("result").annotate(n=Count("id"))
     by_result = {row["result"]: row["n"] for row in counts}
 
     run.changed_count = by_result.get(SnapshotResult.CHANGED, 0)
     run.new_count = by_result.get(SnapshotResult.NEW, 0)
     run.removed_count = by_result.get(SnapshotResult.REMOVED, 0)
-    run.save(update_fields=["changed_count", "new_count", "removed_count"])
+    Run.objects.using(db_alias).filter(id=run.id).update(
+        changed_count=run.changed_count,
+        new_count=run.new_count,
+        removed_count=run.removed_count,
+    )
 
 
 @transaction.atomic(using=WRITER_DB)
@@ -502,10 +507,10 @@ def add_snapshots_to_run(
     added, uploads = _register_snapshots(run, repo, snapshots, verified_baselines)
 
     # Atomically increment total (safe for concurrent shards)
-    Run.objects.filter(id=run_id, team_id=team_id).update(
+    Run.objects.using(WRITER_DB).filter(id=run_id, team_id=team_id).update(
         total_snapshots=F("total_snapshots") + added + unchanged_count
     )
-    _update_run_counts(run)
+    _update_run_counts(run, using=WRITER_DB)
 
     return added, uploads
 
@@ -564,10 +569,10 @@ def complete_run(
 
     # Reconcile final counts (includes shards' unchanged + any removals)
     if unchanged_count or removed:
-        Run.objects.filter(id=run_id, team_id=run.repo.team_id).update(
+        Run.objects.using(WRITER_DB).filter(id=run_id, team_id=run.repo.team_id).update(
             total_snapshots=F("total_snapshots") + unchanged_count,
         )
-        _update_run_counts(run)
+        _update_run_counts(run, using=WRITER_DB)
 
     verify_uploads_and_create_artifacts(run_id)
 

--- a/products/visual_review/backend/tests/test_logic.py
+++ b/products/visual_review/backend/tests/test_logic.py
@@ -458,6 +458,43 @@ class TestRunOperations:
         assert updated.status == RunStatus.FAILED
         assert updated.error_message == "Something failed"
 
+    def test_update_run_counts_reads_and_writes_through_requested_db(self, repo, mocker):
+        run, _ = logic.create_run(
+            repo_id=repo.id,
+            team_id=repo.team_id,
+            run_type=RunType.STORYBOOK,
+            commit_sha="abc",
+            branch="main",
+            pr_number=None,
+            snapshots=[],
+            baseline_hashes={},
+        )
+
+        snapshot_queryset = mocker.Mock()
+        snapshot_queryset.values.return_value.annotate.return_value = [
+            {"result": SnapshotResult.CHANGED, "n": 2},
+            {"result": SnapshotResult.NEW, "n": 1},
+        ]
+        snapshot_manager = mocker.Mock()
+        snapshot_manager.filter.return_value = snapshot_queryset
+
+        run_manager = mocker.Mock()
+        run_manager.filter.return_value.update.return_value = 1
+
+        run_snapshot_using = mocker.patch.object(logic.RunSnapshot.objects, "using", return_value=snapshot_manager)
+        run_using = mocker.patch.object(logic.Run.objects, "using", return_value=run_manager)
+
+        logic._update_run_counts(run, using=logic.WRITER_DB)
+
+        run_snapshot_using.assert_called_once_with(logic.WRITER_DB)
+        snapshot_manager.filter.assert_called_once_with(run_id=run.id)
+        run_using.assert_called_once_with(logic.WRITER_DB)
+        run_manager.filter.assert_called_once_with(id=run.id)
+        run_manager.filter.return_value.update.assert_called_once_with(changed_count=2, new_count=1, removed_count=0)
+        assert run.changed_count == 2
+        assert run.new_count == 1
+        assert run.removed_count == 0
+
 
 @pytest.mark.django_db(databases=PRODUCT_DATABASES)
 class TestApproveRun:

--- a/products/visual_review/backend/tests/test_logic.py
+++ b/products/visual_review/backend/tests/test_logic.py
@@ -478,19 +478,16 @@ class TestRunOperations:
         snapshot_manager = mocker.Mock()
         snapshot_manager.filter.return_value = snapshot_queryset
 
-        run_manager = mocker.Mock()
-        run_manager.filter.return_value.update.return_value = 1
-
         run_snapshot_using = mocker.patch.object(logic.RunSnapshot.objects, "using", return_value=snapshot_manager)
-        run_using = mocker.patch.object(logic.Run.objects, "using", return_value=run_manager)
+        run_save = mocker.patch.object(run, "save")
 
         logic._update_run_counts(run, using=logic.WRITER_DB)
 
         run_snapshot_using.assert_called_once_with(logic.WRITER_DB)
         snapshot_manager.filter.assert_called_once_with(run_id=run.id)
-        run_using.assert_called_once_with(logic.WRITER_DB)
-        run_manager.filter.assert_called_once_with(id=run.id)
-        run_manager.filter.return_value.update.assert_called_once_with(changed_count=2, new_count=1, removed_count=0)
+        run_save.assert_called_once_with(
+            using=logic.WRITER_DB, update_fields=["changed_count", "new_count", "removed_count"]
+        )
         assert run.changed_count == 2
         assert run.new_count == 1
         assert run.removed_count == 0


### PR DESCRIPTION
## Summary
- route visual review count reconciliation through the writer DB alias in write transactions
- prevent `complete_run()` from skipping diff task enqueue due to stale in-transaction run counters
- add a regression test covering the writer-scoped count update path

## Testing
- Not run (not requested)