### PR TITLE
fix(phrocs): use ANSI colors and reduce CPU from ~60% to ~3%

### DIFF
--- a/tools/phrocs/internal/docker/docker.go
+++ b/tools/phrocs/internal/docker/docker.go
@@ -237,9 +237,9 @@ func RenderContainerStatusTable(containers []DockerContainer, width int) string 
 	var sb strings.Builder
 	sb.WriteByte('\n')
 	header := fmt.Sprintf("  %-*s  %-*s  %s", svcW, "SERVICE", stateW, "STATE", "STATUS")
-	sb.WriteString(lipgloss.NewStyle().Bold(true).Foreground(sharedpalette.ColorWhite).Render(header))
+	sb.WriteString(lipgloss.NewStyle().Bold(true).Foreground(sharedpalette.ColorBrightWhite).Render(header))
 	sb.WriteByte('\n')
-	sb.WriteString(lipgloss.NewStyle().Foreground(sharedpalette.ColorDarkGrey).Render("  " + strings.Repeat("─", max(width-4, 0))))
+	sb.WriteString(lipgloss.NewStyle().Foreground(sharedpalette.ColorBrightBlack).Render("  " + strings.Repeat("─", max(width-4, 0))))
 	sb.WriteByte('\n')
 
 	for _, c := range containers {
@@ -258,10 +258,10 @@ func RenderContainerStatusTable(containers []DockerContainer, width int) string 
 			svc = svc[:svcW]
 		}
 		sb.WriteString("  ")
-		sb.WriteString(lipgloss.NewStyle().Foreground(sharedpalette.ColorWhite).Render(fmt.Sprintf("%-*s", svcW, svc)))
+		sb.WriteString(lipgloss.NewStyle().Foreground(sharedpalette.ColorBrightWhite).Render(fmt.Sprintf("%-*s", svcW, svc)))
 		sb.WriteString("  ")
 		sb.WriteString(lipgloss.NewStyle().Foreground(stateColor).Render(fmt.Sprintf("%-*s", stateW, c.State)))
-		sb.WriteString(lipgloss.NewStyle().Foreground(sharedpalette.ColorGrey).Render(fmt.Sprintf("  %s", c.Status)))
+		sb.WriteString(lipgloss.NewStyle().Foreground(sharedpalette.ColorWhite).Render(fmt.Sprintf("  %s", c.Status)))
 		sb.WriteByte('\n')
 	}
 
@@ -290,6 +290,6 @@ func ContainerStateColor(state string) color.Color {
 	case "paused":
 		return sharedpalette.ColorYellow
 	default:
-		return sharedpalette.ColorGrey
+		return sharedpalette.ColorWhite
 	}
 }

--- a/tools/phrocs/internal/palette/palette.go
+++ b/tools/phrocs/internal/palette/palette.go
@@ -1,27 +1,36 @@
 package palette
 
