### PR TITLE
Remove duplicate library version field from survey query

### DIFF
--- a/frontend/src/scenes/surveys/surveyLogic.tsx
+++ b/frontend/src/scenes/surveys/surveyLogic.tsx
@@ -1736,7 +1736,6 @@ export const surveyLogic = kea<surveyLogicType>([
                     }),
                     'timestamp',
                     'person',
-                    `coalesce(JSONExtractString(properties, '$lib_version')) -- Library Version`,
                     `coalesce(JSONExtractString(properties, '$lib')) -- Library`,
                     `coalesce(JSONExtractString(properties, '$current_url')) -- URL`,
                 ]


### PR DESCRIPTION
## TL;DR
Removes a duplicate library version field from the survey responses query that was redundant with the existing library field.

## What changed?
- Removed the `coalesce(JSONExtractString(properties, '$lib_version')) -- Library Version` line from the survey query in `surveyLogic.tsx`
- This field was duplicate/unnecessary alongside the existing library field (`$lib`)

## How did you test this code?
This is a straightforward removal of a duplicate query field. The change maintains the same query structure with the library version field removed, allowing the survey responses table to display the library information without redundancy.

Do not publish to changelog