### PR TITLE
fix: add PostHog AI context for saved insights

### DIFF
--- a/frontend/src/scenes/insights/InsightPageHeader.spec.tsx
+++ b/frontend/src/scenes/insights/InsightPageHeader.spec.tsx
@@ -234,59 +234,67 @@ describe('InsightPageHeader', () => {
     })
 
     describe('insight context for PostHog AI', () => {
-        it('provides context with insight name when viewing a saved insight', () => {
-            const insight = makeInsight({
-                name: 'My Test Insight',
-                user_access_level: AccessControlLevel.Editor,
-            })
-            renderHeader({
+        function findReadDataCall(): Record<string, unknown> | undefined {
+            const call = mockUseMaxTool.mock.calls.find(
+                (c: Record<string, unknown>[]) => c[0]?.identifier === 'read_data'
+            )
+            return call?.[0] as Record<string, unknown> | undefined
+        }
+
+        it.each([
+            {
+                scenario: 'saved insight with explicit name',
                 insightMode: ItemMode.View,
                 dashboardItemId: SAVED_INSIGHT_ID,
-                insight,
-            })
-
-            const readDataCall = mockUseMaxTool.mock.calls.find(
-                (call: Record<string, unknown>[]) => call[0]?.identifier === 'read_data'
-            )
-            expect(readDataCall).not.toBeUndefined()
-            expect(readDataCall![0].active).toBe(true)
-            expect(readDataCall![0].contextDescription).toMatchObject({
-                text: 'My Test Insight',
-            })
-        })
-
-        it('does not provide context for unsaved insights', () => {
-            renderHeader({
+                insight: { name: 'My Test Insight', user_access_level: AccessControlLevel.Editor },
+                expectedActive: true,
+                expectedText: 'My Test Insight',
+                expectedContext: { insight_id: 1, insight_short_id: SAVED_INSIGHT_ID },
+            },
+            {
+                scenario: 'saved insight with derived name',
+                insightMode: ItemMode.View,
+                dashboardItemId: SAVED_INSIGHT_ID,
+                insight: {
+                    name: undefined,
+                    derived_name: 'Pageview count',
+                    user_access_level: AccessControlLevel.Editor,
+                },
+                expectedActive: true,
+                expectedText: 'Pageview count',
+                expectedContext: { insight_id: 1, insight_short_id: SAVED_INSIGHT_ID },
+            },
+            {
+                scenario: 'unsaved insight',
                 insightMode: ItemMode.Edit,
-                dashboardItemId: 'new',
-            })
+                dashboardItemId: 'new' as const,
+                insight: undefined,
+                expectedActive: false,
+                expectedText: undefined,
+                expectedContext: undefined,
+            },
+        ])(
+            '$scenario: active=$expectedActive, text=$expectedText',
+            ({ insightMode, dashboardItemId, insight, expectedActive, expectedText, expectedContext }) => {
+                renderHeader({
+                    insightMode,
+                    dashboardItemId,
+                    insight: insight ? makeInsight(insight) : undefined,
+                })
 
-            const readDataCall = mockUseMaxTool.mock.calls.find(
-                (call: Record<string, unknown>[]) => call[0]?.identifier === 'read_data'
-            )
-            // For new insights, maxToolProps is undefined so useMaxTool is called with active: false
-            expect(readDataCall).not.toBeUndefined()
-            expect(readDataCall![0].active).toBe(false)
-        })
+                const readDataCall = findReadDataCall()
+                expect(readDataCall).not.toBeUndefined()
+                expect(readDataCall!.active).toBe(expectedActive)
 
-        it('uses derived name when insight has no explicit name', () => {
-            const insight = makeInsight({
-                name: undefined,
-                derived_name: 'Pageview count',
-                user_access_level: AccessControlLevel.Editor,
-            })
-            renderHeader({
-                insightMode: ItemMode.View,
-                dashboardItemId: SAVED_INSIGHT_ID,
-                insight,
-            })
-
-            const readDataCall = mockUseMaxTool.mock.calls.find(
-                (call: Record<string, unknown>[]) => call[0]?.identifier === 'read_data'
-            )
-            expect(readDataCall).not.toBeUndefined()
-            expect(readDataCall![0].contextDescription.text).toBe('Pageview count')
-        })
+                if (expectedActive) {
+                    expect(readDataCall!.contextDescription).toMatchObject({
+                        text: expectedText,
+                        icon: expect.anything(),
+                    })
+                    expect(readDataCall!.context).toMatchObject(expectedContext!)
+                }
+            }
+        )
     })
 
     describe('forceEdit', () => {

--- a/frontend/src/scenes/insights/InsightPageHeader.spec.tsx
+++ b/frontend/src/scenes/insights/InsightPageHeader.spec.tsx
@@ -233,6 +233,62 @@ describe('InsightPageHeader', () => {
         })
     })
 
