### PR TITLE
fix(ci): ensure branch exists before ghcommit in update-ai-costs workflow

### DIFF
--- a/.github/workflows/update-ai-costs.yml
+++ b/.github/workflows/update-ai-costs.yml
@@ -130,3 +130,18 @@ jobs:
                       --label "automated" --label "llm-analytics" \
                       --reviewer "PostHog/team-llm-analytics"
                   fi
+
+            - name: Alert Slack on failure
+              if: failure()
+              uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
+              with:
+                  method: chat.postMessage
+                  token: ${{ secrets.SLACK_BOT_TOKEN }}
+                  payload: |
+                      channel: "C0A006STKHR"
+                      text: ":warning: Update AI Costs workflow failed"
+                      blocks:
+                        - type: "section"
+                          text:
+                            type: "mrkdwn"
+                            text: ":warning: *Update AI Costs workflow failed*\n\nLLM cost data is not being updated. This causes `not_found` rates to climb in cost processing.\n\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View failed run>"

--- a/.github/workflows/update-ai-costs.yml
+++ b/.github/workflows/update-ai-costs.yml
@@ -80,6 +80,17 @@ jobs:
                     echo "Closed stale PR #$existing_pr and deleted branch"
                   fi
 
+            - name: Ensure branch exists
+              if: steps.check-changes.outputs.changes == 'true'
+              env:
+                  GH_TOKEN: ${{ steps.app-token.outputs.token }}
+              run: |
+                  if ! gh api repos/${{ github.repository }}/git/ref/heads/chore/llma-update-ai-costs &>/dev/null; then
+                    master_sha=$(gh api repos/${{ github.repository }}/git/ref/heads/master --jq '.object.sha')
+                    gh api repos/${{ github.repository }}/git/refs -f ref=refs/heads/chore/llma-update-ai-costs -f sha="$master_sha"
+                    echo "Created branch from master at $master_sha"
+                  fi
+
             - name: Commit via GitHub API (signed)
               if: steps.check-changes.outputs.changes == 'true'
               uses: planetscale/ghcommit-action@25309d8005ac7c3bcd61d3fe19b69e0fe47dbdde # v0.2.20

--- a/.github/workflows/update-ai-costs.yml
+++ b/.github/workflows/update-ai-costs.yml
@@ -85,7 +85,7 @@ jobs:
               env:
                   GH_TOKEN: ${{ steps.app-token.outputs.token }}
               run: |
-                  if ! gh api repos/${{ github.repository }}/git/ref/heads/chore/llma-update-ai-costs &>/dev/null; then
+                  if ! gh api repos/${{ github.repository }}/git/ref/heads/chore/llma-update-ai-costs 2>/dev/null; then
                     master_sha=$(gh api repos/${{ github.repository }}/git/ref/heads/master --jq '.object.sha')
                     gh api repos/${{ github.repository }}/git/refs -f ref=refs/heads/chore/llma-update-ai-costs -f sha="$master_sha"
                     echo "Created branch from master at $master_sha"


### PR DESCRIPTION
## Problem

The "Update AI Costs" workflow has been failing since March 26 (7 consecutive failures). This is causing `not_found` rates to climb in LLM analytics cost processing because `llm-costs.json` is stale.

PR #52220 switched from `peter-evans/create-pull-request` to `planetscale/ghcommit-action` for signed commits. The old action automatically created the target branch if it didn't exist; the new one requires it to already exist. After a cost-update PR merges and the branch is deleted, every subsequent run fails with `Branch not found`.

## Changes

Adds an "Ensure branch exists" step before `ghcommit-action` that creates `chore/llma-update-ai-costs` from `master` via the GitHub API if the branch doesn't exist.

## How did you test this code?

- Verified the workflow logic matches the GitHub refs API
- Confirmed the 7 consecutive failures all show `Branch not found` in the ghcommit step
- The next scheduled run (10am or 8pm UTC on a weekday) will validate the fix end-to-end

## Publish to changelog?

no