### PR TITLE
fix(flags): address PR feedback on realtime cohort flag targeting

### DIFF
--- a/posthog/api/cohort.py
+++ b/posthog/api/cohort.py
@@ -1089,6 +1089,7 @@ class CohortViewSet(TeamAndOrgViewSetMixin, ForbidDestroyModel, viewsets.ModelVi
             # When realtime cohort flag targeting is enabled, realtime cohorts that have been
             # backfilled are allowed through.
             if self.request.query_params.get("hide_behavioral_cohorts", "false").lower() == "true":
+                # Avoid circular import: feature_flag imports cohort models
                 from posthog.api.feature_flag import _is_realtime_cohort_flag_targeting_enabled
 
                 allow_realtime_backfilled = _is_realtime_cohort_flag_targeting_enabled(self.request)

--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -5,6 +5,7 @@ import json
 import math
 import time
 import logging
+import functools
 from datetime import datetime
 from typing import Any, Optional, cast
 
@@ -808,16 +809,14 @@ class FeatureFlagSerializer(
             is_create=self.instance is None,
         )
 
-    @property
+    @functools.cached_property
     def _allow_realtime_backfilled(self) -> bool:
         """Lazily check whether realtime cohort flag targeting is enabled.
 
         This avoids a potentially expensive feature_enabled() call for flags that don't
         reference any cohort properties.
         """
-        if not hasattr(self, "_allow_realtime_backfilled_cache"):
-            self._allow_realtime_backfilled_cache = _is_realtime_cohort_flag_targeting_enabled(self.context["request"])
-        return self._allow_realtime_backfilled_cache
+        return _is_realtime_cohort_flag_targeting_enabled(self.context["request"])
 
     def validate_filters(self, filters):
         # For some weird internal REST framework reason this field gets validated on a partial PATCH call, even if filters isn't being updatd

--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -815,9 +815,9 @@ class FeatureFlagSerializer(
         This avoids a potentially expensive feature_enabled() call for flags that don't
         reference any cohort properties.
         """
-        if not hasattr(self, "__allow_realtime_backfilled"):
-            self.__allow_realtime_backfilled = _is_realtime_cohort_flag_targeting_enabled(self.context["request"])
-        return self.__allow_realtime_backfilled
+        if not hasattr(self, "_allow_realtime_backfilled_cache"):
+            self._allow_realtime_backfilled_cache = _is_realtime_cohort_flag_targeting_enabled(self.context["request"])
+        return self._allow_realtime_backfilled_cache
 
     def validate_filters(self, filters):
         # For some weird internal REST framework reason this field gets validated on a partial PATCH call, even if filters isn't being updatd

--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -808,6 +808,17 @@ class FeatureFlagSerializer(
             is_create=self.instance is None,
         )
 
+    @property
+    def _allow_realtime_backfilled(self) -> bool:
+        """Lazily check whether realtime cohort flag targeting is enabled.
+
+        This avoids a potentially expensive feature_enabled() call for flags that don't
+        reference any cohort properties.
+        """
+        if not hasattr(self, "__allow_realtime_backfilled"):
+            self.__allow_realtime_backfilled = _is_realtime_cohort_flag_targeting_enabled(self.context["request"])
+        return self.__allow_realtime_backfilled
+
     def validate_filters(self, filters):
         # For some weird internal REST framework reason this field gets validated on a partial PATCH call, even if filters isn't being updatd
         # If we see this, just return the current filters
@@ -949,8 +960,6 @@ class FeatureFlagSerializer(
                     "Invalid variant definitions: Variant rollout percentages must sum to 100.",
                     code="invalid_input",
                 )
-
-        self._allow_realtime_backfilled = _is_realtime_cohort_flag_targeting_enabled(self.context["request"])
 
         for condition in filters["groups"]:
             if condition.get("variant") and condition["variant"] not in variants:
@@ -1247,7 +1256,7 @@ class FeatureFlagSerializer(
                 temporary_flag,
                 team_id,
                 project_id,
-                allow_realtime_backfilled=getattr(self, "_allow_realtime_backfilled", False),
+                allow_realtime_backfilled=self._allow_realtime_backfilled,
             )
         except Exception:
             raise serializers.ValidationError("Can't evaluate flag - please check release conditions")

--- a/posthog/api/test/test_cohort.py
+++ b/posthog/api/test/test_cohort.py
@@ -1535,6 +1535,63 @@ email@example.org,
         else:
             self.assertNotIn(behavioral_cohort.id, result_ids)
 
+    @patch("posthog.api.feature_flag._is_realtime_cohort_flag_targeting_enabled")
+    @patch("posthog.api.cohort.report_user_action")
+    def test_nested_cohort_with_flag_compatible_leaf_visible_when_flag_on(
+        self,
+        patch_capture,
+        mock_flag,
+    ):
+        """A non-behavioral parent cohort that references a realtime+backfilled behavioral
+        leaf cohort should appear in the dropdown when the feature flag is enabled, because the
+        leaf is removed from affected_cohorts before graph propagation."""
+        mock_flag.return_value = True
+
+        # Leaf: realtime+backfilled behavioral cohort
+        leaf_cohort = Cohort.objects.create(
+            team=self.team,
+            name="behavioral leaf",
+            filters={
+                "properties": {
+                    "type": "OR",
+                    "values": [
+                        {
+                            "type": "behavioral",
+                            "key": "$pageview",
+                            "value": "performed_event",
+                            "event_type": "events",
+                            "time_value": 30,
+                            "time_interval": "day",
+                        }
+                    ],
+                }
+            },
+            cohort_type=CohortType.REALTIME,
+            last_backfill_person_properties_at=datetime.now(),
+        )
+
+        # Parent: non-behavioral cohort that references the leaf
+        parent_cohort = Cohort.objects.create(
+            team=self.team,
+            name="parent referencing behavioral leaf",
+            filters={
+                "properties": {
+                    "type": "OR",
+                    "values": [
+                        {"type": "cohort", "key": "id", "value": leaf_cohort.pk},
+                    ],
+                }
+            },
+        )
+
+        response = self.client.get(f"/api/projects/{self.team.id}/cohorts?hide_behavioral_cohorts=true")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        result_ids = {r["id"] for r in response.json()["results"]}
+
+        # Both should appear: the leaf is flag-compatible, so neither it nor its parent is affected
+        self.assertIn(leaf_cohort.id, result_ids)
+        self.assertIn(parent_cohort.id, result_ids)
+
     @patch("django.db.transaction.on_commit", side_effect=lambda func: func())
     def test_cohort_activity_log(self, patch_on_commit):
         self.team.app_urls = ["http://somewebsite.com"]

--- a/posthog/models/feature_flag/test/test_flag_validation.py
+++ b/posthog/models/feature_flag/test/test_flag_validation.py
@@ -1,0 +1,176 @@
+from datetime import datetime
+
+from posthog.test.base import APIBaseTest
+
+from posthog.models.cohort import Cohort
+from posthog.models.cohort.cohort import CohortType
+from posthog.models.feature_flag.flag_validation import _exclude_realtime_backfilled_cohort_properties
+from posthog.models.property.property import Property
+
+
+class TestExcludeRealtimeBackfilledCohortProperties(APIBaseTest):
+    def _make_cohort_property(self, cohort_id: int) -> Property:
+        return Property(type="cohort", key="id", value=cohort_id)
+
+    def _make_person_property(self) -> Property:
+        return Property(type="person", key="email", value="test@posthog.com")
+
+    def test_returns_unchanged_when_disabled(self):
+        cohort = Cohort.objects.create(
+            team=self.team,
+            name="realtime-backfilled",
+            filters={
+                "properties": {
+                    "type": "OR",
+                    "values": [
+                        {
+                            "type": "behavioral",
+                            "key": "$pageview",
+                            "value": "performed_event",
+                            "event_type": "events",
+                            "time_value": 30,
+                            "time_interval": "day",
+                        }
+                    ],
+                }
+            },
+            cohort_type=CohortType.REALTIME,
+            last_backfill_person_properties_at=datetime.now(),
+        )
+        props = [self._make_cohort_property(cohort.pk), self._make_person_property()]
+
+        result = _exclude_realtime_backfilled_cohort_properties(
+            props, self.team.project.id, allow_realtime_backfilled=False
+        )
+        assert result == props
+
+    def test_filters_out_flag_compatible_cohort(self):
+        cohort = Cohort.objects.create(
+            team=self.team,
+            name="realtime-backfilled",
+            filters={
+                "properties": {
+                    "type": "OR",
+                    "values": [
+                        {
+                            "type": "behavioral",
+                            "key": "$pageview",
+                            "value": "performed_event",
+                            "event_type": "events",
+                            "time_value": 30,
+                            "time_interval": "day",
+                        }
+                    ],
+                }
+            },
+            cohort_type=CohortType.REALTIME,
+            last_backfill_person_properties_at=datetime.now(),
+        )
+        person_prop = self._make_person_property()
+        props = [self._make_cohort_property(cohort.pk), person_prop]
+
+        result = _exclude_realtime_backfilled_cohort_properties(
+            props, self.team.project.id, allow_realtime_backfilled=True
+        )
+        assert result == [person_prop]
+
+    def test_keeps_non_backfilled_realtime_cohort(self):
+        cohort = Cohort.objects.create(
+            team=self.team,
+            name="realtime-not-backfilled",
+            filters={
+                "properties": {
+                    "type": "OR",
+                    "values": [
+                        {
+                            "type": "behavioral",
+                            "key": "$pageview",
+                            "value": "performed_event",
+                            "event_type": "events",
+                            "time_value": 30,
+                            "time_interval": "day",
+                        }
+                    ],
+                }
+            },
+            cohort_type=CohortType.REALTIME,
+            last_backfill_person_properties_at=None,
+        )
+        props = [self._make_cohort_property(cohort.pk), self._make_person_property()]
+
+        result = _exclude_realtime_backfilled_cohort_properties(
+            props, self.team.project.id, allow_realtime_backfilled=True
+        )
+        assert result == props
+
+    def test_keeps_non_realtime_behavioral_cohort(self):
+        cohort = Cohort.objects.create(
+            team=self.team,
+            name="dynamic-behavioral",
+            filters={
+                "properties": {
+                    "type": "OR",
+                    "values": [
+                        {
+                            "type": "behavioral",
+                            "key": "$pageview",
+                            "value": "performed_event",
+                            "event_type": "events",
+                            "time_value": 30,
+                            "time_interval": "day",
+                        }
+                    ],
+                }
+            },
+        )
+        props = [self._make_cohort_property(cohort.pk)]
+
+        result = _exclude_realtime_backfilled_cohort_properties(
+            props, self.team.project.id, allow_realtime_backfilled=True
+        )
+        assert result == props
+
+    def test_keeps_non_cohort_properties_untouched(self):
+        person_prop = self._make_person_property()
+        result = _exclude_realtime_backfilled_cohort_properties(
+            [person_prop], self.team.project.id, allow_realtime_backfilled=True
+        )
+        assert result == [person_prop]
+
+    def test_handles_nonexistent_cohort_gracefully(self):
+        props = [self._make_cohort_property(99999)]
+        result = _exclude_realtime_backfilled_cohort_properties(
+            props, self.team.project.id, allow_realtime_backfilled=True
+        )
+        assert result == props
+
+    def test_handles_deleted_cohort(self):
+        cohort = Cohort.objects.create(
+            team=self.team,
+            name="deleted-cohort",
+            filters={
+                "properties": {
+                    "type": "OR",
+                    "values": [
+                        {
+                            "type": "behavioral",
+                            "key": "$pageview",
+                            "value": "performed_event",
+                            "event_type": "events",
+                            "time_value": 30,
+                            "time_interval": "day",
+                        }
+                    ],
+                }
+            },
+            cohort_type=CohortType.REALTIME,
+            last_backfill_person_properties_at=datetime.now(),
+            deleted=True,
+        )
+        props = [self._make_cohort_property(cohort.pk)]
+
+        result = _exclude_realtime_backfilled_cohort_properties(
+            props, self.team.project.id, allow_realtime_backfilled=True
+        )
+        # Deleted cohorts aren't found by the query (deleted=False), so they're kept
+        assert result == props

--- a/posthog/models/feature_flag/test/test_flag_validation.py
+++ b/posthog/models/feature_flag/test/test_flag_validation.py
@@ -2,10 +2,28 @@ from datetime import datetime
 
 from posthog.test.base import APIBaseTest
 
+from parameterized import parameterized
+
 from posthog.models.cohort import Cohort
 from posthog.models.cohort.cohort import CohortType
 from posthog.models.feature_flag.flag_validation import _exclude_realtime_backfilled_cohort_properties
 from posthog.models.property.property import Property
+
+BEHAVIORAL_FILTERS = {
+    "properties": {
+        "type": "OR",
+        "values": [
+            {
+                "type": "behavioral",
+                "key": "$pageview",
+                "value": "performed_event",
+                "event_type": "events",
+                "time_value": 30,
+                "time_interval": "day",
+            }
+        ],
+    }
+}
 
 
 class TestExcludeRealtimeBackfilledCohortProperties(APIBaseTest):
@@ -15,120 +33,53 @@ class TestExcludeRealtimeBackfilledCohortProperties(APIBaseTest):
     def _make_person_property(self) -> Property:
         return Property(type="person", key="email", value="test@posthog.com")
 
-    def test_returns_unchanged_when_disabled(self):
+    @parameterized.expand(
+        [
+            # (name, cohort_kwargs, allow_realtime_backfilled, expect_cohort_filtered)
+            (
+                "disabled_flag_keeps_all",
+                {"cohort_type": CohortType.REALTIME, "last_backfill_person_properties_at": datetime.now()},
+                False,
+                False,
+            ),
+            (
+                "enabled_realtime_backfilled_filtered",
+                {"cohort_type": CohortType.REALTIME, "last_backfill_person_properties_at": datetime.now()},
+                True,
+                True,
+            ),
+            (
+                "enabled_realtime_not_backfilled_kept",
+                {"cohort_type": CohortType.REALTIME, "last_backfill_person_properties_at": None},
+                True,
+                False,
+            ),
+            (
+                "enabled_non_realtime_kept",
+                {},
+                True,
+                False,
+            ),
+        ]
+    )
+    def test_cohort_filtering(self, _name, cohort_kwargs, allow_realtime_backfilled, expect_cohort_filtered):
         cohort = Cohort.objects.create(
             team=self.team,
-            name="realtime-backfilled",
-            filters={
-                "properties": {
-                    "type": "OR",
-                    "values": [
-                        {
-                            "type": "behavioral",
-                            "key": "$pageview",
-                            "value": "performed_event",
-                            "event_type": "events",
-                            "time_value": 30,
-                            "time_interval": "day",
-                        }
-                    ],
-                }
-            },
-            cohort_type=CohortType.REALTIME,
-            last_backfill_person_properties_at=datetime.now(),
-        )
-        props = [self._make_cohort_property(cohort.pk), self._make_person_property()]
-
-        result = _exclude_realtime_backfilled_cohort_properties(
-            props, self.team.project.id, allow_realtime_backfilled=False
-        )
-        assert result == props
-
-    def test_filters_out_flag_compatible_cohort(self):
-        cohort = Cohort.objects.create(
-            team=self.team,
-            name="realtime-backfilled",
-            filters={
-                "properties": {
-                    "type": "OR",
-                    "values": [
-                        {
-                            "type": "behavioral",
-                            "key": "$pageview",
-                            "value": "performed_event",
-                            "event_type": "events",
-                            "time_value": 30,
-                            "time_interval": "day",
-                        }
-                    ],
-                }
-            },
-            cohort_type=CohortType.REALTIME,
-            last_backfill_person_properties_at=datetime.now(),
+            name="test-cohort",
+            filters=BEHAVIORAL_FILTERS,
+            **cohort_kwargs,
         )
         person_prop = self._make_person_property()
         props = [self._make_cohort_property(cohort.pk), person_prop]
 
         result = _exclude_realtime_backfilled_cohort_properties(
-            props, self.team.project.id, allow_realtime_backfilled=True
+            props, self.team.project.id, allow_realtime_backfilled=allow_realtime_backfilled
         )
-        assert result == [person_prop]
 
-    def test_keeps_non_backfilled_realtime_cohort(self):
-        cohort = Cohort.objects.create(
-            team=self.team,
-            name="realtime-not-backfilled",
-            filters={
-                "properties": {
-                    "type": "OR",
-                    "values": [
-                        {
-                            "type": "behavioral",
-                            "key": "$pageview",
-                            "value": "performed_event",
-                            "event_type": "events",
-                            "time_value": 30,
-                            "time_interval": "day",
-                        }
-                    ],
-                }
-            },
-            cohort_type=CohortType.REALTIME,
-            last_backfill_person_properties_at=None,
-        )
-        props = [self._make_cohort_property(cohort.pk), self._make_person_property()]
-
-        result = _exclude_realtime_backfilled_cohort_properties(
-            props, self.team.project.id, allow_realtime_backfilled=True
-        )
-        assert result == props
-
-    def test_keeps_non_realtime_behavioral_cohort(self):
-        cohort = Cohort.objects.create(
-            team=self.team,
-            name="dynamic-behavioral",
-            filters={
-                "properties": {
-                    "type": "OR",
-                    "values": [
-                        {
-                            "type": "behavioral",
-                            "key": "$pageview",
-                            "value": "performed_event",
-                            "event_type": "events",
-                            "time_value": 30,
-                            "time_interval": "day",
-                        }
-                    ],
-                }
-            },
-        )
-        props = [self._make_cohort_property(cohort.pk)]
-
-        result = _exclude_realtime_backfilled_cohort_properties(
-            props, self.team.project.id, allow_realtime_backfilled=True
-        )
-        assert result == props
+        if expect_cohort_filtered:
+            assert result == [person_prop]
+        else:
+            assert result == props
 
     def test_keeps_non_cohort_properties_untouched(self):
         person_prop = self._make_person_property()
@@ -148,21 +99,7 @@ class TestExcludeRealtimeBackfilledCohortProperties(APIBaseTest):
         cohort = Cohort.objects.create(
             team=self.team,
             name="deleted-cohort",
-            filters={
-                "properties": {
-                    "type": "OR",
-                    "values": [
-                        {
-                            "type": "behavioral",
-                            "key": "$pageview",
-                            "value": "performed_event",
-                            "event_type": "events",
-                            "time_value": 30,
-                            "time_interval": "day",
-                        }
-                    ],
-                }
-            },
+            filters=BEHAVIORAL_FILTERS,
             cohort_type=CohortType.REALTIME,
             last_backfill_person_properties_at=datetime.now(),
             deleted=True,

--- a/posthog/tasks/test/__snapshots__/test_process_scheduled_changes.ambr
+++ b/posthog/tasks/test/__snapshots__/test_process_scheduled_changes.ambr
@@ -40,28 +40,6 @@
 # ---
 # name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.10
   '''
-  SELECT "posthog_filesystem"."team_id",
-         "posthog_filesystem"."id",
-         "posthog_filesystem"."path",
-         "posthog_filesystem"."depth",
-         "posthog_filesystem"."type",
-         "posthog_filesystem"."ref",
-         "posthog_filesystem"."href",
-         "posthog_filesystem"."shortcut",
-         "posthog_filesystem"."meta",
-         "posthog_filesystem"."created_at",
-         "posthog_filesystem"."created_by_id",
-         "posthog_filesystem"."project_id"
-  FROM "posthog_filesystem"
-  WHERE ("posthog_filesystem"."ref" = '0001'
-         AND "posthog_filesystem"."team_id" = 99999
-         AND "posthog_filesystem"."type" = 'feature_flag'
-         AND NOT ("posthog_filesystem"."shortcut"
-                  AND "posthog_filesystem"."shortcut" IS NOT NULL))
-  '''
-# ---
-# name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.11
-  '''
   SELECT "posthog_filesystemshortcut"."id",
          "posthog_filesystemshortcut"."team_id",
          "posthog_filesystemshortcut"."user_id",
@@ -79,7 +57,7 @@
                   AND "posthog_filesystemshortcut"."href" IS NOT NULL))
   '''
 # ---
-# name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.12
+# name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.11
   '''
   SELECT "posthog_integration"."id",
          "posthog_integration"."team_id",
@@ -96,7 +74,7 @@
   LIMIT 21
   '''
 # ---
-# name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.13
+# name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.12
   '''
   SELECT "posthog_organization"."id",
          "posthog_organization"."name",
@@ -133,7 +111,7 @@
   LIMIT 21
   '''
 # ---
-# name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.14
+# name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.13
   '''
   SELECT "posthog_organizationintegration"."id",
          "posthog_organizationintegration"."organization_id",
@@ -150,6 +128,16 @@
   LIMIT 21
   '''
 # ---
+# name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.14
+  '''
+  SELECT "posthog_featureflagevaluationcontext"."id",
+         "posthog_featureflagevaluationcontext"."feature_flag_id",
+         "posthog_featureflagevaluationcontext"."evaluation_context_id",
+         "posthog_featureflagevaluationcontext"."created_at"
+  FROM "posthog_featureflagevaluationcontext"
+  WHERE "posthog_featureflagevaluationcontext"."feature_flag_id" = 99999
+  '''
+# ---
 # name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.15
   '''
   SELECT "posthog_featureflagevaluationcontext"."id",
@@ -162,12 +150,18 @@
 # ---
 # name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.16
   '''
-  SELECT "posthog_featureflagevaluationcontext"."id",
-         "posthog_featureflagevaluationcontext"."feature_flag_id",
-         "posthog_featureflagevaluationcontext"."evaluation_context_id",
-         "posthog_featureflagevaluationcontext"."created_at"
-  FROM "posthog_featureflagevaluationcontext"
-  WHERE "posthog_featureflagevaluationcontext"."feature_flag_id" = 99999
+  SELECT "posthog_taggeditem"."id",
+         "posthog_taggeditem"."tag_id",
+         "posthog_taggeditem"."dashboard_id",
+         "posthog_taggeditem"."insight_id",
+         "posthog_taggeditem"."event_definition_id",
+         "posthog_taggeditem"."property_definition_id",
+         "posthog_taggeditem"."action_id",
+         "posthog_taggeditem"."feature_flag_id",
+         "posthog_taggeditem"."experiment_saved_metric_id",
+         "posthog_taggeditem"."ticket_id"
+  FROM "posthog_taggeditem"
+  WHERE "posthog_taggeditem"."feature_flag_id" = 99999
   '''
 # ---
 # name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.17
@@ -188,18 +182,46 @@
 # ---
 # name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.18
   '''
-  SELECT "posthog_taggeditem"."id",
-         "posthog_taggeditem"."tag_id",
-         "posthog_taggeditem"."dashboard_id",
-         "posthog_taggeditem"."insight_id",
-         "posthog_taggeditem"."event_definition_id",
-         "posthog_taggeditem"."property_definition_id",
-         "posthog_taggeditem"."action_id",
-         "posthog_taggeditem"."feature_flag_id",
-         "posthog_taggeditem"."experiment_saved_metric_id",
-         "posthog_taggeditem"."ticket_id"
-  FROM "posthog_taggeditem"
-  WHERE "posthog_taggeditem"."feature_flag_id" = 99999
+  SELECT "posthog_survey"."id",
+         "posthog_survey"."team_id",
+         "posthog_survey"."name",
+         "posthog_survey"."description",
+         "posthog_survey"."linked_flag_id",
+         "posthog_survey"."targeting_flag_id",
+         "posthog_survey"."linked_insight_id",
+         "posthog_survey"."internal_targeting_flag_id",
+         "posthog_survey"."internal_response_sampling_flag_id",
+         "posthog_survey"."type",
+         "posthog_survey"."conditions",
+         "posthog_survey"."questions",
+         "posthog_survey"."appearance",
+         "posthog_survey"."created_at",
+         "posthog_survey"."created_by_id",
+         "posthog_survey"."start_date",
+         "posthog_survey"."end_date",
+         "posthog_survey"."updated_at",
+         "posthog_survey"."archived",
+         "posthog_survey"."responses_limit",
+         "posthog_survey"."response_sampling_start_date",
+         "posthog_survey"."response_sampling_interval_type",
+         "posthog_survey"."response_sampling_interval",
+         "posthog_survey"."response_sampling_limit",
+         "posthog_survey"."response_sampling_daily_limits",
+         "posthog_survey"."iteration_count",
+         "posthog_survey"."iteration_frequency_days",
+         "posthog_survey"."iteration_start_dates",
+         "posthog_survey"."current_iteration",
+         "posthog_survey"."current_iteration_start_date",
+         "posthog_survey"."schedule",
+         "posthog_survey"."enable_partial_responses",
+         "posthog_survey"."enable_iframe_embedding",
+         "posthog_survey"."headline_summary",
+         "posthog_survey"."headline_response_count",
+         "posthog_survey"."question_summaries",
+         "posthog_survey"."form_content",
+         "posthog_survey"."translations"
+  FROM "posthog_survey"
+  WHERE "posthog_survey"."internal_response_sampling_flag_id" = 99999
   '''
 # ---
 # name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.19
@@ -265,46 +287,13 @@
 # ---
 # name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.20
   '''
-  SELECT "posthog_survey"."id",
-         "posthog_survey"."team_id",
-         "posthog_survey"."name",
-         "posthog_survey"."description",
-         "posthog_survey"."linked_flag_id",
-         "posthog_survey"."targeting_flag_id",
-         "posthog_survey"."linked_insight_id",
-         "posthog_survey"."internal_targeting_flag_id",
-         "posthog_survey"."internal_response_sampling_flag_id",
-         "posthog_survey"."type",
-         "posthog_survey"."conditions",
-         "posthog_survey"."questions",
-         "posthog_survey"."appearance",
-         "posthog_survey"."created_at",
-         "posthog_survey"."created_by_id",
-         "posthog_survey"."start_date",
-         "posthog_survey"."end_date",
-         "posthog_survey"."updated_at",
-         "posthog_survey"."archived",
-         "posthog_survey"."responses_limit",
-         "posthog_survey"."response_sampling_start_date",
-         "posthog_survey"."response_sampling_interval_type",
-         "posthog_survey"."response_sampling_interval",
-         "posthog_survey"."response_sampling_limit",
-         "posthog_survey"."response_sampling_daily_limits",
-         "posthog_survey"."iteration_count",
-         "posthog_survey"."iteration_frequency_days",
-         "posthog_survey"."iteration_start_dates",
-         "posthog_survey"."current_iteration",
-         "posthog_survey"."current_iteration_start_date",
-         "posthog_survey"."schedule",
-         "posthog_survey"."enable_partial_responses",
-         "posthog_survey"."enable_iframe_embedding",
-         "posthog_survey"."headline_summary",
-         "posthog_survey"."headline_response_count",
-         "posthog_survey"."question_summaries",
-         "posthog_survey"."form_content",
-         "posthog_survey"."translations"
-  FROM "posthog_survey"
-  WHERE "posthog_survey"."internal_response_sampling_flag_id" = 99999
+  SELECT "ee_featureflagroleaccess"."id",
+         "ee_featureflagroleaccess"."feature_flag_id",
+         "ee_featureflagroleaccess"."role_id",
+         "ee_featureflagroleaccess"."added_at",
+         "ee_featureflagroleaccess"."updated_at"
+  FROM "ee_featureflagroleaccess"
+  WHERE "ee_featureflagroleaccess"."feature_flag_id" = 99999
   '''
 # ---
 # name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.21
@@ -319,17 +308,6 @@
   '''
 # ---
 # name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.22
-  '''
-  SELECT "ee_featureflagroleaccess"."id",
-         "ee_featureflagroleaccess"."feature_flag_id",
-         "ee_featureflagroleaccess"."role_id",
-         "ee_featureflagroleaccess"."added_at",
-         "ee_featureflagroleaccess"."updated_at"
-  FROM "ee_featureflagroleaccess"
-  WHERE "ee_featureflagroleaccess"."feature_flag_id" = 99999
-  '''
-# ---
-# name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.23
   '''
   SELECT "posthog_experiment"."id",
          "posthog_experiment"."name",
@@ -364,6 +342,43 @@
          "posthog_experiment"."conclusion_comment"
   FROM "posthog_experiment"
   WHERE "posthog_experiment"."feature_flag_id" = 99999
+  '''
+# ---
+# name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.23
+  '''
+  SELECT "posthog_organization"."id",
+         "posthog_organization"."name",
+         "posthog_organization"."slug",
+         "posthog_organization"."logo_media_id",
+         "posthog_organization"."created_at",
+         "posthog_organization"."updated_at",
+         "posthog_organization"."is_active",
+         "posthog_organization"."is_not_active_reason",
+         "posthog_organization"."session_cookie_age",
+         "posthog_organization"."is_member_join_email_enabled",
+         "posthog_organization"."is_ai_data_processing_approved",
+         "posthog_organization"."enforce_2fa",
+         "posthog_organization"."members_can_invite",
+         "posthog_organization"."members_can_use_personal_api_keys",
+         "posthog_organization"."allow_publicly_shared_resources",
+         "posthog_organization"."default_role_id",
+         "posthog_organization"."plugins_access_level",
+         "posthog_organization"."for_internal_metrics",
+         "posthog_organization"."default_experiment_stats_method",
+         "posthog_organization"."default_anonymize_ips",
+         "posthog_organization"."is_hipaa",
+         "posthog_organization"."customer_id",
+         "posthog_organization"."available_product_features",
+         "posthog_organization"."usage",
+         "posthog_organization"."never_drop_data",
+         "posthog_organization"."customer_trust_scores",
+         "posthog_organization"."setup_section_2_completed",
+         "posthog_organization"."personalization",
+         "posthog_organization"."domain_whitelist",
+         "posthog_organization"."is_platform"
+  FROM "posthog_organization"
+  WHERE "posthog_organization"."id" = '00000000-0000-0000-0000-000000000000'::uuid
+  LIMIT 21
   '''
 # ---
 # name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.24
@@ -652,43 +667,6 @@
 # ---
 # name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.28
   '''
-  SELECT "posthog_organization"."id",
-         "posthog_organization"."name",
-         "posthog_organization"."slug",
-         "posthog_organization"."logo_media_id",
-         "posthog_organization"."created_at",
-         "posthog_organization"."updated_at",
-         "posthog_organization"."is_active",
-         "posthog_organization"."is_not_active_reason",
-         "posthog_organization"."session_cookie_age",
-         "posthog_organization"."is_member_join_email_enabled",
-         "posthog_organization"."is_ai_data_processing_approved",
-         "posthog_organization"."enforce_2fa",
-         "posthog_organization"."members_can_invite",
-         "posthog_organization"."members_can_use_personal_api_keys",
-         "posthog_organization"."allow_publicly_shared_resources",
-         "posthog_organization"."default_role_id",
-         "posthog_organization"."plugins_access_level",
-         "posthog_organization"."for_internal_metrics",
-         "posthog_organization"."default_experiment_stats_method",
-         "posthog_organization"."default_anonymize_ips",
-         "posthog_organization"."is_hipaa",
-         "posthog_organization"."customer_id",
-         "posthog_organization"."available_product_features",
-         "posthog_organization"."usage",
-         "posthog_organization"."never_drop_data",
-         "posthog_organization"."customer_trust_scores",
-         "posthog_organization"."setup_section_2_completed",
-         "posthog_organization"."personalization",
-         "posthog_organization"."domain_whitelist",
-         "posthog_organization"."is_platform"
-  FROM "posthog_organization"
-  WHERE "posthog_organization"."id" = '00000000-0000-0000-0000-000000000000'::uuid
-  LIMIT 21
-  '''
-# ---
-# name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.29
-  '''
   SELECT "posthog_featureflag"."id",
          "posthog_featureflag"."key",
          "posthog_featureflag"."name",
@@ -716,6 +694,37 @@
   LIMIT 21
   FOR
   UPDATE
+  '''
+# ---
+# name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.29
+  '''
+  SELECT "posthog_featureflag"."id",
+         "posthog_featureflag"."key",
+         "posthog_featureflag"."name",
+         "posthog_featureflag"."filters",
+         "posthog_featureflag"."team_id",
+         "posthog_featureflag"."created_by_id",
+         "posthog_featureflag"."created_at",
+         "posthog_featureflag"."updated_at",
+         "posthog_featureflag"."deleted",
+         "posthog_featureflag"."active",
+         "posthog_featureflag"."version",
+         "posthog_featureflag"."last_modified_by_id",
+         "posthog_featureflag"."rollback_conditions",
+         "posthog_featureflag"."performed_rollback",
+         "posthog_featureflag"."ensure_experience_continuity",
+         "posthog_featureflag"."usage_dashboard_id",
+         "posthog_featureflag"."has_enriched_analytics",
+         "posthog_featureflag"."is_remote_configuration",
+         "posthog_featureflag"."has_encrypted_payloads",
+         "posthog_featureflag"."evaluation_runtime",
+         "posthog_featureflag"."bucketing_identifier",
+         "posthog_featureflag"."last_called_at"
+  FROM "posthog_featureflag"
+  WHERE (NOT ("posthog_featureflag"."deleted")
+         AND "posthog_featureflag"."id" = 99999)
+  ORDER BY "posthog_featureflag"."id" ASC
+  LIMIT 1
   '''
 # ---
 # name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.3
@@ -748,37 +757,6 @@
 # ---
 # name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.30
   '''
-  SELECT "posthog_featureflag"."id",
-         "posthog_featureflag"."key",
-         "posthog_featureflag"."name",
-         "posthog_featureflag"."filters",
-         "posthog_featureflag"."team_id",
-         "posthog_featureflag"."created_by_id",
-         "posthog_featureflag"."created_at",
-         "posthog_featureflag"."updated_at",
-         "posthog_featureflag"."deleted",
-         "posthog_featureflag"."active",
-         "posthog_featureflag"."version",
-         "posthog_featureflag"."last_modified_by_id",
-         "posthog_featureflag"."rollback_conditions",
-         "posthog_featureflag"."performed_rollback",
-         "posthog_featureflag"."ensure_experience_continuity",
-         "posthog_featureflag"."usage_dashboard_id",
-         "posthog_featureflag"."has_enriched_analytics",
-         "posthog_featureflag"."is_remote_configuration",
-         "posthog_featureflag"."has_encrypted_payloads",
-         "posthog_featureflag"."evaluation_runtime",
-         "posthog_featureflag"."bucketing_identifier",
-         "posthog_featureflag"."last_called_at"
-  FROM "posthog_featureflag"
-  WHERE (NOT ("posthog_featureflag"."deleted")
-         AND "posthog_featureflag"."id" = 99999)
-  ORDER BY "posthog_featureflag"."id" ASC
-  LIMIT 1
-  '''
-# ---
-# name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.31
-  '''
   SELECT "posthog_filesystem"."team_id",
          "posthog_filesystem"."id",
          "posthog_filesystem"."path",
@@ -799,7 +777,7 @@
                   AND "posthog_filesystem"."shortcut" IS NOT NULL))
   '''
 # ---
-# name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.32
+# name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.31
   '''
   SELECT "posthog_filesystemshortcut"."id",
          "posthog_filesystemshortcut"."team_id",
@@ -818,7 +796,7 @@
                   AND "posthog_filesystemshortcut"."href" IS NOT NULL))
   '''
 # ---
-# name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.33
+# name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.32
   '''
   SELECT "posthog_integration"."id",
          "posthog_integration"."team_id",
@@ -835,7 +813,7 @@
   LIMIT 21
   '''
 # ---
-# name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.34
+# name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.33
   '''
   SELECT "posthog_organization"."id",
          "posthog_organization"."name",
@@ -872,7 +850,7 @@
   LIMIT 21
   '''
 # ---
-# name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.35
+# name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.34
   '''
   SELECT "posthog_organizationintegration"."id",
          "posthog_organizationintegration"."organization_id",
@@ -889,6 +867,16 @@
   LIMIT 21
   '''
 # ---
+# name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.35
+  '''
+  SELECT "posthog_featureflagevaluationcontext"."id",
+         "posthog_featureflagevaluationcontext"."feature_flag_id",
+         "posthog_featureflagevaluationcontext"."evaluation_context_id",
+         "posthog_featureflagevaluationcontext"."created_at"
+  FROM "posthog_featureflagevaluationcontext"
+  WHERE "posthog_featureflagevaluationcontext"."feature_flag_id" = 99999
+  '''
+# ---
 # name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.36
   '''
   SELECT "posthog_featureflagevaluationcontext"."id",
@@ -901,12 +889,18 @@
 # ---
 # name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.37
   '''
-  SELECT "posthog_featureflagevaluationcontext"."id",
-         "posthog_featureflagevaluationcontext"."feature_flag_id",
-         "posthog_featureflagevaluationcontext"."evaluation_context_id",
-         "posthog_featureflagevaluationcontext"."created_at"
-  FROM "posthog_featureflagevaluationcontext"
-  WHERE "posthog_featureflagevaluationcontext"."feature_flag_id" = 99999
+  SELECT "posthog_taggeditem"."id",
+         "posthog_taggeditem"."tag_id",
+         "posthog_taggeditem"."dashboard_id",
+         "posthog_taggeditem"."insight_id",
+         "posthog_taggeditem"."event_definition_id",
+         "posthog_taggeditem"."property_definition_id",
+         "posthog_taggeditem"."action_id",
+         "posthog_taggeditem"."feature_flag_id",
+         "posthog_taggeditem"."experiment_saved_metric_id",
+         "posthog_taggeditem"."ticket_id"
+  FROM "posthog_taggeditem"
+  WHERE "posthog_taggeditem"."feature_flag_id" = 99999
   '''
 # ---
 # name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.38
@@ -927,18 +921,46 @@
 # ---
 # name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.39
   '''
-  SELECT "posthog_taggeditem"."id",
-         "posthog_taggeditem"."tag_id",
-         "posthog_taggeditem"."dashboard_id",
-         "posthog_taggeditem"."insight_id",
-         "posthog_taggeditem"."event_definition_id",
-         "posthog_taggeditem"."property_definition_id",
-         "posthog_taggeditem"."action_id",
-         "posthog_taggeditem"."feature_flag_id",
-         "posthog_taggeditem"."experiment_saved_metric_id",
-         "posthog_taggeditem"."ticket_id"
-  FROM "posthog_taggeditem"
-  WHERE "posthog_taggeditem"."feature_flag_id" = 99999
+  SELECT "posthog_survey"."id",
+         "posthog_survey"."team_id",
+         "posthog_survey"."name",
+         "posthog_survey"."description",
+         "posthog_survey"."linked_flag_id",
+         "posthog_survey"."targeting_flag_id",
+         "posthog_survey"."linked_insight_id",
+         "posthog_survey"."internal_targeting_flag_id",
+         "posthog_survey"."internal_response_sampling_flag_id",
+         "posthog_survey"."type",
+         "posthog_survey"."conditions",
+         "posthog_survey"."questions",
+         "posthog_survey"."appearance",
+         "posthog_survey"."created_at",
+         "posthog_survey"."created_by_id",
+         "posthog_survey"."start_date",
+         "posthog_survey"."end_date",
+         "posthog_survey"."updated_at",
+         "posthog_survey"."archived",
+         "posthog_survey"."responses_limit",
+         "posthog_survey"."response_sampling_start_date",
+         "posthog_survey"."response_sampling_interval_type",
+         "posthog_survey"."response_sampling_interval",
+         "posthog_survey"."response_sampling_limit",
+         "posthog_survey"."response_sampling_daily_limits",
+         "posthog_survey"."iteration_count",
+         "posthog_survey"."iteration_frequency_days",
+         "posthog_survey"."iteration_start_dates",
+         "posthog_survey"."current_iteration",
+         "posthog_survey"."current_iteration_start_date",
+         "posthog_survey"."schedule",
+         "posthog_survey"."enable_partial_responses",
+         "posthog_survey"."enable_iframe_embedding",
+         "posthog_survey"."headline_summary",
+         "posthog_survey"."headline_response_count",
+         "posthog_survey"."question_summaries",
+         "posthog_survey"."form_content",
+         "posthog_survey"."translations"
+  FROM "posthog_survey"
+  WHERE "posthog_survey"."internal_response_sampling_flag_id" = 99999
   '''
 # ---
 # name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.4
@@ -1025,46 +1047,13 @@
 # ---
 # name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.41
   '''
-  SELECT "posthog_survey"."id",
-         "posthog_survey"."team_id",
-         "posthog_survey"."name",
-         "posthog_survey"."description",
-         "posthog_survey"."linked_flag_id",
-         "posthog_survey"."targeting_flag_id",
-         "posthog_survey"."linked_insight_id",
-         "posthog_survey"."internal_targeting_flag_id",
-         "posthog_survey"."internal_response_sampling_flag_id",
-         "posthog_survey"."type",
-         "posthog_survey"."conditions",
-         "posthog_survey"."questions",
-         "posthog_survey"."appearance",
-         "posthog_survey"."created_at",
-         "posthog_survey"."created_by_id",
-         "posthog_survey"."start_date",
-         "posthog_survey"."end_date",
-         "posthog_survey"."updated_at",
-         "posthog_survey"."archived",
-         "posthog_survey"."responses_limit",
-         "posthog_survey"."response_sampling_start_date",
-         "posthog_survey"."response_sampling_interval_type",
-         "posthog_survey"."response_sampling_interval",
-         "posthog_survey"."response_sampling_limit",
-         "posthog_survey"."response_sampling_daily_limits",
-         "posthog_survey"."iteration_count",
-         "posthog_survey"."iteration_frequency_days",
-         "posthog_survey"."iteration_start_dates",
-         "posthog_survey"."current_iteration",
-         "posthog_survey"."current_iteration_start_date",
-         "posthog_survey"."schedule",
-         "posthog_survey"."enable_partial_responses",
-         "posthog_survey"."enable_iframe_embedding",
-         "posthog_survey"."headline_summary",
-         "posthog_survey"."headline_response_count",
-         "posthog_survey"."question_summaries",
-         "posthog_survey"."form_content",
-         "posthog_survey"."translations"
-  FROM "posthog_survey"
-  WHERE "posthog_survey"."internal_response_sampling_flag_id" = 99999
+  SELECT "ee_featureflagroleaccess"."id",
+         "ee_featureflagroleaccess"."feature_flag_id",
+         "ee_featureflagroleaccess"."role_id",
+         "ee_featureflagroleaccess"."added_at",
+         "ee_featureflagroleaccess"."updated_at"
+  FROM "ee_featureflagroleaccess"
+  WHERE "ee_featureflagroleaccess"."feature_flag_id" = 99999
   '''
 # ---
 # name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.42
@@ -1079,17 +1068,6 @@
   '''
 # ---
 # name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.43
-  '''
-  SELECT "ee_featureflagroleaccess"."id",
-         "ee_featureflagroleaccess"."feature_flag_id",
-         "ee_featureflagroleaccess"."role_id",
-         "ee_featureflagroleaccess"."added_at",
-         "ee_featureflagroleaccess"."updated_at"
-  FROM "ee_featureflagroleaccess"
-  WHERE "ee_featureflagroleaccess"."feature_flag_id" = 99999
-  '''
-# ---
-# name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.44
   '''
   SELECT "posthog_experiment"."id",
          "posthog_experiment"."name",
@@ -1124,6 +1102,43 @@
          "posthog_experiment"."conclusion_comment"
   FROM "posthog_experiment"
   WHERE "posthog_experiment"."feature_flag_id" = 99999
+  '''
+# ---
+# name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.44
+  '''
+  SELECT "posthog_organization"."id",
+         "posthog_organization"."name",
+         "posthog_organization"."slug",
+         "posthog_organization"."logo_media_id",
+         "posthog_organization"."created_at",
+         "posthog_organization"."updated_at",
+         "posthog_organization"."is_active",
+         "posthog_organization"."is_not_active_reason",
+         "posthog_organization"."session_cookie_age",
+         "posthog_organization"."is_member_join_email_enabled",
+         "posthog_organization"."is_ai_data_processing_approved",
+         "posthog_organization"."enforce_2fa",
+         "posthog_organization"."members_can_invite",
+         "posthog_organization"."members_can_use_personal_api_keys",
+         "posthog_organization"."allow_publicly_shared_resources",
+         "posthog_organization"."default_role_id",
+         "posthog_organization"."plugins_access_level",
+         "posthog_organization"."for_internal_metrics",
+         "posthog_organization"."default_experiment_stats_method",
+         "posthog_organization"."default_anonymize_ips",
+         "posthog_organization"."is_hipaa",
+         "posthog_organization"."customer_id",
+         "posthog_organization"."available_product_features",
+         "posthog_organization"."usage",
+         "posthog_organization"."never_drop_data",
+         "posthog_organization"."customer_trust_scores",
+         "posthog_organization"."setup_section_2_completed",
+         "posthog_organization"."personalization",
+         "posthog_organization"."domain_whitelist",
+         "posthog_organization"."is_platform"
+  FROM "posthog_organization"
+  WHERE "posthog_organization"."id" = '00000000-0000-0000-0000-000000000000'::uuid
+  LIMIT 21
   '''
 # ---
 # name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.45
@@ -1500,43 +1515,6 @@
 # ---
 # name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.7
   '''
-  SELECT "posthog_organization"."id",
-         "posthog_organization"."name",
-         "posthog_organization"."slug",
-         "posthog_organization"."logo_media_id",
-         "posthog_organization"."created_at",
-         "posthog_organization"."updated_at",
-         "posthog_organization"."is_active",
-         "posthog_organization"."is_not_active_reason",
-         "posthog_organization"."session_cookie_age",
-         "posthog_organization"."is_member_join_email_enabled",
-         "posthog_organization"."is_ai_data_processing_approved",
-         "posthog_organization"."enforce_2fa",
-         "posthog_organization"."members_can_invite",
-         "posthog_organization"."members_can_use_personal_api_keys",
-         "posthog_organization"."allow_publicly_shared_resources",
-         "posthog_organization"."default_role_id",
-         "posthog_organization"."plugins_access_level",
-         "posthog_organization"."for_internal_metrics",
-         "posthog_organization"."default_experiment_stats_method",
-         "posthog_organization"."default_anonymize_ips",
-         "posthog_organization"."is_hipaa",
-         "posthog_organization"."customer_id",
-         "posthog_organization"."available_product_features",
-         "posthog_organization"."usage",
-         "posthog_organization"."never_drop_data",
-         "posthog_organization"."customer_trust_scores",
-         "posthog_organization"."setup_section_2_completed",
-         "posthog_organization"."personalization",
-         "posthog_organization"."domain_whitelist",
-         "posthog_organization"."is_platform"
-  FROM "posthog_organization"
-  WHERE "posthog_organization"."id" = '00000000-0000-0000-0000-000000000000'::uuid
-  LIMIT 21
-  '''
-# ---
-# name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.8
-  '''
   SELECT "posthog_featureflag"."id",
          "posthog_featureflag"."key",
          "posthog_featureflag"."name",
@@ -1566,7 +1544,7 @@
   UPDATE
   '''
 # ---
-# name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.9
+# name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.8
   '''
   SELECT "posthog_featureflag"."id",
          "posthog_featureflag"."key",
@@ -1595,5 +1573,27 @@
          AND "posthog_featureflag"."id" = 99999)
   ORDER BY "posthog_featureflag"."id" ASC
   LIMIT 1
+  '''
+# ---
+# name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.9
+  '''
+  SELECT "posthog_filesystem"."team_id",
+         "posthog_filesystem"."id",
+         "posthog_filesystem"."path",
+         "posthog_filesystem"."depth",
+         "posthog_filesystem"."type",
+         "posthog_filesystem"."ref",
+         "posthog_filesystem"."href",
+         "posthog_filesystem"."shortcut",
+         "posthog_filesystem"."meta",
+         "posthog_filesystem"."created_at",
+         "posthog_filesystem"."created_by_id",
+         "posthog_filesystem"."project_id"
+  FROM "posthog_filesystem"
+  WHERE ("posthog_filesystem"."ref" = '0001'
+         AND "posthog_filesystem"."team_id" = 99999
+         AND "posthog_filesystem"."type" = 'feature_flag'
+         AND NOT ("posthog_filesystem"."shortcut"
+                  AND "posthog_filesystem"."shortcut" IS NOT NULL))
   '''
 # ---

--- a/rust/feature-flags/src/config.rs
+++ b/rust/feature-flags/src/config.rs
@@ -86,6 +86,16 @@ impl std::fmt::Display for ParseTeamIdsError {
 
 impl std::error::Error for ParseTeamIdsError {}
 
+impl TeamIdCollection {
+    pub fn includes_team(&self, team_id: i32) -> bool {
+        match self {
+            TeamIdCollection::All => true,
+            TeamIdCollection::None => false,
+            TeamIdCollection::TeamIds(ids) => ids.contains(&team_id),
+        }
+    }
+}
+
 impl FromStr for TeamIdCollection {
     type Err = ParseTeamIdsError;
 
@@ -937,22 +947,6 @@ impl Config {
             force_stateless_mode: self.cookieless_force_stateless,
             identifies_ttl_seconds: self.cookieless_identifies_ttl_seconds,
             salt_ttl_seconds: self.cookieless_salt_ttl_seconds,
-        }
-    }
-
-    pub fn is_team_excluded(&self, team_id: i32, teams_to_exclude: &TeamIdCollection) -> bool {
-        match teams_to_exclude {
-            TeamIdCollection::All => true,
-            TeamIdCollection::None => false,
-            TeamIdCollection::TeamIds(ids) => ids.contains(&team_id),
-        }
-    }
-
-    pub fn is_team_included(&self, team_id: i32, teams_to_include: &TeamIdCollection) -> bool {
-        match teams_to_include {
-            TeamIdCollection::All => true,
-            TeamIdCollection::None => false,
-            TeamIdCollection::TeamIds(ids) => ids.contains(&team_id),
         }
     }
 

--- a/rust/feature-flags/src/handler/flags.rs
+++ b/rust/feature-flags/src/handler/flags.rs
@@ -288,7 +288,8 @@ pub async fn evaluate_for_request(
         cohort_membership_provider: state.cohort_membership_provider.clone(),
         enable_realtime_cohort_evaluation: state
             .config
-            .is_team_included(team_id, &state.config.realtime_cohort_evaluation_team_ids),
+            .realtime_cohort_evaluation_team_ids
+            .includes_team(team_id),
     };
 
     evaluation::evaluate_feature_flags(ctx, request_id).await


### PR DESCRIPTION
## Problem

Follow-up to #52315 addressing review feedback from @haacked after merge.

## Changes

**Rust (`config.rs`, `handler/flags.rs`):**
- Moved `is_team_included`/`is_team_excluded` from `Config` methods to `TeamIdCollection::includes_team`, since they never read any `Config` fields. Removed the unused `is_team_excluded` method entirely. Call site now reads `state.config.realtime_cohort_evaluation_team_ids.includes_team(team_id)`.

**Python (`feature_flag.py`):**
- Made the `realtime-cohort-flag-targeting` feature flag check lazy via a `@property` with memoization. Previously it called `posthoganalytics.feature_enabled()` unconditionally during `validate()`, even for flags that don't reference any cohort properties. Now the check is deferred until the first cohort property is encountered.
- Removed the `getattr` fallback in `check_flag_evaluation` since the property is now always accessible.

**Python (`cohort.py`):**
- Added `# Avoid circular import` comment explaining the local import of `_is_realtime_cohort_flag_targeting_enabled`.

**Tests:**
- Added 7 direct unit tests for `_exclude_realtime_backfilled_cohort_properties` in a new `test_flag_validation.py` file, covering: disabled mode, flag-compatible filtering, non-backfilled retention, non-realtime retention, non-cohort passthrough, nonexistent cohort handling, and deleted cohort handling.
- Added a nested cohort dependency test verifying that a non-behavioral parent cohort referencing a realtime+backfilled behavioral leaf cohort correctly appears in the dropdown when the feature flag is on.

## How did you test this code?

- All 7 new `test_flag_validation.py` unit tests pass
- All 4 existing `test_behavioral_cohort_dropdown_visibility` parameterized tests pass
- New `test_nested_cohort_with_flag_compatible_leaf_visible_when_flag_on` passes
- All 4 existing `test_behavioral_cohort_flag_validation` parameterized tests pass (verifying the lazy property change doesn't break existing behavior)
- Rust `cargo check -p feature-flags` compiles cleanly

## Publish to changelog?

No

## Docs update

No docs changes needed.

## 🤖 LLM context

Agent-authored PR addressing post-merge review comments from @haacked on #52315.