-import "charm.land/lipgloss/v2"
+import (
+	"image/color"
 
+	"charm.land/lipgloss/v2"
+)
+
+// ANSI 4-bit colors — these adapt automatically to the terminal's theme,
+// so the UI looks correct on both light and dark backgrounds without
+// needing explicit light/dark branching.
 var (
-	ColorYellow   = lipgloss.Color("#F7A501")
-	ColorBlue     = lipgloss.Color("#1D4AFF")
-	ColorGrey     = lipgloss.Color("#9BA1B2")
-	ColorDarkGrey = lipgloss.Color("#3D3F43")
-	ColorGreen    = lipgloss.Color("#2DCC5D")
-	ColorRed      = lipgloss.Color("#F04438")
-	ColorWhite    = lipgloss.Color("#FFFFFF")
-	ColorBlack    = lipgloss.Color("#151515")
-	ColorMidGrey  = lipgloss.Color("#555860") // focused-border accent
+	BrandYellow = lipgloss.Color("#F7A501")
+	BrandBlue   = lipgloss.Color("#1D4AFF")
+	BrandRed    = lipgloss.Color("#F04438")
+	BrandBlack  = lipgloss.Color("#151515")
 
-	// Subtle background tint for CPU usage bars (htop-style, dark terminals)
-	ColorBarLow  = lipgloss.Color("#1A3A1A") // green tint, low CPU
-	ColorBarMid  = lipgloss.Color("#3A3A1A") // yellow tint, moderate CPU
-	ColorBarHigh = lipgloss.Color("#3A1A1A") // red tint, high CPU
-
-	// Subtle background tint for CPU usage bars (htop-style, light terminals)
-	ColorBarLowLight  = lipgloss.Color("#C8F0C8") // green tint, low CPU
-	ColorBarMidLight  = lipgloss.Color("#F0ECC8") // yellow tint, moderate CPU
-	ColorBarHighLight = lipgloss.Color("#F0C8C8") // red tint, high CPU
+	ColorBlack         color.Color = lipgloss.Black         // ANSI 0: contrast text on bright bg
+	ColorRed           color.Color = lipgloss.Red           // ANSI 1: error/crashed
+	ColorGreen         color.Color = lipgloss.Green         // ANSI 2: running status
+	ColorYellow        color.Color = lipgloss.Yellow        // ANSI 3: warnings, pending
+	ColorBlue          color.Color = lipgloss.Blue          // ANSI 4: copy mode
+	ColorMagenta       color.Color = lipgloss.Magenta       // ANSI 5: (unused)
+	ColorCyan          color.Color = lipgloss.Cyan          // ANSI 6: (unused)
+	ColorWhite         color.Color = lipgloss.White         // ANSI 7: secondary text, inactive items
+	ColorBrightBlack   color.Color = lipgloss.BrightBlack   // ANSI 8: borders, selection bg
+	ColorBrightRed     color.Color = lipgloss.BrightRed     // ANSI 9: (unused)
+	ColorBrightGreen   color.Color = lipgloss.BrightGreen   // ANSI 10: (unused)
+	ColorBrightYellow  color.Color = lipgloss.BrightYellow  // ANSI 11: (unused)
+	ColorBrightBlue    color.Color = lipgloss.BrightBlue    // ANSI 12: (unused)
+	ColorBrightMagenta color.Color = lipgloss.BrightMagenta // ANSI 13: (unused)
+	ColorBrightCyan    color.Color = lipgloss.BrightCyan    // ANSI 14: (unused)
+	ColorBrightWhite   color.Color = lipgloss.BrightWhite   // ANSI 15: primary text
 )
 
 const (

--- a/tools/phrocs/internal/process/manager.go
+++ b/tools/phrocs/internal/process/manager.go
@@ -2,6 +2,7 @@ package process
 
 import (
 	"sync"
+	"sync/atomic"
 
 	tea "charm.land/bubbletea/v2"
 	"github.com/posthog/posthog/phrocs/internal/config"
@@ -14,12 +15,18 @@ type Manager struct {
 	procs  []*Process
 	byName map[string]*Process
 	send   func(tea.Msg)
+
+	// When true, metrics samplers collect process tree stats.
+	// Toggled by the TUI when entering/exiting info mode.
+	metricsEnabled atomic.Bool
 }
 
 func NewManager(cfg *config.Config) *Manager {
+	mgr := &Manager{}
+
 	names := cfg.OrderedNames()
-	procs := make([]*Process, 0, len(names))
-	byName := make(map[string]*Process, len(names))
+	mgr.procs = make([]*Process, 0, len(names))
+	mgr.byName = make(map[string]*Process, len(names))
 
 	for _, name := range names {
 		pcfg := cfg.Procs[name]
@@ -28,14 +35,12 @@ func NewManager(cfg *config.Config) *Manager {
 			pcfg.Shell = docker.StripComposeLogsTail(pcfg.Shell)
 		}
 		proc := NewProcess(name, pcfg, cfg.Scrollback)
-		procs = append(procs, proc)
-		byName[name] = proc
+		proc.metricsEnabled = &mgr.metricsEnabled
+		mgr.procs = append(mgr.procs, proc)
+		mgr.byName[name] = proc
 	}
 
-	return &Manager{
-		procs:  procs,
-		byName: byName,
-	}
+	return mgr
 }
 
 // Must be called before StartAll
@@ -99,4 +104,14 @@ func (m *Manager) Send() func(tea.Msg) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	return m.send
+}
+
+// SetMetricsEnabled toggles whether metrics samplers do expensive collection.
+func (m *Manager) SetMetricsEnabled(on bool) {
+	m.metricsEnabled.Store(on)
+}
+
+// MetricsEnabled returns true when metrics collection is active.
+func (m *Manager) MetricsEnabled() bool {
+	return m.metricsEnabled.Load()
 }

--- a/tools/phrocs/internal/process/manager.go
+++ b/tools/phrocs/internal/process/manager.go
@@ -2,7 +2,6 @@ package process
 
 import (
 	"sync"
-	"sync/atomic"
 
 	tea "charm.land/bubbletea/v2"
 	"github.com/posthog/posthog/phrocs/internal/config"
@@ -16,9 +15,6 @@ type Manager struct {
 	byName map[string]*Process
 	send   func(tea.Msg)
 
-	// When true, metrics samplers collect process tree stats.
-	// Toggled by the TUI when entering/exiting info mode.
-	metricsEnabled atomic.Bool
 }
 
 func NewManager(cfg *config.Config) *Manager {
@@ -35,7 +31,6 @@ func NewManager(cfg *config.Config) *Manager {
 			pcfg.Shell = docker.StripComposeLogsTail(pcfg.Shell)
 		}
 		proc := NewProcess(name, pcfg, cfg.Scrollback)
-		proc.metricsEnabled = &mgr.metricsEnabled
 		mgr.procs = append(mgr.procs, proc)
 		mgr.byName[name] = proc
 	}
@@ -106,12 +101,3 @@ func (m *Manager) Send() func(tea.Msg) {
 	return m.send
 }
 
-// SetMetricsEnabled toggles whether metrics samplers do expensive collection.
-func (m *Manager) SetMetricsEnabled(on bool) {
-	m.metricsEnabled.Store(on)
-}
-
-// MetricsEnabled returns true when metrics collection is active.
-func (m *Manager) MetricsEnabled() bool {
-	return m.metricsEnabled.Load()
-}

--- a/tools/phrocs/internal/process/proc.go
+++ b/tools/phrocs/internal/process/proc.go
@@ -19,7 +19,7 @@ import (
 	"github.com/posthog/posthog/phrocs/internal/config"
 )
 
-const metricsSampleInterval = 5 * time.Second
+const metricsSampleInterval = 1 * time.Second
 const flushInterval = 16 * time.Millisecond
 const stopGracePeriod = 3 * time.Second
 
@@ -61,6 +61,9 @@ type OutputMsg struct {
 	Added   []string
 	Evicted int
 }
+
+// Sent after metrics are sampled so the TUI can refresh the info panel.
+type MetricsMsg struct{}
 
 // Metrics holds the most recent sampled resource usage for a process tree.
 type Metrics struct {
@@ -117,7 +120,7 @@ type Process struct {
 	readyAt        time.Time
 	exitCode       *int
 	metrics        *Metrics
-	metricsEnabled *atomic.Bool // shared with Manager; nil-safe (skips sampling)
+	metricsEnabled atomic.Bool
 }
 
 func NewProcess(name string, cfg config.ProcConfig, scrollback int) *Process {
@@ -139,6 +142,10 @@ func (p *Process) Status() Status {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	return p.status
+}
+
+func (p *Process) SetMetricsEnabled(on bool) {
+	p.metricsEnabled.Store(on)
 }
 
 // CPUPercent returns the most recently sampled CPU usage, or 0 if not yet sampled.
@@ -359,7 +366,7 @@ func (p *Process) Start(send func(tea.Msg)) error {
 	// Send initial status message
 	send(StatusMsg{Name: p.Name, Status: currentStatus})
 
-	go p.startMetricsSampler(cmd.Process.Pid)
+	go p.startMetricsSampler(cmd.Process.Pid, send)
 
 	outChannel := make(chan tea.Msg, 256)
 
@@ -454,7 +461,7 @@ func (p *Process) startWithPipe(cmd *exec.Cmd, send func(tea.Msg)) error {
 
 	send(StatusMsg{Name: p.Name, Status: currentStatus})
 
-	go p.startMetricsSampler(cmd.Process.Pid)
+	go p.startMetricsSampler(cmd.Process.Pid, send)
 
 	outChannel := make(chan tea.Msg, 256)
 
@@ -672,7 +679,7 @@ func (p *Process) bufferLine(line string) (evicted bool, becameReady bool) {
 }
 
 // Sampling CPU/mem/threads every metricsSampleInterval when metrics are enabled.
-func (p *Process) startMetricsSampler(pid int) {
+func (p *Process) startMetricsSampler(pid int, send func(tea.Msg)) {
 	origPID := pid
 
 	ticker := time.NewTicker(metricsSampleInterval)
@@ -691,11 +698,12 @@ func (p *Process) startMetricsSampler(pid int) {
 			return
 		}
 
-		if p.metricsEnabled != nil && !p.metricsEnabled.Load() {
+		if !p.metricsEnabled.Load() {
 			continue
 		}
 
 		p.sampleMetrics()
+		send(MetricsMsg{})
 	}
 }
 

--- a/tools/phrocs/internal/process/proc.go
+++ b/tools/phrocs/internal/process/proc.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"regexp"
 	"sync"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -112,10 +113,11 @@ type Process struct {
 	hasPrompt bool          // true when the last output was a partial line without a trailing \n
 	waitDone  chan struct{} // closed by the goroutine that calls cmd.Wait()
 
-	startedAt time.Time
-	readyAt   time.Time
-	exitCode  *int
-	metrics   *Metrics
+	startedAt      time.Time
+	readyAt        time.Time
+	exitCode       *int
+	metrics        *Metrics
+	metricsEnabled *atomic.Bool // shared with Manager; nil-safe (skips sampling)
 }
 
 func NewProcess(name string, cfg config.ProcConfig, scrollback int) *Process {
@@ -188,8 +190,11 @@ func (p *Process) AppendLine(line string) {
 
 func ptr[T any](v T) *T { return &v }
 
-// Returns a consistent point-in-time view of the process
+// Returns a consistent point-in-time view of the process.
+// If the process is running, metrics are sampled on the spot.
 func (p *Process) Snapshot() Snapshot {
+	p.sampleMetrics()
+
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
@@ -218,6 +223,67 @@ func (p *Process) Snapshot() Snapshot {
 		snap.LastSampledAt = ptr(m.SampledAt)
 	}
 	return snap
+}
+
+// sampleMetrics collects resource usage for the process tree and stores it.
+func (p *Process) sampleMetrics() {
+	p.mu.Lock()
+	pid := 0
+	if p.cmd != nil && p.cmd.Process != nil {
+		pid = p.cmd.Process.Pid
+	}
+	st := p.status
+	p.mu.Unlock()
+
+	if pid == 0 || (st != StatusRunning && st != StatusPending) {
+		return
+	}
+
+	ps, err := gops.NewProcess(int32(pid))
+	if err != nil {
+		return
+	}
+
+	all := collectProcessTree(ps)
+
+	var rssBytes uint64
+	var cpuPct, cpuTime float64
+	var threads, fds int32
+	for _, proc := range all {
+		if mem, err := proc.MemoryInfo(); err == nil {
+			rssBytes += mem.RSS
+		}
+		if c, err := proc.CPUPercent(); err == nil {
+			cpuPct += c
+		}
+		if ct, err := proc.Times(); err == nil {
+			cpuTime += ct.User + ct.System
+		}
+		if t, err := proc.NumThreads(); err == nil {
+			threads += t
+		}
+		if f, err := proc.NumFDs(); err == nil {
+			fds += f
+		}
+	}
+
+	rssMB := float64(rssBytes) / 1024 / 1024
+
+	p.mu.Lock()
+	if p.metrics == nil {
+		p.metrics = &Metrics{}
+	}
+	p.metrics.MemRSSMB = rssMB
+	if rssMB > p.metrics.PeakMemMB {
+		p.metrics.PeakMemMB = rssMB
+	}
+	p.metrics.CPUPercent = cpuPct
+	p.metrics.CPUTimeS = cpuTime
+	p.metrics.Threads = threads
+	p.metrics.Children = len(all) - 1
+	p.metrics.FDs = fds
+	p.metrics.SampledAt = time.Now()
+	p.mu.Unlock()
 }
 
 // buildEnv constructs the environment for the child process.
@@ -605,13 +671,8 @@ func (p *Process) bufferLine(line string) (evicted bool, becameReady bool) {
 	return evicted, becameReady
 }
 
-// Sampling CPU/mem/threads every metricsSampleInterval for the process tree
+// Sampling CPU/mem/threads every metricsSampleInterval when metrics are enabled.
 func (p *Process) startMetricsSampler(pid int) {
-	ps, err := gops.NewProcess(int32(pid))
-	if err != nil {
-		return
-	}
-	_, _ = ps.CPUPercent() // baseline measurement
 	origPID := pid
 
 	ticker := time.NewTicker(metricsSampleInterval)
@@ -627,64 +688,47 @@ func (p *Process) startMetricsSampler(pid int) {
 		p.mu.Unlock()
 
 		if (st != StatusRunning && st != StatusPending) || (currentPID != 0 && currentPID != origPID) {
-			// Process has been restarted with a new PID
 			return
 		}
 
-		all := collectProcessTree(ps)
-
-		var rssBytes uint64
-		var cpuPct, cpuTime float64
-		var threads, fds int32
-		for _, proc := range all {
-			if mem, err := proc.MemoryInfo(); err == nil {
-				rssBytes += mem.RSS
-			}
-			if c, err := proc.CPUPercent(); err == nil {
-				cpuPct += c
-			}
-			if ct, err := proc.Times(); err == nil {
-				cpuTime += ct.User + ct.System
-			}
-			if t, err := proc.NumThreads(); err == nil {
-				threads += t
-			}
-			if f, err := proc.NumFDs(); err == nil {
-				fds += f
-			}
+		if p.metricsEnabled != nil && !p.metricsEnabled.Load() {
+			continue
 		}
 
-		rssMB := float64(rssBytes) / 1024 / 1024
-
-		p.mu.Lock()
-		if p.metrics == nil {
-			p.metrics = &Metrics{}
-		}
-		p.metrics.MemRSSMB = rssMB
-		if rssMB > p.metrics.PeakMemMB {
-			p.metrics.PeakMemMB = rssMB
-		}
-		p.metrics.CPUPercent = cpuPct
-		p.metrics.CPUTimeS = cpuTime
-		p.metrics.Threads = threads
-		p.metrics.Children = len(all) - 1
-		p.metrics.FDs = fds
-		p.metrics.SampledAt = time.Now()
-		p.mu.Unlock()
+		p.sampleMetrics()
 	}
 }
 
-// collectProcessTree returns ps and all its descendants via a depth-first walk.
-func collectProcessTree(ps *gops.Process) []*gops.Process {
-	all := []*gops.Process{ps}
-	children, err := ps.Children()
+// collectProcessTree returns ps and all its descendants.
+func collectProcessTree(root *gops.Process) []*gops.Process {
+	allProcs, err := gops.Processes()
 	if err != nil {
-		return all
+		return []*gops.Process{root}
 	}
-	for _, child := range children {
-		all = append(all, collectProcessTree(child)...)
+
+	// Build parent → children index
+	byPID := make(map[int32]*gops.Process, len(allProcs))
+	childrenOf := make(map[int32][]*gops.Process)
+	for _, p := range allProcs {
+		byPID[p.Pid] = p
+		ppid, err := p.Ppid()
+		if err == nil && ppid > 0 {
+			childrenOf[ppid] = append(childrenOf[ppid], p)
+		}
 	}
-	return all
+
+	// BFS from root
+	result := []*gops.Process{root}
+	queue := []*gops.Process{root}
+	for len(queue) > 0 {
+		cur := queue[0]
+		queue = queue[1:]
+		for _, child := range childrenOf[cur.Pid] {
+			result = append(result, child)
+			queue = append(queue, child)
+		}
+	}
+	return result
 }
 
 // stopSignal returns the syscall signal to use when stopping the process,

--- a/tools/phrocs/internal/tui/app.go
+++ b/tools/phrocs/internal/tui/app.go
@@ -174,10 +174,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case spinner.TickMsg:
 		var cmd tea.Cmd
 		m.spinner, cmd = m.spinner.Update(msg)
-		// Only keep the spinner ticking when something needs it
-		if m.hasPendingProc() {
-			cmds = append(cmds, cmd)
-		}
+		cmds = append(cmds, cmd)
+
+	case process.MetricsMsg:
 		if m.infoMode {
 			m.refreshInfoContent()
 		}
@@ -430,7 +429,7 @@ func (m Model) loadActiveProc() (Model, []tea.Cmd) {
 		m.searchCursor = 0
 		m.activeLines = nil
 		m.infoMode = false
-		m.mgr.SetMetricsEnabled(false)
+		m.disableAllMetrics()
 		m.keys.LazyDocker.SetEnabled(true)
 		m.keys.ProcViewer.SetEnabled(false)
 		m.viewport.SetContent(docker.RenderContainerStatusTable(m.containers, m.viewport.Width()))
@@ -440,7 +439,9 @@ func (m Model) loadActiveProc() (Model, []tea.Cmd) {
 		m.containers = nil
 		m.keys.LazyDocker.SetEnabled(false)
 		m.keys.ProcViewer.SetEnabled(true)
+		m.disableAllMetrics()
 		if m.infoMode {
+			m.toggleMetricsOnSelectedProc()
 			m.refreshInfoContent()
 		} else {
 			m.reloadActiveLines()
@@ -456,6 +457,12 @@ func (m Model) loadActiveProc() (Model, []tea.Cmd) {
 		m.recomputeSearch()
 	}
 	return m, cmds
+}
+
+func (m *Model) disableAllMetrics() {
+	for _, p := range m.services {
+		p.SetMetricsEnabled(false)
+	}
 }
 
 // Reloads activeLines from the process buffer and pushes to the viewport.
@@ -557,11 +564,8 @@ func (m *Model) sortServices() {
 	m.ensureSidebarCursorVisible()
 }
 
-func (m Model) hasPendingProc() bool {
-	for _, p := range m.services {
-		if p.Status() == process.StatusPending {
-			return true
-		}
+func (m Model) toggleMetricsOnSelectedProc() {
+	if p := m.activeProc(); p != nil {
+		p.SetMetricsEnabled(true)
 	}
-	return false
 }

--- a/tools/phrocs/internal/tui/app.go
+++ b/tools/phrocs/internal/tui/app.go
@@ -56,8 +56,7 @@ type Model struct {
 	// Center viewport with output of the active process
 	viewport         viewport.Model
 	viewportAtBottom bool
-	activeContent    string
-	activeLineCount  int
+	activeLines      []string
 
 	// Copy mode: keyboard-driven line selection within the output pane
 	copyMode   bool
@@ -175,8 +174,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case spinner.TickMsg:
 		var cmd tea.Cmd
 		m.spinner, cmd = m.spinner.Update(msg)
-		cmds = append(cmds, cmd)
-		// Refresh info panel on each spinner tick to keep uptime current
+		// Only keep the spinner ticking when something needs it
+		if m.hasPendingProc() {
+			cmds = append(cmds, cmd)
+		}
 		if m.infoMode {
 			m.refreshInfoContent()
 		}
@@ -427,8 +428,9 @@ func (m Model) loadActiveProc() (Model, []tea.Cmd) {
 		m.searchQuery = ""
 		m.searchMatches = nil
 		m.searchCursor = 0
-		m.activeContent = ""
-		m.activeLineCount = 0
+		m.activeLines = nil
+		m.infoMode = false
+		m.mgr.SetMetricsEnabled(false)
 		m.keys.LazyDocker.SetEnabled(true)
 		m.keys.ProcViewer.SetEnabled(false)
 		m.viewport.SetContent(docker.RenderContainerStatusTable(m.containers, m.viewport.Width()))
@@ -438,15 +440,14 @@ func (m Model) loadActiveProc() (Model, []tea.Cmd) {
 		m.containers = nil
 		m.keys.LazyDocker.SetEnabled(false)
 		m.keys.ProcViewer.SetEnabled(true)
-		m.activeContent = m.buildContent()
-		if m.activeContent == "" {
-			m.activeLineCount = 0
+		if m.infoMode {
+			m.refreshInfoContent()
 		} else {
-			m.activeLineCount = strings.Count(m.activeContent, "\n") + 1
+			m.reloadActiveLines()
 		}
-		m.viewport.SetContent(m.activeContent)
 	}
 
+	// Scroll to bottom when switching processes if viewport was already at bottom
 	if m.viewportAtBottom {
 		m.viewport.GotoBottom()
 	}
@@ -457,42 +458,33 @@ func (m Model) loadActiveProc() (Model, []tea.Cmd) {
 	return m, cmds
 }
 
-// Joins the active process's output lines into a viewport content string
-func (m Model) buildContent() string {
+// Reloads activeLines from the process buffer and pushes to the viewport.
+func (m *Model) reloadActiveLines() {
 	p := m.activeProc()
 	if p == nil {
-		return ""
+		m.activeLines = nil
+	} else {
+		m.activeLines = p.Lines()
 	}
-	return strings.Join(p.Lines(), "\n")
+	m.viewport.SetContent(strings.Join(m.activeLines, "\n"))
 }
 
 // applyOutputDelta incrementally updates the viewport content using the
 // batch metadata in OutputMsg. Falls back to a full rebuild on eviction.
 func (m *Model) applyOutputDelta(msg process.OutputMsg) {
 	if msg.Evicted > 0 || len(msg.Added) == 0 {
-		m.activeContent = m.buildContent()
-		if m.activeContent == "" {
-			m.activeLineCount = 0
-		} else {
-			m.activeLineCount = strings.Count(m.activeContent, "\n") + 1
-		}
-		m.viewport.SetContent(m.activeContent)
+		m.reloadActiveLines()
 		if m.searchQuery != "" {
 			m.recomputeSearch()
 		}
 		return
 	}
 
-	if m.activeLineCount == 0 || m.activeContent == "" {
-		m.activeContent = strings.Join(msg.Added, "\n")
-	} else {
-		m.activeContent += "\n" + strings.Join(msg.Added, "\n")
-	}
-	m.activeLineCount += len(msg.Added)
-	m.viewport.SetContent(m.activeContent)
+	m.activeLines = append(m.activeLines, msg.Added...)
+	m.viewport.SetContent(strings.Join(m.activeLines, "\n"))
 
 	if m.searchQuery != "" {
-		startIdx := m.activeLineCount - len(msg.Added)
+		startIdx := len(m.activeLines) - len(msg.Added)
 		for i, line := range msg.Added {
 			m.updateSearchForLine(line, startIdx+i, false)
 		}
@@ -563,4 +555,13 @@ func (m *Model) sortServices() {
 		}
 	}
 	m.ensureSidebarCursorVisible()
+}
+
+func (m Model) hasPendingProc() bool {
+	for _, p := range m.services {
+		if p.Status() == process.StatusPending {
+			return true
+		}
+	}
+	return false
 }

--- a/tools/phrocs/internal/tui/app.go
+++ b/tools/phrocs/internal/tui/app.go
@@ -120,6 +120,9 @@ type Model struct {
 func New(mgr *process.Manager, cfg *config.Config, logger *log.Logger) Model {
 	keys := defaultKeyMap()
 
+	h := help.New()
+	h.Styles = helpStyles()
+
 	return Model{
 		mgr:              mgr,
 		services:         mgr.Procs(),
@@ -132,7 +135,7 @@ func New(mgr *process.Manager, cfg *config.Config, logger *log.Logger) Model {
 		hideHelp:         cfg.HideKeymapWindow,
 		procListWidth:    cfg.ProcListWidth,
 		keys:             keys,
-		help:             help.New(),
+		help:             h,
 		spinner:          spinner.New(spinner.WithSpinner(spinner.MiniDot)),
 		log:              logger,
 	}
@@ -168,7 +171,6 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case tea.BackgroundColorMsg:
 		m.isDark = msg.IsDark()
-		m.help.Styles = helpStyles(m.isDark)
 
 	case spinner.TickMsg:
 		var cmd tea.Cmd
@@ -367,7 +369,7 @@ func (m Model) applySize() Model {
 	// Reduce the viewport width to account for borders
 	vpW := ptyW - horizontalBorderCount
 	if m.isFullScreen() {
-		vpW = m.width - horizontalBorderCount
+		vpW = m.width
 	}
 
 	if !m.ready {

--- a/tools/phrocs/internal/tui/app_test.go
+++ b/tools/phrocs/internal/tui/app_test.go
@@ -547,7 +547,7 @@ func TestCopySelectedText_dockerUsesContainerLogs(t *testing.T) {
 
 func TestOutputMsg_activeProc(t *testing.T) {
 	m := readyModel(t, "backend")
-	// AppendLine puts the line into p.lines; OutputMsg triggers buildContent.
+	// AppendLine puts the line into p.lines; OutputMsg triggers applyOutputDelta.
 	p, _ := m.mgr.Get("backend")
 	p.AppendLine("hello world")
 	before := m.viewport.TotalLineCount()

--- a/tools/phrocs/internal/tui/copy.go
+++ b/tools/phrocs/internal/tui/copy.go
@@ -36,7 +36,7 @@ func (m *Model) applyCopyStyle() {
 			return copyModeStyle
 		}
 		if idx >= lo && idx <= hi {
-			return lipgloss.NewStyle().Background(colorDarkGrey)
+			return lipgloss.NewStyle().Background(colorBlack)
 		}
 		return lipgloss.NewStyle()
 	}

--- a/tools/phrocs/internal/tui/docker.go
+++ b/tools/phrocs/internal/tui/docker.go
@@ -92,16 +92,12 @@ func (m Model) renderContainerSidebar() string {
 			name = truncate(c.Service, innerW-3)
 			iconColor = docker.ContainerStateColor(c.State)
 		}
-		rows = append(rows, renderSidebarRow(icon, name, iconColor, i == m.containerCursor, 0, innerW, m.isDark))
+		rows = append(rows, renderSidebarRow(icon, name, iconColor, i == m.containerCursor, innerW, m.isDark))
 	}
 
 	for i := end - start; i < h; i++ {
 		rows = append(rows, procInactiveStyle.Width(innerW).Render(""))
 	}
 
-	style := borderStyle
-	if m.focusedPane == focusContainers {
-		style = borderFocusedStyle
-	}
-	return style.Height(h).Render(strings.Join(rows, "\n"))
+	return borderFor(m.isDark, m.focusedPane == focusContainers).Height(h).Render(strings.Join(rows, "\n"))
 }

--- a/tools/phrocs/internal/tui/keys.go
+++ b/tools/phrocs/internal/tui/keys.go
@@ -174,14 +174,9 @@ func (m Model) handleInfoKey(msg tea.KeyPressMsg, cmds []tea.Cmd) (Model, []tea.
 
 	case key.Matches(msg, m.keys.Info), msg.Code == tea.KeyEscape:
 		m.infoMode = false
+		m.mgr.SetMetricsEnabled(false)
 		if !m.isDockerMode() {
-			m.activeContent = m.buildContent()
-			if m.activeContent == "" {
-				m.activeLineCount = 0
-			} else {
-				m.activeLineCount = strings.Count(m.activeContent, "\n") + 1
-			}
-			m.viewport.SetContent(m.activeContent)
+			m.reloadActiveLines()
 			m.viewport.GotoBottom()
 			m.viewportAtBottom = true
 		}
@@ -368,6 +363,7 @@ func (m Model) handleNormalKey(msg tea.KeyPressMsg, cmds []tea.Cmd) (tea.Model, 
 
 	case key.Matches(msg, m.keys.Info):
 		m.infoMode = true
+		m.mgr.SetMetricsEnabled(true)
 		m.refreshInfoContent()
 		m.viewport.GotoTop()
 		m.dbg("info mode: enter")

--- a/tools/phrocs/internal/tui/keys.go
+++ b/tools/phrocs/internal/tui/keys.go
@@ -174,7 +174,7 @@ func (m Model) handleInfoKey(msg tea.KeyPressMsg, cmds []tea.Cmd) (Model, []tea.
 
 	case key.Matches(msg, m.keys.Info), msg.Code == tea.KeyEscape:
 		m.infoMode = false
-		m.mgr.SetMetricsEnabled(false)
+		m.disableAllMetrics()
 		if !m.isDockerMode() {
 			m.reloadActiveLines()
 			m.viewport.GotoBottom()
@@ -363,7 +363,7 @@ func (m Model) handleNormalKey(msg tea.KeyPressMsg, cmds []tea.Cmd) (tea.Model, 
 
 	case key.Matches(msg, m.keys.Info):
 		m.infoMode = true
-		m.mgr.SetMetricsEnabled(true)
+		m.toggleMetricsOnSelectedProc()
 		m.refreshInfoContent()
 		m.viewport.GotoTop()
 		m.dbg("info mode: enter")

--- a/tools/phrocs/internal/tui/render.go
+++ b/tools/phrocs/internal/tui/render.go
@@ -163,7 +163,7 @@ func (m *Model) ensureSidebarCursorVisible() {
 
 func (m Model) renderOutput() string {
 	content := lipgloss.JoinHorizontal(lipgloss.Top, m.viewportWithIndicator())
-	if m.copyMode || m.searchMode {
+	if m.isFullScreen() {
 		return content
 	}
 	return borderFor(m.isDark, m.focusedPane == focusOutput).Render(content)

--- a/tools/phrocs/internal/tui/render.go
+++ b/tools/phrocs/internal/tui/render.go
@@ -92,8 +92,7 @@ func (m Model) renderSidebar() string {
 		iconColor := statusIconColor(status)
 
 		name := truncate(p.Name, innerW-3)
-		cpuPct := p.CPUPercent()
-		rows = append(rows, renderSidebarRow(iconChar, name, iconColor, i == m.servicesCursor, cpuPct, innerW, m.isDark))
+		rows = append(rows, renderSidebarRow(iconChar, name, iconColor, i == m.servicesCursor, innerW, m.isDark))
 	}
 
 	if canScrollDown {
@@ -105,11 +104,7 @@ func (m Model) renderSidebar() string {
 		rows = append(rows, procInactiveStyle.Width(innerW).Render(""))
 	}
 
-	style := borderStyle
-	if m.focusedPane == focusServices {
-		style = borderFocusedStyle
-	}
-	return style.Height(h).Render(strings.Join(rows, "\n"))
+	return borderFor(m.isDark, m.focusedPane == focusServices).Height(h).Render(strings.Join(rows, "\n"))
 }
 
 func (m Model) sidebarHeight() int {
@@ -167,12 +162,11 @@ func (m *Model) ensureSidebarCursorVisible() {
 }
 
 func (m Model) renderOutput() string {
-	var style = borderStyle
-	if m.focusedPane == focusOutput {
-		style = borderFocusedStyle
-	}
 	content := lipgloss.JoinHorizontal(lipgloss.Top, m.viewportWithIndicator())
-	return style.Render(content)
+	if m.copyMode || m.searchMode {
+		return content
+	}
+	return borderFor(m.isDark, m.focusedPane == focusOutput).Render(content)
 }
 
 // Overlays a -line counter in the top-right corner of the viewport
@@ -281,8 +275,8 @@ func (m Model) renderInfo() string {
 	snap := p.Snapshot()
 
 	titleStyle := lipgloss.NewStyle().Bold(true).Foreground(colorYellow)
-	labelStyle := lipgloss.NewStyle().Foreground(colorGrey).Width(20)
-	valueStyle := lipgloss.NewStyle().Foreground(colorWhite)
+	labelStyle := lipgloss.NewStyle().Foreground(colorBrightBlack).Width(20)
+	valueStyle := lipgloss.NewStyle()
 
 	row := func(label, value string) string {
 		return labelStyle.Render(label) + valueStyle.Render(value)

--- a/tools/phrocs/internal/tui/styles.go
+++ b/tools/phrocs/internal/tui/styles.go
@@ -145,17 +145,12 @@ func statusIconColor(s process.Status) color.Color {
 	}
 }
 
-// Renders a single sidebar row with icon, name, and an htop-style CPU usage
-// bar as a background fill. cpuPct is the total CPU% for the process tree;
-// the filled portion scales to innerW (100% = full width).
-// Used by both the process sidebar and the container sidebar.
-// subtleBg returns a background/border color that provides gentle contrast
-// against the terminal's background in both light and dark themes.
+// Renders a single sidebar row with icon and name
 func subtleBg(isDark bool) color.Color {
 	if isDark {
-		return colorBrightBlack // ANSI 8: dark gray on dark bg
+		return colorBrightBlack
 	}
-	return colorBrightWhite // ANSI 7: light gray on light bg
+	return colorBrightWhite
 }
 
 // borderFor returns the border style with a foreground appropriate for the

--- a/tools/phrocs/internal/tui/styles.go
+++ b/tools/phrocs/internal/tui/styles.go
@@ -20,15 +20,17 @@ const (
 )
 
 var (
-	colorYellow   = sharedpalette.ColorYellow
-	colorBlue     = sharedpalette.ColorBlue
-	colorGrey     = sharedpalette.ColorGrey
-	colorDarkGrey = sharedpalette.ColorDarkGrey
-	colorGreen    = sharedpalette.ColorGreen
-	colorRed      = sharedpalette.ColorRed
-	colorWhite    = sharedpalette.ColorWhite
-	colorBlack    = sharedpalette.ColorBlack
-	colorMidGrey  = sharedpalette.ColorMidGrey
+	colorYellow      = sharedpalette.ColorYellow
+	colorBlue        = sharedpalette.ColorBlue
+	colorBrightWhite = sharedpalette.ColorBrightWhite
+	colorBrightBlack = sharedpalette.ColorBrightBlack
+	colorGreen       = sharedpalette.ColorGreen
+	colorRed         = sharedpalette.ColorRed
+	colorBlack       = sharedpalette.ColorBlack
+	brandYellow      = sharedpalette.BrandYellow
+	brandBlue        = sharedpalette.BrandBlue
+	brandRed         = sharedpalette.BrandRed
+	brandBlack       = sharedpalette.BrandBlack
 )
 
 // Outer width of the process list column (including border)
@@ -45,53 +47,44 @@ const horizontalBorderCount = 4
 var (
 	// Header
 	headerBrandStyle = lipgloss.NewStyle().
-				Foreground(colorWhite).
 				Bold(true).
 				Padding(0, 1)
 
 	headerMetaStyle = lipgloss.NewStyle().
-			Foreground(colorGrey).
+			Foreground(colorBrightBlack).
 			Padding(0, 1)
 
 	stripesStyle = lipgloss.NewStyle().
 			PaddingLeft(1).
 			Render(
-			lipgloss.NewStyle().Background(colorBlue).Render(" ") +
-				lipgloss.NewStyle().Background(colorYellow).Render(" ") +
-				lipgloss.NewStyle().Background(colorRed).Render(" ") +
-				lipgloss.NewStyle().Background(colorBlack).Render(" "),
+			lipgloss.NewStyle().Background(brandBlue).Render(" ") +
+				lipgloss.NewStyle().Background(brandYellow).Render(" ") +
+				lipgloss.NewStyle().Background(brandRed).Render(" ") +
+				lipgloss.NewStyle().Background(brandBlack).Render(" "),
 		)
 
 	labelStyle = lipgloss.NewStyle().
-			Foreground(colorWhite).
 			Bold(true)
 
-	// Borders
-	borderStyle = lipgloss.NewStyle().
+	// Borders — foreground is set dynamically via borderFor()
+	baseBorderStyle = lipgloss.NewStyle().
 			BorderRight(true).
 			BorderTop(true).
 			BorderBottom(true).
 			BorderLeft(true).
-			BorderStyle(lipgloss.NormalBorder()).
-			BorderForeground(colorDarkGrey)
-
-	borderFocusedStyle = borderStyle.
-				BorderStyle(lipgloss.ThickBorder()).
-				BorderForeground(colorMidGrey)
+			BorderStyle(lipgloss.NormalBorder())
 
 	// Sidebar
 	procInactiveStyle = lipgloss.NewStyle().
-				PaddingLeft(1).
-				Foreground(colorGrey)
+				PaddingLeft(1)
 
 	scrollArrowStyle = lipgloss.NewStyle().
 				PaddingLeft(1).
-				Foreground(colorGrey).
+				Foreground(colorBrightBlack).
 				Align(lipgloss.Center)
 
 	// Footer
 	footerStyle = lipgloss.NewStyle().
-			Foreground(colorGrey).
 			PaddingLeft(1)
 
 	// Scroll position indicator (floating top-right of output pane)
@@ -103,11 +96,11 @@ var (
 	// Copy mode
 	copyModeStyle = lipgloss.NewStyle().
 			Background(colorBlue).
-			Foreground(colorWhite)
+			Foreground(colorBlack)
 
 	// Search mode
 	searchMatchStyle = lipgloss.NewStyle().
-				Background(colorDarkGrey)
+				Background(colorBrightBlack)
 
 	searchCurrentMatchStyle = lipgloss.NewStyle().
 				Background(colorYellow).
@@ -117,7 +110,7 @@ var (
 	warnStyle = lipgloss.NewStyle().
 			Bold(true).
 			Foreground(colorYellow).
-			Background(sharedpalette.ColorBarMid)
+			Background(colorBrightBlack)
 )
 
 func statusIconChar(s process.Status) string {
@@ -144,7 +137,7 @@ func statusIconColor(s process.Status) color.Color {
 	case process.StatusPending:
 		return colorYellow
 	case process.StatusStopped, process.StatusDone:
-		return colorGrey
+		return nil
 	case process.StatusCrashed:
 		return colorRed
 	default:
@@ -152,114 +145,50 @@ func statusIconColor(s process.Status) color.Color {
 	}
 }
 
-// cpuBarColor returns a background tint based on CPU usage percentage.
-func cpuBarColor(cpuPct float64, isDark bool) color.Color {
-	if isDark {
-		switch {
-		case cpuPct >= 150:
-			return sharedpalette.ColorBarHigh
-		case cpuPct >= 50:
-			return sharedpalette.ColorBarMid
-		default:
-			return sharedpalette.ColorBarLow
-		}
-	}
-	switch {
-	case cpuPct >= 150:
-		return sharedpalette.ColorBarHighLight
-	case cpuPct >= 50:
-		return sharedpalette.ColorBarMidLight
-	default:
-		return sharedpalette.ColorBarLowLight
-	}
-}
-
 // Renders a single sidebar row with icon, name, and an htop-style CPU usage
 // bar as a background fill. cpuPct is the total CPU% for the process tree;
 // the filled portion scales to innerW (100% = full width).
 // Used by both the process sidebar and the container sidebar.
-func renderSidebarRow(icon, name string, iconColor color.Color, selected bool, cpuPct float64, innerW int, isDark bool) string {
-	// How many columns the bar fills (cap at innerW)
-	barW := 0
-	if cpuPct > 0 {
-		barW = int(cpuPct / 100.0 * float64(innerW))
-		barW = max(min(barW, innerW), 1)
+// subtleBg returns a background/border color that provides gentle contrast
+// against the terminal's background in both light and dark themes.
+func subtleBg(isDark bool) color.Color {
+	if isDark {
+		return colorBrightBlack // ANSI 8: dark gray on dark bg
 	}
-
-	barBg := cpuBarColor(cpuPct, isDark)
-	nameW := max(innerW-2, 0) // 1 padding + 1 icon
-
-	// Pick background for each segment based on whether it falls within the bar
-	bgFor := func(col int) color.Color {
-		if selected {
-			if barW > 0 && col < barW {
-				return barBg
-			}
-			return colorDarkGrey
-		}
-		if barW > 0 && col < barW {
-			return barBg
-		}
-		return nil
-	}
-
-	textColor := colorGrey
-	if selected {
-		textColor = colorWhite
-	}
-
-	// Icon occupies columns 0 (padding) and 1 (icon char)
-	iconBg := bgFor(0)
-	iconStyle := lipgloss.NewStyle().PaddingLeft(1).Foreground(iconColor)
-	if selected {
-		iconStyle = iconStyle.Bold(true)
-	}
-	if iconBg != nil {
-		iconStyle = iconStyle.Background(iconBg)
-	}
-	iconSeg := iconStyle.Render(icon)
-
-	// Name starts at column 2 and spans nameW columns
-	// Split into filled and unfilled portions based on barW
-	nameContent := " " + name
-	nameRunes := []rune(nameContent)
-	for len(nameRunes) < nameW {
-		nameRunes = append(nameRunes, ' ')
-	}
-	if len(nameRunes) > nameW {
-		nameRunes = nameRunes[:nameW]
-	}
-
-	// The name starts at column 2, so the bar covers columns 2..barW-1
-	nameFillW := max(min(barW-2, nameW), 0)
-
-	filledPart := ""
-	if nameFillW > 0 {
-		s := lipgloss.NewStyle().Foreground(textColor).Background(barBg)
-		if selected {
-			s = s.Bold(true)
-		}
-		filledPart = s.Render(string(nameRunes[:nameFillW]))
-	}
-
-	unfilledRunes := nameRunes[nameFillW:]
-	unfilledStyle := lipgloss.NewStyle().Foreground(textColor)
-	if selected {
-		unfilledStyle = unfilledStyle.Bold(true).Background(colorDarkGrey)
-	}
-	// Pad remaining width so the background extends to the edge
-	unfilledStyle = unfilledStyle.Width(nameW - nameFillW)
-	unfilledPart := unfilledStyle.Render(string(unfilledRunes))
-
-	return iconSeg + filledPart + unfilledPart
+	return colorBrightWhite // ANSI 7: light gray on light bg
 }
 
-func helpStyles(isDark bool) help.Styles {
-	lightDark := lipgloss.LightDark(isDark)
+// borderFor returns the border style with a foreground appropriate for the
+// current terminal background.
+func borderFor(isDark, focused bool) lipgloss.Style {
+	s := baseBorderStyle.BorderForeground(subtleBg(isDark))
+	if focused {
+		s = s.BorderStyle(lipgloss.ThickBorder())
+	}
+	return s
+}
 
-	keyStyle := lipgloss.NewStyle().Foreground(lightDark(lipgloss.Color("#555555"), colorGrey))
-	descStyle := lipgloss.NewStyle().Foreground(lightDark(lipgloss.Color("#777777"), colorMidGrey))
-	sepStyle := lipgloss.NewStyle().Foreground(lightDark(lipgloss.Color("#AAAAAA"), colorDarkGrey))
+func renderSidebarRow(icon, name string, iconColor color.Color, selected bool, innerW int, isDark bool) string {
+	nameW := max(innerW-2, 0) // 1 padding + 1 icon
+	selBg := subtleBg(isDark)
+
+	iconStyle := lipgloss.NewStyle().PaddingLeft(1).Foreground(iconColor)
+	if selected {
+		iconStyle = iconStyle.Bold(true).Background(selBg)
+	}
+
+	nameStyle := lipgloss.NewStyle().Width(nameW)
+	if selected {
+		nameStyle = nameStyle.Bold(true).Background(selBg)
+	}
+
+	return iconStyle.Render(icon) + nameStyle.Render(" "+name)
+}
+
+func helpStyles() help.Styles {
+	keyStyle := lipgloss.NewStyle()
+	descStyle := lipgloss.NewStyle().Foreground(colorBrightBlack)
+	sepStyle := lipgloss.NewStyle().Foreground(colorBrightBlack)
 
 	return help.Styles{
 		ShortKey:       keyStyle,


### PR DESCRIPTION
## Problem

phrocs had several usability and performance issues:
- Hardcoded hex colors looked broken on light terminal themes
- CPU usage was ~60% (vs mprocs at 0.6%) due to expensive process tree scanning and excessive render frequency    
- Copy mode included border characters in copied text
- Info view didn't persist when switching processes
- Quit caused a ~10s terminal freeze

## Changes           

**ANSI terminal colors**: replaced hardcoded hex colors with ANSI 4-bit palette (0–15) so the UI automatically adapts to the user's terminal theme. Brand colors for the header stripes remain as fixed hex.  
     
**CPU usage (~60% → ~3%)**:   
- `collectProcessTree` called gopsutil's `Children()` per node, which scans the *entire system process table* each time. Replaced with a single `Processes()` call + BFS over a parent→children map  
- Metrics sampling now only runs when info view is active (gated by `atomic.Bool`)       
- `Snapshot()` samples metrics on demand instead of relying solely on the background ticker         
- Flush ticker converted from a constant 16ms `time.Ticker` to a one-shot timer that only fires when data arrives — idle processes have zero timer overhead
- Quit runs `StopAll()` in a goroutine so `tea.Quit` returns immediately

**Copy mode**: removed borders and padding in copy/search full-screen modes so terminal text selection doesn't include edge characters.     

**Info view**: persists when switching processes (refreshes for the new process), exits when navigating to a docker-compose process.

| Dark | Light |
|---|---|
|<img width="970" height="704" alt="Screenshot 2026-03-31 at 1 49 11 PM" src="https://github.com/user-attachments/assets/1ccdd6da-6e4b-4913-83c2-81528c3f2883" />|<img width="974" height="710" alt="Screenshot 2026-03-31 at 1 50 17 PM" src="https://github.com/user-attachments/assets/bbcbae1f-cda1-45c2-aa85-e10f8c66311e" />|

## How did you test this code?      

All existing Go tests pass (`go test ./...`). Manually verified:   
- ANSI colors render correctly on dark and light terminal themes
- CPU usage stays at ~3% baseline with 15+ processes
- Copy mode produces clean text without border artifacts           
- Info view updates when switching processes        
- Quit is instant             
     
👉 _Stay up-to-date with [PostHog coding            
conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother
review._       
     
## Publish to changelog?

no

## 🤖 LLM context

Co-authored with Claude Code. Session covered iterative debugging of CPU hotspots using  
Activity Monitor profiling, ANSI color theory for terminal theme adaptation, and
incremental refactoring of the flush/metrics pipeline. 