### PR TITLE
refactor(funnels): replace filters with queries in breakdown tests

### DIFF
--- a/posthog/hogql_queries/insights/funnels/test/breakdown_cases.py
+++ b/posthog/hogql_queries/insights/funnels/test/breakdown_cases.py
@@ -1971,6 +1971,7 @@ def funnel_breakdown_test_factory(funnel_order_type: FunnelOrderType):
                     date_to="2020-01-08",
                 ),
                 funnelsFilter=FunnelsFilter(
+                    breakdownAttributionType=BreakdownAttributionType.FIRST_TOUCH,
                     funnelOrderType=funnel_order_type,
                 ),
                 series=[
@@ -2570,6 +2571,7 @@ def funnel_breakdown_test_factory(funnel_order_type: FunnelOrderType):
                     date_to="2020-01-08",
                 ),
                 funnelsFilter=FunnelsFilter(
+                    breakdownAttributionType=BreakdownAttributionType.FIRST_TOUCH,
                     funnelOrderType=funnel_order_type,
                 ),
                 series=[
@@ -2743,6 +2745,7 @@ def funnel_breakdown_test_factory(funnel_order_type: FunnelOrderType):
                     date_to="2020-01-08",
                 ),
                 funnelsFilter=FunnelsFilter(
+                    breakdownAttributionType=BreakdownAttributionType.FIRST_TOUCH,
                     funnelOrderType=funnel_order_type,
                 ),
                 series=[
@@ -3112,6 +3115,7 @@ def funnel_breakdown_test_factory(funnel_order_type: FunnelOrderType):
                     date_to="2020-01-08",
                 ),
                 funnelsFilter=FunnelsFilter(
+                    breakdownAttributionType=BreakdownAttributionType.FIRST_TOUCH,
                     funnelOrderType=funnel_order_type,
                 ),
                 series=[
@@ -3194,6 +3198,7 @@ def funnel_breakdown_test_factory(funnel_order_type: FunnelOrderType):
                     date_to="2020-01-08",
                 ),
                 funnelsFilter=FunnelsFilter(
+                    breakdownAttributionType=BreakdownAttributionType.FIRST_TOUCH,
                     funnelOrderType=funnel_order_type,
                 ),
                 series=[

--- a/posthog/hogql_queries/insights/funnels/test/breakdown_cases.py
+++ b/posthog/hogql_queries/insights/funnels/test/breakdown_cases.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 from string import ascii_lowercase
-from typing import Any, Literal, Optional, Union, cast, overload
+from typing import Any, Literal, Optional, Union, cast
 from uuid import UUID
 
 from freezegun import freeze_time
@@ -18,20 +18,23 @@ from posthog.test.base import (
 from unittest import skip
 
 from posthog.schema import (
+    ActionsNode,
     BaseMathType,
+    BreakdownAttributionType,
     BreakdownFilter,
     BreakdownType,
     DateRange,
+    EventPropertyFilter,
     EventsNode,
     FunnelsDataWarehouseNode,
     FunnelsFilter,
     FunnelsQuery,
+    PropertyOperator,
 )
 
-from posthog.constants import INSIGHT_FUNNELS, FunnelOrderType
+from posthog.constants import FunnelOrderType
 from posthog.hogql_queries.insights.funnels.funnels_query_runner import FunnelsQueryRunner
-from posthog.hogql_queries.insights.funnels.test.test_funnel_persons import get_actors, get_actors_legacy_filters
-from posthog.hogql_queries.legacy_compatibility.filter_to_query import filter_to_query
+from posthog.hogql_queries.insights.funnels.test.test_funnel_persons import get_actors
 from posthog.models.cohort import Cohort
 from posthog.models.group.util import create_group
 from posthog.models.instance_setting import override_instance_config
@@ -57,33 +60,14 @@ class FunnelStepResult:
 
 def funnel_breakdown_test_factory(funnel_order_type: FunnelOrderType):
     class TestFunnelBreakdown(APIBaseTest):
-        @overload
         def _get_actor_ids_at_step(
             self,
-            filters_or_query: dict[str, Any],
-            funnel_step: int,
-            breakdown_value: Optional[str | float | list[str | float]] = None,
-        ) -> list[str]: ...
-        @overload
-        def _get_actor_ids_at_step(
-            self,
-            filters_or_query: FunnelsQuery,
-            funnel_step: int,
-            breakdown_value: Optional[str | float | list[str | float]] = None,
-        ) -> list[str]: ...
-        def _get_actor_ids_at_step(
-            self,
-            filters_or_query: dict[str, Any] | FunnelsQuery,
+            query: FunnelsQuery,
             funnel_step: int,
             breakdown_value: Optional[str | float | list[str | float]] = None,
         ) -> list[str]:
-            funnels_query = (
-                cast(FunnelsQuery, filter_to_query(filters_or_query))
-                if isinstance(filters_or_query, dict)
-                else filters_or_query
-            )
             actors = get_actors(
-                funnels_query,
+                query,
                 self.team,
                 funnel_step=funnel_step,
                 funnel_step_breakdown=breakdown_value,
@@ -143,20 +127,32 @@ def funnel_breakdown_test_factory(funnel_order_type: FunnelOrderType):
 
         @also_test_with_materialized_columns(["$browser", "$browser_version"])
         def test_funnel_step_multi_property_breakdown_event(self):
-            filters = {
-                "insight": INSIGHT_FUNNELS,
-                "funnel_order_type": funnel_order_type,
-                "events": [
-                    {"id": "sign up", "order": 0},
-                    {"id": "play movie", "order": 1},
-                    {"id": "buy", "order": 2},
+            query = FunnelsQuery(
+                breakdownFilter=BreakdownFilter(
+                    breakdown=["$browser", "$browser_version"],
+                ),
+                dateRange=DateRange(
+                    date_from="2020-01-01",
+                    date_to="2020-01-08",
+                ),
+                funnelsFilter=FunnelsFilter(
+                    funnelOrderType=funnel_order_type,
+                ),
+                series=[
+                    EventsNode(
+                        event="sign up",
+                        name="sign up",
+                    ),
+                    EventsNode(
+                        event="play movie",
+                        name="play movie",
+                    ),
+                    EventsNode(
+                        event="buy",
+                        name="buy",
+                    ),
                 ],
-                "date_from": "2020-01-01",
-                "date_to": "2020-01-08",
-                "funnel_window_days": 7,
-                "breakdown_type": "event",
-                "breakdown": ["$browser", "$browser_version"],
-            }
+            )
 
             journey = {
                 "person1": [
@@ -223,7 +219,6 @@ def funnel_breakdown_test_factory(funnel_order_type: FunnelOrderType):
 
             people = journeys_for(events_by_person=journey, team=self.team)
 
-            query = cast(FunnelsQuery, filter_to_query(filters))
             results = FunnelsQueryRunner(query=query, team=self.team).calculate().results
 
             self._assert_funnel_breakdown_result_is_correct(
@@ -236,10 +231,10 @@ def funnel_breakdown_test_factory(funnel_order_type: FunnelOrderType):
             )
 
             self.assertCountEqual(
-                self._get_actor_ids_at_step(filters, 1, ["Safari", "14"]),
+                self._get_actor_ids_at_step(query, 1, ["Safari", "14"]),
                 [people["person3"].uuid],
             )
-            self.assertCountEqual(self._get_actor_ids_at_step(filters, 2, ["Safari", "14"]), [])
+            self.assertCountEqual(self._get_actor_ids_at_step(query, 2, ["Safari", "14"]), [])
 
             self._assert_funnel_breakdown_result_is_correct(
                 results[1],
@@ -256,11 +251,11 @@ def funnel_breakdown_test_factory(funnel_order_type: FunnelOrderType):
                 ],
             )
             self.assertCountEqual(
-                self._get_actor_ids_at_step(filters, 1, ["Safari", "15"]),
+                self._get_actor_ids_at_step(query, 1, ["Safari", "15"]),
                 [people["person2"].uuid],
             )
             self.assertCountEqual(
-                self._get_actor_ids_at_step(filters, 2, ["Safari", "15"]),
+                self._get_actor_ids_at_step(query, 2, ["Safari", "15"]),
                 [people["person2"].uuid],
             )
 
@@ -285,30 +280,42 @@ def funnel_breakdown_test_factory(funnel_order_type: FunnelOrderType):
                 ],
             )
             self.assertCountEqual(
-                self._get_actor_ids_at_step(filters, 1, ["Chrome", "95"]),
+                self._get_actor_ids_at_step(query, 1, ["Chrome", "95"]),
                 [people["person1"].uuid],
             )
             self.assertCountEqual(
-                self._get_actor_ids_at_step(filters, 2, ["Chrome", "95"]),
+                self._get_actor_ids_at_step(query, 2, ["Chrome", "95"]),
                 [people["person1"].uuid],
             )
 
         @also_test_with_materialized_columns(["$browser"])
         def test_funnel_step_breakdown_event_with_string_only_breakdown(self):
-            filters = {
-                "insight": INSIGHT_FUNNELS,
-                "funnel_order_type": funnel_order_type,
-                "events": [
-                    {"id": "sign up", "order": 0},
-                    {"id": "play movie", "order": 1},
-                    {"id": "buy", "order": 2},
+            query = FunnelsQuery(
+                breakdownFilter=BreakdownFilter(
+                    breakdown="$browser",
+                ),
+                dateRange=DateRange(
+                    date_from="2020-01-01",
+                    date_to="2020-01-08",
+                ),
+                funnelsFilter=FunnelsFilter(
+                    funnelOrderType=funnel_order_type,
+                ),
+                series=[
+                    EventsNode(
+                        event="sign up",
+                        name="sign up",
+                    ),
+                    EventsNode(
+                        event="play movie",
+                        name="play movie",
+                    ),
+                    EventsNode(
+                        event="buy",
+                        name="buy",
+                    ),
                 ],
-                "date_from": "2020-01-01",
-                "date_to": "2020-01-08",
-                "funnel_window_days": 7,
-                "breakdown_type": "event",
-                "breakdown": "$browser",
-            }
+            )
 
             journey = {
                 "person1": [
@@ -351,7 +358,6 @@ def funnel_breakdown_test_factory(funnel_order_type: FunnelOrderType):
 
             people = journeys_for(events_by_person=journey, team=self.team)
 
-            query = cast(FunnelsQuery, filter_to_query(filters))
             results = FunnelsQueryRunner(query=query, team=self.team).calculate().results
 
             self._assert_funnel_breakdown_result_is_correct(
@@ -375,11 +381,11 @@ def funnel_breakdown_test_factory(funnel_order_type: FunnelOrderType):
                 ],
             )
             self.assertCountEqual(
-                self._get_actor_ids_at_step(filters, 1, "Chrome"),
+                self._get_actor_ids_at_step(query, 1, "Chrome"),
                 [people["person1"].uuid],
             )
             self.assertCountEqual(
-                self._get_actor_ids_at_step(filters, 2, "Chrome"),
+                self._get_actor_ids_at_step(query, 2, "Chrome"),
                 [people["person1"].uuid],
             )
             self._assert_funnel_breakdown_result_is_correct(
@@ -398,30 +404,42 @@ def funnel_breakdown_test_factory(funnel_order_type: FunnelOrderType):
             )
 
             self.assertCountEqual(
-                self._get_actor_ids_at_step(filters, 1, "Safari"),
+                self._get_actor_ids_at_step(query, 1, "Safari"),
                 [people["person2"].uuid, people["person3"].uuid],
             )
             self.assertCountEqual(
-                self._get_actor_ids_at_step(filters, 2, "Safari"),
+                self._get_actor_ids_at_step(query, 2, "Safari"),
                 [people["person2"].uuid],
             )
 
         @also_test_with_materialized_columns(["$browser"])
         def test_funnel_step_breakdown_event(self):
-            filters = {
-                "insight": INSIGHT_FUNNELS,
-                "funnel_order_type": funnel_order_type,
-                "events": [
-                    {"id": "sign up", "order": 0},
-                    {"id": "play movie", "order": 1},
-                    {"id": "buy", "order": 2},
+            query = FunnelsQuery(
+                breakdownFilter=BreakdownFilter(
+                    breakdown=["$browser"],
+                ),
+                dateRange=DateRange(
+                    date_from="2020-01-01",
+                    date_to="2020-01-08",
+                ),
+                funnelsFilter=FunnelsFilter(
+                    funnelOrderType=funnel_order_type,
+                ),
+                series=[
+                    EventsNode(
+                        event="sign up",
+                        name="sign up",
+                    ),
+                    EventsNode(
+                        event="play movie",
+                        name="play movie",
+                    ),
+                    EventsNode(
+                        event="buy",
+                        name="buy",
+                    ),
                 ],
-                "date_from": "2020-01-01",
-                "date_to": "2020-01-08",
-                "funnel_window_days": 7,
-                "breakdown_type": "event",
-                "breakdown": ["$browser"],
-            }
+            )
 
             journey = {
                 "person1": [
@@ -464,7 +482,6 @@ def funnel_breakdown_test_factory(funnel_order_type: FunnelOrderType):
 
             people = journeys_for(events_by_person=journey, team=self.team)
 
-            query = cast(FunnelsQuery, filter_to_query(filters))
             results = FunnelsQueryRunner(query=query, team=self.team).calculate().results
 
             self._assert_funnel_breakdown_result_is_correct(
@@ -488,11 +505,11 @@ def funnel_breakdown_test_factory(funnel_order_type: FunnelOrderType):
                 ],
             )
             self.assertCountEqual(
-                self._get_actor_ids_at_step(filters, 1, "Chrome"),
+                self._get_actor_ids_at_step(query, 1, "Chrome"),
                 [people["person1"].uuid],
             )
             self.assertCountEqual(
-                self._get_actor_ids_at_step(filters, 2, "Chrome"),
+                self._get_actor_ids_at_step(query, 2, "Chrome"),
                 [people["person1"].uuid],
             )
 
@@ -512,32 +529,44 @@ def funnel_breakdown_test_factory(funnel_order_type: FunnelOrderType):
             )
 
             self.assertCountEqual(
-                self._get_actor_ids_at_step(filters, 1, "Safari"),
+                self._get_actor_ids_at_step(query, 1, "Safari"),
                 [people["person2"].uuid, people["person3"].uuid],
             )
             self.assertCountEqual(
-                self._get_actor_ids_at_step(filters, 2, "Safari"),
+                self._get_actor_ids_at_step(query, 2, "Safari"),
                 [people["person2"].uuid],
             )
 
         @also_test_with_materialized_columns(["$browser"])
         @skip('Using "Other" as a breakdown is not yet implemented in HogQL Actors Queries')
         def test_funnel_step_breakdown_event_with_other(self):
-            filters = {
-                "insight": INSIGHT_FUNNELS,
-                "funnel_order_type": funnel_order_type,
-                "events": [
-                    {"id": "sign up", "order": 0},
-                    {"id": "play movie", "order": 1},
-                    {"id": "buy", "order": 2},
+            query = FunnelsQuery(
+                breakdownFilter=BreakdownFilter(
+                    breakdown=["$browser"],
+                    breakdown_limit=1,
+                ),
+                dateRange=DateRange(
+                    date_from="2020-01-01",
+                    date_to="2020-01-08",
+                ),
+                funnelsFilter=FunnelsFilter(
+                    funnelOrderType=funnel_order_type,
+                ),
+                series=[
+                    EventsNode(
+                        event="sign up",
+                        name="sign up",
+                    ),
+                    EventsNode(
+                        event="play movie",
+                        name="play movie",
+                    ),
+                    EventsNode(
+                        event="buy",
+                        name="buy",
+                    ),
                 ],
-                "date_from": "2020-01-01",
-                "date_to": "2020-01-08",
-                "funnel_window_days": 7,
-                "breakdown_type": "event",
-                "breakdown": ["$browser"],
-                "breakdown_limit": 1,
-            }
+            )
 
             events_by_person = {
                 "person1": [
@@ -594,7 +623,6 @@ def funnel_breakdown_test_factory(funnel_order_type: FunnelOrderType):
 
             people = journeys_for(events_by_person, self.team)
 
-            query = cast(FunnelsQuery, filter_to_query(filters))
             query_runner = FunnelsQueryRunner(query=query, team=self.team)
             results = query_runner.calculate().results
             results = sort_breakdown_funnel_results(results)
@@ -621,11 +649,11 @@ def funnel_breakdown_test_factory(funnel_order_type: FunnelOrderType):
             )
 
             self.assertCountEqual(
-                self._get_actor_ids_at_step(filters, 1, "Safari"),
+                self._get_actor_ids_at_step(query, 1, "Safari"),
                 [people["person2"].uuid, people["person3"].uuid],
             )
             self.assertCountEqual(
-                self._get_actor_ids_at_step(filters, 2, "Safari"),
+                self._get_actor_ids_at_step(query, 2, "Safari"),
                 [people["person2"].uuid],
             )
 
@@ -649,7 +677,7 @@ def funnel_breakdown_test_factory(funnel_order_type: FunnelOrderType):
             )
 
             self.assertCountEqual(
-                self._get_actor_ids_at_step(filters, 1, "Other"),
+                self._get_actor_ids_at_step(query, 1, "Other"),
                 [
                     people["person1"].uuid,
                     people["person4"].uuid,
@@ -657,26 +685,39 @@ def funnel_breakdown_test_factory(funnel_order_type: FunnelOrderType):
                 ],
             )
             self.assertCountEqual(
-                self._get_actor_ids_at_step(filters, 2, "Other"),
+                self._get_actor_ids_at_step(query, 2, "Other"),
                 [people["person1"].uuid],
             )
             self.assertEqual(2, cast(ast.Constant, query_runner.to_query().limit).value)
 
         @also_test_with_materialized_columns(["$browser"])
         def test_funnel_step_breakdown_event_no_type(self):
-            filters = {
-                "insight": INSIGHT_FUNNELS,
-                "funnel_order_type": funnel_order_type,
-                "events": [
-                    {"id": "sign up", "order": 0},
-                    {"id": "play movie", "order": 1},
-                    {"id": "buy", "order": 2},
+            query = FunnelsQuery(
+                breakdownFilter=BreakdownFilter(
+                    breakdown=["$browser"],
+                ),
+                dateRange=DateRange(
+                    date_from="2020-01-01",
+                    date_to="2020-01-08",
+                ),
+                funnelsFilter=FunnelsFilter(
+                    funnelOrderType=funnel_order_type,
+                ),
+                series=[
+                    EventsNode(
+                        event="sign up",
+                        name="sign up",
+                    ),
+                    EventsNode(
+                        event="play movie",
+                        name="play movie",
+                    ),
+                    EventsNode(
+                        event="buy",
+                        name="buy",
+                    ),
                 ],
-                "date_from": "2020-01-01",
-                "date_to": "2020-01-08",
-                "funnel_window_days": 7,
-                "breakdown": ["$browser"],
-            }
+            )
 
             events_by_person = {
                 "person1": [
@@ -719,7 +760,6 @@ def funnel_breakdown_test_factory(funnel_order_type: FunnelOrderType):
 
             people = journeys_for(events_by_person, self.team)
 
-            query = cast(FunnelsQuery, filter_to_query(filters))
             results = FunnelsQueryRunner(query=query, team=self.team).calculate().results
 
             self._assert_funnel_breakdown_result_is_correct(
@@ -744,11 +784,11 @@ def funnel_breakdown_test_factory(funnel_order_type: FunnelOrderType):
             )
 
             self.assertCountEqual(
-                self._get_actor_ids_at_step(filters, 1, "Chrome"),
+                self._get_actor_ids_at_step(query, 1, "Chrome"),
                 [people["person1"].uuid],
             )
             self.assertCountEqual(
-                self._get_actor_ids_at_step(filters, 2, "Chrome"),
+                self._get_actor_ids_at_step(query, 2, "Chrome"),
                 [people["person1"].uuid],
             )
 
@@ -768,30 +808,43 @@ def funnel_breakdown_test_factory(funnel_order_type: FunnelOrderType):
             )
 
             self.assertCountEqual(
-                self._get_actor_ids_at_step(filters, 1, "Safari"),
+                self._get_actor_ids_at_step(query, 1, "Safari"),
                 [people["person2"].uuid, people["person3"].uuid],
             )
             self.assertCountEqual(
-                self._get_actor_ids_at_step(filters, 2, "Safari"),
+                self._get_actor_ids_at_step(query, 2, "Safari"),
                 [people["person2"].uuid],
             )
 
         @also_test_with_materialized_columns(person_properties=["$browser"])
         def test_funnel_step_breakdown_person(self):
-            filters = {
-                "insight": INSIGHT_FUNNELS,
-                "funnel_order_type": funnel_order_type,
-                "events": [
-                    {"id": "sign up", "order": 0},
-                    {"id": "play movie", "order": 1},
-                    {"id": "buy", "order": 2},
+            query = FunnelsQuery(
+                breakdownFilter=BreakdownFilter(
+                    breakdown=["$browser"],
+                    breakdown_type=BreakdownType.PERSON,
+                ),
+                dateRange=DateRange(
+                    date_from="2020-01-01",
+                    date_to="2020-01-08",
+                ),
+                funnelsFilter=FunnelsFilter(
+                    funnelOrderType=funnel_order_type,
+                ),
+                series=[
+                    EventsNode(
+                        event="sign up",
+                        name="sign up",
+                    ),
+                    EventsNode(
+                        event="play movie",
+                        name="play movie",
+                    ),
+                    EventsNode(
+                        event="buy",
+                        name="buy",
+                    ),
                 ],
-                "date_from": "2020-01-01",
-                "date_to": "2020-01-08",
-                "funnel_window_days": 7,
-                "breakdown_type": "person",
-                "breakdown": ["$browser"],
-            }
+            )
 
             person1 = _create_person(
                 distinct_ids=["person1"],
@@ -817,7 +870,6 @@ def funnel_breakdown_test_factory(funnel_order_type: FunnelOrderType):
             }
             journeys_for(peoples_journeys, self.team, create_people=False)
 
-            query = cast(FunnelsQuery, filter_to_query(filters))
             results = FunnelsQueryRunner(query=query, team=self.team).calculate().results
 
             self._assert_funnel_breakdown_result_is_correct(
@@ -841,8 +893,8 @@ def funnel_breakdown_test_factory(funnel_order_type: FunnelOrderType):
                 ],
             )
 
-            self.assertCountEqual(self._get_actor_ids_at_step(filters, 1, "Chrome"), [person1.uuid])
-            self.assertCountEqual(self._get_actor_ids_at_step(filters, 2, "Chrome"), [person1.uuid])
+            self.assertCountEqual(self._get_actor_ids_at_step(query, 1, "Chrome"), [person1.uuid])
+            self.assertCountEqual(self._get_actor_ids_at_step(query, 2, "Chrome"), [person1.uuid])
 
             self._assert_funnel_breakdown_result_is_correct(
                 results[1],
@@ -859,26 +911,38 @@ def funnel_breakdown_test_factory(funnel_order_type: FunnelOrderType):
                 ],
             )
 
-            self.assertCountEqual(self._get_actor_ids_at_step(filters, 1, "Safari"), [person2.uuid])
-            self.assertCountEqual(self._get_actor_ids_at_step(filters, 3, "Safari"), [])
+            self.assertCountEqual(self._get_actor_ids_at_step(query, 1, "Safari"), [person2.uuid])
+            self.assertCountEqual(self._get_actor_ids_at_step(query, 3, "Safari"), [])
 
         @also_test_with_materialized_columns(["some_breakdown_val"])
         def test_funnel_step_breakdown_limit(self):
-            filters = {
-                "insight": INSIGHT_FUNNELS,
-                "funnel_order_type": funnel_order_type,
-                "events": [
-                    {"id": "sign up", "order": 0},
-                    {"id": "play movie", "order": 1},
-                    {"id": "buy", "order": 2},
+            query = FunnelsQuery(
+                breakdownFilter=BreakdownFilter(
+                    breakdown=["some_breakdown_val"],
+                    breakdown_limit=5,
+                ),
+                dateRange=DateRange(
+                    date_from="2020-01-01",
+                    date_to="2020-01-08",
+                ),
+                funnelsFilter=FunnelsFilter(
+                    funnelOrderType=funnel_order_type,
+                ),
+                series=[
+                    EventsNode(
+                        event="sign up",
+                        name="sign up",
+                    ),
+                    EventsNode(
+                        event="play movie",
+                        name="play movie",
+                    ),
+                    EventsNode(
+                        event="buy",
+                        name="buy",
+                    ),
                 ],
-                "date_from": "2020-01-01",
-                "date_to": "2020-01-08",
-                "funnel_window_days": 7,
-                "breakdown_type": "event",
-                "breakdown": ["some_breakdown_val"],
-                "breakdown_limit": 5,
-            }
+            )
 
             events_by_person = {}
             for num in range(10):
@@ -903,7 +967,6 @@ def funnel_breakdown_test_factory(funnel_order_type: FunnelOrderType):
                     ]
             journeys_for(events_by_person, self.team)
 
-            query = cast(FunnelsQuery, filter_to_query(filters))
             results = FunnelsQueryRunner(query=query, team=self.team).calculate().results
 
             # assert that we give 5 at a time at most and that those values are the most popular ones
@@ -913,21 +976,33 @@ def funnel_breakdown_test_factory(funnel_order_type: FunnelOrderType):
         @also_test_with_materialized_columns(["some_breakdown_val"])
         @skip('Using "Other" as a breakdown is not yet implemented in HogQL Actors Queries')
         def test_funnel_step_custom_breakdown_limit_with_nulls(self):
-            filters = {
-                "insight": INSIGHT_FUNNELS,
-                "funnel_order_type": funnel_order_type,
-                "events": [
-                    {"id": "sign up", "order": 0},
-                    {"id": "play movie", "order": 1},
-                    {"id": "buy", "order": 2},
+            query = FunnelsQuery(
+                breakdownFilter=BreakdownFilter(
+                    breakdown=["some_breakdown_val"],
+                    breakdown_limit=3,
+                ),
+                dateRange=DateRange(
+                    date_from="2020-01-01",
+                    date_to="2020-01-08",
+                ),
+                funnelsFilter=FunnelsFilter(
+                    funnelOrderType=funnel_order_type,
+                ),
+                series=[
+                    EventsNode(
+                        event="sign up",
+                        name="sign up",
+                    ),
+                    EventsNode(
+                        event="play movie",
+                        name="play movie",
+                    ),
+                    EventsNode(
+                        event="buy",
+                        name="buy",
+                    ),
                 ],
-                "date_from": "2020-01-01",
-                "date_to": "2020-01-08",
-                "funnel_window_days": 7,
-                "breakdown_type": "event",
-                "breakdown_limit": 3,
-                "breakdown": ["some_breakdown_val"],
-            }
+            )
 
             events_by_person = {}
             for num in range(5):
@@ -959,31 +1034,42 @@ def funnel_breakdown_test_factory(funnel_order_type: FunnelOrderType):
             ]
             people = journeys_for(events_by_person, self.team)
 
-            query = cast(FunnelsQuery, filter_to_query(filters))
             results = FunnelsQueryRunner(query=query, team=self.team).calculate().results
 
             breakdown_vals = sorted([res[0]["breakdown"] for res in results])
             self.assertEqual([["2"], ["3"], ["4"], ["Other"]], breakdown_vals)
             # skipped 1 and '' because the limit was 3.
-            self.assertTrue(people["person_null"].uuid in self._get_actor_ids_at_step(filters, 1, "Other"))
+            self.assertTrue(people["person_null"].uuid in self._get_actor_ids_at_step(query, 1, "Other"))
 
         @also_test_with_materialized_columns(["some_breakdown_val"])
         def test_funnel_step_custom_breakdown_limit_with_nulls_included(self):
-            filters = {
-                "insight": INSIGHT_FUNNELS,
-                "funnel_order_type": funnel_order_type,
-                "events": [
-                    {"id": "sign up", "order": 0},
-                    {"id": "play movie", "order": 1},
-                    {"id": "buy", "order": 2},
+            query = FunnelsQuery(
+                breakdownFilter=BreakdownFilter(
+                    breakdown=["some_breakdown_val"],
+                    breakdown_limit=6,
+                ),
+                dateRange=DateRange(
+                    date_from="2020-01-01",
+                    date_to="2020-01-08",
+                ),
+                funnelsFilter=FunnelsFilter(
+                    funnelOrderType=funnel_order_type,
+                ),
+                series=[
+                    EventsNode(
+                        event="sign up",
+                        name="sign up",
+                    ),
+                    EventsNode(
+                        event="play movie",
+                        name="play movie",
+                    ),
+                    EventsNode(
+                        event="buy",
+                        name="buy",
+                    ),
                 ],
-                "date_from": "2020-01-01",
-                "date_to": "2020-01-08",
-                "funnel_window_days": 7,
-                "breakdown_type": "event",
-                "breakdown_limit": 6,
-                "breakdown": ["some_breakdown_val"],
-            }
+            )
 
             events_by_person = {}
             for num in range(5):
@@ -1015,7 +1101,6 @@ def funnel_breakdown_test_factory(funnel_order_type: FunnelOrderType):
             ]
             people = journeys_for(events_by_person, self.team)
 
-            query = cast(FunnelsQuery, filter_to_query(filters))
             results = FunnelsQueryRunner(query=query, team=self.team).calculate().results
 
             breakdown_vals = sorted([res[0]["breakdown"] for res in results])
@@ -1023,25 +1108,37 @@ def funnel_breakdown_test_factory(funnel_order_type: FunnelOrderType):
             # included 1 and '' because the limit was 6.
 
             for i in range(1, 5):
-                self.assertEqual(len(self._get_actor_ids_at_step(filters, 3, str(i))), i)
+                self.assertEqual(len(self._get_actor_ids_at_step(query, 3, str(i))), i)
 
-            self.assertEqual([people["person_null"].uuid], self._get_actor_ids_at_step(filters, 1, ""))
-            self.assertEqual([people["person_null"].uuid], self._get_actor_ids_at_step(filters, 3, ""))
+            self.assertEqual([people["person_null"].uuid], self._get_actor_ids_at_step(query, 1, ""))
+            self.assertEqual([people["person_null"].uuid], self._get_actor_ids_at_step(query, 3, ""))
 
         @also_test_with_materialized_columns(["$browser"])
         def test_funnel_step_breakdown_event_single_person_multiple_breakdowns(self):
-            filters = {
-                "insight": INSIGHT_FUNNELS,
-                "funnel_order_type": funnel_order_type,
-                "events": [{"id": "sign up", "order": 0}, {"id": "other event", "order": 0}],
-                "date_from": "2020-01-01",
-                "date_to": "2020-01-08",
-                "funnel_window_days": 7,
-                "breakdown_type": "event",
-                "breakdown": ["$browser"],
-                "breakdown_attribution_type": "step",
-                "breakdown_attribution_value": "0",
-            }
+            query = FunnelsQuery(
+                breakdownFilter=BreakdownFilter(
+                    breakdown=["$browser"],
+                ),
+                dateRange=DateRange(
+                    date_from="2020-01-01",
+                    date_to="2020-01-08",
+                ),
+                funnelsFilter=FunnelsFilter(
+                    breakdownAttributionType=BreakdownAttributionType.STEP,
+                    breakdownAttributionValue=0,
+                    funnelOrderType=funnel_order_type,
+                ),
+                series=[
+                    EventsNode(
+                        event="sign up",
+                        name="sign up",
+                    ),
+                    EventsNode(
+                        event="other event",
+                        name="other event",
+                    ),
+                ],
+            )
 
             # event
             events_by_person = {
@@ -1071,7 +1168,6 @@ def funnel_breakdown_test_factory(funnel_order_type: FunnelOrderType):
             }
             people = journeys_for(events_by_person, self.team)
 
-            query = cast(FunnelsQuery, filter_to_query(filters))
             results = FunnelsQueryRunner(query=query, team=self.team).calculate().results
             results = sorted(results, key=lambda res: res[0]["breakdown"])
 
@@ -1083,7 +1179,7 @@ def funnel_breakdown_test_factory(funnel_order_type: FunnelOrderType):
                 ],
             )
 
-            self.assertCountEqual(self._get_actor_ids_at_step(filters, 1, "0"), [people["person1"].uuid])
+            self.assertCountEqual(self._get_actor_ids_at_step(query, 1, "0"), [people["person1"].uuid])
 
             self._assert_funnel_breakdown_result_is_correct(
                 results[1],
@@ -1094,7 +1190,7 @@ def funnel_breakdown_test_factory(funnel_order_type: FunnelOrderType):
             )
 
             self.assertCountEqual(
-                self._get_actor_ids_at_step(filters, 1, "Chrome"),
+                self._get_actor_ids_at_step(query, 1, "Chrome"),
                 [people["person1"].uuid],
             )
 
@@ -1106,7 +1202,7 @@ def funnel_breakdown_test_factory(funnel_order_type: FunnelOrderType):
                 ],
             )
 
-            self.assertCountEqual(self._get_actor_ids_at_step(filters, 1, "Mac"), [people["person1"].uuid])
+            self.assertCountEqual(self._get_actor_ids_at_step(query, 1, "Mac"), [people["person1"].uuid])
 
             self._assert_funnel_breakdown_result_is_correct(
                 results[3],
@@ -1117,25 +1213,34 @@ def funnel_breakdown_test_factory(funnel_order_type: FunnelOrderType):
             )
 
             self.assertCountEqual(
-                self._get_actor_ids_at_step(filters, 1, "Safari"),
+                self._get_actor_ids_at_step(query, 1, "Safari"),
                 [people["person1"].uuid],
             )
 
         def test_funnel_step_breakdown_event_single_person_events_with_multiple_properties(self):
-            filters = {
-                "insight": INSIGHT_FUNNELS,
-                "funnel_order_type": funnel_order_type,
-                "events": [
-                    {"id": "sign up", "order": 0},
-                    {"id": "play movie", "order": 1},
+            query = FunnelsQuery(
+                breakdownFilter=BreakdownFilter(
+                    breakdown=["$browser"],
+                ),
+                dateRange=DateRange(
+                    date_from="2020-01-01",
+                    date_to="2020-01-08",
+                ),
+                funnelsFilter=FunnelsFilter(
+                    breakdownAttributionType=BreakdownAttributionType.ALL_EVENTS,
+                    funnelOrderType=funnel_order_type,
+                ),
+                series=[
+                    EventsNode(
+                        event="sign up",
+                        name="sign up",
+                    ),
+                    EventsNode(
+                        event="play movie",
+                        name="play movie",
+                    ),
                 ],
-                "date_from": "2020-01-01",
-                "date_to": "2020-01-08",
-                "funnel_window_days": 7,
-                "breakdown_type": "event",
-                "breakdown": ["$browser"],
-                "breakdown_attribution_type": "all_events",
-            }
+            )
 
             people = journeys_for(
                 {
@@ -1165,7 +1270,6 @@ def funnel_breakdown_test_factory(funnel_order_type: FunnelOrderType):
                 self.team,
             )
 
-            query = cast(FunnelsQuery, filter_to_query(filters))
             results = FunnelsQueryRunner(query=query, team=self.team).calculate().results
 
             self.assertEqual(len(results), 2)
@@ -1185,11 +1289,11 @@ def funnel_breakdown_test_factory(funnel_order_type: FunnelOrderType):
             )
 
             self.assertCountEqual(
-                self._get_actor_ids_at_step(filters, 1, "Safari"),
+                self._get_actor_ids_at_step(query, 1, "Safari"),
                 [people["person1"].uuid],
             )
             self.assertCountEqual(
-                self._get_actor_ids_at_step(filters, 2, "Safari"),
+                self._get_actor_ids_at_step(query, 2, "Safari"),
                 [people["person1"].uuid],
             )
 
@@ -1202,10 +1306,10 @@ def funnel_breakdown_test_factory(funnel_order_type: FunnelOrderType):
             )
 
             self.assertCountEqual(
-                self._get_actor_ids_at_step(filters, 1, "Chrome"),
+                self._get_actor_ids_at_step(query, 1, "Chrome"),
                 [people["person1"].uuid],
             )
-            self.assertCountEqual(self._get_actor_ids_at_step(filters, 2, "Chrome"), [])
+            self.assertCountEqual(self._get_actor_ids_at_step(query, 2, "Chrome"), [])
 
         @also_test_with_materialized_columns(person_properties=["key"], verify_no_jsonextract=False)
         def test_funnel_cohort_breakdown(self):
@@ -1228,25 +1332,36 @@ def funnel_breakdown_test_factory(funnel_order_type: FunnelOrderType):
             )
             cohort.calculate_people_ch(pending_version=0)
 
-            filters = {
-                "insight": INSIGHT_FUNNELS,
-                "funnel_order_type": funnel_order_type,
-                "events": [
-                    {"id": "sign up", "order": 0},
-                    {"id": "play movie", "order": 1},
-                    {"id": "buy", "order": 2},
+            query = FunnelsQuery(
+                breakdownFilter=BreakdownFilter(
+                    breakdown=["all", cohort.pk],
+                    breakdown_type=BreakdownType.COHORT,
+                ),
+                dateRange=DateRange(
+                    date_from="2020-01-01",
+                    date_to="2020-01-08",
+                ),
+                funnelsFilter=FunnelsFilter(
+                    breakdownAttributionType=BreakdownAttributionType.STEP,
+                    breakdownAttributionValue=0,
+                    funnelOrderType=funnel_order_type,
+                ),
+                series=[
+                    EventsNode(
+                        event="sign up",
+                        name="sign up",
+                    ),
+                    EventsNode(
+                        event="play movie",
+                        name="play movie",
+                    ),
+                    EventsNode(
+                        event="buy",
+                        name="buy",
+                    ),
                 ],
-                "date_from": "2020-01-01",
-                "date_to": "2020-01-08",
-                "funnel_window_days": 7,
-                "breakdown_type": "cohort",
-                "breakdown": ["all", cohort.pk],
-                "breakdown_attribution_type": "step",
-                "breakdown_attribution_value": 0,
-                # first touch means same user can't be in 'all' and the other cohort both
-            }
+            )
 
-            query = cast(FunnelsQuery, filter_to_query(filters))
             results = FunnelsQueryRunner(query=query, team=self.team).calculate().results
 
             self.assertEqual(len(results[0]), 3)
@@ -1254,43 +1369,54 @@ def funnel_breakdown_test_factory(funnel_order_type: FunnelOrderType):
             self.assertEqual(len(results[1]), 3)
             self.assertEqual(results[1][0]["breakdown"], "test_cohort")
             self.assertCountEqual(
-                self._get_actor_ids_at_step(filters, 1, cohort.pk),
+                self._get_actor_ids_at_step(query, 1, cohort.pk),
                 [people["person1"].uuid],
             )
-            self.assertCountEqual(self._get_actor_ids_at_step(filters, 2, cohort.pk), [])
+            self.assertCountEqual(self._get_actor_ids_at_step(query, 2, cohort.pk), [])
 
             self.assertCountEqual(
-                self._get_actor_ids_at_step(filters, 1, ALL_USERS_COHORT_ID),
+                self._get_actor_ids_at_step(query, 1, ALL_USERS_COHORT_ID),
                 [people["person1"].uuid],
             )
-            self.assertCountEqual(self._get_actor_ids_at_step(filters, 2, ALL_USERS_COHORT_ID), [])
+            self.assertCountEqual(self._get_actor_ids_at_step(query, 2, ALL_USERS_COHORT_ID), [])
 
             # non array
-            filters = {
-                "events": [
-                    {"id": "sign up", "order": 0},
-                    {"id": "play movie", "order": 1},
-                    {"id": "buy", "order": 2},
+            query = FunnelsQuery(
+                breakdownFilter=BreakdownFilter(
+                    breakdown=cohort.pk,
+                    breakdown_type=BreakdownType.COHORT,
+                ),
+                dateRange=DateRange(
+                    date_from="2020-01-01",
+                    date_to="2020-01-08",
+                ),
+                funnelsFilter=FunnelsFilter(),
+                series=[
+                    EventsNode(
+                        event="sign up",
+                        name="sign up",
+                    ),
+                    EventsNode(
+                        event="play movie",
+                        name="play movie",
+                    ),
+                    EventsNode(
+                        event="buy",
+                        name="buy",
+                    ),
                 ],
-                "insight": INSIGHT_FUNNELS,
-                "date_from": "2020-01-01",
-                "date_to": "2020-01-08",
-                "funnel_window_days": 7,
-                "breakdown_type": "cohort",
-                "breakdown": cohort.pk,
-            }
+            )
 
-            query = cast(FunnelsQuery, filter_to_query(filters))
             results = FunnelsQueryRunner(query=query, team=self.team).calculate().results
 
             self.assertEqual(len(results[0]), 3)
             self.assertEqual(results[0][0]["breakdown"], "test_cohort")
             self.assertEqual(results[0][0]["breakdown_value"], cohort.pk)
             self.assertCountEqual(
-                self._get_actor_ids_at_step(filters, 1, cohort.pk),
+                self._get_actor_ids_at_step(query, 1, cohort.pk),
                 [people["person1"].uuid],
             )
-            self.assertCountEqual(self._get_actor_ids_at_step(filters, 2, cohort.pk), [])
+            self.assertCountEqual(self._get_actor_ids_at_step(query, 2, cohort.pk), [])
 
         def test_funnel_cohort_breakdown_shows_not_in_cohort(self):
             _create_person(
@@ -1325,20 +1451,28 @@ def funnel_breakdown_test_factory(funnel_order_type: FunnelOrderType):
             )
             cohort.calculate_people_ch(pending_version=0)
 
-            filters = {
-                "events": [
-                    {"id": "sign up", "order": 0},
-                    {"id": "play movie", "order": 1},
+            query = FunnelsQuery(
+                breakdownFilter=BreakdownFilter(
+                    breakdown=[cohort.pk],
+                    breakdown_type=BreakdownType.COHORT,
+                ),
+                dateRange=DateRange(
+                    date_from="2020-01-01",
+                    date_to="2020-01-08",
+                ),
+                funnelsFilter=FunnelsFilter(),
+                series=[
+                    EventsNode(
+                        event="sign up",
+                        name="sign up",
+                    ),
+                    EventsNode(
+                        event="play movie",
+                        name="play movie",
+                    ),
                 ],
-                "insight": INSIGHT_FUNNELS,
-                "date_from": "2020-01-01",
-                "date_to": "2020-01-08",
-                "funnel_window_days": 7,
-                "breakdown_type": "cohort",
-                "breakdown": [cohort.pk],
-            }
+            )
 
-            query = cast(FunnelsQuery, filter_to_query(filters))
             results = FunnelsQueryRunner(query=query, team=self.team).calculate().results
 
             assert len(results) == 2
@@ -1389,20 +1523,28 @@ def funnel_breakdown_test_factory(funnel_order_type: FunnelOrderType):
             )
             cohort.calculate_people_ch(pending_version=0)
 
-            filters = {
-                "events": [
-                    {"id": "sign up", "order": 0},
-                    {"id": "play movie", "order": 1},
+            query = FunnelsQuery(
+                breakdownFilter=BreakdownFilter(
+                    breakdown=[cohort.pk],
+                    breakdown_type=BreakdownType.COHORT,
+                ),
+                dateRange=DateRange(
+                    date_from="2020-01-01",
+                    date_to="2020-01-08",
+                ),
+                funnelsFilter=FunnelsFilter(),
+                series=[
+                    EventsNode(
+                        event="sign up",
+                        name="sign up",
+                    ),
+                    EventsNode(
+                        event="play movie",
+                        name="play movie",
+                    ),
                 ],
-                "insight": INSIGHT_FUNNELS,
-                "date_from": "2020-01-01",
-                "date_to": "2020-01-08",
-                "funnel_window_days": 7,
-                "breakdown_type": "cohort",
-                "breakdown": [cohort.pk],
-            }
+            )
 
-            query = cast(FunnelsQuery, filter_to_query(filters))
             results = FunnelsQueryRunner(query=query, team=self.team).calculate().results
 
             assert len(results) == 2
@@ -1441,17 +1583,28 @@ def funnel_breakdown_test_factory(funnel_order_type: FunnelOrderType):
             )
             cohort.calculate_people_ch(pending_version=0)
 
-            filters = {
-                "events": [{"id": "sign up", "order": 0}, {"id": "play movie", "order": 1}],
-                "insight": INSIGHT_FUNNELS,
-                "date_from": "2020-01-01",
-                "date_to": "2020-01-08",
-                "funnel_window_days": 7,
-                "breakdown_type": "cohort",
-                "breakdown": ["all", cohort.pk],
-            }
+            query = FunnelsQuery(
+                breakdownFilter=BreakdownFilter(
+                    breakdown=["all", cohort.pk],
+                    breakdown_type=BreakdownType.COHORT,
+                ),
+                dateRange=DateRange(
+                    date_from="2020-01-01",
+                    date_to="2020-01-08",
+                ),
+                funnelsFilter=FunnelsFilter(),
+                series=[
+                    EventsNode(
+                        event="sign up",
+                        name="sign up",
+                    ),
+                    EventsNode(
+                        event="play movie",
+                        name="play movie",
+                    ),
+                ],
+            )
 
-            query = cast(FunnelsQuery, filter_to_query(filters))
             results = FunnelsQueryRunner(query=query, team=self.team).calculate().results
 
             breakdown_labels = {r[0]["breakdown"] for r in results}
@@ -1485,17 +1638,28 @@ def funnel_breakdown_test_factory(funnel_order_type: FunnelOrderType):
             )
             cohort_b.calculate_people_ch(pending_version=0)
 
-            filters = {
-                "events": [{"id": "sign up", "order": 0}, {"id": "play movie", "order": 1}],
-                "insight": INSIGHT_FUNNELS,
-                "date_from": "2020-01-01",
-                "date_to": "2020-01-08",
-                "funnel_window_days": 7,
-                "breakdown_type": "cohort",
-                "breakdown": [cohort_a.pk, cohort_b.pk],
-            }
+            query = FunnelsQuery(
+                breakdownFilter=BreakdownFilter(
+                    breakdown=[cohort_a.pk, cohort_b.pk],
+                    breakdown_type=BreakdownType.COHORT,
+                ),
+                dateRange=DateRange(
+                    date_from="2020-01-01",
+                    date_to="2020-01-08",
+                ),
+                funnelsFilter=FunnelsFilter(),
+                series=[
+                    EventsNode(
+                        event="sign up",
+                        name="sign up",
+                    ),
+                    EventsNode(
+                        event="play movie",
+                        name="play movie",
+                    ),
+                ],
+            )
 
-            query = cast(FunnelsQuery, filter_to_query(filters))
             results = FunnelsQueryRunner(query=query, team=self.team).calculate().results
 
             breakdown_labels = {r[0]["breakdown"] for r in results}
@@ -1537,25 +1701,34 @@ def funnel_breakdown_test_factory(funnel_order_type: FunnelOrderType):
             )
             cohort.calculate_people_ch(pending_version=0)
 
-            filters = {
-                "events": [
-                    {"id": "sign up", "order": 0},
-                    {"id": "play movie", "order": 1},
+            query = FunnelsQuery(
+                breakdownFilter=BreakdownFilter(
+                    breakdown=[cohort.pk],
+                    breakdown_type=BreakdownType.COHORT,
+                ),
+                dateRange=DateRange(
+                    date_from="2020-01-01",
+                    date_to="2020-01-08",
+                ),
+                funnelsFilter=FunnelsFilter(),
+                series=[
+                    EventsNode(
+                        event="sign up",
+                        name="sign up",
+                    ),
+                    EventsNode(
+                        event="play movie",
+                        name="play movie",
+                    ),
                 ],
-                "insight": INSIGHT_FUNNELS,
-                "date_from": "2020-01-01",
-                "date_to": "2020-01-08",
-                "funnel_window_days": 7,
-                "breakdown_type": "cohort",
-                "breakdown": [cohort.pk],
-            }
+            )
 
             # Actors in the cohort at step 1
-            cohort_actors = self._get_actor_ids_at_step(filters, 1, cohort.pk)
+            cohort_actors = self._get_actor_ids_at_step(query, 1, cohort.pk)
             assert cohort_actors == [person_in_cohort.uuid]
 
             # Actors NOT in the cohort at step 1 (simulates clicking "not in cohort" bar)
-            not_in_cohort_actors = self._get_actor_ids_at_step(filters, 1, NOT_IN_COHORT_ID)
+            not_in_cohort_actors = self._get_actor_ids_at_step(query, 1, NOT_IN_COHORT_ID)
             assert not_in_cohort_actors == [person_outside_cohort.uuid]
 
         def test_funnel_single_cohort_breakdown_first_touch(self):
@@ -1656,32 +1829,36 @@ def funnel_breakdown_test_factory(funnel_order_type: FunnelOrderType):
 
             journeys_for(events_by_person, self.team)
 
-            filters = {
-                "insight": INSIGHT_FUNNELS,
-                "funnel_order_type": funnel_order_type,
-                "events": [
-                    {
-                        "id": "user signed up",
-                        "type": "events",
-                        "order": 0,
-                        "properties": [
-                            {
-                                "key": "$current_url",
-                                "operator": "icontains",
-                                "type": "event",
-                                "value": "https://posthog.com/docs",
-                            }
+            query = FunnelsQuery(
+                breakdownFilter=BreakdownFilter(
+                    breakdown=["$current_url"],
+                ),
+                dateRange=DateRange(
+                    date_from="2020-01-01",
+                    date_to="2020-01-14",
+                ),
+                funnelsFilter=FunnelsFilter(
+                    funnelOrderType=funnel_order_type,
+                ),
+                series=[
+                    EventsNode(
+                        event="user signed up",
+                        name="user signed up",
+                        properties=[
+                            EventPropertyFilter(
+                                key="$current_url",
+                                operator=PropertyOperator.ICONTAINS,
+                                value="https://posthog.com/docs",
+                            ),
                         ],
-                    },
-                    {"id": "paid", "type": "events", "order": 1},
+                    ),
+                    EventsNode(
+                        event="paid",
+                        name="paid",
+                    ),
                 ],
-                "date_from": "2020-01-01",
-                "date_to": "2020-01-14",
-                "breakdown": ["$current_url"],
-                "breakdown_type": "event",
-            }
+            )
 
-            query = cast(FunnelsQuery, filter_to_query(filters))
             results = FunnelsQueryRunner(query=query, team=self.team).calculate().results
 
             self._assert_funnel_breakdown_result_is_correct(
@@ -1733,31 +1910,35 @@ def funnel_breakdown_test_factory(funnel_order_type: FunnelOrderType):
 
             journeys_for(events_by_person, self.team)
 
-            filters = {
-                "insight": INSIGHT_FUNNELS,
-                "funnel_order_type": funnel_order_type,
-                "actions": [
-                    {
-                        "id": user_signed_up_action.id,
-                        "order": 0,
-                        "properties": [
-                            {
-                                "key": "$current_url",
-                                "operator": "icontains",
-                                "type": "event",
-                                "value": "https://posthog.com/docs",
-                            }
+            query = FunnelsQuery(
+                breakdownFilter=BreakdownFilter(
+                    breakdown=["$current_url"],
+                ),
+                dateRange=DateRange(
+                    date_from="2020-01-01",
+                    date_to="2020-01-14",
+                ),
+                funnelsFilter=FunnelsFilter(
+                    funnelOrderType=funnel_order_type,
+                ),
+                series=[
+                    ActionsNode(
+                        id=user_signed_up_action.id,
+                        properties=[
+                            EventPropertyFilter(
+                                key="$current_url",
+                                operator=PropertyOperator.ICONTAINS,
+                                value="https://posthog.com/docs",
+                            ),
                         ],
-                    }
+                    ),
+                    EventsNode(
+                        event="paid",
+                        name="paid",
+                    ),
                 ],
-                "events": [{"id": "paid", "type": "events", "order": 1}],
-                "date_from": "2020-01-01",
-                "date_to": "2020-01-14",
-                "breakdown": ["$current_url"],
-                "breakdown_type": "event",
-            }
+            )
 
-            query = cast(FunnelsQuery, filter_to_query(filters))
             results = FunnelsQueryRunner(query=query, team=self.team).calculate().results
 
             self._assert_funnel_breakdown_result_is_correct(
@@ -1781,17 +1962,28 @@ def funnel_breakdown_test_factory(funnel_order_type: FunnelOrderType):
             )
 
         def test_funnel_step_breakdown_with_first_touch_attribution(self):
-            filters = {
-                "insight": INSIGHT_FUNNELS,
-                "funnel_order_type": funnel_order_type,
-                "events": [{"id": "sign up", "order": 0}, {"id": "buy", "order": 1}],
-                "date_from": "2020-01-01",
-                "date_to": "2020-01-08",
-                "funnel_window_days": 7,
-                "breakdown_type": "event",
-                "breakdown": ["$browser"],
-                "breakdown_attribution_type": "first_touch",
-            }
+            query = FunnelsQuery(
+                breakdownFilter=BreakdownFilter(
+                    breakdown=["$browser"],
+                ),
+                dateRange=DateRange(
+                    date_from="2020-01-01",
+                    date_to="2020-01-08",
+                ),
+                funnelsFilter=FunnelsFilter(
+                    funnelOrderType=funnel_order_type,
+                ),
+                series=[
+                    EventsNode(
+                        event="sign up",
+                        name="sign up",
+                    ),
+                    EventsNode(
+                        event="buy",
+                        name="buy",
+                    ),
+                ],
+            )
 
             # event
             events_by_person = {
@@ -1840,7 +2032,6 @@ def funnel_breakdown_test_factory(funnel_order_type: FunnelOrderType):
             }
             people = journeys_for(events_by_person, self.team)
 
-            query = cast(FunnelsQuery, filter_to_query(filters))
             results = FunnelsQueryRunner(query=query, team=self.team).calculate().results
             results = sorted(results, key=lambda res: res[0]["breakdown"])
 
@@ -1860,7 +2051,7 @@ def funnel_breakdown_test_factory(funnel_order_type: FunnelOrderType):
                 ],
             )
 
-            self.assertCountEqual(self._get_actor_ids_at_step(filters, 1, ""), [people["person5"].uuid])
+            self.assertCountEqual(self._get_actor_ids_at_step(query, 1, ""), [people["person5"].uuid])
 
             self._assert_funnel_breakdown_result_is_correct(
                 results[1],
@@ -1876,7 +2067,7 @@ def funnel_breakdown_test_factory(funnel_order_type: FunnelOrderType):
                 ],
             )
 
-            self.assertCountEqual(self._get_actor_ids_at_step(filters, 1, "0"), [people["person4"].uuid])
+            self.assertCountEqual(self._get_actor_ids_at_step(query, 1, "0"), [people["person4"].uuid])
 
             self._assert_funnel_breakdown_result_is_correct(
                 results[2],
@@ -1893,7 +2084,7 @@ def funnel_breakdown_test_factory(funnel_order_type: FunnelOrderType):
             )
 
             self.assertCountEqual(
-                self._get_actor_ids_at_step(filters, 1, "Chrome"),
+                self._get_actor_ids_at_step(query, 1, "Chrome"),
                 [people["person1"].uuid],
             )
 
@@ -1911,7 +2102,7 @@ def funnel_breakdown_test_factory(funnel_order_type: FunnelOrderType):
                 ],
             )
 
-            self.assertCountEqual(self._get_actor_ids_at_step(filters, 1, "Mac"), [people["person3"].uuid])
+            self.assertCountEqual(self._get_actor_ids_at_step(query, 1, "Mac"), [people["person3"].uuid])
 
             self._assert_funnel_breakdown_result_is_correct(
                 results[4],
@@ -1928,22 +2119,34 @@ def funnel_breakdown_test_factory(funnel_order_type: FunnelOrderType):
             )
 
             self.assertCountEqual(
-                self._get_actor_ids_at_step(filters, 1, "Safari"),
+                self._get_actor_ids_at_step(query, 1, "Safari"),
                 [people["person2"].uuid],
             )
 
         def test_funnel_step_breakdown_with_last_touch_attribution(self):
-            filters = {
-                "insight": INSIGHT_FUNNELS,
-                "funnel_order_type": funnel_order_type,
-                "events": [{"id": "sign up", "order": 0}, {"id": "buy", "order": 1}],
-                "date_from": "2020-01-01",
-                "date_to": "2020-01-08",
-                "funnel_window_days": 7,
-                "breakdown_type": "event",
-                "breakdown": ["$browser"],
-                "breakdown_attribution_type": "last_touch",
-            }
+            query = FunnelsQuery(
+                breakdownFilter=BreakdownFilter(
+                    breakdown=["$browser"],
+                ),
+                dateRange=DateRange(
+                    date_from="2020-01-01",
+                    date_to="2020-01-08",
+                ),
+                funnelsFilter=FunnelsFilter(
+                    breakdownAttributionType=BreakdownAttributionType.LAST_TOUCH,
+                    funnelOrderType=funnel_order_type,
+                ),
+                series=[
+                    EventsNode(
+                        event="sign up",
+                        name="sign up",
+                    ),
+                    EventsNode(
+                        event="buy",
+                        name="buy",
+                    ),
+                ],
+            )
 
             # event
             events_by_person = {
@@ -1992,7 +2195,6 @@ def funnel_breakdown_test_factory(funnel_order_type: FunnelOrderType):
             }
             people = journeys_for(events_by_person, self.team)
 
-            query = cast(FunnelsQuery, filter_to_query(filters))
             results = FunnelsQueryRunner(query=query, team=self.team).calculate().results
             results = sorted(results, key=lambda res: res[0]["breakdown"])
 
@@ -2012,7 +2214,7 @@ def funnel_breakdown_test_factory(funnel_order_type: FunnelOrderType):
                 ],
             )
 
-            self.assertCountEqual(self._get_actor_ids_at_step(filters, 1, ""), [people["person5"].uuid])
+            self.assertCountEqual(self._get_actor_ids_at_step(query, 1, ""), [people["person5"].uuid])
 
             self._assert_funnel_breakdown_result_is_correct(
                 results[1],
@@ -2029,7 +2231,7 @@ def funnel_breakdown_test_factory(funnel_order_type: FunnelOrderType):
             )
 
             self.assertCountEqual(
-                self._get_actor_ids_at_step(filters, 1, "Alakazam"),
+                self._get_actor_ids_at_step(query, 1, "Alakazam"),
                 [people["person4"].uuid],
             )
 
@@ -2048,7 +2250,7 @@ def funnel_breakdown_test_factory(funnel_order_type: FunnelOrderType):
             )
 
             self.assertCountEqual(
-                self._get_actor_ids_at_step(filters, 1, "Chrome"),
+                self._get_actor_ids_at_step(query, 1, "Chrome"),
                 [people["person1"].uuid],
             )
 
@@ -2066,7 +2268,7 @@ def funnel_breakdown_test_factory(funnel_order_type: FunnelOrderType):
                 ],
             )
 
