### PR TITLE
feat: Centralize recent items data with shared model and add dev login credentials

### DIFF
--- a/common/hogli/devenv/generator.py
+++ b/common/hogli/devenv/generator.py
@@ -274,7 +274,12 @@ echo ''
 printf '{gray}  ─────────────────────────────────────{reset}\\n'
 printf '  {bold}Products:{reset}  {blue}{", ".join(products)}{reset}\\n'
 printf '  {bold}Processes:{reset} {process_count} active\\n'
-printf '  {gray}Run {reset}{blue}hogli dev:setup{reset}{gray} to tailor this to your workflow.{reset}\\n'"""
+printf '  {gray}Run {reset}{blue}hogli dev:setup{reset}{gray} to tailor this to your workflow.{reset}\\n'
+echo ''
+printf '{gray}  ─────────────────────────────────────{reset}\\n'
+printf '  {bold}Log in with:{reset} test@posthog.com - {blue}12345678{reset}\\n'
+printf '  {gray}Run {reset}{blue}hogli dev:setup{reset}{gray} to tailor this to your workflow.{reset}\\n'
+"""
         return {"shell": shell}
 
     def _add_startup_message(self, proc_config: dict[str, Any], process_name: str, reason: str) -> dict[str, Any]:

--- a/frontend/src/layout/panel-layout/ProjectTree/menus/RecentItemsMenu.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/menus/RecentItemsMenu.tsx
@@ -1,4 +1,4 @@
-import { useActions, useValues } from 'kea'
+import { useValues } from 'kea'
 import { useState } from 'react'
 
 import { IconClock } from '@posthog/icons'
