### PR TITLE
fix(dashboards): handle numeric search query params from URL

### DIFF
--- a/frontend/src/scenes/dashboard/dashboards/dashboardsLogic.test.ts
+++ b/frontend/src/scenes/dashboard/dashboards/dashboardsLogic.test.ts
@@ -221,4 +221,15 @@ describe('dashboardsLogic', () => {
             filters: expect.objectContaining({ search: 'needle' }),
         })
     })
+
+    it('loads search from URL when the router coerces it to a number', async () => {
+        logic.unmount()
+        router.actions.push(urls.dashboards(), { search: 33333333 as unknown as string })
+        logic = dashboardsLogic({ tabId: '1' })
+        logic.mount()
+
+        await expectLogic(logic).toMatchValues({
+            filters: expect.objectContaining({ search: '33333333' }),
+        })
+    })
 })

--- a/frontend/src/scenes/dashboard/dashboards/dashboardsLogic.ts
+++ b/frontend/src/scenes/dashboard/dashboards/dashboardsLogic.ts
@@ -44,6 +44,11 @@ export const DEFAULT_FILTERS: DashboardsFilters = {
 
 export type DashboardFuse = Fuse<DashboardBasicType> // This is exported for kea-typegen
 
+/** Router may coerce numeric-looking query values to numbers; search text must stay a string. */
+function urlSearchParamToString(value: unknown): string {
+    return `${value ?? ''}`
+}
+
 export const dashboardsLogic = kea<dashboardsLogicType>([
     path(['scenes', 'dashboard', 'dashboardsLogic']),
     tabAwareScene(),
@@ -189,7 +194,7 @@ export const dashboardsLogic = kea<dashboardsLogicType>([
         },
         setSearch: ({ search }) => {
             const nextSearch = search ?? ''
-            const currentSearch = (router.values.searchParams['search'] as string | undefined) ?? ''
+            const currentSearch = urlSearchParamToString(router.values.searchParams['search'])
 
             if (nextSearch === currentSearch) {
                 return
@@ -211,7 +216,7 @@ export const dashboardsLogic = kea<dashboardsLogicType>([
             const tab = (searchParams['tab'] as DashboardsTab | undefined) || DashboardsTab.All
             actions.setCurrentTab(tab)
 
-            const search = typeof searchParams['search'] === 'string' ? searchParams['search'] : ''
+            const search = urlSearchParamToString(searchParams['search'])
             actions.setFilters({ search })
         },
     })),


### PR DESCRIPTION
## Problem

On the dashboards list, a search that was entirely digits was written to the URL and triggered a search pass, but the in-memory filter then reset to empty. The input went blank and the table showed unfiltered results. That happened because kea-router can deserialize numeric-looking query values as JavaScript numbers, and the scene only treated `search` as valid when `typeof === 'string'`.

## Changes

Add `urlSearchParamToString` in `dashboardsLogic` and use it when hydrating `filters.search` from `/dashboard` URL params and when comparing the current URL value in `setSearch` (actionToUrl), so both paths agree. Add a regression test that mounts with a numeric `search` in `searchParams`.

## How did you test this code?

Locally.
## Publish to changelog?

No.