-            self.assertCountEqual(self._get_actor_ids_at_step(filters, 1, "Mac"), [people["person3"].uuid])
+            self.assertCountEqual(self._get_actor_ids_at_step(query, 1, "Mac"), [people["person3"].uuid])
 
             self._assert_funnel_breakdown_result_is_correct(
                 results[4],
@@ -2083,23 +2285,35 @@ def funnel_breakdown_test_factory(funnel_order_type: FunnelOrderType):
             )
 
             self.assertCountEqual(
-                self._get_actor_ids_at_step(filters, 1, "Safari"),
+                self._get_actor_ids_at_step(query, 1, "Safari"),
                 [people["person2"].uuid],
             )
 
         def test_funnel_step_breakdown_with_step_attribution(self):
-            filters = {
-                "insight": INSIGHT_FUNNELS,
-                "funnel_order_type": funnel_order_type,
-                "events": [{"id": "sign up", "order": 0}, {"id": "buy", "order": 1}],
-                "date_from": "2020-01-01",
-                "date_to": "2020-01-08",
-                "funnel_window_days": 7,
-                "breakdown_type": "event",
-                "breakdown": ["$browser"],
-                "breakdown_attribution_type": "step",
-                "breakdown_attribution_value": "0",
-            }
+            query = FunnelsQuery(
+                breakdownFilter=BreakdownFilter(
+                    breakdown=["$browser"],
+                ),
+                dateRange=DateRange(
+                    date_from="2020-01-01",
+                    date_to="2020-01-08",
+                ),
+                funnelsFilter=FunnelsFilter(
+                    breakdownAttributionType=BreakdownAttributionType.STEP,
+                    breakdownAttributionValue=0,
+                    funnelOrderType=funnel_order_type,
+                ),
+                series=[
+                    EventsNode(
+                        event="sign up",
+                        name="sign up",
+                    ),
+                    EventsNode(
+                        event="buy",
+                        name="buy",
+                    ),
+                ],
+            )
 
             # event
             events_by_person = {
@@ -2143,7 +2357,6 @@ def funnel_breakdown_test_factory(funnel_order_type: FunnelOrderType):
             }
             people = journeys_for(events_by_person, self.team)
 
