### PR TITLE
fix(revenue-analytics): Persons materialized view joins

### DIFF
--- a/posthog/hogql/database/schema/persons_revenue_analytics.py
+++ b/posthog/hogql/database/schema/persons_revenue_analytics.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-from typing import Any, cast
+from typing import Literal
 
 from posthog.schema import DatabaseSchemaManagedViewTableKind
 
@@ -12,7 +12,6 @@ from posthog.hogql.database.models import (
     LazyJoinToAdd,
     LazyTable,
     LazyTableToAdd,
-    SavedQuery,
     StringDatabaseField,
 )
 from posthog.hogql.errors import ResolutionError
@@ -34,43 +33,20 @@ FIELDS: dict[str, FieldOrTable] = {
 
 
 def _select_from_persons_revenue_analytics_table(context: HogQLContext) -> ast.SelectQuery | ast.SelectSetQuery:
-    from products.revenue_analytics.backend.views import (
-        RevenueAnalyticsBaseView,
-        RevenueAnalyticsCustomerView,
-        RevenueAnalyticsMRRView,
-        RevenueAnalyticsRevenueItemView,
-    )
+    from products.revenue_analytics.backend.views import RevenueAnalyticsCustomerView, RevenueAnalyticsRevenueItemView
 
     if not context.database:
         return ast.SelectQuery.empty(columns=FIELDS)
 
-    customer_schema = VIEW_SCHEMAS[DatabaseSchemaManagedViewTableKind.REVENUE_ANALYTICS_CUSTOMER]
-    mrr_schema = VIEW_SCHEMAS[DatabaseSchemaManagedViewTableKind.REVENUE_ANALYTICS_MRR]
-    revenue_item_schema = VIEW_SCHEMAS[DatabaseSchemaManagedViewTableKind.REVENUE_ANALYTICS_REVENUE_ITEM]
-
     # Get all customer/mrr/revenue item tuples from the existing views making sure we ignore `all`
     # since the `persons` join is in the child view
-    all_views = defaultdict[str, dict[DatabaseSchemaManagedViewTableKind, RevenueAnalyticsBaseView]](defaultdict)
+    all_views = defaultdict[str, dict](defaultdict)
     for view_name in context.database.get_view_names():
-        view = cast(SavedQuery | RevenueAnalyticsBaseView, context.database.get_table(view_name))
-        prefix = ".".join(view_name.split(".")[:-1])
-
-        # Might need to convert to RevenueAnalyticsBaseView from a SavedQuery if the FF is enabled
-        # Soon we'll be able to remove all of this and handle them all using the `SavedQuery` logic directly
-        if view_name.endswith(customer_schema.source_suffix) or view_name.endswith(customer_schema.events_suffix):
-            if not isinstance(view, RevenueAnalyticsBaseView):
-                view = RevenueAnalyticsCustomerView(**_base_view_args_from_saved_query(view))
-            all_views[prefix][DatabaseSchemaManagedViewTableKind.REVENUE_ANALYTICS_CUSTOMER] = view
-        elif view_name.endswith(revenue_item_schema.source_suffix) or view_name.endswith(
-            revenue_item_schema.events_suffix
-        ):
-            if not isinstance(view, RevenueAnalyticsBaseView):
-                view = RevenueAnalyticsRevenueItemView(**_base_view_args_from_saved_query(view))
-            all_views[prefix][DatabaseSchemaManagedViewTableKind.REVENUE_ANALYTICS_REVENUE_ITEM] = view
-        elif view_name.endswith(mrr_schema.source_suffix) or view_name.endswith(mrr_schema.events_suffix):
-            if not isinstance(view, RevenueAnalyticsBaseView):
-                view = RevenueAnalyticsMRRView(**_base_view_args_from_saved_query(view))
-            all_views[prefix][DatabaseSchemaManagedViewTableKind.REVENUE_ANALYTICS_MRR] = view
+        table_kind = _get_table_kind(view_name)
+        if table_kind is not None:
+            view = context.database.get_table(view_name)
+            prefix = ".".join(view_name.split(".")[:-1])
+            all_views[prefix][table_kind] = view
 
     # Iterate over all possible view tuples and figure out which queries we can add to the set
     queries = []
@@ -86,7 +62,7 @@ def _select_from_persons_revenue_analytics_table(context: HogQLContext) -> ast.S
         # If we're working with event views, we can use the customer's id field directly
         # Otherwise, we need to join with the persons table by checking whether it exists
         person_id_chain: list[str | int] | None = None
-        if customer_view.is_event_view():
+        if _is_event_view(customer_view.name):
             person_id_chain = [RevenueAnalyticsCustomerView.get_generic_view_alias(), "id"]
         else:
             persons_lazy_join = customer_view.fields.get("persons")
@@ -183,19 +159,51 @@ def _select_from_persons_revenue_analytics_table(context: HogQLContext) -> ast.S
         return ast.SelectSetQuery.create_from_queries(queries, set_operator="UNION ALL")
 
 
-def _base_view_args_from_saved_query(saved_query: SavedQuery) -> dict[str, Any]:
-    return {
-        "id": saved_query.id,
-        "query": saved_query.query,
-        "name": saved_query.name,
-        "fields": saved_query.fields,
-        "metadata": saved_query.metadata,
-        # :KLUDGE: None of these properties below are great but it's all we can do to figure this one out for now
-        # We'll be able to come up with a better solution we don't need to support the old managed views anymore
-        "prefix": ".".join(saved_query.name.split(".")[:-1]),
-        "source_id": None,  # Not used so just ignore it
-        "event_name": saved_query.name.split(".")[2] if "revenue_analytics.events" in saved_query.name else None,
-    }
+def _get_table_kind(
+    view_name: str,
+) -> (
+    Literal[
+        DatabaseSchemaManagedViewTableKind.REVENUE_ANALYTICS_CUSTOMER,
+        DatabaseSchemaManagedViewTableKind.REVENUE_ANALYTICS_MRR,
+        DatabaseSchemaManagedViewTableKind.REVENUE_ANALYTICS_REVENUE_ITEM,
+    ]
+    | None
+):
+    if _is_customer_schema(view_name=view_name):
+        return DatabaseSchemaManagedViewTableKind.REVENUE_ANALYTICS_CUSTOMER
+
+    if _is_mrr_schema(view_name=view_name):
+        return DatabaseSchemaManagedViewTableKind.REVENUE_ANALYTICS_MRR
+
+    if _is_revenue_item_schema(view_name=view_name):
+        return DatabaseSchemaManagedViewTableKind.REVENUE_ANALYTICS_REVENUE_ITEM
+
+    return None
+
+
+def _is_customer_schema(view_name: str) -> bool:
+    customer_schema = VIEW_SCHEMAS[DatabaseSchemaManagedViewTableKind.REVENUE_ANALYTICS_CUSTOMER]
+    return view_name.endswith(customer_schema.source_suffix) or view_name.endswith(customer_schema.events_suffix)
+
+
+def _is_mrr_schema(view_name: str) -> bool:
+    mrr_schema = VIEW_SCHEMAS[DatabaseSchemaManagedViewTableKind.REVENUE_ANALYTICS_MRR]
+    return view_name.endswith(mrr_schema.source_suffix) or view_name.endswith(mrr_schema.events_suffix)
+
+
+def _is_revenue_item_schema(view_name: str) -> bool:
+    revenue_item_schema = VIEW_SCHEMAS[DatabaseSchemaManagedViewTableKind.REVENUE_ANALYTICS_REVENUE_ITEM]
+    return view_name.endswith(revenue_item_schema.source_suffix) or view_name.endswith(
+        revenue_item_schema.events_suffix
+    )
+
+
+def _is_event_view(view_name: str) -> bool:
+    return _get_event_name(view_name) is not None
+
+
+def _get_event_name(view_name: str) -> str | None:
+    return view_name.split(".")[2] if "revenue_analytics.events" in view_name else None
 
 
 class PersonsRevenueAnalyticsTable(LazyTable):

--- a/posthog/hogql/database/schema/test/__snapshots__/test_persons_revenue_analytics.ambr
+++ b/posthog/hogql/database/schema/test/__snapshots__/test_persons_revenue_analytics.ambr
@@ -5106,178 +5106,21 @@
             coalesce(revenue_agg.revenue, accurateCastOrNull(0, 'Decimal64(10)')) AS revenue,
             coalesce(mrr_agg.mrr, accurateCastOrNull(0, 'Decimal64(10)')) AS mrr
      FROM
-       (SELECT toString(persons.id) AS id,
-               'revenue_analytics.events.purchase' AS source_label,
-               persons.created_at AS timestamp,
-               persons.properties___name AS name,
-               persons.properties___email AS email,
-               persons.properties___phone AS phone,
-               persons.properties___address AS address,
-               persons.properties___metadata AS metadata,
-               persons.`properties___$geoip_country_name` AS country,
-               formatDateTime(toStartOfMonth(persons.created_at), '%Y-%m') AS cohort,
-               NULL AS initial_coupon,
-               NULL AS initial_coupon_id
-        FROM
-          (SELECT person.id AS id,
-                  replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'name'), ''), 'null'), '^"|"$', '') AS properties___name,
-                  replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'email'), ''), 'null'), '^"|"$', '') AS properties___email,
-                  replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'phone'), ''), 'null'), '^"|"$', '') AS properties___phone,
-                  replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'address'), ''), 'null'), '^"|"$', '') AS properties___address,
-                  replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'metadata'), ''), 'null'), '^"|"$', '') AS properties___metadata,
-                  replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, '$geoip_country_name'), ''), 'null'), '^"|"$', '') AS `properties___$geoip_country_name`,
-                  toTimeZone(person.created_at, 'UTC') AS created_at
-           FROM person
-           WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
-                                                         (SELECT person.id AS id, max(person.version) AS version
-                                                          FROM person
-                                                          WHERE equals(person.team_id, 99999)
-                                                          GROUP BY person.id
-                                                          HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0))))) SETTINGS optimize_aggregation_in_order=1) AS persons
-        INNER JOIN
-          (SELECT DISTINCT events__person.id AS person_id
-           FROM events
-           LEFT OUTER JOIN
-             (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
-                     person_distinct_id_overrides.distinct_id AS distinct_id
-              FROM person_distinct_id_overrides
-              WHERE equals(person_distinct_id_overrides.team_id, 99999)
-              GROUP BY person_distinct_id_overrides.distinct_id
-              HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-           INNER JOIN
-             (SELECT person.id AS id
-              FROM person
-              WHERE equals(person.team_id, 99999)
-              GROUP BY person.id
-              HAVING and(ifNull(equals(tupleElement(argMax(tuple(person.is_deleted), person.version), 1), 0), 0), ifNull(less(tupleElement(argMax(tuple(toTimeZone(person.created_at, 'UTC')), person.version), 1), plus(now64(6, 'UTC'), toIntervalDay(1))), 0)) SETTINGS optimize_aggregation_in_order=1) AS events__person ON equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), events__person.id)
-           WHERE equals(events.team_id, 99999)) AS events ON equals(persons.id, events.person_id)
-        ORDER BY persons.created_at DESC) AS revenue_analytics_customer
+       (SELECT *
+        FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-revenue_analytics_events_purchase_customer_events_revenue_view/revenue_analytics.events.purchase.customer_events_revenue_view/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` Nullable(String), `name` Nullable(String), `email` Nullable(String), `phone` Nullable(String), `cohort` Nullable(String), `address` Nullable(String), `country` Nullable(String), `metadata` Nullable(String), `timestamp` Nullable(DateTime64(6, \'UTC\')), `source_label` Nullable(String), `initial_coupon` Nullable(String), `initial_coupon_id` Nullable(String)')) AS revenue_analytics_customer
      LEFT JOIN
        (SELECT revenue_analytics_revenue_item.customer_id AS customer_id,
                sum(revenue_analytics_revenue_item.amount) AS revenue
-        FROM
-          (SELECT toString(events.uuid) AS id,
-                  toString(events.uuid) AS invoice_item_id,
-                  'revenue_analytics.events.purchase' AS source_label,
-                  toTimeZone(events.timestamp, 'UTC') AS timestamp,
-                  timestamp AS created_at,
-                  0 AS is_recurring,
-                  NULL AS product_id,
-                  toString(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS customer_id,
-                  events.`$group_0` AS group_0_key,
-                  events.`$group_1` AS group_1_key,
-                  events.`$group_2` AS group_2_key,
-                  events.`$group_3` AS group_3_key,
-                  events.`$group_4` AS group_4_key,
-                  NULL AS invoice_id,
-                  NULL AS subscription_id,
-                  toString(events.`$session_id`) AS session_id,
-                  events.event AS event_name,
-                  NULL AS coupon,
-                  coupon AS coupon_id,
-                  'USD' AS original_currency,
-                  accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)') AS original_amount,
-                  in(original_currency,
-                     ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
-                    if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
-                    divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
-                    'USD' AS currency,
-                    if(isNull('USD'), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals('USD', 'USD'), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(1, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))) AS amount
-           FROM events
-           LEFT OUTER JOIN
-             (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
-                     person_distinct_id_overrides.distinct_id AS distinct_id
-              FROM person_distinct_id_overrides
-              WHERE equals(person_distinct_id_overrides.team_id, 99999)
-              GROUP BY person_distinct_id_overrides.distinct_id
-              HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-           WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), 1, isNotNull(amount)))
-           ORDER BY timestamp DESC) AS revenue_analytics_revenue_item
+        FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-revenue_analytics_events_purchase_revenue_item_events_revenue_view/revenue_analytics.events.purchase.revenue_item_events_revenue_view/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` Nullable(String), `amount` Nullable(Decimal64(10)), `coupon` Nullable(String), `currency` Nullable(String), `coupon_id` Nullable(String), `timestamp` Nullable(DateTime64(6, \'UTC\')), `created_at` Nullable(DateTime64(6, \'UTC\')), `event_name` Nullable(String), `invoice_id` Nullable(String), `product_id` Nullable(String), `session_id` Nullable(String), `customer_id` Nullable(String), `group_0_key` Nullable(String), `group_1_key` Nullable(String), `group_2_key` Nullable(String), `group_3_key` Nullable(String), `group_4_key` Nullable(String), `is_recurring` Nullable(Boolean), `source_label` Nullable(String), `invoice_item_id` Nullable(String), `original_amount` Nullable(Decimal64(10)), `subscription_id` Nullable(String), `original_currency` Nullable(String), `currency_aware_amount` Nullable(Decimal64(10)), `currency_aware_divider` Nullable(Decimal64(10)), `enable_currency_aware_divider` Nullable(Boolean)') AS revenue_analytics_revenue_item
         GROUP BY customer_id) AS revenue_agg ON equals(revenue_analytics_customer.id, revenue_agg.customer_id)
      LEFT JOIN
        (SELECT `revenue_analytics.events.purchase.mrr_events_revenue_view`.customer_id AS customer_id,
                sum(`revenue_analytics.events.purchase.mrr_events_revenue_view`.mrr) AS mrr
-        FROM
-          (SELECT union.source_label AS source_label,
-                  union.customer_id AS customer_id,
-                  union.subscription_id AS subscription_id,
-                  argMax(union.amount, union.timestamp) AS mrr
-           FROM
-             (SELECT revenue_item.source_label AS source_label,
-                     revenue_item.customer_id AS customer_id,
-                     revenue_item.subscription_id AS subscription_id,
-                     toStartOfMonth(toTimeZone(revenue_item.timestamp, 'UTC')) AS timestamp,
-                     sum(revenue_item.amount) AS amount
-              FROM
-                (SELECT toString(events.uuid) AS id,
-                        toString(events.uuid) AS invoice_item_id,
-                        'revenue_analytics.events.purchase' AS source_label,
-                        toTimeZone(events.timestamp, 'UTC') AS timestamp,
-                        timestamp AS created_at,
-                        0 AS is_recurring,
-                        NULL AS product_id,
-                        toString(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS customer_id,
-                        events.`$group_0` AS group_0_key,
-                        events.`$group_1` AS group_1_key,
-                        events.`$group_2` AS group_2_key,
-                        events.`$group_3` AS group_3_key,
-                        events.`$group_4` AS group_4_key,
-                        NULL AS invoice_id,
-                        NULL AS subscription_id,
-                        toString(events.`$session_id`) AS session_id,
-                        events.event AS event_name,
-                        NULL AS coupon,
-                        coupon AS coupon_id,
-                        'USD' AS original_currency,
-                        accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)') AS original_amount,
-                        in(original_currency,
-                           ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
-                          if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
-                          divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
-                          'USD' AS currency,
-                          if(isNull('USD'), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals('USD', 'USD'), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(1, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))) AS amount
-                 FROM events
-                 LEFT OUTER JOIN
-                   (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
-                           person_distinct_id_overrides.distinct_id AS distinct_id
-                    FROM person_distinct_id_overrides
-                    WHERE equals(person_distinct_id_overrides.team_id, 99999)
-                    GROUP BY person_distinct_id_overrides.distinct_id
-                    HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-                 WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), 1, isNotNull(amount)))
-                 ORDER BY timestamp DESC) AS revenue_item
-              WHERE and(revenue_item.is_recurring, isNotNull(revenue_item.subscription_id), greaterOrEquals(timestamp, toStartOfMonth(addDays(toDateTime64('today', 6, 'UTC'), -60))), lessOrEquals(timestamp, toDateTime64('today', 6, 'UTC')))
-              GROUP BY revenue_item.source_label,
-                       revenue_item.customer_id,
-                       revenue_item.subscription_id, timestamp
-              ORDER BY timestamp DESC
-              UNION ALL SELECT `revenue_analytics.events.purchase.subscription_events_revenue_view`.source_label AS source_label,
-                               `revenue_analytics.events.purchase.subscription_events_revenue_view`.customer_id AS customer_id,
-                               `revenue_analytics.events.purchase.subscription_events_revenue_view`.id AS subscription_id,
-                               toTimeZone(`revenue_analytics.events.purchase.subscription_events_revenue_view`.ended_at, 'UTC') AS timestamp,
-                               accurateCastOrNull(0, 'Decimal64(10)') AS amount
-              FROM
-                (SELECT '' AS id,
-                        '' AS source_label,
-                        '' AS plan_id,
-                        '' AS product_id,
-                        '' AS customer_id,
-                        '' AS status,
-                        toDateTime64('1970-01-01 00:00:00.000000', 6, 'UTC') AS started_at,
-                        toDateTime64('1970-01-01 00:00:00.000000', 6, 'UTC') AS ended_at,
-                        '' AS metadata
-                 WHERE 0) AS `revenue_analytics.events.purchase.subscription_events_revenue_view`
-              WHERE and(greaterOrEquals(timestamp, toStartOfMonth(addDays(toDateTime64('today', 6, 'UTC'), -60))), lessOrEquals(timestamp, toDateTime64('today', 6, 'UTC')))
-              ORDER BY timestamp DESC) AS
-           union
-           GROUP BY source_label,
-                    customer_id,
-                    subscription_id
-           ORDER BY customer_id ASC,
-                    subscription_id ASC) AS `revenue_analytics.events.purchase.mrr_events_revenue_view`
+        FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-revenue_analytics_events_purchase_mrr_events_revenue_view/revenue_analytics.events.purchase.mrr_events_revenue_view/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`mrr` Nullable(Decimal64(10)), `customer_id` Nullable(String), `source_label` Nullable(String), `subscription_id` Nullable(String)') AS `revenue_analytics.events.purchase.mrr_events_revenue_view`
         GROUP BY customer_id) AS mrr_agg ON equals(revenue_analytics_customer.id, mrr_agg.customer_id)) AS persons__revenue_analytics ON equals(toString(persons.persons___id), toString(persons__revenue_analytics.person_id))
   WHERE ifNull(equals(persons.id, '00000000-0000-0000-0000-000000000000'), 0)
-  LIMIT 100 SETTINGS readonly=2,
+  LIMIT 100 SETTINGS format_csv_allow_double_quotes=1,
+                     readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,
                      max_ast_elements=4000000,
@@ -5306,28 +5149,8 @@
             coalesce(revenue_agg.revenue, accurateCastOrNull(0, 'Decimal64(10)')) AS revenue,
             coalesce(mrr_agg.mrr, accurateCastOrNull(0, 'Decimal64(10)')) AS mrr
      FROM
-       (SELECT outer.id AS id,
-               'stripe.posthog_test' AS source_label,
-               parseDateTime64BestEffortOrNull(toString(outer.created), 6, 'UTC') AS timestamp,
-               outer.name AS name,
-               outer.email AS email,
-               outer.phone AS phone,
-               outer.address AS address,
-               outer.metadata AS metadata,
-               JSONExtractString(address, 'country') AS country,
-               cohort_inner.cohort AS cohort,
-               cohort_inner.initial_coupon AS initial_coupon,
-               cohort_inner.initial_coupon_id AS initial_coupon_id
-        FROM
-          (SELECT *
-           FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_customers/posthog_test_stripe_customer/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `name` String, `email` String, `phone` String, `address` String, `created` DateTime, `metadata` String')) AS outer
-        LEFT JOIN
-          (SELECT invoice.customer AS customer_id,
-                  formatDateTime(toStartOfMonth(min(parseDateTime64BestEffortOrNull(toString(invoice.created), 6, 'UTC'))), '%Y-%m') AS cohort,
-                  argMin(JSONExtractString(invoice.discount, 'coupon', 'name'), parseDateTime64BestEffortOrNull(toString(invoice.created), 6, 'UTC')) AS initial_coupon,
-                  argMin(JSONExtractString(invoice.discount, 'coupon', 'id'), parseDateTime64BestEffortOrNull(toString(invoice.created), 6, 'UTC')) AS initial_coupon_id
-           FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `subscription` String, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS invoice
-           GROUP BY invoice.customer) AS cohort_inner ON equals(cohort_inner.customer_id, outer.id)) AS revenue_analytics_customer
+       (SELECT *
+        FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-stripe_posthog_test_customer_revenue_view/stripe.posthog_test.customer_revenue_view/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` Nullable(String), `name` Nullable(String), `email` Nullable(String), `phone` Nullable(String), `cohort` Nullable(String), `address` Nullable(String), `country` Nullable(String), `metadata` Nullable(String), `timestamp` Nullable(DateTime64(6, \'UTC\')), `source_label` Nullable(String), `initial_coupon` Nullable(String), `initial_coupon_id` Nullable(String)')) AS revenue_analytics_customer
      LEFT JOIN
        (SELECT persons.id AS id,
                persons__pdi.distinct_id AS revenue_analytics_customer__persons___pdi___distinct_id
@@ -5348,146 +5171,12 @@
      LEFT JOIN
        (SELECT revenue_analytics_revenue_item.customer_id AS customer_id,
                sum(revenue_analytics_revenue_item.amount) AS revenue
-        FROM
-          (SELECT if(ifNull(greater(invoice.period_months, 1), 0), concat(ifNull(toString(invoice.invoice_item_id), ''), '_', ifNull(toString(invoice.month_index), '')), invoice.invoice_item_id) AS id,
-                  invoice.invoice_item_id AS invoice_item_id,
-                  'stripe.posthog_test' AS source_label,
-                  addMonths(invoice.timestamp, invoice.month_index) AS timestamp,
-                  invoice.created_at AS created_at,
-                  ifNull(notEmpty(invoice.subscription_id), 0) AS is_recurring,
-                  invoice.product_id AS product_id,
-                  invoice.customer_id AS customer_id,
-                  NULL AS group_0_key,
-                  NULL AS group_1_key,
-                  NULL AS group_2_key,
-                  NULL AS group_3_key,
-                  NULL AS group_4_key,
-                  invoice.id AS invoice_id,
-                  invoice.subscription_id AS subscription_id,
-                  NULL AS session_id,
-                  NULL AS event_name,
-                  JSONExtractString(invoice.discount, 'coupon', 'name') AS coupon,
-                  JSONExtractString(invoice.discount, 'coupon', 'id') AS coupon_id,
-                  upper(invoice.currency) AS original_currency,
-                  accurateCastOrNull(invoice.amount_captured, 'Decimal64(10)') AS original_amount,
-                  in(original_currency,
-                     ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
-                    if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
-                    divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
-                    'GBP' AS currency,
-                    divideDecimal(if(equals(original_currency, currency), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal64(1, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10))))), accurateCastOrNull(invoice.period_months, 'Decimal64(10)')) AS amount
-           FROM
-             (SELECT posthog_test_stripe_invoice.id AS id,
-                     parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC') AS created_at,
-                     posthog_test_stripe_invoice.customer AS customer_id,
-                     posthog_test_stripe_invoice.subscription AS subscription_id,
-                     posthog_test_stripe_invoice.discount AS discount,
-                     arrayJoin(JSONExtractArrayRaw(assumeNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(posthog_test_stripe_invoice.lines, 'data'), ''), 'null'), '^"|"$', '')))) AS data,
-                     JSONExtractString(data, 'id') AS invoice_item_id,
-                     JSONExtractUInt(data, 'amount') AS amount_before_discount,
-                     coalesce(arraySum(arrayMap(x -> JSONExtractInt(x, 'amount'), JSONExtractArrayRaw(data, 'discount_amounts'))), 0) AS discount_amount,
-                     greatest(minus(amount_before_discount, discount_amount), 0) AS amount_captured,
-                     JSONExtractString(data, 'currency') AS currency,
-                     JSONExtractString(data, 'price', 'product') AS product_id,
-                     fromUnixTimestamp(JSONExtractUInt(data, 'period', 'start')) AS period_start,
-                     fromUnixTimestamp(JSONExtractUInt(data, 'period', 'end')) AS period_end,
-                     greatest(toInt16(round(divide(dateDiff('day', ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')), ifNull(period_end, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC'))), 30.44))), 1) AS period_months,
-                     arrayJoin(range(0, period_months)) AS month_index,
-                     ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')) AS timestamp
-              FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `subscription` String, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS posthog_test_stripe_invoice
-              WHERE posthog_test_stripe_invoice.paid) AS invoice) AS revenue_analytics_revenue_item
+        FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-stripe_posthog_test_revenue_item_revenue_view/stripe.posthog_test.revenue_item_revenue_view/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` Nullable(String), `amount` Nullable(Decimal64(10)), `coupon` Nullable(String), `currency` Nullable(String), `coupon_id` Nullable(String), `timestamp` Nullable(DateTime64(6, \'UTC\')), `created_at` Nullable(DateTime64(6, \'UTC\')), `event_name` Nullable(String), `invoice_id` Nullable(String), `product_id` Nullable(String), `session_id` Nullable(String), `customer_id` Nullable(String), `group_0_key` Nullable(String), `group_1_key` Nullable(String), `group_2_key` Nullable(String), `group_3_key` Nullable(String), `group_4_key` Nullable(String), `is_recurring` Nullable(Boolean), `source_label` Nullable(String), `invoice_item_id` Nullable(String), `original_amount` Nullable(Decimal64(10)), `subscription_id` Nullable(String), `original_currency` Nullable(String), `currency_aware_amount` Nullable(Decimal64(10)), `currency_aware_divider` Nullable(Decimal64(10)), `enable_currency_aware_divider` Nullable(Boolean)') AS revenue_analytics_revenue_item
         GROUP BY customer_id) AS revenue_agg ON equals(revenue_analytics_customer.id, revenue_agg.customer_id)
      LEFT JOIN
        (SELECT `stripe.posthog_test.mrr_revenue_view`.customer_id AS customer_id,
                sum(`stripe.posthog_test.mrr_revenue_view`.mrr) AS mrr
-        FROM
-          (SELECT union.source_label AS source_label,
-                  union.customer_id AS customer_id,
-                  union.subscription_id AS subscription_id,
-                  argMax(union.amount, union.timestamp) AS mrr
-           FROM
-             (SELECT revenue_item.source_label AS source_label,
-                     revenue_item.customer_id AS customer_id,
-                     revenue_item.subscription_id AS subscription_id,
-                     toStartOfMonth(toTimeZone(revenue_item.timestamp, 'UTC')) AS timestamp,
-                     sum(revenue_item.amount) AS amount
-              FROM
-                (SELECT if(ifNull(greater(invoice.period_months, 1), 0), concat(ifNull(toString(invoice.invoice_item_id), ''), '_', ifNull(toString(invoice.month_index), '')), invoice.invoice_item_id) AS id,
-                        invoice.invoice_item_id AS invoice_item_id,
-                        'stripe.posthog_test' AS source_label,
-                        addMonths(invoice.timestamp, invoice.month_index) AS timestamp,
-                        invoice.created_at AS created_at,
-                        ifNull(notEmpty(invoice.subscription_id), 0) AS is_recurring,
-                        invoice.product_id AS product_id,
-                        invoice.customer_id AS customer_id,
-                        NULL AS group_0_key,
-                        NULL AS group_1_key,
-                        NULL AS group_2_key,
-                        NULL AS group_3_key,
-                        NULL AS group_4_key,
-                        invoice.id AS invoice_id,
-                        invoice.subscription_id AS subscription_id,
-                        NULL AS session_id,
-                        NULL AS event_name,
-                        JSONExtractString(invoice.discount, 'coupon', 'name') AS coupon,
-                        JSONExtractString(invoice.discount, 'coupon', 'id') AS coupon_id,
-                        upper(invoice.currency) AS original_currency,
-                        accurateCastOrNull(invoice.amount_captured, 'Decimal64(10)') AS original_amount,
-                        in(original_currency,
-                           ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
-                          if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
-                          divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
-                          'GBP' AS currency,
-                          divideDecimal(if(equals(original_currency, currency), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal64(1, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10))))), accurateCastOrNull(invoice.period_months, 'Decimal64(10)')) AS amount
-                 FROM
-                   (SELECT posthog_test_stripe_invoice.id AS id,
-                           parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC') AS created_at,
-                           posthog_test_stripe_invoice.customer AS customer_id,
-                           posthog_test_stripe_invoice.subscription AS subscription_id,
-                           posthog_test_stripe_invoice.discount AS discount,
-                           arrayJoin(JSONExtractArrayRaw(assumeNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(posthog_test_stripe_invoice.lines, 'data'), ''), 'null'), '^"|"$', '')))) AS data,
-                           JSONExtractString(data, 'id') AS invoice_item_id,
-                           JSONExtractUInt(data, 'amount') AS amount_before_discount,
-                           coalesce(arraySum(arrayMap(x -> JSONExtractInt(x, 'amount'), JSONExtractArrayRaw(data, 'discount_amounts'))), 0) AS discount_amount,
-                           greatest(minus(amount_before_discount, discount_amount), 0) AS amount_captured,
-                           JSONExtractString(data, 'currency') AS currency,
-                           JSONExtractString(data, 'price', 'product') AS product_id,
-                           fromUnixTimestamp(JSONExtractUInt(data, 'period', 'start')) AS period_start,
-                           fromUnixTimestamp(JSONExtractUInt(data, 'period', 'end')) AS period_end,
-                           greatest(toInt16(round(divide(dateDiff('day', ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')), ifNull(period_end, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC'))), 30.44))), 1) AS period_months,
-                           arrayJoin(range(0, period_months)) AS month_index,
-                           ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')) AS timestamp
-                    FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `subscription` String, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS posthog_test_stripe_invoice
-                    WHERE posthog_test_stripe_invoice.paid) AS invoice) AS revenue_item
-              WHERE and(revenue_item.is_recurring, isNotNull(revenue_item.subscription_id), greaterOrEquals(timestamp, toStartOfMonth(addDays(toDateTime64('today', 6, 'UTC'), -60))), lessOrEquals(timestamp, toDateTime64('today', 6, 'UTC')))
-              GROUP BY revenue_item.source_label,
-                       revenue_item.customer_id,
-                       revenue_item.subscription_id, timestamp
-              ORDER BY timestamp DESC
-              UNION ALL SELECT `stripe.posthog_test.subscription_revenue_view`.source_label AS source_label,
-                               `stripe.posthog_test.subscription_revenue_view`.customer_id AS customer_id,
-                               `stripe.posthog_test.subscription_revenue_view`.id AS subscription_id,
-                               toTimeZone(`stripe.posthog_test.subscription_revenue_view`.ended_at, 'UTC') AS timestamp,
-                               accurateCastOrNull(0, 'Decimal64(10)') AS amount
-              FROM
-                (SELECT '' AS id,
-                        '' AS source_label,
-                        '' AS plan_id,
-                        '' AS product_id,
-                        '' AS customer_id,
-                        '' AS status,
-                        toDateTime64('1970-01-01 00:00:00.000000', 6, 'UTC') AS started_at,
-                        toDateTime64('1970-01-01 00:00:00.000000', 6, 'UTC') AS ended_at,
-                        '' AS metadata
-                 WHERE 0) AS `stripe.posthog_test.subscription_revenue_view`
-              WHERE and(greaterOrEquals(timestamp, toStartOfMonth(addDays(toDateTime64('today', 6, 'UTC'), -60))), lessOrEquals(timestamp, toDateTime64('today', 6, 'UTC')))
-              ORDER BY timestamp DESC) AS
-           union
-           GROUP BY source_label,
-                    customer_id,
-                    subscription_id
-           ORDER BY customer_id ASC,
-                    subscription_id ASC) AS `stripe.posthog_test.mrr_revenue_view`
+        FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-stripe_posthog_test_mrr_revenue_view/stripe.posthog_test.mrr_revenue_view/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`mrr` Nullable(Decimal64(10)), `customer_id` Nullable(String), `source_label` Nullable(String), `subscription_id` Nullable(String)') AS `stripe.posthog_test.mrr_revenue_view`
         GROUP BY customer_id) AS mrr_agg ON equals(revenue_analytics_customer.id, mrr_agg.customer_id)) AS persons__revenue_analytics ON equals(toString(persons.persons___id), toString(persons__revenue_analytics.person_id))
   ORDER BY persons.id ASC
   LIMIT 100 SETTINGS format_csv_allow_double_quotes=1,
@@ -5520,28 +5209,8 @@
             coalesce(revenue_agg.revenue, accurateCastOrNull(0, 'Decimal64(10)')) AS revenue,
             coalesce(mrr_agg.mrr, accurateCastOrNull(0, 'Decimal64(10)')) AS mrr
      FROM
