### PR TITLE
fix(llma): normalize OpenAI Responses API items with correct roles

### DIFF
--- a/products/llm_analytics/frontend/types.ts
+++ b/products/llm_analytics/frontend/types.ts
@@ -143,6 +143,43 @@ export interface AnthropicInputMessage {
     content: string | AnthropicCompletionMessage[]
 }
 
+// OpenAI Responses API types (role-less, use `type` instead)
+export interface OpenAIResponsesFunctionCall {
+    type: 'function_call'
+    call_id: string
+    name: string
+    arguments: string
+    id?: string
+    status?: string
+}
+
+export interface OpenAIResponsesFunctionCallOutput {
+    type: 'function_call_output'
+    call_id: string
+    output: string
+}
+
+/** Responses API built-in tool calls (web_search_call, reasoning, etc.) */
+export interface OpenAIResponsesBuiltinToolCall {
+    type:
+        | 'web_search_call'
+        | 'code_interpreter_call'
+        | 'image_generation_call'
+        | 'mcp_call'
+        | 'file_search_call'
+        | 'computer_call'
+    id?: string
+    status?: string
+    [key: string]: unknown
+}
+
+export interface OpenAIResponsesReasoning {
+    type: 'reasoning'
+    id?: string
+    summary?: { type: string; text: string }[]
+    [key: string]: unknown
+}
+
 export type InputMessage = OpenAICompletionMessage | AnthropicInputMessage
 export type CompletionMessage = OpenAICompletionMessage | AnthropicCompletionMessage
 

--- a/products/llm_analytics/frontend/utils.test.ts
+++ b/products/llm_analytics/frontend/utils.test.ts
@@ -424,53 +424,23 @@ describe('LLM Analytics utils', () => {
             ])
         })
 
-        it('parses web_search_call as an assistant tool call', () => {
-            const message = {
-                type: 'web_search_call',
-                id: 'ws_123',
-                status: 'completed',
-            }
-
+        it.each([
+            ['web_search_call', 'ws_123', { type: 'web_search_call', id: 'ws_123', status: 'completed' }],
+            [
+                'code_interpreter_call',
+                'ci_123',
+                { type: 'code_interpreter_call', id: 'ci_123', status: 'completed', code: 'print("hello")' },
+            ],
+            ['image_generation_call', 'ig_123', { type: 'image_generation_call', id: 'ig_123', status: 'completed' }],
+            ['mcp_call', 'mcp_123', { type: 'mcp_call', id: 'mcp_123', status: 'completed' }],
+            ['file_search_call', 'fs_123', { type: 'file_search_call', id: 'fs_123', status: 'completed' }],
+            ['computer_call', 'cc_123', { type: 'computer_call', id: 'cc_123', status: 'completed' }],
+        ])('parses %s as an assistant tool call', (toolType, toolId, message) => {
             expect(normalizeMessage(message, 'user')).toEqual([
                 {
                     role: 'assistant',
                     content: JSON.stringify(message),
-                    tool_calls: [
-                        {
-                            type: 'function',
-                            id: 'ws_123',
-                            function: {
-                                name: 'web_search_call',
-                                arguments: {},
-                            },
-                        },
-                    ],
-                },
-            ])
-        })
-
-        it('parses code_interpreter_call as an assistant tool call', () => {
-            const message = {
-                type: 'code_interpreter_call',
-                id: 'ci_123',
-                status: 'completed',
-                code: 'print("hello")',
-            }
-
-            expect(normalizeMessage(message, 'user')).toEqual([
-                {
-                    role: 'assistant',
-                    content: JSON.stringify(message),
-                    tool_calls: [
-                        {
-                            type: 'function',
-                            id: 'ci_123',
-                            function: {
-                                name: 'code_interpreter_call',
-                                arguments: {},
-                            },
-                        },
-                    ],
+                    tool_calls: [{ type: 'function', id: toolId, function: { name: toolType, arguments: {} } }],
                 },
             ])
         })

--- a/products/llm_analytics/frontend/utils.test.ts
+++ b/products/llm_analytics/frontend/utils.test.ts
@@ -349,6 +349,159 @@ describe('LLM Analytics utils', () => {
         })
     })
 