-            query = cast(FunnelsQuery, filter_to_query(filters))
             results = FunnelsQueryRunner(query=query, team=self.team).calculate().results
             results = sorted(results, key=lambda res: res[0]["breakdown"])
 
@@ -2163,7 +2376,7 @@ def funnel_breakdown_test_factory(funnel_order_type: FunnelOrderType):
                 ],
             )
 
-            self.assertCountEqual(self._get_actor_ids_at_step(filters, 1, ""), [people["person2"].uuid])
+            self.assertCountEqual(self._get_actor_ids_at_step(query, 1, ""), [people["person2"].uuid])
 
             self._assert_funnel_breakdown_result_is_correct(
                 results[1],
@@ -2179,7 +2392,7 @@ def funnel_breakdown_test_factory(funnel_order_type: FunnelOrderType):
                 ],
             )
 
-            self.assertCountEqual(self._get_actor_ids_at_step(filters, 1, "0"), [people["person4"].uuid])
+            self.assertCountEqual(self._get_actor_ids_at_step(query, 1, "0"), [people["person4"].uuid])
 
             self._assert_funnel_breakdown_result_is_correct(
                 results[2],
@@ -2196,7 +2409,7 @@ def funnel_breakdown_test_factory(funnel_order_type: FunnelOrderType):
             )
 
             self.assertCountEqual(
-                self._get_actor_ids_at_step(filters, 1, "Chrome"),
+                self._get_actor_ids_at_step(query, 1, "Chrome"),
                 [people["person1"].uuid],
             )
 