-       (SELECT outer.id AS id,
-               'stripe.posthog_test' AS source_label,
-               parseDateTime64BestEffortOrNull(toString(outer.created), 6, 'UTC') AS timestamp,
-               outer.name AS name,
-               outer.email AS email,
-               outer.phone AS phone,
-               outer.address AS address,
-               outer.metadata AS metadata,
-               JSONExtractString(address, 'country') AS country,
-               cohort_inner.cohort AS cohort,
-               cohort_inner.initial_coupon AS initial_coupon,
-               cohort_inner.initial_coupon_id AS initial_coupon_id
-        FROM
-          (SELECT *
-           FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_customers/posthog_test_stripe_customer/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `name` String, `email` String, `phone` String, `address` String, `created` DateTime, `metadata` String')) AS outer
-        LEFT JOIN
-          (SELECT invoice.customer AS customer_id,
-                  formatDateTime(toStartOfMonth(min(parseDateTime64BestEffortOrNull(toString(invoice.created), 6, 'UTC'))), '%Y-%m') AS cohort,
-                  argMin(JSONExtractString(invoice.discount, 'coupon', 'name'), parseDateTime64BestEffortOrNull(toString(invoice.created), 6, 'UTC')) AS initial_coupon,
-                  argMin(JSONExtractString(invoice.discount, 'coupon', 'id'), parseDateTime64BestEffortOrNull(toString(invoice.created), 6, 'UTC')) AS initial_coupon_id
-           FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `subscription` String, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS invoice
-           GROUP BY invoice.customer) AS cohort_inner ON equals(cohort_inner.customer_id, outer.id)) AS revenue_analytics_customer
+       (SELECT *
+        FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-stripe_posthog_test_customer_revenue_view/stripe.posthog_test.customer_revenue_view/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` Nullable(String), `name` Nullable(String), `email` Nullable(String), `phone` Nullable(String), `cohort` Nullable(String), `address` Nullable(String), `country` Nullable(String), `metadata` Nullable(String), `timestamp` Nullable(DateTime64(6, \'UTC\')), `source_label` Nullable(String), `initial_coupon` Nullable(String), `initial_coupon_id` Nullable(String)')) AS revenue_analytics_customer
      LEFT JOIN
        (SELECT persons.id AS id,
                persons__pdi.distinct_id AS revenue_analytics_customer__persons___pdi___distinct_id
@@ -5562,146 +5231,12 @@
      LEFT JOIN
        (SELECT revenue_analytics_revenue_item.customer_id AS customer_id,
                sum(revenue_analytics_revenue_item.amount) AS revenue
-        FROM
-          (SELECT if(ifNull(greater(invoice.period_months, 1), 0), concat(ifNull(toString(invoice.invoice_item_id), ''), '_', ifNull(toString(invoice.month_index), '')), invoice.invoice_item_id) AS id,
-                  invoice.invoice_item_id AS invoice_item_id,
-                  'stripe.posthog_test' AS source_label,
-                  addMonths(invoice.timestamp, invoice.month_index) AS timestamp,
-                  invoice.created_at AS created_at,
-                  ifNull(notEmpty(invoice.subscription_id), 0) AS is_recurring,
-                  invoice.product_id AS product_id,
-                  invoice.customer_id AS customer_id,
-                  NULL AS group_0_key,
-                  NULL AS group_1_key,
-                  NULL AS group_2_key,
-                  NULL AS group_3_key,
-                  NULL AS group_4_key,
-                  invoice.id AS invoice_id,
-                  invoice.subscription_id AS subscription_id,
-                  NULL AS session_id,
-                  NULL AS event_name,
-                  JSONExtractString(invoice.discount, 'coupon', 'name') AS coupon,
-                  JSONExtractString(invoice.discount, 'coupon', 'id') AS coupon_id,
-                  upper(invoice.currency) AS original_currency,
-                  accurateCastOrNull(invoice.amount_captured, 'Decimal64(10)') AS original_amount,
-                  in(original_currency,
-                     ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
-                    if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
-                    divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
-                    'GBP' AS currency,
-                    divideDecimal(if(equals(original_currency, currency), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal64(1, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10))))), accurateCastOrNull(invoice.period_months, 'Decimal64(10)')) AS amount
-           FROM
-             (SELECT posthog_test_stripe_invoice.id AS id,
-                     parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC') AS created_at,
-                     posthog_test_stripe_invoice.customer AS customer_id,
-                     posthog_test_stripe_invoice.subscription AS subscription_id,
-                     posthog_test_stripe_invoice.discount AS discount,
-                     arrayJoin(JSONExtractArrayRaw(assumeNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(posthog_test_stripe_invoice.lines, 'data'), ''), 'null'), '^"|"$', '')))) AS data,
-                     JSONExtractString(data, 'id') AS invoice_item_id,
-                     JSONExtractUInt(data, 'amount') AS amount_before_discount,
-                     coalesce(arraySum(arrayMap(x -> JSONExtractInt(x, 'amount'), JSONExtractArrayRaw(data, 'discount_amounts'))), 0) AS discount_amount,
-                     greatest(minus(amount_before_discount, discount_amount), 0) AS amount_captured,
-                     JSONExtractString(data, 'currency') AS currency,
-                     JSONExtractString(data, 'price', 'product') AS product_id,
-                     fromUnixTimestamp(JSONExtractUInt(data, 'period', 'start')) AS period_start,
-                     fromUnixTimestamp(JSONExtractUInt(data, 'period', 'end')) AS period_end,
-                     greatest(toInt16(round(divide(dateDiff('day', ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')), ifNull(period_end, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC'))), 30.44))), 1) AS period_months,
-                     arrayJoin(range(0, period_months)) AS month_index,
-                     ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')) AS timestamp
-              FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `subscription` String, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS posthog_test_stripe_invoice
-              WHERE posthog_test_stripe_invoice.paid) AS invoice) AS revenue_analytics_revenue_item
+        FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-stripe_posthog_test_revenue_item_revenue_view/stripe.posthog_test.revenue_item_revenue_view/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` Nullable(String), `amount` Nullable(Decimal64(10)), `coupon` Nullable(String), `currency` Nullable(String), `coupon_id` Nullable(String), `timestamp` Nullable(DateTime64(6, \'UTC\')), `created_at` Nullable(DateTime64(6, \'UTC\')), `event_name` Nullable(String), `invoice_id` Nullable(String), `product_id` Nullable(String), `session_id` Nullable(String), `customer_id` Nullable(String), `group_0_key` Nullable(String), `group_1_key` Nullable(String), `group_2_key` Nullable(String), `group_3_key` Nullable(String), `group_4_key` Nullable(String), `is_recurring` Nullable(Boolean), `source_label` Nullable(String), `invoice_item_id` Nullable(String), `original_amount` Nullable(Decimal64(10)), `subscription_id` Nullable(String), `original_currency` Nullable(String), `currency_aware_amount` Nullable(Decimal64(10)), `currency_aware_divider` Nullable(Decimal64(10)), `enable_currency_aware_divider` Nullable(Boolean)') AS revenue_analytics_revenue_item
         GROUP BY customer_id) AS revenue_agg ON equals(revenue_analytics_customer.id, revenue_agg.customer_id)
      LEFT JOIN
        (SELECT `stripe.posthog_test.mrr_revenue_view`.customer_id AS customer_id,
                sum(`stripe.posthog_test.mrr_revenue_view`.mrr) AS mrr
-        FROM
-          (SELECT union.source_label AS source_label,
-                  union.customer_id AS customer_id,
-                  union.subscription_id AS subscription_id,
-                  argMax(union.amount, union.timestamp) AS mrr
-           FROM
-             (SELECT revenue_item.source_label AS source_label,
-                     revenue_item.customer_id AS customer_id,
-                     revenue_item.subscription_id AS subscription_id,
-                     toStartOfMonth(toTimeZone(revenue_item.timestamp, 'UTC')) AS timestamp,
-                     sum(revenue_item.amount) AS amount
-              FROM
-                (SELECT if(ifNull(greater(invoice.period_months, 1), 0), concat(ifNull(toString(invoice.invoice_item_id), ''), '_', ifNull(toString(invoice.month_index), '')), invoice.invoice_item_id) AS id,
-                        invoice.invoice_item_id AS invoice_item_id,
-                        'stripe.posthog_test' AS source_label,
-                        addMonths(invoice.timestamp, invoice.month_index) AS timestamp,
-                        invoice.created_at AS created_at,
-                        ifNull(notEmpty(invoice.subscription_id), 0) AS is_recurring,
-                        invoice.product_id AS product_id,
-                        invoice.customer_id AS customer_id,
-                        NULL AS group_0_key,
-                        NULL AS group_1_key,
-                        NULL AS group_2_key,
-                        NULL AS group_3_key,
-                        NULL AS group_4_key,
-                        invoice.id AS invoice_id,
-                        invoice.subscription_id AS subscription_id,
-                        NULL AS session_id,
-                        NULL AS event_name,
-                        JSONExtractString(invoice.discount, 'coupon', 'name') AS coupon,
-                        JSONExtractString(invoice.discount, 'coupon', 'id') AS coupon_id,
-                        upper(invoice.currency) AS original_currency,
-                        accurateCastOrNull(invoice.amount_captured, 'Decimal64(10)') AS original_amount,
-                        in(original_currency,
-                           ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
-                          if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
-                          divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
-                          'GBP' AS currency,
-                          divideDecimal(if(equals(original_currency, currency), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal64(1, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10))))), accurateCastOrNull(invoice.period_months, 'Decimal64(10)')) AS amount
-                 FROM
-                   (SELECT posthog_test_stripe_invoice.id AS id,
-                           parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC') AS created_at,
-                           posthog_test_stripe_invoice.customer AS customer_id,
-                           posthog_test_stripe_invoice.subscription AS subscription_id,
-                           posthog_test_stripe_invoice.discount AS discount,
-                           arrayJoin(JSONExtractArrayRaw(assumeNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(posthog_test_stripe_invoice.lines, 'data'), ''), 'null'), '^"|"$', '')))) AS data,
-                           JSONExtractString(data, 'id') AS invoice_item_id,
-                           JSONExtractUInt(data, 'amount') AS amount_before_discount,
-                           coalesce(arraySum(arrayMap(x -> JSONExtractInt(x, 'amount'), JSONExtractArrayRaw(data, 'discount_amounts'))), 0) AS discount_amount,
-                           greatest(minus(amount_before_discount, discount_amount), 0) AS amount_captured,
-                           JSONExtractString(data, 'currency') AS currency,
-                           JSONExtractString(data, 'price', 'product') AS product_id,
-                           fromUnixTimestamp(JSONExtractUInt(data, 'period', 'start')) AS period_start,
-                           fromUnixTimestamp(JSONExtractUInt(data, 'period', 'end')) AS period_end,
-                           greatest(toInt16(round(divide(dateDiff('day', ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')), ifNull(period_end, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC'))), 30.44))), 1) AS period_months,
-                           arrayJoin(range(0, period_months)) AS month_index,
-                           ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')) AS timestamp
-                    FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `subscription` String, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS posthog_test_stripe_invoice
-                    WHERE posthog_test_stripe_invoice.paid) AS invoice) AS revenue_item
-              WHERE and(revenue_item.is_recurring, isNotNull(revenue_item.subscription_id), greaterOrEquals(timestamp, toStartOfMonth(addDays(toDateTime64('today', 6, 'UTC'), -60))), lessOrEquals(timestamp, toDateTime64('today', 6, 'UTC')))
-              GROUP BY revenue_item.source_label,
-                       revenue_item.customer_id,
-                       revenue_item.subscription_id, timestamp
-              ORDER BY timestamp DESC
-              UNION ALL SELECT `stripe.posthog_test.subscription_revenue_view`.source_label AS source_label,
-                               `stripe.posthog_test.subscription_revenue_view`.customer_id AS customer_id,
-                               `stripe.posthog_test.subscription_revenue_view`.id AS subscription_id,
-                               toTimeZone(`stripe.posthog_test.subscription_revenue_view`.ended_at, 'UTC') AS timestamp,
-                               accurateCastOrNull(0, 'Decimal64(10)') AS amount
-              FROM
-                (SELECT '' AS id,
-                        '' AS source_label,
-                        '' AS plan_id,
-                        '' AS product_id,
-                        '' AS customer_id,
-                        '' AS status,
-                        toDateTime64('1970-01-01 00:00:00.000000', 6, 'UTC') AS started_at,
-                        toDateTime64('1970-01-01 00:00:00.000000', 6, 'UTC') AS ended_at,
-                        '' AS metadata
-                 WHERE 0) AS `stripe.posthog_test.subscription_revenue_view`
-              WHERE and(greaterOrEquals(timestamp, toStartOfMonth(addDays(toDateTime64('today', 6, 'UTC'), -60))), lessOrEquals(timestamp, toDateTime64('today', 6, 'UTC')))
-              ORDER BY timestamp DESC) AS
-           union
-           GROUP BY source_label,
-                    customer_id,
-                    subscription_id
-           ORDER BY customer_id ASC,
-                    subscription_id ASC) AS `stripe.posthog_test.mrr_revenue_view`
+        FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-stripe_posthog_test_mrr_revenue_view/stripe.posthog_test.mrr_revenue_view/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`mrr` Nullable(Decimal64(10)), `customer_id` Nullable(String), `source_label` Nullable(String), `subscription_id` Nullable(String)') AS `stripe.posthog_test.mrr_revenue_view`
         GROUP BY customer_id) AS mrr_agg ON equals(revenue_analytics_customer.id, mrr_agg.customer_id)) AS persons__revenue_analytics ON equals(toString(persons.persons___id), toString(persons__revenue_analytics.person_id))
   ORDER BY persons.id ASC
   LIMIT 100 SETTINGS format_csv_allow_double_quotes=1,
@@ -5728,199 +5263,17 @@
             coalesce(revenue_agg.revenue, accurateCastOrNull(0, 'Decimal64(10)')) AS revenue,
             coalesce(mrr_agg.mrr, accurateCastOrNull(0, 'Decimal64(10)')) AS mrr
      FROM
-       (SELECT toString(persons.id) AS id,
-               'revenue_analytics.events.purchase' AS source_label,
-               persons.created_at AS timestamp,
-               persons.properties___name AS name,
-               persons.properties___email AS email,
-               persons.properties___phone AS phone,
-               persons.properties___address AS address,
-               persons.properties___metadata AS metadata,
-               persons.`properties___$geoip_country_name` AS country,
-               formatDateTime(toStartOfMonth(persons.created_at), '%Y-%m') AS cohort,
-               NULL AS initial_coupon,
-               NULL AS initial_coupon_id
-        FROM
-          (SELECT person.id AS id,
-                  replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'name'), ''), 'null'), '^"|"$', '') AS properties___name,
-                  replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'email'), ''), 'null'), '^"|"$', '') AS properties___email,
-                  replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'phone'), ''), 'null'), '^"|"$', '') AS properties___phone,
-                  replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'address'), ''), 'null'), '^"|"$', '') AS properties___address,
-                  replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'metadata'), ''), 'null'), '^"|"$', '') AS properties___metadata,
-                  replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, '$geoip_country_name'), ''), 'null'), '^"|"$', '') AS `properties___$geoip_country_name`,
-                  toTimeZone(person.created_at, 'UTC') AS created_at
-           FROM person
-           WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
-                                                         (SELECT person.id AS id, max(person.version) AS version
-                                                          FROM person
-                                                          WHERE equals(person.team_id, 99999)
-                                                          GROUP BY person.id
-                                                          HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0))))) SETTINGS optimize_aggregation_in_order=1) AS persons
-        INNER JOIN
-          (SELECT DISTINCT events__person.id AS person_id
-           FROM events
-           LEFT OUTER JOIN
-             (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
-                     person_distinct_id_overrides.distinct_id AS distinct_id
-              FROM person_distinct_id_overrides
-              WHERE equals(person_distinct_id_overrides.team_id, 99999)
-              GROUP BY person_distinct_id_overrides.distinct_id
-              HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-           INNER JOIN
-             (SELECT person.id AS id
-              FROM person
-              WHERE equals(person.team_id, 99999)
-              GROUP BY person.id
-              HAVING and(ifNull(equals(tupleElement(argMax(tuple(person.is_deleted), person.version), 1), 0), 0), ifNull(less(tupleElement(argMax(tuple(toTimeZone(person.created_at, 'UTC')), person.version), 1), plus(now64(6, 'UTC'), toIntervalDay(1))), 0)) SETTINGS optimize_aggregation_in_order=1) AS events__person ON equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), events__person.id)
-           WHERE equals(events.team_id, 99999)) AS events ON equals(persons.id, events.person_id)
-        ORDER BY persons.created_at DESC) AS revenue_analytics_customer
+       (SELECT *
+        FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-revenue_analytics_events_purchase_customer_events_revenue_view/revenue_analytics.events.purchase.customer_events_revenue_view/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` Nullable(String), `name` Nullable(String), `email` Nullable(String), `phone` Nullable(String), `cohort` Nullable(String), `address` Nullable(String), `country` Nullable(String), `metadata` Nullable(String), `timestamp` Nullable(DateTime64(6, \'UTC\')), `source_label` Nullable(String), `initial_coupon` Nullable(String), `initial_coupon_id` Nullable(String)')) AS revenue_analytics_customer
      LEFT JOIN
        (SELECT revenue_analytics_revenue_item.customer_id AS customer_id,
                sum(revenue_analytics_revenue_item.amount) AS revenue
-        FROM
-          (SELECT toString(events.uuid) AS id,
-                  toString(events.uuid) AS invoice_item_id,
-                  'revenue_analytics.events.purchase' AS source_label,
-                  toTimeZone(events.timestamp, 'UTC') AS timestamp,
-                  timestamp AS created_at,
-                  isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'subscription_id'), ''), 'null'), '^"|"$', '')) AS is_recurring,
-                  NULL AS product_id,
-                  toString(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS customer_id,
-                  events.`$group_0` AS group_0_key,
-                  events.`$group_1` AS group_1_key,
-                  events.`$group_2` AS group_2_key,
-                  events.`$group_3` AS group_3_key,
-                  events.`$group_4` AS group_4_key,
-                  NULL AS invoice_id,
-                  replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'subscription_id'), ''), 'null'), '^"|"$', '') AS subscription_id,
-                  toString(events.`$session_id`) AS session_id,
-                  events.event AS event_name,
-                  NULL AS coupon,
-                  coupon AS coupon_id,
-                  'USD' AS original_currency,
-                  accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)') AS original_amount,
-                  in(original_currency,
-                     ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
-                    if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
-                    divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
-                    'USD' AS currency,
-                    if(isNull('USD'), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals('USD', 'USD'), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(1, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))) AS amount
-           FROM events
-           LEFT OUTER JOIN
-             (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
-                     person_distinct_id_overrides.distinct_id AS distinct_id
-              FROM person_distinct_id_overrides
-              WHERE equals(person_distinct_id_overrides.team_id, 99999)
-              GROUP BY person_distinct_id_overrides.distinct_id
-              HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-           WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), 1, isNotNull(amount)))
-           ORDER BY timestamp DESC) AS revenue_analytics_revenue_item
+        FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-revenue_analytics_events_purchase_revenue_item_events_revenue_view/revenue_analytics.events.purchase.revenue_item_events_revenue_view/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` Nullable(String), `amount` Nullable(Decimal64(10)), `coupon` Nullable(String), `currency` Nullable(String), `coupon_id` Nullable(String), `timestamp` Nullable(DateTime64(6, \'UTC\')), `created_at` Nullable(DateTime64(6, \'UTC\')), `event_name` Nullable(String), `invoice_id` Nullable(String), `product_id` Nullable(String), `session_id` Nullable(String), `customer_id` Nullable(String), `group_0_key` Nullable(String), `group_1_key` Nullable(String), `group_2_key` Nullable(String), `group_3_key` Nullable(String), `group_4_key` Nullable(String), `is_recurring` Nullable(Boolean), `source_label` Nullable(String), `invoice_item_id` Nullable(String), `original_amount` Nullable(Decimal64(10)), `subscription_id` Nullable(String), `original_currency` Nullable(String), `currency_aware_amount` Nullable(Decimal64(10)), `currency_aware_divider` Nullable(Decimal64(10)), `enable_currency_aware_divider` Nullable(Boolean)') AS revenue_analytics_revenue_item
         GROUP BY customer_id) AS revenue_agg ON equals(revenue_analytics_customer.id, revenue_agg.customer_id)
      LEFT JOIN
        (SELECT `revenue_analytics.events.purchase.mrr_events_revenue_view`.customer_id AS customer_id,
                sum(`revenue_analytics.events.purchase.mrr_events_revenue_view`.mrr) AS mrr
-        FROM
-          (SELECT union.source_label AS source_label,
-                  union.customer_id AS customer_id,
-                  union.subscription_id AS subscription_id,
-                  argMax(union.amount, union.timestamp) AS mrr
-           FROM
-             (SELECT revenue_item.source_label AS source_label,
-                     revenue_item.customer_id AS customer_id,
-                     revenue_item.subscription_id AS subscription_id,
-                     toStartOfMonth(toTimeZone(revenue_item.timestamp, 'UTC')) AS timestamp,
-                     sum(revenue_item.amount) AS amount
-              FROM
-                (SELECT toString(events.uuid) AS id,
-                        toString(events.uuid) AS invoice_item_id,
-                        'revenue_analytics.events.purchase' AS source_label,
-                        toTimeZone(events.timestamp, 'UTC') AS timestamp,
-                        timestamp AS created_at,
-                        isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'subscription_id'), ''), 'null'), '^"|"$', '')) AS is_recurring,
-                        NULL AS product_id,
-                        toString(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS customer_id,
-                        events.`$group_0` AS group_0_key,
-                        events.`$group_1` AS group_1_key,
-                        events.`$group_2` AS group_2_key,
-                        events.`$group_3` AS group_3_key,
-                        events.`$group_4` AS group_4_key,
-                        NULL AS invoice_id,
-                        replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'subscription_id'), ''), 'null'), '^"|"$', '') AS subscription_id,
-                        toString(events.`$session_id`) AS session_id,
-                        events.event AS event_name,
-                        NULL AS coupon,
-                        coupon AS coupon_id,
-                        'USD' AS original_currency,
-                        accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)') AS original_amount,
-                        in(original_currency,
-                           ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
-                          if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
-                          divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
-                          'USD' AS currency,
-                          if(isNull('USD'), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals('USD', 'USD'), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(1, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))) AS amount
-                 FROM events
-                 LEFT OUTER JOIN
-                   (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
-                           person_distinct_id_overrides.distinct_id AS distinct_id
-                    FROM person_distinct_id_overrides
-                    WHERE equals(person_distinct_id_overrides.team_id, 99999)
-                    GROUP BY person_distinct_id_overrides.distinct_id
-                    HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-                 WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), 1, isNotNull(amount)))
-                 ORDER BY timestamp DESC) AS revenue_item
-              WHERE and(revenue_item.is_recurring, isNotNull(revenue_item.subscription_id), greaterOrEquals(timestamp, toStartOfMonth(addDays(toDateTime64('explicit_redacted_timestamp', 6, 'UTC'), -60))), lessOrEquals(timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')))
-              GROUP BY revenue_item.source_label,
-                       revenue_item.customer_id,
-                       revenue_item.subscription_id, timestamp
-              ORDER BY timestamp DESC
-              UNION ALL SELECT `revenue_analytics.events.purchase.subscription_events_revenue_view`.source_label AS source_label,
-                               `revenue_analytics.events.purchase.subscription_events_revenue_view`.customer_id AS customer_id,
-                               `revenue_analytics.events.purchase.subscription_events_revenue_view`.id AS subscription_id,
-                               toTimeZone(`revenue_analytics.events.purchase.subscription_events_revenue_view`.ended_at, 'UTC') AS timestamp,
-                               accurateCastOrNull(0, 'Decimal64(10)') AS amount
-              FROM
-                (SELECT subscription_id AS id,
-                        'revenue_analytics.events.purchase' AS source_label,
-                        NULL AS plan_id,
-                        product_id AS product_id,
-                        toString(person_id) AS customer_id,
-                        NULL AS status,
-                        min_timestamp AS started_at,
-                        if(ifNull(greater(max_timestamp_plus_dropoff_days, today()), 0), NULL, max_timestamp_plus_dropoff_days) AS ended_at,
-                        NULL AS metadata
-                 FROM
-                   (SELECT events__person.id AS person_id,
-                           replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'subscription_id'), ''), 'null'), '^"|"$', '') AS subscription_id,
-                           NULL AS product_id,
-                           min(toTimeZone(events.timestamp, 'UTC')) AS min_timestamp,
-                           max(toTimeZone(events.timestamp, 'UTC')) AS max_timestamp,
-                           addDays(max_timestamp, 45.0) AS max_timestamp_plus_dropoff_days
-                    FROM events
-                    LEFT OUTER JOIN
-                      (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
-                              person_distinct_id_overrides.distinct_id AS distinct_id
-                       FROM person_distinct_id_overrides
-                       WHERE equals(person_distinct_id_overrides.team_id, 99999)
-                       GROUP BY person_distinct_id_overrides.distinct_id
-                       HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-                    INNER JOIN
-                      (SELECT person.id AS id
-                       FROM person
-                       WHERE equals(person.team_id, 99999)
-                       GROUP BY person.id
-                       HAVING and(ifNull(equals(tupleElement(argMax(tuple(person.is_deleted), person.version), 1), 0), 0), ifNull(less(tupleElement(argMax(tuple(toTimeZone(person.created_at, 'UTC')), person.version), 1), plus(now64(6, 'UTC'), toIntervalDay(1))), 0)) SETTINGS optimize_aggregation_in_order=1) AS events__person ON equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), events__person.id)
-                    WHERE and(equals(events.team_id, 99999), and(1, isNotNull(subscription_id)))
-                    GROUP BY subscription_id,
-                             person_id)
-                 ORDER BY started_at DESC) AS `revenue_analytics.events.purchase.subscription_events_revenue_view`
-              WHERE and(greaterOrEquals(timestamp, toStartOfMonth(addDays(toDateTime64('explicit_redacted_timestamp', 6, 'UTC'), -60))), lessOrEquals(timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')))
-              ORDER BY timestamp DESC) AS
-           union
-           GROUP BY source_label,
-                    customer_id,
-                    subscription_id
-           ORDER BY customer_id ASC,
-                    subscription_id ASC) AS `revenue_analytics.events.purchase.mrr_events_revenue_view`
+        FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-revenue_analytics_events_purchase_mrr_events_revenue_view/revenue_analytics.events.purchase.mrr_events_revenue_view/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`mrr` Nullable(Decimal64(10)), `customer_id` Nullable(String), `source_label` Nullable(String), `subscription_id` Nullable(String)') AS `revenue_analytics.events.purchase.mrr_events_revenue_view`
         GROUP BY customer_id) AS mrr_agg ON equals(revenue_analytics_customer.id, mrr_agg.customer_id)) AS persons_revenue_analytics
   ORDER BY persons_revenue_analytics.person_id ASC
   LIMIT 100 SETTINGS format_csv_allow_double_quotes=1,
@@ -5947,28 +5300,8 @@
             coalesce(revenue_agg.revenue, accurateCastOrNull(0, 'Decimal64(10)')) AS revenue,
             coalesce(mrr_agg.mrr, accurateCastOrNull(0, 'Decimal64(10)')) AS mrr
      FROM
-       (SELECT outer.id AS id,
-               'stripe.posthog_test' AS source_label,
-               parseDateTime64BestEffortOrNull(toString(outer.created), 6, 'UTC') AS timestamp,
-               outer.name AS name,
-               outer.email AS email,
-               outer.phone AS phone,
-               outer.address AS address,
-               outer.metadata AS metadata,
-               JSONExtractString(address, 'country') AS country,
-               cohort_inner.cohort AS cohort,
-               cohort_inner.initial_coupon AS initial_coupon,
-               cohort_inner.initial_coupon_id AS initial_coupon_id
-        FROM
-          (SELECT *
-           FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_customers/posthog_test_stripe_customer/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `name` String, `email` String, `phone` String, `address` String, `created` DateTime, `metadata` String')) AS outer
-        LEFT JOIN
-          (SELECT invoice.customer AS customer_id,
-                  formatDateTime(toStartOfMonth(min(parseDateTime64BestEffortOrNull(toString(invoice.created), 6, 'UTC'))), '%Y-%m') AS cohort,
-                  argMin(JSONExtractString(invoice.discount, 'coupon', 'name'), parseDateTime64BestEffortOrNull(toString(invoice.created), 6, 'UTC')) AS initial_coupon,
-                  argMin(JSONExtractString(invoice.discount, 'coupon', 'id'), parseDateTime64BestEffortOrNull(toString(invoice.created), 6, 'UTC')) AS initial_coupon_id
-           FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `subscription` String, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS invoice
-           GROUP BY invoice.customer) AS cohort_inner ON equals(cohort_inner.customer_id, outer.id)) AS revenue_analytics_customer
+       (SELECT *
+        FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-stripe_posthog_test_customer_revenue_view/stripe.posthog_test.customer_revenue_view/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` Nullable(String), `name` Nullable(String), `email` Nullable(String), `phone` Nullable(String), `cohort` Nullable(String), `address` Nullable(String), `country` Nullable(String), `metadata` Nullable(String), `timestamp` Nullable(DateTime64(6, \'UTC\')), `source_label` Nullable(String), `initial_coupon` Nullable(String), `initial_coupon_id` Nullable(String)')) AS revenue_analytics_customer
      LEFT JOIN
        (SELECT persons.id AS id,
                persons__pdi.distinct_id AS revenue_analytics_customer__persons___pdi___distinct_id
@@ -5989,146 +5322,12 @@
      LEFT JOIN
        (SELECT revenue_analytics_revenue_item.customer_id AS customer_id,
                sum(revenue_analytics_revenue_item.amount) AS revenue
-        FROM
-          (SELECT if(ifNull(greater(invoice.period_months, 1), 0), concat(ifNull(toString(invoice.invoice_item_id), ''), '_', ifNull(toString(invoice.month_index), '')), invoice.invoice_item_id) AS id,
-                  invoice.invoice_item_id AS invoice_item_id,
-                  'stripe.posthog_test' AS source_label,
-                  addMonths(invoice.timestamp, invoice.month_index) AS timestamp,
-                  invoice.created_at AS created_at,
-                  ifNull(notEmpty(invoice.subscription_id), 0) AS is_recurring,
-                  invoice.product_id AS product_id,
-                  invoice.customer_id AS customer_id,
-                  NULL AS group_0_key,
-                  NULL AS group_1_key,
-                  NULL AS group_2_key,
-                  NULL AS group_3_key,
-                  NULL AS group_4_key,
-                  invoice.id AS invoice_id,
-                  invoice.subscription_id AS subscription_id,
-                  NULL AS session_id,
-                  NULL AS event_name,
-                  JSONExtractString(invoice.discount, 'coupon', 'name') AS coupon,
-                  JSONExtractString(invoice.discount, 'coupon', 'id') AS coupon_id,
-                  upper(invoice.currency) AS original_currency,
-                  accurateCastOrNull(invoice.amount_captured, 'Decimal64(10)') AS original_amount,
-                  in(original_currency,
-                     ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
-                    if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
-                    divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
-                    'GBP' AS currency,
-                    divideDecimal(if(equals(original_currency, currency), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal64(1, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10))))), accurateCastOrNull(invoice.period_months, 'Decimal64(10)')) AS amount
-           FROM
-             (SELECT posthog_test_stripe_invoice.id AS id,
-                     parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC') AS created_at,
-                     posthog_test_stripe_invoice.customer AS customer_id,
-                     posthog_test_stripe_invoice.subscription AS subscription_id,
-                     posthog_test_stripe_invoice.discount AS discount,
-                     arrayJoin(JSONExtractArrayRaw(assumeNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(posthog_test_stripe_invoice.lines, 'data'), ''), 'null'), '^"|"$', '')))) AS data,
-                     JSONExtractString(data, 'id') AS invoice_item_id,
-                     JSONExtractUInt(data, 'amount') AS amount_before_discount,
-                     coalesce(arraySum(arrayMap(x -> JSONExtractInt(x, 'amount'), JSONExtractArrayRaw(data, 'discount_amounts'))), 0) AS discount_amount,
-                     greatest(minus(amount_before_discount, discount_amount), 0) AS amount_captured,
-                     JSONExtractString(data, 'currency') AS currency,
-                     JSONExtractString(data, 'price', 'product') AS product_id,
-                     fromUnixTimestamp(JSONExtractUInt(data, 'period', 'start')) AS period_start,
-                     fromUnixTimestamp(JSONExtractUInt(data, 'period', 'end')) AS period_end,
-                     greatest(toInt16(round(divide(dateDiff('day', ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')), ifNull(period_end, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC'))), 30.44))), 1) AS period_months,
-                     arrayJoin(range(0, period_months)) AS month_index,
-                     ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')) AS timestamp
-              FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `subscription` String, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS posthog_test_stripe_invoice
-              WHERE posthog_test_stripe_invoice.paid) AS invoice) AS revenue_analytics_revenue_item
+        FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-stripe_posthog_test_revenue_item_revenue_view/stripe.posthog_test.revenue_item_revenue_view/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` Nullable(String), `amount` Nullable(Decimal64(10)), `coupon` Nullable(String), `currency` Nullable(String), `coupon_id` Nullable(String), `timestamp` Nullable(DateTime64(6, \'UTC\')), `created_at` Nullable(DateTime64(6, \'UTC\')), `event_name` Nullable(String), `invoice_id` Nullable(String), `product_id` Nullable(String), `session_id` Nullable(String), `customer_id` Nullable(String), `group_0_key` Nullable(String), `group_1_key` Nullable(String), `group_2_key` Nullable(String), `group_3_key` Nullable(String), `group_4_key` Nullable(String), `is_recurring` Nullable(Boolean), `source_label` Nullable(String), `invoice_item_id` Nullable(String), `original_amount` Nullable(Decimal64(10)), `subscription_id` Nullable(String), `original_currency` Nullable(String), `currency_aware_amount` Nullable(Decimal64(10)), `currency_aware_divider` Nullable(Decimal64(10)), `enable_currency_aware_divider` Nullable(Boolean)') AS revenue_analytics_revenue_item
         GROUP BY customer_id) AS revenue_agg ON equals(revenue_analytics_customer.id, revenue_agg.customer_id)
      LEFT JOIN
        (SELECT `stripe.posthog_test.mrr_revenue_view`.customer_id AS customer_id,
                sum(`stripe.posthog_test.mrr_revenue_view`.mrr) AS mrr
-        FROM
-          (SELECT union.source_label AS source_label,
-                  union.customer_id AS customer_id,
-                  union.subscription_id AS subscription_id,
-                  argMax(union.amount, union.timestamp) AS mrr
-           FROM
-             (SELECT revenue_item.source_label AS source_label,
-                     revenue_item.customer_id AS customer_id,
-                     revenue_item.subscription_id AS subscription_id,
-                     toStartOfMonth(toTimeZone(revenue_item.timestamp, 'UTC')) AS timestamp,
-                     sum(revenue_item.amount) AS amount
-              FROM
-                (SELECT if(ifNull(greater(invoice.period_months, 1), 0), concat(ifNull(toString(invoice.invoice_item_id), ''), '_', ifNull(toString(invoice.month_index), '')), invoice.invoice_item_id) AS id,
-                        invoice.invoice_item_id AS invoice_item_id,
-                        'stripe.posthog_test' AS source_label,
-                        addMonths(invoice.timestamp, invoice.month_index) AS timestamp,
-                        invoice.created_at AS created_at,
-                        ifNull(notEmpty(invoice.subscription_id), 0) AS is_recurring,
-                        invoice.product_id AS product_id,
-                        invoice.customer_id AS customer_id,
-                        NULL AS group_0_key,
-                        NULL AS group_1_key,
-                        NULL AS group_2_key,
-                        NULL AS group_3_key,
-                        NULL AS group_4_key,
-                        invoice.id AS invoice_id,
-                        invoice.subscription_id AS subscription_id,
-                        NULL AS session_id,
-                        NULL AS event_name,
-                        JSONExtractString(invoice.discount, 'coupon', 'name') AS coupon,
-                        JSONExtractString(invoice.discount, 'coupon', 'id') AS coupon_id,
-                        upper(invoice.currency) AS original_currency,
-                        accurateCastOrNull(invoice.amount_captured, 'Decimal64(10)') AS original_amount,
-                        in(original_currency,
-                           ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
-                          if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
-                          divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
-                          'GBP' AS currency,
-                          divideDecimal(if(equals(original_currency, currency), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal64(1, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10))))), accurateCastOrNull(invoice.period_months, 'Decimal64(10)')) AS amount
-                 FROM
-                   (SELECT posthog_test_stripe_invoice.id AS id,
-                           parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC') AS created_at,
-                           posthog_test_stripe_invoice.customer AS customer_id,
-                           posthog_test_stripe_invoice.subscription AS subscription_id,
-                           posthog_test_stripe_invoice.discount AS discount,
-                           arrayJoin(JSONExtractArrayRaw(assumeNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(posthog_test_stripe_invoice.lines, 'data'), ''), 'null'), '^"|"$', '')))) AS data,
-                           JSONExtractString(data, 'id') AS invoice_item_id,
-                           JSONExtractUInt(data, 'amount') AS amount_before_discount,
-                           coalesce(arraySum(arrayMap(x -> JSONExtractInt(x, 'amount'), JSONExtractArrayRaw(data, 'discount_amounts'))), 0) AS discount_amount,
-                           greatest(minus(amount_before_discount, discount_amount), 0) AS amount_captured,
-                           JSONExtractString(data, 'currency') AS currency,
-                           JSONExtractString(data, 'price', 'product') AS product_id,
-                           fromUnixTimestamp(JSONExtractUInt(data, 'period', 'start')) AS period_start,
-                           fromUnixTimestamp(JSONExtractUInt(data, 'period', 'end')) AS period_end,
-                           greatest(toInt16(round(divide(dateDiff('day', ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')), ifNull(period_end, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC'))), 30.44))), 1) AS period_months,
-                           arrayJoin(range(0, period_months)) AS month_index,
-                           ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')) AS timestamp
-                    FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `subscription` String, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS posthog_test_stripe_invoice
-                    WHERE posthog_test_stripe_invoice.paid) AS invoice) AS revenue_item
-              WHERE and(revenue_item.is_recurring, isNotNull(revenue_item.subscription_id), greaterOrEquals(timestamp, toStartOfMonth(addDays(toDateTime64('2025-05-30 00:00:00.000000', 6, 'UTC'), -60))), lessOrEquals(timestamp, toDateTime64('2025-05-30 00:00:00.000000', 6, 'UTC')))
-              GROUP BY revenue_item.source_label,
-                       revenue_item.customer_id,
-                       revenue_item.subscription_id, timestamp
-              ORDER BY timestamp DESC
-              UNION ALL SELECT `stripe.posthog_test.subscription_revenue_view`.source_label AS source_label,
-                               `stripe.posthog_test.subscription_revenue_view`.customer_id AS customer_id,
-                               `stripe.posthog_test.subscription_revenue_view`.id AS subscription_id,
-                               toTimeZone(`stripe.posthog_test.subscription_revenue_view`.ended_at, 'UTC') AS timestamp,
-                               accurateCastOrNull(0, 'Decimal64(10)') AS amount
-              FROM
-                (SELECT '' AS id,
-                        '' AS source_label,
-                        '' AS plan_id,
-                        '' AS product_id,
-                        '' AS customer_id,
-                        '' AS status,
-                        toDateTime64('1970-01-01 00:00:00.000000', 6, 'UTC') AS started_at,
-                        toDateTime64('1970-01-01 00:00:00.000000', 6, 'UTC') AS ended_at,
-                        '' AS metadata
-                 WHERE 0) AS `stripe.posthog_test.subscription_revenue_view`
-              WHERE and(greaterOrEquals(timestamp, toStartOfMonth(addDays(toDateTime64('2025-05-30 00:00:00.000000', 6, 'UTC'), -60))), lessOrEquals(timestamp, toDateTime64('2025-05-30 00:00:00.000000', 6, 'UTC')))
-              ORDER BY timestamp DESC) AS
-           union
-           GROUP BY source_label,
-                    customer_id,
-                    subscription_id
-           ORDER BY customer_id ASC,
-                    subscription_id ASC) AS `stripe.posthog_test.mrr_revenue_view`
+        FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-stripe_posthog_test_mrr_revenue_view/stripe.posthog_test.mrr_revenue_view/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`mrr` Nullable(Decimal64(10)), `customer_id` Nullable(String), `source_label` Nullable(String), `subscription_id` Nullable(String)') AS `stripe.posthog_test.mrr_revenue_view`
         GROUP BY customer_id) AS mrr_agg ON equals(revenue_analytics_customer.id, mrr_agg.customer_id)) AS persons_revenue_analytics
   ORDER BY persons_revenue_analytics.mrr DESC,
            persons_revenue_analytics.revenue DESC
