### PR TITLE
fix: Pagination for Typeform responses across forms

### DIFF
--- a/posthog/temporal/data_imports/sources/common/rest_source/__init__.py
+++ b/posthog/temporal/data_imports/sources/common/rest_source/__init__.py
@@ -265,7 +265,7 @@ def _make_paginate_dependent_resource(
             for child_page in client.paginate(
                 method=method,
                 path=formatted_path,
-                params=params,
+                params=dict(params),
                 paginator=paginator,
                 data_selector=data_selector,
                 hooks=hooks,

--- a/posthog/temporal/data_imports/sources/common/rest_source/tests/test_fanout.py
+++ b/posthog/temporal/data_imports/sources/common/rest_source/tests/test_fanout.py
@@ -1,15 +1,18 @@
+import asyncio
 from dataclasses import dataclass
 from typing import Any
 
 import pytest
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 from dlt.sources.helpers.rest_client.paginators import BasePaginator
 
+from posthog.temporal.data_imports.sources.common.rest_source import _make_paginate_dependent_resource
 from posthog.temporal.data_imports.sources.common.rest_source.fanout import (
     DependentEndpointConfig,
     build_dependent_resource,
 )
+from posthog.temporal.data_imports.sources.common.rest_source.typing import ResolvedParam
 
 
 @dataclass
@@ -166,3 +169,64 @@ def test_build_dependent_resource_rejects_params_in_endpoint_extras(mock_rest_ap
             db_incremental_field_last_value=None,
             child_endpoint_extra={"params": {"limit": 1}},
         )
+
+
+def test_paginate_dependent_resource_does_not_leak_params_across_parents() -> None:
+    captured_initial_params: list[dict[str, Any]] = []
+
+    def fake_paginate(**kwargs):
+        params = kwargs["params"]
+        # Snapshot the params as they arrive for the first page of each parent
+        captured_initial_params.append(dict(params))
+        # Page 1: return data with original params
+        yield [{"id": "child_1", "token": "tok_page1"}]
+        # Between pages the real paginator mutates params (removes since/until, adds before)
+        params.pop("since", None)
+        params.pop("until", None)
+        params["before"] = "tok_page1"
+        # Page 2: return data with mutated params
+        yield [{"id": "child_2", "token": "tok_page2"}]
+
+    mock_client = Mock()
+    mock_client.paginate = fake_paginate
+
+    resolved_param = ResolvedParam(
+        param_name="parent_id",
+        resolve_config={"type": "resolve", "resource": "parents", "field": "id"},
+    )
+
+    paginate_fn = _make_paginate_dependent_resource(
+        client=mock_client,
+        resolved_param=resolved_param,
+        include_from_parent=[],
+        default_columns_config=None,
+        incremental_object=None,
+        incremental_param=None,
+        incremental_cursor_transform=None,
+        db_incremental_field_last_value=None,
+    )
+
+    async def run():
+        results = []
+        async for page in paginate_fn(
+            items=[{"id": "parent_a"}, {"id": "parent_b"}],
+            method="get",
+            path="/parents/{parent_id}/children",
+            params={"page_size": 100, "since": "2026-01-01", "until": "2026-03-01"},
+            paginator=None,
+            data_selector="items",
+            hooks=None,
+        ):
+            if isinstance(page, list):
+                results.append(page)
+        return results
+
+    asyncio.run(run())
+
+    assert len(captured_initial_params) == 2
+    # Parent B's first request must have the original since/until,
+    # not the before token left over from parent A's page 2
+    for params_snapshot in captured_initial_params:
+        assert params_snapshot["since"] == "2026-01-01"
+        assert params_snapshot["until"] == "2026-03-01"
+        assert "before" not in params_snapshot

--- a/posthog/temporal/data_imports/sources/typeform/tests/test_typeform.py
+++ b/posthog/temporal/data_imports/sources/typeform/tests/test_typeform.py
@@ -84,6 +84,24 @@ class TestTypeformTransport:
         assert "since" not in request.params
         assert "until" not in request.params
 
+    def test_responses_paginator_init_request_resets_state_between_forms(self) -> None:
+        paginator = TypeformResponsesPaginator()
+        response = Mock()
+
+        # Simulate mid-stream state: Form A fetched one page but there are more
+        paginator.update_state(response, data=[{"token": "tok_a1"}])
+        assert paginator._cursor == "tok_a1"
+
+        # Reset for Form B — must clear the stale cursor
+        paginator.init_request(Mock())
+
+        # update_request should not inject stale cursor from Form A
+        request_b = Mock()
+        request_b.params = {"page_size": 1000, "since": "2026-03-01", "until": "2026-03-25"}
+        paginator.update_request(request_b)
+        assert "before" not in request_b.params
+        assert request_b.params["since"] == "2026-03-01"
+
     def test_validated_api_base_url_rejects_unknown(self) -> None:
         with pytest.raises(
             ValueError,

--- a/posthog/temporal/data_imports/sources/typeform/typeform.py
+++ b/posthog/temporal/data_imports/sources/typeform/typeform.py
@@ -104,6 +104,10 @@ class TypeformResponsesPaginator(BasePaginator):
         super().__init__()
         self._cursor: str | None = None
 
+    def init_request(self, request: Request) -> None:
+        self._cursor = None
+        self._has_next_page = True
+
     def update_state(self, response: Response, data: list[Any] | None = None) -> None:
         if not data:
             self._cursor = None


### PR DESCRIPTION
## Problem

https://posthoghelp.zendesk.com/agent/tickets/54179 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/56188)

Typeform responses syncs were failing with 400 when the account has multiple forms - pagination params were leaking across forms for Typeform responses, meaning the next form gets a stale token from the previous form.

## Changes

Shallow copy the `params` for each parent item, and add an `init_request` to reset the paginator state between forms (this probably isn't needed with the `params` copy, but won't hurt).


## How did you test this code?

Unit tests. Reproduced the issue locally by creating two forms with responses and reducing the page size - confirmed the fix successfully fetches responses from both forms.

- Fix Typeform responses sync failing with 400 when the account has multiple forms          
  - In the fan-out loop, the paginator mutates the shared `params` dict (swaps `since`/`until`
   for `before` token). This leaks into the next form's first request, sending a stale token  
  from the previous form                                                                      
  - Shallow-copy params per parent item, and add `init_request` to reset paginator state      
  between forms          