@@ -2214,21 +2427,33 @@ def funnel_breakdown_test_factory(funnel_order_type: FunnelOrderType):
                 ],
             )
 
-            self.assertCountEqual(self._get_actor_ids_at_step(filters, 1, "Mac"), [people["person3"].uuid])
+            self.assertCountEqual(self._get_actor_ids_at_step(query, 1, "Mac"), [people["person3"].uuid])
 
         def test_funnel_step_breakdown_with_step_one_attribution(self):
-            filters = {
-                "insight": INSIGHT_FUNNELS,
-                "funnel_order_type": funnel_order_type,
-                "events": [{"id": "sign up", "order": 0}, {"id": "buy", "order": 1}],
-                "date_from": "2020-01-01",
-                "date_to": "2020-01-08",
-                "funnel_window_days": 7,
-                "breakdown_type": "event",
-                "breakdown": ["$browser"],
-                "breakdown_attribution_type": "step",
-                "breakdown_attribution_value": "1",
-            }
+            query = FunnelsQuery(
+                breakdownFilter=BreakdownFilter(
+                    breakdown=["$browser"],
+                ),
+                dateRange=DateRange(
+                    date_from="2020-01-01",
+                    date_to="2020-01-08",
+                ),
+                funnelsFilter=FunnelsFilter(
+                    breakdownAttributionType=BreakdownAttributionType.STEP,
+                    breakdownAttributionValue=1,
+                    funnelOrderType=funnel_order_type,
+                ),
+                series=[
+                    EventsNode(
+                        event="sign up",
+                        name="sign up",
+                    ),
+                    EventsNode(
+                        event="buy",
+                        name="buy",
+                    ),
+                ],
+            )
 
             # event
             events_by_person = {
@@ -2272,7 +2497,6 @@ def funnel_breakdown_test_factory(funnel_order_type: FunnelOrderType):
             }
             people = journeys_for(events_by_person, self.team)
 
