### PR TITLE
fix(dashboards): disable impossible actions on built-in official templates

### DIFF
--- a/frontend/src/scenes/dashboard/dashboards/templates/DashboardTemplatesTable.tsx
+++ b/frontend/src/scenes/dashboard/dashboards/templates/DashboardTemplatesTable.tsx
@@ -95,10 +95,9 @@ export const DashboardTemplatesTable = (): JSX.Element | null => {
                 }
                 const { id, scope } = record
                 const builtInOfficial = isBuiltInOfficialTemplate(record)
-                const makePrivateDisabledReason =
-                    scope === 'global' && builtInOfficial
-                        ? 'Built-in official templates cannot be made team-only'
-                        : undefined
+                const makePrivateDisabledReason = builtInOfficial
+                    ? 'Built-in official templates cannot be made team-only'
+                    : undefined
 
                 return (
                     <More

--- a/frontend/src/scenes/dashboard/dashboards/templates/DashboardTemplatesTable.tsx
+++ b/frontend/src/scenes/dashboard/dashboards/templates/DashboardTemplatesTable.tsx
@@ -21,6 +21,11 @@ const templatesTableLogic = dashboardTemplatesLogic({ scope: 'default' })
 
 const POPULAR_TEMPLATE_TOOLTIP = 'One of our most popular templates'
 
+/** Matches backend: global scope + no team means the template is org-wide only and cannot be made team-private. */
+function isBuiltInOfficialTemplate(record: Pick<DashboardTemplateType, 'scope' | 'team_id'>): boolean {
+    return record.scope === 'global' && record.team_id == null
+}
+
 export const DashboardTemplatesTable = (): JSX.Element | null => {
     const { allTemplates, allTemplatesLoading, templateFilter, templateNameOrdering } = useValues(templatesTableLogic)
     const { setTemplateFilter, setTemplateNameOrdering } = useActions(templatesTableLogic)
@@ -84,10 +89,17 @@ export const DashboardTemplatesTable = (): JSX.Element | null => {
         },
         {
             width: 0,
-            render: (_, { id, scope }: DashboardTemplateType) => {
+            render: (_, record: DashboardTemplateType) => {
                 if (!user?.is_staff) {
                     return null
                 }
+                const { id, scope } = record
+                const builtInOfficial = isBuiltInOfficialTemplate(record)
+                const makePrivateDisabledReason =
+                    scope === 'global' && builtInOfficial
+                        ? 'Built-in official templates cannot be made team-only'
+                        : undefined
+
                 return (
                     <More
                         overlay={
@@ -119,6 +131,7 @@ export const DashboardTemplatesTable = (): JSX.Element | null => {
                                         })
                                     }}
                                     fullWidth
+                                    disabledReason={makePrivateDisabledReason}
                                 >
                                     Make visible to {scope === 'global' ? 'this team only' : 'everyone'}
                                 </LemonButton>
@@ -146,7 +159,9 @@ export const DashboardTemplatesTable = (): JSX.Element | null => {
                                     status="danger"
                                     disabledReason={
                                         scope === 'global'
-                                            ? 'Cannot delete global dashboard templates, make them team only first'
+                                            ? builtInOfficial
+                                                ? 'Built-in official templates cannot be deleted'
+                                                : 'Cannot delete a global template until it is team-only'
                                             : undefined
                                     }
                                 >


### PR DESCRIPTION
## Problem

Staff users could open the dashboard templates table overflow menu on **Official** (built-in global) templates and choose **Make visible to this team only**, which the API rejects with *"The original templates cannot be made private as they would be lost."* The **Delete** control was already disabled for globals but told users to make the template team-only first, which is impossible for those rows.

## Changes

- Detect built-in official templates as `scope === 'global'` with no `team_id`, matching the backend guard in `DashboardTemplateSerializer.update`.
- Disable **Make visible to this team only** for those rows with a clear tooltip.
- Replace misleading delete disabled copy for built-in vs other global templates.

## How did you test this code?

Not run in a browser. Change is limited to `disabledReason` / menu state; reviewers can confirm on **Project settings → Dashboard templates** (staff): built-in Official rows should show disabled make-team-only and updated delete tooltip.

## Publish to changelog?

no

## Docs update

N/A for this small UX fix.

## 🤖 LLM context

This PR was authored with Cursor (agent). The implementation aligns the staff templates table with existing backend validation in `products/dashboards/backend/api/dashboard_templates.py` (reject `scope: team` when `scope` was global and `team_id` is unset).
