### PR TITLE
feat(insights): track legacy filtersToQueryNode call sites

### DIFF
--- a/frontend/src/queries/nodes/InsightQuery/utils/filtersToQueryNode.ts
+++ b/frontend/src/queries/nodes/InsightQuery/utils/filtersToQueryNode.ts
@@ -372,9 +372,22 @@ const strToBool = (value: any): boolean | undefined => {
     return ['y', 'yes', 't', 'true', 'on', '1'].includes(String(value).toLowerCase())
 }
 
-export const filtersToQueryNode = (filters: Partial<FilterType>): InsightQueryNode => {
+export type FiltersToQueryNodeTrackingContext = {
+    source: string
+}
+
+export const filtersToQueryNode = (
+    filters: Partial<FilterType>,
+    trackingContext?: FiltersToQueryNodeTrackingContext
+): InsightQueryNode => {
     const captureException = (message: string): void => {
         posthog.captureException(new Error(message), { filters, DataExploration: true })
+    }
+    if (trackingContext) {
+        posthog.capture('legacy_filters_to_query_node_called', {
+            source: trackingContext.source,
+            insight: filters.insight,
+        })
     }
 
     if (!filters.insight) {

--- a/frontend/src/queries/nodes/InsightViz/utils.ts
+++ b/frontend/src/queries/nodes/InsightViz/utils.ts
@@ -102,7 +102,10 @@ export function getQueryFromInsightLike(insight: {
     if (insight.query) {
         query = insight.query
     } else if (insight.filters && Object.keys(insight.filters).filter((k) => k != 'filter_test_accounts').length > 0) {
-        query = { kind: NodeKind.InsightVizNode, source: filtersToQueryNode(insight.filters) } as InsightVizNode
+        query = {
+            kind: NodeKind.InsightVizNode,
+            source: filtersToQueryNode(insight.filters, { source: 'insight_viz_get_query_from_insight_like' }),
+        } as InsightVizNode
     } else {
         query = null
     }
@@ -112,7 +115,7 @@ export function getQueryFromInsightLike(insight: {
 
 export const queryFromFilters = (filters: Partial<FilterType>): InsightVizNode => ({
     kind: NodeKind.InsightVizNode,
-    source: filtersToQueryNode(filters),
+    source: filtersToQueryNode(filters, { source: 'insight_viz_query_from_filters' }),
 })
 
 export const queryFromKind = (

--- a/frontend/src/scenes/saved-insights/activityDescriptions.tsx
+++ b/frontend/src/scenes/saved-insights/activityDescriptions.tsx
@@ -245,7 +245,9 @@ const insightActionsMapping: Record<
 }
 
 function summarizeChanges(filtersAfter: Partial<FilterType>): ChangeMapping | null {
-    const query = filtersToQueryNode(filtersAfter)
+    const query = filtersToQueryNode(filtersAfter, {
+        source: 'saved_insights_activity_descriptions',
+    })
     const trendsQuery = query as TrendsQuery
 
     return {


### PR DESCRIPTION
## Problem

I want to get rid of the legacy `filtersToQueryNode` function

## Changes

Adds tracking to call sites, to be absolutely sure it's not required any more.

## How did you test this code?

n/a