### PR TITLE
chore(insights): remove queryFromFilters test helper

### DIFF
--- a/frontend/src/lib/components/AddToDashboard/addToDashboardModalLogic.test.ts
+++ b/frontend/src/lib/components/AddToDashboard/addToDashboardModalLogic.test.ts
@@ -7,7 +7,7 @@ import { insightLogic } from 'scenes/insights/insightLogic'
 
 import { useMocks } from '~/mocks/jest'
 import { dashboardsModel } from '~/models/dashboardsModel'
-import { queryFromFilters } from '~/queries/nodes/InsightViz/utils'
+import { NodeKind } from '~/queries/schema/schema-general'
 import { initKeaTests } from '~/test/init'
 import {
     AccessControlLevel,
@@ -15,7 +15,6 @@ import {
     DashboardBasicType,
     DashboardType,
     InsightShortId,
-    InsightType,
     QueryBasedInsightModel,
     UserBasicType,
 } from '~/types'
@@ -28,7 +27,13 @@ const MOCK_INSIGHT: QueryBasedInsightModel = {
     id: 1,
     short_id: Insight1,
     name: 'Test Insight',
-    query: queryFromFilters({ insight: InsightType.TRENDS, events: [{ id: '$pageview' }] }),
+    query: {
+        kind: NodeKind.InsightVizNode,
+        source: {
+            kind: NodeKind.TrendsQuery,
+            series: [{ kind: NodeKind.EventsNode, event: '$pageview', math: 'total' }],
+        },
+    },
     dashboards: [1, 2],
     dashboard_tiles: [{ dashboard_id: 1 }, { dashboard_id: 2 }] as any,
     result: ['result'],

--- a/frontend/src/queries/nodes/InsightViz/utils.ts
+++ b/frontend/src/queries/nodes/InsightViz/utils.ts
@@ -113,11 +113,6 @@ export function getQueryFromInsightLike(insight: {
     return query
 }
 
-export const queryFromFilters = (filters: Partial<FilterType>): InsightVizNode => ({
-    kind: NodeKind.InsightVizNode,
-    source: filtersToQueryNode(filters, { source: 'insight_viz_query_from_filters' }),
-})
-
 export const queryFromKind = (
     kind: ProductAnalyticsInsightNodeKind,
     filterTestAccountsDefault: boolean

--- a/frontend/src/scenes/insights/insightLogic.test.ts
+++ b/frontend/src/scenes/insights/insightLogic.test.ts
@@ -15,13 +15,15 @@ import { useMocks } from '~/mocks/jest'
 import { dashboardsModel } from '~/models/dashboardsModel'
 import { insightsModel } from '~/models/insightsModel'
 import { examples } from '~/queries/examples'
-import { DataTableNode, NodeKind } from '~/queries/schema/schema-general'
+import { DataTableNode, type InsightVizNode, NodeKind } from '~/queries/schema/schema-general'
 import { initKeaTests } from '~/test/init'
 import {
     AccessControlLevel,
     AnyPropertyFilter,
+    BaseMathType,
     DashboardTile,
     DashboardType,
+    FilterLogicalOperator,
     FilterType,
     InsightLogicProps,
     InsightShortId,
@@ -369,18 +371,18 @@ describe('insightLogic', () => {
 
         describe('props with filters, no cached results, respects doNotLoad', () => {
             it('does not make a query', async () => {
-                const insight: Partial<QueryBasedInsightModel> = {
+                const insight: Partial<QueryBasedInsightModel<InsightVizNode>> = {
                     short_id: Insight42,
                     query: {
                         kind: NodeKind.InsightVizNode,
                         source: {
                             kind: NodeKind.TrendsQuery,
-                            series: [{ kind: NodeKind.EventsNode, event: 3, throw: true, math: 'total' }],
+                            series: [{ kind: NodeKind.EventsNode, event: '3', math: BaseMathType.TotalCount }],
                             properties: {
-                                type: 'AND',
+                                type: FilterLogicalOperator.And,
                                 values: [
                                     {
-                                        type: 'AND',
+                                        type: FilterLogicalOperator.And,
                                         values: [
                                             {
                                                 value: 'a',
@@ -419,7 +421,7 @@ describe('insightLogic', () => {
                                             },
                                         ],
                                     },
-                                    series: [partial({ event: 3 })],
+                                    series: [partial({ event: '3' })],
                                 },
                             },
                         },

--- a/frontend/src/scenes/insights/insightLogic.test.ts
+++ b/frontend/src/scenes/insights/insightLogic.test.ts
@@ -15,7 +15,6 @@ import { useMocks } from '~/mocks/jest'
 import { dashboardsModel } from '~/models/dashboardsModel'
 import { insightsModel } from '~/models/insightsModel'
 import { examples } from '~/queries/examples'
-import { queryFromFilters } from '~/queries/nodes/InsightViz/utils'
 import { DataTableNode, NodeKind } from '~/queries/schema/schema-general'
 import { initKeaTests } from '~/test/init'
 import {
@@ -39,6 +38,18 @@ const API_FILTERS: Partial<FilterType> = {
     insight: InsightType.TRENDS as InsightType,
     events: [{ id: 3 }],
     properties: [{ value: 'a', operator: PropertyOperator.Exact, key: 'a', type: 'a' } as any as AnyPropertyFilter],
+}
+
+const API_QUERY = {
+    kind: NodeKind.InsightVizNode,
+    source: {
+        kind: NodeKind.TrendsQuery,
+        series: [{ kind: NodeKind.EventsNode, event: 3, math: 'total' }],
+        properties: {
+            type: 'AND',
+            values: [{ type: 'AND', values: [{ key: 'a', type: 'a', value: 'a', operator: PropertyOperator.Exact }] }],
+        },
+    },
 }
 
 const Insight12 = '12' as InsightShortId
@@ -92,7 +103,7 @@ function insightModelWith(properties: Record<string, any>): QueryBasedInsightMod
         id: 42,
         short_id: Insight42,
         result: ['result 42'],
-        query: queryFromFilters(API_FILTERS),
+        query: API_QUERY,
         dashboards: [],
         dashboard_tiles: [],
         saved: true,
@@ -360,13 +371,29 @@ describe('insightLogic', () => {
             it('does not make a query', async () => {
                 const insight: Partial<QueryBasedInsightModel> = {
                     short_id: Insight42,
-                    query: queryFromFilters({
-                        insight: InsightType.TRENDS,
-                        events: [{ id: 3, throw: true }],
-                        properties: [
-                            { value: 'a', operator: PropertyOperator.Exact, key: 'a', type: PropertyFilterType.Person },
-                        ],
-                    }),
+                    query: {
+                        kind: NodeKind.InsightVizNode,
+                        source: {
+                            kind: NodeKind.TrendsQuery,
+                            series: [{ kind: NodeKind.EventsNode, event: 3, throw: true, math: 'total' }],
+                            properties: {
+                                type: 'AND',
+                                values: [
+                                    {
+                                        type: 'AND',
+                                        values: [
+                                            {
+                                                value: 'a',
+                                                operator: PropertyOperator.Exact,
+                                                key: 'a',
+                                                type: PropertyFilterType.Person,
+                                            },
+                                        ],
+                                    },
+                                ],
+                            },
+                        },
+                    },
                 }
                 logic = insightLogic({
                     dashboardItemId: Insight42,
@@ -461,7 +488,7 @@ describe('insightLogic', () => {
     test('keeps saved name, description, tags', async () => {
         const insightProps: InsightLogicProps = {
             dashboardItemId: Insight43,
-            cachedInsight: { ...createEmptyInsight(Insight43), id: 123, query: queryFromFilters(API_FILTERS) },
+            cachedInsight: { ...createEmptyInsight(Insight43), id: 123, query: API_QUERY },
         }
 
         logic = insightLogic(insightProps)
@@ -980,7 +1007,7 @@ describe('insightLogic', () => {
         ])('is %s → %s', (_label, propsOverride, expected) => {
             logic = insightLogic({
                 dashboardItemId: Insight42,
-                cachedInsight: { ...partialInsight42, query: queryFromFilters(API_FILTERS) },
+                cachedInsight: { ...partialInsight42, query: API_QUERY },
                 ...propsOverride,
             })
             logic.mount()
@@ -996,7 +1023,7 @@ describe('insightLogic', () => {
         ])('returns correct value when %s', (_label, propsOverride, expected) => {
             logic = insightLogic({
                 dashboardItemId: Insight42,
-                cachedInsight: { ...partialInsight42, query: queryFromFilters(API_FILTERS) },
+                cachedInsight: { ...partialInsight42, query: API_QUERY },
                 ...propsOverride,
             })
             logic.mount()
@@ -1014,7 +1041,7 @@ describe('insightLogic', () => {
                 dashboardItemId: Insight42,
                 cachedInsight: {
                     ...partialInsight42,
-                    query: queryFromFilters(API_FILTERS),
+                    query: API_QUERY,
                     user_access_level: accessLevel,
                 },
             })
@@ -1030,7 +1057,7 @@ describe('insightLogic', () => {
                 dashboardItemId: Insight43,
                 cachedInsight: {
                     ...partialInsight43,
-                    query: queryFromFilters(API_FILTERS),
+                    query: API_QUERY,
                     name: 'Original 43',
                     description: 'Original description',
                     tags: [],
@@ -1091,7 +1118,7 @@ describe('insightLogic', () => {
                 dashboardItemId: Insight43,
                 cachedInsight: {
                     ...partialInsight43,
-                    query: queryFromFilters(API_FILTERS),
+                    query: API_QUERY,
                     name: 'Foobar 43',
                     description: 'Lorem ipsum.',
                     tags: ['good'],

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -2298,8 +2298,8 @@ export interface InsightModel extends Cacheable, WithAccessControl {
     _create_in_folder?: string | null
 }
 
-export interface QueryBasedInsightModel extends Omit<InsightModel, 'filters'> {
-    query: Node | null
+export interface QueryBasedInsightModel<R extends Node<Record<string, any>>> extends Omit<InsightModel, 'filters'> {
+    query: R | null
 }
 
 export interface EndpointType extends WithAccessControl {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -2298,7 +2298,10 @@ export interface InsightModel extends Cacheable, WithAccessControl {
     _create_in_folder?: string | null
 }
 
-export interface QueryBasedInsightModel<R extends Node<Record<string, any>>> extends Omit<InsightModel, 'filters'> {
+export interface QueryBasedInsightModel<R extends Node<Record<string, any>> = Node<Record<string, any>>> extends Omit<
+    InsightModel,
+    'filters'
+> {
     query: R | null
 }
 


### PR DESCRIPTION
## Problem

The legacy function `queryFromFilters` is used only in tests.

## Changes

Replaces it with equivalent objects, and removes the function.

## How did you test this code?

Tests still run.