### PR TITLE
chore(oauth): add structured logging for token refresh debugging

### DIFF
--- a/posthog/api/oauth/views.py
+++ b/posthog/api/oauth/views.py
@@ -127,9 +127,9 @@ class OAuthValidator(OAuth2Validator):
 
         Non-DCR OAuth clients still get rotation per the default setting.
         """
-        if hasattr(request, "client") and request.client:
-            if getattr(request.client, "is_dcr_client", False):
-                return False
+        is_dcr = hasattr(request, "client") and request.client and getattr(request.client, "is_dcr_client", False)
+        if is_dcr:
+            return False
         return oauth2_settings.ROTATE_REFRESH_TOKEN
 
     def _get_token_expires_in(self, request) -> int:
@@ -148,7 +148,17 @@ class OAuthValidator(OAuth2Validator):
         Sets token["expires_in"] before calling parent, which uses this value
         when calculating the actual expiry datetime stored in the database.
         """
-        token["expires_in"] = self._get_token_expires_in(request)
+        expires_in = self._get_token_expires_in(request)
+        token["expires_in"] = expires_in
+        client_id = getattr(request.client, "client_id", None) if hasattr(request, "client") else None
+        is_dcr = hasattr(request, "client") and request.client and getattr(request.client, "is_dcr_client", False)
+        logger.info(
+            "oauth_save_bearer_token",
+            client_id_prefix=str(client_id)[:8] if client_id else "unknown",
+            is_dcr_client=is_dcr,
+            expires_in=expires_in,
+            grant_type=getattr(request, "grant_type", "unknown"),
+        )
         return super().save_bearer_token(token, request, *args, **kwargs)
 
     def get_additional_claims(self, request):
@@ -465,7 +475,22 @@ class OAuthTokenView(TokenView):
                     status=400,
                 )
 
+        grant_type = request.POST.get("grant_type", "unknown")
+        client_id = request.POST.get("client_id", "")
+        logger.info(
+            "oauth_token_request",
+            grant_type=grant_type,
+            client_id_prefix=client_id[:8] if client_id else "unknown",
+        )
+
         response = super().post(request, *args, **kwargs)
+
+        logger.info(
+            "oauth_token_response",
+            grant_type=grant_type,
+            client_id_prefix=client_id[:8] if client_id else "unknown",
+            status=response.status_code,
+        )
 
         if response.status_code == 200:
             try:

--- a/posthog/api/oauth/views.py
+++ b/posthog/api/oauth/views.py
@@ -151,11 +151,10 @@ class OAuthValidator(OAuth2Validator):
         expires_in = self._get_token_expires_in(request)
         token["expires_in"] = expires_in
         client_id = getattr(request.client, "client_id", None) if hasattr(request, "client") else None
-        is_dcr = hasattr(request, "client") and request.client and getattr(request.client, "is_dcr_client", False)
         logger.info(
             "oauth_save_bearer_token",
             client_id_prefix=str(client_id)[:8] if client_id else "unknown",
-            is_dcr_client=is_dcr,
+            is_dcr_client=expires_in != oauth2_settings.ACCESS_TOKEN_EXPIRE_SECONDS,
             expires_in=expires_in,
             grant_type=getattr(request, "grant_type", "unknown"),
         )
@@ -477,10 +476,11 @@ class OAuthTokenView(TokenView):
 
         grant_type = request.POST.get("grant_type", "unknown")
         client_id = request.POST.get("client_id", "")
+        client_id_prefix = client_id[:8] if client_id else "unknown"
         logger.info(
             "oauth_token_request",
             grant_type=grant_type,
-            client_id_prefix=client_id[:8] if client_id else "unknown",
+            client_id_prefix=client_id_prefix,
         )
 
         response = super().post(request, *args, **kwargs)
@@ -488,7 +488,7 @@ class OAuthTokenView(TokenView):
         logger.info(
             "oauth_token_response",
             grant_type=grant_type,
-            client_id_prefix=client_id[:8] if client_id else "unknown",
+            client_id_prefix=client_id_prefix,
             status=response.status_code,
         )
 

--- a/services/oauth-proxy/src/handlers/token.ts
+++ b/services/oauth-proxy/src/handlers/token.ts
@@ -49,8 +49,26 @@ export async function handleToken(request: Request, kv: KVNamespace): Promise<Re
                 redirectUriRewrite = { from: storedRedirectUri, to: proxyCallbackUrl }
             }
 
+            console.info(
+                JSON.stringify({
+                    handler: 'token',
+                    grant_type: grantType,
+                    client_id_prefix: clientIdPrefix,
+                    region_source: 'kv',
+                    region,
+                })
+            )
             const response = await proxyWithMapping(rebuild(), kv, clientId, region, redirectUriRewrite)
-
+            console.info(
+                JSON.stringify({
+                    handler: 'token',
+                    grant_type: grantType,
+                    client_id_prefix: clientIdPrefix,
+                    region_source: 'kv',
+                    region,
+                    status: response.status,
+                })
+            )
             return response
         }
     }
