### PR TITLE
feat: Enable open telemetry plugin via setting in Temporal

### DIFF
--- a/posthog/management/commands/start_temporal_worker.py
+++ b/posthog/management/commands/start_temporal_worker.py
@@ -481,8 +481,9 @@ class Command(BaseCommand):
         tag_queries(kind="temporal")
 
         enable_otel = settings.TEMPORAL_OTEL_PLUGIN_ENABLED is True and settings.OTEL_SERVICE_NAME is not None
-        if enable_otel:
-            initialize_otel(settings.OTEL_SERVICE_NAME)
+        if enable_otel is True:
+            # Mypy doesn't understand we have already checked settings.OTEL_SERVICE_NAME
+            initialize_otel(settings.OTEL_SERVICE_NAME)  # type: ignore
 
         async def shutdown_all(
             worker: ManagedWorker, health_srv: HealthCheckServer | None, sig: signal.Signals

--- a/posthog/management/commands/start_temporal_worker.py
+++ b/posthog/management/commands/start_temporal_worker.py
@@ -12,6 +12,7 @@ import structlog
 from temporalio import workflow
 
 from posthog.temporal.common.base import PostHogWorkflow
+from posthog.temporal.common.open_telemetry import initialize_otel
 
 with workflow.unsafe.imports_passed_through():
     from django.conf import settings
@@ -479,6 +480,9 @@ class Command(BaseCommand):
 
         tag_queries(kind="temporal")
 
+        if settings.TEMPORAL_OTEL_PLUGIN_ENABLED is True:
+            initialize_otel(settings.OTEL_SERVICE_NAME)
+
         async def shutdown_all(
             worker: ManagedWorker, health_srv: HealthCheckServer | None, sig: signal.Signals
         ) -> None:
@@ -556,6 +560,7 @@ class Command(BaseCommand):
                     target_memory_usage=target_memory_usage,
                     target_cpu_usage=target_cpu_usage,
                     enable_combined_metrics_server=not disable_combined_metrics_server,
+                    enable_open_telemetry_plugin=settings.TEMPORAL_OTEL_PLUGIN_ENABLED,
                 )
             )
 

--- a/posthog/management/commands/start_temporal_worker.py
+++ b/posthog/management/commands/start_temporal_worker.py
@@ -480,7 +480,8 @@ class Command(BaseCommand):
 
         tag_queries(kind="temporal")
 
-        if settings.TEMPORAL_OTEL_PLUGIN_ENABLED is True:
+        enable_otel = settings.TEMPORAL_OTEL_PLUGIN_ENABLED is True and settings.OTEL_SERVICE_NAME is not None
+        if enable_otel:
             initialize_otel(settings.OTEL_SERVICE_NAME)
 
         async def shutdown_all(
@@ -560,7 +561,7 @@ class Command(BaseCommand):
                     target_memory_usage=target_memory_usage,
                     target_cpu_usage=target_cpu_usage,
                     enable_combined_metrics_server=not disable_combined_metrics_server,
-                    enable_open_telemetry_plugin=settings.TEMPORAL_OTEL_PLUGIN_ENABLED,
+                    enable_open_telemetry_plugin=enable_otel,
                 )
             )
 

