### PR TITLE
fix(dashboards): remove duplicate edit layout from scene side panel

### DIFF
--- a/frontend/src/scenes/dashboard/DashboardScenePanel.tsx
+++ b/frontend/src/scenes/dashboard/DashboardScenePanel.tsx
@@ -1,20 +1,9 @@
 import { useActions, useValues } from 'kea'
 import { router } from 'kea-router'
 
-import {
-    IconCode2,
-    IconCopy,
-    IconGraph,
-    IconGridMasonry,
-    IconNotebook,
-    IconPalette,
-    IconScreen,
-    IconTrash,
-} from '@posthog/icons'
+import { IconCode2, IconCopy, IconGraph, IconNotebook, IconPalette, IconScreen, IconTrash } from '@posthog/icons'
 
 import { AccessControlAction } from 'lib/components/AccessControlAction'
-import { AppShortcut } from 'lib/components/AppShortcuts/AppShortcut'
-import { keyBinds } from 'lib/components/AppShortcuts/shortcuts'
 import { SceneExportDropdownMenu } from 'lib/components/Scenes/InsightOrDashboard/SceneExportDropdownMenu'
 import { SceneDuplicate } from 'lib/components/Scenes/SceneDuplicate'
 import { SceneFile } from 'lib/components/Scenes/SceneFile'
@@ -32,11 +21,9 @@ import { deleteDashboardLogic } from 'scenes/dashboard/deleteDashboardLogic'
 import { duplicateDashboardLogic } from 'scenes/dashboard/duplicateDashboardLogic'
 import { interProjectCopyLogic } from 'scenes/resource-transfer/interProjectCopyLogic'
 import { sceneLogic } from 'scenes/sceneLogic'
-import { Scene } from 'scenes/sceneTypes'
 import { urls } from 'scenes/urls'
 import { userLogic } from 'scenes/userLogic'
 
-import { sidePanelStateLogic } from '~/layout/navigation-3000/sidepanel/sidePanelStateLogic'
 import {
     ScenePanel,
     ScenePanelActionsSection,
@@ -60,7 +47,6 @@ export function DashboardScenePanel(): JSX.Element | null {
         dashboardMode,
         canEditDashboard,
         isSavingTags,
-        currentLayoutSize,
         isPinned,
         asDashboardTemplate,
         effectiveEditBarFilters,
@@ -74,7 +60,6 @@ export function DashboardScenePanel(): JSX.Element | null {
     const { showInsightColorsModal } = useActions(dashboardInsightColorsModalLogic)
     const { newTab } = useActions(sceneLogic)
     const { setScenePanelOpen } = useActions(sceneLayoutLogic)
-    const { closeSidePanel } = useActions(sidePanelStateLogic)
     const { showDuplicateDashboardModal } = useActions(duplicateDashboardLogic)
     const { showDeleteDashboardModal } = useActions(deleteDashboardLogic)
 
@@ -146,38 +131,6 @@ export function DashboardScenePanel(): JSX.Element | null {
                                 Customize colors
                             </ButtonPrimitive>
                         )}
-                        <AppShortcut
-                            name="ToggleEditMode"
-                            scope={Scene.Dashboard}
-                            keybind={[keyBinds.edit]}
-                            intent="Toggle edit mode"
-                            interaction="click"
-                            disabled={tiles.length === 0 && dashboardMode !== DashboardMode.Edit}
-                        >
-                            <ButtonPrimitive
-                                onClick={() => {
-                                    if (dashboardMode === DashboardMode.Edit) {
-                                        setDashboardMode(null, DashboardEventSource.SceneCommonButtons)
-                                    } else {
-                                        setDashboardMode(DashboardMode.Edit, DashboardEventSource.SceneCommonButtons)
-                                        closeSidePanel()
-                                    }
-                                }}
-                                menuItem
-                                active={dashboardMode === DashboardMode.Edit}
-                                data-attr={`${RESOURCE_TYPE}-edit-layout`}
-                                tooltip="Toggle edit mode"
-                                tooltipPlacement="left"
-                                disabled={tiles.length === 0 && dashboardMode !== DashboardMode.Edit}
-                                disabledReasons={{
-                                    'Add at least one tile to edit layout':
-                                        tiles.length === 0 && dashboardMode !== DashboardMode.Edit,
-                                }}
-                            >
-                                <IconGridMasonry />
-                                {currentLayoutSize === 'xs' ? 'Edit dashboard' : 'Edit layout'}
-                            </ButtonPrimitive>
-                        </AppShortcut>
                         <ButtonPrimitive
                             onClick={() => createNotebookFromDashboard(dashboard)}
                             menuItem


### PR DESCRIPTION
## Problem

The dashboard scene side panel duplicated **Edit layout** / **Edit dashboard** (narrow breakpoint label) next to the same control in the scene header, which added noise and two ways to do the same thing.

<img width="1334" height="792" alt="CleanShot 2026-03-31 at 15 03 47@2x" src="https://github.com/user-attachments/assets/624048a0-328c-4d91-baab-c1c711044c41" />

## Changes

Refers to this one
<img width="924" height="1014" alt="CleanShot 2026-03-31 at 15 03 16@2x" src="https://github.com/user-attachments/assets/756f338a-7fe4-47f5-a63e-20d6df651d9a" />


## How did you test this code?
Locally.
## Publish to changelog?

no

