### PR TITLE
feat(experiments): Move matured users toggle from per-metric to per-experiment

### DIFF
--- a/ee/clickhouse/views/experiments.py
+++ b/ee/clickhouse/views/experiments.py
@@ -91,6 +91,7 @@ class ExperimentSerializer(UserAccessControlSerializerMixin, serializers.ModelSe
             "primary_metrics_ordered_uuids",
             "secondary_metrics_ordered_uuids",
             "exposure_preaggregation_enabled",
+            "only_count_matured_users",
             "status",
             "user_access_level",
         ]
@@ -146,6 +147,7 @@ class ExperimentSerializer(UserAccessControlSerializerMixin, serializers.ModelSe
                     instance.start_date,
                     get_experiment_stats_method(instance),
                     instance.exposure_criteria,
+                    only_count_matured_users=instance.only_count_matured_users,
                 )
 
         return data
@@ -197,6 +199,7 @@ class ExperimentSerializer(UserAccessControlSerializerMixin, serializers.ModelSe
         filters = validated_data.pop("filters", None)
         scheduling_config = validated_data.pop("scheduling_config", None)
         exposure_preaggregation_enabled = validated_data.pop("exposure_preaggregation_enabled", False)
+        only_count_matured_users = validated_data.pop("only_count_matured_users", False)
         archived = validated_data.pop("archived", False)
         deleted = validated_data.pop("deleted", False)
         conclusion = validated_data.pop("conclusion", None)
@@ -229,6 +232,7 @@ class ExperimentSerializer(UserAccessControlSerializerMixin, serializers.ModelSe
             filters=filters,
             scheduling_config=scheduling_config,
             exposure_preaggregation_enabled=exposure_preaggregation_enabled,
+            only_count_matured_users=only_count_matured_users,
             archived=archived,
             deleted=deleted,
             conclusion=conclusion,

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -15413,9 +15413,6 @@
                 "name": {
                     "type": "string"
                 },
-                "only_count_matured_users": {
-                    "type": "boolean"
-                },
                 "response": {
                     "type": "object"
                 },
@@ -15715,9 +15712,6 @@
                 "name": {
                     "type": "string"
                 },
-                "only_count_matured_users": {
-                    "type": "boolean"
-                },
                 "response": {
                     "type": "object"
                 },
@@ -15807,9 +15801,6 @@
                 },
                 "name": {
                     "type": "string"
-                },
-                "only_count_matured_users": {
-                    "type": "boolean"
                 },
                 "response": {
                     "type": "object"
@@ -16123,9 +16114,6 @@
                 "numerator": {
                     "$ref": "#/definitions/ExperimentMetricSource"
                 },
-                "only_count_matured_users": {
-                    "type": "boolean"
-                },
                 "response": {
                     "type": "object"
                 },
@@ -16194,9 +16182,6 @@
                 },
                 "name": {
                     "type": "string"
-                },
-                "only_count_matured_users": {
-                    "type": "boolean"
                 },
                 "response": {
                     "type": "object"

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -3244,7 +3244,6 @@ export interface ExperimentMetricBaseProperties extends Node {
     name?: string
     conversion_window?: integer
     conversion_window_unit?: FunnelConversionWindowTimeUnit
-    only_count_matured_users?: boolean
     goal?: ExperimentMetricGoal
     isSharedMetric?: boolean
     sharedMetricId?: number

--- a/frontend/src/queries/validators.js
+++ b/frontend/src/queries/validators.js
@@ -5375,7 +5375,6 @@ const schema58 = {
         lower_bound_percentile: { type: 'number' },
         metric_type: { const: 'mean', type: 'string' },
         name: { type: 'string' },
-        only_count_matured_users: { type: 'boolean' },
         response: { type: 'object' },
         sharedMetricId: { type: 'number' },
         source: { $ref: '#/definitions/ExperimentMetricSource' },
@@ -9436,22 +9435,25 @@ function validate73(data, { instancePath = '', parentData, parentDataProperty, r
                                                                 var valid0 = true
                                                             }
                                                             if (valid0) {
-                                                                if (data.only_count_matured_users !== undefined) {
+                                                                if (data.response !== undefined) {
+                                                                    let data11 = data.response
                                                                     const _errs26 = errors
                                                                     if (
-                                                                        typeof data.only_count_matured_users !==
-                                                                        'boolean'
+                                                                        !(
+                                                                            data11 &&
+                                                                            typeof data11 == 'object' &&
+                                                                            !Array.isArray(data11)
+                                                                        )
                                                                     ) {
                                                                         validate73.errors = [
                                                                             {
                                                                                 instancePath:
-                                                                                    instancePath +
-                                                                                    '/only_count_matured_users',
+                                                                                    instancePath + '/response',
                                                                                 schemaPath:
-                                                                                    '#/properties/only_count_matured_users/type',
+                                                                                    '#/properties/response/type',
                                                                                 keyword: 'type',
-                                                                                params: { type: 'boolean' },
-                                                                                message: 'must be boolean',
+                                                                                params: { type: 'object' },
+                                                                                message: 'must be object',
                                                                             },
                                                                         ]
                                                                         return false
@@ -9461,25 +9463,25 @@ function validate73(data, { instancePath = '', parentData, parentDataProperty, r
                                                                     var valid0 = true
                                                                 }
                                                                 if (valid0) {
-                                                                    if (data.response !== undefined) {
-                                                                        let data12 = data.response
+                                                                    if (data.sharedMetricId !== undefined) {
+                                                                        let data12 = data.sharedMetricId
                                                                         const _errs28 = errors
                                                                         if (
                                                                             !(
-                                                                                data12 &&
-                                                                                typeof data12 == 'object' &&
-                                                                                !Array.isArray(data12)
+                                                                                typeof data12 == 'number' &&
+                                                                                isFinite(data12)
                                                                             )
                                                                         ) {
                                                                             validate73.errors = [
                                                                                 {
                                                                                     instancePath:
-                                                                                        instancePath + '/response',
+                                                                                        instancePath +
+                                                                                        '/sharedMetricId',
                                                                                     schemaPath:
-                                                                                        '#/properties/response/type',
+                                                                                        '#/properties/sharedMetricId/type',
                                                                                     keyword: 'type',
-                                                                                    params: { type: 'object' },
-                                                                                    message: 'must be object',
+                                                                                    params: { type: 'number' },
+                                                                                    message: 'must be number',
                                                                                 },
                                                                             ]
                                                                             return false
@@ -9489,84 +9491,77 @@ function validate73(data, { instancePath = '', parentData, parentDataProperty, r
                                                                         var valid0 = true
                                                                     }
                                                                     if (valid0) {
-                                                                        if (data.sharedMetricId !== undefined) {
-                                                                            let data13 = data.sharedMetricId
+                                                                        if (data.source !== undefined) {
                                                                             const _errs30 = errors
                                                                             if (
-                                                                                !(
-                                                                                    typeof data13 == 'number' &&
-                                                                                    isFinite(data13)
-                                                                                )
+                                                                                !validate78(data.source, {
+                                                                                    instancePath:
+                                                                                        instancePath + '/source',
+                                                                                    parentData: data,
+                                                                                    parentDataProperty: 'source',
+                                                                                    rootData,
+                                                                                })
                                                                             ) {
-                                                                                validate73.errors = [
-                                                                                    {
-                                                                                        instancePath:
-                                                                                            instancePath +
-                                                                                            '/sharedMetricId',
-                                                                                        schemaPath:
-                                                                                            '#/properties/sharedMetricId/type',
-                                                                                        keyword: 'type',
-                                                                                        params: { type: 'number' },
-                                                                                        message: 'must be number',
-                                                                                    },
-                                                                                ]
-                                                                                return false
+                                                                                vErrors =
+                                                                                    vErrors === null
+                                                                                        ? validate78.errors
+                                                                                        : vErrors.concat(
+                                                                                              validate78.errors
+                                                                                          )
+                                                                                errors = vErrors.length
                                                                             }
                                                                             var valid0 = _errs30 === errors
                                                                         } else {
                                                                             var valid0 = true
                                                                         }
                                                                         if (valid0) {
-                                                                            if (data.source !== undefined) {
-                                                                                const _errs32 = errors
+                                                                            if (
+                                                                                data.upper_bound_percentile !==
+                                                                                undefined
+                                                                            ) {
+                                                                                let data14 = data.upper_bound_percentile
+                                                                                const _errs31 = errors
                                                                                 if (
-                                                                                    !validate78(data.source, {
-                                                                                        instancePath:
-                                                                                            instancePath + '/source',
-                                                                                        parentData: data,
-                                                                                        parentDataProperty: 'source',
-                                                                                        rootData,
-                                                                                    })
+                                                                                    !(
+                                                                                        typeof data14 == 'number' &&
+                                                                                        isFinite(data14)
+                                                                                    )
                                                                                 ) {
-                                                                                    vErrors =
-                                                                                        vErrors === null
-                                                                                            ? validate78.errors
-                                                                                            : vErrors.concat(
-                                                                                                  validate78.errors
-                                                                                              )
-                                                                                    errors = vErrors.length
+                                                                                    validate73.errors = [
+                                                                                        {
+                                                                                            instancePath:
+                                                                                                instancePath +
+                                                                                                '/upper_bound_percentile',
+                                                                                            schemaPath:
+                                                                                                '#/properties/upper_bound_percentile/type',
+                                                                                            keyword: 'type',
+                                                                                            params: { type: 'number' },
+                                                                                            message: 'must be number',
+                                                                                        },
+                                                                                    ]
+                                                                                    return false
                                                                                 }
-                                                                                var valid0 = _errs32 === errors
+                                                                                var valid0 = _errs31 === errors
                                                                             } else {
                                                                                 var valid0 = true
                                                                             }
                                                                             if (valid0) {
-                                                                                if (
-                                                                                    data.upper_bound_percentile !==
-                                                                                    undefined
-                                                                                ) {
-                                                                                    let data15 =
-                                                                                        data.upper_bound_percentile
+                                                                                if (data.uuid !== undefined) {
                                                                                     const _errs33 = errors
-                                                                                    if (
-                                                                                        !(
-                                                                                            typeof data15 == 'number' &&
-                                                                                            isFinite(data15)
-                                                                                        )
-                                                                                    ) {
+                                                                                    if (typeof data.uuid !== 'string') {
                                                                                         validate73.errors = [
                                                                                             {
                                                                                                 instancePath:
                                                                                                     instancePath +
-                                                                                                    '/upper_bound_percentile',
+                                                                                                    '/uuid',
                                                                                                 schemaPath:
-                                                                                                    '#/properties/upper_bound_percentile/type',
+                                                                                                    '#/properties/uuid/type',
                                                                                                 keyword: 'type',
                                                                                                 params: {
-                                                                                                    type: 'number',
+                                                                                                    type: 'string',
                                                                                                 },
                                                                                                 message:
-                                                                                                    'must be number',
+                                                                                                    'must be string',
                                                                                             },
                                                                                         ]
                                                                                         return false
@@ -9576,25 +9571,29 @@ function validate73(data, { instancePath = '', parentData, parentDataProperty, r
                                                                                     var valid0 = true
                                                                                 }
                                                                                 if (valid0) {
-                                                                                    if (data.uuid !== undefined) {
+                                                                                    if (data.version !== undefined) {
+                                                                                        let data16 = data.version
                                                                                         const _errs35 = errors
                                                                                         if (
-                                                                                            typeof data.uuid !==
-                                                                                            'string'
+                                                                                            !(
+                                                                                                typeof data16 ==
+                                                                                                    'number' &&
+                                                                                                isFinite(data16)
+                                                                                            )
                                                                                         ) {
                                                                                             validate73.errors = [
                                                                                                 {
                                                                                                     instancePath:
                                                                                                         instancePath +
-                                                                                                        '/uuid',
+                                                                                                        '/version',
                                                                                                     schemaPath:
-                                                                                                        '#/properties/uuid/type',
+                                                                                                        '#/properties/version/type',
                                                                                                     keyword: 'type',
                                                                                                     params: {
-                                                                                                        type: 'string',
+                                                                                                        type: 'number',
                                                                                                     },
                                                                                                     message:
-                                                                                                        'must be string',
+                                                                                                        'must be number',
                                                                                                 },
                                                                                             ]
                                                                                             return false
@@ -9602,42 +9601,6 @@ function validate73(data, { instancePath = '', parentData, parentDataProperty, r
                                                                                         var valid0 = _errs35 === errors
                                                                                     } else {
                                                                                         var valid0 = true
-                                                                                    }
-                                                                                    if (valid0) {
-                                                                                        if (
-                                                                                            data.version !== undefined
-                                                                                        ) {
-                                                                                            let data17 = data.version
-                                                                                            const _errs37 = errors
-                                                                                            if (
-                                                                                                !(
-                                                                                                    typeof data17 ==
-                                                                                                        'number' &&
-                                                                                                    isFinite(data17)
-                                                                                                )
-                                                                                            ) {
-                                                                                                validate73.errors = [
-                                                                                                    {
-                                                                                                        instancePath:
-                                                                                                            instancePath +
-                                                                                                            '/version',
-                                                                                                        schemaPath:
-                                                                                                            '#/properties/version/type',
-                                                                                                        keyword: 'type',
-                                                                                                        params: {
-                                                                                                            type: 'number',
-                                                                                                        },
-                                                                                                        message:
-                                                                                                            'must be number',
-                                                                                                    },
-                                                                                                ]
-                                                                                                return false
-                                                                                            }
-                                                                                            var valid0 =
-                                                                                                _errs37 === errors
-                                                                                        } else {
-                                                                                            var valid0 = true
-                                                                                        }
                                                                                     }
                                                                                 }
                                                                             }
@@ -9686,7 +9649,6 @@ const schema91 = {
         kind: { const: 'ExperimentMetric', type: 'string' },
         metric_type: { const: 'funnel', type: 'string' },
         name: { type: 'string' },
-        only_count_matured_users: { type: 'boolean' },
         response: { type: 'object' },
         series: { items: { $ref: '#/definitions/ExperimentFunnelMetricStep' }, type: 'array' },
         sharedMetricId: { type: 'number' },
@@ -10051,21 +10013,23 @@ function validate101(data, { instancePath = '', parentData, parentDataProperty, 
                                                             var valid0 = true
                                                         }
                                                         if (valid0) {
-                                                            if (data.only_count_matured_users !== undefined) {
+                                                            if (data.response !== undefined) {
+                                                                let data10 = data.response
                                                                 const _errs25 = errors
                                                                 if (
-                                                                    typeof data.only_count_matured_users !== 'boolean'
+                                                                    !(
+                                                                        data10 &&
+                                                                        typeof data10 == 'object' &&
+                                                                        !Array.isArray(data10)
+                                                                    )
                                                                 ) {
                                                                     validate101.errors = [
                                                                         {
-                                                                            instancePath:
-                                                                                instancePath +
-                                                                                '/only_count_matured_users',
-                                                                            schemaPath:
-                                                                                '#/properties/only_count_matured_users/type',
+                                                                            instancePath: instancePath + '/response',
+                                                                            schemaPath: '#/properties/response/type',
                                                                             keyword: 'type',
-                                                                            params: { type: 'boolean' },
-                                                                            message: 'must be boolean',
+                                                                            params: { type: 'object' },
+                                                                            message: 'must be object',
                                                                         },
                                                                     ]
                                                                     return false
@@ -10075,106 +10039,99 @@ function validate101(data, { instancePath = '', parentData, parentDataProperty, 
                                                                 var valid0 = true
                                                             }
                                                             if (valid0) {
-                                                                if (data.response !== undefined) {
-                                                                    let data11 = data.response
+                                                                if (data.series !== undefined) {
+                                                                    let data11 = data.series
                                                                     const _errs27 = errors
-                                                                    if (
-                                                                        !(
-                                                                            data11 &&
-                                                                            typeof data11 == 'object' &&
-                                                                            !Array.isArray(data11)
-                                                                        )
-                                                                    ) {
-                                                                        validate101.errors = [
-                                                                            {
-                                                                                instancePath:
-                                                                                    instancePath + '/response',
-                                                                                schemaPath:
-                                                                                    '#/properties/response/type',
-                                                                                keyword: 'type',
-                                                                                params: { type: 'object' },
-                                                                                message: 'must be object',
-                                                                            },
-                                                                        ]
-                                                                        return false
+                                                                    if (errors === _errs27) {
+                                                                        if (Array.isArray(data11)) {
+                                                                            var valid5 = true
+                                                                            const len0 = data11.length
+                                                                            for (let i0 = 0; i0 < len0; i0++) {
+                                                                                const _errs29 = errors
+                                                                                if (
+                                                                                    !validate103(data11[i0], {
+                                                                                        instancePath:
+                                                                                            instancePath +
+                                                                                            '/series/' +
+                                                                                            i0,
+                                                                                        parentData: data11,
+                                                                                        parentDataProperty: i0,
+                                                                                        rootData,
+                                                                                    })
+                                                                                ) {
+                                                                                    vErrors =
+                                                                                        vErrors === null
+                                                                                            ? validate103.errors
+                                                                                            : vErrors.concat(
+                                                                                                  validate103.errors
+                                                                                              )
+                                                                                    errors = vErrors.length
+                                                                                }
+                                                                                var valid5 = _errs29 === errors
+                                                                                if (!valid5) {
+                                                                                    break
+                                                                                }
+                                                                            }
+                                                                        } else {
+                                                                            validate101.errors = [
+                                                                                {
+                                                                                    instancePath:
+                                                                                        instancePath + '/series',
+                                                                                    schemaPath:
+                                                                                        '#/properties/series/type',
+                                                                                    keyword: 'type',
+                                                                                    params: { type: 'array' },
+                                                                                    message: 'must be array',
+                                                                                },
+                                                                            ]
+                                                                            return false
+                                                                        }
                                                                     }
                                                                     var valid0 = _errs27 === errors
                                                                 } else {
                                                                     var valid0 = true
                                                                 }
                                                                 if (valid0) {
-                                                                    if (data.series !== undefined) {
-                                                                        let data12 = data.series
-                                                                        const _errs29 = errors
-                                                                        if (errors === _errs29) {
-                                                                            if (Array.isArray(data12)) {
-                                                                                var valid5 = true
-                                                                                const len0 = data12.length
-                                                                                for (let i0 = 0; i0 < len0; i0++) {
-                                                                                    const _errs31 = errors
-                                                                                    if (
-                                                                                        !validate103(data12[i0], {
-                                                                                            instancePath:
-                                                                                                instancePath +
-                                                                                                '/series/' +
-                                                                                                i0,
-                                                                                            parentData: data12,
-                                                                                            parentDataProperty: i0,
-                                                                                            rootData,
-                                                                                        })
-                                                                                    ) {
-                                                                                        vErrors =
-                                                                                            vErrors === null
-                                                                                                ? validate103.errors
-                                                                                                : vErrors.concat(
-                                                                                                      validate103.errors
-                                                                                                  )
-                                                                                        errors = vErrors.length
-                                                                                    }
-                                                                                    var valid5 = _errs31 === errors
-                                                                                    if (!valid5) {
-                                                                                        break
-                                                                                    }
-                                                                                }
-                                                                            } else {
-                                                                                validate101.errors = [
-                                                                                    {
-                                                                                        instancePath:
-                                                                                            instancePath + '/series',
-                                                                                        schemaPath:
-                                                                                            '#/properties/series/type',
-                                                                                        keyword: 'type',
-                                                                                        params: { type: 'array' },
-                                                                                        message: 'must be array',
-                                                                                    },
-                                                                                ]
-                                                                                return false
-                                                                            }
+                                                                    if (data.sharedMetricId !== undefined) {
+                                                                        let data13 = data.sharedMetricId
+                                                                        const _errs30 = errors
+                                                                        if (
+                                                                            !(
+                                                                                typeof data13 == 'number' &&
+                                                                                isFinite(data13)
+                                                                            )
+                                                                        ) {
+                                                                            validate101.errors = [
+                                                                                {
+                                                                                    instancePath:
+                                                                                        instancePath +
+                                                                                        '/sharedMetricId',
+                                                                                    schemaPath:
+                                                                                        '#/properties/sharedMetricId/type',
+                                                                                    keyword: 'type',
+                                                                                    params: { type: 'number' },
+                                                                                    message: 'must be number',
+                                                                                },
+                                                                            ]
+                                                                            return false
                                                                         }
-                                                                        var valid0 = _errs29 === errors
+                                                                        var valid0 = _errs30 === errors
                                                                     } else {
                                                                         var valid0 = true
                                                                     }
                                                                     if (valid0) {
-                                                                        if (data.sharedMetricId !== undefined) {
-                                                                            let data14 = data.sharedMetricId
+                                                                        if (data.uuid !== undefined) {
                                                                             const _errs32 = errors
-                                                                            if (
-                                                                                !(
-                                                                                    typeof data14 == 'number' &&
-                                                                                    isFinite(data14)
-                                                                                )
-                                                                            ) {
+                                                                            if (typeof data.uuid !== 'string') {
                                                                                 validate101.errors = [
                                                                                     {
                                                                                         instancePath:
-                                                                                            instancePath +
-                                                                                            '/sharedMetricId',
+                                                                                            instancePath + '/uuid',
                                                                                         schemaPath:
-                                                                                            '#/properties/sharedMetricId/type',
+                                                                                            '#/properties/uuid/type',
                                                                                         keyword: 'type',
-                                                                                        params: { type: 'number' },
-                                                                                        message: 'must be number',
+                                                                                        params: { type: 'string' },
+                                                                                        message: 'must be string',
                                                                                     },
                                                                                 ]
                                                                                 return false
@@ -10184,18 +10141,25 @@ function validate101(data, { instancePath = '', parentData, parentDataProperty, 
                                                                             var valid0 = true
                                                                         }
                                                                         if (valid0) {
-                                                                            if (data.uuid !== undefined) {
+                                                                            if (data.version !== undefined) {
+                                                                                let data15 = data.version
                                                                                 const _errs34 = errors
-                                                                                if (typeof data.uuid !== 'string') {
+                                                                                if (
+                                                                                    !(
+                                                                                        typeof data15 == 'number' &&
+                                                                                        isFinite(data15)
+                                                                                    )
+                                                                                ) {
                                                                                     validate101.errors = [
                                                                                         {
                                                                                             instancePath:
-                                                                                                instancePath + '/uuid',
+                                                                                                instancePath +
+                                                                                                '/version',
                                                                                             schemaPath:
-                                                                                                '#/properties/uuid/type',
+                                                                                                '#/properties/version/type',
                                                                                             keyword: 'type',
-                                                                                            params: { type: 'string' },
-                                                                                            message: 'must be string',
+                                                                                            params: { type: 'number' },
+                                                                                            message: 'must be number',
                                                                                         },
                                                                                     ]
                                                                                     return false
@@ -10203,38 +10167,6 @@ function validate101(data, { instancePath = '', parentData, parentDataProperty, 
                                                                                 var valid0 = _errs34 === errors
                                                                             } else {
                                                                                 var valid0 = true
-                                                                            }
-                                                                            if (valid0) {
-                                                                                if (data.version !== undefined) {
-                                                                                    let data16 = data.version
-                                                                                    const _errs36 = errors
-                                                                                    if (
-                                                                                        !(
-                                                                                            typeof data16 == 'number' &&
-                                                                                            isFinite(data16)
-                                                                                        )
-                                                                                    ) {
-                                                                                        validate101.errors = [
-                                                                                            {
-                                                                                                instancePath:
-                                                                                                    instancePath +
-                                                                                                    '/version',
-                                                                                                schemaPath:
-                                                                                                    '#/properties/version/type',
-                                                                                                keyword: 'type',
-                                                                                                params: {
-                                                                                                    type: 'number',
-                                                                                                },
-                                                                                                message:
-                                                                                                    'must be number',
-                                                                                            },
-                                                                                        ]
-                                                                                        return false
-                                                                                    }
-                                                                                    var valid0 = _errs36 === errors
-                                                                                } else {
-                                                                                    var valid0 = true
-                                                                                }
                                                                             }
                                                                         }
                                                                     }
@@ -10282,7 +10214,6 @@ const schema97 = {
         metric_type: { const: 'ratio', type: 'string' },
         name: { type: 'string' },
         numerator: { $ref: '#/definitions/ExperimentMetricSource' },
-        only_count_matured_users: { type: 'boolean' },
         response: { type: 'object' },
         sharedMetricId: { type: 'number' },
         uuid: { type: 'string' },
@@ -10603,22 +10534,25 @@ function validate108(data, { instancePath = '', parentData, parentDataProperty, 
                                                                 var valid0 = true
                                                             }
                                                             if (valid0) {
-                                                                if (data.only_count_matured_users !== undefined) {
+                                                                if (data.response !== undefined) {
+                                                                    let data11 = data.response
                                                                     const _errs24 = errors
                                                                     if (
-                                                                        typeof data.only_count_matured_users !==
-                                                                        'boolean'
+                                                                        !(
+                                                                            data11 &&
+                                                                            typeof data11 == 'object' &&
+                                                                            !Array.isArray(data11)
+                                                                        )
                                                                     ) {
                                                                         validate108.errors = [
                                                                             {
                                                                                 instancePath:
-                                                                                    instancePath +
-                                                                                    '/only_count_matured_users',
+                                                                                    instancePath + '/response',
                                                                                 schemaPath:
-                                                                                    '#/properties/only_count_matured_users/type',
+                                                                                    '#/properties/response/type',
                                                                                 keyword: 'type',
-                                                                                params: { type: 'boolean' },
-                                                                                message: 'must be boolean',
+                                                                                params: { type: 'object' },
+                                                                                message: 'must be object',
                                                                             },
                                                                         ]
                                                                         return false
@@ -10628,25 +10562,25 @@ function validate108(data, { instancePath = '', parentData, parentDataProperty, 
                                                                     var valid0 = true
                                                                 }
                                                                 if (valid0) {
-                                                                    if (data.response !== undefined) {
-                                                                        let data12 = data.response
+                                                                    if (data.sharedMetricId !== undefined) {
+                                                                        let data12 = data.sharedMetricId
                                                                         const _errs26 = errors
                                                                         if (
                                                                             !(
-                                                                                data12 &&
-                                                                                typeof data12 == 'object' &&
-                                                                                !Array.isArray(data12)
+                                                                                typeof data12 == 'number' &&
+                                                                                isFinite(data12)
                                                                             )
                                                                         ) {
                                                                             validate108.errors = [
                                                                                 {
                                                                                     instancePath:
-                                                                                        instancePath + '/response',
+                                                                                        instancePath +
+                                                                                        '/sharedMetricId',
                                                                                     schemaPath:
-                                                                                        '#/properties/response/type',
+                                                                                        '#/properties/sharedMetricId/type',
                                                                                     keyword: 'type',
-                                                                                    params: { type: 'object' },
-                                                                                    message: 'must be object',
+                                                                                    params: { type: 'number' },
+                                                                                    message: 'must be number',
                                                                                 },
                                                                             ]
                                                                             return false
@@ -10656,25 +10590,18 @@ function validate108(data, { instancePath = '', parentData, parentDataProperty, 
                                                                         var valid0 = true
                                                                     }
                                                                     if (valid0) {
-                                                                        if (data.sharedMetricId !== undefined) {
-                                                                            let data13 = data.sharedMetricId
+                                                                        if (data.uuid !== undefined) {
                                                                             const _errs28 = errors
-                                                                            if (
-                                                                                !(
-                                                                                    typeof data13 == 'number' &&
-                                                                                    isFinite(data13)
-                                                                                )
-                                                                            ) {
+                                                                            if (typeof data.uuid !== 'string') {
                                                                                 validate108.errors = [
                                                                                     {
                                                                                         instancePath:
-                                                                                            instancePath +
-                                                                                            '/sharedMetricId',
+                                                                                            instancePath + '/uuid',
                                                                                         schemaPath:
-                                                                                            '#/properties/sharedMetricId/type',
+                                                                                            '#/properties/uuid/type',
                                                                                         keyword: 'type',
-                                                                                        params: { type: 'number' },
-                                                                                        message: 'must be number',
+                                                                                        params: { type: 'string' },
+                                                                                        message: 'must be string',
                                                                                     },
                                                                                 ]
                                                                                 return false
@@ -10684,18 +10611,25 @@ function validate108(data, { instancePath = '', parentData, parentDataProperty, 
                                                                             var valid0 = true
                                                                         }
                                                                         if (valid0) {
-                                                                            if (data.uuid !== undefined) {
+                                                                            if (data.version !== undefined) {
+                                                                                let data14 = data.version
                                                                                 const _errs30 = errors
-                                                                                if (typeof data.uuid !== 'string') {
+                                                                                if (
+                                                                                    !(
+                                                                                        typeof data14 == 'number' &&
+                                                                                        isFinite(data14)
+                                                                                    )
+                                                                                ) {
                                                                                     validate108.errors = [
                                                                                         {
                                                                                             instancePath:
-                                                                                                instancePath + '/uuid',
+                                                                                                instancePath +
+                                                                                                '/version',
                                                                                             schemaPath:
-                                                                                                '#/properties/uuid/type',
+                                                                                                '#/properties/version/type',
                                                                                             keyword: 'type',
-                                                                                            params: { type: 'string' },
-                                                                                            message: 'must be string',
+                                                                                            params: { type: 'number' },
+                                                                                            message: 'must be number',
                                                                                         },
                                                                                     ]
                                                                                     return false
@@ -10703,38 +10637,6 @@ function validate108(data, { instancePath = '', parentData, parentDataProperty, 
                                                                                 var valid0 = _errs30 === errors
                                                                             } else {
                                                                                 var valid0 = true
-                                                                            }
-                                                                            if (valid0) {
-                                                                                if (data.version !== undefined) {
-                                                                                    let data15 = data.version
-                                                                                    const _errs32 = errors
-                                                                                    if (
-                                                                                        !(
-                                                                                            typeof data15 == 'number' &&
-                                                                                            isFinite(data15)
-                                                                                        )
-                                                                                    ) {
-                                                                                        validate108.errors = [
-                                                                                            {
-                                                                                                instancePath:
-                                                                                                    instancePath +
-                                                                                                    '/version',
-                                                                                                schemaPath:
-                                                                                                    '#/properties/version/type',
-                                                                                                keyword: 'type',
-                                                                                                params: {
-                                                                                                    type: 'number',
-                                                                                                },
-                                                                                                message:
-                                                                                                    'must be number',
-                                                                                            },
-                                                                                        ]
-                                                                                        return false
-                                                                                    }
-                                                                                    var valid0 = _errs32 === errors
-                                                                                } else {
-                                                                                    var valid0 = true
-                                                                                }
                                                                             }
                                                                         }
                                                                     }
@@ -10781,7 +10683,6 @@ const schema101 = {
         kind: { const: 'ExperimentMetric', type: 'string' },
         metric_type: { const: 'retention', type: 'string' },
         name: { type: 'string' },
-        only_count_matured_users: { type: 'boolean' },
         response: { type: 'object' },
         retention_window_end: { $ref: '#/definitions/integer' },
         retention_window_start: { $ref: '#/definitions/integer' },
@@ -11098,21 +10999,23 @@ function validate113(data, { instancePath = '', parentData, parentDataProperty, 
                                                             var valid0 = true
                                                         }
                                                         if (valid0) {
-                                                            if (data.only_count_matured_users !== undefined) {
+                                                            if (data.response !== undefined) {
+                                                                let data10 = data.response
                                                                 const _errs23 = errors
                                                                 if (
-                                                                    typeof data.only_count_matured_users !== 'boolean'
+                                                                    !(
+                                                                        data10 &&
+                                                                        typeof data10 == 'object' &&
+                                                                        !Array.isArray(data10)
+                                                                    )
                                                                 ) {
                                                                     validate113.errors = [
                                                                         {
-                                                                            instancePath:
-                                                                                instancePath +
-                                                                                '/only_count_matured_users',
-                                                                            schemaPath:
-                                                                                '#/properties/only_count_matured_users/type',
+                                                                            instancePath: instancePath + '/response',
+                                                                            schemaPath: '#/properties/response/type',
                                                                             keyword: 'type',
-                                                                            params: { type: 'boolean' },
-                                                                            message: 'must be boolean',
+                                                                            params: { type: 'object' },
+                                                                            message: 'must be object',
                                                                         },
                                                                     ]
                                                                     return false
@@ -11122,25 +11025,27 @@ function validate113(data, { instancePath = '', parentData, parentDataProperty, 
                                                                 var valid0 = true
                                                             }
                                                             if (valid0) {
-                                                                if (data.response !== undefined) {
-                                                                    let data11 = data.response
+                                                                if (data.retention_window_end !== undefined) {
+                                                                    let data11 = data.retention_window_end
                                                                     const _errs25 = errors
                                                                     if (
                                                                         !(
-                                                                            data11 &&
-                                                                            typeof data11 == 'object' &&
-                                                                            !Array.isArray(data11)
+                                                                            typeof data11 == 'number' &&
+                                                                            !(data11 % 1) &&
+                                                                            !isNaN(data11) &&
+                                                                            isFinite(data11)
                                                                         )
                                                                     ) {
                                                                         validate113.errors = [
                                                                             {
                                                                                 instancePath:
-                                                                                    instancePath + '/response',
+                                                                                    instancePath +
+                                                                                    '/retention_window_end',
                                                                                 schemaPath:
-                                                                                    '#/properties/response/type',
+                                                                                    '#/definitions/integer/type',
                                                                                 keyword: 'type',
-                                                                                params: { type: 'object' },
-                                                                                message: 'must be object',
+                                                                                params: { type: 'integer' },
+                                                                                message: 'must be integer',
                                                                             },
                                                                         ]
                                                                         return false
@@ -11150,9 +11055,9 @@ function validate113(data, { instancePath = '', parentData, parentDataProperty, 
                                                                     var valid0 = true
                                                                 }
                                                                 if (valid0) {
-                                                                    if (data.retention_window_end !== undefined) {
-                                                                        let data12 = data.retention_window_end
-                                                                        const _errs27 = errors
+                                                                    if (data.retention_window_start !== undefined) {
+                                                                        let data12 = data.retention_window_start
+                                                                        const _errs28 = errors
                                                                         if (
                                                                             !(
                                                                                 typeof data12 == 'number' &&
@@ -11165,7 +11070,7 @@ function validate113(data, { instancePath = '', parentData, parentDataProperty, 
                                                                                 {
                                                                                     instancePath:
                                                                                         instancePath +
-                                                                                        '/retention_window_end',
+                                                                                        '/retention_window_start',
                                                                                     schemaPath:
                                                                                         '#/definitions/integer/type',
                                                                                     keyword: 'type',
@@ -11175,119 +11080,110 @@ function validate113(data, { instancePath = '', parentData, parentDataProperty, 
                                                                             ]
                                                                             return false
                                                                         }
-                                                                        var valid0 = _errs27 === errors
+                                                                        var valid0 = _errs28 === errors
                                                                     } else {
                                                                         var valid0 = true
                                                                     }
                                                                     if (valid0) {
-                                                                        if (data.retention_window_start !== undefined) {
-                                                                            let data13 = data.retention_window_start
-                                                                            const _errs30 = errors
+                                                                        if (data.retention_window_unit !== undefined) {
+                                                                            let data13 = data.retention_window_unit
+                                                                            const _errs31 = errors
+                                                                            if (typeof data13 !== 'string') {
+                                                                                validate113.errors = [
+                                                                                    {
+                                                                                        instancePath:
+                                                                                            instancePath +
+                                                                                            '/retention_window_unit',
+                                                                                        schemaPath:
+                                                                                            '#/definitions/FunnelConversionWindowTimeUnit/type',
+                                                                                        keyword: 'type',
+                                                                                        params: { type: 'string' },
+                                                                                        message: 'must be string',
+                                                                                    },
+                                                                                ]
+                                                                                return false
+                                                                            }
                                                                             if (
                                                                                 !(
-                                                                                    typeof data13 == 'number' &&
-                                                                                    !(data13 % 1) &&
-                                                                                    !isNaN(data13) &&
-                                                                                    isFinite(data13)
+                                                                                    data13 === 'second' ||
+                                                                                    data13 === 'minute' ||
+                                                                                    data13 === 'hour' ||
+                                                                                    data13 === 'day' ||
+                                                                                    data13 === 'week' ||
+                                                                                    data13 === 'month'
                                                                                 )
                                                                             ) {
                                                                                 validate113.errors = [
                                                                                     {
                                                                                         instancePath:
                                                                                             instancePath +
-                                                                                            '/retention_window_start',
+                                                                                            '/retention_window_unit',
                                                                                         schemaPath:
-                                                                                            '#/definitions/integer/type',
-                                                                                        keyword: 'type',
-                                                                                        params: { type: 'integer' },
-                                                                                        message: 'must be integer',
+                                                                                            '#/definitions/FunnelConversionWindowTimeUnit/enum',
+                                                                                        keyword: 'enum',
+                                                                                        params: {
+                                                                                            allowedValues:
+                                                                                                schema72.enum,
+                                                                                        },
+                                                                                        message:
+                                                                                            'must be equal to one of the allowed values',
                                                                                     },
                                                                                 ]
                                                                                 return false
                                                                             }
-                                                                            var valid0 = _errs30 === errors
+                                                                            var valid0 = _errs31 === errors
                                                                         } else {
                                                                             var valid0 = true
                                                                         }
                                                                         if (valid0) {
-                                                                            if (
-                                                                                data.retention_window_unit !== undefined
-                                                                            ) {
-                                                                                let data14 = data.retention_window_unit
-                                                                                const _errs33 = errors
-                                                                                if (typeof data14 !== 'string') {
-                                                                                    validate113.errors = [
-                                                                                        {
-                                                                                            instancePath:
-                                                                                                instancePath +
-                                                                                                '/retention_window_unit',
-                                                                                            schemaPath:
-                                                                                                '#/definitions/FunnelConversionWindowTimeUnit/type',
-                                                                                            keyword: 'type',
-                                                                                            params: { type: 'string' },
-                                                                                            message: 'must be string',
-                                                                                        },
-                                                                                    ]
-                                                                                    return false
-                                                                                }
+                                                                            if (data.sharedMetricId !== undefined) {
+                                                                                let data14 = data.sharedMetricId
+                                                                                const _errs34 = errors
                                                                                 if (
                                                                                     !(
-                                                                                        data14 === 'second' ||
-                                                                                        data14 === 'minute' ||
-                                                                                        data14 === 'hour' ||
-                                                                                        data14 === 'day' ||
-                                                                                        data14 === 'week' ||
-                                                                                        data14 === 'month'
+                                                                                        typeof data14 == 'number' &&
+                                                                                        isFinite(data14)
                                                                                     )
                                                                                 ) {
                                                                                     validate113.errors = [
                                                                                         {
                                                                                             instancePath:
                                                                                                 instancePath +
-                                                                                                '/retention_window_unit',
+                                                                                                '/sharedMetricId',
                                                                                             schemaPath:
-                                                                                                '#/definitions/FunnelConversionWindowTimeUnit/enum',
-                                                                                            keyword: 'enum',
-                                                                                            params: {
-                                                                                                allowedValues:
-                                                                                                    schema72.enum,
-                                                                                            },
-                                                                                            message:
-                                                                                                'must be equal to one of the allowed values',
+                                                                                                '#/properties/sharedMetricId/type',
+                                                                                            keyword: 'type',
+                                                                                            params: { type: 'number' },
+                                                                                            message: 'must be number',
                                                                                         },
                                                                                     ]
                                                                                     return false
                                                                                 }
-                                                                                var valid0 = _errs33 === errors
+                                                                                var valid0 = _errs34 === errors
                                                                             } else {
                                                                                 var valid0 = true
                                                                             }
                                                                             if (valid0) {
-                                                                                if (data.sharedMetricId !== undefined) {
-                                                                                    let data15 = data.sharedMetricId
+                                                                                if (data.start_event !== undefined) {
                                                                                     const _errs36 = errors
                                                                                     if (
-                                                                                        !(
-                                                                                            typeof data15 == 'number' &&
-                                                                                            isFinite(data15)
-                                                                                        )
+                                                                                        !validate78(data.start_event, {
+                                                                                            instancePath:
+                                                                                                instancePath +
+                                                                                                '/start_event',
+                                                                                            parentData: data,
+                                                                                            parentDataProperty:
+                                                                                                'start_event',
+                                                                                            rootData,
+                                                                                        })
                                                                                     ) {
-                                                                                        validate113.errors = [
-                                                                                            {
-                                                                                                instancePath:
-                                                                                                    instancePath +
-                                                                                                    '/sharedMetricId',
-                                                                                                schemaPath:
-                                                                                                    '#/properties/sharedMetricId/type',
-                                                                                                keyword: 'type',
-                                                                                                params: {
-                                                                                                    type: 'number',
-                                                                                                },
-                                                                                                message:
-                                                                                                    'must be number',
-                                                                                            },
-                                                                                        ]
-                                                                                        return false
+                                                                                        vErrors =
+                                                                                            vErrors === null
+                                                                                                ? validate78.errors
+                                                                                                : vErrors.concat(
+                                                                                                      validate78.errors
+                                                                                                  )
+                                                                                        errors = vErrors.length
                                                                                     }
                                                                                     var valid0 = _errs36 === errors
                                                                                 } else {
@@ -11295,89 +11191,83 @@ function validate113(data, { instancePath = '', parentData, parentDataProperty, 
                                                                                 }
                                                                                 if (valid0) {
                                                                                     if (
-                                                                                        data.start_event !== undefined
+                                                                                        data.start_handling !==
+                                                                                        undefined
                                                                                     ) {
-                                                                                        const _errs38 = errors
+                                                                                        let data16 = data.start_handling
+                                                                                        const _errs37 = errors
                                                                                         if (
-                                                                                            !validate78(
-                                                                                                data.start_event,
+                                                                                            typeof data16 !== 'string'
+                                                                                        ) {
+                                                                                            validate113.errors = [
                                                                                                 {
                                                                                                     instancePath:
                                                                                                         instancePath +
-                                                                                                        '/start_event',
-                                                                                                    parentData: data,
-                                                                                                    parentDataProperty:
-                                                                                                        'start_event',
-                                                                                                    rootData,
-                                                                                                }
+                                                                                                        '/start_handling',
+                                                                                                    schemaPath:
+                                                                                                        '#/properties/start_handling/type',
+                                                                                                    keyword: 'type',
+                                                                                                    params: {
+                                                                                                        type: 'string',
+                                                                                                    },
+                                                                                                    message:
+                                                                                                        'must be string',
+                                                                                                },
+                                                                                            ]
+                                                                                            return false
+                                                                                        }
+                                                                                        if (
+                                                                                            !(
+                                                                                                data16 ===
+                                                                                                    'first_seen' ||
+                                                                                                data16 === 'last_seen'
                                                                                             )
                                                                                         ) {
-                                                                                            vErrors =
-                                                                                                vErrors === null
-                                                                                                    ? validate78.errors
-                                                                                                    : vErrors.concat(
-                                                                                                          validate78.errors
-                                                                                                      )
-                                                                                            errors = vErrors.length
+                                                                                            validate113.errors = [
+                                                                                                {
+                                                                                                    instancePath:
+                                                                                                        instancePath +
+                                                                                                        '/start_handling',
+                                                                                                    schemaPath:
+                                                                                                        '#/properties/start_handling/enum',
+                                                                                                    keyword: 'enum',
+                                                                                                    params: {
+                                                                                                        allowedValues:
+                                                                                                            schema101
+                                                                                                                .properties
+                                                                                                                .start_handling
+                                                                                                                .enum,
+                                                                                                    },
+                                                                                                    message:
+                                                                                                        'must be equal to one of the allowed values',
+                                                                                                },
+                                                                                            ]
+                                                                                            return false
                                                                                         }
-                                                                                        var valid0 = _errs38 === errors
+                                                                                        var valid0 = _errs37 === errors
                                                                                     } else {
                                                                                         var valid0 = true
                                                                                     }
                                                                                     if (valid0) {
-                                                                                        if (
-                                                                                            data.start_handling !==
-                                                                                            undefined
-                                                                                        ) {
-                                                                                            let data17 =
-                                                                                                data.start_handling
+                                                                                        if (data.uuid !== undefined) {
                                                                                             const _errs39 = errors
                                                                                             if (
-                                                                                                typeof data17 !==
+                                                                                                typeof data.uuid !==
                                                                                                 'string'
                                                                                             ) {
                                                                                                 validate113.errors = [
                                                                                                     {
                                                                                                         instancePath:
                                                                                                             instancePath +
-                                                                                                            '/start_handling',
+                                                                                                            '/uuid',
                                                                                                         schemaPath:
-                                                                                                            '#/properties/start_handling/type',
+                                                                                                            '#/properties/uuid/type',
                                                                                                         keyword: 'type',
                                                                                                         params: {
                                                                                                             type: 'string',
                                                                                                         },
                                                                                                         message:
                                                                                                             'must be string',
-                                                                                                    },
-                                                                                                ]
-                                                                                                return false
-                                                                                            }
-                                                                                            if (
-                                                                                                !(
-                                                                                                    data17 ===
-                                                                                                        'first_seen' ||
-                                                                                                    data17 ===
-                                                                                                        'last_seen'
-                                                                                                )
-                                                                                            ) {
-                                                                                                validate113.errors = [
-                                                                                                    {
-                                                                                                        instancePath:
-                                                                                                            instancePath +
-                                                                                                            '/start_handling',
-                                                                                                        schemaPath:
-                                                                                                            '#/properties/start_handling/enum',
-                                                                                                        keyword: 'enum',
-                                                                                                        params: {
-                                                                                                            allowedValues:
-                                                                                                                schema101
-                                                                                                                    .properties
-                                                                                                                    .start_handling
-                                                                                                                    .enum,
-                                                                                                        },
-                                                                                                        message:
-                                                                                                            'must be equal to one of the allowed values',
                                                                                                     },
                                                                                                 ]
                                                                                                 return false
@@ -11389,28 +11279,34 @@ function validate113(data, { instancePath = '', parentData, parentDataProperty, 
                                                                                         }
                                                                                         if (valid0) {
                                                                                             if (
-                                                                                                data.uuid !== undefined
+                                                                                                data.version !==
+                                                                                                undefined
                                                                                             ) {
+                                                                                                let data18 =
+                                                                                                    data.version
                                                                                                 const _errs41 = errors
                                                                                                 if (
-                                                                                                    typeof data.uuid !==
-                                                                                                    'string'
+                                                                                                    !(
+                                                                                                        typeof data18 ==
+                                                                                                            'number' &&
+                                                                                                        isFinite(data18)
+                                                                                                    )
                                                                                                 ) {
                                                                                                     validate113.errors =
                                                                                                         [
                                                                                                             {
                                                                                                                 instancePath:
                                                                                                                     instancePath +
-                                                                                                                    '/uuid',
+                                                                                                                    '/version',
                                                                                                                 schemaPath:
-                                                                                                                    '#/properties/uuid/type',
+                                                                                                                    '#/properties/version/type',
                                                                                                                 keyword:
                                                                                                                     'type',
                                                                                                                 params: {
-                                                                                                                    type: 'string',
+                                                                                                                    type: 'number',
                                                                                                                 },
                                                                                                                 message:
-                                                                                                                    'must be string',
+                                                                                                                    'must be number',
                                                                                                             },
                                                                                                         ]
                                                                                                     return false
@@ -11419,50 +11315,6 @@ function validate113(data, { instancePath = '', parentData, parentDataProperty, 
                                                                                                     _errs41 === errors
                                                                                             } else {
                                                                                                 var valid0 = true
-                                                                                            }
-                                                                                            if (valid0) {
-                                                                                                if (
-                                                                                                    data.version !==
-                                                                                                    undefined
-                                                                                                ) {
-                                                                                                    let data19 =
-                                                                                                        data.version
-                                                                                                    const _errs43 =
-                                                                                                        errors
-                                                                                                    if (
-                                                                                                        !(
-                                                                                                            typeof data19 ==
-                                                                                                                'number' &&
-                                                                                                            isFinite(
-                                                                                                                data19
-                                                                                                            )
-                                                                                                        )
-                                                                                                    ) {
-                                                                                                        validate113.errors =
-                                                                                                            [
-                                                                                                                {
-                                                                                                                    instancePath:
-                                                                                                                        instancePath +
-                                                                                                                        '/version',
-                                                                                                                    schemaPath:
-                                                                                                                        '#/properties/version/type',
-                                                                                                                    keyword:
-                                                                                                                        'type',
-                                                                                                                    params: {
-                                                                                                                        type: 'number',
-                                                                                                                    },
-                                                                                                                    message:
-                                                                                                                        'must be number',
-                                                                                                                },
-                                                                                                            ]
-                                                                                                        return false
-                                                                                                    }
-                                                                                                    var valid0 =
-                                                                                                        _errs43 ===
-                                                                                                        errors
-                                                                                                } else {
-                                                                                                    var valid0 = true
-                                                                                                }
                                                                                             }
                                                                                         }
                                                                                     }

--- a/frontend/src/scenes/experiments/ExperimentMetricConversionWindowFilter.tsx
+++ b/frontend/src/scenes/experiments/ExperimentMetricConversionWindowFilter.tsx
@@ -1,6 +1,3 @@
-import { LemonCheckbox } from '@posthog/lemon-ui'
-
-import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { LemonInput } from 'lib/lemon-ui/LemonInput'
 import { LemonRadio } from 'lib/lemon-ui/LemonRadio'
 import { LemonSelect, LemonSelectOption } from 'lib/lemon-ui/LemonSelect'
@@ -18,8 +15,6 @@ export function ExperimentMetricConversionWindowFilter({
     metric: ExperimentMetric
     handleSetMetric: (newMetric: ExperimentMetric) => void
 }): JSX.Element {
-    const showMaturedUsersOption = useFeatureFlag('EXPERIMENTS_MATURED_USERS_FILTER')
-
     const options: LemonSelectOption<FunnelConversionWindowTimeUnit>[] = Object.keys(TIME_INTERVAL_BOUNDS).map(
         (unit) => ({
             label: capitalizeFirstLetter(pluralize(metric.conversion_window ?? 72, unit, `${unit}s`, false)),
@@ -58,8 +53,6 @@ export function ExperimentMetricConversionWindowFilter({
                             conversion_window: value === 'experiment_duration' ? undefined : 14,
                             conversion_window_unit:
                                 value === 'experiment_duration' ? undefined : FunnelConversionWindowTimeUnit.Day,
-                            only_count_matured_users:
-                                value === 'experiment_duration' ? undefined : metric.only_count_matured_users,
                         })
                     }
                     options={[
@@ -74,46 +67,27 @@ export function ExperimentMetricConversionWindowFilter({
                     ]}
                 />
                 {metric.conversion_window_unit !== undefined && (
-                    <>
-                        <div className="flex items-center gap-2">
-                            <LemonInput
-                                type="number"
-                                className="max-w-20"
-                                fullWidth={false}
-                                min={intervalBounds[0]}
-                                max={intervalBounds[1]}
-                                value={metric.conversion_window || 1}
-                                onChange={(value) => {
-                                    handleSetMetric({ ...metric, conversion_window: value || undefined })
-                                }}
-                            />
-                            <LemonSelect
-                                dropdownMatchSelectWidth={false}
-                                value={metric.conversion_window_unit}
-                                onChange={(value) =>
-                                    handleSetMetric({ ...metric, conversion_window_unit: value || undefined })
-                                }
-                                options={options}
-                            />
-                        </div>
-                        {showMaturedUsersOption && (
-                            <div className="flex items-center gap-2">
-                                <LemonCheckbox
-                                    label="Only count matured users"
-                                    checked={metric.only_count_matured_users ?? false}
-                                    onChange={(checked) =>
-                                        handleSetMetric({
-                                            ...metric,
-                                            only_count_matured_users: checked || undefined,
-                                        })
-                                    }
-                                />
-                                <span className="text-muted text-xs">
-                                    Exclude users from calculations until their full conversion window has elapsed.
-                                </span>
-                            </div>
-                        )}
-                    </>
+                    <div className="flex items-center gap-2">
+                        <LemonInput
+                            type="number"
+                            className="max-w-20"
+                            fullWidth={false}
+                            min={intervalBounds[0]}
+                            max={intervalBounds[1]}
+                            value={metric.conversion_window || 1}
+                            onChange={(value) => {
+                                handleSetMetric({ ...metric, conversion_window: value || undefined })
+                            }}
+                        />
+                        <LemonSelect
+                            dropdownMatchSelectWidth={false}
+                            value={metric.conversion_window_unit}
+                            onChange={(value) =>
+                                handleSetMetric({ ...metric, conversion_window_unit: value || undefined })
+                            }
+                            options={options}
+                        />
+                    </div>
                 )}
             </div>
         </SceneSection>

--- a/frontend/src/scenes/experiments/ExperimentView/SettingsTab.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/SettingsTab.tsx
@@ -1,9 +1,10 @@
 import { useActions, useValues } from 'kea'
 
 import { IconPencil } from '@posthog/icons'
-import { LemonButton } from '@posthog/lemon-ui'
+import { LemonButton, LemonCheckbox } from '@posthog/lemon-ui'
 
 import { FEATURE_FLAGS } from 'lib/constants'
+import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { LinkedHogFunctions } from 'scenes/hog-functions/list/LinkedHogFunctions'
 import { urls } from 'scenes/urls'
@@ -16,8 +17,10 @@ import { StatsMethodModal } from './StatsMethodModal'
 
 export function SettingsTab(): JSX.Element {
     const { experiment, statsMethod } = useValues(experimentLogic)
+    const { updateExperiment } = useActions(experimentLogic)
     const { openStatsEngineModal } = useActions(modalsLogic)
     const { featureFlags } = useValues(featureFlagLogic)
+    const showMaturedUsersOption = useFeatureFlag('EXPERIMENTS_MATURED_USERS_FILTER')
 
     const isBayesian = statsMethod === ExperimentStatsMethod.Bayesian
 
@@ -43,6 +46,24 @@ export function SettingsTab(): JSX.Element {
                 </div>
                 <StatsMethodModal />
             </div>
+            {showMaturedUsersOption && (
+                <div>
+                    <h2 className="font-semibold text-lg">Conversion windows</h2>
+                    <div className="flex items-center gap-2">
+                        <LemonCheckbox
+                            label="Only count matured users"
+                            checked={experiment.only_count_matured_users ?? false}
+                            onChange={(checked) => {
+                                updateExperiment({ only_count_matured_users: checked })
+                            }}
+                        />
+                    </div>
+                    <p className="text-muted text-xs mt-1">
+                        Only count users whose full conversion window has elapsed. Applies to metrics with a custom time
+                        window.
+                    </p>
+                </div>
+            )}
             {shouldShowSignificanceAlerts && (
                 <div>
                     <h2 className="font-semibold text-lg">Notifications</h2>

--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -1697,7 +1697,8 @@ export const experimentLogic = kea<experimentLogicType>([
                     payload?.end_date !== undefined ||
                     payload?.metrics !== undefined ||
                     payload?.metrics_secondary !== undefined ||
-                    payload?.stats_config !== undefined
+                    payload?.stats_config !== undefined ||
+                    payload?.only_count_matured_users !== undefined
                 actions.refreshExperimentResults(forceRefresh, 'config_change')
             }
         },

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -4448,6 +4448,7 @@ export interface Experiment {
         timeseries?: boolean
     }
     exposure_preaggregation_enabled?: boolean
+    only_count_matured_users?: boolean
     _create_in_folder?: string | null
     conclusion?: ExperimentConclusion | null
     conclusion_comment?: string | null

--- a/posthog/api/test/__snapshots__/test_feature_flag.ambr
+++ b/posthog/api/test/__snapshots__/test_feature_flag.ambr
@@ -2373,6 +2373,7 @@
          "posthog_experiment"."stats_config",
          "posthog_experiment"."scheduling_config",
          "posthog_experiment"."exposure_preaggregation_enabled",
+         "posthog_experiment"."only_count_matured_users",
          "posthog_experiment"."status",
          "posthog_experiment"."conclusion",
          "posthog_experiment"."conclusion_comment"
@@ -2676,6 +2677,7 @@
          "posthog_experiment"."stats_config",
          "posthog_experiment"."scheduling_config",
          "posthog_experiment"."exposure_preaggregation_enabled",
+         "posthog_experiment"."only_count_matured_users",
          "posthog_experiment"."status",
          "posthog_experiment"."conclusion",
          "posthog_experiment"."conclusion_comment"

--- a/posthog/api/test/__snapshots__/test_organization_feature_flag.ambr
+++ b/posthog/api/test/__snapshots__/test_organization_feature_flag.ambr
@@ -2883,6 +2883,7 @@
          "posthog_experiment"."stats_config",
          "posthog_experiment"."scheduling_config",
          "posthog_experiment"."exposure_preaggregation_enabled",
+         "posthog_experiment"."only_count_matured_users",
          "posthog_experiment"."status",
          "posthog_experiment"."conclusion",
          "posthog_experiment"."conclusion_comment"
@@ -2920,6 +2921,7 @@
          "posthog_experiment"."stats_config",
          "posthog_experiment"."scheduling_config",
          "posthog_experiment"."exposure_preaggregation_enabled",
+         "posthog_experiment"."only_count_matured_users",
          "posthog_experiment"."status",
          "posthog_experiment"."conclusion",
          "posthog_experiment"."conclusion_comment"

--- a/posthog/hogql_queries/experiments/experiment_metric_fingerprint.py
+++ b/posthog/hogql_queries/experiments/experiment_metric_fingerprint.py
@@ -18,11 +18,16 @@ METRIC_FIELDS_TO_IGNORE: set[str] = {
     "name",
     "kind",
     "fingerprint",
+    "only_count_matured_users",
 }
 
 
 def compute_metric_fingerprint(
-    metric: dict, start_date: Any, stats_method: str | None = None, exposure_criteria: dict | None = None
+    metric: dict,
+    start_date: Any,
+    stats_method: str | None = None,
+    exposure_criteria: dict | None = None,
+    only_count_matured_users: bool = False,
 ) -> str:
     """
     Compute fingerprint for a metric.
@@ -50,7 +55,7 @@ def compute_metric_fingerprint(
     if stats_method is None:
         stats_method = "bayesian"
 
-    fingerprint_data = {
+    fingerprint_data: dict[str, Any] = {
         "metric": clean_metric,
         "start_date": start_date_str,
         "stats_method": stats_method,
@@ -58,6 +63,9 @@ def compute_metric_fingerprint(
 
     if exposure_criteria:
         fingerprint_data["exposure_criteria"] = exposure_criteria
+
+    if only_count_matured_users:
+        fingerprint_data["only_count_matured_users"] = True
 
     # Create deterministic JSON string with sorted keys at all levels
     json_str = json.dumps(fingerprint_data, sort_keys=True, separators=(",", ":"))

--- a/posthog/hogql_queries/experiments/experiment_query_builder.py
+++ b/posthog/hogql_queries/experiments/experiment_query_builder.py
@@ -86,9 +86,11 @@ class ExperimentQueryBuilder:
         ] = None,
         breakdowns: list[Breakdown] | None = None,
         force_precomputation: bool = False,
+        only_count_matured_users: bool = False,
     ):
         self.team = team
         self.metric = metric
+        self.only_count_matured_users = only_count_matured_users
         self.feature_flag_key = feature_flag_key
         self.variants = variants
         self.date_range_query = date_range_query
@@ -263,7 +265,7 @@ class ExperimentQueryBuilder:
         """
         if self.metric is None:
             return None
-        if not getattr(self.metric, "only_count_matured_users", False):
+        if not self.only_count_matured_users:
             return None
 
         maturity_seconds = self._get_maturity_window_seconds()

--- a/posthog/hogql_queries/experiments/experiment_query_runner.py
+++ b/posthog/hogql_queries/experiments/experiment_query_runner.py
@@ -214,6 +214,7 @@ class ExperimentQueryRunner(QueryRunner):
             metric=self.metric,
             breakdowns=self._get_breakdowns_for_builder(),
             force_precomputation=self.force_precomputation,
+            only_count_matured_users=self.experiment.only_count_matured_users,
         )
 
         # Skip precomputation for data warehouse metrics because the precomputed table

--- a/posthog/hogql_queries/experiments/test/experiment_query_runner/test_funnel_metric.py
+++ b/posthog/hogql_queries/experiments/test/experiment_query_runner/test_funnel_metric.py
@@ -2619,7 +2619,6 @@ class TestExperimentFunnelMetric(ExperimentQueryRunnerBaseTest):
             ],
             conversion_window=7,
             conversion_window_unit=FunnelConversionWindowTimeUnit.DAY,
-            only_count_matured_users=True,
         )
 
         experiment_query = ExperimentQuery(
@@ -2628,6 +2627,7 @@ class TestExperimentFunnelMetric(ExperimentQueryRunnerBaseTest):
             metric=metric,
         )
 
+        experiment.only_count_matured_users = True
         experiment.metrics = [metric.model_dump(mode="json")]
         self._save_experiment_with_precomputation(experiment, use_precomputation)
 

--- a/posthog/hogql_queries/experiments/test/experiment_query_runner/test_mean_metric.py
+++ b/posthog/hogql_queries/experiments/test/experiment_query_runner/test_mean_metric.py
@@ -1115,7 +1115,6 @@ class TestExperimentMeanMetric(ExperimentQueryRunnerBaseTest):
             ),
             conversion_window=7,
             conversion_window_unit=FunnelConversionWindowTimeUnit.DAY,
-            only_count_matured_users=True,
         )
 
         experiment_query = ExperimentQuery(
@@ -1124,6 +1123,7 @@ class TestExperimentMeanMetric(ExperimentQueryRunnerBaseTest):
             metric=metric,
         )
 
+        experiment.only_count_matured_users = True
         experiment.metrics = [metric.model_dump(mode="json")]
         self._save_experiment_with_precomputation(experiment, use_precomputation)
 

--- a/posthog/hogql_queries/experiments/test/experiment_query_runner/test_ratio_metric.py
+++ b/posthog/hogql_queries/experiments/test/experiment_query_runner/test_ratio_metric.py
@@ -1163,7 +1163,6 @@ class TestExperimentRatioMetric(ExperimentQueryRunnerBaseTest):
             ),
             conversion_window=7,
             conversion_window_unit=FunnelConversionWindowTimeUnit.DAY,
-            only_count_matured_users=True,
         )
 
         experiment_query = ExperimentQuery(
@@ -1172,6 +1171,7 @@ class TestExperimentRatioMetric(ExperimentQueryRunnerBaseTest):
             metric=metric,
         )
 
+        experiment.only_count_matured_users = True
         experiment.metrics = [metric.model_dump(mode="json")]
         self._save_experiment_with_precomputation(experiment, use_precomputation)
 

--- a/posthog/hogql_queries/experiments/test/experiment_query_runner/test_retention_metric.py
+++ b/posthog/hogql_queries/experiments/test/experiment_query_runner/test_retention_metric.py
@@ -1691,7 +1691,6 @@ class TestExperimentRetentionMetric(ExperimentQueryRunnerBaseTest):
             start_handling=StartHandling.FIRST_SEEN,
             conversion_window=3,
             conversion_window_unit=FunnelConversionWindowTimeUnit.DAY,
-            only_count_matured_users=True,
         )
 
         experiment_query = ExperimentQuery(
@@ -1700,6 +1699,7 @@ class TestExperimentRetentionMetric(ExperimentQueryRunnerBaseTest):
             metric=metric,
         )
 
+        experiment.only_count_matured_users = True
         experiment.metrics = [metric.model_dump(mode="json")]
         self._save_experiment_with_precomputation(experiment, use_precomputation)
 

--- a/posthog/models/resource_transfer/test/__snapshots__/test_visitor_field_snapshots.ambr
+++ b/posthog/models/resource_transfer/test/__snapshots__/test_visitor_field_snapshots.ambr
@@ -197,6 +197,7 @@
     'metrics',
     'metrics_secondary',
     'name',
+    'only_count_matured_users',
     'parameters',
     'primary_metrics_ordered_uuids',
     'scheduling_config',

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -5975,7 +5975,6 @@ class ExperimentMetricBaseProperties(BaseModel):
     isSharedMetric: bool | None = None
     kind: Literal["ExperimentMetric"] = "ExperimentMetric"
     name: str | None = None
-    only_count_matured_users: bool | None = None
     response: dict[str, Any] | None = None
     sharedMetricId: float | None = None
     uuid: str | None = None
@@ -17631,7 +17630,6 @@ class ExperimentRatioMetric(BaseModel):
     metric_type: Literal["ratio"] = "ratio"
     name: str | None = None
     numerator: EventsNode | ActionsNode | ExperimentDataWarehouseNode
-    only_count_matured_users: bool | None = None
     response: dict[str, Any] | None = None
     sharedMetricId: float | None = None
     uuid: str | None = None
@@ -17661,7 +17659,6 @@ class ExperimentRetentionMetric(BaseModel):
     kind: Literal["ExperimentMetric"] = "ExperimentMetric"
     metric_type: Literal["retention"] = "retention"
     name: str | None = None
-    only_count_matured_users: bool | None = None
     response: dict[str, Any] | None = None
     retention_window_end: int
     retention_window_start: int
@@ -18684,7 +18681,6 @@ class ExperimentFunnelMetric(BaseModel):
     kind: Literal["ExperimentMetric"] = "ExperimentMetric"
     metric_type: Literal["funnel"] = "funnel"
     name: str | None = None
-    only_count_matured_users: bool | None = None
     response: dict[str, Any] | None = None
     series: list[EventsNode | ActionsNode]
     sharedMetricId: float | None = None
@@ -18707,7 +18703,6 @@ class ExperimentMeanMetric(BaseModel):
     lower_bound_percentile: float | None = None
     metric_type: Literal["mean"] = "mean"
     name: str | None = None
-    only_count_matured_users: bool | None = None
     response: dict[str, Any] | None = None
     sharedMetricId: float | None = None
     source: EventsNode | ActionsNode | ExperimentDataWarehouseNode

--- a/posthog/tasks/test/__snapshots__/test_process_scheduled_changes.ambr
+++ b/posthog/tasks/test/__snapshots__/test_process_scheduled_changes.ambr
@@ -336,6 +336,7 @@
          "posthog_experiment"."stats_config",
          "posthog_experiment"."scheduling_config",
          "posthog_experiment"."exposure_preaggregation_enabled",
+         "posthog_experiment"."only_count_matured_users",
          "posthog_experiment"."status",
          "posthog_experiment"."conclusion",
          "posthog_experiment"."conclusion_comment"
@@ -1095,6 +1096,7 @@
          "posthog_experiment"."stats_config",
          "posthog_experiment"."scheduling_config",
          "posthog_experiment"."exposure_preaggregation_enabled",
+         "posthog_experiment"."only_count_matured_users",
          "posthog_experiment"."status",
          "posthog_experiment"."conclusion",
          "posthog_experiment"."conclusion_comment"

--- a/posthog/temporal/experiments/activities.py
+++ b/posthog/temporal/experiments/activities.py
@@ -80,6 +80,7 @@ def _get_experiment_regular_metrics_for_hour_sync(hour: int) -> list[ExperimentR
                 experiment.start_date,
                 get_experiment_stats_method(experiment),
                 experiment.exposure_criteria,
+                only_count_matured_users=experiment.only_count_matured_users,
             )
 
             experiment_metrics.append(
@@ -327,6 +328,7 @@ def _get_experiment_saved_metrics_for_hour_sync(hour: int) -> list[ExperimentSav
                 experiment.start_date,
                 get_experiment_stats_method(experiment),
                 experiment.exposure_criteria,
+                only_count_matured_users=experiment.only_count_matured_users,
             )
 
             experiment_metrics.append(

--- a/products/experiments/backend/experiment_service.py
+++ b/products/experiments/backend/experiment_service.py
@@ -193,6 +193,7 @@ class ExperimentService:
         filters: dict | None = None,
         scheduling_config: dict | None = None,
         exposure_preaggregation_enabled: bool = False,
+        only_count_matured_users: bool = False,
         archived: bool = False,
         deleted: bool = False,
         conclusion: str | None = None,
@@ -222,10 +223,22 @@ class ExperimentService:
         stats_method = "bayesian" if stats_config is None else stats_config.get("method", "bayesian")
         if metrics is not None:
             for metric in metrics:
-                metric["fingerprint"] = compute_metric_fingerprint(metric, start_date, stats_method, exposure_criteria)
+                metric["fingerprint"] = compute_metric_fingerprint(
+                    metric,
+                    start_date,
+                    stats_method,
+                    exposure_criteria,
+                    only_count_matured_users=only_count_matured_users,
+                )
         if metrics_secondary is not None:
             for metric in metrics_secondary:
-                metric["fingerprint"] = compute_metric_fingerprint(metric, start_date, stats_method, exposure_criteria)
+                metric["fingerprint"] = compute_metric_fingerprint(
+                    metric,
+                    start_date,
+                    stats_method,
+                    exposure_criteria,
+                    only_count_matured_users=only_count_matured_users,
+                )
 
         if metrics is not None:
             primary_ordering = list(primary_metrics_ordered_uuids or [])
@@ -264,6 +277,7 @@ class ExperimentService:
             "secondary_metrics_ordered_uuids": secondary_metrics_ordered_uuids,
             "scheduling_config": scheduling_config,
             "exposure_preaggregation_enabled": exposure_preaggregation_enabled,
+            "only_count_matured_users": only_count_matured_users,
             "archived": archived,
             "deleted": deleted,
             "conclusion": conclusion,
@@ -410,6 +424,7 @@ class ExperimentService:
         start_date: datetime | None,
         stats_config: dict | None,
         exposure_criteria: dict | None,
+        only_count_matured_users: bool = False,
     ) -> list[dict]:
         """Recompute fingerprints for a list of metrics. Returns a new list with updated fingerprints."""
         stats_method = "bayesian" if stats_config is None else stats_config.get("method", "bayesian")
@@ -417,7 +432,11 @@ class ExperimentService:
         for metric in metrics:
             metric_copy = deepcopy(metric)
             metric_copy["fingerprint"] = compute_metric_fingerprint(
-                metric_copy, start_date, stats_method, exposure_criteria
+                metric_copy,
+                start_date,
+                stats_method,
+                exposure_criteria,
+                only_count_matured_users=only_count_matured_users,
             )
             updated.append(metric_copy)
         return updated
@@ -1114,12 +1133,17 @@ class ExperimentService:
         start_date = update_data.get("start_date", experiment.start_date)
         stats_config = update_data.get("stats_config", experiment.stats_config)
         exposure_criteria = update_data.get("exposure_criteria", experiment.exposure_criteria)
+        only_count_matured_users = update_data.get("only_count_matured_users", experiment.only_count_matured_users)
 
         for metric_field in ["metrics", "metrics_secondary"]:
             metrics = update_data.get(metric_field, getattr(experiment, metric_field, None))
             if metrics:
                 update_data[metric_field] = self._recompute_fingerprints(
-                    metrics, start_date, stats_config, exposure_criteria
+                    metrics,
+                    start_date,
+                    stats_config,
+                    exposure_criteria,
+                    only_count_matured_users=only_count_matured_users,
                 )
 
         # --- metric ordering sync + validation -----------------------------
@@ -1196,6 +1220,7 @@ class ExperimentService:
             "primary_metrics_ordered_uuids",
             "secondary_metrics_ordered_uuids",
             "saved_metrics_ids",
+            "only_count_matured_users",
         }
         extra_keys = set(update_data.keys()) - expected_keys
 
@@ -1287,6 +1312,7 @@ class ExperimentService:
             primary_metrics_ordered_uuids=source_experiment.primary_metrics_ordered_uuids,
             secondary_metrics_ordered_uuids=source_experiment.secondary_metrics_ordered_uuids,
             exposure_preaggregation_enabled=source_experiment.exposure_preaggregation_enabled,
+            only_count_matured_users=source_experiment.only_count_matured_users,
             serializer_context=serializer_context,
         )
 

--- a/products/experiments/backend/migrations/0002_experiment_only_count_matured_users.py
+++ b/products/experiments/backend/migrations/0002_experiment_only_count_matured_users.py
@@ -1,0 +1,36 @@
+from django.db import migrations, models
+
+
+def migrate_metric_field_to_experiment(apps, schema_editor):
+    """Move only_count_matured_users from per-metric JSON to experiment-level field.
+
+    Scans experiments for metrics containing only_count_matured_users: true,
+    sets the experiment-level field, and strips the key from metric dicts.
+    """
+    Experiment = apps.get_model("experiments", "Experiment")
+
+    for experiment in Experiment.objects.all().iterator(chunk_size=1000):
+        found = False
+        for metrics_field in ("metrics", "metrics_secondary"):
+            metrics = getattr(experiment, metrics_field) or []
+            for metric in metrics:
+                if metric.pop("only_count_matured_users", None):
+                    found = True
+        if found:
+            experiment.only_count_matured_users = True
+            experiment.save(update_fields=["only_count_matured_users", "metrics", "metrics_secondary"])
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("experiments", "0001_migrate_experiments_models"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="experiment",
+            name="only_count_matured_users",
+            field=models.BooleanField(default=False),
+        ),
+        migrations.RunPython(migrate_metric_field_to_experiment, migrations.RunPython.noop),
+    ]

--- a/products/experiments/backend/migrations/0002_experiment_only_count_matured_users.py
+++ b/products/experiments/backend/migrations/0002_experiment_only_count_matured_users.py
@@ -1,26 +1,6 @@
 from django.db import migrations, models
 
 
-def migrate_metric_field_to_experiment(apps, schema_editor):
-    """Move only_count_matured_users from per-metric JSON to experiment-level field.
-
-    Scans experiments for metrics containing only_count_matured_users: true,
-    sets the experiment-level field, and strips the key from metric dicts.
-    """
-    Experiment = apps.get_model("experiments", "Experiment")
-
-    for experiment in Experiment.objects.all().iterator(chunk_size=1000):
-        found = False
-        for metrics_field in ("metrics", "metrics_secondary"):
-            metrics = getattr(experiment, metrics_field) or []
-            for metric in metrics:
-                if metric.pop("only_count_matured_users", None):
-                    found = True
-        if found:
-            experiment.only_count_matured_users = True
-            experiment.save(update_fields=["only_count_matured_users", "metrics", "metrics_secondary"])
-
-
 class Migration(migrations.Migration):
     dependencies = [
         ("experiments", "0001_migrate_experiments_models"),
@@ -32,5 +12,4 @@ class Migration(migrations.Migration):
             name="only_count_matured_users",
             field=models.BooleanField(default=False),
         ),
-        migrations.RunPython(migrate_metric_field_to_experiment, migrations.RunPython.noop),
     ]

--- a/products/experiments/backend/migrations/0003_migrate_only_count_matured_users_to_experiment.py
+++ b/products/experiments/backend/migrations/0003_migrate_only_count_matured_users_to_experiment.py
@@ -1,0 +1,35 @@
+from django.db import migrations
+
+
+def migrate_metric_field_to_experiment(apps, schema_editor):
+    """Move only_count_matured_users from per-metric JSON to experiment-level field.
+
+    Scans experiments for metrics containing only_count_matured_users,
+    sets the experiment-level field, and strips the key from metric dicts.
+    """
+    Experiment = apps.get_model("experiments", "Experiment")
+
+    for experiment in Experiment.objects.all().iterator(chunk_size=1000):
+        found = False
+        modified = False
+        for metrics_field in ("metrics", "metrics_secondary"):
+            metrics = getattr(experiment, metrics_field) or []
+            for metric in metrics:
+                popped = metric.pop("only_count_matured_users", None)
+                if popped is not None:
+                    modified = True
+                    if popped:
+                        found = True
+        if modified:
+            experiment.only_count_matured_users = found
+            experiment.save(update_fields=["only_count_matured_users", "metrics", "metrics_secondary"])
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("experiments", "0002_experiment_only_count_matured_users"),
+    ]
+
+    operations = [
+        migrations.RunPython(migrate_metric_field_to_experiment, migrations.RunPython.noop),
+    ]

--- a/products/experiments/backend/migrations/max_migration.txt
+++ b/products/experiments/backend/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0002_experiment_only_count_matured_users
+0003_migrate_only_count_matured_users_to_experiment

--- a/products/experiments/backend/migrations/max_migration.txt
+++ b/products/experiments/backend/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0001_migrate_experiments_models
+0002_experiment_only_count_matured_users

--- a/products/experiments/backend/models/experiment.py
+++ b/products/experiments/backend/models/experiment.py
@@ -71,6 +71,7 @@ class Experiment(FileSystemSyncMixin, ModelActivityMixin, RootTeamMixin, models.
     scheduling_config = models.JSONField(default=dict, null=True, blank=True)
 
     exposure_preaggregation_enabled = models.BooleanField(default=False)
+    only_count_matured_users = models.BooleanField(default=False)
 
     status = models.CharField(
         max_length=20,

--- a/products/experiments/frontend/generated/api.schemas.ts
+++ b/products/experiments/frontend/generated/api.schemas.ts
@@ -320,6 +320,7 @@ export interface ExperimentApi {
     primary_metrics_ordered_uuids?: unknown | null
     secondary_metrics_ordered_uuids?: unknown | null
     exposure_preaggregation_enabled?: boolean
+    only_count_matured_users?: boolean
     readonly status: ExperimentStatusEnumApi | NullEnumApi | null
     /**
      * The effective access level the user has for this object
@@ -385,6 +386,7 @@ export interface PatchedExperimentApi {
     primary_metrics_ordered_uuids?: unknown | null
     secondary_metrics_ordered_uuids?: unknown | null
     exposure_preaggregation_enabled?: boolean
+    only_count_matured_users?: boolean
     readonly status?: ExperimentStatusEnumApi | NullEnumApi | null
     /**
      * The effective access level the user has for this object

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -13579,6 +13579,7 @@ export namespace Schemas {
       primary_metrics_ordered_uuids?: unknown | null;
       secondary_metrics_ordered_uuids?: unknown | null;
       exposure_preaggregation_enabled?: boolean;
+      only_count_matured_users?: boolean;
       readonly status: ExperimentStatusEnum | NullEnum | null;
       /**
        * The effective access level the user has for this object
@@ -13938,8 +13939,6 @@ export namespace Schemas {
       /** @nullable */
       name?: string | null;
       /** @nullable */
-      only_count_matured_users?: boolean | null;
-      /** @nullable */
       response?: ExperimentFunnelMetricResponse;
       series: (EventsNode | ActionsNode)[];
       /** @nullable */
@@ -13990,8 +13989,6 @@ export namespace Schemas {
       metric_type?: ExperimentMeanMetricMetricType;
       /** @nullable */
       name?: string | null;
-      /** @nullable */
-      only_count_matured_users?: boolean | null;
       /** @nullable */
       response?: ExperimentMeanMetricResponse;
       /** @nullable */
@@ -14051,8 +14048,6 @@ export namespace Schemas {
       name?: string | null;
       numerator: EventsNode | ActionsNode | ExperimentDataWarehouseNode;
       /** @nullable */
-      only_count_matured_users?: boolean | null;
-      /** @nullable */
       response?: ExperimentRatioMetricResponse;
       /** @nullable */
       sharedMetricId?: number | null;
@@ -14107,8 +14102,6 @@ export namespace Schemas {
       metric_type?: ExperimentRetentionMetricMetricType;
       /** @nullable */
       name?: string | null;
-      /** @nullable */
-      only_count_matured_users?: boolean | null;
       /** @nullable */
       response?: ExperimentRetentionMetricResponse;
       retention_window_end: number;
@@ -22398,6 +22391,7 @@ export namespace Schemas {
       primary_metrics_ordered_uuids?: unknown | null;
       secondary_metrics_ordered_uuids?: unknown | null;
       exposure_preaggregation_enabled?: boolean;
+      only_count_matured_users?: boolean;
       readonly status?: ExperimentStatusEnum | NullEnum | null;
       /**
        * The effective access level the user has for this object


### PR DESCRIPTION
## Problem

The "only count matured users" toggle is a per-metric field. Changing it on a shared metric affects every experiment using that metric. It's a viewing preference for how to handle in-progress conversions, not a property of the metric definition itself.

## Changes

Based on [feedback](https://posthog.slack.com/archives/C0862M4NJHG/p1774907184639099?thread_ts=1773198758.324809&cid=C0862M4NJHG), moving `only_count_matured_users` from a per-metric field on `ExperimentMetricBaseProperties` to a per-experiment BooleanField on the Experiment model. The toggle now lives in the experiment Settings tab. Only applies to metrics with a custom time window - metrics using "experiment duration" are unaffected.

<img width="683" height="278" alt="image" src="https://github.com/user-attachments/assets/9e8f63a4-c009-4f7a-a614-3f304fcef2a3" />

## How did you test this code?

Updated tests