-            query = cast(FunnelsQuery, filter_to_query(filters))
             results = FunnelsQueryRunner(query=query, team=self.team).calculate().results
             results = sorted(results, key=lambda res: res[0]["breakdown"])
 
@@ -2294,7 +2518,7 @@ def funnel_breakdown_test_factory(funnel_order_type: FunnelOrderType):
             )
 
             self.assertCountEqual(
-                self._get_actor_ids_at_step(filters, 1, ""),
+                self._get_actor_ids_at_step(query, 1, ""),
                 [people["person1"].uuid, people["person3"].uuid],
             )
 
@@ -2313,7 +2537,7 @@ def funnel_breakdown_test_factory(funnel_order_type: FunnelOrderType):
             )
 
             self.assertCountEqual(
-                self._get_actor_ids_at_step(filters, 1, "Safari"),
+                self._get_actor_ids_at_step(query, 1, "Safari"),
                 [people["person2"].uuid],
             )
 
@@ -2332,22 +2556,33 @@ def funnel_breakdown_test_factory(funnel_order_type: FunnelOrderType):
             )
 
             self.assertCountEqual(
-                self._get_actor_ids_at_step(filters, 1, "alakazam"),
+                self._get_actor_ids_at_step(query, 1, "alakazam"),
                 [people["person4"].uuid],
             )
 
         def test_funnel_step_multiple_breakdown_with_first_touch_attribution(self):