@@ -6199,176 +5398,17 @@
                      coalesce(revenue_agg.revenue, accurateCastOrNull(0, 'Decimal64(10)')) AS revenue,
                      coalesce(mrr_agg.mrr, accurateCastOrNull(0, 'Decimal64(10)')) AS mrr
               FROM
-                (SELECT toString(persons.id) AS id,
-                        'revenue_analytics.events.purchase' AS source_label,
-                        persons.created_at AS timestamp,
-                        persons.properties___name AS name,
-                        persons.properties___email AS email,
-                        persons.properties___phone AS phone,
-                        persons.properties___address AS address,
-                        persons.properties___metadata AS metadata,
-                        persons.`properties___$geoip_country_name` AS country,
-                        formatDateTime(toStartOfMonth(persons.created_at), '%Y-%m') AS cohort,
-                        NULL AS initial_coupon,
-                        NULL AS initial_coupon_id
-                 FROM
-                   (SELECT person.id AS id,
-                           replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'name'), ''), 'null'), '^"|"$', '') AS properties___name,
-                           replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'email'), ''), 'null'), '^"|"$', '') AS properties___email,
-                           replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'phone'), ''), 'null'), '^"|"$', '') AS properties___phone,
-                           replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'address'), ''), 'null'), '^"|"$', '') AS properties___address,
-                           replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'metadata'), ''), 'null'), '^"|"$', '') AS properties___metadata,
-                           replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, '$geoip_country_name'), ''), 'null'), '^"|"$', '') AS `properties___$geoip_country_name`,
-                           toTimeZone(person.created_at, 'UTC') AS created_at
-                    FROM person
-                    WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
-                                                                  (SELECT person.id AS id, max(person.version) AS version
-                                                                   FROM person
-                                                                   WHERE equals(person.team_id, 99999)
-                                                                   GROUP BY person.id
-                                                                   HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0))))) SETTINGS optimize_aggregation_in_order=1) AS persons
-                 INNER JOIN
-                   (SELECT DISTINCT events__pdi__person.id AS person_id
-                    FROM events
-                    INNER JOIN
-                      (SELECT tupleElement(argMax(tuple(person_distinct_id2.person_id), person_distinct_id2.version), 1) AS events__pdi___person_id,
-                              tupleElement(argMax(tuple(person_distinct_id2.person_id), person_distinct_id2.version), 1) AS person_id,
-                              person_distinct_id2.distinct_id AS distinct_id
-                       FROM person_distinct_id2
-                       WHERE equals(person_distinct_id2.team_id, 99999)
-                       GROUP BY person_distinct_id2.distinct_id
-                       HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id2.is_deleted), person_distinct_id2.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__pdi ON equals(events.distinct_id, events__pdi.distinct_id)
-                    INNER JOIN
-                      (SELECT person.id AS id
-                       FROM person
-                       WHERE equals(person.team_id, 99999)
-                       GROUP BY person.id
-                       HAVING and(ifNull(equals(tupleElement(argMax(tuple(person.is_deleted), person.version), 1), 0), 0), ifNull(less(tupleElement(argMax(tuple(toTimeZone(person.created_at, 'UTC')), person.version), 1), plus(now64(6, 'UTC'), toIntervalDay(1))), 0)) SETTINGS optimize_aggregation_in_order=1) AS events__pdi__person ON equals(events__pdi.events__pdi___person_id, events__pdi__person.id)
-                    WHERE equals(events.team_id, 99999)) AS events ON equals(persons.id, events.person_id)
-                 ORDER BY persons.created_at DESC) AS revenue_analytics_customer
+                (SELECT *
+                 FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-revenue_analytics_events_purchase_customer_events_revenue_view/revenue_analytics.events.purchase.customer_events_revenue_view/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` Nullable(String), `name` Nullable(String), `email` Nullable(String), `phone` Nullable(String), `cohort` Nullable(String), `address` Nullable(String), `country` Nullable(String), `metadata` Nullable(String), `timestamp` Nullable(DateTime64(6, \'UTC\')), `source_label` Nullable(String), `initial_coupon` Nullable(String), `initial_coupon_id` Nullable(String)')) AS revenue_analytics_customer
               LEFT JOIN
                 (SELECT revenue_analytics_revenue_item.customer_id AS customer_id,
                         sum(revenue_analytics_revenue_item.amount) AS revenue
-                 FROM
-                   (SELECT toString(events.uuid) AS id,
-                           toString(events.uuid) AS invoice_item_id,
-                           'revenue_analytics.events.purchase' AS source_label,
-                           toTimeZone(events.timestamp, 'UTC') AS timestamp,
-                           timestamp AS created_at,
-                           0 AS is_recurring,
-                           NULL AS product_id,
-                           toString(events__pdi.person_id) AS customer_id,
-                           events.`$group_0` AS group_0_key,
-                           events.`$group_1` AS group_1_key,
-                           events.`$group_2` AS group_2_key,
-                           events.`$group_3` AS group_3_key,
-                           events.`$group_4` AS group_4_key,
-                           NULL AS invoice_id,
-                           NULL AS subscription_id,
-                           toString(events.`$session_id`) AS session_id,
-                           events.event AS event_name,
-                           NULL AS coupon,
-                           coupon AS coupon_id,
-                           'USD' AS original_currency,
-                           accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)') AS original_amount,
-                           in(original_currency,
-                              ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
-                             if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
-                             divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
-                             'USD' AS currency,
-                             if(isNull('USD'), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals('USD', 'USD'), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(1, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))) AS amount
-                    FROM events
-                    INNER JOIN
-                      (SELECT tupleElement(argMax(tuple(person_distinct_id2.person_id), person_distinct_id2.version), 1) AS person_id,
-                              person_distinct_id2.distinct_id AS distinct_id
-                       FROM person_distinct_id2
-                       WHERE equals(person_distinct_id2.team_id, 99999)
-                       GROUP BY person_distinct_id2.distinct_id
-                       HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id2.is_deleted), person_distinct_id2.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__pdi ON equals(events.distinct_id, events__pdi.distinct_id)
-                    WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), 1, isNotNull(amount)))
-                    ORDER BY timestamp DESC) AS revenue_analytics_revenue_item
+                 FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-revenue_analytics_events_purchase_revenue_item_events_revenue_view/revenue_analytics.events.purchase.revenue_item_events_revenue_view/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` Nullable(String), `amount` Nullable(Decimal64(10)), `coupon` Nullable(String), `currency` Nullable(String), `coupon_id` Nullable(String), `timestamp` Nullable(DateTime64(6, \'UTC\')), `created_at` Nullable(DateTime64(6, \'UTC\')), `event_name` Nullable(String), `invoice_id` Nullable(String), `product_id` Nullable(String), `session_id` Nullable(String), `customer_id` Nullable(String), `group_0_key` Nullable(String), `group_1_key` Nullable(String), `group_2_key` Nullable(String), `group_3_key` Nullable(String), `group_4_key` Nullable(String), `is_recurring` Nullable(Boolean), `source_label` Nullable(String), `invoice_item_id` Nullable(String), `original_amount` Nullable(Decimal64(10)), `subscription_id` Nullable(String), `original_currency` Nullable(String), `currency_aware_amount` Nullable(Decimal64(10)), `currency_aware_divider` Nullable(Decimal64(10)), `enable_currency_aware_divider` Nullable(Boolean)') AS revenue_analytics_revenue_item
                  GROUP BY customer_id) AS revenue_agg ON equals(revenue_analytics_customer.id, revenue_agg.customer_id)
               LEFT JOIN
                 (SELECT `revenue_analytics.events.purchase.mrr_events_revenue_view`.customer_id AS customer_id,
                         sum(`revenue_analytics.events.purchase.mrr_events_revenue_view`.mrr) AS mrr
-                 FROM
-                   (SELECT union.source_label AS source_label,
-                           union.customer_id AS customer_id,
-                           union.subscription_id AS subscription_id,
-                           argMax(union.amount, union.timestamp) AS mrr
-                    FROM
-                      (SELECT revenue_item.source_label AS source_label,
-                              revenue_item.customer_id AS customer_id,
-                              revenue_item.subscription_id AS subscription_id,
-                              toStartOfMonth(toTimeZone(revenue_item.timestamp, 'UTC')) AS timestamp,
-                              sum(revenue_item.amount) AS amount
-                       FROM
-                         (SELECT toString(events.uuid) AS id,
-                                 toString(events.uuid) AS invoice_item_id,
-                                 'revenue_analytics.events.purchase' AS source_label,
-                                 toTimeZone(events.timestamp, 'UTC') AS timestamp,
-                                 timestamp AS created_at,
-                                 0 AS is_recurring,
-                                 NULL AS product_id,
-                                 toString(events__pdi.person_id) AS customer_id,
-                                 events.`$group_0` AS group_0_key,
-                                 events.`$group_1` AS group_1_key,
-                                 events.`$group_2` AS group_2_key,
-                                 events.`$group_3` AS group_3_key,
-                                 events.`$group_4` AS group_4_key,
-                                 NULL AS invoice_id,
-                                 NULL AS subscription_id,
-                                 toString(events.`$session_id`) AS session_id,
-                                 events.event AS event_name,
-                                 NULL AS coupon,
-                                 coupon AS coupon_id,
-                                 'USD' AS original_currency,
-                                 accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)') AS original_amount,
-                                 in(original_currency,
-                                    ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
-                                   if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
-                                   divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
-                                   'USD' AS currency,
-                                   if(isNull('USD'), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals('USD', 'USD'), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(1, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))) AS amount
-                          FROM events
-                          INNER JOIN
-                            (SELECT tupleElement(argMax(tuple(person_distinct_id2.person_id), person_distinct_id2.version), 1) AS person_id,
-                                    person_distinct_id2.distinct_id AS distinct_id
-                             FROM person_distinct_id2
-                             WHERE equals(person_distinct_id2.team_id, 99999)
-                             GROUP BY person_distinct_id2.distinct_id
-                             HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id2.is_deleted), person_distinct_id2.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__pdi ON equals(events.distinct_id, events__pdi.distinct_id)
-                          WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), 1, isNotNull(amount)))
-                          ORDER BY timestamp DESC) AS revenue_item
-                       WHERE and(revenue_item.is_recurring, isNotNull(revenue_item.subscription_id), greaterOrEquals(timestamp, toStartOfMonth(addDays(toDateTime64('today', 6, 'UTC'), -60))), lessOrEquals(timestamp, toDateTime64('today', 6, 'UTC')))
-                       GROUP BY revenue_item.source_label,
-                                revenue_item.customer_id,
-                                revenue_item.subscription_id, timestamp
-                       ORDER BY timestamp DESC
-                       UNION ALL SELECT `revenue_analytics.events.purchase.subscription_events_revenue_view`.source_label AS source_label,
-                                        `revenue_analytics.events.purchase.subscription_events_revenue_view`.customer_id AS customer_id,
-                                        `revenue_analytics.events.purchase.subscription_events_revenue_view`.id AS subscription_id,
-                                        toTimeZone(`revenue_analytics.events.purchase.subscription_events_revenue_view`.ended_at, 'UTC') AS timestamp,
-                                        accurateCastOrNull(0, 'Decimal64(10)') AS amount
-                       FROM
-                         (SELECT '' AS id,
-                                 '' AS source_label,
-                                 '' AS plan_id,
-                                 '' AS product_id,
-                                 '' AS customer_id,
-                                 '' AS status,
-                                 toDateTime64('1970-01-01 00:00:00.000000', 6, 'UTC') AS started_at,
-                                 toDateTime64('1970-01-01 00:00:00.000000', 6, 'UTC') AS ended_at,
-                                 '' AS metadata
-                          WHERE 0) AS `revenue_analytics.events.purchase.subscription_events_revenue_view`
-                       WHERE and(greaterOrEquals(timestamp, toStartOfMonth(addDays(toDateTime64('today', 6, 'UTC'), -60))), lessOrEquals(timestamp, toDateTime64('today', 6, 'UTC')))
-                       ORDER BY timestamp DESC) AS
-                    union
-                    GROUP BY source_label,
-                             customer_id,
-                             subscription_id
-                    ORDER BY customer_id ASC,
-                             subscription_id ASC) AS `revenue_analytics.events.purchase.mrr_events_revenue_view`
+                 FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-revenue_analytics_events_purchase_mrr_events_revenue_view/revenue_analytics.events.purchase.mrr_events_revenue_view/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`mrr` Nullable(Decimal64(10)), `customer_id` Nullable(String), `source_label` Nullable(String), `subscription_id` Nullable(String)') AS `revenue_analytics.events.purchase.mrr_events_revenue_view`
                  GROUP BY customer_id) AS mrr_agg ON equals(revenue_analytics_customer.id, mrr_agg.customer_id)) AS e__pdi__person__revenue_analytics ON equals(toString(e__pdi__person.e__pdi__person___id), toString(e__pdi__person__revenue_analytics.person_id))
            WHERE and(equals(e.team_id, 99999), greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toStartOfInterval(assumeNotNull(toDateTime('2025-05-29 00:00:00', 'UTC')), toIntervalDay(1))), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), assumeNotNull(toDateTime('2025-05-30 23:59:59', 'UTC'))), equals(e.event, '$pageview'))
            GROUP BY day_start,
@@ -6437,7 +5477,8 @@
      FROM top_n_and_other_breakdown_values
      GROUP BY top_n_and_other_breakdown_values.breakdown_value)
   ORDER BY if(has(breakdown_value, '$$_posthog_breakdown_other_$$'), 2, if(has(breakdown_value, '$$_posthog_breakdown_null_$$'), 1, 0)) ASC, arraySum(total) DESC, breakdown_value ASC
-  LIMIT 50000 SETTINGS readonly=2,
+  LIMIT 50000 SETTINGS format_csv_allow_double_quotes=1,
+                       readonly=2,
                        max_execution_time=60,
                        allow_experimental_object_type=1,
                        max_ast_elements=4000000,
@@ -6488,148 +5529,17 @@
                      coalesce(revenue_agg.revenue, accurateCastOrNull(0, 'Decimal64(10)')) AS revenue,
                      coalesce(mrr_agg.mrr, accurateCastOrNull(0, 'Decimal64(10)')) AS mrr
               FROM
-                (SELECT toString(persons.id) AS id,
-                        'revenue_analytics.events.purchase' AS source_label,
-                        persons.created_at AS timestamp,
-                        persons.properties___name AS name,
-                        persons.properties___email AS email,
-                        persons.properties___phone AS phone,
-                        persons.properties___address AS address,
-                        persons.properties___metadata AS metadata,
-                        persons.`properties___$geoip_country_name` AS country,
-                        formatDateTime(toStartOfMonth(persons.created_at), '%Y-%m') AS cohort,
-                        NULL AS initial_coupon,
-                        NULL AS initial_coupon_id
-                 FROM
-                   (SELECT person.id AS id,
-                           replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'name'), ''), 'null'), '^"|"$', '') AS properties___name,
-                           replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'email'), ''), 'null'), '^"|"$', '') AS properties___email,
-                           replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'phone'), ''), 'null'), '^"|"$', '') AS properties___phone,
-                           replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'address'), ''), 'null'), '^"|"$', '') AS properties___address,
-                           replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'metadata'), ''), 'null'), '^"|"$', '') AS properties___metadata,
-                           replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, '$geoip_country_name'), ''), 'null'), '^"|"$', '') AS `properties___$geoip_country_name`,
-                           toTimeZone(person.created_at, 'UTC') AS created_at
-                    FROM person
-                    WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
-                                                                  (SELECT person.id AS id, max(person.version) AS version
-                                                                   FROM person
-                                                                   WHERE equals(person.team_id, 99999)
-                                                                   GROUP BY person.id
-                                                                   HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0))))) SETTINGS optimize_aggregation_in_order=1) AS persons
-                 INNER JOIN
-                   (SELECT DISTINCT events.person_id AS person_id
-                    FROM events
-                    WHERE equals(events.team_id, 99999)) AS events ON equals(persons.id, events.person_id)
-                 ORDER BY persons.created_at DESC) AS revenue_analytics_customer
+                (SELECT *
+                 FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-revenue_analytics_events_purchase_customer_events_revenue_view/revenue_analytics.events.purchase.customer_events_revenue_view/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` Nullable(String), `name` Nullable(String), `email` Nullable(String), `phone` Nullable(String), `cohort` Nullable(String), `address` Nullable(String), `country` Nullable(String), `metadata` Nullable(String), `timestamp` Nullable(DateTime64(6, \'UTC\')), `source_label` Nullable(String), `initial_coupon` Nullable(String), `initial_coupon_id` Nullable(String)')) AS revenue_analytics_customer
               LEFT JOIN
                 (SELECT revenue_analytics_revenue_item.customer_id AS customer_id,
                         sum(revenue_analytics_revenue_item.amount) AS revenue
-                 FROM
-                   (SELECT toString(events.uuid) AS id,
-                           toString(events.uuid) AS invoice_item_id,
-                           'revenue_analytics.events.purchase' AS source_label,
-                           toTimeZone(events.timestamp, 'UTC') AS timestamp,
-                           timestamp AS created_at,
-                           0 AS is_recurring,
-                           NULL AS product_id,
-                           toString(events.person_id) AS customer_id,
-                           events.`$group_0` AS group_0_key,
-                           events.`$group_1` AS group_1_key,
-                           events.`$group_2` AS group_2_key,
-                           events.`$group_3` AS group_3_key,
-                           events.`$group_4` AS group_4_key,
-                           NULL AS invoice_id,
-                           NULL AS subscription_id,
-                           toString(events.`$session_id`) AS session_id,
-                           events.event AS event_name,
-                           NULL AS coupon,
-                           coupon AS coupon_id,
-                           'USD' AS original_currency,
-                           accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)') AS original_amount,
-                           in(original_currency,
-                              ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
-                             if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
-                             divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
-                             'USD' AS currency,
-                             if(isNull('USD'), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals('USD', 'USD'), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(1, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))) AS amount
-                    FROM events
-                    WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), 1, isNotNull(amount)))
-                    ORDER BY timestamp DESC) AS revenue_analytics_revenue_item
+                 FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-revenue_analytics_events_purchase_revenue_item_events_revenue_view/revenue_analytics.events.purchase.revenue_item_events_revenue_view/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` Nullable(String), `amount` Nullable(Decimal64(10)), `coupon` Nullable(String), `currency` Nullable(String), `coupon_id` Nullable(String), `timestamp` Nullable(DateTime64(6, \'UTC\')), `created_at` Nullable(DateTime64(6, \'UTC\')), `event_name` Nullable(String), `invoice_id` Nullable(String), `product_id` Nullable(String), `session_id` Nullable(String), `customer_id` Nullable(String), `group_0_key` Nullable(String), `group_1_key` Nullable(String), `group_2_key` Nullable(String), `group_3_key` Nullable(String), `group_4_key` Nullable(String), `is_recurring` Nullable(Boolean), `source_label` Nullable(String), `invoice_item_id` Nullable(String), `original_amount` Nullable(Decimal64(10)), `subscription_id` Nullable(String), `original_currency` Nullable(String), `currency_aware_amount` Nullable(Decimal64(10)), `currency_aware_divider` Nullable(Decimal64(10)), `enable_currency_aware_divider` Nullable(Boolean)') AS revenue_analytics_revenue_item
                  GROUP BY customer_id) AS revenue_agg ON equals(revenue_analytics_customer.id, revenue_agg.customer_id)
               LEFT JOIN
                 (SELECT `revenue_analytics.events.purchase.mrr_events_revenue_view`.customer_id AS customer_id,
                         sum(`revenue_analytics.events.purchase.mrr_events_revenue_view`.mrr) AS mrr
-                 FROM
-                   (SELECT union.source_label AS source_label,
-                           union.customer_id AS customer_id,
-                           union.subscription_id AS subscription_id,
-                           argMax(union.amount, union.timestamp) AS mrr
-                    FROM
-                      (SELECT revenue_item.source_label AS source_label,
-                              revenue_item.customer_id AS customer_id,
-                              revenue_item.subscription_id AS subscription_id,
-                              toStartOfMonth(toTimeZone(revenue_item.timestamp, 'UTC')) AS timestamp,
-                              sum(revenue_item.amount) AS amount
-                       FROM
-                         (SELECT toString(events.uuid) AS id,
-                                 toString(events.uuid) AS invoice_item_id,
-                                 'revenue_analytics.events.purchase' AS source_label,
-                                 toTimeZone(events.timestamp, 'UTC') AS timestamp,
-                                 timestamp AS created_at,
-                                 0 AS is_recurring,
-                                 NULL AS product_id,
-                                 toString(events.person_id) AS customer_id,
-                                 events.`$group_0` AS group_0_key,
-                                 events.`$group_1` AS group_1_key,
-                                 events.`$group_2` AS group_2_key,
-                                 events.`$group_3` AS group_3_key,
-                                 events.`$group_4` AS group_4_key,
-                                 NULL AS invoice_id,
-                                 NULL AS subscription_id,
-                                 toString(events.`$session_id`) AS session_id,
-                                 events.event AS event_name,
-                                 NULL AS coupon,
-                                 coupon AS coupon_id,
-                                 'USD' AS original_currency,
-                                 accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)') AS original_amount,
-                                 in(original_currency,
-                                    ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
-                                   if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
-                                   divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
-                                   'USD' AS currency,
-                                   if(isNull('USD'), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals('USD', 'USD'), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(1, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))) AS amount
-                          FROM events
-                          WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), 1, isNotNull(amount)))
-                          ORDER BY timestamp DESC) AS revenue_item
-                       WHERE and(revenue_item.is_recurring, isNotNull(revenue_item.subscription_id), greaterOrEquals(timestamp, toStartOfMonth(addDays(toDateTime64('today', 6, 'UTC'), -60))), lessOrEquals(timestamp, toDateTime64('today', 6, 'UTC')))
-                       GROUP BY revenue_item.source_label,
-                                revenue_item.customer_id,
-                                revenue_item.subscription_id, timestamp
-                       ORDER BY timestamp DESC
-                       UNION ALL SELECT `revenue_analytics.events.purchase.subscription_events_revenue_view`.source_label AS source_label,
-                                        `revenue_analytics.events.purchase.subscription_events_revenue_view`.customer_id AS customer_id,
-                                        `revenue_analytics.events.purchase.subscription_events_revenue_view`.id AS subscription_id,
-                                        toTimeZone(`revenue_analytics.events.purchase.subscription_events_revenue_view`.ended_at, 'UTC') AS timestamp,
-                                        accurateCastOrNull(0, 'Decimal64(10)') AS amount
-                       FROM
-                         (SELECT '' AS id,
-                                 '' AS source_label,
-                                 '' AS plan_id,
-                                 '' AS product_id,
-                                 '' AS customer_id,
-                                 '' AS status,
-                                 toDateTime64('1970-01-01 00:00:00.000000', 6, 'UTC') AS started_at,
-                                 toDateTime64('1970-01-01 00:00:00.000000', 6, 'UTC') AS ended_at,
-                                 '' AS metadata
-                          WHERE 0) AS `revenue_analytics.events.purchase.subscription_events_revenue_view`
-                       WHERE and(greaterOrEquals(timestamp, toStartOfMonth(addDays(toDateTime64('today', 6, 'UTC'), -60))), lessOrEquals(timestamp, toDateTime64('today', 6, 'UTC')))
-                       ORDER BY timestamp DESC) AS
-                    union
-                    GROUP BY source_label,
-                             customer_id,
-                             subscription_id
-                    ORDER BY customer_id ASC,
-                             subscription_id ASC) AS `revenue_analytics.events.purchase.mrr_events_revenue_view`
+                 FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-revenue_analytics_events_purchase_mrr_events_revenue_view/revenue_analytics.events.purchase.mrr_events_revenue_view/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`mrr` Nullable(Decimal64(10)), `customer_id` Nullable(String), `source_label` Nullable(String), `subscription_id` Nullable(String)') AS `revenue_analytics.events.purchase.mrr_events_revenue_view`
                  GROUP BY customer_id) AS mrr_agg ON equals(revenue_analytics_customer.id, mrr_agg.customer_id)) AS e__poe__revenue_analytics ON equals(toString(e.person_id), toString(e__poe__revenue_analytics.person_id))
            WHERE and(equals(e.team_id, 99999), greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toStartOfInterval(assumeNotNull(toDateTime('2025-05-29 00:00:00', 'UTC')), toIntervalDay(1))), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), assumeNotNull(toDateTime('2025-05-30 23:59:59', 'UTC'))), equals(e.event, '$pageview'))
            GROUP BY day_start,
@@ -6698,7 +5608,8 @@
      FROM top_n_and_other_breakdown_values
      GROUP BY top_n_and_other_breakdown_values.breakdown_value)
   ORDER BY if(has(breakdown_value, '$$_posthog_breakdown_other_$$'), 2, if(has(breakdown_value, '$$_posthog_breakdown_null_$$'), 1, 0)) ASC, arraySum(total) DESC, breakdown_value ASC
-  LIMIT 50000 SETTINGS readonly=2,
+  LIMIT 50000 SETTINGS format_csv_allow_double_quotes=1,
+                       readonly=2,
                        max_execution_time=60,
                        allow_experimental_object_type=1,
                        max_ast_elements=4000000,
@@ -6756,169 +5667,17 @@
                      coalesce(revenue_agg.revenue, accurateCastOrNull(0, 'Decimal64(10)')) AS revenue,
                      coalesce(mrr_agg.mrr, accurateCastOrNull(0, 'Decimal64(10)')) AS mrr
               FROM
-                (SELECT toString(persons.id) AS id,
-                        'revenue_analytics.events.purchase' AS source_label,
-                        persons.created_at AS timestamp,
-                        persons.properties___name AS name,
-                        persons.properties___email AS email,
-                        persons.properties___phone AS phone,
-                        persons.properties___address AS address,
-                        persons.properties___metadata AS metadata,
-                        persons.`properties___$geoip_country_name` AS country,
-                        formatDateTime(toStartOfMonth(persons.created_at), '%Y-%m') AS cohort,
-                        NULL AS initial_coupon,
-                        NULL AS initial_coupon_id
-                 FROM
-                   (SELECT person.id AS id,
-                           replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'name'), ''), 'null'), '^"|"$', '') AS properties___name,
-                           replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'email'), ''), 'null'), '^"|"$', '') AS properties___email,
-                           replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'phone'), ''), 'null'), '^"|"$', '') AS properties___phone,
-                           replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'address'), ''), 'null'), '^"|"$', '') AS properties___address,
-                           replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'metadata'), ''), 'null'), '^"|"$', '') AS properties___metadata,
-                           replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, '$geoip_country_name'), ''), 'null'), '^"|"$', '') AS `properties___$geoip_country_name`,
-                           toTimeZone(person.created_at, 'UTC') AS created_at
-                    FROM person
-                    WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
-                                                                  (SELECT person.id AS id, max(person.version) AS version
-                                                                   FROM person
-                                                                   WHERE equals(person.team_id, 99999)
-                                                                   GROUP BY person.id
-                                                                   HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0))))) SETTINGS optimize_aggregation_in_order=1) AS persons
-                 INNER JOIN
-                   (SELECT DISTINCT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS person_id
-                    FROM events
-                    LEFT OUTER JOIN
-                      (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
-                              person_distinct_id_overrides.distinct_id AS distinct_id
-                       FROM person_distinct_id_overrides
-                       WHERE equals(person_distinct_id_overrides.team_id, 99999)
-                       GROUP BY person_distinct_id_overrides.distinct_id
-                       HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-                    WHERE equals(events.team_id, 99999)) AS events ON equals(persons.id, events.person_id)
-                 ORDER BY persons.created_at DESC) AS revenue_analytics_customer
+                (SELECT *
+                 FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-revenue_analytics_events_purchase_customer_events_revenue_view/revenue_analytics.events.purchase.customer_events_revenue_view/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` Nullable(String), `name` Nullable(String), `email` Nullable(String), `phone` Nullable(String), `cohort` Nullable(String), `address` Nullable(String), `country` Nullable(String), `metadata` Nullable(String), `timestamp` Nullable(DateTime64(6, \'UTC\')), `source_label` Nullable(String), `initial_coupon` Nullable(String), `initial_coupon_id` Nullable(String)')) AS revenue_analytics_customer
               LEFT JOIN
                 (SELECT revenue_analytics_revenue_item.customer_id AS customer_id,
                         sum(revenue_analytics_revenue_item.amount) AS revenue
-                 FROM
-                   (SELECT toString(events.uuid) AS id,
-                           toString(events.uuid) AS invoice_item_id,
-                           'revenue_analytics.events.purchase' AS source_label,
-                           toTimeZone(events.timestamp, 'UTC') AS timestamp,
-                           timestamp AS created_at,
-                           0 AS is_recurring,
-                           NULL AS product_id,
-                           toString(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS customer_id,
-                           events.`$group_0` AS group_0_key,
-                           events.`$group_1` AS group_1_key,
-                           events.`$group_2` AS group_2_key,
-                           events.`$group_3` AS group_3_key,
-                           events.`$group_4` AS group_4_key,
-                           NULL AS invoice_id,
-                           NULL AS subscription_id,
-                           toString(events.`$session_id`) AS session_id,
-                           events.event AS event_name,
-                           NULL AS coupon,
-                           coupon AS coupon_id,
-                           'USD' AS original_currency,
-                           accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)') AS original_amount,
-                           in(original_currency,
-                              ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
-                             if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
-                             divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
-                             'USD' AS currency,
-                             if(isNull('USD'), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals('USD', 'USD'), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(1, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))) AS amount
-                    FROM events
-                    LEFT OUTER JOIN
-                      (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
-                              person_distinct_id_overrides.distinct_id AS distinct_id
-                       FROM person_distinct_id_overrides
-                       WHERE equals(person_distinct_id_overrides.team_id, 99999)
-                       GROUP BY person_distinct_id_overrides.distinct_id
-                       HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-                    WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), 1, isNotNull(amount)))
-                    ORDER BY timestamp DESC) AS revenue_analytics_revenue_item
+                 FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-revenue_analytics_events_purchase_revenue_item_events_revenue_view/revenue_analytics.events.purchase.revenue_item_events_revenue_view/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` Nullable(String), `amount` Nullable(Decimal64(10)), `coupon` Nullable(String), `currency` Nullable(String), `coupon_id` Nullable(String), `timestamp` Nullable(DateTime64(6, \'UTC\')), `created_at` Nullable(DateTime64(6, \'UTC\')), `event_name` Nullable(String), `invoice_id` Nullable(String), `product_id` Nullable(String), `session_id` Nullable(String), `customer_id` Nullable(String), `group_0_key` Nullable(String), `group_1_key` Nullable(String), `group_2_key` Nullable(String), `group_3_key` Nullable(String), `group_4_key` Nullable(String), `is_recurring` Nullable(Boolean), `source_label` Nullable(String), `invoice_item_id` Nullable(String), `original_amount` Nullable(Decimal64(10)), `subscription_id` Nullable(String), `original_currency` Nullable(String), `currency_aware_amount` Nullable(Decimal64(10)), `currency_aware_divider` Nullable(Decimal64(10)), `enable_currency_aware_divider` Nullable(Boolean)') AS revenue_analytics_revenue_item
                  GROUP BY customer_id) AS revenue_agg ON equals(revenue_analytics_customer.id, revenue_agg.customer_id)
               LEFT JOIN
                 (SELECT `revenue_analytics.events.purchase.mrr_events_revenue_view`.customer_id AS customer_id,
                         sum(`revenue_analytics.events.purchase.mrr_events_revenue_view`.mrr) AS mrr
-                 FROM
-                   (SELECT union.source_label AS source_label,
-                           union.customer_id AS customer_id,
-                           union.subscription_id AS subscription_id,
-                           argMax(union.amount, union.timestamp) AS mrr
-                    FROM
-                      (SELECT revenue_item.source_label AS source_label,
-                              revenue_item.customer_id AS customer_id,
-                              revenue_item.subscription_id AS subscription_id,
-                              toStartOfMonth(toTimeZone(revenue_item.timestamp, 'UTC')) AS timestamp,
-                              sum(revenue_item.amount) AS amount
-                       FROM
-                         (SELECT toString(events.uuid) AS id,
-                                 toString(events.uuid) AS invoice_item_id,
-                                 'revenue_analytics.events.purchase' AS source_label,
-                                 toTimeZone(events.timestamp, 'UTC') AS timestamp,
-                                 timestamp AS created_at,
-                                 0 AS is_recurring,
-                                 NULL AS product_id,
-                                 toString(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS customer_id,
-                                 events.`$group_0` AS group_0_key,
-                                 events.`$group_1` AS group_1_key,
-                                 events.`$group_2` AS group_2_key,
-                                 events.`$group_3` AS group_3_key,
-                                 events.`$group_4` AS group_4_key,
-                                 NULL AS invoice_id,
-                                 NULL AS subscription_id,
-                                 toString(events.`$session_id`) AS session_id,
-                                 events.event AS event_name,
-                                 NULL AS coupon,
-                                 coupon AS coupon_id,
-                                 'USD' AS original_currency,
-                                 accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)') AS original_amount,
-                                 in(original_currency,
-                                    ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
-                                   if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
-                                   divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
-                                   'USD' AS currency,
-                                   if(isNull('USD'), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals('USD', 'USD'), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(1, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))) AS amount
-                          FROM events
-                          LEFT OUTER JOIN
-                            (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
-                                    person_distinct_id_overrides.distinct_id AS distinct_id
-                             FROM person_distinct_id_overrides
-                             WHERE equals(person_distinct_id_overrides.team_id, 99999)
-                             GROUP BY person_distinct_id_overrides.distinct_id
-                             HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-                          WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), 1, isNotNull(amount)))
-                          ORDER BY timestamp DESC) AS revenue_item
-                       WHERE and(revenue_item.is_recurring, isNotNull(revenue_item.subscription_id), greaterOrEquals(timestamp, toStartOfMonth(addDays(toDateTime64('today', 6, 'UTC'), -60))), lessOrEquals(timestamp, toDateTime64('today', 6, 'UTC')))
-                       GROUP BY revenue_item.source_label,
-                                revenue_item.customer_id,
-                                revenue_item.subscription_id, timestamp
-                       ORDER BY timestamp DESC
-                       UNION ALL SELECT `revenue_analytics.events.purchase.subscription_events_revenue_view`.source_label AS source_label,
-                                        `revenue_analytics.events.purchase.subscription_events_revenue_view`.customer_id AS customer_id,
-                                        `revenue_analytics.events.purchase.subscription_events_revenue_view`.id AS subscription_id,
-                                        toTimeZone(`revenue_analytics.events.purchase.subscription_events_revenue_view`.ended_at, 'UTC') AS timestamp,
-                                        accurateCastOrNull(0, 'Decimal64(10)') AS amount
-                       FROM
-                         (SELECT '' AS id,
-                                 '' AS source_label,
-                                 '' AS plan_id,
-                                 '' AS product_id,
-                                 '' AS customer_id,
-                                 '' AS status,
-                                 toDateTime64('1970-01-01 00:00:00.000000', 6, 'UTC') AS started_at,
-                                 toDateTime64('1970-01-01 00:00:00.000000', 6, 'UTC') AS ended_at,
-                                 '' AS metadata
-                          WHERE 0) AS `revenue_analytics.events.purchase.subscription_events_revenue_view`
-                       WHERE and(greaterOrEquals(timestamp, toStartOfMonth(addDays(toDateTime64('today', 6, 'UTC'), -60))), lessOrEquals(timestamp, toDateTime64('today', 6, 'UTC')))
-                       ORDER BY timestamp DESC) AS
-                    union
-                    GROUP BY source_label,
-                             customer_id,
-                             subscription_id
-                    ORDER BY customer_id ASC,
-                             subscription_id ASC) AS `revenue_analytics.events.purchase.mrr_events_revenue_view`
+                 FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-revenue_analytics_events_purchase_mrr_events_revenue_view/revenue_analytics.events.purchase.mrr_events_revenue_view/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`mrr` Nullable(Decimal64(10)), `customer_id` Nullable(String), `source_label` Nullable(String), `subscription_id` Nullable(String)') AS `revenue_analytics.events.purchase.mrr_events_revenue_view`
                  GROUP BY customer_id) AS mrr_agg ON equals(revenue_analytics_customer.id, mrr_agg.customer_id)) AS e__poe__revenue_analytics ON equals(toString(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id)), toString(e__poe__revenue_analytics.person_id))
            WHERE and(equals(e.team_id, 99999), greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toStartOfInterval(assumeNotNull(toDateTime('2025-05-29 00:00:00', 'UTC')), toIntervalDay(1))), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), assumeNotNull(toDateTime('2025-05-30 23:59:59', 'UTC'))), equals(e.event, '$pageview'))
            GROUP BY day_start,