@@ -59,6 +77,15 @@ export async function handleToken(request: Request, kv: KVNamespace): Promise<Re
     // For authorization_code grants without a stored region, return an error
     // rather than leaking the auth code to the wrong server.
     if (grantType === 'authorization_code') {
+        console.info(
+            JSON.stringify({
+                handler: 'token',
+                grant_type: grantType,
+                client_id_prefix: clientIdPrefix,
+                region_source: 'none',
+                error: 'no_region_for_auth_code',
+            })
+        )
         return new Response(
             JSON.stringify({
                 error: 'invalid_request',
@@ -68,8 +95,25 @@ export async function handleToken(request: Request, kv: KVNamespace): Promise<Re
         )
     }
 
+    console.info(
+        JSON.stringify({
+            handler: 'token',
+            grant_type: grantType,
+            client_id_prefix: clientIdPrefix,
+            region_source: 'try_both',
+        })
+    )
     const { response, region } = await tryBothRegions(rebuild(), '/oauth/token/')
-
+    console.info(
+        JSON.stringify({
+            handler: 'token',
+            grant_type: grantType,
+            client_id_prefix: clientIdPrefix,
+            region_source: 'try_both',
+            resolved_region: region,
+            status: response.status,
+        })
+    )
     return response
 }
 

--- a/services/oauth-proxy/src/handlers/token.ts
+++ b/services/oauth-proxy/src/handlers/token.ts
@@ -27,6 +27,8 @@ export async function handleToken(request: Request, kv: KVNamespace): Promise<Re
         grantType = formParams.get('grant_type')
     }
 
+    const clientIdPrefix = clientId?.slice(0, 8) ?? 'none'
+
     const rebuild = (): Request =>
         new Request(request.url, {
             method: request.method,
@@ -46,7 +48,10 @@ export async function handleToken(request: Request, kv: KVNamespace): Promise<Re
                 const proxyCallbackUrl = `${new URL(request.url).origin}/oauth/callback/`
                 redirectUriRewrite = { from: storedRedirectUri, to: proxyCallbackUrl }
             }
-            return proxyWithMapping(rebuild(), kv, clientId, region, redirectUriRewrite)
+
+            const response = await proxyWithMapping(rebuild(), kv, clientId, region, redirectUriRewrite)
+
+            return response
         }
     }
 
@@ -63,7 +68,8 @@ export async function handleToken(request: Request, kv: KVNamespace): Promise<Re
         )
     }
 
-    const { response } = await tryBothRegions(rebuild(), '/oauth/token/')
+    const { response, region } = await tryBothRegions(rebuild(), '/oauth/token/')
+
     return response
 }
 

--- a/services/oauth-proxy/src/lib/proxy.ts
+++ b/services/oauth-proxy/src/lib/proxy.ts
@@ -93,6 +93,7 @@ export async function tryBothRegions(request: Request, path: string): Promise<{ 
     })
 
     if (usResponse.ok) {
+        console.info(JSON.stringify({ fn: 'tryBothRegions', path, resolved: 'us', us_status: usResponse.status }))
         return { response: usResponse, region: 'us' }
     }
 
@@ -106,9 +107,27 @@ export async function tryBothRegions(request: Request, path: string): Promise<{ 
     })
 
     if (euResponse.ok) {
+        console.info(
+            JSON.stringify({
+                fn: 'tryBothRegions',
+                path,
+                resolved: 'eu',
+                us_status: usResponse.status,
+                eu_status: euResponse.status,
+            })
+        )
         return { response: euResponse, region: 'eu' }
     }
 
+    console.info(
+        JSON.stringify({
+            fn: 'tryBothRegions',
+            path,
+            resolved: 'none',
+            us_status: usResponse.status,
+            eu_status: euResponse.status,
+        })
+    )
     return {
         response: new Response(
             JSON.stringify({ error: 'invalid_request', error_description: 'Unable to determine region' }),


### PR DESCRIPTION
## Problem

We have **zero visibility** into OAuth token refresh requests across both the OAuth proxy (`oauth.posthog.com`) and the Django OAuth token endpoint. Users report needing to re-authenticate the PostHog MCP every ~24 hours in Claude Code despite us issuing 7-day tokens with non-rotating refresh tokens. We can't debug this without seeing what's actually happening.

## Changes

**OAuth proxy** (`services/oauth-proxy/`):
- Token handler: logs grant_type, client_id prefix, region routing decision (KV lookup vs tryBothRegions), and response status
- `tryBothRegions`: logs which region resolved and upstream status codes from both US and EU

**Django OAuth** (`posthog/api/oauth/views.py`):
- `OAuthTokenView.post()`: logs incoming token requests and responses with grant_type, client_id prefix, status
- `OAuthValidator.save_bearer_token()`: logs the expires_in being set and whether client is DCR (7-day) or default (1-hour)

All client_ids are truncated to first 8 chars for privacy. No tokens or secrets are logged.

## How did you test this?

- Verified `console.info` is the correct pattern (used by MCP server's `logging.ts`, allowed by oxlint `no-console` rule which permits info/warn/error)
- Verified structlog pattern matches existing Django OAuth logging

## Changelog

No