-            filters = {
-                "insight": INSIGHT_FUNNELS,
-                "funnel_order_type": funnel_order_type,
-                "events": [{"id": "sign up", "order": 0}, {"id": "buy", "order": 1}],
-                "date_from": "2020-01-01",
-                "date_to": "2020-01-08",
-                "funnel_window_days": 7,
-                "breakdown_type": "event",
-                "breakdown": ["$browser", "$version"],
-                "breakdown_attribution_type": "first_touch",
-            }
+            query = FunnelsQuery(
+                breakdownFilter=BreakdownFilter(
+                    breakdown=["$browser", "$version"],
+                ),
+                dateRange=DateRange(
+                    date_from="2020-01-01",
+                    date_to="2020-01-08",
+                ),
+                funnelsFilter=FunnelsFilter(
+                    funnelOrderType=funnel_order_type,
+                ),
+                series=[
+                    EventsNode(
+                        event="sign up",
+                        name="sign up",
+                    ),
+                    EventsNode(
+                        event="buy",
+                        name="buy",
+                    ),
+                ],
+            )
 
             # event
             events_by_person = {
@@ -2399,7 +2634,6 @@ def funnel_breakdown_test_factory(funnel_order_type: FunnelOrderType):
             }
             people = journeys_for(events_by_person, self.team)
 
-            query = cast(FunnelsQuery, filter_to_query(filters))
             results = FunnelsQueryRunner(query=query, team=self.team).calculate().results
             results = sorted(results, key=lambda res: res[0]["breakdown"])
 
@@ -2420,7 +2654,7 @@ def funnel_breakdown_test_factory(funnel_order_type: FunnelOrderType):
             )
 
             self.assertCountEqual(
-                self._get_actor_ids_at_step(filters, 1, ["", ""]),
+                self._get_actor_ids_at_step(query, 1, ["", ""]),
                 [people["person5"].uuid],
             )
 
@@ -2438,7 +2672,7 @@ def funnel_breakdown_test_factory(funnel_order_type: FunnelOrderType):
                 ],
             )
             self.assertCountEqual(
-                self._get_actor_ids_at_step(filters, 1, ["0", "0"]),
+                self._get_actor_ids_at_step(query, 1, ["0", "0"]),
                 [people["person4"].uuid],
             )
 
@@ -2457,7 +2691,7 @@ def funnel_breakdown_test_factory(funnel_order_type: FunnelOrderType):
             )
 
             self.assertCountEqual(
-                self._get_actor_ids_at_step(filters, 1, ["Chrome", "xyz"]),
+                self._get_actor_ids_at_step(query, 1, ["Chrome", "xyz"]),
                 [people["person1"].uuid],
             )
 
@@ -2476,7 +2710,7 @@ def funnel_breakdown_test_factory(funnel_order_type: FunnelOrderType):
             )
 
             self.assertCountEqual(
-                self._get_actor_ids_at_step(filters, 1, ["Mac", ""]),
+                self._get_actor_ids_at_step(query, 1, ["Mac", ""]),
                 [people["person3"].uuid],
             )
 
@@ -2495,22 +2729,33 @@ def funnel_breakdown_test_factory(funnel_order_type: FunnelOrderType):
             )
 
             self.assertCountEqual(
-                self._get_actor_ids_at_step(filters, 1, ["Safari", "xyz"]),
+                self._get_actor_ids_at_step(query, 1, ["Safari", "xyz"]),
                 [people["person2"].uuid],
             )
 
         def test_funnel_step_multiple_breakdown_with_first_touch_attribution_incomplete_funnel(self):
-            filters = {
-                "insight": INSIGHT_FUNNELS,
-                "funnel_order_type": funnel_order_type,
-                "events": [{"id": "sign up", "order": 0}, {"id": "buy", "order": 1}],
-                "date_from": "2020-01-01",
-                "date_to": "2020-01-08",
-                "funnel_window_days": 7,
-                "breakdown_type": "event",
-                "breakdown": ["$browser", "$version"],
-                "breakdown_attribution_type": "first_touch",
-            }
+            query = FunnelsQuery(
+                breakdownFilter=BreakdownFilter(
+                    breakdown=["$browser", "$version"],
+                ),
+                dateRange=DateRange(
+                    date_from="2020-01-01",
+                    date_to="2020-01-08",
+                ),
+                funnelsFilter=FunnelsFilter(
+                    funnelOrderType=funnel_order_type,
+                ),
+                series=[
+                    EventsNode(
+                        event="sign up",
+                        name="sign up",
+                    ),
+                    EventsNode(
+                        event="buy",
+                        name="buy",
+                    ),
+                ],
+            )
 
             # event
             events_by_person = {
@@ -2554,7 +2799,6 @@ def funnel_breakdown_test_factory(funnel_order_type: FunnelOrderType):
             }
             people = journeys_for(events_by_person, self.team)
 
-            query = cast(FunnelsQuery, filter_to_query(filters))
             results = FunnelsQueryRunner(query=query, team=self.team).calculate().results
             results = sorted(results, key=lambda res: res[0]["breakdown"])
 
@@ -2575,7 +2819,7 @@ def funnel_breakdown_test_factory(funnel_order_type: FunnelOrderType):
             )
 
             self.assertCountEqual(
-                self._get_actor_ids_at_step(filters, 1, ["", ""]),
+                self._get_actor_ids_at_step(query, 1, ["", ""]),
                 [people["person5"].uuid],
             )
 
@@ -2587,7 +2831,7 @@ def funnel_breakdown_test_factory(funnel_order_type: FunnelOrderType):
                 ],
             )
             self.assertCountEqual(
-                self._get_actor_ids_at_step(filters, 1, ["0", "0"]),
+                self._get_actor_ids_at_step(query, 1, ["0", "0"]),
                 [people["person4"].uuid],
             )
 
@@ -2606,7 +2850,7 @@ def funnel_breakdown_test_factory(funnel_order_type: FunnelOrderType):
             )
 
             self.assertCountEqual(
-                self._get_actor_ids_at_step(filters, 1, ["Chrome", "xyz"]),
+                self._get_actor_ids_at_step(query, 1, ["Chrome", "xyz"]),
                 [people["person1"].uuid],
             )
 
@@ -2619,10 +2863,10 @@ def funnel_breakdown_test_factory(funnel_order_type: FunnelOrderType):
             )
 
             self.assertCountEqual(
-                self._get_actor_ids_at_step(filters, 1, ["Mac", ""]),
+                self._get_actor_ids_at_step(query, 1, ["Mac", ""]),
                 [people["person3"].uuid],
             )
-            self.assertCountEqual(self._get_actor_ids_at_step(filters, 2, ["Mac", ""]), [])
+            self.assertCountEqual(self._get_actor_ids_at_step(query, 2, ["Mac", ""]), [])
 
             self._assert_funnel_breakdown_result_is_correct(
                 results[4],
@@ -2639,23 +2883,35 @@ def funnel_breakdown_test_factory(funnel_order_type: FunnelOrderType):
             )
 
             self.assertCountEqual(
-                self._get_actor_ids_at_step(filters, 1, ["Safari", "xyz"]),
+                self._get_actor_ids_at_step(query, 1, ["Safari", "xyz"]),
                 [people["person2"].uuid],
             )
 
         def test_funnel_step_breakdown_with_step_one_attribution_incomplete_funnel(self):