--- a/posthog/models/resource_transfer/test/__snapshots__/test_visitor_field_snapshots.ambr
+++ b/posthog/models/resource_transfer/test/__snapshots__/test_visitor_field_snapshots.ambr
@@ -452,7 +452,6 @@
   list([
     'DoesNotExist',
     'MultipleObjectsReturned',
-    '__annotations__',
     '__doc__',
     '__module__',
     '__repr__',

--- a/posthog/models/resource_transfer/test/__snapshots__/test_visitor_field_snapshots.ambr
+++ b/posthog/models/resource_transfer/test/__snapshots__/test_visitor_field_snapshots.ambr
@@ -452,6 +452,7 @@
   list([
     'DoesNotExist',
     'MultipleObjectsReturned',
+    '__annotations__',
     '__doc__',
     '__module__',
     '__repr__',

--- a/posthog/settings/temporal.py
+++ b/posthog/settings/temporal.py
@@ -31,6 +31,7 @@ TEMPORAL_COMBINED_METRICS_SERVER_ENABLED: bool = get_from_env(
 )
 
 TEMPORAL_LOG_LEVEL: str = os.getenv("TEMPORAL_LOG_LEVEL", "INFO")
+TEMPORAL_OTEL_PLUGIN_ENABLED: bool = get_from_env("TEMPORAL_OTEL_PLUGIN_ENABLED", False, type_cast=str_to_bool)
 
 SANDBOX_PROVIDER: str | None = get_from_env(
     "SANDBOX_PROVIDER", None, optional=True

--- a/posthog/temporal/common/open_telemetry.py
+++ b/posthog/temporal/common/open_telemetry.py
@@ -1,7 +1,7 @@
 from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
 from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace.export import BatchSpanProcessor
-from opentelemetry.trace import set_trace_provider
+from opentelemetry.trace import set_tracer_provider
 from temporalio.contrib.opentelemetry import create_tracer_provider
 
 
@@ -15,4 +15,4 @@ def initialize_otel(service_name: str) -> None:
     provider = create_tracer_provider(resource=resource)
 
     provider.add_span_processor(BatchSpanProcessor(OTLPSpanExporter()))
-    set_trace_provider(provider)
+    set_tracer_provider(provider)

--- a/posthog/temporal/common/open_telemetry.py
+++ b/posthog/temporal/common/open_telemetry.py
@@ -1,0 +1,18 @@
+from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from opentelemetry.trace import set_trace_provider
+from temporalio.contrib.opentelemetry import create_tracer_provider
+
+
+def initialize_otel(service_name: str) -> None:
+    """Initialize Open Telemetry for Temporal workers.
+
+    This uses Temporal's replay-safe tracer provider which is meant to work with
+    Temporal's `OpenTelemetryPlugin`.
+    """
+    resource = Resource.create(attributes={"service.name": service_name})
+    provider = create_tracer_provider(resource=resource)
+
+    provider.add_span_processor(BatchSpanProcessor(OTLPSpanExporter()))
+    set_trace_provider(provider)

--- a/posthog/temporal/common/worker.py
+++ b/posthog/temporal/common/worker.py
@@ -7,6 +7,8 @@ from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 
 from prometheus_client import REGISTRY
+from temporalio.client import Plugin
+from temporalio.contrib.opentelemetry import OpenTelemetryPlugin
 from temporalio.runtime import PrometheusConfig, Runtime, TelemetryConfig
 from temporalio.worker import ResourceBasedSlotConfig, UnsandboxedWorkflowRunner, Worker, WorkerTuner
 
@@ -156,6 +158,7 @@ async def create_worker(
     target_memory_usage: float | None = None,
     target_cpu_usage: float | None = None,
     enable_combined_metrics_server: bool = True,
+    enable_open_telemetry_plugin: bool = False,
 ) -> ManagedWorker:
     """Connect to Temporal server and return a ManagedWorker containing the Worker and metrics server.
 
@@ -204,6 +207,11 @@ async def create_worker(
     else:
         # Expose Temporal SDK metrics directly on the public metrics port.
         temporal_metrics_bind_address = f"0.0.0.0:{metrics_port}"
+
+    if enable_open_telemetry_plugin:
+        plugins: collections.abc.Sequence[Plugin] | None = (OpenTelemetryPlugin(add_temporal_spans=True),)
+    else:
+        plugins = None
 
     runtime = Runtime(
         telemetry=TelemetryConfig(
@@ -315,6 +323,7 @@ async def create_worker(
             # Worker will flush heartbeats every
             # min(heartbeat_timeout * 0.8, max_heartbeat_throttle_interval).
             max_heartbeat_throttle_interval=dt.timedelta(seconds=5),
+            plugins=plugins,
         )
 
     return ManagedWorker(worker=worker, metrics_server=metrics_server)

--- a/posthog/temporal/common/worker.py
+++ b/posthog/temporal/common/worker.py
@@ -7,10 +7,9 @@ from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 
 from prometheus_client import REGISTRY
-from temporalio.client import Plugin
 from temporalio.contrib.opentelemetry import OpenTelemetryPlugin
 from temporalio.runtime import PrometheusConfig, Runtime, TelemetryConfig
-from temporalio.worker import ResourceBasedSlotConfig, UnsandboxedWorkflowRunner, Worker, WorkerTuner
+from temporalio.worker import Plugin, ResourceBasedSlotConfig, UnsandboxedWorkflowRunner, Worker, WorkerTuner
 
 from posthog.temporal.common.client import connect
 from posthog.temporal.common.combined_metrics_server import CombinedMetricsServer
@@ -209,9 +208,9 @@ async def create_worker(
         temporal_metrics_bind_address = f"0.0.0.0:{metrics_port}"
 
     if enable_open_telemetry_plugin:
-        plugins: collections.abc.Sequence[Plugin] | None = (OpenTelemetryPlugin(add_temporal_spans=True),)
+        plugins: collections.abc.Sequence[Plugin] = (OpenTelemetryPlugin(add_temporal_spans=True),)
     else:
-        plugins = None
+        plugins = ()
 
     runtime = Runtime(
         telemetry=TelemetryConfig(


### PR DESCRIPTION
## Problem

We don't have tracing in temporal workers. Temporal sets up its own tracer which supports replaying, and uses a plugin for instrumentation of all the common client calls.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

* Setup the temporal tracer.
* Enable the plugin.
* Put everything behind a new setting `TEMPORAL_OTEL_PLUGIN_ENABLED`, `False` by default so teams using temporal can opt-in when they see fit.

Not done: I've omitted all the instrumentation the django app does in `otel_instrumentation.py`. This seemed like too much for temporal workers? Each team does a different thing, so I think each team can work out what they need to instrument. For batch exports: Let's get basic tracing enabled and then work out how to further instrument things.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