+    describe('OpenAI Responses API', () => {
+        it('parses a function_call item as an assistant tool call', () => {
+            const message = {
+                type: 'function_call',
+                call_id: 'call_tLji37A7lp7Buy7hcqUPMUXE',
+                name: 'search_category',
+                arguments: '{"dimensions":[],"list_all":true}',
+            }
+
+            expect(normalizeMessage(message, 'user')).toEqual([
+                {
+                    role: 'assistant',
+                    content: '',
+                    tool_calls: [
+                        {
+                            type: 'function',
+                            id: 'call_tLji37A7lp7Buy7hcqUPMUXE',
+                            function: {
+                                name: 'search_category',
+                                arguments: { dimensions: [], list_all: true },
+                            },
+                        },
+                    ],
+                },
+            ])
+        })
+
+        it('parses a function_call_output item as a tool result', () => {
+            const message = {
+                type: 'function_call_output',
+                call_id: 'call_tLji37A7lp7Buy7hcqUPMUXE',
+                output: '{"categories":[{"id":"149288","name":"Asheville Cloud Shaker"}]}',
+            }
+
+            expect(normalizeMessage(message, 'user')).toEqual([
+                {
+                    role: 'assistant (tool result)',
+                    content: '{"categories":[{"id":"149288","name":"Asheville Cloud Shaker"}]}',
+                    tool_call_id: 'call_tLji37A7lp7Buy7hcqUPMUXE',
+                },
+            ])
+        })
+
+        it('parses a reasoning item as assistant thinking', () => {
+            const message = {
+                type: 'reasoning',
+                id: 'rs_123',
+                summary: [
+                    { type: 'summary_text', text: 'Thinking about the query...' },
+                    { type: 'summary_text', text: 'Deciding on a response.' },
+                ],
+            }
+
+            expect(normalizeMessage(message, 'user')).toEqual([
+                {
+                    role: 'assistant (thinking)',
+                    content: 'Thinking about the query...\nDeciding on a response.',
+                },
+            ])
+        })
+
+        it('handles reasoning with no summary', () => {
+            const message = {
+                type: 'reasoning',
+                id: 'rs_456',
+            }
+
+            expect(normalizeMessage(message, 'user')).toEqual([
+                {
+                    role: 'assistant (thinking)',
+                    content: '',
+                },
+            ])
+        })
+
+        it('parses web_search_call as an assistant tool call', () => {
+            const message = {
+                type: 'web_search_call',
+                id: 'ws_123',
+                status: 'completed',
+            }
+
+            expect(normalizeMessage(message, 'user')).toEqual([
+                {
+                    role: 'assistant',
+                    content: JSON.stringify(message),
+                    tool_calls: [
+                        {
+                            type: 'function',
+                            id: 'ws_123',
+                            function: {
+                                name: 'web_search_call',
+                                arguments: {},
+                            },
+                        },
+                    ],
+                },
+            ])
+        })
+
+        it('parses code_interpreter_call as an assistant tool call', () => {
+            const message = {
+                type: 'code_interpreter_call',
+                id: 'ci_123',
+                status: 'completed',
+                code: 'print("hello")',
+            }
+
+            expect(normalizeMessage(message, 'user')).toEqual([
+                {
+                    role: 'assistant',
+                    content: JSON.stringify(message),
+                    tool_calls: [
+                        {
+                            type: 'function',
+                            id: 'ci_123',
+                            function: {
+                                name: 'code_interpreter_call',
+                                arguments: {},
+                            },
+                        },
+                    ],
+                },
+            ])
+        })
+
+        it('handles function_call with unparseable arguments', () => {
+            const message = {
+                type: 'function_call',
+                call_id: 'call_abc',
+                name: 'my_func',
+                arguments: '{invalid json',
+            }
+
+            expect(normalizeMessage(message, 'user')).toEqual([
+                {
+                    role: 'assistant',
+                    content: '',
+                    tool_calls: [
+                        {
+                            type: 'function',
+                            id: 'call_abc',
+                            function: {
+                                name: 'my_func',
+                                arguments: '{invalid json',
+                            },
+                        },
+                    ],
+                },
+            ])
+        })
+    })
+
     it('normalizeMessage: handles new array-based content format', () => {
         const message = {
             role: 'assistant',

--- a/products/llm_analytics/frontend/utils.ts
+++ b/products/llm_analytics/frontend/utils.ts
@@ -29,6 +29,10 @@ import {
     OpenAICompletionMessage,
     OpenAIFileMessage,
     OpenAIImageURLMessage,
+    OpenAIResponsesBuiltinToolCall,
+    OpenAIResponsesFunctionCall,
+    OpenAIResponsesFunctionCallOutput,
+    OpenAIResponsesReasoning,
     OpenAIToolCall,
     VercelSDKImageMessage,
     VercelSDKInputImageMessage,
@@ -307,6 +311,52 @@ export function isAnthropicRoleBasedMessage(input: unknown): input is AnthropicI
         'content' in input &&
         (typeof input.content === 'string' || Array.isArray(input.content))
     )
+}
+
+// OpenAI Responses API type guards
+const OPENAI_RESPONSES_BUILTIN_TOOL_TYPES = new Set([
+    'web_search_call',
+    'code_interpreter_call',
+    'image_generation_call',
+    'mcp_call',
+    'file_search_call',
+    'computer_call',
+])
+
+export function isOpenAIResponsesFunctionCall(input: unknown): input is OpenAIResponsesFunctionCall {
+    return (
+        !!input &&
+        typeof input === 'object' &&
+        'type' in input &&
+        input.type === 'function_call' &&
+        'name' in input &&
+        'call_id' in input
+    )
+}
+
+export function isOpenAIResponsesFunctionCallOutput(input: unknown): input is OpenAIResponsesFunctionCallOutput {
+    return (
+        !!input &&
+        typeof input === 'object' &&
+        'type' in input &&
+        input.type === 'function_call_output' &&
+        'call_id' in input &&
+        'output' in input
+    )
+}
+
+export function isOpenAIResponsesBuiltinToolCall(input: unknown): input is OpenAIResponsesBuiltinToolCall {
+    return (
+        !!input &&
+        typeof input === 'object' &&
+        'type' in input &&
+        typeof input.type === 'string' &&
+        OPENAI_RESPONSES_BUILTIN_TOOL_TYPES.has(input.type)
+    )
+}
+
+export function isOpenAIResponsesReasoning(input: unknown): input is OpenAIResponsesReasoning {
+    return !!input && typeof input === 'object' && 'type' in input && input.type === 'reasoning'
 }
 
 export function isVercelSDKTextMessage(input: unknown): input is VercelSDKTextMessage {
@@ -801,6 +851,74 @@ export function normalizeMessage(rawMessage: unknown, defaultRole: string): Comp
                 role: toolResultRole,
                 content: rawMessage.content,
                 tool_call_id: rawMessage.tool_use_id,
+            },
+        ]
+    }
+
+    // OpenAI Responses API
+    // Function call (role-less, uses `type` instead)
+    if (isOpenAIResponsesFunctionCall(rawMessage)) {
+        let parsedArguments: Record<string, any> | string = rawMessage.arguments
+        if (typeof rawMessage.arguments === 'string') {
+            try {
+                parsedArguments = JSON.parse(rawMessage.arguments)
+            } catch {
+                parsedArguments = rawMessage.arguments
+            }
+        }
+        return [
+            {
+                role: 'assistant',
+                content: '',
+                tool_calls: [
+                    {
+                        type: 'function',
+                        id: rawMessage.call_id,
+                        function: {
+                            name: rawMessage.name,
+                            arguments: parsedArguments,
+                        },
+                    },
+                ],
+            },
+        ]
+    }
+    // Function call output
+    if (isOpenAIResponsesFunctionCallOutput(rawMessage)) {
+        return [
+            {
+                role: normalizeRole('assistant (tool result)', roleToUse),
+                content: rawMessage.output,
+                tool_call_id: rawMessage.call_id,
+            },
+        ]
+    }
+    // Reasoning
+    if (isOpenAIResponsesReasoning(rawMessage)) {
+        const summaryText = Array.isArray(rawMessage.summary) ? rawMessage.summary.map((s) => s.text).join('\n') : ''
+        return [
+            {
+                role: normalizeRole('assistant (thinking)', roleToUse),
+                content: summaryText,
+            },
+        ]
+    }
+    // Built-in tool calls (web_search_call, code_interpreter_call, etc.)
+    if (isOpenAIResponsesBuiltinToolCall(rawMessage)) {
+        return [
+            {
+                role: 'assistant',
+                content: JSON.stringify(rawMessage),
+                tool_calls: [
+                    {
+                        type: 'function',
+                        id: rawMessage.id,
+                        function: {
+                            name: rawMessage.type,
+                            arguments: {},
+                        },
+                    },
+                ],
             },
         ]
     }