+    describe('insight context for PostHog AI', () => {
+        it('provides context with insight name when viewing a saved insight', () => {
+            const insight = makeInsight({
+                name: 'My Test Insight',
+                user_access_level: AccessControlLevel.Editor,
+            })
+            renderHeader({
+                insightMode: ItemMode.View,
+                dashboardItemId: SAVED_INSIGHT_ID,
+                insight,
+            })
+
+            const readDataCall = mockUseMaxTool.mock.calls.find(
+                (call: Record<string, unknown>[]) => call[0]?.identifier === 'read_data'
+            )
+            expect(readDataCall).not.toBeUndefined()
+            expect(readDataCall![0].active).toBe(true)
+            expect(readDataCall![0].contextDescription).toMatchObject({
+                text: 'My Test Insight',
+            })
+        })
+
+        it('does not provide context for unsaved insights', () => {
+            renderHeader({
+                insightMode: ItemMode.Edit,
+                dashboardItemId: 'new',
+            })
+
+            const readDataCall = mockUseMaxTool.mock.calls.find(
+                (call: Record<string, unknown>[]) => call[0]?.identifier === 'read_data'
+            )
+            // For new insights, maxToolProps is undefined so useMaxTool is called with active: false
+            expect(readDataCall).not.toBeUndefined()
+            expect(readDataCall![0].active).toBe(false)
+        })
+
+        it('uses derived name when insight has no explicit name', () => {
+            const insight = makeInsight({
+                name: undefined,
+                derived_name: 'Pageview count',
+                user_access_level: AccessControlLevel.Editor,
+            })
+            renderHeader({
+                insightMode: ItemMode.View,
+                dashboardItemId: SAVED_INSIGHT_ID,
+                insight,
+            })
+
+            const readDataCall = mockUseMaxTool.mock.calls.find(
+                (call: Record<string, unknown>[]) => call[0]?.identifier === 'read_data'
+            )
+            expect(readDataCall).not.toBeUndefined()
+            expect(readDataCall![0].contextDescription.text).toBe('Pageview count')
+        })
+    })
+
     describe('forceEdit', () => {
         it('shows the editable name input in Edit mode', () => {
             renderHeader({

--- a/frontend/src/scenes/insights/InsightPageHeader.tsx
+++ b/frontend/src/scenes/insights/InsightPageHeader.tsx
@@ -51,6 +51,26 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
 
     const canCreateAlertForInsight = areAlertsSupportedForInsight(query)
 
+    const insightDisplayName = insight?.name || insight?.derived_name
+
+    const readDataMaxToolProps = useMemo(
+        () =>
+            hasDashboardItemId && insight?.short_id
+                ? {
+                      identifier: 'read_data' as const,
+                      context: {
+                          insight_id: insight.id,
+                          insight_short_id: insight.short_id,
+                      },
+                      contextDescription: {
+                          text: insightDisplayName || 'Insight',
+                          icon: iconForType(getInsightIconTypeFromQuery(query)),
+                      },
+                  }
+                : undefined,
+        [hasDashboardItemId, insight?.short_id, insight?.id, insightDisplayName, query]
+    )
+
     useMaxTool({
         identifier: 'upsert_alert',
         active: canCreateAlertForInsight && hasDashboardItemId && !!insight.id,
@@ -96,17 +116,7 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
                 renameDebounceMs={0}
                 saveOnBlur
                 descriptionMaxLength={400}
-                maxToolProps={
-                    hasDashboardItemId && insight?.short_id
-                        ? {
-                              identifier: 'read_data',
-                              contextDescription: {
-                                  text: defaultInsightName || 'Insight',
-                                  icon: iconForType(getInsightIconTypeFromQuery(query)),
-                              },
-                          }
-                        : undefined
-                }
+                maxToolProps={readDataMaxToolProps}
                 actions={
                     <>
                         {insightMode === ItemMode.Edit && hasDashboardItemId && (

--- a/frontend/src/scenes/insights/InsightPageHeader.tsx
+++ b/frontend/src/scenes/insights/InsightPageHeader.tsx
@@ -15,6 +15,7 @@ import { useMaxTool } from 'scenes/max/useMaxTool'
 import { urls } from 'scenes/urls'
 
 import { breadcrumbsLogic } from '~/layout/navigation/Breadcrumbs/breadcrumbsLogic'
+import { iconForType } from '~/layout/panel-layout/ProjectTree/defaultTree'
 import { getLastNewFolder } from '~/layout/panel-layout/ProjectTree/projectTreeLogic'
 import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
 import { isDataVisualizationNode } from '~/queries/utils'
@@ -95,6 +96,17 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
                 renameDebounceMs={0}
                 saveOnBlur
                 descriptionMaxLength={400}
+                maxToolProps={
+                    hasDashboardItemId && insight?.short_id
+                        ? {
+                              identifier: 'read_data',
+                              contextDescription: {
+                                  text: defaultInsightName || 'Insight',
+                                  icon: iconForType(getInsightIconTypeFromQuery(query)),
+                              },
+                          }
+                        : undefined
+                }
                 actions={
                     <>
                         {insightMode === ItemMode.Edit && hasDashboardItemId && (


### PR DESCRIPTION
## Problem

PostHog AI needs context about which insight is being viewed to provide better assistance. Currently, the InsightPageHeader doesn't provide this information to the AI tools.

## Changes

- Added `maxToolProps` to the `SceneTitleSection` component in `InsightPageHeader.tsx` to pass insight context to PostHog AI
- The context includes the insight name (or derived name if no explicit name exists) and an icon representing the insight type
- Context is only provided for saved insights (when `hasDashboardItemId` and `insight?.short_id` exist), not for new/unsaved insights
- Added comprehensive test coverage in `InsightPageHeader.spec.tsx` to verify:
  - Context is provided with insight name when viewing a saved insight
  - Context is not provided for unsaved insights
  - Derived name is used as fallback when insight has no explicit name

## How did you test this code?

Added three new test cases covering the insight context functionality:
1. `provides context with insight name when viewing a saved insight` - verifies context is passed with the correct insight name
2. `does not provide context for unsaved insights` - verifies new insights don't get context
3. `uses derived name when insight has no explicit name` - verifies fallback to derived_name

All tests pass and validate the maxToolProps configuration.

## Publish to changelog?

no

https://claude.ai/code/session_01Cxy5DWAeuwa4MjYExHDsCU