-            filters = {
-                "insight": INSIGHT_FUNNELS,
-                "funnel_order_type": funnel_order_type,
-                "events": [{"id": "sign up", "order": 0}, {"id": "buy", "order": 1}],
-                "date_from": "2020-01-01",
-                "date_to": "2020-01-08",
-                "funnel_window_days": 7,
-                "breakdown_type": "event",
-                "breakdown": ["$browser"],
-                "breakdown_attribution_type": "step",
-                "breakdown_attribution_value": "1",
-            }
+            query = FunnelsQuery(
+                breakdownFilter=BreakdownFilter(
+                    breakdown=["$browser"],
+                ),
+                dateRange=DateRange(
+                    date_from="2020-01-01",
+                    date_to="2020-01-08",
+                ),
+                funnelsFilter=FunnelsFilter(
+                    breakdownAttributionType=BreakdownAttributionType.STEP,
+                    breakdownAttributionValue=1,
+                    funnelOrderType=funnel_order_type,
+                ),
+                series=[
+                    EventsNode(
+                        event="sign up",
+                        name="sign up",
+                    ),
+                    EventsNode(
+                        event="buy",
+                        name="buy",
+                    ),
+                ],
+            )
 
             # event
             events_by_person = {
@@ -2695,7 +2951,6 @@ def funnel_breakdown_test_factory(funnel_order_type: FunnelOrderType):
             }
             people = journeys_for(events_by_person, self.team)
 
-            query = cast(FunnelsQuery, filter_to_query(filters))
             results = FunnelsQueryRunner(query=query, team=self.team).calculate().results
             results = sorted(results, key=lambda res: res[0]["breakdown"])
 
@@ -2717,7 +2972,7 @@ def funnel_breakdown_test_factory(funnel_order_type: FunnelOrderType):
                 ],
             )
 
-            self.assertCountEqual(self._get_actor_ids_at_step(filters, 1, ""), [people["person1"].uuid])
+            self.assertCountEqual(self._get_actor_ids_at_step(query, 1, ""), [people["person1"].uuid])
 
             self._assert_funnel_breakdown_result_is_correct(
                 results[1],
@@ -2734,23 +2989,35 @@ def funnel_breakdown_test_factory(funnel_order_type: FunnelOrderType):
             )
 
             self.assertCountEqual(
-                self._get_actor_ids_at_step(filters, 1, "alakazam"),
+                self._get_actor_ids_at_step(query, 1, "alakazam"),
                 [people["person4"].uuid],
             )
 
         def test_funnel_step_non_array_breakdown_with_step_one_attribution_incomplete_funnel(self):
-            filters = {
-                "insight": INSIGHT_FUNNELS,
-                "funnel_order_type": funnel_order_type,
-                "events": [{"id": "sign up", "order": 0}, {"id": "buy", "order": 1}],
-                "date_from": "2020-01-01",
-                "date_to": "2020-01-08",
-                "funnel_window_days": 7,
-                "breakdown_type": "event",
-                "breakdown": "$browser",
-                "breakdown_attribution_type": "step",
-                "breakdown_attribution_value": "1",
-            }
+            query = FunnelsQuery(
+                breakdownFilter=BreakdownFilter(
+                    breakdown="$browser",
+                ),
+                dateRange=DateRange(
+                    date_from="2020-01-01",
+                    date_to="2020-01-08",
+                ),
+                funnelsFilter=FunnelsFilter(
+                    breakdownAttributionType=BreakdownAttributionType.STEP,
+                    breakdownAttributionValue=1,
+                    funnelOrderType=funnel_order_type,
+                ),
+                series=[
+                    EventsNode(
+                        event="sign up",
+                        name="sign up",
+                    ),
+                    EventsNode(
+                        event="buy",
+                        name="buy",
+                    ),
+                ],
+            )
 
             # event
             events_by_person = {
@@ -2790,7 +3057,6 @@ def funnel_breakdown_test_factory(funnel_order_type: FunnelOrderType):
             }
             people = journeys_for(events_by_person, self.team)
 
-            query = cast(FunnelsQuery, filter_to_query(filters))
             results = FunnelsQueryRunner(query=query, team=self.team).calculate().results
             results = sorted(results, key=lambda res: res[0]["breakdown"])
 
@@ -2812,7 +3078,7 @@ def funnel_breakdown_test_factory(funnel_order_type: FunnelOrderType):
                 ],
             )
 
-            self.assertCountEqual(self._get_actor_ids_at_step(filters, 1, ""), [people["person1"].uuid])
+            self.assertCountEqual(self._get_actor_ids_at_step(query, 1, ""), [people["person1"].uuid])
 
             self._assert_funnel_breakdown_result_is_correct(
                 results[1],
@@ -2829,7 +3095,7 @@ def funnel_breakdown_test_factory(funnel_order_type: FunnelOrderType):
             )
 
             self.assertCountEqual(
-                self._get_actor_ids_at_step(filters, 1, "alakazam"),
+                self._get_actor_ids_at_step(query, 1, "alakazam"),
                 [people["person4"].uuid],
             )
 
@@ -2837,17 +3103,28 @@ def funnel_breakdown_test_factory(funnel_order_type: FunnelOrderType):
         def test_funnel_step_multiple_breakdown_snapshot(self):
             # No person querying here, so snapshots are more legible
 
-            filters = {
-                "insight": INSIGHT_FUNNELS,
-                "funnel_order_type": funnel_order_type,
-                "events": [{"id": "sign up", "order": 0}, {"id": "buy", "order": 1}],
-                "date_from": "2020-01-01",
-                "date_to": "2020-01-08",
-                "funnel_window_days": 7,
-                "breakdown_type": "event",
-                "breakdown": ["$browser", "$version"],
-                "breakdown_attribution_type": "first_touch",
-            }
+            query = FunnelsQuery(
+                breakdownFilter=BreakdownFilter(
+                    breakdown=["$browser", "$version"],
+                ),
+                dateRange=DateRange(
+                    date_from="2020-01-01",
+                    date_to="2020-01-08",
+                ),
+                funnelsFilter=FunnelsFilter(
+                    funnelOrderType=funnel_order_type,
+                ),
+                series=[
+                    EventsNode(
+                        event="sign up",
+                        name="sign up",
+                    ),
+                    EventsNode(
+                        event="buy",
+                        name="buy",
+                    ),
+                ],
+            )
 
             # event
             events_by_person = {
@@ -2899,7 +3176,6 @@ def funnel_breakdown_test_factory(funnel_order_type: FunnelOrderType):
             }
             journeys_for(events_by_person, self.team)
 
-            query = cast(FunnelsQuery, filter_to_query(filters))
             results = FunnelsQueryRunner(query=query, team=self.team).calculate().results
             results = sorted(results, key=lambda res: res[0]["breakdown"])
 
@@ -2909,24 +3185,34 @@ def funnel_breakdown_test_factory(funnel_order_type: FunnelOrderType):
         def test_funnel_breakdown_correct_breakdown_props_are_chosen(self):
             # No person querying here, so snapshots are more legible
 