@@ -34,14 +34,10 @@ const getItemName = (item: FileSystemEntry): string => {
 
 export function RecentItemsMenu(): JSX.Element {
     const { recentItems, recentItemsLoading } = useValues(recentItemsMenuLogic)
-    const { loadRecentItems } = useActions(recentItemsMenuLogic)
     const [isOpen, setIsOpen] = useState(false)
 
     const handleOpenChange = (open: boolean): void => {
         setIsOpen(open)
-        if (open) {
-            loadRecentItems({})
-        }
     }
 
     useAppShortcut({

--- a/frontend/src/layout/panel-layout/ProjectTree/menus/recentItemsMenuLogic.ts
+++ b/frontend/src/layout/panel-layout/ProjectTree/menus/recentItemsMenuLogic.ts
@@ -1,8 +1,6 @@
-import { afterMount, kea, path } from 'kea'
-import { loaders } from 'kea-loaders'
+import { connect, kea, path, selectors } from 'kea'
 
-import api from 'lib/api'
-
+import { recentItemsModel } from '~/models/recentItemsModel'
 import { FileSystemEntry } from '~/queries/schema/schema-general'
 
 import type { recentItemsMenuLogicType } from './recentItemsMenuLogicType'
@@ -11,23 +9,14 @@ const RECENT_ITEMS_LIMIT = 10
 
 export const recentItemsMenuLogic = kea<recentItemsMenuLogicType>([
     path(['layout', 'panel-layout', 'ProjectTree', 'menus', 'recentItemsMenuLogic']),
-    loaders({
+    connect(() => ({
+        values: [recentItemsModel, ['recents as cachedRecents', 'recentsLoading']],
+    })),
+    selectors({
         recentItems: [
-            [] as FileSystemEntry[],
-            {
-                loadRecentItems: async (_, breakpoint) => {
-                    const response = await api.fileSystem.list({
-                        orderBy: '-last_viewed_at',
-                        notType: 'folder',
-                        limit: RECENT_ITEMS_LIMIT,
-                    })
-                    breakpoint()
-                    return response.results
-                },
-            },
+            (s) => [s.cachedRecents],
+            (cachedRecents): FileSystemEntry[] => cachedRecents.slice(0, RECENT_ITEMS_LIMIT),
         ],
-    }),
-    afterMount(({ actions }) => {
-        actions.loadRecentItems({})
+        recentItemsLoading: [(s) => [s.recentsLoading], (recentsLoading): boolean => recentsLoading],
     }),
 ])

--- a/frontend/src/layout/panel-layout/ai-first/tabs/NavTabBrowse.tsx
+++ b/frontend/src/layout/panel-layout/ai-first/tabs/NavTabBrowse.tsx
@@ -188,7 +188,6 @@ export function NavTabBrowse(): JSX.Element {
     const { firstTabIsActive } = useValues(sceneLogic)
     const isProductAutonomyEnabled = useFeatureFlag('PRODUCT_AUTONOMY')
     const { recentItems, recentItemsLoading } = useValues(navRecentsLogic)
-    const { loadRecentItems } = useActions(navRecentsLogic)
     const { isEditMode, checkedItems } = useValues(inlineEditAppsLogic)
     const { enterEditMode, saveAndExitEditMode, toggleProduct } = useActions(inlineEditAppsLogic)
     const currentPath = removeProjectIdIfPresent(pathname)
@@ -326,9 +325,6 @@ export function NavTabBrowse(): JSX.Element {
                             section: 'recents',
                             is_open: !expandedNavSections.recents,
                         })
-                        if (!expandedNavSections.recents) {
-                            loadRecentItems({})
-                        }
                         toggleNavSection('recents')
                     }}
                     className="mt-2 group/colorful-product-icons colorful-product-icons-true"

--- a/frontend/src/layout/panel-layout/ai-first/tabs/navRecentsLogic.ts
+++ b/frontend/src/layout/panel-layout/ai-first/tabs/navRecentsLogic.ts
@@ -1,42 +1,22 @@
-import { afterMount, kea, path } from 'kea'
-import { loaders } from 'kea-loaders'
+import { connect, kea, path, selectors } from 'kea'
 
-import api from 'lib/api'
-
+import { recentItemsModel } from '~/models/recentItemsModel'
 import { FileSystemEntry } from '~/queries/schema/schema-general'
 
 import type { navRecentsLogicType } from './navRecentsLogicType'
 
 const NAV_RECENTS_LIMIT = 15
-const RECENTS_POLL_INTERVAL_MS = 30000
 
 export const navRecentsLogic = kea<navRecentsLogicType>([
     path(['layout', 'panel-layout', 'ai-first', 'tabs', 'navRecentsLogic']),
-    loaders({
+    connect(() => ({
+        values: [recentItemsModel, ['recents as cachedRecents', 'recentsLoading']],
+    })),
+    selectors({
         recentItems: [
-            [] as FileSystemEntry[],
-            {
-                loadRecentItems: async (_, breakpoint) => {
-                    const response = await api.fileSystem.list({
-                        orderBy: '-last_viewed_at',
-                        notType: 'folder',
-                        limit: NAV_RECENTS_LIMIT,
-                    })
-                    breakpoint()
-                    return response.results
-                },
-            },
+            (s) => [s.cachedRecents],
+            (cachedRecents): FileSystemEntry[] => cachedRecents.slice(0, NAV_RECENTS_LIMIT),
         ],
-    }),
-    afterMount(({ actions, cache }) => {
-        actions.loadRecentItems({})
-        cache.disposables.add(() => {
-            const pollInterval = setInterval(() => {
-                if (document.visibilityState === 'visible') {
-                    actions.loadRecentItems({})
-                }
-            }, RECENTS_POLL_INTERVAL_MS)
-            return () => clearInterval(pollInterval)
-        }, 'recentsPoll')
+        recentItemsLoading: [(s) => [s.recentsLoading], (recentsLoading): boolean => recentsLoading],
     }),
 ])

--- a/frontend/src/lib/components/Search/searchLogic.tsx
+++ b/frontend/src/lib/components/Search/searchLogic.tsx
@@ -1,4 +1,4 @@
-import { actions, afterMount, connect, kea, key, listeners, path, props, reducers, selectors } from 'kea'
+import { actions, connect, kea, key, listeners, path, props, reducers, selectors } from 'kea'
 import { loaders } from 'kea-loaders'
 
 import { IconClock, IconDownload } from '@posthog/icons'
@@ -11,10 +11,12 @@ import { GroupQueryResult, mapGroupQueryResponse } from 'lib/utils/groups'
 import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
 import { urls } from 'scenes/urls'
 
+import { projectTreeDataLogic } from '~/layout/panel-layout/ProjectTree/projectTreeDataLogic'
 import { splitPath, unescapePath } from '~/layout/panel-layout/ProjectTree/utils'
 import { groupsModel } from '~/models/groupsModel'
+import { recentItemsModel } from '~/models/recentItemsModel'
 import { getTreeItemsMetadata, getTreeItemsNew, getTreeItemsProducts } from '~/products'
-import { FileSystemEntry, FileSystemViewLogEntry, GroupsQueryResponse } from '~/queries/schema/schema-general'
+import { FileSystemEntry, GroupsQueryResponse } from '~/queries/schema/schema-general'
 import { SETTINGS_MAP } from '~/scenes/settings/SettingsMap'
 import { SettingSectionId } from '~/scenes/settings/types'
 import { ActivityTab, GroupTypeIndex, PersonType, SearchResponse } from '~/types'
@@ -68,52 +70,32 @@ export const searchLogic = kea<searchLogicType>([
             ['featureFlags'],
             preflightLogic,
             ['isDev'],
+            recentItemsModel,
+            ['recents as cachedRecents', 'recentsLoading', 'sceneLogViewsByRef', 'sceneLogViewsByRefLoading'],
+            projectTreeDataLogic,
+            ['shortcutData as cachedStarred'],
         ],
     })),
     actions({
         setSearch: (search: string) => ({ search }),
     }),
     loaders(({ values }) => ({
-        sceneLogViews: [
-            [] as FileSystemViewLogEntry[],
+        searchedRecents: [
+            null as FileSystemEntry[] | null,
             {
-                loadSceneLogViews: async () => {
-                    return await api.fileSystemLogView.list({ type: 'scene' })
-                },
-            },
-        ],
-        recents: [
-            { results: [], hasMore: false } as { results: FileSystemEntry[]; hasMore: boolean },
-            {
-                loadRecents: async ({ search }: { search: string }, breakpoint) => {
+                searchRecents: async ({ search }: { search: string }, breakpoint) => {
                     const searchTerm = search.trim()
-
+                    if (!searchTerm) {
+                        return null
+                    }
                     const response = await api.fileSystem.list({
-                        search: searchTerm || undefined,
+                        search: searchTerm,
                         limit: RECENTS_LIMIT + 1,
                         orderBy: '-last_viewed_at',
                         notType: 'folder',
                     })
                     breakpoint()
-
-                    return {
-                        results: response.results.slice(0, RECENTS_LIMIT),
-                        hasMore: response.results.length > RECENTS_LIMIT,
-                    }
-                },
-            },
-        ],
-        starredShortcuts: [
-            [] as FileSystemEntry[],
-            {
-                loadStarredShortcuts: async (_, breakpoint) => {
-                    const response = await api.fileSystemShortcuts.list({
-                        ordering: '-created_at',
-                        limit: STARRED_LIMIT * 2,
-                    })
-                    breakpoint()
-                    // Server orders by created_at; over-fetch so we still have ~STARRED_LIMIT after dropping folders.
-                    return response.results.filter((e) => e.type !== 'folder').slice(0, STARRED_LIMIT)
+                    return response.results.slice(0, RECENTS_LIMIT)
                 },
             },
         ],
@@ -230,54 +212,11 @@ export const searchLogic = kea<searchLogicType>([
                 loadUnifiedSearchResultsFailure: () => false,
             },
         ],
-        recentsHasLoaded: [
-            false,
-            {
-                loadRecentsSuccess: () => true,
-                loadRecentsFailure: () => true,
-            },
-        ],
-        starredHasLoaded: [
-            false,
-            {
-                loadStarredShortcutsSuccess: () => true,
-                loadStarredShortcutsFailure: () => true,
-            },
-        ],
-        sceneLogViewsHasLoaded: [
-            false,
-            {
-                loadSceneLogViewsSuccess: () => true,
-                loadSceneLogViewsFailure: () => true,
-            },
-        ],
-        isAppsLoading: [
-            true,
-            {
-                loadSceneLogViewsSuccess: () => false,
-                loadSceneLogViewsFailure: () => false,
-            },
-        ],
     }),
     selectors({
-        sceneLogViewsByRef: [
-            (s) => [s.sceneLogViews],
-            (sceneLogViews): Record<string, string> => {
-                return sceneLogViews.reduce(
-                    (acc, { ref, viewed_at }) => {
-                        const current = acc[ref]
-                        if (!current || Date.parse(viewed_at) > Date.parse(current)) {
-                            acc[ref] = viewed_at
-                        }
-                        return acc
-                    },
-                    {} as Record<string, string>
-                )
-            },
-        ],
         isSearching: [
             (s) => [
-                s.recentsLoading,
+                s.searchedRecentsLoading,
                 s.unifiedSearchResultsLoading,
                 s.groupSearchResultsLoading,
                 s.personSearchResultsLoading,
@@ -286,7 +225,7 @@ export const searchLogic = kea<searchLogicType>([
                 s.search,
             ],
             (
-                recentsLoading: boolean,
+                searchedRecentsLoading: boolean,
                 unifiedSearchResultsLoading: boolean,
                 groupSearchResultsLoading: boolean,
                 personSearchResultsLoading: boolean,
@@ -294,7 +233,7 @@ export const searchLogic = kea<searchLogicType>([
                 searchPending: boolean,
                 search: string
             ): boolean =>
-                (recentsLoading ||
+                (searchedRecentsLoading ||
                     unifiedSearchResultsLoading ||
                     groupSearchResultsLoading ||
                     personSearchResultsLoading ||
@@ -303,9 +242,10 @@ export const searchLogic = kea<searchLogicType>([
                 search.trim() !== '',
         ],
         recentItems: [
-            (s) => [s.recents],
-            (recents): SearchItem[] => {
-                return recents.results.map((item) => {
+            (s) => [s.searchedRecents, s.cachedRecents, s.search],
+            (searchedRecents, cachedRecents, search): SearchItem[] => {
+                const source = search.trim() ? (searchedRecents ?? []) : cachedRecents.slice(0, RECENTS_LIMIT)
+                return source.map((item) => {
                     const name = splitPath(item.path).pop()
                     return {
                         id: item.path,
@@ -320,21 +260,24 @@ export const searchLogic = kea<searchLogicType>([
             },
         ],
         starredItems: [
-            (s) => [s.starredShortcuts],
-            (starredShortcuts): SearchItem[] => {
-                return starredShortcuts.map((item) => {
-                    const name = splitPath(item.path).pop()
-                    return {
-                        id: `starred-${item.id}`,
-                        name: name ? unescapePath(name) : item.path,
-                        category: 'starred',
-                        href: item.href || '#',
-                        lastViewedAt: item.last_viewed_at ?? null,
-                        itemType: item.type ?? null,
-                        searchKeywords: ['starred', 'favorite', 'favourite', 'shortcut'],
-                        record: item as unknown as Record<string, unknown>,
-                    }
-                })
+            (s) => [s.cachedStarred],
+            (cachedStarred): SearchItem[] => {
+                return cachedStarred
+                    .filter((e) => e.type !== 'folder')
+                    .slice(0, STARRED_LIMIT)
+                    .map((item) => {
+                        const name = splitPath(item.path).pop()
+                        return {
+                            id: `starred-${item.id}`,
+                            name: name ? unescapePath(name) : item.path,
+                            category: 'starred',
+                            href: item.href || '#',
+                            lastViewedAt: item.last_viewed_at ?? null,
+                            itemType: item.type ?? null,
+                            searchKeywords: ['starred', 'favorite', 'favourite', 'shortcut'],
+                            record: item as unknown as Record<string, unknown>,
+                        }
+                    })
             },
         ],
         appsItems: [
@@ -810,10 +753,7 @@ export const searchLogic = kea<searchLogicType>([
             (s) => [
                 s.unifiedSearchResultsLoading,
                 s.recentsLoading,
-                s.recentsHasLoaded,
-                s.starredShortcutsLoading,
-                s.starredHasLoaded,
-                s.isAppsLoading,
+                s.sceneLogViewsByRefLoading,
                 s.personSearchResultsLoading,
                 s.groupSearchResultsLoading,
                 s.playlistSearchResultsLoading,
@@ -821,20 +761,17 @@ export const searchLogic = kea<searchLogicType>([
             (
                 unifiedSearchResultsLoading: boolean,
                 recentsLoading: boolean,
-                recentsHasLoaded: boolean,
-                starredShortcutsLoading: boolean,
-                starredHasLoaded: boolean,
-                isAppsLoading: boolean,
+                sceneLogViewsByRefLoading: boolean,
                 personSearchResultsLoading: boolean,
                 groupSearchResultsLoading: boolean,
                 playlistSearchResultsLoading: boolean
             ) => ({
                 unifiedSearchResultsLoading,
                 recentsLoading,
-                recentsHasLoaded,
-                starredLoading: starredShortcutsLoading,
-                starredHasLoaded,
-                isAppsLoading,
+                recentsHasLoaded: !recentsLoading,
+                starredLoading: false,
+                starredHasLoaded: true,
+                isAppsLoading: sceneLogViewsByRefLoading,
                 personSearchResultsLoading,
                 groupSearchResultsLoading,
                 playlistSearchResultsLoading,
@@ -1098,41 +1035,17 @@ export const searchLogic = kea<searchLogicType>([
             },
         ],
     }),
-    listeners(({ actions, values }) => ({
+    listeners(({ actions }) => ({
         setSearch: async ({ search }, breakpoint) => {
             await breakpoint(150)
 
-            // Always load recents on first call (e.g. when defaultSearchValue is non-empty)
-            if (search.trim() === '' || !values.recentsHasLoaded) {
-                actions.loadRecents({ search: '' })
-            }
-            if (search.trim() === '' || !values.starredHasLoaded) {
-                actions.loadStarredShortcuts(undefined)
-            }
-
             if (search.trim() !== '') {
+                actions.searchRecents({ search })
                 actions.loadUnifiedSearchResults({ searchTerm: search })
                 actions.loadPersonSearchResults({ searchTerm: search })
                 actions.loadGroupSearchResults({ searchTerm: search })
                 actions.loadPlaylistSearchResults({ searchTerm: search })
             }
         },
-        [commandLogic.actionTypes.openCommand]: () => {
-            // Load recents only when modal opens, not on mount
-            if (values.recents.results.length === 0) {
-                actions.loadRecents({ search: '' })
-            }
-            if (!values.starredHasLoaded) {
-                actions.loadStarredShortcuts(undefined)
-            }
-            // Load scene log views for app last viewed timestamps
-            if (values.sceneLogViews.length === 0) {
-                actions.loadSceneLogViews()
-            }
-        },
     })),
-    afterMount(({ actions }) => {
-        // Load scene log views on mount for app last viewed timestamps
-        actions.loadSceneLogViews()
-    }),
 ])

--- a/frontend/src/lib/hooks/useFileSystemLogView.ts
+++ b/frontend/src/lib/hooks/useFileSystemLogView.ts
@@ -2,6 +2,8 @@ import { useEffect } from 'react'
 
 import api, { ApiConfig } from 'lib/api'
 
+import { recentItemsModel } from '~/models/recentItemsModel'
+
 type FileSystemLogViewType =
     | 'experiment'
     | 'feature_flag'
@@ -28,6 +30,7 @@ export function trackFileSystemLogView({ type, ref, enabled = true }: TrackFileS
         return
     }
 
+    recentItemsModel.findMounted()?.actions.recordView(type, String(ref))
     void api.fileSystemLogView.create({ type, ref: String(ref) })
 }
 

--- a/frontend/src/models/recentItemsModel.ts
+++ b/frontend/src/models/recentItemsModel.ts
@@ -1,0 +1,85 @@
+import { actions, afterMount, kea, path, reducers } from 'kea'
+import { loaders } from 'kea-loaders'
+
+import api from 'lib/api'
+import { permanentlyMount } from 'lib/utils/kea-logic-builders'
+
+import { FileSystemEntry } from '~/queries/schema/schema-general'
+
+import type { recentItemsModelType } from './recentItemsModelType'
+
+const RECENTS_FETCH_LIMIT = 20
+
+export const recentItemsModel = kea<recentItemsModelType>([
+    path(['models', 'recentItemsModel']),
+
+    actions({
+        recordView: (type: string, ref: string) => ({ type, ref }),
+    }),
+
+    loaders({
+        recents: [
+            [] as FileSystemEntry[],
+            {
+                loadRecents: async () => {
+                    const response = await api.fileSystem.list({
+                        orderBy: '-last_viewed_at',
+                        notType: 'folder',
+                        limit: RECENTS_FETCH_LIMIT,
+                    })
+                    return response.results
+                },
+            },
+        ],
+        sceneLogViewsByRef: [
+            {} as Record<string, string>,
+            {
+                loadSceneLogViews: async () => {
+                    const results = await api.fileSystemLogView.list({ type: 'scene' })
+                    const record: Record<string, string> = {}
+                    for (const { ref, viewed_at } of results) {
+                        const current = record[ref]
+                        if (!current || Date.parse(viewed_at) > Date.parse(current)) {
+                            record[ref] = viewed_at
+                        }
+                    }
+                    return record
+                },
+            },
+        ],
+    }),
+
+    reducers({
+        recents: [
+            [] as FileSystemEntry[],
+            {
+                recordView: (state, { type, ref }) => {
+                    const idx = state.findIndex((e) => e.type === type && e.ref === ref)
+                    if (idx < 0) {
+                        return state
+                    }
+                    const item = { ...state[idx], last_viewed_at: new Date().toISOString() }
+                    return [item, ...state.slice(0, idx), ...state.slice(idx + 1)]
+                },
+            },
+        ],
+        sceneLogViewsByRef: [
+            {} as Record<string, string>,
+            {
+                recordView: (state, { type, ref }) => {
+                    if (type !== 'scene') {
+                        return state
+                    }
+                    return { ...state, [ref]: new Date().toISOString() }
+                },
+            },
+        ],
+    }),
+
+    afterMount(({ actions }) => {
+        actions.loadRecents()
+        actions.loadSceneLogViews()
+    }),
+
+    permanentlyMount(),
+])

--- a/frontend/src/scenes/project-homepage/ai-first/aiFirstHomepageLogic.ts
+++ b/frontend/src/scenes/project-homepage/ai-first/aiFirstHomepageLogic.ts
@@ -1,8 +1,6 @@
 import { actions, afterMount, connect, kea, listeners, path, reducers, selectors } from 'kea'
-import { loaders } from 'kea-loaders'
 import { actionToUrl, router, urlToAction } from 'kea-router'
 
-import api from 'lib/api'
 import { maxLogic } from 'scenes/max/maxLogic'
 import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
@@ -10,6 +8,7 @@ import { urls } from 'scenes/urls'
 import { projectTreeDataLogic } from '~/layout/panel-layout/ProjectTree/projectTreeDataLogic'
 import { splitPath, unescapePath } from '~/layout/panel-layout/ProjectTree/utils'
 import { dashboardsModel } from '~/models/dashboardsModel'
+import { recentItemsModel } from '~/models/recentItemsModel'
 import { FileSystemEntry } from '~/queries/schema/schema-general'
 import { sceneLogic } from '~/scenes/sceneLogic'
 import { emptySceneParams } from '~/scenes/scenes'
@@ -82,14 +81,16 @@ export const aiFirstHomepageLogic = kea<aiFirstHomepageLogicType>([
             ['homepage'],
             dashboardsModel,
             ['pinnedDashboards', 'dashboardsLoading'],
+            recentItemsModel,
+            ['recents as cachedRecents', 'recentsLoading'],
+            projectTreeDataLogic,
+            ['shortcutData as cachedStarred'],
         ],
         actions: [
             maxLogic({ tabId: HOMEPAGE_TAB_ID }),
             ['openConversation', 'startNewConversation', 'setQuestion'],
             sceneLogic,
             ['setHomepage'],
-            projectTreeDataLogic,
-            ['deleteShortcutSuccess', 'addShortcutItemSuccess'],
         ],
     })),
 
@@ -101,31 +102,6 @@ export const aiFirstHomepageLogic = kea<aiFirstHomepageLogicType>([
         returnToIdle: true,
         setPreviousHomepage: (tab: SceneTab | null) => ({ tab }),
         revertToPreviousHomepage: true,
-    }),
-
-    loaders({
-        recentItems: [
-            [] as FileSystemEntry[],
-            {
-                loadRecentItems: async () => {
-                    const response = await api.fileSystem.list({
-                        limit: GRID_LIMIT,
-                        orderBy: '-last_viewed_at',
-                        notType: 'folder',
-                    })
-                    return response.results
-                },
-            },
-        ],
-        starredItems: [
-            [] as FileSystemEntry[],
-            {
-                loadStarredItems: async () => {
-                    const response = await api.fileSystemShortcuts.list()
-                    return response.results.filter((entry) => entry.type !== 'folder').slice(0, GRID_LIMIT)
-                },
-            },
-        ],
     }),
 
     reducers({
@@ -176,6 +152,16 @@ export const aiFirstHomepageLogic = kea<aiFirstHomepageLogicType>([
     }),
 
     selectors({
+        recentItems: [
+            (s) => [s.cachedRecents],
+            (cachedRecents): FileSystemEntry[] => cachedRecents.slice(0, GRID_LIMIT),
+        ],
+        recentItemsLoading: [(s) => [s.recentsLoading], (recentsLoading): boolean => recentsLoading],
+        starredItems: [
+            (s) => [s.cachedStarred],
+            (cachedStarred): FileSystemEntry[] => cachedStarred.filter((e) => e.type !== 'folder').slice(0, GRID_LIMIT),
+        ],
+        starredItemsLoading: [() => [], (): boolean => false],
         mode: [(s) => [s.layoutState], (layoutState): HomepageMode => layoutState.mode],
         animationPhase: [(s) => [s.layoutState], (layoutState): AnimationPhase => layoutState.animationPhase],
         pinnedDashboardItems: [
@@ -216,12 +202,6 @@ export const aiFirstHomepageLogic = kea<aiFirstHomepageLogicType>([
     }),
 
     listeners(({ actions, values }) => ({
-        deleteShortcutSuccess: () => {
-            actions.loadStarredItems()
-        },
-        addShortcutItemSuccess: () => {
-            actions.loadStarredItems()
-        },
         submitQuery: async ({ mode }, breakpoint) => {
             if (mode === 'ai' && !values.conversationId) {
                 actions.startNewConversation()
@@ -307,10 +287,6 @@ export const aiFirstHomepageLogic = kea<aiFirstHomepageLogicType>([
     })),
 
     afterMount(({ actions, values }) => {
-        // Load grid data (pinnedDashboards comes from dashboardsModel, loaded automatically)
-        actions.loadRecentItems()
-        actions.loadStarredItems()
-
         // Capture the previous homepage on first visit so we can revert later
         const stored = loadPreviousHomepage()
         if (stored) {


### PR DESCRIPTION
## Problem

Recent items functionality was duplicated across multiple components, leading to unnecessary API calls and inconsistent data management. Each component was independently fetching and managing recent items data, causing performance issues and code duplication.

## Changes

- Created a centralized `recentItemsModel` to manage recent items and scene log views data
- Refactored `recentItemsMenuLogic`, `navRecentsLogic`, `searchLogic`, and `aiFirstHomepageLogic` to use the shared model instead of individual loaders
- Removed redundant API calls and polling mechanisms from individual components
- Added optimistic updates for view tracking to improve perceived performance
- Updated development environment generator to display login credentials (test@posthog.com - 12345678) in the startup message
- Removed unused imports and actions from components that no longer manage their own data loading

The centralized model loads data once on mount and shares it across all components, while still allowing for real-time updates when users view items.

[CleanShot 2026-03-31 at 11.47.58.mp4 <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/9e578f27-6209-446a-9961-690576d2aae6.mp4" />](https://app.graphite.com/user-attachments/video/9e578f27-6209-446a-9961-690576d2aae6.mp4)

## Publish to changelog?

No

## Docs update

No docs update needed as this is an internal refactoring.