### PR TITLE
fix(subscriptions): correct empty state copy for dashboard context

### DIFF
--- a/frontend/src/lib/components/Subscriptions/views/ManageSubscriptions.tsx
+++ b/frontend/src/lib/components/Subscriptions/views/ManageSubscriptions.tsx
@@ -91,7 +91,7 @@ export function ManageSubscriptions({
     const { subscriptions, subscriptionsLoading } = useValues(logic)
     const { deleteSubscription } = useActions(logic)
 
-    const subscriptionResourceNoun = insightShortId ? 'insight' : dashboardId ? 'dashboard' : 'insight'
+    const subscriptionResourceNoun = !insightShortId && dashboardId ? 'dashboard' : 'insight'
 
     return (
         <>

--- a/frontend/src/lib/components/Subscriptions/views/ManageSubscriptions.tsx
+++ b/frontend/src/lib/components/Subscriptions/views/ManageSubscriptions.tsx
@@ -91,6 +91,8 @@ export function ManageSubscriptions({
     const { subscriptions, subscriptionsLoading } = useValues(logic)
     const { deleteSubscription } = useActions(logic)
 
+    const subscriptionResourceNoun = insightShortId ? 'insight' : dashboardId ? 'dashboard' : 'insight'
+
     return (
         <>
             <LemonModal.Header>
@@ -123,7 +125,7 @@ export function ManageSubscriptions({
                     </div>
                 ) : (
                     <div className="flex flex-col p-4 items-center text-center">
-                        <h3>There are no subscriptions for this insight</h3>
+                        <h3>There are no subscriptions for this {subscriptionResourceNoun}</h3>
 
                         <p>Once subscriptions are created they will display here. </p>
 


### PR DESCRIPTION
## Problem

The manage subscriptions modal empty state always said "this insight", even when opened from a dashboard.

## Changes

- `ManageSubscriptions` derives `subscriptionResourceNoun` from `insightShortId` / `dashboardId` (insight wins if both, matching subscription URL helpers).



<img width="4226" height="1306" alt="CleanShot 2026-03-31 at 15 10 21@2x" src="https://github.com/user-attachments/assets/a94eb2cf-0c5f-44e1-b8fa-8b2e6448387e" />

## How did you test this code?

Local.

## Publish to changelog?

no

## Docs update

N/A — user-facing copy fix only.

## LLM context

Co-authored with Cursor agent: branch rebased onto `origin/master`, commit message set to `fix(subscriptions):` per repo conventions.

Made with [Cursor](https://cursor.com)