### PR DESCRIPTION
## Problem

OpenAI Responses API items (`function_call`, `function_call_output`, `reasoning`, `web_search_call`, etc.) use `type` instead of `role` to identify the message kind. The `normalizeMessage()` function had no handlers for these types, so they fell through to the unsupported message path and were assigned the `defaultRole` (typically `user` for inputs). This caused function calls and function outputs to display as "user" messages in the trace view.

Reported by a user in https://posthoghelp.zendesk.com/agent/tickets/54178 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/56673)

## Changes

- Added TypeScript interfaces for OpenAI Responses API item types (`OpenAIResponsesFunctionCall`, `OpenAIResponsesFunctionCallOutput`, `OpenAIResponsesBuiltinToolCall`, `OpenAIResponsesReasoning`) in `types.ts`
- Added type guards and normalization handlers in `utils.ts`:
  - `function_call` -> `role: 'assistant'` with `tool_calls` array
  - `function_call_output` -> `role: 'assistant (tool result)'` with `tool_call_id`
  - `reasoning` -> `role: 'assistant (thinking)'` with summary text
  - Built-in tool calls (`web_search_call`, `code_interpreter_call`, `image_generation_call`, `mcp_call`, `file_search_call`, `computer_call`) -> `role: 'assistant'` with `tool_calls`
- Added 7 test cases covering all new handlers and edge cases

## How did you test this code?

- Added unit tests for all new Responses API item types in `utils.test.ts`
- All 85 tests pass

## Publish to changelog?

no