### PR TITLE
fix(llma): normalize nested token objects instead of dropping AI events

### DIFF
--- a/nodejs/src/ingestion/event-preprocessing/validate-ai-event-tokens.test.ts
+++ b/nodejs/src/ingestion/event-preprocessing/validate-ai-event-tokens.test.ts
@@ -155,5 +155,16 @@ describe('createValidateAiEventTokensStep', () => {
                 expect(result.warnings).toHaveLength(1)
             }
         })
+
+        it('does not add missing token properties to the event', async () => {
+            const input = createEvent('$ai_generation', { $ai_input_tokens: 100 })
+            const result = await step(input)
+            expect(result.type).toBe(PipelineResultType.OK)
+            if (result.type === PipelineResultType.OK) {
+                expect(result.value.event.properties?.['$ai_input_tokens']).toBe(100)
+                expect('$ai_output_tokens' in (result.value.event.properties ?? {})).toBe(false)
+                expect('$ai_reasoning_tokens' in (result.value.event.properties ?? {})).toBe(false)
+            }
+        })
     })
 })

--- a/nodejs/src/ingestion/event-preprocessing/validate-ai-event-tokens.test.ts
+++ b/nodejs/src/ingestion/event-preprocessing/validate-ai-event-tokens.test.ts
@@ -21,15 +21,25 @@ const INVALID_TOKEN_VALUES: [unknown, string][] = [
     [NaN, 'NaN'],
     [Infinity, 'Infinity'],
     [-Infinity, 'negative Infinity'],
-    [{}, 'empty object'],
-    [{ value: 100 }, 'object with value'],
-    [[], 'empty array'],
-    [[100], 'array with number'],
     ['invalid', 'non-numeric string'],
     ['100abc', 'string with trailing chars'],
     ['abc100', 'string with leading chars'],
     [true, 'boolean true'],
     [false, 'boolean false'],
+]
+
+const NORMALIZABLE_TOKEN_VALUES: [unknown, number, string][] = [
+    [{ total: 100 }, 100, 'object with numeric total'],
+    [{ total: 0 }, 0, 'object with zero total'],
+    [{ total: 100.5, noCache: 100.5, cacheRead: 0 }, 100.5, 'Vercel V3 input tokens'],
+    [{ total: 50, text: 50, reasoning: 0 }, 50, 'Vercel V3 output tokens'],
+]
+
+const NON_NORMALIZABLE_OBJECT_VALUES: [unknown, string][] = [
+    [{}, 'empty object'],
+    [{ value: 100 }, 'object without total'],
+    [[], 'empty array'],
+    [[100], 'array with number'],
 ]
 
 const TOKEN_PROPERTIES = [
@@ -61,11 +71,11 @@ describe('createValidateAiEventTokensStep', () => {
         expect(result).toEqual(ok(input))
     }
 
-    const expectDropped = async (input: ReturnType<typeof createEvent>, property: string, value: unknown) => {
+    const expectNulledWithWarning = async (input: ReturnType<typeof createEvent>, property: string, value: unknown) => {
         const result = await step(input)
-        expect(result.type).toBe(PipelineResultType.DROP)
-        if (result.type === PipelineResultType.DROP) {
-            expect(result.reason).toBe(`invalid_ai_token_property:${property}`)
+        expect(result.type).toBe(PipelineResultType.OK)
+        if (result.type === PipelineResultType.OK) {
+            expect(result.value.event.properties?.[property]).toBeNull()
             expect(result.warnings).toHaveLength(1)
             expect(result.warnings[0]).toMatchObject({
                 type: 'invalid_ai_token_property',
@@ -92,10 +102,58 @@ describe('createValidateAiEventTokensStep', () => {
                 await expectAllowed(input)
             })
 
-            it.each(INVALID_TOKEN_VALUES)('drops invalid value: %p (%s)', async (value) => {
+            it.each(INVALID_TOKEN_VALUES)('nulls invalid value with warning: %p (%s)', async (value) => {
                 const input = createEvent(eventType, { [property]: value })
-                await expectDropped(input, property, value)
+                await expectNulledWithWarning(input, property, value)
             })
+
+            it.each(NORMALIZABLE_TOKEN_VALUES)(
+                'normalizes object with total: %p -> %p (%s)',
+                async (value, expected) => {
+                    const input = createEvent(eventType, { [property]: value })
+                    const result = await step(input)
+                    expect(result.type).toBe(PipelineResultType.OK)
+                    if (result.type === PipelineResultType.OK) {
+                        expect(result.value.event.properties?.[property]).toBe(expected)
+                        expect(result.warnings).toHaveLength(0)
+                    }
+                }
+            )
+
+            it.each(NON_NORMALIZABLE_OBJECT_VALUES)(
+                'nulls non-normalizable object with warning: %p (%s)',
+                async (value) => {
+                    const input = createEvent(eventType, { [property]: value })
+                    const result = await step(input)
+                    expect(result.type).toBe(PipelineResultType.OK)
+                    if (result.type === PipelineResultType.OK) {
+                        expect(result.value.event.properties?.[property]).toBeNull()
+                        expect(result.warnings).toHaveLength(1)
+                    }
+                }
+            )
+        })
+    })
+
+    describe('normalization edge cases', () => {
+        it('normalizes object with total that is NaN to null with warning', async () => {
+            const input = createEvent('$ai_generation', { $ai_input_tokens: { total: NaN } })
+            const result = await step(input)
+            expect(result.type).toBe(PipelineResultType.OK)
+            if (result.type === PipelineResultType.OK) {
+                expect(result.value.event.properties?.['$ai_input_tokens']).toBeNull()
+                expect(result.warnings).toHaveLength(1)
+            }
+        })
+
+        it('normalizes object with non-numeric total to null with warning', async () => {
+            const input = createEvent('$ai_generation', { $ai_input_tokens: { total: 'not a number' } })
+            const result = await step(input)
+            expect(result.type).toBe(PipelineResultType.OK)
+            if (result.type === PipelineResultType.OK) {
+                expect(result.value.event.properties?.['$ai_input_tokens']).toBeNull()
+                expect(result.warnings).toHaveLength(1)
+            }
         })
     })
 })

--- a/nodejs/src/ingestion/event-preprocessing/validate-ai-event-tokens.ts
+++ b/nodejs/src/ingestion/event-preprocessing/validate-ai-event-tokens.ts
@@ -1,6 +1,7 @@
 import { PipelineEvent } from '../../types'
 import { AI_EVENT_TYPES } from '../ai'
-import { drop, ok } from '../pipelines/results'
+import { PipelineWarning } from '../pipelines/pipeline.interface'
+import { ok } from '../pipelines/results'
 import { ProcessingStep } from '../pipelines/steps'
 
 const TOKEN_PROPERTIES = [
@@ -38,6 +39,21 @@ function isValidBigDecimalInput(value: unknown): boolean {
     return false
 }
 
+/**
+ * Some SDKs (e.g. posthog-ai < 7.3.0 with Vercel AI SDK V3) send token counts
+ * as nested objects like `{ total: 10585, noCache: 10585, cacheRead: 0 }` instead
+ * of plain numbers. Extract the numeric `total` field when present.
+ */
+function normalizeTokenValue(value: unknown): unknown {
+    if (value !== null && typeof value === 'object' && !Array.isArray(value)) {
+        const obj = value as Record<string, unknown>
+        if ('total' in obj) {
+            return obj.total
+        }
+    }
+    return value
+}
+
 export function createValidateAiEventTokensStep<T extends { event: PipelineEvent }>(): ProcessingStep<T, T> {
     return async function validateAiEventTokensStep(input) {
         const { event } = input
@@ -52,29 +68,26 @@ export function createValidateAiEventTokensStep<T extends { event: PipelineEvent
             return Promise.resolve(ok(input))
         }
 
-        for (const prop of TOKEN_PROPERTIES) {
-            const value = properties[prop]
+        const warnings: PipelineWarning[] = []
 
-            if (!isValidBigDecimalInput(value)) {
-                return Promise.resolve(
-                    drop(
-                        `invalid_ai_token_property:${prop}`,
-                        [],
-                        [
-                            {
-                                type: 'invalid_ai_token_property',
-                                details: {
-                                    property: prop,
-                                    value: String(value),
-                                    valueType: typeof value,
-                                },
-                            },
-                        ]
-                    )
-                )
+        for (const prop of TOKEN_PROPERTIES) {
+            const raw = properties[prop]
+            const normalized = normalizeTokenValue(raw)
+            properties[prop] = normalized
+
+            if (!isValidBigDecimalInput(normalized)) {
+                warnings.push({
+                    type: 'invalid_ai_token_property',
+                    details: {
+                        property: prop,
+                        value: String(normalized),
+                        valueType: typeof normalized,
+                    },
+                })
+                properties[prop] = null
             }
         }
 
-        return Promise.resolve(ok(input))
+        return Promise.resolve(ok(input, [], warnings))
     }
 }

--- a/nodejs/src/ingestion/event-preprocessing/validate-ai-event-tokens.ts
+++ b/nodejs/src/ingestion/event-preprocessing/validate-ai-event-tokens.ts
@@ -71,6 +71,9 @@ export function createValidateAiEventTokensStep<T extends { event: PipelineEvent
         const warnings: PipelineWarning[] = []
 
         for (const prop of TOKEN_PROPERTIES) {
+            if (!(prop in properties)) {
+                continue
+            }
             const raw = properties[prop]
             const normalized = normalizeTokenValue(raw)
             properties[prop] = normalized

--- a/nodejs/src/ingestion/ingestion-consumer.test.ts
+++ b/nodejs/src/ingestion/ingestion-consumer.test.ts
@@ -814,7 +814,7 @@ describe('IngestionConsumer', () => {
             expect(recentEventMessage?.value.historical_migration).toBeUndefined()
         })
 
-        it('should drop AI events with invalid token properties', async () => {
+        it('should process AI events with invalid token properties by nulling the bad values', async () => {
             const events = [
                 createEvent({
                     distinct_id: 'user-valid-ai',
@@ -843,6 +843,16 @@ describe('IngestionConsumer', () => {
                     },
                 }),
                 createEvent({
+                    distinct_id: 'user-nested-token-objects',
+                    event: '$ai_generation',
+                    properties: {
+                        $ai_input_tokens: { total: 10585, noCache: 10585, cacheRead: 0, cacheWrite: 0 },
+                        $ai_output_tokens: { total: 163, text: 163, reasoning: 0 },
+                        $ai_provider: 'amazon-bedrock',
+                        $ai_model: 'anthropic.claude-sonnet-4-6',
+                    },
+                }),
+                createEvent({
                     distinct_id: 'user-non-ai',
                     event: '$pageview',
                     properties: {
@@ -857,19 +867,30 @@ describe('IngestionConsumer', () => {
             const producedMessages = mockProducerObserver.getProducedKafkaMessages()
             const eventsTopicMessages = producedMessages.filter((m) => m.topic === 'clickhouse_events_json_test')
 
-            // Valid AI event should be processed
-            const validAiEvent = eventsTopicMessages.find((m) => m.value.event === '$ai_generation')
+            // Valid AI event should be processed with tokens intact
+            const validAiEvent = eventsTopicMessages.find((m) => m.value.distinct_id === 'user-valid-ai')
             expect(validAiEvent).toBeDefined()
-            expect(validAiEvent?.value.distinct_id).toBe('user-valid-ai')
 
-            // Invalid AI events should be dropped (not in the output)
+            // AI event with invalid string token should be processed with token nulled
             const invalidAiEvent = eventsTopicMessages.find((m) => m.value.distinct_id === 'user-invalid-ai')
-            expect(invalidAiEvent).toBeUndefined()
+            expect(invalidAiEvent).toBeDefined()
+            expect(parseJSON(invalidAiEvent?.value.properties as any).$ai_input_tokens).toBeNull()
 
+            // AI event with non-normalizable object token should be processed with token nulled
             const invalidCacheEvent = eventsTopicMessages.find((m) => m.value.distinct_id === 'user-invalid-ai-cache')
-            expect(invalidCacheEvent).toBeUndefined()
+            expect(invalidCacheEvent).toBeDefined()
+            expect(parseJSON(invalidCacheEvent?.value.properties as any).$ai_cache_read_input_tokens).toBeNull()
+            expect(parseJSON(invalidCacheEvent?.value.properties as any).$ai_input_tokens).toBe(100)
 
-            // Non-AI event with invalid token property should still be processed (validation only applies to AI events)
+            // AI event with nested token objects (Bedrock/Vercel V3) should be normalized
+            const nestedTokenEvent = eventsTopicMessages.find(
+                (m) => m.value.distinct_id === 'user-nested-token-objects'
+            )
+            expect(nestedTokenEvent).toBeDefined()
+            expect(parseJSON(nestedTokenEvent?.value.properties as any).$ai_input_tokens).toBe(10585)
+            expect(parseJSON(nestedTokenEvent?.value.properties as any).$ai_output_tokens).toBe(163)
+
+            // Non-AI event with invalid token property should still be processed unchanged
             const nonAiEvent = eventsTopicMessages.find((m) => m.value.event === '$pageview')
             expect(nonAiEvent).toBeDefined()
             expect(nonAiEvent?.value.distinct_id).toBe('user-non-ai')


### PR DESCRIPTION
## Problem

Closes #52887

A user reported that Bedrock model generations were not appearing in LLM analytics despite events being sent successfully (confirmed via SDK debug logs). The `validateAiEventTokensStep` in the ingestion pipeline was silently dropping `$ai_generation` events when token properties (`$ai_input_tokens`, `$ai_output_tokens`) contained nested objects instead of plain numbers. This happens when users on `@posthog/ai` < 7.3.0 use the Vercel AI SDK V3 with providers like Amazon Bedrock, which returns token usage as `{ total: 10585, noCache: 10585, cacheRead: 0 }`.

Events were dropped with only a debug-level log — no user-facing feedback at all. Users see events succeed in their SDK debug console but they never appear in LLM analytics.

Zendesk: https://posthoghelp.zendesk.com/agent/tickets/52751 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/56467)

## Changes

Two changes to `validateAiEventTokensStep`:

1. **Normalize nested token objects** — if a token property is an object with a numeric `total` field, extract that value instead of rejecting it.
2. **Never drop events for invalid token values** — instead of `drop()`, null out the invalid property, attach an ingestion warning, and return `ok()`. The event still flows through the pipeline and appears in LLM analytics (cost calculation handles null tokens gracefully).

## How did you test this code?

Unit tests updated and passing (847 tests). Tests cover:
- Valid values pass through unchanged
- Nested objects with `total` field are normalized to the numeric value
- Non-normalizable objects (no `total`, arrays) get nulled with a warning
- Edge cases like `{ total: NaN }` and `{ total: "not a number" }`
- Missing token properties are not added to the event
- Non-AI events are unaffected
- Integration test updated to verify events with invalid/nested tokens are processed (not dropped)

No publish to changelog

## Docs update

No docs changes needed.
