### PR TITLE
fix(phai): output details of 400 errors

### DIFF
--- a/frontend/src/scenes/max/maxThreadLogic.test.ts
+++ b/frontend/src/scenes/max/maxThreadLogic.test.ts
@@ -5,7 +5,7 @@ import { partial } from 'kea-test-utils'
 import { expectLogic } from 'kea-test-utils'
 import React from 'react'
 
-import api from 'lib/api'
+import api, { ApiError } from 'lib/api'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { lemonToast } from 'lib/lemon-ui/LemonToast'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
@@ -935,6 +935,56 @@ describe('maxThreadLogic', () => {
                     },
                 ],
             })
+        })
+    })
+
+    describe('400 error message handling', () => {
+        it('surfaces server detail message for 400 errors', async () => {
+            jest.spyOn(api.conversations, 'stream').mockRejectedValue(
+                new ApiError('Bad Request', 400, undefined, { detail: 'The server error message' })
+            )
+
+            logic.unmount()
+            maxLogicInstance.actions.setConversationId(MOCK_TEMP_CONVERSATION_ID)
+            logic = maxThreadLogic({ conversationId: MOCK_TEMP_CONVERSATION_ID, tabId: 'test' })
+            logic.mount()
+
+            await expectLogic(logic, () => {
+                logic.actions.askMax('hello')
+            })
+                .toDispatchActions(['askMax', 'addMessage', 'completeThreadGeneration'])
+                .toMatchValues({
+                    threadGrouped: expect.arrayContaining([
+                        expect.objectContaining({
+                            type: AssistantMessageType.Failure,
+                            content: 'The server error message',
+                        }),
+                    ]),
+                })
+        })
+
+        it('shows content length message for 400 errors with content attr', async () => {
+            jest.spyOn(api.conversations, 'stream').mockRejectedValue(
+                new ApiError('Bad Request', 400, undefined, { attr: 'content', detail: 'Content too long' })
+            )
+
+            logic.unmount()
+            maxLogicInstance.actions.setConversationId(MOCK_TEMP_CONVERSATION_ID)
+            logic = maxThreadLogic({ conversationId: MOCK_TEMP_CONVERSATION_ID, tabId: 'test' })
+            logic.mount()
+
+            await expectLogic(logic, () => {
+                logic.actions.askMax('hello')
+            })
+                .toDispatchActions(['askMax', 'addMessage', 'completeThreadGeneration'])
+                .toMatchValues({
+                    threadGrouped: expect.arrayContaining([
+                        expect.objectContaining({
+                            type: AssistantMessageType.Failure,
+                            content: 'Oops! Your message is too long. Ensure it has no more than 40000 characters.',
+                        }),
+                    ]),
+                })
         })
     })
 

--- a/frontend/src/scenes/max/maxThreadLogic.tsx
+++ b/frontend/src/scenes/max/maxThreadLogic.tsx
@@ -727,6 +727,8 @@ export const maxThreadLogic = kea<maxThreadLogicType>([
                             if (e.data?.attr === 'content') {
                                 relevantErrorMessage.content =
                                     'Oops! Your message is too long. Ensure it has no more than 40000 characters.'
+                            } else if (e.detail) {
+                                relevantErrorMessage.content = e.detail
                             }
                         }
 


### PR DESCRIPTION
## Problem

When the PostHog AI API returns a 400 error, the error handling only displays a custom message for content length errors (when `attr: 'content'`). Other 400 errors with a `detail` field are not surfaced to the user, resulting in a poor experience when the server provides helpful error information.

## Changes

- Updated `maxThreadLogic.tsx` to surface the server's `detail` message for 400 errors that don't have a `content` attribute
- Added `ApiError` import to the test file to support new test cases
- Added comprehensive test coverage for 400 error handling:
  - Test for surfacing generic server detail messages
  - Test for content length validation messages with the `attr: 'content'` field

## How did you test this code?

Added two new test cases in `maxThreadLogic.test.ts` that verify:
1. Generic 400 errors with a `detail` field display the server message
2. Content-specific 400 errors (with `attr: 'content'`) display the custom content length message

Both tests verify the error message appears in the thread as a failure message with the correct content.

https://claude.ai/code/session_01RobqKjqpnCSNRsqHyFY7pL