-            filters = {
-                "insight": INSIGHT_FUNNELS,
-                "funnel_order_type": funnel_order_type,
-                "events": [
-                    {"id": "sign up", "order": 0},
-                    {
-                        "id": "buy",
-                        "properties": [{"type": "event", "key": "$version", "value": "xyz"}],
-                        "order": 1,
-                    },
+            query = FunnelsQuery(
+                breakdownFilter=BreakdownFilter(
+                    breakdown="$browser",
+                ),
+                dateRange=DateRange(
+                    date_from="2020-01-01",
+                    date_to="2020-01-08",
+                ),
+                funnelsFilter=FunnelsFilter(
+                    funnelOrderType=funnel_order_type,
+                ),
+                series=[
+                    EventsNode(
+                        event="sign up",
+                        name="sign up",
+                    ),
+                    EventsNode(
+                        event="buy",
+                        name="buy",
+                        properties=[
+                            EventPropertyFilter(
+                                key="$version",
+                                value="xyz",
+                            ),
+                        ],
+                    ),
                 ],
-                "date_from": "2020-01-01",
-                "date_to": "2020-01-08",
-                "funnel_window_days": 7,
-                "breakdown_type": "event",
-                "breakdown": "$browser",
-                "breakdown_attribution_type": "first_touch",
-            }
+            )
 
             # event
             events_by_person = {
@@ -2971,7 +3257,6 @@ def funnel_breakdown_test_factory(funnel_order_type: FunnelOrderType):
             }
             journeys_for(events_by_person, self.team)
 
-            query = cast(FunnelsQuery, filter_to_query(filters))
             results = FunnelsQueryRunner(query=query, team=self.team).calculate().results
             results = sorted(results, key=lambda res: res[0]["breakdown"])
 
@@ -2986,25 +3271,36 @@ def funnel_breakdown_test_factory(funnel_order_type: FunnelOrderType):
         def test_funnel_breakdown_correct_breakdown_props_are_chosen_for_step(self):
             # No person querying here, so snapshots are more legible
 
-            filters = {
-                "insight": INSIGHT_FUNNELS,
-                "funnel_order_type": funnel_order_type,
-                "events": [
-                    {"id": "sign up", "order": 0},
-                    {
-                        "id": "buy",
-                        "properties": [{"type": "event", "key": "$version", "value": "xyz"}],
-                        "order": 1,
-                    },
+            query = FunnelsQuery(
+                breakdownFilter=BreakdownFilter(
+                    breakdown="$browser",
+                ),
+                dateRange=DateRange(
+                    date_from="2020-01-01",
+                    date_to="2020-01-08",
+                ),
+                funnelsFilter=FunnelsFilter(
+                    breakdownAttributionType=BreakdownAttributionType.STEP,
+                    breakdownAttributionValue=1,
+                    funnelOrderType=funnel_order_type,
+                ),
+                series=[
+                    EventsNode(
+                        event="sign up",
+                        name="sign up",
+                    ),
+                    EventsNode(
+                        event="buy",
+                        name="buy",
+                        properties=[
+                            EventPropertyFilter(
+                                key="$version",
+                                value="xyz",
+                            ),
+                        ],
+                    ),
                 ],
-                "date_from": "2020-01-01",
-                "date_to": "2020-01-08",
-                "funnel_window_days": 7,
-                "breakdown_type": "event",
-                "breakdown": "$browser",
-                "breakdown_attribution_type": "step",
-                "breakdown_attribution_value": "1",
-            }
+            )
 
             # event
             events_by_person = {
@@ -3049,7 +3345,6 @@ def funnel_breakdown_test_factory(funnel_order_type: FunnelOrderType):
             }
             journeys_for(events_by_person, self.team)
 
-            query = cast(FunnelsQuery, filter_to_query(filters))
             results = FunnelsQueryRunner(query=query, team=self.team).calculate().results
             results = sorted(results, key=lambda res: res[0]["breakdown"])
 
@@ -3058,20 +3353,30 @@ def funnel_breakdown_test_factory(funnel_order_type: FunnelOrderType):
             self.assertCountEqual([res[0]["breakdown"] for res in results], [["Mac"], ["Safari"]])
 
         def test_funnel_step_breakdown_with_first_time_for_user_math(self):
-            filters = {
-                "insight": INSIGHT_FUNNELS,
-                "funnel_order_type": funnel_order_type,
-                "events": [
-                    {"id": "sign up", "order": 0, "math": BaseMathType.FIRST_TIME_FOR_USER},
-                    {"id": "play movie", "order": 1},
+            query = FunnelsQuery(
+                breakdownFilter=BreakdownFilter(
+                    breakdown=["$browser"],
+                ),
+                dateRange=DateRange(
+                    date_from="2020-01-01",
+                    date_to="2020-01-08",
+                ),
+                funnelsFilter=FunnelsFilter(
+                    breakdownAttributionType=BreakdownAttributionType.ALL_EVENTS,
+                    funnelOrderType=funnel_order_type,
+                ),
+                series=[
+                    EventsNode(
+                        event="sign up",
+                        math=BaseMathType.FIRST_TIME_FOR_USER,
+                        name="sign up",
+                    ),
+                    EventsNode(
+                        event="play movie",
+                        name="play movie",
+                    ),
                 ],
-                "date_from": "2020-01-01",
-                "date_to": "2020-01-08",
-                "funnel_window_days": 7,
-                "breakdown_type": "event",
-                "breakdown": ["$browser"],
-                "breakdown_attribution_type": "all_events",
-            }
+            )
 
             people = journeys_for(
                 {
@@ -3101,7 +3406,6 @@ def funnel_breakdown_test_factory(funnel_order_type: FunnelOrderType):
                 self.team,
             )
 
-            query = cast(FunnelsQuery, filter_to_query(filters))
             results = FunnelsQueryRunner(query=query, team=self.team).calculate().results
 
             self.assertEqual(len(results), 1)
@@ -3120,11 +3424,11 @@ def funnel_breakdown_test_factory(funnel_order_type: FunnelOrderType):
             )
 
             self.assertCountEqual(
-                self._get_actor_ids_at_step(filters, 1, "Safari"),
+                self._get_actor_ids_at_step(query, 1, "Safari"),
                 [people["person1"].uuid],
             )
             self.assertCountEqual(
-                self._get_actor_ids_at_step(filters, 2, "Safari"),
+                self._get_actor_ids_at_step(query, 2, "Safari"),
                 [people["person1"].uuid],
             )
 
@@ -3548,9 +3852,14 @@ def funnel_breakdown_test_factory(funnel_order_type: FunnelOrderType):
 
 def funnel_breakdown_group_test_factory(funnel_order_type: FunnelOrderType):
     class TestFunnelBreakdownGroup(APIBaseTest):
-        def _get_actor_ids_at_step(self, filter, funnel_step, breakdown_value=None):
-            actors = get_actors_legacy_filters(
-                filter,
+        def _get_actor_ids_at_step(
+            self,
+            query: FunnelsQuery,
+            funnel_step: int,
+            breakdown_value: Optional[str | float | list[str | float]] = None,
+        ) -> list[str]:
+            actors = get_actors(
+                query,
                 self.team,
                 funnel_step=funnel_step,
                 funnel_step_breakdown=breakdown_value,
@@ -3660,23 +3969,35 @@ def funnel_breakdown_group_test_factory(funnel_order_type: FunnelOrderType):
                 self.team,
             )
 
-            filters = {
-                "events": [
-                    {"id": "sign up", "order": 0},
-                    {"id": "play movie", "order": 1},
-                    {"id": "buy", "order": 2},
+            query = FunnelsQuery(
+                breakdownFilter=BreakdownFilter(
+                    breakdown="industry",
+                    breakdown_group_type_index=0,
+                    breakdown_type=BreakdownType.GROUP,
+                ),
+                dateRange=DateRange(
+                    date_from="2020-01-01",
+                    date_to="2020-01-08",
+                ),
+                funnelsFilter=FunnelsFilter(
+                    funnelOrderType=funnel_order_type,
+                ),
+                series=[
+                    EventsNode(
+                        event="sign up",
+                        name="sign up",
+                    ),
+                    EventsNode(
+                        event="play movie",
+                        name="play movie",
+                    ),
+                    EventsNode(
+                        event="buy",
+                        name="buy",
+                    ),
                 ],
-                "insight": INSIGHT_FUNNELS,
-                "date_from": "2020-01-01",
-                "date_to": "2020-01-08",
-                "funnel_window_days": 7,
-                "breakdown": "industry",
-                "breakdown_type": "group",
-                "breakdown_group_type_index": 0,
-                "funnel_order_type": funnel_order_type,
-            }
+            )
 
-            query = cast(FunnelsQuery, filter_to_query(filters))
             results = FunnelsQueryRunner(query=query, team=self.team).calculate().results
 
             self._assert_funnel_breakdown_result_is_correct(
@@ -3702,11 +4023,11 @@ def funnel_breakdown_group_test_factory(funnel_order_type: FunnelOrderType):
 
             # Querying persons when aggregating by persons should be ok, despite group breakdown
             self.assertCountEqual(
-                self._get_actor_ids_at_step(filters, 1, "finance"),
+                self._get_actor_ids_at_step(query, 1, "finance"),
                 [people["person1"].uuid],
             )
             self.assertCountEqual(
-                self._get_actor_ids_at_step(filters, 2, "finance"),
+                self._get_actor_ids_at_step(query, 2, "finance"),
                 [people["person1"].uuid],
             )
 
@@ -3726,11 +4047,11 @@ def funnel_breakdown_group_test_factory(funnel_order_type: FunnelOrderType):
             )
 
             self.assertCountEqual(
-                self._get_actor_ids_at_step(filters, 1, "technology"),
+                self._get_actor_ids_at_step(query, 1, "technology"),
                 [people["person2"].uuid, people["person3"].uuid],
             )
             self.assertCountEqual(
-                self._get_actor_ids_at_step(filters, 2, "technology"),
+                self._get_actor_ids_at_step(query, 2, "technology"),
                 [people["person2"].uuid],
             )
 
@@ -3781,24 +4102,36 @@ def funnel_breakdown_group_test_factory(funnel_order_type: FunnelOrderType):
                 self.team,
             )
 
-            filters = {
-                "events": [
-                    {"id": "sign up", "order": 0},
-                    {"id": "play movie", "order": 1},
-                    {"id": "buy", "order": 2},
+            query = FunnelsQuery(
+                aggregation_group_type_index=0,
+                breakdownFilter=BreakdownFilter(
+                    breakdown="industry",
+                    breakdown_group_type_index=0,
+                    breakdown_type=BreakdownType.GROUP,
+                ),
+                dateRange=DateRange(
+                    date_from="2020-01-01",
+                    date_to="2020-01-08",
+                ),
+                funnelsFilter=FunnelsFilter(
+                    funnelOrderType=funnel_order_type,
+                ),
+                series=[
+                    EventsNode(
+                        event="sign up",
+                        name="sign up",
+                    ),
+                    EventsNode(
+                        event="play movie",
+                        name="play movie",
+                    ),
+                    EventsNode(
+                        event="buy",
+                        name="buy",
+                    ),
                 ],
-                "insight": INSIGHT_FUNNELS,
-                "date_from": "2020-01-01",
-                "date_to": "2020-01-08",
-                "funnel_window_days": 7,
-                "breakdown": "industry",
-                "breakdown_type": "group",
-                "breakdown_group_type_index": 0,
-                "aggregation_group_type_index": 0,
-                "funnel_order_type": funnel_order_type,
-            }
+            )
 
-            query = cast(FunnelsQuery, filter_to_query(filters))
             results = FunnelsQueryRunner(query=query, team=self.team).calculate().results
 
             self._assert_funnel_breakdown_result_is_correct(
@@ -3890,24 +4223,37 @@ def funnel_breakdown_group_test_factory(funnel_order_type: FunnelOrderType):
                 self.team,
             )
 
-            filters = {
-                "events": [
-                    {"id": "sign up", "order": 0},
-                    {"id": "play movie", "order": 1},
-                    {"id": "buy", "order": 2},
+            query = FunnelsQuery(
+                aggregation_group_type_index=0,
+                breakdownFilter=BreakdownFilter(
+                    breakdown="industry",
+                    breakdown_group_type_index=0,
+                    breakdown_type=BreakdownType.GROUP,
+                ),
+                dateRange=DateRange(
+                    date_from="2020-01-01",
+                    date_to="2020-01-08",
+                ),
+                funnelsFilter=FunnelsFilter(
+                    funnelOrderType=funnel_order_type,
+                ),
+                series=[
+                    EventsNode(
+                        event="sign up",
+                        name="sign up",
+                    ),
+                    EventsNode(
+                        event="play movie",
+                        name="play movie",
+                    ),
+                    EventsNode(
+                        event="buy",
+                        name="buy",
+                    ),
                 ],
-                "insight": INSIGHT_FUNNELS,
-                "date_from": "2020-01-01",
-                "date_to": "2020-01-08",
-                "funnel_window_days": 7,
-                "breakdown": "industry",
-                "breakdown_type": "group",
-                "breakdown_group_type_index": 0,
-                "aggregation_group_type_index": 0,
-                "funnel_order_type": funnel_order_type,
-            }
+            )
+
             with override_instance_config("PERSON_ON_EVENTS_ENABLED", True):
-                query = cast(FunnelsQuery, filter_to_query(filters))
                 results = FunnelsQueryRunner(query=query, team=self.team).calculate().results
 
             self._assert_funnel_breakdown_result_is_correct(

--- a/posthog/hogql_queries/insights/funnels/test/test_funnel_strict.py
+++ b/posthog/hogql_queries/insights/funnels/test/test_funnel_strict.py
@@ -123,8 +123,8 @@ class TestFunnelStrictStepsBreakdown(
                 },
             ],
         )
-        self.assertCountEqual(self._get_actor_ids_at_step(filters, 1, ["Safari"]), [people["person2"].uuid])
-        self.assertCountEqual(self._get_actor_ids_at_step(filters, 2, ["Safari"]), [people["person2"].uuid])
+        self.assertCountEqual(self._get_actor_ids_at_step(query, 1, ["Safari"]), [people["person2"].uuid])
+        self.assertCountEqual(self._get_actor_ids_at_step(query, 2, ["Safari"]), [people["person2"].uuid])
 
         assert_funnel_results_equal(
             results[1],
@@ -157,8 +157,8 @@ class TestFunnelStrictStepsBreakdown(
                 },
             ],
         )
-        self.assertCountEqual(self._get_actor_ids_at_step(filters, 1, ["Chrome"]), [people["person1"].uuid])
-        self.assertCountEqual(self._get_actor_ids_at_step(filters, 2, ["Chrome"]), [])
+        self.assertCountEqual(self._get_actor_ids_at_step(query, 1, ["Chrome"]), [people["person1"].uuid])
+        self.assertCountEqual(self._get_actor_ids_at_step(query, 2, ["Chrome"]), [])
 
 
 class TestStrictFunnelGroupBreakdown(

--- a/posthog/hogql_queries/insights/funnels/test/test_funnel_unordered.py
+++ b/posthog/hogql_queries/insights/funnels/test/test_funnel_unordered.py
@@ -111,8 +111,8 @@ class TestFunnelUnorderedStepsBreakdown(
                 },
             ],
         )
-        self.assertCountEqual(self._get_actor_ids_at_step(filters, 1, ["Safari"]), [person1.uuid])
-        self.assertCountEqual(self._get_actor_ids_at_step(filters, 2, ["Safari"]), [person1.uuid])
+        self.assertCountEqual(self._get_actor_ids_at_step(query, 1, ["Safari"]), [person1.uuid])
+        self.assertCountEqual(self._get_actor_ids_at_step(query, 2, ["Safari"]), [person1.uuid])
         assert_funnel_results_equal(
             results[1],
             [
@@ -144,8 +144,8 @@ class TestFunnelUnorderedStepsBreakdown(
                 },
             ],
         )
-        self.assertCountEqual(self._get_actor_ids_at_step(filters, 1, ["Chrome"]), [person1.uuid])
-        self.assertCountEqual(self._get_actor_ids_at_step(filters, 2, ["Chrome"]), [])
+        self.assertCountEqual(self._get_actor_ids_at_step(query, 1, ["Chrome"]), [person1.uuid])
+        self.assertCountEqual(self._get_actor_ids_at_step(query, 2, ["Chrome"]), [])
 
     def test_funnel_step_breakdown_with_step_attribution(self):
         # overridden from factory, since with no order, step one is step zero, and vice versa
@@ -211,7 +211,7 @@ class TestFunnelUnorderedStepsBreakdown(
 
         self.assertEqual(len(results), 6)
 
-        self.assertCountEqual(self._get_actor_ids_at_step(filters, 1, "Mac"), [people["person3"].uuid])
+        self.assertCountEqual(self._get_actor_ids_at_step(query, 1, "Mac"), [people["person3"].uuid])
 
     def test_funnel_step_breakdown_with_step_one_attribution(self):
         # overridden from factory, since with no order, step one is step zero, and vice versa


### PR DESCRIPTION
## Problem

We want to get rid of legacy "filters".

## Changes

Replaces them in `posthog/hogql_queries/insights/funnels/test/breakdown_cases.py`.

## How did you test this code?

Tests still run