### PR TITLE
fix(mcp): remove uv dependency from Cloudflare Pages build

### DIFF
--- a/services/mcp/scripts/generate-ui-apps.ts
+++ b/services/mcp/scripts/generate-ui-apps.ts
@@ -395,13 +395,23 @@ function main(): void {
 }
 
 function formatOutput(generatedFiles: string[]): void {
-    const formatResult = spawnSync(path.join(ROOT_DIR, 'bin/hogli'), ['format:js', ...generatedFiles], {
+    // Run oxlint + oxfmt directly instead of going through `bin/hogli format:js`,
+    // which requires `uv` (Python) and fails in environments like Cloudflare Pages
+    // where the uv version doesn't match pyproject.toml's required-version.
+    const oxlintResult = spawnSync('pnpm', ['oxlint', '--fix', '--fix-suggestions', '--quiet', ...generatedFiles], {
         stdio: 'inherit',
         cwd: ROOT_DIR,
     })
+    if (oxlintResult.status && oxlintResult.status !== 0) {
+        process.exit(oxlintResult.status)
+    }
 
-    if (formatResult.status && formatResult.status !== 0) {
-        process.exit(formatResult.status)
+    const oxfmtResult = spawnSync('pnpm', ['exec', 'oxfmt', '--no-error-on-unmatched-pattern', ...generatedFiles], {
+        stdio: 'inherit',
+        cwd: ROOT_DIR,
+    })
+    if (oxfmtResult.status && oxfmtResult.status !== 0) {
+        process.exit(oxfmtResult.status)
     }
 }
 


### PR DESCRIPTION
## Problem

The MCP service Cloudflare Pages build fails because `generate-ui-apps.ts` calls `bin/hogli format:js` to format generated files. `hogli` uses `uv run --script`, which checks `pyproject.toml`'s `required-version = "~=0.10.2"` — but Cloudflare's build environment has `uv 0.11.1`, causing a version mismatch error.

## Changes

Replace the `bin/hogli format:js` call in `formatOutput()` with direct `pnpm oxlint` + `pnpm exec oxfmt` invocations — the same commands `hogli format:js` runs internally. This removes the Python/uv dependency from the MCP build pipeline.

## How did you test this code?

- Ran `pnpm run generate:ui-apps` — passes with formatting applied
- Ran `pnpm run build` — all 21 UI apps built successfully

## Publish to changelog?

no

## 🤖 LLM context

Agent-authored fix. The root cause was traced from the Cloudflare build log through the `formatOutput` → `hogli` → `uv` dependency chain.