### PR TITLE
fix(insights): mock quick filters request in insight logic test

### DIFF
--- a/frontend/src/scenes/insights/insightLogic.test.ts
+++ b/frontend/src/scenes/insights/insightLogic.test.ts
@@ -128,6 +128,9 @@ describe('insightLogic', () => {
         useMocks({
             get: {
                 '/api/projects/:team/tags': [],
+                '/api/environments/:team_id/quick_filters/': {
+                    results: [],
+                },
                 '/api/environments/:team_id/insights/trend/': async (req) => {
                     const clientQueryId = req.url.searchParams.get('client_query_id')
                     if (clientQueryId !== null) {


### PR DESCRIPTION
### Motivation
- Prevent unmocked quick filters API calls from `quickFiltersLogic` on mount which surface as jsdom `XMLHttpRequest`/`AggregateError` noise during the `insightLogic` test run.

### Description
- Add a GET mock for `/api/environments/:team_id/quick_filters/` to `frontend/src/scenes/insights/insightLogic.test.ts` that returns an empty `{ results: [] }` payload so `loadQuickFilters` resolves without issuing a real network request.

### Testing
- Ran `pnpm --filter=@posthog/frontend jest frontend/src/scenes/insights/insightLogic.test.ts`, which exited early and failed due to a local dependency resolution error (`Cannot find module '@posthog/hogvm'`), so the mock change could not be validated end-to-end in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc077b1a488332a918d088337b26f4)