### PR TITLE
fix(dashboards): do not abort tile refresh when saving from edit mode

### DIFF
--- a/frontend/src/scenes/dashboard/dashboardLogic.test.ts
+++ b/frontend/src/scenes/dashboard/dashboardLogic.test.ts
@@ -761,6 +761,7 @@ describe('dashboardLogic', () => {
                     expect(logic.values.refreshStatus[insight1.short_id]?.refreshed).toBe(true)
                     expect(logic.values.refreshStatus[insight2.short_id]?.refreshed).toBe(true)
                 } finally {
+                    releaseBarrier!()
                     getInsightWithRetrySpy.mockRestore()
                 }
             })

--- a/frontend/src/scenes/dashboard/dashboardLogic.test.ts
+++ b/frontend/src/scenes/dashboard/dashboardLogic.test.ts
@@ -692,6 +692,79 @@ describe('dashboardLogic', () => {
                     })
             })
 
+            it('save during in-flight dashboard refresh does not abort insight fetches', async () => {
+                const dashboard = dashboards[5]
+                const insight1 = dashboard.tiles[0].insight!
+                const insight2 = dashboard.tiles[1].insight!
+
+                let releaseBarrier: () => void
+                const barrier = new Promise<void>((resolve): void => {
+                    releaseBarrier = resolve
+                })
+
+                const realGetInsightWithRetry =
+                    jest.requireActual<typeof dashboardUtils>('./dashboardUtils').getInsightWithRetry
+
+                const getInsightWithRetrySpy = jest
+                    .spyOn(dashboardUtils, 'getInsightWithRetry')
+                    .mockImplementation(
+                        async (
+                            ...args: Parameters<typeof realGetInsightWithRetry>
+                        ): ReturnType<typeof realGetInsightWithRetry> => {
+                            await barrier
+                            return realGetInsightWithRetry(...args)
+                        }
+                    )
+
+                try {
+                    ;(api.update as jest.Mock).mockClear()
+
+                    // forceRefresh: true so every insight tile hits getInsightWithRetry (applyFilters/preview can skip fresh tiles)
+                    const refreshDone = expectLogic(logic, () => {
+                        logic.actions.triggerDashboardRefresh()
+                    }).toFinishAllListeners()
+
+                    const deadline = Date.now() + 5000
+                    while (getInsightWithRetrySpy.mock.calls.length < 2) {
+                        if (Date.now() > deadline) {
+                            throw new Error('Timed out waiting for insight fetches to start')
+                        }
+                        await new Promise((r) => setTimeout(r, 0))
+                    }
+
+                    const firstTile = dashboard.tiles[0]
+                    const currentLayouts = logic.values.layouts
+                    const modifiedLayouts: any = {
+                        ...currentLayouts,
+                        sm: currentLayouts.sm?.map((layout) =>
+                            layout.i === String(firstTile.id) ? { ...layout, x: (layout.x ?? 0) + 1 } : layout
+                        ),
+                    }
+
+                    logic.actions.updateLayouts(modifiedLayouts)
+                    logic.actions.saveEditModeChanges()
+
+                    // Do not use toFinishAllListeners here: it would wait for refreshDashboardItems too,
+                    // while refresh is intentionally blocked on `barrier`.
+                    const saveDeadline = Date.now() + 5000
+                    while ((api.update as jest.Mock).mock.calls.length < 1) {
+                        if (Date.now() > saveDeadline) {
+                            throw new Error('Timed out waiting for saveEditModeChanges to call api.update')
+                        }
+                        await new Promise((r) => setTimeout(r, 0))
+                    }
+                    expect(api.update).toHaveBeenCalledTimes(1)
+
+                    releaseBarrier!()
+                    await refreshDone
+
+                    expect(logic.values.refreshStatus[insight1.short_id]?.refreshed).toBe(true)
+                    expect(logic.values.refreshStatus[insight2.short_id]?.refreshed).toBe(true)
+                } finally {
+                    getInsightWithRetrySpy.mockRestore()
+                }
+            })
+
             it('manual refresh does not update last refresh when insights fail', async () => {
                 const dashboard = dashboards[5]
                 const insight1 = dashboard.tiles[0].insight!

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -417,8 +417,6 @@ export const dashboardLogic = kea<dashboardLogicType>([
                     return null
                 },
                 saveEditModeChanges: async (_, breakpoint) => {
-                    actions.abortAnyRunningQuery()
-
                     try {
                         // Only persist sm layouts; xs layouts are derived on the fly
                         const layoutsToUpdate = (values.dashboard?.tiles || []).map((tile) => ({


### PR DESCRIPTION
## Problem

Saving a dashboard from edit mode called `abortAnyRunningQuery()` at the start of `saveEditModeChanges`. That shares the same `AbortController` as an in-flight **preview / tile refresh** (for example after **Apply filters** on a large dashboard, or any full refresh). Saving while tiles were still loading aborted those requests, cleared refresh state badly, and left every tile showing **“Chart data didn’t load”** with no follow-up refresh—an abrupt, broken-looking dashboard.

**How this showed up in practice:** changing the date range enters edit mode; the user clicks **Apply filters**; while data is still loading they click **Save**. The save path aborted the apply refresh, so all in-flight insight fetches were cancelled.

## Changes

- Stop calling `abortAnyRunningQuery()` when starting `saveEditModeChanges`, so save no longer cancels a concurrent dashboard insight refresh batch.
- Add a Jest regression test that stalls `getInsightWithRetry` until after save has issued the dashboard PATCH, then asserts both tiles still reach a refreshed state.

## How did you test this code?

- Ran `pnpm --filter=@posthog/frontend jest frontend/src/scenes/dashboard/dashboardLogic.test.ts -t "save during in-flight"`.
- I am an agent and did not manually verify in the browser.

## Publish to changelog?

no

## Docs update

Not required.

## LLM context

This PR was drafted by an assistant. The bug was found by tracing dashboard edit/save and refresh: `saveEditModeChanges` unconditionally aborted the shared controller used by `refreshDashboardItems` / `getInsightWithRetry`. Fix removes that abort; tradeoff is a rarer case where filters change after a preview starts but before save without re-applying—possible brief mismatch until another refresh. Regression test uses `triggerDashboardRefresh` (forced refresh so all tiles hit the network in tests), layout-only save to avoid a second preview from `setDates`/`setProperties` on small dashboards, and avoids `toFinishAllListeners` on save while refresh is blocked (otherwise kea-test-utils waits on the same listener).