@@ -6987,7 +5746,8 @@
      FROM top_n_and_other_breakdown_values
      GROUP BY top_n_and_other_breakdown_values.breakdown_value)
   ORDER BY if(has(breakdown_value, '$$_posthog_breakdown_other_$$'), 2, if(has(breakdown_value, '$$_posthog_breakdown_null_$$'), 1, 0)) ASC, arraySum(total) DESC, breakdown_value ASC
-  LIMIT 50000 SETTINGS readonly=2,
+  LIMIT 50000 SETTINGS format_csv_allow_double_quotes=1,
+                       readonly=2,
                        max_execution_time=60,
                        allow_experimental_object_type=1,
                        max_ast_elements=4000000,
@@ -7052,175 +5812,17 @@
                      coalesce(revenue_agg.revenue, accurateCastOrNull(0, 'Decimal64(10)')) AS revenue,
                      coalesce(mrr_agg.mrr, accurateCastOrNull(0, 'Decimal64(10)')) AS mrr
               FROM
-                (SELECT toString(persons.id) AS id,
-                        'revenue_analytics.events.purchase' AS source_label,
-                        persons.created_at AS timestamp,
-                        persons.properties___name AS name,
-                        persons.properties___email AS email,
-                        persons.properties___phone AS phone,
-                        persons.properties___address AS address,
-                        persons.properties___metadata AS metadata,
-                        persons.`properties___$geoip_country_name` AS country,
-                        formatDateTime(toStartOfMonth(persons.created_at), '%Y-%m') AS cohort,
-                        NULL AS initial_coupon,
-                        NULL AS initial_coupon_id
-                 FROM
-                   (SELECT person.id AS id,
-                           replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'name'), ''), 'null'), '^"|"$', '') AS properties___name,
-                           replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'email'), ''), 'null'), '^"|"$', '') AS properties___email,
-                           replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'phone'), ''), 'null'), '^"|"$', '') AS properties___phone,
-                           replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'address'), ''), 'null'), '^"|"$', '') AS properties___address,
-                           replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'metadata'), ''), 'null'), '^"|"$', '') AS properties___metadata,
-                           replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, '$geoip_country_name'), ''), 'null'), '^"|"$', '') AS `properties___$geoip_country_name`,
-                           toTimeZone(person.created_at, 'UTC') AS created_at
-                    FROM person
-                    WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
-                                                                  (SELECT person.id AS id, max(person.version) AS version
-                                                                   FROM person
-                                                                   WHERE equals(person.team_id, 99999)
-                                                                   GROUP BY person.id
-                                                                   HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0))))) SETTINGS optimize_aggregation_in_order=1) AS persons
-                 INNER JOIN
-                   (SELECT DISTINCT events__person.id AS person_id
-                    FROM events
-                    LEFT OUTER JOIN
-                      (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
-                              person_distinct_id_overrides.distinct_id AS distinct_id
-                       FROM person_distinct_id_overrides
-                       WHERE equals(person_distinct_id_overrides.team_id, 99999)
-                       GROUP BY person_distinct_id_overrides.distinct_id
-                       HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-                    INNER JOIN
-                      (SELECT person.id AS id
-                       FROM person
-                       WHERE equals(person.team_id, 99999)
-                       GROUP BY person.id
-                       HAVING and(ifNull(equals(tupleElement(argMax(tuple(person.is_deleted), person.version), 1), 0), 0), ifNull(less(tupleElement(argMax(tuple(toTimeZone(person.created_at, 'UTC')), person.version), 1), plus(now64(6, 'UTC'), toIntervalDay(1))), 0)) SETTINGS optimize_aggregation_in_order=1) AS events__person ON equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), events__person.id)
-                    WHERE equals(events.team_id, 99999)) AS events ON equals(persons.id, events.person_id)
-                 ORDER BY persons.created_at DESC) AS revenue_analytics_customer
+                (SELECT *
+                 FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-revenue_analytics_events_purchase_customer_events_revenue_view/revenue_analytics.events.purchase.customer_events_revenue_view/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` Nullable(String), `name` Nullable(String), `email` Nullable(String), `phone` Nullable(String), `cohort` Nullable(String), `address` Nullable(String), `country` Nullable(String), `metadata` Nullable(String), `timestamp` Nullable(DateTime64(6, \'UTC\')), `source_label` Nullable(String), `initial_coupon` Nullable(String), `initial_coupon_id` Nullable(String)')) AS revenue_analytics_customer
               LEFT JOIN
                 (SELECT revenue_analytics_revenue_item.customer_id AS customer_id,
                         sum(revenue_analytics_revenue_item.amount) AS revenue
-                 FROM
-                   (SELECT toString(events.uuid) AS id,
-                           toString(events.uuid) AS invoice_item_id,
-                           'revenue_analytics.events.purchase' AS source_label,
-                           toTimeZone(events.timestamp, 'UTC') AS timestamp,
-                           timestamp AS created_at,
-                           0 AS is_recurring,
-                           NULL AS product_id,
-                           toString(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS customer_id,
-                           events.`$group_0` AS group_0_key,
-                           events.`$group_1` AS group_1_key,
-                           events.`$group_2` AS group_2_key,
-                           events.`$group_3` AS group_3_key,
-                           events.`$group_4` AS group_4_key,
-                           NULL AS invoice_id,
-                           NULL AS subscription_id,
-                           toString(events.`$session_id`) AS session_id,
-                           events.event AS event_name,
-                           NULL AS coupon,
-                           coupon AS coupon_id,
-                           'USD' AS original_currency,
-                           accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)') AS original_amount,
-                           in(original_currency,
-                              ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
-                             if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
-                             divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
-                             'USD' AS currency,
-                             if(isNull('USD'), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals('USD', 'USD'), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(1, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))) AS amount
-                    FROM events
-                    LEFT OUTER JOIN
-                      (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
-                              person_distinct_id_overrides.distinct_id AS distinct_id
-                       FROM person_distinct_id_overrides
-                       WHERE equals(person_distinct_id_overrides.team_id, 99999)
-                       GROUP BY person_distinct_id_overrides.distinct_id
-                       HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-                    WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), 1, isNotNull(amount)))
-                    ORDER BY timestamp DESC) AS revenue_analytics_revenue_item
+                 FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-revenue_analytics_events_purchase_revenue_item_events_revenue_view/revenue_analytics.events.purchase.revenue_item_events_revenue_view/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` Nullable(String), `amount` Nullable(Decimal64(10)), `coupon` Nullable(String), `currency` Nullable(String), `coupon_id` Nullable(String), `timestamp` Nullable(DateTime64(6, \'UTC\')), `created_at` Nullable(DateTime64(6, \'UTC\')), `event_name` Nullable(String), `invoice_id` Nullable(String), `product_id` Nullable(String), `session_id` Nullable(String), `customer_id` Nullable(String), `group_0_key` Nullable(String), `group_1_key` Nullable(String), `group_2_key` Nullable(String), `group_3_key` Nullable(String), `group_4_key` Nullable(String), `is_recurring` Nullable(Boolean), `source_label` Nullable(String), `invoice_item_id` Nullable(String), `original_amount` Nullable(Decimal64(10)), `subscription_id` Nullable(String), `original_currency` Nullable(String), `currency_aware_amount` Nullable(Decimal64(10)), `currency_aware_divider` Nullable(Decimal64(10)), `enable_currency_aware_divider` Nullable(Boolean)') AS revenue_analytics_revenue_item
                  GROUP BY customer_id) AS revenue_agg ON equals(revenue_analytics_customer.id, revenue_agg.customer_id)
               LEFT JOIN
                 (SELECT `revenue_analytics.events.purchase.mrr_events_revenue_view`.customer_id AS customer_id,
                         sum(`revenue_analytics.events.purchase.mrr_events_revenue_view`.mrr) AS mrr
-                 FROM
-                   (SELECT union.source_label AS source_label,
-                           union.customer_id AS customer_id,
-                           union.subscription_id AS subscription_id,
-                           argMax(union.amount, union.timestamp) AS mrr
-                    FROM
-                      (SELECT revenue_item.source_label AS source_label,
-                              revenue_item.customer_id AS customer_id,
-                              revenue_item.subscription_id AS subscription_id,
-                              toStartOfMonth(toTimeZone(revenue_item.timestamp, 'UTC')) AS timestamp,
-                              sum(revenue_item.amount) AS amount
-                       FROM
-                         (SELECT toString(events.uuid) AS id,
-                                 toString(events.uuid) AS invoice_item_id,
-                                 'revenue_analytics.events.purchase' AS source_label,
-                                 toTimeZone(events.timestamp, 'UTC') AS timestamp,
-                                 timestamp AS created_at,
-                                 0 AS is_recurring,
-                                 NULL AS product_id,
-                                 toString(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS customer_id,
-                                 events.`$group_0` AS group_0_key,
-                                 events.`$group_1` AS group_1_key,
-                                 events.`$group_2` AS group_2_key,
-                                 events.`$group_3` AS group_3_key,
-                                 events.`$group_4` AS group_4_key,
-                                 NULL AS invoice_id,
-                                 NULL AS subscription_id,
-                                 toString(events.`$session_id`) AS session_id,
-                                 events.event AS event_name,
-                                 NULL AS coupon,
-                                 coupon AS coupon_id,
-                                 'USD' AS original_currency,
-                                 accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)') AS original_amount,
-                                 in(original_currency,
-                                    ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
-                                   if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
-                                   divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
-                                   'USD' AS currency,
-                                   if(isNull('USD'), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals('USD', 'USD'), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(1, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))) AS amount
-                          FROM events
-                          LEFT OUTER JOIN
-                            (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
-                                    person_distinct_id_overrides.distinct_id AS distinct_id
-                             FROM person_distinct_id_overrides
-                             WHERE equals(person_distinct_id_overrides.team_id, 99999)
-                             GROUP BY person_distinct_id_overrides.distinct_id
-                             HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-                          WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), 1, isNotNull(amount)))
-                          ORDER BY timestamp DESC) AS revenue_item
-                       WHERE and(revenue_item.is_recurring, isNotNull(revenue_item.subscription_id), greaterOrEquals(timestamp, toStartOfMonth(addDays(toDateTime64('today', 6, 'UTC'), -60))), lessOrEquals(timestamp, toDateTime64('today', 6, 'UTC')))
-                       GROUP BY revenue_item.source_label,
-                                revenue_item.customer_id,
-                                revenue_item.subscription_id, timestamp
-                       ORDER BY timestamp DESC
-                       UNION ALL SELECT `revenue_analytics.events.purchase.subscription_events_revenue_view`.source_label AS source_label,
-                                        `revenue_analytics.events.purchase.subscription_events_revenue_view`.customer_id AS customer_id,
-                                        `revenue_analytics.events.purchase.subscription_events_revenue_view`.id AS subscription_id,
-                                        toTimeZone(`revenue_analytics.events.purchase.subscription_events_revenue_view`.ended_at, 'UTC') AS timestamp,
-                                        accurateCastOrNull(0, 'Decimal64(10)') AS amount
-                       FROM
-                         (SELECT '' AS id,
-                                 '' AS source_label,
-                                 '' AS plan_id,
-                                 '' AS product_id,
-                                 '' AS customer_id,
-                                 '' AS status,
-                                 toDateTime64('1970-01-01 00:00:00.000000', 6, 'UTC') AS started_at,
-                                 toDateTime64('1970-01-01 00:00:00.000000', 6, 'UTC') AS ended_at,
-                                 '' AS metadata
-                          WHERE 0) AS `revenue_analytics.events.purchase.subscription_events_revenue_view`
-                       WHERE and(greaterOrEquals(timestamp, toStartOfMonth(addDays(toDateTime64('today', 6, 'UTC'), -60))), lessOrEquals(timestamp, toDateTime64('today', 6, 'UTC')))
-                       ORDER BY timestamp DESC) AS
-                    union
-                    GROUP BY source_label,
-                             customer_id,
-                             subscription_id
-                    ORDER BY customer_id ASC,
-                             subscription_id ASC) AS `revenue_analytics.events.purchase.mrr_events_revenue_view`
+                 FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-revenue_analytics_events_purchase_mrr_events_revenue_view/revenue_analytics.events.purchase.mrr_events_revenue_view/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`mrr` Nullable(Decimal64(10)), `customer_id` Nullable(String), `source_label` Nullable(String), `subscription_id` Nullable(String)') AS `revenue_analytics.events.purchase.mrr_events_revenue_view`
                  GROUP BY customer_id) AS mrr_agg ON equals(revenue_analytics_customer.id, mrr_agg.customer_id)) AS e__person__revenue_analytics ON equals(toString(e__person.e__person___id), toString(e__person__revenue_analytics.person_id))
            WHERE and(equals(e.team_id, 99999), greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toStartOfInterval(assumeNotNull(toDateTime('2025-05-29 00:00:00', 'UTC')), toIntervalDay(1))), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), assumeNotNull(toDateTime('2025-05-30 23:59:59', 'UTC'))), equals(e.event, '$pageview'))
            GROUP BY day_start,
@@ -7289,7 +5891,8 @@
      FROM top_n_and_other_breakdown_values
      GROUP BY top_n_and_other_breakdown_values.breakdown_value)
   ORDER BY if(has(breakdown_value, '$$_posthog_breakdown_other_$$'), 2, if(has(breakdown_value, '$$_posthog_breakdown_null_$$'), 1, 0)) ASC, arraySum(total) DESC, breakdown_value ASC
-  LIMIT 50000 SETTINGS readonly=2,
+  LIMIT 50000 SETTINGS format_csv_allow_double_quotes=1,
+                       readonly=2,
                        max_execution_time=60,
                        allow_experimental_object_type=1,
                        max_ast_elements=4000000,

