### PR TITLE
fix(insights): fix selecting intervals in retention table when navigated from dashboard

### DIFF
--- a/frontend/src/scenes/retention/RetentionTable.tsx
+++ b/frontend/src/scenes/retention/RetentionTable.tsx
@@ -43,7 +43,7 @@ export function RetentionTable({
     const { openModal } = useActions(retentionModalLogic(insightProps))
 
     const selectedInterval = retentionFilter?.selectedInterval ?? null
-    const allowSelectingColumns = !insightProps.dashboardId && !inSharedMode && !embedded
+    const allowSelectingColumns = !inSharedMode && !embedded
 
     const backgroundColor = theme?.['preset-1'] || '#000000' // Default to black if no color found
     const backgroundColorMean = theme?.['preset-2'] || '#000000' // Default to black if no color found


### PR DESCRIPTION
## Problem

Coming to a retention chart from a dashboard does not allow selecting intervals in the retention table.


https://github.com/user-attachments/assets/0ff70e4f-3842-4c4b-b65b-f522756325da


## Changes


https://github.com/user-attachments/assets/98a244f1-88e1-40c7-ab04-134ed0f9c5a9


## How did you test this code?

Manually.

1. Create a retention chart and add it to a dashboard
2. Go to the dashboard and click on the chart
3. Go to insight edit
4. Should be able to click on the intervals (column headers). 

Note that this should be allowed only in edit mode

## Publish to changelog?

No