--- a/posthog/hogql/database/schema/test/__snapshots__/test_persons_revenue_analytics.ambr
+++ b/posthog/hogql/database/schema/test/__snapshots__/test_persons_revenue_analytics.ambr
@@ -5086,3 +5086,2218 @@
                        use_hive_partitioning=0
   '''
 # ---
+# name: TestPersonsRevenueAnalyticsManagedViewsets.test_get_revenue_for_events
+  '''
+  SELECT persons__revenue_analytics.revenue AS revenue,
+         persons__revenue_analytics.revenue AS `$virt_revenue`
+  FROM
+    (SELECT tupleElement(argMax(tuple(person.id), person.version), 1) AS persons___id,
+            person.id AS id
+     FROM person
+     WHERE and(equals(person.team_id, 99999), in(id,
+                                                   (SELECT where_optimization.id AS id
+                                                    FROM person AS where_optimization
+                                                    WHERE and(equals(where_optimization.team_id, 99999), equals(where_optimization.id, '00000000-0000-0000-0000-000000000000')))))
+     GROUP BY person.id
+     HAVING and(ifNull(equals(tupleElement(argMax(tuple(person.is_deleted), person.version), 1), 0), 0), ifNull(less(tupleElement(argMax(tuple(toTimeZone(person.created_at, 'UTC')), person.version), 1), plus(now64(6, 'UTC'), toIntervalDay(1))), 0))) AS persons
+  LEFT JOIN
+    (SELECT 99999 AS team_id,
+            revenue_analytics_customer.id AS person_id,
+            coalesce(revenue_agg.revenue, accurateCastOrNull(0, 'Decimal64(10)')) AS revenue,
+            coalesce(mrr_agg.mrr, accurateCastOrNull(0, 'Decimal64(10)')) AS mrr
+     FROM
+       (SELECT toString(persons.id) AS id,
+               'revenue_analytics.events.purchase' AS source_label,
+               persons.created_at AS timestamp,
+               persons.properties___name AS name,
+               persons.properties___email AS email,
+               persons.properties___phone AS phone,
+               persons.properties___address AS address,
+               persons.properties___metadata AS metadata,
+               persons.`properties___$geoip_country_name` AS country,
+               formatDateTime(toStartOfMonth(persons.created_at), '%Y-%m') AS cohort,
+               NULL AS initial_coupon,
+               NULL AS initial_coupon_id
+        FROM
+          (SELECT person.id AS id,
+                  replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'name'), ''), 'null'), '^"|"$', '') AS properties___name,
+                  replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'email'), ''), 'null'), '^"|"$', '') AS properties___email,
+                  replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'phone'), ''), 'null'), '^"|"$', '') AS properties___phone,
+                  replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'address'), ''), 'null'), '^"|"$', '') AS properties___address,
+                  replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'metadata'), ''), 'null'), '^"|"$', '') AS properties___metadata,
+                  replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, '$geoip_country_name'), ''), 'null'), '^"|"$', '') AS `properties___$geoip_country_name`,
+                  toTimeZone(person.created_at, 'UTC') AS created_at
+           FROM person
+           WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
+                                                         (SELECT person.id AS id, max(person.version) AS version
+                                                          FROM person
+                                                          WHERE equals(person.team_id, 99999)
+                                                          GROUP BY person.id
+                                                          HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0))))) SETTINGS optimize_aggregation_in_order=1) AS persons
+        INNER JOIN
+          (SELECT DISTINCT events__person.id AS person_id
+           FROM events
+           LEFT OUTER JOIN
+             (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
+                     person_distinct_id_overrides.distinct_id AS distinct_id
+              FROM person_distinct_id_overrides
+              WHERE equals(person_distinct_id_overrides.team_id, 99999)
+              GROUP BY person_distinct_id_overrides.distinct_id
+              HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+           INNER JOIN
+             (SELECT person.id AS id
+              FROM person
+              WHERE equals(person.team_id, 99999)
+              GROUP BY person.id
+              HAVING and(ifNull(equals(tupleElement(argMax(tuple(person.is_deleted), person.version), 1), 0), 0), ifNull(less(tupleElement(argMax(tuple(toTimeZone(person.created_at, 'UTC')), person.version), 1), plus(now64(6, 'UTC'), toIntervalDay(1))), 0)) SETTINGS optimize_aggregation_in_order=1) AS events__person ON equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), events__person.id)
+           WHERE equals(events.team_id, 99999)) AS events ON equals(persons.id, events.person_id)
+        ORDER BY persons.created_at DESC) AS revenue_analytics_customer
+     LEFT JOIN
+       (SELECT revenue_analytics_revenue_item.customer_id AS customer_id,
+               sum(revenue_analytics_revenue_item.amount) AS revenue
+        FROM
+          (SELECT toString(events.uuid) AS id,
+                  toString(events.uuid) AS invoice_item_id,
+                  'revenue_analytics.events.purchase' AS source_label,
+                  toTimeZone(events.timestamp, 'UTC') AS timestamp,
+                  timestamp AS created_at,
+                  0 AS is_recurring,
+                  NULL AS product_id,
+                  toString(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS customer_id,
+                  events.`$group_0` AS group_0_key,
+                  events.`$group_1` AS group_1_key,
+                  events.`$group_2` AS group_2_key,
+                  events.`$group_3` AS group_3_key,
+                  events.`$group_4` AS group_4_key,
+                  NULL AS invoice_id,
+                  NULL AS subscription_id,
+                  toString(events.`$session_id`) AS session_id,
+                  events.event AS event_name,
+                  NULL AS coupon,
+                  coupon AS coupon_id,
+                  'USD' AS original_currency,
+                  accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)') AS original_amount,
+                  in(original_currency,
+                     ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
+                    if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
+                    divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
+                    'USD' AS currency,
+                    if(isNull('USD'), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals('USD', 'USD'), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(1, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))) AS amount
+           FROM events
+           LEFT OUTER JOIN
+             (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
+                     person_distinct_id_overrides.distinct_id AS distinct_id
+              FROM person_distinct_id_overrides
+              WHERE equals(person_distinct_id_overrides.team_id, 99999)
+              GROUP BY person_distinct_id_overrides.distinct_id
+              HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+           WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), 1, isNotNull(amount)))
+           ORDER BY timestamp DESC) AS revenue_analytics_revenue_item
+        GROUP BY customer_id) AS revenue_agg ON equals(revenue_analytics_customer.id, revenue_agg.customer_id)
+     LEFT JOIN
+       (SELECT `revenue_analytics.events.purchase.mrr_events_revenue_view`.customer_id AS customer_id,
+               sum(`revenue_analytics.events.purchase.mrr_events_revenue_view`.mrr) AS mrr
+        FROM
+          (SELECT union.source_label AS source_label,
+                  union.customer_id AS customer_id,
+                  union.subscription_id AS subscription_id,
+                  argMax(union.amount, union.timestamp) AS mrr
+           FROM
+             (SELECT revenue_item.source_label AS source_label,
+                     revenue_item.customer_id AS customer_id,
+                     revenue_item.subscription_id AS subscription_id,
+                     toStartOfMonth(toTimeZone(revenue_item.timestamp, 'UTC')) AS timestamp,
+                     sum(revenue_item.amount) AS amount
+              FROM
+                (SELECT toString(events.uuid) AS id,
+                        toString(events.uuid) AS invoice_item_id,
+                        'revenue_analytics.events.purchase' AS source_label,
+                        toTimeZone(events.timestamp, 'UTC') AS timestamp,
+                        timestamp AS created_at,
+                        0 AS is_recurring,
+                        NULL AS product_id,
+                        toString(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS customer_id,
+                        events.`$group_0` AS group_0_key,
+                        events.`$group_1` AS group_1_key,
+                        events.`$group_2` AS group_2_key,
+                        events.`$group_3` AS group_3_key,
+                        events.`$group_4` AS group_4_key,
+                        NULL AS invoice_id,
+                        NULL AS subscription_id,
+                        toString(events.`$session_id`) AS session_id,
+                        events.event AS event_name,
+                        NULL AS coupon,
+                        coupon AS coupon_id,
+                        'USD' AS original_currency,
+                        accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)') AS original_amount,
+                        in(original_currency,
+                           ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
+                          if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
+                          divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
+                          'USD' AS currency,
+                          if(isNull('USD'), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals('USD', 'USD'), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(1, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))) AS amount
+                 FROM events
+                 LEFT OUTER JOIN
+                   (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
+                           person_distinct_id_overrides.distinct_id AS distinct_id
+                    FROM person_distinct_id_overrides
+                    WHERE equals(person_distinct_id_overrides.team_id, 99999)
+                    GROUP BY person_distinct_id_overrides.distinct_id
+                    HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+                 WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), 1, isNotNull(amount)))
+                 ORDER BY timestamp DESC) AS revenue_item
+              WHERE and(revenue_item.is_recurring, isNotNull(revenue_item.subscription_id), greaterOrEquals(timestamp, toStartOfMonth(addDays(toDateTime64('today', 6, 'UTC'), -60))), lessOrEquals(timestamp, toDateTime64('today', 6, 'UTC')))
+              GROUP BY revenue_item.source_label,
+                       revenue_item.customer_id,
+                       revenue_item.subscription_id, timestamp
+              ORDER BY timestamp DESC
+              UNION ALL SELECT `revenue_analytics.events.purchase.subscription_events_revenue_view`.source_label AS source_label,
+                               `revenue_analytics.events.purchase.subscription_events_revenue_view`.customer_id AS customer_id,
+                               `revenue_analytics.events.purchase.subscription_events_revenue_view`.id AS subscription_id,
+                               toTimeZone(`revenue_analytics.events.purchase.subscription_events_revenue_view`.ended_at, 'UTC') AS timestamp,
+                               accurateCastOrNull(0, 'Decimal64(10)') AS amount
+              FROM
+                (SELECT '' AS id,
+                        '' AS source_label,
+                        '' AS plan_id,
+                        '' AS product_id,
+                        '' AS customer_id,
+                        '' AS status,
+                        toDateTime64('1970-01-01 00:00:00.000000', 6, 'UTC') AS started_at,
+                        toDateTime64('1970-01-01 00:00:00.000000', 6, 'UTC') AS ended_at,
+                        '' AS metadata
+                 WHERE 0) AS `revenue_analytics.events.purchase.subscription_events_revenue_view`
+              WHERE and(greaterOrEquals(timestamp, toStartOfMonth(addDays(toDateTime64('today', 6, 'UTC'), -60))), lessOrEquals(timestamp, toDateTime64('today', 6, 'UTC')))
+              ORDER BY timestamp DESC) AS
+           union
+           GROUP BY source_label,
+                    customer_id,
+                    subscription_id
+           ORDER BY customer_id ASC,
+                    subscription_id ASC) AS `revenue_analytics.events.purchase.mrr_events_revenue_view`
+        GROUP BY customer_id) AS mrr_agg ON equals(revenue_analytics_customer.id, mrr_agg.customer_id)) AS persons__revenue_analytics ON equals(toString(persons.persons___id), toString(persons__revenue_analytics.person_id))
+  WHERE ifNull(equals(persons.id, '00000000-0000-0000-0000-000000000000'), 0)
+  LIMIT 100 SETTINGS readonly=2,
+                     max_execution_time=60,
+                     allow_experimental_object_type=1,
+                     max_ast_elements=4000000,
+                     max_expanded_ast_elements=4000000,
+                     max_bytes_before_external_group_by=0,
+                     transform_null_in=1,
+                     optimize_min_equality_disjunction_chain_length=4294967295,
+                     allow_experimental_join_condition=1,
+                     use_hive_partitioning=0
+  '''
+# ---
+# name: TestPersonsRevenueAnalyticsManagedViewsets.test_get_revenue_for_schema_source_for_id_join
+  '''
+  SELECT persons.id AS id,
+         persons__revenue_analytics.revenue AS revenue
+  FROM
+    (SELECT tupleElement(argMax(tuple(person.id), person.version), 1) AS persons___id,
+            person.id AS id
+     FROM person
+     WHERE equals(person.team_id, 99999)
+     GROUP BY person.id
+     HAVING and(ifNull(equals(tupleElement(argMax(tuple(person.is_deleted), person.version), 1), 0), 0), ifNull(less(tupleElement(argMax(tuple(toTimeZone(person.created_at, 'UTC')), person.version), 1), plus(now64(6, 'UTC'), toIntervalDay(1))), 0)) SETTINGS optimize_aggregation_in_order=1) AS persons
+  LEFT JOIN
+    (SELECT 99999 AS team_id,
+            revenue_analytics_customer__persons.id AS person_id,
+            coalesce(revenue_agg.revenue, accurateCastOrNull(0, 'Decimal64(10)')) AS revenue,
+            coalesce(mrr_agg.mrr, accurateCastOrNull(0, 'Decimal64(10)')) AS mrr
+     FROM
+       (SELECT outer.id AS id,
+               'stripe.posthog_test' AS source_label,
+               parseDateTime64BestEffortOrNull(toString(outer.created), 6, 'UTC') AS timestamp,
+               outer.name AS name,
+               outer.email AS email,
+               outer.phone AS phone,
+               outer.address AS address,
+               outer.metadata AS metadata,
+               JSONExtractString(address, 'country') AS country,
+               cohort_inner.cohort AS cohort,
+               cohort_inner.initial_coupon AS initial_coupon,
+               cohort_inner.initial_coupon_id AS initial_coupon_id
+        FROM
+          (SELECT *
+           FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_customers/posthog_test_stripe_customer/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `name` String, `email` String, `phone` String, `address` String, `created` DateTime, `metadata` String')) AS outer
+        LEFT JOIN
+          (SELECT invoice.customer AS customer_id,
+                  formatDateTime(toStartOfMonth(min(parseDateTime64BestEffortOrNull(toString(invoice.created), 6, 'UTC'))), '%Y-%m') AS cohort,
+                  argMin(JSONExtractString(invoice.discount, 'coupon', 'name'), parseDateTime64BestEffortOrNull(toString(invoice.created), 6, 'UTC')) AS initial_coupon,
+                  argMin(JSONExtractString(invoice.discount, 'coupon', 'id'), parseDateTime64BestEffortOrNull(toString(invoice.created), 6, 'UTC')) AS initial_coupon_id
+           FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `subscription` String, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS invoice
+           GROUP BY invoice.customer) AS cohort_inner ON equals(cohort_inner.customer_id, outer.id)) AS revenue_analytics_customer
+     LEFT JOIN
+       (SELECT persons.id AS id,
+               persons__pdi.distinct_id AS revenue_analytics_customer__persons___pdi___distinct_id
+        FROM
+          (SELECT tupleElement(argMax(tuple(person.id), person.version), 1) AS persons___id,
+                  person.id AS id
+           FROM person
+           WHERE equals(person.team_id, 99999)
+           GROUP BY person.id
+           HAVING and(ifNull(equals(tupleElement(argMax(tuple(person.is_deleted), person.version), 1), 0), 0), ifNull(less(tupleElement(argMax(tuple(toTimeZone(person.created_at, 'UTC')), person.version), 1), plus(now64(6, 'UTC'), toIntervalDay(1))), 0)) SETTINGS optimize_aggregation_in_order=1) AS persons
+        INNER JOIN
+          (SELECT tupleElement(argMax(tuple(person_distinct_id2.person_id), person_distinct_id2.version), 1) AS person_id,
+                  person_distinct_id2.distinct_id AS distinct_id
+           FROM person_distinct_id2
+           WHERE equals(person_distinct_id2.team_id, 99999)
+           GROUP BY person_distinct_id2.distinct_id
+           HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id2.is_deleted), person_distinct_id2.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS persons__pdi ON equals(persons.persons___id, persons__pdi.person_id)) AS revenue_analytics_customer__persons ON equals(revenue_analytics_customer.id, revenue_analytics_customer__persons.revenue_analytics_customer__persons___pdi___distinct_id)
+     LEFT JOIN
+       (SELECT revenue_analytics_revenue_item.customer_id AS customer_id,
+               sum(revenue_analytics_revenue_item.amount) AS revenue
+        FROM
+          (SELECT if(ifNull(greater(invoice.period_months, 1), 0), concat(ifNull(toString(invoice.invoice_item_id), ''), '_', ifNull(toString(invoice.month_index), '')), invoice.invoice_item_id) AS id,
+                  invoice.invoice_item_id AS invoice_item_id,
+                  'stripe.posthog_test' AS source_label,
+                  addMonths(invoice.timestamp, invoice.month_index) AS timestamp,
+                  invoice.created_at AS created_at,
+                  ifNull(notEmpty(invoice.subscription_id), 0) AS is_recurring,
+                  invoice.product_id AS product_id,
+                  invoice.customer_id AS customer_id,
+                  NULL AS group_0_key,
+                  NULL AS group_1_key,
+                  NULL AS group_2_key,
+                  NULL AS group_3_key,
+                  NULL AS group_4_key,
+                  invoice.id AS invoice_id,
+                  invoice.subscription_id AS subscription_id,
+                  NULL AS session_id,
+                  NULL AS event_name,
+                  JSONExtractString(invoice.discount, 'coupon', 'name') AS coupon,
+                  JSONExtractString(invoice.discount, 'coupon', 'id') AS coupon_id,
+                  upper(invoice.currency) AS original_currency,
+                  accurateCastOrNull(invoice.amount_captured, 'Decimal64(10)') AS original_amount,
+                  in(original_currency,
+                     ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
+                    if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
+                    divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
+                    'GBP' AS currency,
+                    divideDecimal(if(equals(original_currency, currency), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal64(1, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10))))), accurateCastOrNull(invoice.period_months, 'Decimal64(10)')) AS amount
+           FROM
+             (SELECT posthog_test_stripe_invoice.id AS id,
+                     parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC') AS created_at,
+                     posthog_test_stripe_invoice.customer AS customer_id,
+                     posthog_test_stripe_invoice.subscription AS subscription_id,
+                     posthog_test_stripe_invoice.discount AS discount,
+                     arrayJoin(JSONExtractArrayRaw(assumeNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(posthog_test_stripe_invoice.lines, 'data'), ''), 'null'), '^"|"$', '')))) AS data,
+                     JSONExtractString(data, 'id') AS invoice_item_id,
+                     JSONExtractUInt(data, 'amount') AS amount_before_discount,
+                     coalesce(arraySum(arrayMap(x -> JSONExtractInt(x, 'amount'), JSONExtractArrayRaw(data, 'discount_amounts'))), 0) AS discount_amount,
+                     greatest(minus(amount_before_discount, discount_amount), 0) AS amount_captured,
+                     JSONExtractString(data, 'currency') AS currency,
+                     JSONExtractString(data, 'price', 'product') AS product_id,
+                     fromUnixTimestamp(JSONExtractUInt(data, 'period', 'start')) AS period_start,
+                     fromUnixTimestamp(JSONExtractUInt(data, 'period', 'end')) AS period_end,
+                     greatest(toInt16(round(divide(dateDiff('day', ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')), ifNull(period_end, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC'))), 30.44))), 1) AS period_months,
+                     arrayJoin(range(0, period_months)) AS month_index,
+                     ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')) AS timestamp
+              FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `subscription` String, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS posthog_test_stripe_invoice
+              WHERE posthog_test_stripe_invoice.paid) AS invoice) AS revenue_analytics_revenue_item
+        GROUP BY customer_id) AS revenue_agg ON equals(revenue_analytics_customer.id, revenue_agg.customer_id)
+     LEFT JOIN
+       (SELECT `stripe.posthog_test.mrr_revenue_view`.customer_id AS customer_id,
+               sum(`stripe.posthog_test.mrr_revenue_view`.mrr) AS mrr
+        FROM
+          (SELECT union.source_label AS source_label,
+                  union.customer_id AS customer_id,
+                  union.subscription_id AS subscription_id,
+                  argMax(union.amount, union.timestamp) AS mrr
+           FROM
+             (SELECT revenue_item.source_label AS source_label,
+                     revenue_item.customer_id AS customer_id,
+                     revenue_item.subscription_id AS subscription_id,
+                     toStartOfMonth(toTimeZone(revenue_item.timestamp, 'UTC')) AS timestamp,
+                     sum(revenue_item.amount) AS amount
+              FROM
+                (SELECT if(ifNull(greater(invoice.period_months, 1), 0), concat(ifNull(toString(invoice.invoice_item_id), ''), '_', ifNull(toString(invoice.month_index), '')), invoice.invoice_item_id) AS id,
+                        invoice.invoice_item_id AS invoice_item_id,
+                        'stripe.posthog_test' AS source_label,
+                        addMonths(invoice.timestamp, invoice.month_index) AS timestamp,
+                        invoice.created_at AS created_at,
+                        ifNull(notEmpty(invoice.subscription_id), 0) AS is_recurring,
+                        invoice.product_id AS product_id,
+                        invoice.customer_id AS customer_id,
+                        NULL AS group_0_key,
+                        NULL AS group_1_key,
+                        NULL AS group_2_key,
+                        NULL AS group_3_key,
+                        NULL AS group_4_key,
+                        invoice.id AS invoice_id,
+                        invoice.subscription_id AS subscription_id,
+                        NULL AS session_id,
+                        NULL AS event_name,
+                        JSONExtractString(invoice.discount, 'coupon', 'name') AS coupon,
+                        JSONExtractString(invoice.discount, 'coupon', 'id') AS coupon_id,
+                        upper(invoice.currency) AS original_currency,
+                        accurateCastOrNull(invoice.amount_captured, 'Decimal64(10)') AS original_amount,
+                        in(original_currency,
+                           ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
+                          if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
+                          divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
+                          'GBP' AS currency,
+                          divideDecimal(if(equals(original_currency, currency), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal64(1, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10))))), accurateCastOrNull(invoice.period_months, 'Decimal64(10)')) AS amount
+                 FROM
+                   (SELECT posthog_test_stripe_invoice.id AS id,
+                           parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC') AS created_at,
+                           posthog_test_stripe_invoice.customer AS customer_id,
+                           posthog_test_stripe_invoice.subscription AS subscription_id,
+                           posthog_test_stripe_invoice.discount AS discount,
+                           arrayJoin(JSONExtractArrayRaw(assumeNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(posthog_test_stripe_invoice.lines, 'data'), ''), 'null'), '^"|"$', '')))) AS data,
+                           JSONExtractString(data, 'id') AS invoice_item_id,
+                           JSONExtractUInt(data, 'amount') AS amount_before_discount,
+                           coalesce(arraySum(arrayMap(x -> JSONExtractInt(x, 'amount'), JSONExtractArrayRaw(data, 'discount_amounts'))), 0) AS discount_amount,
+                           greatest(minus(amount_before_discount, discount_amount), 0) AS amount_captured,
+                           JSONExtractString(data, 'currency') AS currency,
+                           JSONExtractString(data, 'price', 'product') AS product_id,
+                           fromUnixTimestamp(JSONExtractUInt(data, 'period', 'start')) AS period_start,
+                           fromUnixTimestamp(JSONExtractUInt(data, 'period', 'end')) AS period_end,
+                           greatest(toInt16(round(divide(dateDiff('day', ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')), ifNull(period_end, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC'))), 30.44))), 1) AS period_months,
+                           arrayJoin(range(0, period_months)) AS month_index,
+                           ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')) AS timestamp
+                    FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `subscription` String, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS posthog_test_stripe_invoice
+                    WHERE posthog_test_stripe_invoice.paid) AS invoice) AS revenue_item
+              WHERE and(revenue_item.is_recurring, isNotNull(revenue_item.subscription_id), greaterOrEquals(timestamp, toStartOfMonth(addDays(toDateTime64('today', 6, 'UTC'), -60))), lessOrEquals(timestamp, toDateTime64('today', 6, 'UTC')))
+              GROUP BY revenue_item.source_label,
+                       revenue_item.customer_id,
+                       revenue_item.subscription_id, timestamp
+              ORDER BY timestamp DESC
+              UNION ALL SELECT `stripe.posthog_test.subscription_revenue_view`.source_label AS source_label,
+                               `stripe.posthog_test.subscription_revenue_view`.customer_id AS customer_id,
+                               `stripe.posthog_test.subscription_revenue_view`.id AS subscription_id,
+                               toTimeZone(`stripe.posthog_test.subscription_revenue_view`.ended_at, 'UTC') AS timestamp,
+                               accurateCastOrNull(0, 'Decimal64(10)') AS amount
+              FROM
+                (SELECT '' AS id,
+                        '' AS source_label,
+                        '' AS plan_id,
+                        '' AS product_id,
+                        '' AS customer_id,
+                        '' AS status,
+                        toDateTime64('1970-01-01 00:00:00.000000', 6, 'UTC') AS started_at,
+                        toDateTime64('1970-01-01 00:00:00.000000', 6, 'UTC') AS ended_at,
+                        '' AS metadata
+                 WHERE 0) AS `stripe.posthog_test.subscription_revenue_view`
+              WHERE and(greaterOrEquals(timestamp, toStartOfMonth(addDays(toDateTime64('today', 6, 'UTC'), -60))), lessOrEquals(timestamp, toDateTime64('today', 6, 'UTC')))
+              ORDER BY timestamp DESC) AS
+           union
+           GROUP BY source_label,
+                    customer_id,
+                    subscription_id
+           ORDER BY customer_id ASC,
+                    subscription_id ASC) AS `stripe.posthog_test.mrr_revenue_view`
+        GROUP BY customer_id) AS mrr_agg ON equals(revenue_analytics_customer.id, mrr_agg.customer_id)) AS persons__revenue_analytics ON equals(toString(persons.persons___id), toString(persons__revenue_analytics.person_id))
+  ORDER BY persons.id ASC
+  LIMIT 100 SETTINGS format_csv_allow_double_quotes=1,
+                     readonly=2,
+                     max_execution_time=60,
+                     allow_experimental_object_type=1,
+                     max_ast_elements=4000000,
+                     max_expanded_ast_elements=4000000,
+                     max_bytes_before_external_group_by=0,
+                     transform_null_in=1,
+                     optimize_min_equality_disjunction_chain_length=4294967295,
+                     allow_experimental_join_condition=1,
+                     use_hive_partitioning=0
+  '''
+# ---
+# name: TestPersonsRevenueAnalyticsManagedViewsets.test_get_revenue_for_schema_source_for_id_join.1
+  '''
+  SELECT persons.id AS id,
+         persons__revenue_analytics.revenue AS `$virt_revenue`
+  FROM
+    (SELECT tupleElement(argMax(tuple(person.id), person.version), 1) AS persons___id,
+            person.id AS id
+     FROM person
+     WHERE equals(person.team_id, 99999)
+     GROUP BY person.id
+     HAVING and(ifNull(equals(tupleElement(argMax(tuple(person.is_deleted), person.version), 1), 0), 0), ifNull(less(tupleElement(argMax(tuple(toTimeZone(person.created_at, 'UTC')), person.version), 1), plus(now64(6, 'UTC'), toIntervalDay(1))), 0)) SETTINGS optimize_aggregation_in_order=1) AS persons
+  LEFT JOIN
+    (SELECT 99999 AS team_id,
+            revenue_analytics_customer__persons.id AS person_id,
+            coalesce(revenue_agg.revenue, accurateCastOrNull(0, 'Decimal64(10)')) AS revenue,
+            coalesce(mrr_agg.mrr, accurateCastOrNull(0, 'Decimal64(10)')) AS mrr
+     FROM
+       (SELECT outer.id AS id,
+               'stripe.posthog_test' AS source_label,
+               parseDateTime64BestEffortOrNull(toString(outer.created), 6, 'UTC') AS timestamp,
+               outer.name AS name,
+               outer.email AS email,
+               outer.phone AS phone,
+               outer.address AS address,
+               outer.metadata AS metadata,
+               JSONExtractString(address, 'country') AS country,
+               cohort_inner.cohort AS cohort,
+               cohort_inner.initial_coupon AS initial_coupon,
+               cohort_inner.initial_coupon_id AS initial_coupon_id
+        FROM
+          (SELECT *
+           FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_customers/posthog_test_stripe_customer/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `name` String, `email` String, `phone` String, `address` String, `created` DateTime, `metadata` String')) AS outer
+        LEFT JOIN
+          (SELECT invoice.customer AS customer_id,
+                  formatDateTime(toStartOfMonth(min(parseDateTime64BestEffortOrNull(toString(invoice.created), 6, 'UTC'))), '%Y-%m') AS cohort,
+                  argMin(JSONExtractString(invoice.discount, 'coupon', 'name'), parseDateTime64BestEffortOrNull(toString(invoice.created), 6, 'UTC')) AS initial_coupon,
+                  argMin(JSONExtractString(invoice.discount, 'coupon', 'id'), parseDateTime64BestEffortOrNull(toString(invoice.created), 6, 'UTC')) AS initial_coupon_id
+           FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `subscription` String, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS invoice
+           GROUP BY invoice.customer) AS cohort_inner ON equals(cohort_inner.customer_id, outer.id)) AS revenue_analytics_customer
+     LEFT JOIN
+       (SELECT persons.id AS id,
+               persons__pdi.distinct_id AS revenue_analytics_customer__persons___pdi___distinct_id
+        FROM
+          (SELECT tupleElement(argMax(tuple(person.id), person.version), 1) AS persons___id,
+                  person.id AS id
+           FROM person
+           WHERE equals(person.team_id, 99999)
+           GROUP BY person.id
+           HAVING and(ifNull(equals(tupleElement(argMax(tuple(person.is_deleted), person.version), 1), 0), 0), ifNull(less(tupleElement(argMax(tuple(toTimeZone(person.created_at, 'UTC')), person.version), 1), plus(now64(6, 'UTC'), toIntervalDay(1))), 0)) SETTINGS optimize_aggregation_in_order=1) AS persons
+        INNER JOIN
+          (SELECT tupleElement(argMax(tuple(person_distinct_id2.person_id), person_distinct_id2.version), 1) AS person_id,
+                  person_distinct_id2.distinct_id AS distinct_id
+           FROM person_distinct_id2
+           WHERE equals(person_distinct_id2.team_id, 99999)
+           GROUP BY person_distinct_id2.distinct_id
+           HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id2.is_deleted), person_distinct_id2.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS persons__pdi ON equals(persons.persons___id, persons__pdi.person_id)) AS revenue_analytics_customer__persons ON equals(revenue_analytics_customer.id, revenue_analytics_customer__persons.revenue_analytics_customer__persons___pdi___distinct_id)
+     LEFT JOIN
+       (SELECT revenue_analytics_revenue_item.customer_id AS customer_id,
+               sum(revenue_analytics_revenue_item.amount) AS revenue
+        FROM
+          (SELECT if(ifNull(greater(invoice.period_months, 1), 0), concat(ifNull(toString(invoice.invoice_item_id), ''), '_', ifNull(toString(invoice.month_index), '')), invoice.invoice_item_id) AS id,
+                  invoice.invoice_item_id AS invoice_item_id,
+                  'stripe.posthog_test' AS source_label,
+                  addMonths(invoice.timestamp, invoice.month_index) AS timestamp,
+                  invoice.created_at AS created_at,
+                  ifNull(notEmpty(invoice.subscription_id), 0) AS is_recurring,
+                  invoice.product_id AS product_id,
+                  invoice.customer_id AS customer_id,
+                  NULL AS group_0_key,
+                  NULL AS group_1_key,
+                  NULL AS group_2_key,
+                  NULL AS group_3_key,
+                  NULL AS group_4_key,
+                  invoice.id AS invoice_id,
+                  invoice.subscription_id AS subscription_id,
+                  NULL AS session_id,
+                  NULL AS event_name,
+                  JSONExtractString(invoice.discount, 'coupon', 'name') AS coupon,
+                  JSONExtractString(invoice.discount, 'coupon', 'id') AS coupon_id,
+                  upper(invoice.currency) AS original_currency,
+                  accurateCastOrNull(invoice.amount_captured, 'Decimal64(10)') AS original_amount,
+                  in(original_currency,
+                     ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
+                    if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
+                    divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
+                    'GBP' AS currency,
+                    divideDecimal(if(equals(original_currency, currency), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal64(1, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10))))), accurateCastOrNull(invoice.period_months, 'Decimal64(10)')) AS amount
+           FROM
+             (SELECT posthog_test_stripe_invoice.id AS id,
+                     parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC') AS created_at,
+                     posthog_test_stripe_invoice.customer AS customer_id,
+                     posthog_test_stripe_invoice.subscription AS subscription_id,
+                     posthog_test_stripe_invoice.discount AS discount,
+                     arrayJoin(JSONExtractArrayRaw(assumeNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(posthog_test_stripe_invoice.lines, 'data'), ''), 'null'), '^"|"$', '')))) AS data,
+                     JSONExtractString(data, 'id') AS invoice_item_id,
+                     JSONExtractUInt(data, 'amount') AS amount_before_discount,
+                     coalesce(arraySum(arrayMap(x -> JSONExtractInt(x, 'amount'), JSONExtractArrayRaw(data, 'discount_amounts'))), 0) AS discount_amount,
+                     greatest(minus(amount_before_discount, discount_amount), 0) AS amount_captured,
+                     JSONExtractString(data, 'currency') AS currency,
+                     JSONExtractString(data, 'price', 'product') AS product_id,
+                     fromUnixTimestamp(JSONExtractUInt(data, 'period', 'start')) AS period_start,
+                     fromUnixTimestamp(JSONExtractUInt(data, 'period', 'end')) AS period_end,
+                     greatest(toInt16(round(divide(dateDiff('day', ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')), ifNull(period_end, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC'))), 30.44))), 1) AS period_months,
+                     arrayJoin(range(0, period_months)) AS month_index,
+                     ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')) AS timestamp
+              FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `subscription` String, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS posthog_test_stripe_invoice
+              WHERE posthog_test_stripe_invoice.paid) AS invoice) AS revenue_analytics_revenue_item
+        GROUP BY customer_id) AS revenue_agg ON equals(revenue_analytics_customer.id, revenue_agg.customer_id)
+     LEFT JOIN
+       (SELECT `stripe.posthog_test.mrr_revenue_view`.customer_id AS customer_id,
+               sum(`stripe.posthog_test.mrr_revenue_view`.mrr) AS mrr
+        FROM
+          (SELECT union.source_label AS source_label,
+                  union.customer_id AS customer_id,
+                  union.subscription_id AS subscription_id,
+                  argMax(union.amount, union.timestamp) AS mrr
+           FROM
+             (SELECT revenue_item.source_label AS source_label,
+                     revenue_item.customer_id AS customer_id,
+                     revenue_item.subscription_id AS subscription_id,
+                     toStartOfMonth(toTimeZone(revenue_item.timestamp, 'UTC')) AS timestamp,
+                     sum(revenue_item.amount) AS amount
+              FROM
+                (SELECT if(ifNull(greater(invoice.period_months, 1), 0), concat(ifNull(toString(invoice.invoice_item_id), ''), '_', ifNull(toString(invoice.month_index), '')), invoice.invoice_item_id) AS id,
+                        invoice.invoice_item_id AS invoice_item_id,
+                        'stripe.posthog_test' AS source_label,
+                        addMonths(invoice.timestamp, invoice.month_index) AS timestamp,
+                        invoice.created_at AS created_at,
+                        ifNull(notEmpty(invoice.subscription_id), 0) AS is_recurring,
+                        invoice.product_id AS product_id,
+                        invoice.customer_id AS customer_id,
+                        NULL AS group_0_key,
+                        NULL AS group_1_key,
+                        NULL AS group_2_key,
+                        NULL AS group_3_key,
+                        NULL AS group_4_key,
+                        invoice.id AS invoice_id,
+                        invoice.subscription_id AS subscription_id,
+                        NULL AS session_id,
+                        NULL AS event_name,
+                        JSONExtractString(invoice.discount, 'coupon', 'name') AS coupon,
+                        JSONExtractString(invoice.discount, 'coupon', 'id') AS coupon_id,
+                        upper(invoice.currency) AS original_currency,
+                        accurateCastOrNull(invoice.amount_captured, 'Decimal64(10)') AS original_amount,
+                        in(original_currency,
+                           ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
+                          if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
+                          divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
+                          'GBP' AS currency,
+                          divideDecimal(if(equals(original_currency, currency), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal64(1, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10))))), accurateCastOrNull(invoice.period_months, 'Decimal64(10)')) AS amount
+                 FROM
+                   (SELECT posthog_test_stripe_invoice.id AS id,
+                           parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC') AS created_at,
+                           posthog_test_stripe_invoice.customer AS customer_id,
+                           posthog_test_stripe_invoice.subscription AS subscription_id,
+                           posthog_test_stripe_invoice.discount AS discount,
+                           arrayJoin(JSONExtractArrayRaw(assumeNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(posthog_test_stripe_invoice.lines, 'data'), ''), 'null'), '^"|"$', '')))) AS data,
+                           JSONExtractString(data, 'id') AS invoice_item_id,
+                           JSONExtractUInt(data, 'amount') AS amount_before_discount,
+                           coalesce(arraySum(arrayMap(x -> JSONExtractInt(x, 'amount'), JSONExtractArrayRaw(data, 'discount_amounts'))), 0) AS discount_amount,
+                           greatest(minus(amount_before_discount, discount_amount), 0) AS amount_captured,
+                           JSONExtractString(data, 'currency') AS currency,
+                           JSONExtractString(data, 'price', 'product') AS product_id,
+                           fromUnixTimestamp(JSONExtractUInt(data, 'period', 'start')) AS period_start,
+                           fromUnixTimestamp(JSONExtractUInt(data, 'period', 'end')) AS period_end,
+                           greatest(toInt16(round(divide(dateDiff('day', ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')), ifNull(period_end, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC'))), 30.44))), 1) AS period_months,
+                           arrayJoin(range(0, period_months)) AS month_index,
+                           ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')) AS timestamp
+                    FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `subscription` String, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS posthog_test_stripe_invoice
+                    WHERE posthog_test_stripe_invoice.paid) AS invoice) AS revenue_item
+              WHERE and(revenue_item.is_recurring, isNotNull(revenue_item.subscription_id), greaterOrEquals(timestamp, toStartOfMonth(addDays(toDateTime64('today', 6, 'UTC'), -60))), lessOrEquals(timestamp, toDateTime64('today', 6, 'UTC')))
+              GROUP BY revenue_item.source_label,
+                       revenue_item.customer_id,
+                       revenue_item.subscription_id, timestamp
+              ORDER BY timestamp DESC
+              UNION ALL SELECT `stripe.posthog_test.subscription_revenue_view`.source_label AS source_label,
+                               `stripe.posthog_test.subscription_revenue_view`.customer_id AS customer_id,
+                               `stripe.posthog_test.subscription_revenue_view`.id AS subscription_id,
+                               toTimeZone(`stripe.posthog_test.subscription_revenue_view`.ended_at, 'UTC') AS timestamp,
+                               accurateCastOrNull(0, 'Decimal64(10)') AS amount
+              FROM
+                (SELECT '' AS id,
+                        '' AS source_label,
+                        '' AS plan_id,
+                        '' AS product_id,
+                        '' AS customer_id,
+                        '' AS status,
+                        toDateTime64('1970-01-01 00:00:00.000000', 6, 'UTC') AS started_at,
+                        toDateTime64('1970-01-01 00:00:00.000000', 6, 'UTC') AS ended_at,
+                        '' AS metadata
+                 WHERE 0) AS `stripe.posthog_test.subscription_revenue_view`
+              WHERE and(greaterOrEquals(timestamp, toStartOfMonth(addDays(toDateTime64('today', 6, 'UTC'), -60))), lessOrEquals(timestamp, toDateTime64('today', 6, 'UTC')))
+              ORDER BY timestamp DESC) AS
+           union
+           GROUP BY source_label,
+                    customer_id,
+                    subscription_id
+           ORDER BY customer_id ASC,
+                    subscription_id ASC) AS `stripe.posthog_test.mrr_revenue_view`
+        GROUP BY customer_id) AS mrr_agg ON equals(revenue_analytics_customer.id, mrr_agg.customer_id)) AS persons__revenue_analytics ON equals(toString(persons.persons___id), toString(persons__revenue_analytics.person_id))
+  ORDER BY persons.id ASC
+  LIMIT 100 SETTINGS format_csv_allow_double_quotes=1,
+                     readonly=2,
+                     max_execution_time=60,
+                     allow_experimental_object_type=1,
+                     max_ast_elements=4000000,
+                     max_expanded_ast_elements=4000000,
+                     max_bytes_before_external_group_by=0,
+                     transform_null_in=1,
+                     optimize_min_equality_disjunction_chain_length=4294967295,
+                     allow_experimental_join_condition=1,
+                     use_hive_partitioning=0
+  '''
+# ---
+# name: TestPersonsRevenueAnalyticsManagedViewsets.test_query_revenue_analytics_table_events
+  '''
+  SELECT persons_revenue_analytics.person_id AS person_id,
+         persons_revenue_analytics.revenue AS revenue,
+         persons_revenue_analytics.mrr AS mrr
+  FROM
+    (SELECT 99999 AS team_id,
+            revenue_analytics_customer.id AS person_id,
+            coalesce(revenue_agg.revenue, accurateCastOrNull(0, 'Decimal64(10)')) AS revenue,
+            coalesce(mrr_agg.mrr, accurateCastOrNull(0, 'Decimal64(10)')) AS mrr
+     FROM
+       (SELECT toString(persons.id) AS id,
+               'revenue_analytics.events.purchase' AS source_label,
+               persons.created_at AS timestamp,
+               persons.properties___name AS name,
+               persons.properties___email AS email,
+               persons.properties___phone AS phone,
+               persons.properties___address AS address,
+               persons.properties___metadata AS metadata,
+               persons.`properties___$geoip_country_name` AS country,
+               formatDateTime(toStartOfMonth(persons.created_at), '%Y-%m') AS cohort,
+               NULL AS initial_coupon,
+               NULL AS initial_coupon_id
+        FROM
+          (SELECT person.id AS id,
+                  replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'name'), ''), 'null'), '^"|"$', '') AS properties___name,
+                  replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'email'), ''), 'null'), '^"|"$', '') AS properties___email,
+                  replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'phone'), ''), 'null'), '^"|"$', '') AS properties___phone,
+                  replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'address'), ''), 'null'), '^"|"$', '') AS properties___address,
+                  replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'metadata'), ''), 'null'), '^"|"$', '') AS properties___metadata,
+                  replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, '$geoip_country_name'), ''), 'null'), '^"|"$', '') AS `properties___$geoip_country_name`,
+                  toTimeZone(person.created_at, 'UTC') AS created_at
+           FROM person
+           WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
+                                                         (SELECT person.id AS id, max(person.version) AS version
+                                                          FROM person
+                                                          WHERE equals(person.team_id, 99999)
+                                                          GROUP BY person.id
+                                                          HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0))))) SETTINGS optimize_aggregation_in_order=1) AS persons
+        INNER JOIN
+          (SELECT DISTINCT events__person.id AS person_id
+           FROM events
+           LEFT OUTER JOIN
+             (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
+                     person_distinct_id_overrides.distinct_id AS distinct_id
+              FROM person_distinct_id_overrides
+              WHERE equals(person_distinct_id_overrides.team_id, 99999)
+              GROUP BY person_distinct_id_overrides.distinct_id
+              HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+           INNER JOIN
+             (SELECT person.id AS id
+              FROM person
+              WHERE equals(person.team_id, 99999)
+              GROUP BY person.id
+              HAVING and(ifNull(equals(tupleElement(argMax(tuple(person.is_deleted), person.version), 1), 0), 0), ifNull(less(tupleElement(argMax(tuple(toTimeZone(person.created_at, 'UTC')), person.version), 1), plus(now64(6, 'UTC'), toIntervalDay(1))), 0)) SETTINGS optimize_aggregation_in_order=1) AS events__person ON equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), events__person.id)
+           WHERE equals(events.team_id, 99999)) AS events ON equals(persons.id, events.person_id)
+        ORDER BY persons.created_at DESC) AS revenue_analytics_customer
+     LEFT JOIN
+       (SELECT revenue_analytics_revenue_item.customer_id AS customer_id,
+               sum(revenue_analytics_revenue_item.amount) AS revenue
+        FROM
+          (SELECT toString(events.uuid) AS id,
+                  toString(events.uuid) AS invoice_item_id,
+                  'revenue_analytics.events.purchase' AS source_label,
+                  toTimeZone(events.timestamp, 'UTC') AS timestamp,
+                  timestamp AS created_at,
+                  isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'subscription_id'), ''), 'null'), '^"|"$', '')) AS is_recurring,
+                  NULL AS product_id,
+                  toString(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS customer_id,
+                  events.`$group_0` AS group_0_key,
+                  events.`$group_1` AS group_1_key,
+                  events.`$group_2` AS group_2_key,
+                  events.`$group_3` AS group_3_key,
+                  events.`$group_4` AS group_4_key,
+                  NULL AS invoice_id,
+                  replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'subscription_id'), ''), 'null'), '^"|"$', '') AS subscription_id,
+                  toString(events.`$session_id`) AS session_id,
+                  events.event AS event_name,
+                  NULL AS coupon,
+                  coupon AS coupon_id,
+                  'USD' AS original_currency,
+                  accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)') AS original_amount,
+                  in(original_currency,
+                     ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
+                    if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
+                    divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
+                    'USD' AS currency,
+                    if(isNull('USD'), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals('USD', 'USD'), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(1, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))) AS amount
+           FROM events
+           LEFT OUTER JOIN
+             (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
+                     person_distinct_id_overrides.distinct_id AS distinct_id
+              FROM person_distinct_id_overrides
+              WHERE equals(person_distinct_id_overrides.team_id, 99999)
+              GROUP BY person_distinct_id_overrides.distinct_id
+              HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+           WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), 1, isNotNull(amount)))
+           ORDER BY timestamp DESC) AS revenue_analytics_revenue_item
+        GROUP BY customer_id) AS revenue_agg ON equals(revenue_analytics_customer.id, revenue_agg.customer_id)
+     LEFT JOIN
+       (SELECT `revenue_analytics.events.purchase.mrr_events_revenue_view`.customer_id AS customer_id,
+               sum(`revenue_analytics.events.purchase.mrr_events_revenue_view`.mrr) AS mrr
+        FROM
+          (SELECT union.source_label AS source_label,
+                  union.customer_id AS customer_id,
+                  union.subscription_id AS subscription_id,
+                  argMax(union.amount, union.timestamp) AS mrr
+           FROM
+             (SELECT revenue_item.source_label AS source_label,
+                     revenue_item.customer_id AS customer_id,
+                     revenue_item.subscription_id AS subscription_id,
+                     toStartOfMonth(toTimeZone(revenue_item.timestamp, 'UTC')) AS timestamp,
+                     sum(revenue_item.amount) AS amount
+              FROM
+                (SELECT toString(events.uuid) AS id,
+                        toString(events.uuid) AS invoice_item_id,
+                        'revenue_analytics.events.purchase' AS source_label,
+                        toTimeZone(events.timestamp, 'UTC') AS timestamp,
+                        timestamp AS created_at,
+                        isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'subscription_id'), ''), 'null'), '^"|"$', '')) AS is_recurring,
+                        NULL AS product_id,
+                        toString(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS customer_id,
+                        events.`$group_0` AS group_0_key,
+                        events.`$group_1` AS group_1_key,
+                        events.`$group_2` AS group_2_key,
+                        events.`$group_3` AS group_3_key,
+                        events.`$group_4` AS group_4_key,
+                        NULL AS invoice_id,
+                        replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'subscription_id'), ''), 'null'), '^"|"$', '') AS subscription_id,
+                        toString(events.`$session_id`) AS session_id,
+                        events.event AS event_name,
+                        NULL AS coupon,
+                        coupon AS coupon_id,
+                        'USD' AS original_currency,
+                        accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)') AS original_amount,
+                        in(original_currency,
+                           ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
+                          if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
+                          divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
+                          'USD' AS currency,
+                          if(isNull('USD'), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals('USD', 'USD'), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(1, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))) AS amount
+                 FROM events
+                 LEFT OUTER JOIN
+                   (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
+                           person_distinct_id_overrides.distinct_id AS distinct_id
+                    FROM person_distinct_id_overrides
+                    WHERE equals(person_distinct_id_overrides.team_id, 99999)
+                    GROUP BY person_distinct_id_overrides.distinct_id
+                    HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+                 WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), 1, isNotNull(amount)))
+                 ORDER BY timestamp DESC) AS revenue_item
+              WHERE and(revenue_item.is_recurring, isNotNull(revenue_item.subscription_id), greaterOrEquals(timestamp, toStartOfMonth(addDays(toDateTime64('explicit_redacted_timestamp', 6, 'UTC'), -60))), lessOrEquals(timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')))
+              GROUP BY revenue_item.source_label,
+                       revenue_item.customer_id,
+                       revenue_item.subscription_id, timestamp
+              ORDER BY timestamp DESC
+              UNION ALL SELECT `revenue_analytics.events.purchase.subscription_events_revenue_view`.source_label AS source_label,
+                               `revenue_analytics.events.purchase.subscription_events_revenue_view`.customer_id AS customer_id,
+                               `revenue_analytics.events.purchase.subscription_events_revenue_view`.id AS subscription_id,
+                               toTimeZone(`revenue_analytics.events.purchase.subscription_events_revenue_view`.ended_at, 'UTC') AS timestamp,
+                               accurateCastOrNull(0, 'Decimal64(10)') AS amount
+              FROM
+                (SELECT subscription_id AS id,
+                        'revenue_analytics.events.purchase' AS source_label,
+                        NULL AS plan_id,
+                        product_id AS product_id,
+                        toString(person_id) AS customer_id,
+                        NULL AS status,
+                        min_timestamp AS started_at,
+                        if(ifNull(greater(max_timestamp_plus_dropoff_days, today()), 0), NULL, max_timestamp_plus_dropoff_days) AS ended_at,
+                        NULL AS metadata
+                 FROM
+                   (SELECT events__person.id AS person_id,
+                           replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'subscription_id'), ''), 'null'), '^"|"$', '') AS subscription_id,
+                           NULL AS product_id,
+                           min(toTimeZone(events.timestamp, 'UTC')) AS min_timestamp,
+                           max(toTimeZone(events.timestamp, 'UTC')) AS max_timestamp,
+                           addDays(max_timestamp, 45.0) AS max_timestamp_plus_dropoff_days
+                    FROM events
+                    LEFT OUTER JOIN
+                      (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
+                              person_distinct_id_overrides.distinct_id AS distinct_id
+                       FROM person_distinct_id_overrides
+                       WHERE equals(person_distinct_id_overrides.team_id, 99999)
+                       GROUP BY person_distinct_id_overrides.distinct_id
+                       HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+                    INNER JOIN
+                      (SELECT person.id AS id
+                       FROM person
+                       WHERE equals(person.team_id, 99999)
+                       GROUP BY person.id
+                       HAVING and(ifNull(equals(tupleElement(argMax(tuple(person.is_deleted), person.version), 1), 0), 0), ifNull(less(tupleElement(argMax(tuple(toTimeZone(person.created_at, 'UTC')), person.version), 1), plus(now64(6, 'UTC'), toIntervalDay(1))), 0)) SETTINGS optimize_aggregation_in_order=1) AS events__person ON equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), events__person.id)
+                    WHERE and(equals(events.team_id, 99999), and(1, isNotNull(subscription_id)))
+                    GROUP BY subscription_id,
+                             person_id)
+                 ORDER BY started_at DESC) AS `revenue_analytics.events.purchase.subscription_events_revenue_view`
+              WHERE and(greaterOrEquals(timestamp, toStartOfMonth(addDays(toDateTime64('explicit_redacted_timestamp', 6, 'UTC'), -60))), lessOrEquals(timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')))
+              ORDER BY timestamp DESC) AS
+           union
+           GROUP BY source_label,
+                    customer_id,
+                    subscription_id
+           ORDER BY customer_id ASC,
+                    subscription_id ASC) AS `revenue_analytics.events.purchase.mrr_events_revenue_view`
+        GROUP BY customer_id) AS mrr_agg ON equals(revenue_analytics_customer.id, mrr_agg.customer_id)) AS persons_revenue_analytics
+  ORDER BY persons_revenue_analytics.person_id ASC
+  LIMIT 100 SETTINGS format_csv_allow_double_quotes=1,
+                     readonly=2,
+                     max_execution_time=60,
+                     allow_experimental_object_type=1,
+                     max_ast_elements=4000000,
+                     max_expanded_ast_elements=4000000,
+                     max_bytes_before_external_group_by=0,
+                     transform_null_in=1,
+                     optimize_min_equality_disjunction_chain_length=4294967295,
+                     allow_experimental_join_condition=1,
+                     use_hive_partitioning=0
+  '''
+# ---
+# name: TestPersonsRevenueAnalyticsManagedViewsets.test_query_revenue_analytics_table_sources
+  '''
+  SELECT persons_revenue_analytics.person_id AS person_id,
+         persons_revenue_analytics.revenue AS revenue,
+         persons_revenue_analytics.mrr AS mrr
+  FROM
+    (SELECT 99999 AS team_id,
+            revenue_analytics_customer__persons.id AS person_id,
+            coalesce(revenue_agg.revenue, accurateCastOrNull(0, 'Decimal64(10)')) AS revenue,
+            coalesce(mrr_agg.mrr, accurateCastOrNull(0, 'Decimal64(10)')) AS mrr
+     FROM
+       (SELECT outer.id AS id,
+               'stripe.posthog_test' AS source_label,
+               parseDateTime64BestEffortOrNull(toString(outer.created), 6, 'UTC') AS timestamp,
+               outer.name AS name,
+               outer.email AS email,
+               outer.phone AS phone,
+               outer.address AS address,
+               outer.metadata AS metadata,
+               JSONExtractString(address, 'country') AS country,
+               cohort_inner.cohort AS cohort,
+               cohort_inner.initial_coupon AS initial_coupon,
+               cohort_inner.initial_coupon_id AS initial_coupon_id
+        FROM
+          (SELECT *
+           FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_customers/posthog_test_stripe_customer/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `name` String, `email` String, `phone` String, `address` String, `created` DateTime, `metadata` String')) AS outer
+        LEFT JOIN
+          (SELECT invoice.customer AS customer_id,
+                  formatDateTime(toStartOfMonth(min(parseDateTime64BestEffortOrNull(toString(invoice.created), 6, 'UTC'))), '%Y-%m') AS cohort,
+                  argMin(JSONExtractString(invoice.discount, 'coupon', 'name'), parseDateTime64BestEffortOrNull(toString(invoice.created), 6, 'UTC')) AS initial_coupon,
+                  argMin(JSONExtractString(invoice.discount, 'coupon', 'id'), parseDateTime64BestEffortOrNull(toString(invoice.created), 6, 'UTC')) AS initial_coupon_id
+           FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `subscription` String, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS invoice
+           GROUP BY invoice.customer) AS cohort_inner ON equals(cohort_inner.customer_id, outer.id)) AS revenue_analytics_customer
+     LEFT JOIN
+       (SELECT persons.id AS id,
+               persons__pdi.distinct_id AS revenue_analytics_customer__persons___pdi___distinct_id
+        FROM
+          (SELECT tupleElement(argMax(tuple(person.id), person.version), 1) AS persons___id,
+                  person.id AS id
+           FROM person
+           WHERE equals(person.team_id, 99999)
+           GROUP BY person.id
+           HAVING and(ifNull(equals(tupleElement(argMax(tuple(person.is_deleted), person.version), 1), 0), 0), ifNull(less(tupleElement(argMax(tuple(toTimeZone(person.created_at, 'UTC')), person.version), 1), plus(now64(6, 'UTC'), toIntervalDay(1))), 0)) SETTINGS optimize_aggregation_in_order=1) AS persons
+        INNER JOIN
+          (SELECT tupleElement(argMax(tuple(person_distinct_id2.person_id), person_distinct_id2.version), 1) AS person_id,
+                  person_distinct_id2.distinct_id AS distinct_id
+           FROM person_distinct_id2
+           WHERE equals(person_distinct_id2.team_id, 99999)
+           GROUP BY person_distinct_id2.distinct_id
+           HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id2.is_deleted), person_distinct_id2.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS persons__pdi ON equals(persons.persons___id, persons__pdi.person_id)) AS revenue_analytics_customer__persons ON equals(revenue_analytics_customer.id, revenue_analytics_customer__persons.revenue_analytics_customer__persons___pdi___distinct_id)
+     LEFT JOIN
+       (SELECT revenue_analytics_revenue_item.customer_id AS customer_id,
+               sum(revenue_analytics_revenue_item.amount) AS revenue
+        FROM
+          (SELECT if(ifNull(greater(invoice.period_months, 1), 0), concat(ifNull(toString(invoice.invoice_item_id), ''), '_', ifNull(toString(invoice.month_index), '')), invoice.invoice_item_id) AS id,
+                  invoice.invoice_item_id AS invoice_item_id,
+                  'stripe.posthog_test' AS source_label,
+                  addMonths(invoice.timestamp, invoice.month_index) AS timestamp,
+                  invoice.created_at AS created_at,
+                  ifNull(notEmpty(invoice.subscription_id), 0) AS is_recurring,
+                  invoice.product_id AS product_id,
+                  invoice.customer_id AS customer_id,
+                  NULL AS group_0_key,
+                  NULL AS group_1_key,
+                  NULL AS group_2_key,
+                  NULL AS group_3_key,
+                  NULL AS group_4_key,
+                  invoice.id AS invoice_id,
+                  invoice.subscription_id AS subscription_id,
+                  NULL AS session_id,
+                  NULL AS event_name,
+                  JSONExtractString(invoice.discount, 'coupon', 'name') AS coupon,
+                  JSONExtractString(invoice.discount, 'coupon', 'id') AS coupon_id,
+                  upper(invoice.currency) AS original_currency,
+                  accurateCastOrNull(invoice.amount_captured, 'Decimal64(10)') AS original_amount,
+                  in(original_currency,
+                     ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
+                    if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
+                    divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
+                    'GBP' AS currency,
+                    divideDecimal(if(equals(original_currency, currency), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal64(1, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10))))), accurateCastOrNull(invoice.period_months, 'Decimal64(10)')) AS amount
+           FROM
+             (SELECT posthog_test_stripe_invoice.id AS id,
+                     parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC') AS created_at,
+                     posthog_test_stripe_invoice.customer AS customer_id,
+                     posthog_test_stripe_invoice.subscription AS subscription_id,
+                     posthog_test_stripe_invoice.discount AS discount,
+                     arrayJoin(JSONExtractArrayRaw(assumeNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(posthog_test_stripe_invoice.lines, 'data'), ''), 'null'), '^"|"$', '')))) AS data,
+                     JSONExtractString(data, 'id') AS invoice_item_id,
+                     JSONExtractUInt(data, 'amount') AS amount_before_discount,
+                     coalesce(arraySum(arrayMap(x -> JSONExtractInt(x, 'amount'), JSONExtractArrayRaw(data, 'discount_amounts'))), 0) AS discount_amount,
+                     greatest(minus(amount_before_discount, discount_amount), 0) AS amount_captured,
+                     JSONExtractString(data, 'currency') AS currency,
+                     JSONExtractString(data, 'price', 'product') AS product_id,
+                     fromUnixTimestamp(JSONExtractUInt(data, 'period', 'start')) AS period_start,
+                     fromUnixTimestamp(JSONExtractUInt(data, 'period', 'end')) AS period_end,
+                     greatest(toInt16(round(divide(dateDiff('day', ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')), ifNull(period_end, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC'))), 30.44))), 1) AS period_months,
+                     arrayJoin(range(0, period_months)) AS month_index,
+                     ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')) AS timestamp
+              FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `subscription` String, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS posthog_test_stripe_invoice
+              WHERE posthog_test_stripe_invoice.paid) AS invoice) AS revenue_analytics_revenue_item
+        GROUP BY customer_id) AS revenue_agg ON equals(revenue_analytics_customer.id, revenue_agg.customer_id)
+     LEFT JOIN
+       (SELECT `stripe.posthog_test.mrr_revenue_view`.customer_id AS customer_id,
+               sum(`stripe.posthog_test.mrr_revenue_view`.mrr) AS mrr
+        FROM
+          (SELECT union.source_label AS source_label,
+                  union.customer_id AS customer_id,
+                  union.subscription_id AS subscription_id,
+                  argMax(union.amount, union.timestamp) AS mrr
+           FROM
+             (SELECT revenue_item.source_label AS source_label,
+                     revenue_item.customer_id AS customer_id,
+                     revenue_item.subscription_id AS subscription_id,
+                     toStartOfMonth(toTimeZone(revenue_item.timestamp, 'UTC')) AS timestamp,
+                     sum(revenue_item.amount) AS amount
+              FROM
+                (SELECT if(ifNull(greater(invoice.period_months, 1), 0), concat(ifNull(toString(invoice.invoice_item_id), ''), '_', ifNull(toString(invoice.month_index), '')), invoice.invoice_item_id) AS id,
+                        invoice.invoice_item_id AS invoice_item_id,
+                        'stripe.posthog_test' AS source_label,
+                        addMonths(invoice.timestamp, invoice.month_index) AS timestamp,
+                        invoice.created_at AS created_at,
+                        ifNull(notEmpty(invoice.subscription_id), 0) AS is_recurring,
+                        invoice.product_id AS product_id,
+                        invoice.customer_id AS customer_id,
+                        NULL AS group_0_key,
+                        NULL AS group_1_key,
+                        NULL AS group_2_key,
+                        NULL AS group_3_key,
+                        NULL AS group_4_key,
+                        invoice.id AS invoice_id,
+                        invoice.subscription_id AS subscription_id,
+                        NULL AS session_id,
+                        NULL AS event_name,
+                        JSONExtractString(invoice.discount, 'coupon', 'name') AS coupon,
+                        JSONExtractString(invoice.discount, 'coupon', 'id') AS coupon_id,
+                        upper(invoice.currency) AS original_currency,
+                        accurateCastOrNull(invoice.amount_captured, 'Decimal64(10)') AS original_amount,
+                        in(original_currency,
+                           ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
+                          if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
+                          divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
+                          'GBP' AS currency,
+                          divideDecimal(if(equals(original_currency, currency), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal64(1, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10))))), accurateCastOrNull(invoice.period_months, 'Decimal64(10)')) AS amount
+                 FROM
+                   (SELECT posthog_test_stripe_invoice.id AS id,
+                           parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC') AS created_at,
+                           posthog_test_stripe_invoice.customer AS customer_id,
+                           posthog_test_stripe_invoice.subscription AS subscription_id,
+                           posthog_test_stripe_invoice.discount AS discount,
+                           arrayJoin(JSONExtractArrayRaw(assumeNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(posthog_test_stripe_invoice.lines, 'data'), ''), 'null'), '^"|"$', '')))) AS data,
+                           JSONExtractString(data, 'id') AS invoice_item_id,
+                           JSONExtractUInt(data, 'amount') AS amount_before_discount,
+                           coalesce(arraySum(arrayMap(x -> JSONExtractInt(x, 'amount'), JSONExtractArrayRaw(data, 'discount_amounts'))), 0) AS discount_amount,
+                           greatest(minus(amount_before_discount, discount_amount), 0) AS amount_captured,
+                           JSONExtractString(data, 'currency') AS currency,
+                           JSONExtractString(data, 'price', 'product') AS product_id,
+                           fromUnixTimestamp(JSONExtractUInt(data, 'period', 'start')) AS period_start,
+                           fromUnixTimestamp(JSONExtractUInt(data, 'period', 'end')) AS period_end,
+                           greatest(toInt16(round(divide(dateDiff('day', ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')), ifNull(period_end, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC'))), 30.44))), 1) AS period_months,
+                           arrayJoin(range(0, period_months)) AS month_index,
+                           ifNull(period_start, parseDateTime64BestEffortOrNull(toString(posthog_test_stripe_invoice.created), 6, 'UTC')) AS timestamp
+                    FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices/posthog_test_stripe_invoice/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `tax` Int64, `paid` UInt8, `lines` String, `total` Int64, `charge` String, `issuer` String, `number` String, `object` String, `status` String, `created` DateTime, `currency` String, `customer` String, `discount` String, `due_date` DateTime, `livemode` UInt8, `metadata` String, `subtotal` Int64, `attempted` UInt8, `discounts` String, `rendering` String, `amount_due` Int64, `amount_paid` Int64, `description` String, `invoice_pdf` String, `account_name` String, `auto_advance` UInt8, `effective_at` DateTime, `subscription` String, `attempt_count` UInt8, `automatic_tax` String, `customer_name` String, `period_end_at` DateTime, `billing_reason` String, `customer_email` String, `ending_balance` Int64, `payment_intent` String, `account_country` String, `amount_shipping` Int64, `period_start_at` DateTime, `amount_remaining` Int64, `customer_address` String, `customer_tax_ids` String, `paid_out_of_band` UInt8, `payment_settings` String, `starting_balance` Int64, `collection_method` String, `default_tax_rates` String, `total_tax_amounts` String, `hosted_invoice_url` String, `status_transitions` String, `customer_tax_exempt` String, `total_excluding_tax` Int64, `subscription_details` String, `webhooks_delivered_at` DateTime, `subtotal_excluding_tax` Int64, `total_discount_amounts` String, `pre_payment_credit_notes_amount` Int64, `post_payment_credit_notes_amount` Int64') AS posthog_test_stripe_invoice
+                    WHERE posthog_test_stripe_invoice.paid) AS invoice) AS revenue_item
+              WHERE and(revenue_item.is_recurring, isNotNull(revenue_item.subscription_id), greaterOrEquals(timestamp, toStartOfMonth(addDays(toDateTime64('2025-05-30 00:00:00.000000', 6, 'UTC'), -60))), lessOrEquals(timestamp, toDateTime64('2025-05-30 00:00:00.000000', 6, 'UTC')))
+              GROUP BY revenue_item.source_label,
+                       revenue_item.customer_id,
+                       revenue_item.subscription_id, timestamp
+              ORDER BY timestamp DESC
+              UNION ALL SELECT `stripe.posthog_test.subscription_revenue_view`.source_label AS source_label,
+                               `stripe.posthog_test.subscription_revenue_view`.customer_id AS customer_id,
+                               `stripe.posthog_test.subscription_revenue_view`.id AS subscription_id,
+                               toTimeZone(`stripe.posthog_test.subscription_revenue_view`.ended_at, 'UTC') AS timestamp,
+                               accurateCastOrNull(0, 'Decimal64(10)') AS amount
+              FROM
+                (SELECT '' AS id,
+                        '' AS source_label,
+                        '' AS plan_id,
+                        '' AS product_id,
+                        '' AS customer_id,
+                        '' AS status,
+                        toDateTime64('1970-01-01 00:00:00.000000', 6, 'UTC') AS started_at,
+                        toDateTime64('1970-01-01 00:00:00.000000', 6, 'UTC') AS ended_at,
+                        '' AS metadata
+                 WHERE 0) AS `stripe.posthog_test.subscription_revenue_view`
+              WHERE and(greaterOrEquals(timestamp, toStartOfMonth(addDays(toDateTime64('2025-05-30 00:00:00.000000', 6, 'UTC'), -60))), lessOrEquals(timestamp, toDateTime64('2025-05-30 00:00:00.000000', 6, 'UTC')))
+              ORDER BY timestamp DESC) AS
+           union
+           GROUP BY source_label,
+                    customer_id,
+                    subscription_id
+           ORDER BY customer_id ASC,
+                    subscription_id ASC) AS `stripe.posthog_test.mrr_revenue_view`
+        GROUP BY customer_id) AS mrr_agg ON equals(revenue_analytics_customer.id, mrr_agg.customer_id)) AS persons_revenue_analytics
+  ORDER BY persons_revenue_analytics.mrr DESC,
+           persons_revenue_analytics.revenue DESC
+  LIMIT 100 SETTINGS format_csv_allow_double_quotes=1,
+                     readonly=2,
+                     max_execution_time=60,
+                     allow_experimental_object_type=1,
+                     max_ast_elements=4000000,
+                     max_expanded_ast_elements=4000000,
+                     max_bytes_before_external_group_by=0,
+                     transform_null_in=1,
+                     optimize_min_equality_disjunction_chain_length=4294967295,
+                     allow_experimental_join_condition=1,
+                     use_hive_partitioning=0
+  '''
+# ---
+# name: TestPersonsRevenueAnalyticsManagedViewsets.test_virtual_property_in_trend_0_disabled
+  '''
+  SELECT toTimeZone(events.timestamp, 'UTC') AS timestamp
+  FROM events
+  WHERE and(equals(events.team_id, 99999), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('1980-01-01 00:00:00.000000', 6, 'UTC')), equals(events.event, '$pageview'))
+  ORDER BY toTimeZone(events.timestamp, 'UTC') ASC
+  LIMIT 1 SETTINGS readonly=2,
+                   max_execution_time=60,
+                   allow_experimental_object_type=1,
+                   max_ast_elements=4000000,
+                   max_expanded_ast_elements=4000000,
+                   max_bytes_before_external_group_by=0,
+                   transform_null_in=1,
+                   optimize_min_equality_disjunction_chain_length=4294967295,
+                   allow_experimental_join_condition=1,
+                   use_hive_partitioning=0
+  '''
+# ---
+# name: TestPersonsRevenueAnalyticsManagedViewsets.test_virtual_property_in_trend_0_disabled.1
+  '''
+  WITH breakdown_series AS
+    (SELECT count AS count,
+                     day_start AS day_start,
+                     breakdown_value AS breakdown_value
+     FROM
+       (SELECT sum(total) AS count,
+               day_start AS day_start,
+               [ifNull(toString(breakdown_value_1), '$$_posthog_breakdown_null_$$')] AS breakdown_value
+        FROM
+          (SELECT count() AS total,
+                  toStartOfDay(toTimeZone(e.timestamp, 'UTC')) AS day_start,
+                  ifNull(nullIf(leftUTF8(toString(e__pdi__person__revenue_analytics.revenue), 400), ''), '$$_posthog_breakdown_null_$$') AS breakdown_value_1
+           FROM events AS e
+           INNER JOIN
+             (SELECT tupleElement(argMax(tuple(person_distinct_id2.person_id), person_distinct_id2.version), 1) AS e__pdi___person_id,
+                     tupleElement(argMax(tuple(person_distinct_id2.person_id), person_distinct_id2.version), 1) AS person_id,
+                     person_distinct_id2.distinct_id AS distinct_id
+              FROM person_distinct_id2
+              WHERE equals(person_distinct_id2.team_id, 99999)
+              GROUP BY person_distinct_id2.distinct_id
+              HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id2.is_deleted), person_distinct_id2.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__pdi ON equals(e.distinct_id, e__pdi.distinct_id)
+           INNER JOIN
+             (SELECT tupleElement(argMax(tuple(person.id), person.version), 1) AS e__pdi__person___id,
+                     person.id AS id
+              FROM person
+              WHERE equals(person.team_id, 99999)
+              GROUP BY person.id
+              HAVING and(ifNull(equals(tupleElement(argMax(tuple(person.is_deleted), person.version), 1), 0), 0), ifNull(less(tupleElement(argMax(tuple(toTimeZone(person.created_at, 'UTC')), person.version), 1), plus(now64(6, 'UTC'), toIntervalDay(1))), 0)) SETTINGS optimize_aggregation_in_order=1) AS e__pdi__person ON equals(e__pdi.e__pdi___person_id, e__pdi__person.e__pdi__person___id)
+           LEFT JOIN
+             (SELECT 99999 AS team_id,
+                     revenue_analytics_customer.id AS person_id,
+                     coalesce(revenue_agg.revenue, accurateCastOrNull(0, 'Decimal64(10)')) AS revenue,
+                     coalesce(mrr_agg.mrr, accurateCastOrNull(0, 'Decimal64(10)')) AS mrr
+              FROM
+                (SELECT toString(persons.id) AS id,
+                        'revenue_analytics.events.purchase' AS source_label,
+                        persons.created_at AS timestamp,
+                        persons.properties___name AS name,
+                        persons.properties___email AS email,
+                        persons.properties___phone AS phone,
+                        persons.properties___address AS address,
+                        persons.properties___metadata AS metadata,
+                        persons.`properties___$geoip_country_name` AS country,
+                        formatDateTime(toStartOfMonth(persons.created_at), '%Y-%m') AS cohort,
+                        NULL AS initial_coupon,
+                        NULL AS initial_coupon_id
+                 FROM
+                   (SELECT person.id AS id,
+                           replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'name'), ''), 'null'), '^"|"$', '') AS properties___name,
+                           replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'email'), ''), 'null'), '^"|"$', '') AS properties___email,
+                           replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'phone'), ''), 'null'), '^"|"$', '') AS properties___phone,
+                           replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'address'), ''), 'null'), '^"|"$', '') AS properties___address,
+                           replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'metadata'), ''), 'null'), '^"|"$', '') AS properties___metadata,
+                           replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, '$geoip_country_name'), ''), 'null'), '^"|"$', '') AS `properties___$geoip_country_name`,
+                           toTimeZone(person.created_at, 'UTC') AS created_at
+                    FROM person
+                    WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
+                                                                  (SELECT person.id AS id, max(person.version) AS version
+                                                                   FROM person
+                                                                   WHERE equals(person.team_id, 99999)
+                                                                   GROUP BY person.id
+                                                                   HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0))))) SETTINGS optimize_aggregation_in_order=1) AS persons
+                 INNER JOIN
+                   (SELECT DISTINCT events__pdi__person.id AS person_id
+                    FROM events
+                    INNER JOIN
+                      (SELECT tupleElement(argMax(tuple(person_distinct_id2.person_id), person_distinct_id2.version), 1) AS events__pdi___person_id,
+                              tupleElement(argMax(tuple(person_distinct_id2.person_id), person_distinct_id2.version), 1) AS person_id,
+                              person_distinct_id2.distinct_id AS distinct_id
+                       FROM person_distinct_id2
+                       WHERE equals(person_distinct_id2.team_id, 99999)
+                       GROUP BY person_distinct_id2.distinct_id
+                       HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id2.is_deleted), person_distinct_id2.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__pdi ON equals(events.distinct_id, events__pdi.distinct_id)
+                    INNER JOIN
+                      (SELECT person.id AS id
+                       FROM person
+                       WHERE equals(person.team_id, 99999)
+                       GROUP BY person.id
+                       HAVING and(ifNull(equals(tupleElement(argMax(tuple(person.is_deleted), person.version), 1), 0), 0), ifNull(less(tupleElement(argMax(tuple(toTimeZone(person.created_at, 'UTC')), person.version), 1), plus(now64(6, 'UTC'), toIntervalDay(1))), 0)) SETTINGS optimize_aggregation_in_order=1) AS events__pdi__person ON equals(events__pdi.events__pdi___person_id, events__pdi__person.id)
+                    WHERE equals(events.team_id, 99999)) AS events ON equals(persons.id, events.person_id)
+                 ORDER BY persons.created_at DESC) AS revenue_analytics_customer
+              LEFT JOIN
+                (SELECT revenue_analytics_revenue_item.customer_id AS customer_id,
+                        sum(revenue_analytics_revenue_item.amount) AS revenue
+                 FROM
+                   (SELECT toString(events.uuid) AS id,
+                           toString(events.uuid) AS invoice_item_id,
+                           'revenue_analytics.events.purchase' AS source_label,
+                           toTimeZone(events.timestamp, 'UTC') AS timestamp,
+                           timestamp AS created_at,
+                           0 AS is_recurring,
+                           NULL AS product_id,
+                           toString(events__pdi.person_id) AS customer_id,
+                           events.`$group_0` AS group_0_key,
+                           events.`$group_1` AS group_1_key,
+                           events.`$group_2` AS group_2_key,
+                           events.`$group_3` AS group_3_key,
+                           events.`$group_4` AS group_4_key,
+                           NULL AS invoice_id,
+                           NULL AS subscription_id,
+                           toString(events.`$session_id`) AS session_id,
+                           events.event AS event_name,
+                           NULL AS coupon,
+                           coupon AS coupon_id,
+                           'USD' AS original_currency,
+                           accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)') AS original_amount,
+                           in(original_currency,
+                              ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
+                             if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
+                             divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
+                             'USD' AS currency,
+                             if(isNull('USD'), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals('USD', 'USD'), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(1, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))) AS amount
+                    FROM events
+                    INNER JOIN
+                      (SELECT tupleElement(argMax(tuple(person_distinct_id2.person_id), person_distinct_id2.version), 1) AS person_id,
+                              person_distinct_id2.distinct_id AS distinct_id
+                       FROM person_distinct_id2
+                       WHERE equals(person_distinct_id2.team_id, 99999)
+                       GROUP BY person_distinct_id2.distinct_id
+                       HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id2.is_deleted), person_distinct_id2.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__pdi ON equals(events.distinct_id, events__pdi.distinct_id)
+                    WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), 1, isNotNull(amount)))
+                    ORDER BY timestamp DESC) AS revenue_analytics_revenue_item
+                 GROUP BY customer_id) AS revenue_agg ON equals(revenue_analytics_customer.id, revenue_agg.customer_id)
+              LEFT JOIN
+                (SELECT `revenue_analytics.events.purchase.mrr_events_revenue_view`.customer_id AS customer_id,
+                        sum(`revenue_analytics.events.purchase.mrr_events_revenue_view`.mrr) AS mrr
+                 FROM
+                   (SELECT union.source_label AS source_label,
+                           union.customer_id AS customer_id,
+                           union.subscription_id AS subscription_id,
+                           argMax(union.amount, union.timestamp) AS mrr
+                    FROM
+                      (SELECT revenue_item.source_label AS source_label,
+                              revenue_item.customer_id AS customer_id,
+                              revenue_item.subscription_id AS subscription_id,
+                              toStartOfMonth(toTimeZone(revenue_item.timestamp, 'UTC')) AS timestamp,
+                              sum(revenue_item.amount) AS amount
+                       FROM
+                         (SELECT toString(events.uuid) AS id,
+                                 toString(events.uuid) AS invoice_item_id,
+                                 'revenue_analytics.events.purchase' AS source_label,
+                                 toTimeZone(events.timestamp, 'UTC') AS timestamp,
+                                 timestamp AS created_at,
+                                 0 AS is_recurring,
+                                 NULL AS product_id,
+                                 toString(events__pdi.person_id) AS customer_id,
+                                 events.`$group_0` AS group_0_key,
+                                 events.`$group_1` AS group_1_key,
+                                 events.`$group_2` AS group_2_key,
+                                 events.`$group_3` AS group_3_key,
+                                 events.`$group_4` AS group_4_key,
+                                 NULL AS invoice_id,
+                                 NULL AS subscription_id,
+                                 toString(events.`$session_id`) AS session_id,
+                                 events.event AS event_name,
+                                 NULL AS coupon,
+                                 coupon AS coupon_id,
+                                 'USD' AS original_currency,
+                                 accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)') AS original_amount,
+                                 in(original_currency,
+                                    ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
+                                   if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
+                                   divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
+                                   'USD' AS currency,
+                                   if(isNull('USD'), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals('USD', 'USD'), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(1, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))) AS amount
+                          FROM events
+                          INNER JOIN
+                            (SELECT tupleElement(argMax(tuple(person_distinct_id2.person_id), person_distinct_id2.version), 1) AS person_id,
+                                    person_distinct_id2.distinct_id AS distinct_id
+                             FROM person_distinct_id2
+                             WHERE equals(person_distinct_id2.team_id, 99999)
+                             GROUP BY person_distinct_id2.distinct_id
+                             HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id2.is_deleted), person_distinct_id2.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__pdi ON equals(events.distinct_id, events__pdi.distinct_id)
+                          WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), 1, isNotNull(amount)))
+                          ORDER BY timestamp DESC) AS revenue_item
+                       WHERE and(revenue_item.is_recurring, isNotNull(revenue_item.subscription_id), greaterOrEquals(timestamp, toStartOfMonth(addDays(toDateTime64('today', 6, 'UTC'), -60))), lessOrEquals(timestamp, toDateTime64('today', 6, 'UTC')))
+                       GROUP BY revenue_item.source_label,
+                                revenue_item.customer_id,
+                                revenue_item.subscription_id, timestamp
+                       ORDER BY timestamp DESC
+                       UNION ALL SELECT `revenue_analytics.events.purchase.subscription_events_revenue_view`.source_label AS source_label,
+                                        `revenue_analytics.events.purchase.subscription_events_revenue_view`.customer_id AS customer_id,
+                                        `revenue_analytics.events.purchase.subscription_events_revenue_view`.id AS subscription_id,
+                                        toTimeZone(`revenue_analytics.events.purchase.subscription_events_revenue_view`.ended_at, 'UTC') AS timestamp,
+                                        accurateCastOrNull(0, 'Decimal64(10)') AS amount
+                       FROM
+                         (SELECT '' AS id,
+                                 '' AS source_label,
+                                 '' AS plan_id,
+                                 '' AS product_id,
+                                 '' AS customer_id,
+                                 '' AS status,
+                                 toDateTime64('1970-01-01 00:00:00.000000', 6, 'UTC') AS started_at,
+                                 toDateTime64('1970-01-01 00:00:00.000000', 6, 'UTC') AS ended_at,
+                                 '' AS metadata
+                          WHERE 0) AS `revenue_analytics.events.purchase.subscription_events_revenue_view`
+                       WHERE and(greaterOrEquals(timestamp, toStartOfMonth(addDays(toDateTime64('today', 6, 'UTC'), -60))), lessOrEquals(timestamp, toDateTime64('today', 6, 'UTC')))
+                       ORDER BY timestamp DESC) AS
+                    union
+                    GROUP BY source_label,
+                             customer_id,
+                             subscription_id
+                    ORDER BY customer_id ASC,
+                             subscription_id ASC) AS `revenue_analytics.events.purchase.mrr_events_revenue_view`
+                 GROUP BY customer_id) AS mrr_agg ON equals(revenue_analytics_customer.id, mrr_agg.customer_id)) AS e__pdi__person__revenue_analytics ON equals(toString(e__pdi__person.e__pdi__person___id), toString(e__pdi__person__revenue_analytics.person_id))
+           WHERE and(equals(e.team_id, 99999), greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toStartOfInterval(assumeNotNull(toDateTime('2025-05-29 00:00:00', 'UTC')), toIntervalDay(1))), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), assumeNotNull(toDateTime('2025-05-30 23:59:59', 'UTC'))), equals(e.event, '$pageview'))
+           GROUP BY day_start,
+                    breakdown_value_1)
+        GROUP BY day_start,
+                 breakdown_value_1
+        ORDER BY day_start ASC,
+                 breakdown_value ASC)),
+       totals_per_breakdown AS
+    (SELECT breakdown_series.breakdown_value AS breakdown_value,
+            sum(breakdown_series.count) AS total_count_for_breakdown,
+            if(has(breakdown_series.breakdown_value, '$$_posthog_breakdown_other_$$'), 2, if(has(breakdown_series.breakdown_value, '$$_posthog_breakdown_null_$$'), 1, 0)) AS ordering
+     FROM breakdown_series
+     GROUP BY breakdown_series.breakdown_value),
+       ranked_breakdown_totals AS
+    (SELECT totals_per_breakdown.breakdown_value AS breakdown_value,
+            totals_per_breakdown.ordering AS ordering,
+            totals_per_breakdown.total_count_for_breakdown AS total_count_for_breakdown,
+            row_number() OVER (
+                               ORDER BY totals_per_breakdown.ordering ASC, totals_per_breakdown.total_count_for_breakdown DESC, totals_per_breakdown.breakdown_value ASC) AS breakdown_rank
+     FROM totals_per_breakdown),
+       ranked_breakdown_values AS
+    (SELECT breakdown_series.count AS count,
+            toTimeZone(breakdown_series.day_start, 'UTC') AS day_start,
+            breakdown_series.breakdown_value AS breakdown_value,
+            ranked_breakdown_totals.ordering AS ordering,
+            ranked_breakdown_totals.breakdown_rank AS breakdown_rank
+     FROM breakdown_series
+     JOIN ranked_breakdown_totals ON equals(ranked_breakdown_totals.breakdown_value, breakdown_series.breakdown_value)),
+       top_n_breakdown_values AS
+    (SELECT toTimeZone(ranked_breakdown_values.day_start, 'UTC') AS day_start,
+            ranked_breakdown_values.count AS value,
+            ranked_breakdown_values.breakdown_value AS breakdown_value
+     FROM ranked_breakdown_values
+     WHERE ifNull(lessOrEquals(ranked_breakdown_values.breakdown_rank, 25), 0)),
+       other_breakdown_values AS
+    (SELECT toTimeZone(ranked_breakdown_values.day_start, 'UTC') AS day_start,
+            sum(ranked_breakdown_values.count) AS value,
+            ['$$_posthog_breakdown_other_$$'] AS breakdown_value
+     FROM ranked_breakdown_values
+     WHERE ifNull(greater(ranked_breakdown_values.breakdown_rank, 25), 0)
+     GROUP BY toTimeZone(ranked_breakdown_values.day_start, 'UTC')),
+       top_n_and_other_breakdown_values AS
+    (SELECT day_start AS day_start,
+            value AS value,
+            breakdown_value AS breakdown_value
+     FROM
+       (SELECT toTimeZone(top_n_breakdown_values.day_start, 'UTC') AS day_start,
+               top_n_breakdown_values.value AS value,
+               top_n_breakdown_values.breakdown_value AS breakdown_value
+        FROM top_n_breakdown_values
+        UNION ALL SELECT toTimeZone(other_breakdown_values.day_start, 'UTC') AS day_start,
+                         other_breakdown_values.value AS value,
+                         other_breakdown_values.breakdown_value AS breakdown_value
+        FROM other_breakdown_values)
+     ORDER BY day_start ASC,
+              value ASC)
+  SELECT arrayMap(number -> plus(toStartOfInterval(assumeNotNull(toDateTime('2025-05-29 00:00:00', 'UTC')), toIntervalDay(1)), toIntervalDay(number)), range(0, plus(coalesce(dateDiff('day', toStartOfInterval(assumeNotNull(toDateTime('2025-05-29 00:00:00', 'UTC')), toIntervalDay(1)), toStartOfInterval(assumeNotNull(toDateTime('2025-05-30 23:59:59', 'UTC')), toIntervalDay(1)))), 1))) AS date,
+         arrayMap(d -> arraySum(arrayMap((v, dd) -> if(ifNull(equals(dd, d), isNull(dd)
+                                                              and isNull(d)), v, 0), vals, days)), date) AS total,
+         breakdown_value AS breakdown_value
+  FROM
+    (SELECT groupArray(toTimeZone(top_n_and_other_breakdown_values.day_start, 'UTC')) AS days,
+            groupArray(top_n_and_other_breakdown_values.value) AS vals,
+            top_n_and_other_breakdown_values.breakdown_value AS breakdown_value
+     FROM top_n_and_other_breakdown_values
+     GROUP BY top_n_and_other_breakdown_values.breakdown_value)
+  ORDER BY if(has(breakdown_value, '$$_posthog_breakdown_other_$$'), 2, if(has(breakdown_value, '$$_posthog_breakdown_null_$$'), 1, 0)) ASC, arraySum(total) DESC, breakdown_value ASC
+  LIMIT 50000 SETTINGS readonly=2,
+                       max_execution_time=60,
+                       allow_experimental_object_type=1,
+                       max_ast_elements=4000000,
+                       max_expanded_ast_elements=4000000,
+                       max_bytes_before_external_group_by=0,
+                       transform_null_in=1,
+                       optimize_min_equality_disjunction_chain_length=4294967295,
+                       allow_experimental_join_condition=1,
+                       use_hive_partitioning=0
+  '''
+# ---
+# name: TestPersonsRevenueAnalyticsManagedViewsets.test_virtual_property_in_trend_1_person_id_no_override_properties_on_events
+  '''
+  SELECT toTimeZone(events.timestamp, 'UTC') AS timestamp
+  FROM events
+  WHERE and(equals(events.team_id, 99999), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('1980-01-01 00:00:00.000000', 6, 'UTC')), equals(events.event, '$pageview'))
+  ORDER BY toTimeZone(events.timestamp, 'UTC') ASC
+  LIMIT 1 SETTINGS readonly=2,
+                   max_execution_time=60,
+                   allow_experimental_object_type=1,
+                   max_ast_elements=4000000,
+                   max_expanded_ast_elements=4000000,
+                   max_bytes_before_external_group_by=0,
+                   transform_null_in=1,
+                   optimize_min_equality_disjunction_chain_length=4294967295,
+                   allow_experimental_join_condition=1,
+                   use_hive_partitioning=0
+  '''
+# ---
+# name: TestPersonsRevenueAnalyticsManagedViewsets.test_virtual_property_in_trend_1_person_id_no_override_properties_on_events.1
+  '''
+  WITH breakdown_series AS
+    (SELECT count AS count,
+                     day_start AS day_start,
+                     breakdown_value AS breakdown_value
+     FROM
+       (SELECT sum(total) AS count,
+               day_start AS day_start,
+               [ifNull(toString(breakdown_value_1), '$$_posthog_breakdown_null_$$')] AS breakdown_value
+        FROM
+          (SELECT count() AS total,
+                  toStartOfDay(toTimeZone(e.timestamp, 'UTC')) AS day_start,
+                  ifNull(nullIf(leftUTF8(toString(e__poe__revenue_analytics.revenue), 400), ''), '$$_posthog_breakdown_null_$$') AS breakdown_value_1
+           FROM events AS e
+           LEFT JOIN
+             (SELECT 99999 AS team_id,
+                     revenue_analytics_customer.id AS person_id,
+                     coalesce(revenue_agg.revenue, accurateCastOrNull(0, 'Decimal64(10)')) AS revenue,
+                     coalesce(mrr_agg.mrr, accurateCastOrNull(0, 'Decimal64(10)')) AS mrr
+              FROM
+                (SELECT toString(persons.id) AS id,
+                        'revenue_analytics.events.purchase' AS source_label,
+                        persons.created_at AS timestamp,
+                        persons.properties___name AS name,
+                        persons.properties___email AS email,
+                        persons.properties___phone AS phone,
+                        persons.properties___address AS address,
+                        persons.properties___metadata AS metadata,
+                        persons.`properties___$geoip_country_name` AS country,
+                        formatDateTime(toStartOfMonth(persons.created_at), '%Y-%m') AS cohort,
+                        NULL AS initial_coupon,
+                        NULL AS initial_coupon_id
+                 FROM
+                   (SELECT person.id AS id,
+                           replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'name'), ''), 'null'), '^"|"$', '') AS properties___name,
+                           replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'email'), ''), 'null'), '^"|"$', '') AS properties___email,
+                           replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'phone'), ''), 'null'), '^"|"$', '') AS properties___phone,
+                           replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'address'), ''), 'null'), '^"|"$', '') AS properties___address,
+                           replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'metadata'), ''), 'null'), '^"|"$', '') AS properties___metadata,
+                           replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, '$geoip_country_name'), ''), 'null'), '^"|"$', '') AS `properties___$geoip_country_name`,
+                           toTimeZone(person.created_at, 'UTC') AS created_at
+                    FROM person
+                    WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
+                                                                  (SELECT person.id AS id, max(person.version) AS version
+                                                                   FROM person
+                                                                   WHERE equals(person.team_id, 99999)
+                                                                   GROUP BY person.id
+                                                                   HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0))))) SETTINGS optimize_aggregation_in_order=1) AS persons
+                 INNER JOIN
+                   (SELECT DISTINCT events.person_id AS person_id
+                    FROM events
+                    WHERE equals(events.team_id, 99999)) AS events ON equals(persons.id, events.person_id)
+                 ORDER BY persons.created_at DESC) AS revenue_analytics_customer
+              LEFT JOIN
+                (SELECT revenue_analytics_revenue_item.customer_id AS customer_id,
+                        sum(revenue_analytics_revenue_item.amount) AS revenue
+                 FROM
+                   (SELECT toString(events.uuid) AS id,
+                           toString(events.uuid) AS invoice_item_id,
+                           'revenue_analytics.events.purchase' AS source_label,
+                           toTimeZone(events.timestamp, 'UTC') AS timestamp,
+                           timestamp AS created_at,
+                           0 AS is_recurring,
+                           NULL AS product_id,
+                           toString(events.person_id) AS customer_id,
+                           events.`$group_0` AS group_0_key,
+                           events.`$group_1` AS group_1_key,
+                           events.`$group_2` AS group_2_key,
+                           events.`$group_3` AS group_3_key,
+                           events.`$group_4` AS group_4_key,
+                           NULL AS invoice_id,
+                           NULL AS subscription_id,
+                           toString(events.`$session_id`) AS session_id,
+                           events.event AS event_name,
+                           NULL AS coupon,
+                           coupon AS coupon_id,
+                           'USD' AS original_currency,
+                           accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)') AS original_amount,
+                           in(original_currency,
+                              ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
+                             if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
+                             divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
+                             'USD' AS currency,
+                             if(isNull('USD'), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals('USD', 'USD'), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(1, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))) AS amount
+                    FROM events
+                    WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), 1, isNotNull(amount)))
+                    ORDER BY timestamp DESC) AS revenue_analytics_revenue_item
+                 GROUP BY customer_id) AS revenue_agg ON equals(revenue_analytics_customer.id, revenue_agg.customer_id)
+              LEFT JOIN
+                (SELECT `revenue_analytics.events.purchase.mrr_events_revenue_view`.customer_id AS customer_id,
+                        sum(`revenue_analytics.events.purchase.mrr_events_revenue_view`.mrr) AS mrr
+                 FROM
+                   (SELECT union.source_label AS source_label,
+                           union.customer_id AS customer_id,
+                           union.subscription_id AS subscription_id,
+                           argMax(union.amount, union.timestamp) AS mrr
+                    FROM
+                      (SELECT revenue_item.source_label AS source_label,
+                              revenue_item.customer_id AS customer_id,
+                              revenue_item.subscription_id AS subscription_id,
+                              toStartOfMonth(toTimeZone(revenue_item.timestamp, 'UTC')) AS timestamp,
+                              sum(revenue_item.amount) AS amount
+                       FROM
+                         (SELECT toString(events.uuid) AS id,
+                                 toString(events.uuid) AS invoice_item_id,
+                                 'revenue_analytics.events.purchase' AS source_label,
+                                 toTimeZone(events.timestamp, 'UTC') AS timestamp,
+                                 timestamp AS created_at,
+                                 0 AS is_recurring,
+                                 NULL AS product_id,
+                                 toString(events.person_id) AS customer_id,
+                                 events.`$group_0` AS group_0_key,
+                                 events.`$group_1` AS group_1_key,
+                                 events.`$group_2` AS group_2_key,
+                                 events.`$group_3` AS group_3_key,
+                                 events.`$group_4` AS group_4_key,
+                                 NULL AS invoice_id,
+                                 NULL AS subscription_id,
+                                 toString(events.`$session_id`) AS session_id,
+                                 events.event AS event_name,
+                                 NULL AS coupon,
+                                 coupon AS coupon_id,
+                                 'USD' AS original_currency,
+                                 accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)') AS original_amount,
+                                 in(original_currency,
+                                    ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
+                                   if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
+                                   divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
+                                   'USD' AS currency,
+                                   if(isNull('USD'), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals('USD', 'USD'), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(1, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))) AS amount
+                          FROM events
+                          WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), 1, isNotNull(amount)))
+                          ORDER BY timestamp DESC) AS revenue_item
+                       WHERE and(revenue_item.is_recurring, isNotNull(revenue_item.subscription_id), greaterOrEquals(timestamp, toStartOfMonth(addDays(toDateTime64('today', 6, 'UTC'), -60))), lessOrEquals(timestamp, toDateTime64('today', 6, 'UTC')))
+                       GROUP BY revenue_item.source_label,
+                                revenue_item.customer_id,
+                                revenue_item.subscription_id, timestamp
+                       ORDER BY timestamp DESC
+                       UNION ALL SELECT `revenue_analytics.events.purchase.subscription_events_revenue_view`.source_label AS source_label,
+                                        `revenue_analytics.events.purchase.subscription_events_revenue_view`.customer_id AS customer_id,
+                                        `revenue_analytics.events.purchase.subscription_events_revenue_view`.id AS subscription_id,
+                                        toTimeZone(`revenue_analytics.events.purchase.subscription_events_revenue_view`.ended_at, 'UTC') AS timestamp,
+                                        accurateCastOrNull(0, 'Decimal64(10)') AS amount
+                       FROM
+                         (SELECT '' AS id,
+                                 '' AS source_label,
+                                 '' AS plan_id,
+                                 '' AS product_id,
+                                 '' AS customer_id,
+                                 '' AS status,
+                                 toDateTime64('1970-01-01 00:00:00.000000', 6, 'UTC') AS started_at,
+                                 toDateTime64('1970-01-01 00:00:00.000000', 6, 'UTC') AS ended_at,
+                                 '' AS metadata
+                          WHERE 0) AS `revenue_analytics.events.purchase.subscription_events_revenue_view`
+                       WHERE and(greaterOrEquals(timestamp, toStartOfMonth(addDays(toDateTime64('today', 6, 'UTC'), -60))), lessOrEquals(timestamp, toDateTime64('today', 6, 'UTC')))
+                       ORDER BY timestamp DESC) AS
+                    union
+                    GROUP BY source_label,
+                             customer_id,
+                             subscription_id
+                    ORDER BY customer_id ASC,
+                             subscription_id ASC) AS `revenue_analytics.events.purchase.mrr_events_revenue_view`
+                 GROUP BY customer_id) AS mrr_agg ON equals(revenue_analytics_customer.id, mrr_agg.customer_id)) AS e__poe__revenue_analytics ON equals(toString(e.person_id), toString(e__poe__revenue_analytics.person_id))
+           WHERE and(equals(e.team_id, 99999), greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toStartOfInterval(assumeNotNull(toDateTime('2025-05-29 00:00:00', 'UTC')), toIntervalDay(1))), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), assumeNotNull(toDateTime('2025-05-30 23:59:59', 'UTC'))), equals(e.event, '$pageview'))
+           GROUP BY day_start,
+                    breakdown_value_1)
+        GROUP BY day_start,
+                 breakdown_value_1
+        ORDER BY day_start ASC,
+                 breakdown_value ASC)),
+       totals_per_breakdown AS
+    (SELECT breakdown_series.breakdown_value AS breakdown_value,
+            sum(breakdown_series.count) AS total_count_for_breakdown,
+            if(has(breakdown_series.breakdown_value, '$$_posthog_breakdown_other_$$'), 2, if(has(breakdown_series.breakdown_value, '$$_posthog_breakdown_null_$$'), 1, 0)) AS ordering
+     FROM breakdown_series
+     GROUP BY breakdown_series.breakdown_value),
+       ranked_breakdown_totals AS
+    (SELECT totals_per_breakdown.breakdown_value AS breakdown_value,
+            totals_per_breakdown.ordering AS ordering,
+            totals_per_breakdown.total_count_for_breakdown AS total_count_for_breakdown,
+            row_number() OVER (
+                               ORDER BY totals_per_breakdown.ordering ASC, totals_per_breakdown.total_count_for_breakdown DESC, totals_per_breakdown.breakdown_value ASC) AS breakdown_rank
+     FROM totals_per_breakdown),
+       ranked_breakdown_values AS
+    (SELECT breakdown_series.count AS count,
+            toTimeZone(breakdown_series.day_start, 'UTC') AS day_start,
+            breakdown_series.breakdown_value AS breakdown_value,
+            ranked_breakdown_totals.ordering AS ordering,
+            ranked_breakdown_totals.breakdown_rank AS breakdown_rank
+     FROM breakdown_series
+     JOIN ranked_breakdown_totals ON equals(ranked_breakdown_totals.breakdown_value, breakdown_series.breakdown_value)),
+       top_n_breakdown_values AS
+    (SELECT toTimeZone(ranked_breakdown_values.day_start, 'UTC') AS day_start,
+            ranked_breakdown_values.count AS value,
+            ranked_breakdown_values.breakdown_value AS breakdown_value
+     FROM ranked_breakdown_values
+     WHERE ifNull(lessOrEquals(ranked_breakdown_values.breakdown_rank, 25), 0)),
+       other_breakdown_values AS
+    (SELECT toTimeZone(ranked_breakdown_values.day_start, 'UTC') AS day_start,
+            sum(ranked_breakdown_values.count) AS value,
+            ['$$_posthog_breakdown_other_$$'] AS breakdown_value
+     FROM ranked_breakdown_values
+     WHERE ifNull(greater(ranked_breakdown_values.breakdown_rank, 25), 0)
+     GROUP BY toTimeZone(ranked_breakdown_values.day_start, 'UTC')),
+       top_n_and_other_breakdown_values AS
+    (SELECT day_start AS day_start,
+            value AS value,
+            breakdown_value AS breakdown_value
+     FROM
+       (SELECT toTimeZone(top_n_breakdown_values.day_start, 'UTC') AS day_start,
+               top_n_breakdown_values.value AS value,
+               top_n_breakdown_values.breakdown_value AS breakdown_value
+        FROM top_n_breakdown_values
+        UNION ALL SELECT toTimeZone(other_breakdown_values.day_start, 'UTC') AS day_start,
+                         other_breakdown_values.value AS value,
+                         other_breakdown_values.breakdown_value AS breakdown_value
+        FROM other_breakdown_values)
+     ORDER BY day_start ASC,
+              value ASC)
+  SELECT arrayMap(number -> plus(toStartOfInterval(assumeNotNull(toDateTime('2025-05-29 00:00:00', 'UTC')), toIntervalDay(1)), toIntervalDay(number)), range(0, plus(coalesce(dateDiff('day', toStartOfInterval(assumeNotNull(toDateTime('2025-05-29 00:00:00', 'UTC')), toIntervalDay(1)), toStartOfInterval(assumeNotNull(toDateTime('2025-05-30 23:59:59', 'UTC')), toIntervalDay(1)))), 1))) AS date,
+         arrayMap(d -> arraySum(arrayMap((v, dd) -> if(ifNull(equals(dd, d), isNull(dd)
+                                                              and isNull(d)), v, 0), vals, days)), date) AS total,
+         breakdown_value AS breakdown_value
+  FROM
+    (SELECT groupArray(toTimeZone(top_n_and_other_breakdown_values.day_start, 'UTC')) AS days,
+            groupArray(top_n_and_other_breakdown_values.value) AS vals,
+            top_n_and_other_breakdown_values.breakdown_value AS breakdown_value
+     FROM top_n_and_other_breakdown_values
+     GROUP BY top_n_and_other_breakdown_values.breakdown_value)
+  ORDER BY if(has(breakdown_value, '$$_posthog_breakdown_other_$$'), 2, if(has(breakdown_value, '$$_posthog_breakdown_null_$$'), 1, 0)) ASC, arraySum(total) DESC, breakdown_value ASC
+  LIMIT 50000 SETTINGS readonly=2,
+                       max_execution_time=60,
+                       allow_experimental_object_type=1,
+                       max_ast_elements=4000000,
+                       max_expanded_ast_elements=4000000,
+                       max_bytes_before_external_group_by=0,
+                       transform_null_in=1,
+                       optimize_min_equality_disjunction_chain_length=4294967295,
+                       allow_experimental_join_condition=1,
+                       use_hive_partitioning=0
+  '''
+# ---
+# name: TestPersonsRevenueAnalyticsManagedViewsets.test_virtual_property_in_trend_2_person_id_override_properties_on_events
+  '''
+  SELECT toTimeZone(events.timestamp, 'UTC') AS timestamp
+  FROM events
+  WHERE and(equals(events.team_id, 99999), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('1980-01-01 00:00:00.000000', 6, 'UTC')), equals(events.event, '$pageview'))
+  ORDER BY toTimeZone(events.timestamp, 'UTC') ASC
+  LIMIT 1 SETTINGS readonly=2,
+                   max_execution_time=60,
+                   allow_experimental_object_type=1,
+                   max_ast_elements=4000000,
+                   max_expanded_ast_elements=4000000,
+                   max_bytes_before_external_group_by=0,
+                   transform_null_in=1,
+                   optimize_min_equality_disjunction_chain_length=4294967295,
+                   allow_experimental_join_condition=1,
+                   use_hive_partitioning=0
+  '''
+# ---
+# name: TestPersonsRevenueAnalyticsManagedViewsets.test_virtual_property_in_trend_2_person_id_override_properties_on_events.1
+  '''
+  WITH breakdown_series AS
+    (SELECT count AS count,
+                     day_start AS day_start,
+                     breakdown_value AS breakdown_value
+     FROM
+       (SELECT sum(total) AS count,
+               day_start AS day_start,
+               [ifNull(toString(breakdown_value_1), '$$_posthog_breakdown_null_$$')] AS breakdown_value
+        FROM
+          (SELECT count() AS total,
+                  toStartOfDay(toTimeZone(e.timestamp, 'UTC')) AS day_start,
+                  ifNull(nullIf(leftUTF8(toString(e__poe__revenue_analytics.revenue), 400), ''), '$$_posthog_breakdown_null_$$') AS breakdown_value_1
+           FROM events AS e
+           LEFT OUTER JOIN
+             (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
+                     person_distinct_id_overrides.distinct_id AS distinct_id
+              FROM person_distinct_id_overrides
+              WHERE equals(person_distinct_id_overrides.team_id, 99999)
+              GROUP BY person_distinct_id_overrides.distinct_id
+              HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+           LEFT JOIN
+             (SELECT 99999 AS team_id,
+                     revenue_analytics_customer.id AS person_id,
+                     coalesce(revenue_agg.revenue, accurateCastOrNull(0, 'Decimal64(10)')) AS revenue,
+                     coalesce(mrr_agg.mrr, accurateCastOrNull(0, 'Decimal64(10)')) AS mrr
+              FROM
+                (SELECT toString(persons.id) AS id,
+                        'revenue_analytics.events.purchase' AS source_label,
+                        persons.created_at AS timestamp,
+                        persons.properties___name AS name,
+                        persons.properties___email AS email,
+                        persons.properties___phone AS phone,
+                        persons.properties___address AS address,
+                        persons.properties___metadata AS metadata,
+                        persons.`properties___$geoip_country_name` AS country,
+                        formatDateTime(toStartOfMonth(persons.created_at), '%Y-%m') AS cohort,
+                        NULL AS initial_coupon,
+                        NULL AS initial_coupon_id
+                 FROM
+                   (SELECT person.id AS id,
+                           replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'name'), ''), 'null'), '^"|"$', '') AS properties___name,
+                           replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'email'), ''), 'null'), '^"|"$', '') AS properties___email,
+                           replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'phone'), ''), 'null'), '^"|"$', '') AS properties___phone,
+                           replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'address'), ''), 'null'), '^"|"$', '') AS properties___address,
+                           replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'metadata'), ''), 'null'), '^"|"$', '') AS properties___metadata,
+                           replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, '$geoip_country_name'), ''), 'null'), '^"|"$', '') AS `properties___$geoip_country_name`,
+                           toTimeZone(person.created_at, 'UTC') AS created_at
+                    FROM person
+                    WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
+                                                                  (SELECT person.id AS id, max(person.version) AS version
+                                                                   FROM person
+                                                                   WHERE equals(person.team_id, 99999)
+                                                                   GROUP BY person.id
+                                                                   HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0))))) SETTINGS optimize_aggregation_in_order=1) AS persons
+                 INNER JOIN
+                   (SELECT DISTINCT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS person_id
+                    FROM events
+                    LEFT OUTER JOIN
+                      (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
+                              person_distinct_id_overrides.distinct_id AS distinct_id
+                       FROM person_distinct_id_overrides
+                       WHERE equals(person_distinct_id_overrides.team_id, 99999)
+                       GROUP BY person_distinct_id_overrides.distinct_id
+                       HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+                    WHERE equals(events.team_id, 99999)) AS events ON equals(persons.id, events.person_id)
+                 ORDER BY persons.created_at DESC) AS revenue_analytics_customer
+              LEFT JOIN
+                (SELECT revenue_analytics_revenue_item.customer_id AS customer_id,
+                        sum(revenue_analytics_revenue_item.amount) AS revenue
+                 FROM
+                   (SELECT toString(events.uuid) AS id,
+                           toString(events.uuid) AS invoice_item_id,
+                           'revenue_analytics.events.purchase' AS source_label,
+                           toTimeZone(events.timestamp, 'UTC') AS timestamp,
+                           timestamp AS created_at,
+                           0 AS is_recurring,
+                           NULL AS product_id,
+                           toString(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS customer_id,
+                           events.`$group_0` AS group_0_key,
+                           events.`$group_1` AS group_1_key,
+                           events.`$group_2` AS group_2_key,
+                           events.`$group_3` AS group_3_key,
+                           events.`$group_4` AS group_4_key,
+                           NULL AS invoice_id,
+                           NULL AS subscription_id,
+                           toString(events.`$session_id`) AS session_id,
+                           events.event AS event_name,
+                           NULL AS coupon,
+                           coupon AS coupon_id,
+                           'USD' AS original_currency,
+                           accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)') AS original_amount,
+                           in(original_currency,
+                              ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
+                             if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
+                             divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
+                             'USD' AS currency,
+                             if(isNull('USD'), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals('USD', 'USD'), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(1, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))) AS amount
+                    FROM events
+                    LEFT OUTER JOIN
+                      (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
+                              person_distinct_id_overrides.distinct_id AS distinct_id
+                       FROM person_distinct_id_overrides
+                       WHERE equals(person_distinct_id_overrides.team_id, 99999)
+                       GROUP BY person_distinct_id_overrides.distinct_id
+                       HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+                    WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), 1, isNotNull(amount)))
+                    ORDER BY timestamp DESC) AS revenue_analytics_revenue_item
+                 GROUP BY customer_id) AS revenue_agg ON equals(revenue_analytics_customer.id, revenue_agg.customer_id)
+              LEFT JOIN
+                (SELECT `revenue_analytics.events.purchase.mrr_events_revenue_view`.customer_id AS customer_id,
+                        sum(`revenue_analytics.events.purchase.mrr_events_revenue_view`.mrr) AS mrr
+                 FROM
+                   (SELECT union.source_label AS source_label,
+                           union.customer_id AS customer_id,
+                           union.subscription_id AS subscription_id,
+                           argMax(union.amount, union.timestamp) AS mrr
+                    FROM
+                      (SELECT revenue_item.source_label AS source_label,
+                              revenue_item.customer_id AS customer_id,
+                              revenue_item.subscription_id AS subscription_id,
+                              toStartOfMonth(toTimeZone(revenue_item.timestamp, 'UTC')) AS timestamp,
+                              sum(revenue_item.amount) AS amount
+                       FROM
+                         (SELECT toString(events.uuid) AS id,
+                                 toString(events.uuid) AS invoice_item_id,
+                                 'revenue_analytics.events.purchase' AS source_label,
+                                 toTimeZone(events.timestamp, 'UTC') AS timestamp,
+                                 timestamp AS created_at,
+                                 0 AS is_recurring,
+                                 NULL AS product_id,
+                                 toString(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS customer_id,
+                                 events.`$group_0` AS group_0_key,
+                                 events.`$group_1` AS group_1_key,
+                                 events.`$group_2` AS group_2_key,
+                                 events.`$group_3` AS group_3_key,
+                                 events.`$group_4` AS group_4_key,
+                                 NULL AS invoice_id,
+                                 NULL AS subscription_id,
+                                 toString(events.`$session_id`) AS session_id,
+                                 events.event AS event_name,
+                                 NULL AS coupon,
+                                 coupon AS coupon_id,
+                                 'USD' AS original_currency,
+                                 accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)') AS original_amount,
+                                 in(original_currency,
+                                    ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
+                                   if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
+                                   divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
+                                   'USD' AS currency,
+                                   if(isNull('USD'), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals('USD', 'USD'), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(1, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))) AS amount
+                          FROM events
+                          LEFT OUTER JOIN
+                            (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
+                                    person_distinct_id_overrides.distinct_id AS distinct_id
+                             FROM person_distinct_id_overrides
+                             WHERE equals(person_distinct_id_overrides.team_id, 99999)
+                             GROUP BY person_distinct_id_overrides.distinct_id
+                             HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+                          WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), 1, isNotNull(amount)))
+                          ORDER BY timestamp DESC) AS revenue_item
+                       WHERE and(revenue_item.is_recurring, isNotNull(revenue_item.subscription_id), greaterOrEquals(timestamp, toStartOfMonth(addDays(toDateTime64('today', 6, 'UTC'), -60))), lessOrEquals(timestamp, toDateTime64('today', 6, 'UTC')))
+                       GROUP BY revenue_item.source_label,
+                                revenue_item.customer_id,
+                                revenue_item.subscription_id, timestamp
+                       ORDER BY timestamp DESC
+                       UNION ALL SELECT `revenue_analytics.events.purchase.subscription_events_revenue_view`.source_label AS source_label,
+                                        `revenue_analytics.events.purchase.subscription_events_revenue_view`.customer_id AS customer_id,
+                                        `revenue_analytics.events.purchase.subscription_events_revenue_view`.id AS subscription_id,
+                                        toTimeZone(`revenue_analytics.events.purchase.subscription_events_revenue_view`.ended_at, 'UTC') AS timestamp,
+                                        accurateCastOrNull(0, 'Decimal64(10)') AS amount
+                       FROM
+                         (SELECT '' AS id,
+                                 '' AS source_label,
+                                 '' AS plan_id,
+                                 '' AS product_id,
+                                 '' AS customer_id,
+                                 '' AS status,
+                                 toDateTime64('1970-01-01 00:00:00.000000', 6, 'UTC') AS started_at,
+                                 toDateTime64('1970-01-01 00:00:00.000000', 6, 'UTC') AS ended_at,
+                                 '' AS metadata
+                          WHERE 0) AS `revenue_analytics.events.purchase.subscription_events_revenue_view`
+                       WHERE and(greaterOrEquals(timestamp, toStartOfMonth(addDays(toDateTime64('today', 6, 'UTC'), -60))), lessOrEquals(timestamp, toDateTime64('today', 6, 'UTC')))
+                       ORDER BY timestamp DESC) AS
+                    union
+                    GROUP BY source_label,
+                             customer_id,
+                             subscription_id
+                    ORDER BY customer_id ASC,
+                             subscription_id ASC) AS `revenue_analytics.events.purchase.mrr_events_revenue_view`
+                 GROUP BY customer_id) AS mrr_agg ON equals(revenue_analytics_customer.id, mrr_agg.customer_id)) AS e__poe__revenue_analytics ON equals(toString(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id)), toString(e__poe__revenue_analytics.person_id))
+           WHERE and(equals(e.team_id, 99999), greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toStartOfInterval(assumeNotNull(toDateTime('2025-05-29 00:00:00', 'UTC')), toIntervalDay(1))), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), assumeNotNull(toDateTime('2025-05-30 23:59:59', 'UTC'))), equals(e.event, '$pageview'))
+           GROUP BY day_start,
+                    breakdown_value_1)
+        GROUP BY day_start,
+                 breakdown_value_1
+        ORDER BY day_start ASC,
+                 breakdown_value ASC)),
+       totals_per_breakdown AS
+    (SELECT breakdown_series.breakdown_value AS breakdown_value,
+            sum(breakdown_series.count) AS total_count_for_breakdown,
+            if(has(breakdown_series.breakdown_value, '$$_posthog_breakdown_other_$$'), 2, if(has(breakdown_series.breakdown_value, '$$_posthog_breakdown_null_$$'), 1, 0)) AS ordering
+     FROM breakdown_series
+     GROUP BY breakdown_series.breakdown_value),
+       ranked_breakdown_totals AS
+    (SELECT totals_per_breakdown.breakdown_value AS breakdown_value,
+            totals_per_breakdown.ordering AS ordering,
+            totals_per_breakdown.total_count_for_breakdown AS total_count_for_breakdown,
+            row_number() OVER (
+                               ORDER BY totals_per_breakdown.ordering ASC, totals_per_breakdown.total_count_for_breakdown DESC, totals_per_breakdown.breakdown_value ASC) AS breakdown_rank
+     FROM totals_per_breakdown),
+       ranked_breakdown_values AS
+    (SELECT breakdown_series.count AS count,
+            toTimeZone(breakdown_series.day_start, 'UTC') AS day_start,
+            breakdown_series.breakdown_value AS breakdown_value,
+            ranked_breakdown_totals.ordering AS ordering,
+            ranked_breakdown_totals.breakdown_rank AS breakdown_rank
+     FROM breakdown_series
+     JOIN ranked_breakdown_totals ON equals(ranked_breakdown_totals.breakdown_value, breakdown_series.breakdown_value)),
+       top_n_breakdown_values AS
+    (SELECT toTimeZone(ranked_breakdown_values.day_start, 'UTC') AS day_start,
+            ranked_breakdown_values.count AS value,
+            ranked_breakdown_values.breakdown_value AS breakdown_value
+     FROM ranked_breakdown_values
+     WHERE ifNull(lessOrEquals(ranked_breakdown_values.breakdown_rank, 25), 0)),
+       other_breakdown_values AS
+    (SELECT toTimeZone(ranked_breakdown_values.day_start, 'UTC') AS day_start,
+            sum(ranked_breakdown_values.count) AS value,
+            ['$$_posthog_breakdown_other_$$'] AS breakdown_value
+     FROM ranked_breakdown_values
+     WHERE ifNull(greater(ranked_breakdown_values.breakdown_rank, 25), 0)
+     GROUP BY toTimeZone(ranked_breakdown_values.day_start, 'UTC')),
+       top_n_and_other_breakdown_values AS
+    (SELECT day_start AS day_start,
+            value AS value,
+            breakdown_value AS breakdown_value
+     FROM
+       (SELECT toTimeZone(top_n_breakdown_values.day_start, 'UTC') AS day_start,
+               top_n_breakdown_values.value AS value,
+               top_n_breakdown_values.breakdown_value AS breakdown_value
+        FROM top_n_breakdown_values
+        UNION ALL SELECT toTimeZone(other_breakdown_values.day_start, 'UTC') AS day_start,
+                         other_breakdown_values.value AS value,
+                         other_breakdown_values.breakdown_value AS breakdown_value
+        FROM other_breakdown_values)
+     ORDER BY day_start ASC,
+              value ASC)
+  SELECT arrayMap(number -> plus(toStartOfInterval(assumeNotNull(toDateTime('2025-05-29 00:00:00', 'UTC')), toIntervalDay(1)), toIntervalDay(number)), range(0, plus(coalesce(dateDiff('day', toStartOfInterval(assumeNotNull(toDateTime('2025-05-29 00:00:00', 'UTC')), toIntervalDay(1)), toStartOfInterval(assumeNotNull(toDateTime('2025-05-30 23:59:59', 'UTC')), toIntervalDay(1)))), 1))) AS date,
+         arrayMap(d -> arraySum(arrayMap((v, dd) -> if(ifNull(equals(dd, d), isNull(dd)
+                                                              and isNull(d)), v, 0), vals, days)), date) AS total,
+         breakdown_value AS breakdown_value
+  FROM
+    (SELECT groupArray(toTimeZone(top_n_and_other_breakdown_values.day_start, 'UTC')) AS days,
+            groupArray(top_n_and_other_breakdown_values.value) AS vals,
+            top_n_and_other_breakdown_values.breakdown_value AS breakdown_value
+     FROM top_n_and_other_breakdown_values
+     GROUP BY top_n_and_other_breakdown_values.breakdown_value)
+  ORDER BY if(has(breakdown_value, '$$_posthog_breakdown_other_$$'), 2, if(has(breakdown_value, '$$_posthog_breakdown_null_$$'), 1, 0)) ASC, arraySum(total) DESC, breakdown_value ASC
+  LIMIT 50000 SETTINGS readonly=2,
+                       max_execution_time=60,
+                       allow_experimental_object_type=1,
+                       max_ast_elements=4000000,
+                       max_expanded_ast_elements=4000000,
+                       max_bytes_before_external_group_by=0,
+                       transform_null_in=1,
+                       optimize_min_equality_disjunction_chain_length=4294967295,
+                       allow_experimental_join_condition=1,
+                       use_hive_partitioning=0
+  '''
+# ---
+# name: TestPersonsRevenueAnalyticsManagedViewsets.test_virtual_property_in_trend_3_person_id_override_properties_joined
+  '''
+  SELECT toTimeZone(events.timestamp, 'UTC') AS timestamp
+  FROM events
+  WHERE and(equals(events.team_id, 99999), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('1980-01-01 00:00:00.000000', 6, 'UTC')), equals(events.event, '$pageview'))
+  ORDER BY toTimeZone(events.timestamp, 'UTC') ASC
+  LIMIT 1 SETTINGS readonly=2,
+                   max_execution_time=60,
+                   allow_experimental_object_type=1,
+                   max_ast_elements=4000000,
+                   max_expanded_ast_elements=4000000,
+                   max_bytes_before_external_group_by=0,
+                   transform_null_in=1,
+                   optimize_min_equality_disjunction_chain_length=4294967295,
+                   allow_experimental_join_condition=1,
+                   use_hive_partitioning=0
+  '''
+# ---
+# name: TestPersonsRevenueAnalyticsManagedViewsets.test_virtual_property_in_trend_3_person_id_override_properties_joined.1
+  '''
+  WITH breakdown_series AS
+    (SELECT count AS count,
+                     day_start AS day_start,
+                     breakdown_value AS breakdown_value
+     FROM
+       (SELECT sum(total) AS count,
+               day_start AS day_start,
+               [ifNull(toString(breakdown_value_1), '$$_posthog_breakdown_null_$$')] AS breakdown_value
+        FROM
+          (SELECT count() AS total,
+                  toStartOfDay(toTimeZone(e.timestamp, 'UTC')) AS day_start,
+                  ifNull(nullIf(leftUTF8(toString(e__person__revenue_analytics.revenue), 400), ''), '$$_posthog_breakdown_null_$$') AS breakdown_value_1
+           FROM events AS e
+           LEFT OUTER JOIN
+             (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
+                     person_distinct_id_overrides.distinct_id AS distinct_id
+              FROM person_distinct_id_overrides
+              WHERE equals(person_distinct_id_overrides.team_id, 99999)
+              GROUP BY person_distinct_id_overrides.distinct_id
+              HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+           INNER JOIN
+             (SELECT tupleElement(argMax(tuple(person.id), person.version), 1) AS e__person___id,
+                     person.id AS id
+              FROM person
+              WHERE equals(person.team_id, 99999)
+              GROUP BY person.id
+              HAVING and(ifNull(equals(tupleElement(argMax(tuple(person.is_deleted), person.version), 1), 0), 0), ifNull(less(tupleElement(argMax(tuple(toTimeZone(person.created_at, 'UTC')), person.version), 1), plus(now64(6, 'UTC'), toIntervalDay(1))), 0)) SETTINGS optimize_aggregation_in_order=1) AS e__person ON equals(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id), e__person.e__person___id)
+           LEFT JOIN
+             (SELECT 99999 AS team_id,
+                     revenue_analytics_customer.id AS person_id,
+                     coalesce(revenue_agg.revenue, accurateCastOrNull(0, 'Decimal64(10)')) AS revenue,
+                     coalesce(mrr_agg.mrr, accurateCastOrNull(0, 'Decimal64(10)')) AS mrr
+              FROM
+                (SELECT toString(persons.id) AS id,
+                        'revenue_analytics.events.purchase' AS source_label,
+                        persons.created_at AS timestamp,
+                        persons.properties___name AS name,
+                        persons.properties___email AS email,
+                        persons.properties___phone AS phone,
+                        persons.properties___address AS address,
+                        persons.properties___metadata AS metadata,
+                        persons.`properties___$geoip_country_name` AS country,
+                        formatDateTime(toStartOfMonth(persons.created_at), '%Y-%m') AS cohort,
+                        NULL AS initial_coupon,
+                        NULL AS initial_coupon_id
+                 FROM
+                   (SELECT person.id AS id,
+                           replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'name'), ''), 'null'), '^"|"$', '') AS properties___name,
+                           replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'email'), ''), 'null'), '^"|"$', '') AS properties___email,
+                           replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'phone'), ''), 'null'), '^"|"$', '') AS properties___phone,
+                           replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'address'), ''), 'null'), '^"|"$', '') AS properties___address,
+                           replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'metadata'), ''), 'null'), '^"|"$', '') AS properties___metadata,
+                           replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, '$geoip_country_name'), ''), 'null'), '^"|"$', '') AS `properties___$geoip_country_name`,
+                           toTimeZone(person.created_at, 'UTC') AS created_at
+                    FROM person
+                    WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
+                                                                  (SELECT person.id AS id, max(person.version) AS version
+                                                                   FROM person
+                                                                   WHERE equals(person.team_id, 99999)
+                                                                   GROUP BY person.id
+                                                                   HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0))))) SETTINGS optimize_aggregation_in_order=1) AS persons
+                 INNER JOIN
+                   (SELECT DISTINCT events__person.id AS person_id
+                    FROM events
+                    LEFT OUTER JOIN
+                      (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
+                              person_distinct_id_overrides.distinct_id AS distinct_id
+                       FROM person_distinct_id_overrides
+                       WHERE equals(person_distinct_id_overrides.team_id, 99999)
+                       GROUP BY person_distinct_id_overrides.distinct_id
+                       HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+                    INNER JOIN
+                      (SELECT person.id AS id
+                       FROM person
+                       WHERE equals(person.team_id, 99999)
+                       GROUP BY person.id
+                       HAVING and(ifNull(equals(tupleElement(argMax(tuple(person.is_deleted), person.version), 1), 0), 0), ifNull(less(tupleElement(argMax(tuple(toTimeZone(person.created_at, 'UTC')), person.version), 1), plus(now64(6, 'UTC'), toIntervalDay(1))), 0)) SETTINGS optimize_aggregation_in_order=1) AS events__person ON equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), events__person.id)
+                    WHERE equals(events.team_id, 99999)) AS events ON equals(persons.id, events.person_id)
+                 ORDER BY persons.created_at DESC) AS revenue_analytics_customer
+              LEFT JOIN
+                (SELECT revenue_analytics_revenue_item.customer_id AS customer_id,
+                        sum(revenue_analytics_revenue_item.amount) AS revenue
+                 FROM
+                   (SELECT toString(events.uuid) AS id,
+                           toString(events.uuid) AS invoice_item_id,
+                           'revenue_analytics.events.purchase' AS source_label,
+                           toTimeZone(events.timestamp, 'UTC') AS timestamp,
+                           timestamp AS created_at,
+                           0 AS is_recurring,
+                           NULL AS product_id,
+                           toString(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS customer_id,
+                           events.`$group_0` AS group_0_key,
+                           events.`$group_1` AS group_1_key,
+                           events.`$group_2` AS group_2_key,
+                           events.`$group_3` AS group_3_key,
+                           events.`$group_4` AS group_4_key,
+                           NULL AS invoice_id,
+                           NULL AS subscription_id,
+                           toString(events.`$session_id`) AS session_id,
+                           events.event AS event_name,
+                           NULL AS coupon,
+                           coupon AS coupon_id,
+                           'USD' AS original_currency,
+                           accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)') AS original_amount,
+                           in(original_currency,
+                              ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
+                             if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
+                             divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
+                             'USD' AS currency,
+                             if(isNull('USD'), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals('USD', 'USD'), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(1, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))) AS amount
+                    FROM events
+                    LEFT OUTER JOIN
+                      (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
+                              person_distinct_id_overrides.distinct_id AS distinct_id
+                       FROM person_distinct_id_overrides
+                       WHERE equals(person_distinct_id_overrides.team_id, 99999)
+                       GROUP BY person_distinct_id_overrides.distinct_id
+                       HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+                    WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), 1, isNotNull(amount)))
+                    ORDER BY timestamp DESC) AS revenue_analytics_revenue_item
+                 GROUP BY customer_id) AS revenue_agg ON equals(revenue_analytics_customer.id, revenue_agg.customer_id)
+              LEFT JOIN
+                (SELECT `revenue_analytics.events.purchase.mrr_events_revenue_view`.customer_id AS customer_id,
+                        sum(`revenue_analytics.events.purchase.mrr_events_revenue_view`.mrr) AS mrr
+                 FROM
+                   (SELECT union.source_label AS source_label,
+                           union.customer_id AS customer_id,
+                           union.subscription_id AS subscription_id,
+                           argMax(union.amount, union.timestamp) AS mrr
+                    FROM
+                      (SELECT revenue_item.source_label AS source_label,
+                              revenue_item.customer_id AS customer_id,
+                              revenue_item.subscription_id AS subscription_id,
+                              toStartOfMonth(toTimeZone(revenue_item.timestamp, 'UTC')) AS timestamp,
+                              sum(revenue_item.amount) AS amount
+                       FROM
+                         (SELECT toString(events.uuid) AS id,
+                                 toString(events.uuid) AS invoice_item_id,
+                                 'revenue_analytics.events.purchase' AS source_label,
+                                 toTimeZone(events.timestamp, 'UTC') AS timestamp,
+                                 timestamp AS created_at,
+                                 0 AS is_recurring,
+                                 NULL AS product_id,
+                                 toString(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS customer_id,
+                                 events.`$group_0` AS group_0_key,
+                                 events.`$group_1` AS group_1_key,
+                                 events.`$group_2` AS group_2_key,
+                                 events.`$group_3` AS group_3_key,
+                                 events.`$group_4` AS group_4_key,
+                                 NULL AS invoice_id,
+                                 NULL AS subscription_id,
+                                 toString(events.`$session_id`) AS session_id,
+                                 events.event AS event_name,
+                                 NULL AS coupon,
+                                 coupon AS coupon_id,
+                                 'USD' AS original_currency,
+                                 accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)') AS original_amount,
+                                 in(original_currency,
+                                    ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
+                                   if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
+                                   divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
+                                   'USD' AS currency,
+                                   if(isNull('USD'), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals('USD', 'USD'), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(1, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))) AS amount
+                          FROM events
+                          LEFT OUTER JOIN
+                            (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
+                                    person_distinct_id_overrides.distinct_id AS distinct_id
+                             FROM person_distinct_id_overrides
+                             WHERE equals(person_distinct_id_overrides.team_id, 99999)
+                             GROUP BY person_distinct_id_overrides.distinct_id
+                             HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+                          WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), 1, isNotNull(amount)))
+                          ORDER BY timestamp DESC) AS revenue_item
+                       WHERE and(revenue_item.is_recurring, isNotNull(revenue_item.subscription_id), greaterOrEquals(timestamp, toStartOfMonth(addDays(toDateTime64('today', 6, 'UTC'), -60))), lessOrEquals(timestamp, toDateTime64('today', 6, 'UTC')))
+                       GROUP BY revenue_item.source_label,
+                                revenue_item.customer_id,
+                                revenue_item.subscription_id, timestamp
+                       ORDER BY timestamp DESC
+                       UNION ALL SELECT `revenue_analytics.events.purchase.subscription_events_revenue_view`.source_label AS source_label,
+                                        `revenue_analytics.events.purchase.subscription_events_revenue_view`.customer_id AS customer_id,
+                                        `revenue_analytics.events.purchase.subscription_events_revenue_view`.id AS subscription_id,
+                                        toTimeZone(`revenue_analytics.events.purchase.subscription_events_revenue_view`.ended_at, 'UTC') AS timestamp,
+                                        accurateCastOrNull(0, 'Decimal64(10)') AS amount
+                       FROM
+                         (SELECT '' AS id,
+                                 '' AS source_label,
+                                 '' AS plan_id,
+                                 '' AS product_id,
+                                 '' AS customer_id,
+                                 '' AS status,
+                                 toDateTime64('1970-01-01 00:00:00.000000', 6, 'UTC') AS started_at,
+                                 toDateTime64('1970-01-01 00:00:00.000000', 6, 'UTC') AS ended_at,
+                                 '' AS metadata
+                          WHERE 0) AS `revenue_analytics.events.purchase.subscription_events_revenue_view`
+                       WHERE and(greaterOrEquals(timestamp, toStartOfMonth(addDays(toDateTime64('today', 6, 'UTC'), -60))), lessOrEquals(timestamp, toDateTime64('today', 6, 'UTC')))
+                       ORDER BY timestamp DESC) AS
+                    union
+                    GROUP BY source_label,
+                             customer_id,
+                             subscription_id
+                    ORDER BY customer_id ASC,
+                             subscription_id ASC) AS `revenue_analytics.events.purchase.mrr_events_revenue_view`
+                 GROUP BY customer_id) AS mrr_agg ON equals(revenue_analytics_customer.id, mrr_agg.customer_id)) AS e__person__revenue_analytics ON equals(toString(e__person.e__person___id), toString(e__person__revenue_analytics.person_id))
+           WHERE and(equals(e.team_id, 99999), greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toStartOfInterval(assumeNotNull(toDateTime('2025-05-29 00:00:00', 'UTC')), toIntervalDay(1))), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), assumeNotNull(toDateTime('2025-05-30 23:59:59', 'UTC'))), equals(e.event, '$pageview'))
+           GROUP BY day_start,
+                    breakdown_value_1)
+        GROUP BY day_start,
+                 breakdown_value_1
+        ORDER BY day_start ASC,
+                 breakdown_value ASC)),
+       totals_per_breakdown AS
+    (SELECT breakdown_series.breakdown_value AS breakdown_value,
+            sum(breakdown_series.count) AS total_count_for_breakdown,
+            if(has(breakdown_series.breakdown_value, '$$_posthog_breakdown_other_$$'), 2, if(has(breakdown_series.breakdown_value, '$$_posthog_breakdown_null_$$'), 1, 0)) AS ordering
+     FROM breakdown_series
+     GROUP BY breakdown_series.breakdown_value),
+       ranked_breakdown_totals AS
+    (SELECT totals_per_breakdown.breakdown_value AS breakdown_value,
+            totals_per_breakdown.ordering AS ordering,
+            totals_per_breakdown.total_count_for_breakdown AS total_count_for_breakdown,
+            row_number() OVER (
+                               ORDER BY totals_per_breakdown.ordering ASC, totals_per_breakdown.total_count_for_breakdown DESC, totals_per_breakdown.breakdown_value ASC) AS breakdown_rank
+     FROM totals_per_breakdown),
+       ranked_breakdown_values AS
+    (SELECT breakdown_series.count AS count,
+            toTimeZone(breakdown_series.day_start, 'UTC') AS day_start,
+            breakdown_series.breakdown_value AS breakdown_value,
+            ranked_breakdown_totals.ordering AS ordering,
+            ranked_breakdown_totals.breakdown_rank AS breakdown_rank
+     FROM breakdown_series
+     JOIN ranked_breakdown_totals ON equals(ranked_breakdown_totals.breakdown_value, breakdown_series.breakdown_value)),
+       top_n_breakdown_values AS
+    (SELECT toTimeZone(ranked_breakdown_values.day_start, 'UTC') AS day_start,
+            ranked_breakdown_values.count AS value,
+            ranked_breakdown_values.breakdown_value AS breakdown_value
+     FROM ranked_breakdown_values
+     WHERE ifNull(lessOrEquals(ranked_breakdown_values.breakdown_rank, 25), 0)),
+       other_breakdown_values AS
+    (SELECT toTimeZone(ranked_breakdown_values.day_start, 'UTC') AS day_start,
+            sum(ranked_breakdown_values.count) AS value,
+            ['$$_posthog_breakdown_other_$$'] AS breakdown_value
+     FROM ranked_breakdown_values
+     WHERE ifNull(greater(ranked_breakdown_values.breakdown_rank, 25), 0)
+     GROUP BY toTimeZone(ranked_breakdown_values.day_start, 'UTC')),
+       top_n_and_other_breakdown_values AS
+    (SELECT day_start AS day_start,
+            value AS value,
+            breakdown_value AS breakdown_value
+     FROM
+       (SELECT toTimeZone(top_n_breakdown_values.day_start, 'UTC') AS day_start,
+               top_n_breakdown_values.value AS value,
+               top_n_breakdown_values.breakdown_value AS breakdown_value
+        FROM top_n_breakdown_values
+        UNION ALL SELECT toTimeZone(other_breakdown_values.day_start, 'UTC') AS day_start,
+                         other_breakdown_values.value AS value,
+                         other_breakdown_values.breakdown_value AS breakdown_value
+        FROM other_breakdown_values)
+     ORDER BY day_start ASC,
+              value ASC)
+  SELECT arrayMap(number -> plus(toStartOfInterval(assumeNotNull(toDateTime('2025-05-29 00:00:00', 'UTC')), toIntervalDay(1)), toIntervalDay(number)), range(0, plus(coalesce(dateDiff('day', toStartOfInterval(assumeNotNull(toDateTime('2025-05-29 00:00:00', 'UTC')), toIntervalDay(1)), toStartOfInterval(assumeNotNull(toDateTime('2025-05-30 23:59:59', 'UTC')), toIntervalDay(1)))), 1))) AS date,
+         arrayMap(d -> arraySum(arrayMap((v, dd) -> if(ifNull(equals(dd, d), isNull(dd)
+                                                              and isNull(d)), v, 0), vals, days)), date) AS total,
+         breakdown_value AS breakdown_value
+  FROM
+    (SELECT groupArray(toTimeZone(top_n_and_other_breakdown_values.day_start, 'UTC')) AS days,
+            groupArray(top_n_and_other_breakdown_values.value) AS vals,
+            top_n_and_other_breakdown_values.breakdown_value AS breakdown_value
+     FROM top_n_and_other_breakdown_values
+     GROUP BY top_n_and_other_breakdown_values.breakdown_value)
+  ORDER BY if(has(breakdown_value, '$$_posthog_breakdown_other_$$'), 2, if(has(breakdown_value, '$$_posthog_breakdown_null_$$'), 1, 0)) ASC, arraySum(total) DESC, breakdown_value ASC
+  LIMIT 50000 SETTINGS readonly=2,
+                       max_execution_time=60,
+                       allow_experimental_object_type=1,
+                       max_ast_elements=4000000,
+                       max_expanded_ast_elements=4000000,
+                       max_bytes_before_external_group_by=0,
+                       transform_null_in=1,
+                       optimize_min_equality_disjunction_chain_length=4294967295,
+                       allow_experimental_join_condition=1,
+                       use_hive_partitioning=0
+  '''
+# ---

--- a/posthog/hogql/database/schema/test/test_persons_revenue_analytics.py
+++ b/posthog/hogql/database/schema/test/test_persons_revenue_analytics.py
@@ -48,8 +48,7 @@ INVOICES_TEST_BUCKET = "test_storage_bucket-posthog.revenue_analytics.insights_q
 CUSTOMERS_TEST_BUCKET = "test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_customers"
 
 
-@snapshot_clickhouse_queries
-class TestPersonsRevenueAnalytics(ClickhouseTestMixin, APIBaseTest):
+class TestPersonsRevenueAnalyticsMixin(ClickhouseTestMixin, APIBaseTest):
     PURCHASE_EVENT_NAME = "purchase"
     REVENUE_PROPERTY = "revenue"
     SUBSCRIPTION_PROPERTY = "subscription_id"
@@ -185,12 +184,9 @@ class TestPersonsRevenueAnalytics(ClickhouseTestMixin, APIBaseTest):
         self.team.base_currency = CurrencyCode.GBP.value
         self.team.save()
 
-    def create_managed_viewsets(self):
-        self.viewset, _ = DataWarehouseManagedViewSet.objects.get_or_create(
-            team=self.team, kind=DataWarehouseManagedViewSetKind.REVENUE_ANALYTICS
-        )
-        self.viewset.sync_views()
 
+@snapshot_clickhouse_queries
+class TestPersonsRevenueAnalytics(TestPersonsRevenueAnalyticsMixin):
     def test_get_revenue_for_events(self):
         self.setup_events()
 
@@ -215,33 +211,6 @@ class TestPersonsRevenueAnalytics(ClickhouseTestMixin, APIBaseTest):
             )
 
             self.assertEqual(response.results[0], (Decimal("350.42"), Decimal("350.42")))
-
-    def test_get_revenue_for_events_with_managed_viewsets_ff(self):
-        with patch("posthoganalytics.feature_enabled", return_value=True):
-            self.setup_events()
-
-            self.team.revenue_analytics_config.events = [
-                RevenueAnalyticsEventItem(
-                    eventName=self.PURCHASE_EVENT_NAME,
-                    revenueProperty=self.REVENUE_PROPERTY,
-                    revenueCurrencyProperty=RevenueCurrencyPropertyConfig(static="USD"),
-                    currencyAwareDecimal=True,
-                )
-            ]
-            self.team.revenue_analytics_config.save()
-            self.team.save()
-            self.create_managed_viewsets()
-
-            with freeze_time(self.QUERY_TIMESTAMP):
-                response = execute_hogql_query(
-                    parse_select(
-                        "select revenue_analytics.revenue, $virt_revenue from persons where id = {id}",
-                        placeholders={"id": ast.Constant(value=self.person_id)},
-                    ),
-                    self.team,
-                )
-
-                self.assertEqual(response.results[0], (Decimal("350.42"), Decimal("350.42")))
 
     def test_get_revenue_for_schema_source_for_id_join(self):
         self.setup_schema_sources()
@@ -275,43 +244,6 @@ class TestPersonsRevenueAnalytics(ClickhouseTestMixin, APIBaseTest):
                         (distinct_id_to_person_id["dummy"], None),
                     ],
                 )
-
-    def test_get_revenue_for_schema_source_for_id_join_with_managed_viewsets_ff(self):
-        with patch("posthoganalytics.feature_enabled", return_value=True):
-            self.setup_schema_sources()
-
-            self.join.source_table_key = "id"
-            self.join.save()
-
-            self.create_managed_viewsets()
-
-            # These are the 6 IDs inside the CSV files, plus an extra dummy/empty one
-            distinct_id_to_person_id: dict[str, str] = {}
-            for distinct_id in ["cus_1", "cus_2", "cus_3", "cus_4", "cus_5", "cus_6", "dummy"]:
-                person = _create_person(team_id=self.team.pk, distinct_ids=[distinct_id])
-                distinct_id_to_person_id[distinct_id] = person.uuid
-
-            with freeze_time(self.QUERY_TIMESTAMP):
-                queries = [
-                    "SELECT id, revenue_analytics.revenue from persons order by id asc",
-                    "SELECT id, $virt_revenue from persons order by id asc",
-                ]
-
-                for query in queries:
-                    response = execute_hogql_query(parse_select(query), self.team, modifiers=self.MODIFIERS)
-
-                    self.assertEqual(
-                        response.results,
-                        [
-                            (distinct_id_to_person_id["cus_1"], Decimal("283.8496260553")),
-                            (distinct_id_to_person_id["cus_2"], Decimal("482.2158673452")),
-                            (distinct_id_to_person_id["cus_3"], Decimal("4161.34422")),
-                            (distinct_id_to_person_id["cus_4"], Decimal("254.12345")),
-                            (distinct_id_to_person_id["cus_5"], Decimal("1494.0562")),
-                            (distinct_id_to_person_id["cus_6"], Decimal("2796.37014")),
-                            (distinct_id_to_person_id["dummy"], None),
-                        ],
-                    )
 
     def test_get_revenue_for_schema_source_for_email_join(self):
         self.setup_schema_sources()
@@ -471,39 +403,6 @@ class TestPersonsRevenueAnalytics(ClickhouseTestMixin, APIBaseTest):
                 ],
             )
 
-    def test_query_revenue_analytics_table_sources_with_managed_viewsets_ff(self):
-        with patch("posthoganalytics.feature_enabled", return_value=True):
-            self.setup_schema_sources()
-            self.join.source_table_key = "id"
-            self.join.save()
-            # Create persons matching customer IDs from the stripe data
-            distinct_id_to_person_id: dict[str, str] = {}
-            for distinct_id in ["cus_1", "cus_2", "cus_3", "cus_4", "cus_5", "cus_6"]:
-                person = _create_person(team_id=self.team.pk, distinct_ids=[distinct_id])
-                distinct_id_to_person_id[distinct_id] = person.uuid
-
-            with freeze_time(self.QUERY_TIMESTAMP):
-                self.create_managed_viewsets()
-                results = execute_hogql_query(
-                    parse_select(
-                        "SELECT person_id, revenue, mrr FROM persons_revenue_analytics ORDER BY mrr DESC, revenue DESC"
-                    ),
-                    self.team,
-                    modifiers=self.MODIFIERS,
-                )
-
-                self.assertEqual(
-                    results.results,
-                    [
-                        (distinct_id_to_person_id["cus_3"], Decimal("4161.34422"), Decimal("1546.59444")),
-                        (distinct_id_to_person_id["cus_6"], Decimal("2796.37014"), Decimal("1459.02008")),
-                        (distinct_id_to_person_id["cus_4"], Decimal("254.12345"), Decimal("83.16695")),
-                        (distinct_id_to_person_id["cus_5"], Decimal("1494.0562"), Decimal("43.82703")),
-                        (distinct_id_to_person_id["cus_2"], Decimal("482.2158673452"), Decimal("40.8052916666")),
-                        (distinct_id_to_person_id["cus_1"], Decimal("283.8496260553"), Decimal("22.9631447238")),
-                    ],
-                )
-
     def test_query_revenue_analytics_table_events(self):
         self.setup_events_with_subscriptions()
 
@@ -533,40 +432,6 @@ class TestPersonsRevenueAnalytics(ClickhouseTestMixin, APIBaseTest):
                 results.results,
                 [(self.person_id, Decimal("350.84"), Decimal("250.42"))],
             )
-
-    def test_query_revenue_analytics_table_events_with_managed_viewsets_ff(self):
-        with patch("posthoganalytics.feature_enabled", return_value=True):
-            self.setup_events_with_subscriptions()
-
-            self.team.revenue_analytics_config.events = [
-                RevenueAnalyticsEventItem(
-                    eventName=self.PURCHASE_EVENT_NAME,
-                    revenueProperty=self.REVENUE_PROPERTY,
-                    revenueCurrencyProperty=RevenueCurrencyPropertyConfig(static="USD"),
-                    currencyAwareDecimal=True,
-                    subscriptionProperty=self.SUBSCRIPTION_PROPERTY,
-                    subscriptionDropoffMode=SubscriptionDropoffMode.AFTER_DROPOFF_PERIOD,  # Better default for tests
-                )
-            ]
-            self.team.revenue_analytics_config.save()
-            self.team.save()
-
-            with freeze_time(self.QUERY_TIMESTAMP):
-                self.create_managed_viewsets()  # Make sure this runs inside the freeze_time context
-
-                results = execute_hogql_query(
-                    parse_select(
-                        "SELECT person_id, revenue, mrr FROM persons_revenue_analytics ORDER BY person_id ASC"
-                    ),
-                    self.team,
-                    modifiers=self.MODIFIERS,
-                )
-
-                # MRR is calculated from recurring events (those with subscription_id)
-                self.assertEqual(
-                    results.results,
-                    [(self.person_id, Decimal("350.84"), Decimal("250.42"))],
-                )
 
     @parameterized.expand([e.value for e in PersonsOnEventsMode])
     def test_virtual_property_in_trend(self, mode):
@@ -600,37 +465,177 @@ class TestPersonsRevenueAnalytics(ClickhouseTestMixin, APIBaseTest):
 
         assert results[0]["breakdown_value"] == ["350.42"]
 
+
+@snapshot_clickhouse_queries
+class TestPersonsRevenueAnalyticsManagedViewsets(TestPersonsRevenueAnalyticsMixin):
+    def setUp(self) -> None:
+        super().setUp()
+        self.mock_flag = patch("posthoganalytics.feature_enabled", return_value=True)
+        self.mock_flag.start()
+
+    def tearDown(self) -> None:
+        super().tearDown()
+        self.mock_flag.stop()
+
+    def create_managed_viewsets(self):
+        self.viewset, _ = DataWarehouseManagedViewSet.objects.get_or_create(
+            team=self.team, kind=DataWarehouseManagedViewSetKind.REVENUE_ANALYTICS
+        )
+        self.viewset.sync_views()
+
     @parameterized.expand([e.value for e in PersonsOnEventsMode])
-    def test_virtual_property_in_trend_with_managed_viewsets_ff(self, mode):
-        with patch("posthoganalytics.feature_enabled", return_value=True):
-            self.setup_events()
+    def test_virtual_property_in_trend(self, mode):
+        self.setup_events()
+        self.team.revenue_analytics_config.events = [
+            RevenueAnalyticsEventItem(
+                eventName=self.PURCHASE_EVENT_NAME,
+                revenueProperty=self.REVENUE_PROPERTY,
+                revenueCurrencyProperty=RevenueCurrencyPropertyConfig(static="USD"),
+                currencyAwareDecimal=True,
+            )
+        ]
+        self.team.revenue_analytics_config.save()
+        self.team.save()
 
-            self.team.revenue_analytics_config.events = [
-                RevenueAnalyticsEventItem(
-                    eventName=self.PURCHASE_EVENT_NAME,
-                    revenueProperty=self.REVENUE_PROPERTY,
-                    revenueCurrencyProperty=RevenueCurrencyPropertyConfig(static="USD"),
-                    currencyAwareDecimal=True,
-                )
-            ]
-            self.team.revenue_analytics_config.save()
-            self.team.save()
+        self.create_managed_viewsets()
 
+        # Breaking down by revenue doesnt make any sense, but this is just proving it works
+        with freeze_time(self.QUERY_TIMESTAMP):
+            query = TrendsQuery(
+                **{
+                    "kind": "TrendsQuery",
+                    "series": [{"kind": "EventsNode", "name": "$pageview", "event": "$pageview", "math": "total"}],
+                    "trendsFilter": {},
+                    "breakdownFilter": {"breakdowns": [{"property": "$virt_revenue", "type": "person"}]},
+                },
+                dateRange=DateRange(date_from="all", date_to=None),
+                modifiers=HogQLQueryModifiers(personsOnEventsMode=mode),
+            )
+            tqr = TrendsQueryRunner(team=self.team, query=query)
+            results = tqr.calculate().results
+
+        assert results[0]["breakdown_value"] == ["350.42"]
+
+    def test_query_revenue_analytics_table_events(self):
+        self.setup_events_with_subscriptions()
+        self.team.revenue_analytics_config.events = [
+            RevenueAnalyticsEventItem(
+                eventName=self.PURCHASE_EVENT_NAME,
+                revenueProperty=self.REVENUE_PROPERTY,
+                revenueCurrencyProperty=RevenueCurrencyPropertyConfig(static="USD"),
+                currencyAwareDecimal=True,
+                subscriptionProperty=self.SUBSCRIPTION_PROPERTY,
+                subscriptionDropoffMode=SubscriptionDropoffMode.AFTER_DROPOFF_PERIOD,  # Better default for tests
+            )
+        ]
+        self.team.revenue_analytics_config.save()
+        self.team.save()
+
+        with freeze_time(self.QUERY_TIMESTAMP):
+            self.create_managed_viewsets()  # Make sure this runs inside the freeze_time context
+
+            results = execute_hogql_query(
+                parse_select("SELECT person_id, revenue, mrr FROM persons_revenue_analytics ORDER BY person_id ASC"),
+                self.team,
+                modifiers=self.MODIFIERS,
+            )
+
+            # MRR is calculated from recurring events (those with subscription_id)
+            self.assertEqual(
+                results.results,
+                [(self.person_id, Decimal("350.84"), Decimal("250.42"))],
+            )
+
+    def test_query_revenue_analytics_table_sources(self):
+        self.setup_schema_sources()
+        self.join.source_table_key = "id"
+        self.join.save()
+        # Create persons matching customer IDs from the stripe data
+        distinct_id_to_person_id: dict[str, str] = {}
+        for distinct_id in ["cus_1", "cus_2", "cus_3", "cus_4", "cus_5", "cus_6"]:
+            person = _create_person(team_id=self.team.pk, distinct_ids=[distinct_id])
+            distinct_id_to_person_id[distinct_id] = person.uuid
+
+        with freeze_time(self.QUERY_TIMESTAMP):
             self.create_managed_viewsets()
+            results = execute_hogql_query(
+                parse_select(
+                    "SELECT person_id, revenue, mrr FROM persons_revenue_analytics ORDER BY mrr DESC, revenue DESC"
+                ),
+                self.team,
+                modifiers=self.MODIFIERS,
+            )
 
-            # Breaking down by revenue doesnt make any sense, but this is just proving it works
-            with freeze_time(self.QUERY_TIMESTAMP):
-                query = TrendsQuery(
-                    **{
-                        "kind": "TrendsQuery",
-                        "series": [{"kind": "EventsNode", "name": "$pageview", "event": "$pageview", "math": "total"}],
-                        "trendsFilter": {},
-                        "breakdownFilter": {"breakdowns": [{"property": "$virt_revenue", "type": "person"}]},
-                    },
-                    dateRange=DateRange(date_from="all", date_to=None),
-                    modifiers=HogQLQueryModifiers(personsOnEventsMode=mode),
+            self.assertEqual(
+                results.results,
+                [
+                    (distinct_id_to_person_id["cus_3"], Decimal("4161.34422"), Decimal("1546.59444")),
+                    (distinct_id_to_person_id["cus_6"], Decimal("2796.37014"), Decimal("1459.02008")),
+                    (distinct_id_to_person_id["cus_4"], Decimal("254.12345"), Decimal("83.16695")),
+                    (distinct_id_to_person_id["cus_5"], Decimal("1494.0562"), Decimal("43.82703")),
+                    (distinct_id_to_person_id["cus_2"], Decimal("482.2158673452"), Decimal("40.8052916666")),
+                    (distinct_id_to_person_id["cus_1"], Decimal("283.8496260553"), Decimal("22.9631447238")),
+                ],
+            )
+
+    def test_get_revenue_for_schema_source_for_id_join(self):
+        self.setup_schema_sources()
+
+        self.join.source_table_key = "id"
+        self.join.save()
+
+        self.create_managed_viewsets()
+
+        # These are the 6 IDs inside the CSV files, plus an extra dummy/empty one
+        distinct_id_to_person_id: dict[str, str] = {}
+        for distinct_id in ["cus_1", "cus_2", "cus_3", "cus_4", "cus_5", "cus_6", "dummy"]:
+            person = _create_person(team_id=self.team.pk, distinct_ids=[distinct_id])
+            distinct_id_to_person_id[distinct_id] = person.uuid
+
+        with freeze_time(self.QUERY_TIMESTAMP):
+            queries = [
+                "SELECT id, revenue_analytics.revenue from persons order by id asc",
+                "SELECT id, $virt_revenue from persons order by id asc",
+            ]
+
+            for query in queries:
+                response = execute_hogql_query(parse_select(query), self.team, modifiers=self.MODIFIERS)
+
+                self.assertEqual(
+                    response.results,
+                    [
+                        (distinct_id_to_person_id["cus_1"], Decimal("283.8496260553")),
+                        (distinct_id_to_person_id["cus_2"], Decimal("482.2158673452")),
+                        (distinct_id_to_person_id["cus_3"], Decimal("4161.34422")),
+                        (distinct_id_to_person_id["cus_4"], Decimal("254.12345")),
+                        (distinct_id_to_person_id["cus_5"], Decimal("1494.0562")),
+                        (distinct_id_to_person_id["cus_6"], Decimal("2796.37014")),
+                        (distinct_id_to_person_id["dummy"], None),
+                    ],
                 )
-                tqr = TrendsQueryRunner(team=self.team, query=query)
-                results = tqr.calculate().results
 
-            assert results[0]["breakdown_value"] == ["350.42"]
+    def test_get_revenue_for_events(self):
+        self.setup_events()
+
+        self.team.revenue_analytics_config.events = [
+            RevenueAnalyticsEventItem(
+                eventName=self.PURCHASE_EVENT_NAME,
+                revenueProperty=self.REVENUE_PROPERTY,
+                revenueCurrencyProperty=RevenueCurrencyPropertyConfig(static="USD"),
+                currencyAwareDecimal=True,
+            )
+        ]
+        self.team.revenue_analytics_config.save()
+        self.team.save()
+        self.create_managed_viewsets()
+
+        with freeze_time(self.QUERY_TIMESTAMP):
+            response = execute_hogql_query(
+                parse_select(
+                    "select revenue_analytics.revenue, $virt_revenue from persons where id = {id}",
+                    placeholders={"id": ast.Constant(value=self.person_id)},
+                ),
+                self.team,
+            )
+
+            self.assertEqual(response.results[0], (Decimal("350.42"), Decimal("350.42")))

--- a/posthog/hogql/database/schema/test/test_persons_revenue_analytics.py
+++ b/posthog/hogql/database/schema/test/test_persons_revenue_analytics.py
@@ -1,3 +1,6 @@
+import csv
+import tempfile
+from datetime import datetime
 from decimal import Decimal
 from pathlib import Path
 
@@ -34,7 +37,7 @@ from posthog.temporal.data_imports.sources.stripe.constants import (
     INVOICE_RESOURCE_NAME as STRIPE_INVOICE_RESOURCE_NAME,
 )
 
-from products.data_warehouse.backend.models import DataWarehouseJoin, ExternalDataSchema
+from products.data_warehouse.backend.models import DataWarehouseJoin, DataWarehouseSavedQuery, ExternalDataSchema
 from products.data_warehouse.backend.models.datawarehouse_managed_viewset import DataWarehouseManagedViewSet
 from products.data_warehouse.backend.test.utils import create_data_warehouse_table_from_csv
 from products.data_warehouse.backend.types import DataWarehouseManagedViewSetKind
@@ -44,8 +47,9 @@ from products.revenue_analytics.backend.hogql_queries.test.data.structure import
 )
 from products.revenue_analytics.backend.views.schemas.customer import SCHEMA
 
-INVOICES_TEST_BUCKET = "test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_invoices"
-CUSTOMERS_TEST_BUCKET = "test_storage_bucket-posthog.revenue_analytics.insights_query_runner.stripe_customers"
+TEST_BUCKET_BASE = "test_storage_bucket"
+INVOICES_TEST_BUCKET = f"{TEST_BUCKET_BASE}-posthog.revenue_analytics.insights_query_runner.stripe_invoices"
+CUSTOMERS_TEST_BUCKET = f"{TEST_BUCKET_BASE}-posthog.revenue_analytics.insights_query_runner.stripe_customers"
 
 
 class TestPersonsRevenueAnalyticsMixin(ClickhouseTestMixin, APIBaseTest):
@@ -466,7 +470,6 @@ class TestPersonsRevenueAnalytics(TestPersonsRevenueAnalyticsMixin):
         assert results[0]["breakdown_value"] == ["350.42"]
 
 
-@snapshot_clickhouse_queries
 class TestPersonsRevenueAnalyticsManagedViewsets(TestPersonsRevenueAnalyticsMixin):
     def setUp(self) -> None:
         super().setUp()
@@ -474,14 +477,68 @@ class TestPersonsRevenueAnalyticsManagedViewsets(TestPersonsRevenueAnalyticsMixi
         self.mock_flag.start()
 
     def tearDown(self) -> None:
-        super().tearDown()
         self.mock_flag.stop()
+        if hasattr(self, "_materialized_cleanups"):
+            for cleanup in self._materialized_cleanups:
+                cleanup()
+        super().tearDown()
 
-    def create_managed_viewsets(self):
-        self.viewset, _ = DataWarehouseManagedViewSet.objects.get_or_create(
-            team=self.team, kind=DataWarehouseManagedViewSetKind.REVENUE_ANALYTICS
-        )
-        self.viewset.sync_views()
+    def create_and_materialize_viewsets(self):
+        with freeze_time(self.QUERY_TIMESTAMP):
+            viewset, _ = DataWarehouseManagedViewSet.objects.get_or_create(
+                team=self.team, kind=DataWarehouseManagedViewSetKind.REVENUE_ANALYTICS
+            )
+            viewset.sync_views()
+            materialization_csvs = self._get_materialization_csvs()
+        self._upload_materialized_csvs(materialization_csvs)
+
+    def _get_materialization_csvs(self):
+        materialization_csvs = []
+        for saved_query in DataWarehouseSavedQuery.objects.filter(
+            team=self.team, managed_viewset__isnull=False
+        ).order_by("name"):
+            query_text = saved_query.query.get("query", "") if isinstance(saved_query.query, dict) else ""
+            if not query_text:
+                continue
+
+            response = execute_hogql_query(parse_select(query_text), team=self.team, modifiers=self.MODIFIERS)
+
+            with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as csv_file:
+                writer = csv.writer(csv_file)
+                writer.writerow(response.columns or [])
+                for row in response.results or []:
+                    writer.writerow(
+                        [value.strftime("%Y-%m-%d %H:%M:%S") if isinstance(value, datetime) else value for value in row]
+                    )
+                csv_path = Path(csv_file.name)
+
+            nullable_columns = {}
+            for col_name, col_def in (saved_query.columns or {}).items():
+                if isinstance(col_def, dict):
+                    ch_type = col_def["clickhouse"]
+                    if not ch_type.startswith("Nullable("):
+                        col_def = {**col_def, "clickhouse": f"Nullable({ch_type})"}
+                nullable_columns[col_name] = col_def
+
+            materialization_csvs.append((saved_query, csv_path, nullable_columns))
+
+        return materialization_csvs
+
+    def _upload_materialized_csvs(self, materialization_csvs):
+        self._materialized_cleanups = []
+        for saved_query, csv_path, nullable_columns in materialization_csvs:
+            table, _, _, _, cleanup = create_data_warehouse_table_from_csv(
+                csv_path,
+                saved_query.name,
+                nullable_columns,
+                f"{TEST_BUCKET_BASE}-{saved_query.name.replace('.', '_')}",
+                self.team,
+                source_prefix="",
+            )
+            self._materialized_cleanups.append(cleanup)
+            saved_query.table = table
+            saved_query.is_materialized = True
+            saved_query.save()
 
     @parameterized.expand([e.value for e in PersonsOnEventsMode])
     def test_virtual_property_in_trend(self, mode):
@@ -497,10 +554,10 @@ class TestPersonsRevenueAnalyticsManagedViewsets(TestPersonsRevenueAnalyticsMixi
         self.team.revenue_analytics_config.save()
         self.team.save()
 
-        self.create_managed_viewsets()
+        self.create_and_materialize_viewsets()
 
         # Breaking down by revenue doesnt make any sense, but this is just proving it works
-        with freeze_time(self.QUERY_TIMESTAMP):
+        with freeze_time(self.QUERY_TIMESTAMP), self.snapshot_select_queries():
             query = TrendsQuery(
                 **{
                     "kind": "TrendsQuery",
@@ -530,10 +587,9 @@ class TestPersonsRevenueAnalyticsManagedViewsets(TestPersonsRevenueAnalyticsMixi
         ]
         self.team.revenue_analytics_config.save()
         self.team.save()
+        self.create_and_materialize_viewsets()
 
-        with freeze_time(self.QUERY_TIMESTAMP):
-            self.create_managed_viewsets()  # Make sure this runs inside the freeze_time context
-
+        with freeze_time(self.QUERY_TIMESTAMP), self.snapshot_select_queries():
             results = execute_hogql_query(
                 parse_select("SELECT person_id, revenue, mrr FROM persons_revenue_analytics ORDER BY person_id ASC"),
                 self.team,
@@ -555,9 +611,8 @@ class TestPersonsRevenueAnalyticsManagedViewsets(TestPersonsRevenueAnalyticsMixi
         for distinct_id in ["cus_1", "cus_2", "cus_3", "cus_4", "cus_5", "cus_6"]:
             person = _create_person(team_id=self.team.pk, distinct_ids=[distinct_id])
             distinct_id_to_person_id[distinct_id] = person.uuid
-
-        with freeze_time(self.QUERY_TIMESTAMP):
-            self.create_managed_viewsets()
+        self.create_and_materialize_viewsets()
+        with freeze_time(self.QUERY_TIMESTAMP), self.snapshot_select_queries():
             results = execute_hogql_query(
                 parse_select(
                     "SELECT person_id, revenue, mrr FROM persons_revenue_analytics ORDER BY mrr DESC, revenue DESC"
@@ -580,11 +635,8 @@ class TestPersonsRevenueAnalyticsManagedViewsets(TestPersonsRevenueAnalyticsMixi
 
     def test_get_revenue_for_schema_source_for_id_join(self):
         self.setup_schema_sources()
-
         self.join.source_table_key = "id"
         self.join.save()
-
-        self.create_managed_viewsets()
 
         # These are the 6 IDs inside the CSV files, plus an extra dummy/empty one
         distinct_id_to_person_id: dict[str, str] = {}
@@ -592,7 +644,8 @@ class TestPersonsRevenueAnalyticsManagedViewsets(TestPersonsRevenueAnalyticsMixi
             person = _create_person(team_id=self.team.pk, distinct_ids=[distinct_id])
             distinct_id_to_person_id[distinct_id] = person.uuid
 
-        with freeze_time(self.QUERY_TIMESTAMP):
+        self.create_and_materialize_viewsets()
+        with freeze_time(self.QUERY_TIMESTAMP), self.snapshot_select_queries():
             queries = [
                 "SELECT id, revenue_analytics.revenue from persons order by id asc",
                 "SELECT id, $virt_revenue from persons order by id asc",
@@ -616,7 +669,6 @@ class TestPersonsRevenueAnalyticsManagedViewsets(TestPersonsRevenueAnalyticsMixi
 
     def test_get_revenue_for_events(self):
         self.setup_events()
-
         self.team.revenue_analytics_config.events = [
             RevenueAnalyticsEventItem(
                 eventName=self.PURCHASE_EVENT_NAME,
@@ -627,9 +679,9 @@ class TestPersonsRevenueAnalyticsManagedViewsets(TestPersonsRevenueAnalyticsMixi
         ]
         self.team.revenue_analytics_config.save()
         self.team.save()
-        self.create_managed_viewsets()
+        self.create_and_materialize_viewsets()
 
-        with freeze_time(self.QUERY_TIMESTAMP):
+        with freeze_time(self.QUERY_TIMESTAMP), self.snapshot_select_queries():
             response = execute_hogql_query(
                 parse_select(
                     "select revenue_analytics.revenue, $virt_revenue from persons where id = {id}",

--- a/posthog/test/base.py
+++ b/posthog/test/base.py
@@ -204,11 +204,9 @@ from products.event_definitions.backend.models.property_definition import (
 # Make sure freezegun ignores our utils class that times functions
 freezegun.configure(extend_ignore_list=["posthog.test.assert_faster_than"])
 
-
 persons_cache_tests: list[dict[str, Any]] = []
 events_cache_tests: list[dict[str, Any]] = []
 persons_ordering_int: int = 0
-
 
 # Expand string diffs
 unittest.util._MAX_LENGTH = 2000  # type: ignore
@@ -838,12 +836,13 @@ class NonAtomicBaseTest(PostHogTestCase, ErrorResponsesMixin, TransactionTestCas
                 conn = connections[db_name]
                 with conn.cursor() as cursor:
                     cursor.execute("""
-                        SELECT tablename FROM pg_tables
-                        WHERE schemaname = 'public'
-                        AND tablename NOT LIKE 'pg_%'
-                        AND tablename NOT LIKE '_sqlx_%'
-                        AND tablename NOT LIKE '_persons_migrations'
-                    """)
+                                   SELECT tablename
+                                   FROM pg_tables
+                                   WHERE schemaname = 'public'
+                                     AND tablename NOT LIKE 'pg_%'
+                                     AND tablename NOT LIKE '_sqlx_%'
+                                     AND tablename NOT LIKE '_persons_migrations'
+                                   """)
                     tables = [row[0] for row in cursor.fetchall()]
                     if tables:
                         cursor.execute(f"TRUNCATE TABLE {', '.join(tables)} RESTART IDENTITY CASCADE")
@@ -869,19 +868,21 @@ class NonAtomicBaseTestKeepIdentities(PostHogTestCase, ErrorResponsesMixin, Tran
             with conn.cursor() as cursor:
                 if db_name in ("persons_db_writer", "persons_db_reader"):
                     cursor.execute("""
-                        SELECT tablename FROM pg_tables
-                        WHERE schemaname = 'public'
-                        AND tablename NOT LIKE 'pg_%'
-                        AND tablename NOT LIKE '_sqlx_%'
-                        AND tablename NOT LIKE '_persons_migrations'
-                    """)
+                                   SELECT tablename
+                                   FROM pg_tables
+                                   WHERE schemaname = 'public'
+                                     AND tablename NOT LIKE 'pg_%'
+                                     AND tablename NOT LIKE '_sqlx_%'
+                                     AND tablename NOT LIKE '_persons_migrations'
+                                   """)
                 else:
                     cursor.execute("""
-                        SELECT tablename FROM pg_tables
-                        WHERE schemaname = 'public'
-                        AND tablename NOT LIKE 'pg_%'
-                        AND tablename NOT LIKE 'django_%'
-                    """)
+                                   SELECT tablename
+                                   FROM pg_tables
+                                   WHERE schemaname = 'public'
+                                     AND tablename NOT LIKE 'pg_%'
+                                     AND tablename NOT LIKE 'django_%'
+                                   """)
                 tables = [row[0] for row in cursor.fetchall()]
                 if tables:
                     cursor.execute(f"TRUNCATE TABLE {', '.join(tables)} CASCADE")
@@ -1472,6 +1473,16 @@ class ClickhouseTestMixin(QueryMatchingTest):
 
         with patch_clickhouse_client_execute(execute_wrapper):
             yield queries
+
+    @contextmanager
+    def snapshot_select_queries(self):
+        with self.capture_select_queries() as queries:
+            yield queries
+
+        replace_all_numbers = getattr(self, "snapshot_replace_all_numbers", False)
+        for query in queries:
+            if "FROM system.columns" not in query:
+                self.assertQueryMatchesSnapshot(query, replace_all_numbers=replace_all_numbers)
 
 
 def run_clickhouse_statement_in_parallel(statements: list[str]):


### PR DESCRIPTION
## Problem
When querying `$virt_revenue` or `$virt_mrr` from `persons`, the revenue analytics lazy join crashes with `AttributeError: 'DataWarehouseTable' object has no attribute 'id'` when the `managed-viewsets` feature flag is ON and views are materialized.

The root cause: `_select_from_persons_revenue_analytics_table` assumed every view returned by `get_table()` is either a `RevenueAnalyticsBaseView` or a `SavedQuery`, but materialized views return a `DataWarehouseTable` (S3Table). The function tried to convert it via `_base_view_args_from_saved_query`, which accesses `.id` — a field `DataWarehouseTable` doesn't have.

This was not caught in the unit tests because we weren't materializing the saved queries for the tests with `managed-viewsets` flag on.

Related to https://github.com/PostHog/posthog/issues/52270
## Changes
**Fix materialized view handling in persons revenue analytics join** (`persons_revenue_analytics.py`):
- The view collection loop now works with any `Table` subclass — it only uses `name` and `fields`, which are available on all types
- Extracted code to helper functions (will reuse them when refactoring groups joins)

**Test infrastructure** (`test_persons_revenue_analytics.py`):
- Split `TestPersonsRevenueAnalytics` in two classes: one with `materialized-views` flag `True` and the other `False`
- Extracted `PersonsRevenueAnalyticsSetupMixin` to share setup across test classes
- Add setup functions to actually materialize the saved queries, making tests nearly identical to the real case

## How did you test this code?
All unit tests in `test_persons_revenue_analytics.py` passing; query snapshot changes reflecting that we're now reading from the materialized results (i.e. `.csv` file)
Manually: 
- set up revenue analytics locally with `managed-viewsets` flag on;
- wait for the sync to happen;
- create join between revenue analytics and persons tables
- go to SQL editor and query `SELECT $virt_mrr, $virt_revenue from persons` -> the query should work


## Publish to changelog?
no

## Docs update
no

## 🤖 LLM context