### PR TITLE
feat(surveys): add multi-language translation support UI

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -212,6 +212,7 @@ export const FEATURE_FLAGS = {
     STARTUP_PROGRAM_INTENT: 'startup-program-intent', // owner: @pawel-cebula #team-billing
     SURVEYS_ACTIONS: 'surveys-actions', // owner: #team-surveys
     SURVEYS_ADAPTIVE_LIMITS: 'surveys-adaptive-limits', // owner: #team-surveys
+    SURVEYS_TRANSLATIONS: 'surveys-translations', // owner: #team-surveys
     SURVEYS_AI_FIRST_EMPTY_STATE: 'surveys-ai-first-empty-state', // owner: #team-surveys, enables ai-first empty state
     SURVEYS_REDESIGNED_VIEW: 'surveys-redesigned-view', // owner: #team-surveys, enables the redesigned survey view with sidebar
     TRACK_DETACHED_ELEMENTS: 'track-detached-elements', // owner: @pauldambra #team-replay

--- a/frontend/src/scenes/surveys/SurveyAppearanceUtils.tsx
+++ b/frontend/src/scenes/surveys/SurveyAppearanceUtils.tsx
@@ -154,6 +154,7 @@ export function HTMLEditor({
     activeTab,
     textPlaceholder,
     textMinRows = 2,
+    className,
 }: {
     value?: string
     onChange: (value: any) => void
@@ -161,6 +162,7 @@ export function HTMLEditor({
     activeTab: SurveyQuestionDescriptionContentType
     textPlaceholder?: string
     textMinRows?: number
+    className?: string
 }): JSX.Element {
     return (
         <>
@@ -177,6 +179,7 @@ export function HTMLEditor({
                                 value={value}
                                 onChange={(v) => onChange(v)}
                                 placeholder={textPlaceholder}
+                                className={className}
                             />
                         ),
                     },

--- a/frontend/src/scenes/surveys/SurveyAppearanceUtils.tsx
+++ b/frontend/src/scenes/surveys/SurveyAppearanceUtils.tsx
@@ -154,6 +154,7 @@ export function HTMLEditor({
     activeTab,
     textPlaceholder,
     textMinRows = 2,
+    disableTabSwitching = false,
     className,
 }: {
     value?: string
@@ -162,13 +163,14 @@ export function HTMLEditor({
     activeTab: SurveyQuestionDescriptionContentType
     textPlaceholder?: string
     textMinRows?: number
+    disableTabSwitching?: boolean
     className?: string
 }): JSX.Element {
     return (
         <>
             <LemonTabs
                 activeKey={activeTab}
-                onChange={onTabChange}
+                onChange={disableTabSwitching ? undefined : onTabChange}
                 tabs={[
                     {
                         key: 'text',

--- a/frontend/src/scenes/surveys/SurveyEdit.tsx
+++ b/frontend/src/scenes/surveys/SurveyEdit.tsx
@@ -73,8 +73,8 @@ import { SurveyEditQuestionGroup, SurveyEditQuestionHeader } from './SurveyEditQ
 import { SurveyFormAppearance } from './SurveyFormAppearance'
 import { DataCollectionType, SurveyEditSection, surveyLogic } from './surveyLogic'
 import { surveysLogic } from './surveysLogic'
-import { canUseSurveyWizard } from './utils'
 import { COMMON_LANGUAGES } from './SurveyTranslations'
+import { canUseSurveyWizard } from './utils'
 
 function SurveyCompletionConditions(): JSX.Element {
     const { survey, dataCollectionType, isAdaptiveLimitFFEnabled } = useValues(surveyLogic)
@@ -292,22 +292,21 @@ export default function SurveyEdit({ id }: { id: string }): JSX.Element {
     } = useActions(surveyLogic)
     const { setPreferredEditor } = useActions(surveysLogic)
     const { featureFlags } = useValues(enabledFeaturesLogic)
-    const { guidedEditorEnabled } = useValues(surveyLogic)
+    const surveyTranslationsEnabled = !!featureFlags[FEATURE_FLAGS.SURVEYS_TRANSLATIONS]
+    const activeEditingLanguage = surveyTranslationsEnabled ? editingLanguage : null
+    const hasActiveTranslationValidationErrors = surveyTranslationsEnabled && hasTranslationValidationErrors
+    const activeTranslationValidationErrors = surveyTranslationsEnabled ? translationValidationErrors : []
     const previewSurvey = useMemo(() => {
-        if (!editingLanguage || !survey.translations?.[editingLanguage]) {
+        if (!activeEditingLanguage || !survey.translations?.[activeEditingLanguage]) {
             return survey
         }
 
         const processed = { ...survey }
-        const translation = survey.translations[editingLanguage]
+        const translation = survey.translations[activeEditingLanguage]
 
         if (translation.name) {
             processed.name = translation.name
         }
-        if (translation.description) {
-            processed.description = translation.description
-        }
-
         if (
             translation.thankYouMessageHeader ||
             translation.thankYouMessageDescription ||
@@ -328,7 +327,7 @@ export default function SurveyEdit({ id }: { id: string }): JSX.Element {
         }
 
         processed.questions = survey.questions.map((q) => {
-            const qTrans = q.translations?.[editingLanguage]
+            const qTrans = q.translations?.[activeEditingLanguage]
             if (qTrans) {
                 return {
                     ...q,
@@ -345,19 +344,24 @@ export default function SurveyEdit({ id }: { id: string }): JSX.Element {
         })
 
         return processed
-    }, [survey, editingLanguage])
+    }, [survey, activeEditingLanguage])
     const sortedItemIds = survey.questions.map((_, idx) => idx.toString())
     const { thankYouMessageDescriptionContentType = null } = survey.appearance ?? {}
     useMountedLogic(actionsModel)
 
     const [showFlowModal, setShowFlowModal] = useState(false)
 
-    // Auto-expand Steps panel when a language is selected for translation or when returning to default
+    // Auto-expand Steps panel when a language is selected for translation.
     useEffect(() => {
-        if (editingLanguage !== undefined) {
+        if (!surveyTranslationsEnabled && editingLanguage !== null) {
+            setEditingLanguage(null)
+            return
+        }
+
+        if (activeEditingLanguage !== null) {
             setSelectedSection(SurveyEditSection.Steps)
         }
-    }, [editingLanguage, setSelectedSection])
+    }, [activeEditingLanguage, editingLanguage, setEditingLanguage, setSelectedSection, surveyTranslationsEnabled])
 
     const handleCancelClick = (): void => {
         editingSurvey(false)
@@ -416,24 +420,26 @@ export default function SurveyEdit({ id }: { id: string }): JSX.Element {
 
     return (
         <SceneContent>
-            <div className={`flex flex-col gap-y-4 ${editingLanguage || hasTranslationValidationErrors ? 'mt-1' : ''}`}>
+            <div
+                className={`flex flex-col gap-y-4 ${
+                    activeEditingLanguage || hasActiveTranslationValidationErrors ? 'mt-1' : ''
+                }`}
+            >
                 <SceneTitleSection
-                    name={editingLanguage ? (survey.translations?.[editingLanguage]?.name ?? '') : survey.name}
-                    description={
-                        editingLanguage
-                            ? (survey.translations?.[editingLanguage]?.description ?? '')
-                            : survey.description
+                    name={
+                        activeEditingLanguage ? (survey.translations?.[activeEditingLanguage]?.name ?? '') : survey.name
                     }
+                    description={activeEditingLanguage ? null : survey.description}
                     resourceType={{
                         type: 'survey',
                     }}
                     canEdit
                     onNameChange={(name) => {
-                        if (editingLanguage) {
+                        if (activeEditingLanguage) {
                             setSurveyValue('translations', {
                                 ...survey.translations,
-                                [editingLanguage]: {
-                                    ...survey.translations?.[editingLanguage],
+                                [activeEditingLanguage]: {
+                                    ...survey.translations?.[activeEditingLanguage],
                                     name,
                                 },
                             })
@@ -442,17 +448,7 @@ export default function SurveyEdit({ id }: { id: string }): JSX.Element {
                         }
                     }}
                     onDescriptionChange={(description) => {
-                        if (editingLanguage) {
-                            setSurveyValue('translations', {
-                                ...survey.translations,
-                                [editingLanguage]: {
-                                    ...survey.translations?.[editingLanguage],
-                                    description,
-                                },
-                            })
-                        } else {
-                            setSurveyValue('description', description)
-                        }
+                        setSurveyValue('description', description)
                     }}
                     renameDebounceMs={0}
                     forceEdit
@@ -486,7 +482,7 @@ export default function SurveyEdit({ id }: { id: string }): JSX.Element {
                                 form="survey"
                                 size="small"
                                 disabledReason={
-                                    hasTranslationValidationErrors
+                                    hasActiveTranslationValidationErrors
                                         ? 'Cannot save: please fix translation validation errors below'
                                         : undefined
                                 }
@@ -504,7 +500,8 @@ export default function SurveyEdit({ id }: { id: string }): JSX.Element {
                             (survey.questions &&
                                 survey.questions.some((q) => q.translations && Object.keys(q.translations).length > 0))
                         )
-                        const shouldShowValidationErrors = hasTranslationValidationErrors && hasActualTranslations
+                        const shouldShowValidationErrors =
+                            surveyTranslationsEnabled && hasActiveTranslationValidationErrors && hasActualTranslations
 
                         if (shouldShowValidationErrors) {
                             return (
@@ -518,7 +515,7 @@ export default function SurveyEdit({ id }: { id: string }): JSX.Element {
                                                 children: (
                                                     <span className="text-sm">
                                                         ⚠️ Translation validation issues (
-                                                        {translationValidationErrors.length})
+                                                        {activeTranslationValidationErrors.length})
                                                     </span>
                                                 ),
                                                 className: 'bg-warning-highlight',
@@ -526,17 +523,21 @@ export default function SurveyEdit({ id }: { id: string }): JSX.Element {
                                             content: (
                                                 <div className="text-sm">
                                                     {(() => {
-                                                        const errorsByLanguage = translationValidationErrors.reduce(
-                                                            (acc, error) => {
-                                                                const lang = error.language
-                                                                if (!acc[lang]) {
-                                                                    acc[lang] = []
-                                                                }
-                                                                acc[lang].push(error)
-                                                                return acc
-                                                            },
-                                                            {} as Record<string, typeof translationValidationErrors>
-                                                        )
+                                                        const errorsByLanguage =
+                                                            activeTranslationValidationErrors.reduce(
+                                                                (acc, error) => {
+                                                                    const lang = error.language
+                                                                    if (!acc[lang]) {
+                                                                        acc[lang] = []
+                                                                    }
+                                                                    acc[lang].push(error)
+                                                                    return acc
+                                                                },
+                                                                {} as Record<
+                                                                    string,
+                                                                    typeof activeTranslationValidationErrors
+                                                                >
+                                                            )
 
                                                         return Object.entries(errorsByLanguage).map(
                                                             ([lang, errors]) => (
@@ -581,14 +582,14 @@ export default function SurveyEdit({ id }: { id: string }): JSX.Element {
                                     ]}
                                 />
                             )
-                        } else if (editingLanguage) {
+                        } else if (activeEditingLanguage) {
                             return (
                                 <div className="px-4 py-2 mt-1 mb-1.5 bg-warning-highlight rounded border border-warning">
                                     <span className="text-sm">
                                         Editing translation for{' '}
                                         <strong>
-                                            {COMMON_LANGUAGES.find((l) => l.value === editingLanguage)?.label ||
-                                                editingLanguage}
+                                            {COMMON_LANGUAGES.find((l) => l.value === activeEditingLanguage)?.label ||
+                                                activeEditingLanguage}
                                         </strong>
                                         . Only user-facing text can be translated - all other fields are editable in the{' '}
                                         <button
@@ -813,7 +814,7 @@ export default function SurveyEdit({ id }: { id: string }): JSX.Element {
                                                                             setSelectedPageIndex={setSelectedPageIndex}
                                                                             setSurveyValue={setSurveyValue}
                                                                             translationValidationErrors={
-                                                                                translationValidationErrors
+                                                                                activeTranslationValidationErrors
                                                                             }
                                                                             translationErrorsByQuestion={
                                                                                 translationErrorsByQuestion
@@ -939,10 +940,10 @@ export default function SurveyEdit({ id }: { id: string }): JSX.Element {
                                                                                               >
                                                                                                   <LemonInput
                                                                                                       value={
-                                                                                                          editingLanguage
+                                                                                                          activeEditingLanguage
                                                                                                               ? (survey
                                                                                                                     .translations?.[
-                                                                                                                    editingLanguage
+                                                                                                                    activeEditingLanguage
                                                                                                                 ]
                                                                                                                     ?.thankYouMessageHeader ??
                                                                                                                 '')
@@ -955,17 +956,17 @@ export default function SurveyEdit({ id }: { id: string }): JSX.Element {
                                                                                                           val
                                                                                                       ) => {
                                                                                                           if (
-                                                                                                              editingLanguage
+                                                                                                              activeEditingLanguage
                                                                                                           ) {
                                                                                                               setSurveyValue(
                                                                                                                   'translations',
                                                                                                                   {
                                                                                                                       ...survey.translations,
-                                                                                                                      [editingLanguage]:
+                                                                                                                      [activeEditingLanguage]:
                                                                                                                           {
                                                                                                                               ...survey
                                                                                                                                   .translations?.[
-                                                                                                                                  editingLanguage
+                                                                                                                                  activeEditingLanguage
                                                                                                                               ],
                                                                                                                               thankYouMessageHeader:
                                                                                                                                   val,
@@ -984,7 +985,7 @@ export default function SurveyEdit({ id }: { id: string }): JSX.Element {
                                                                                                           }
                                                                                                       }}
                                                                                                       placeholder={
-                                                                                                          editingLanguage
+                                                                                                          activeEditingLanguage
                                                                                                               ? survey
                                                                                                                     .appearance
                                                                                                                     .thankYouMessageHeader
@@ -1017,10 +1018,10 @@ export default function SurveyEdit({ id }: { id: string }): JSX.Element {
                                                                                               >
                                                                                                   <HTMLEditor
                                                                                                       value={
-                                                                                                          editingLanguage
+                                                                                                          activeEditingLanguage
                                                                                                               ? (survey
                                                                                                                     .translations?.[
-                                                                                                                    editingLanguage
+                                                                                                                    activeEditingLanguage
                                                                                                                 ]
                                                                                                                     ?.thankYouMessageDescription ??
                                                                                                                 '')
@@ -1033,17 +1034,17 @@ export default function SurveyEdit({ id }: { id: string }): JSX.Element {
                                                                                                           val
                                                                                                       ) => {
                                                                                                           if (
-                                                                                                              editingLanguage
+                                                                                                              activeEditingLanguage
                                                                                                           ) {
                                                                                                               setSurveyValue(
                                                                                                                   'translations',
                                                                                                                   {
                                                                                                                       ...survey.translations,
-                                                                                                                      [editingLanguage]:
+                                                                                                                      [activeEditingLanguage]:
                                                                                                                           {
                                                                                                                               ...survey
                                                                                                                                   .translations?.[
-                                                                                                                                  editingLanguage
+                                                                                                                                  activeEditingLanguage
                                                                                                                               ],
                                                                                                                               thankYouMessageDescription:
                                                                                                                                   val,
@@ -1063,7 +1064,7 @@ export default function SurveyEdit({ id }: { id: string }): JSX.Element {
                                                                                                           }
                                                                                                       }}
                                                                                                       onTabChange={
-                                                                                                          editingLanguage
+                                                                                                          activeEditingLanguage
                                                                                                               ? undefined
                                                                                                               : (
                                                                                                                     key
@@ -1088,14 +1089,14 @@ export default function SurveyEdit({ id }: { id: string }): JSX.Element {
                                                                                                           'text'
                                                                                                       }
                                                                                                       textPlaceholder={
-                                                                                                          editingLanguage
+                                                                                                          activeEditingLanguage
                                                                                                               ? survey
                                                                                                                     .appearance
                                                                                                                     .thankYouMessageDescription
                                                                                                               : 'ex: We really appreciate it.'
                                                                                                       }
                                                                                                       disableTabSwitching={
-                                                                                                          !!editingLanguage
+                                                                                                          !!activeEditingLanguage
                                                                                                       }
                                                                                                       className={getFieldErrorClass(
                                                                                                           'thankYouMessageDescription'
@@ -1124,10 +1125,10 @@ export default function SurveyEdit({ id }: { id: string }): JSX.Element {
                                                                                               >
                                                                                                   <LemonInput
                                                                                                       value={
-                                                                                                          editingLanguage
+                                                                                                          activeEditingLanguage
                                                                                                               ? (survey
                                                                                                                     .translations?.[
-                                                                                                                    editingLanguage
+                                                                                                                    activeEditingLanguage
                                                                                                                 ]
                                                                                                                     ?.thankYouMessageCloseButtonText ??
                                                                                                                 '')
@@ -1140,17 +1141,17 @@ export default function SurveyEdit({ id }: { id: string }): JSX.Element {
                                                                                                           val
                                                                                                       ) => {
                                                                                                           if (
-                                                                                                              editingLanguage
+                                                                                                              activeEditingLanguage
                                                                                                           ) {
                                                                                                               setSurveyValue(
                                                                                                                   'translations',
                                                                                                                   {
                                                                                                                       ...survey.translations,
-                                                                                                                      [editingLanguage]:
+                                                                                                                      [activeEditingLanguage]:
                                                                                                                           {
                                                                                                                               ...survey
                                                                                                                                   .translations?.[
-                                                                                                                                  editingLanguage
+                                                                                                                                  activeEditingLanguage
                                                                                                                               ],
                                                                                                                               thankYouMessageCloseButtonText:
                                                                                                                                   val,
@@ -1169,7 +1170,7 @@ export default function SurveyEdit({ id }: { id: string }): JSX.Element {
                                                                                                           }
                                                                                                       }}
                                                                                                       placeholder={
-                                                                                                          editingLanguage
+                                                                                                          activeEditingLanguage
                                                                                                               ? survey
                                                                                                                     .appearance
                                                                                                                     .thankYouMessageCloseButtonText
@@ -1186,7 +1187,7 @@ export default function SurveyEdit({ id }: { id: string }): JSX.Element {
                                                                                   <LemonField.Pure className="mt-2">
                                                                                       <Tooltip
                                                                                           title={
-                                                                                              editingLanguage
+                                                                                              activeEditingLanguage
                                                                                                   ? 'Auto disappear can only be changed in the default language'
                                                                                                   : undefined
                                                                                           }
@@ -1198,7 +1199,7 @@ export default function SurveyEdit({ id }: { id: string }): JSX.Element {
                                                                                               }
                                                                                               label="Auto disappear"
                                                                                               disabled={
-                                                                                                  editingLanguage !==
+                                                                                                  activeEditingLanguage !==
                                                                                                   null
                                                                                               }
                                                                                               onChange={(checked) =>
@@ -1230,9 +1231,9 @@ export default function SurveyEdit({ id }: { id: string }): JSX.Element {
                                                         type="secondary"
                                                         className="w-max"
                                                         icon={<IconPlus />}
-                                                        disabled={editingLanguage !== null}
+                                                        disabled={activeEditingLanguage !== null}
                                                         disabledReason={
-                                                            editingLanguage
+                                                            activeEditingLanguage
                                                                 ? 'Cannot add questions while editing a translation'
                                                                 : undefined
                                                         }
@@ -1297,11 +1298,15 @@ export default function SurveyEdit({ id }: { id: string }): JSX.Element {
                                         </>
                                     ),
                                 },
-                                {
-                                    key: SurveyEditSection.Translations,
-                                    header: 'Translations',
-                                    content: <SurveyTranslations />,
-                                },
+                                ...(surveyTranslationsEnabled
+                                    ? [
+                                          {
+                                              key: SurveyEditSection.Translations,
+                                              header: 'Translations',
+                                              content: <SurveyTranslations />,
+                                          },
+                                      ]
+                                    : []),
                                 ...(survey.type !== SurveyType.API
                                     ? [
                                           {
@@ -1874,7 +1879,7 @@ export default function SurveyEdit({ id }: { id: string }): JSX.Element {
                     <div className="h-full">
                         <div
                             className={`sticky ${
-                                editingLanguage || hasTranslationValidationErrors ? 'top-28' : 'top-16'
+                                activeEditingLanguage || hasActiveTranslationValidationErrors ? 'top-28' : 'top-16'
                             }`}
                         >
                             <SurveyFormAppearance

--- a/frontend/src/scenes/surveys/SurveyEdit.tsx
+++ b/frontend/src/scenes/surveys/SurveyEdit.tsx
@@ -6,7 +6,7 @@ import { BindLogic, useActions, useMountedLogic, useValues } from 'kea'
 import { router } from 'kea-router'
 import { useEffect, useMemo, useState } from 'react'
 
-import { IconGitBranch, IconInfo, IconPlus, IconTrash } from '@posthog/icons'
+import { IconGitBranch, IconInfo, IconPlus, IconTrash, IconWarning } from '@posthog/icons'
 import {
     LemonButton,
     LemonCalendarSelect,
@@ -275,6 +275,8 @@ export default function SurveyEdit({ id }: { id: string }): JSX.Element {
         surveyLoading,
         translationValidationErrors,
         hasTranslationValidationErrors,
+        translationErrorsByQuestion,
+        translationErrorsForField,
     } = useValues(surveyLogic)
     const {
         setSurveyValue,
@@ -313,7 +315,9 @@ export default function SurveyEdit({ id }: { id: string }): JSX.Element {
         ) {
             processed.appearance = {
                 ...survey.appearance,
-                ...(translation.thankYouMessageHeader && { thankYouMessageHeader: translation.thankYouMessageHeader }),
+                ...(translation.thankYouMessageHeader && {
+                    thankYouMessageHeader: translation.thankYouMessageHeader,
+                }),
                 ...(translation.thankYouMessageDescription && {
                     thankYouMessageDescription: translation.thankYouMessageDescription,
                 }),
@@ -383,6 +387,31 @@ export default function SurveyEdit({ id }: { id: string }): JSX.Element {
         setSurveyValue('targeting_flag', null)
         setSurveyValue('remove_targeting_flag', true)
         setFlagPropertyErrors(null)
+    }
+
+    const getFieldError = (
+        fieldKey: string
+    ): { language: string; questionIndex: number; field: string; error: string } | undefined => {
+        return translationErrorsForField(-1, fieldKey)
+    }
+
+    const getFieldErrorClass = (fieldKey: string): string => {
+        const fieldError = getFieldError(fieldKey)
+        return fieldError ? 'border border-warning hover:border-primary' : ''
+    }
+
+    const getConfirmationMessageErrors = (): number => {
+        let count = 0
+        if (getFieldError('thankYouMessageHeader')) {
+            count++
+        }
+        if (getFieldError('thankYouMessageDescription')) {
+            count++
+        }
+        if (getFieldError('thankYouMessageCloseButtonText')) {
+            count++
+        }
+        return count
     }
 
     return (
@@ -532,7 +561,9 @@ export default function SurveyEdit({ id }: { id: string }): JSX.Element {
                                                                         {errors.map((error, idx) => (
                                                                             <li key={idx}>
                                                                                 {error.questionIndex >= 0
-                                                                                    ? `Question ${error.questionIndex + 1}`
+                                                                                    ? `Question ${
+                                                                                          error.questionIndex + 1
+                                                                                      }`
                                                                                     : 'Survey'}{' '}
                                                                                 - {formatFieldName(error.field)}:{' '}
                                                                                 {error.error}
@@ -683,9 +714,13 @@ export default function SurveyEdit({ id }: { id: string }): JSX.Element {
                                                                         query parameter to the URL. Here's an example:
                                                                         {'\n'}
                                                                         <Link
-                                                                            to={`https://us.posthog.com/external_surveys/01984280-fc8a-0000-28a5-01078e2d553f?distinct_id=${user?.email ?? 'john@acme.co'}`}
+                                                                            to={`https://us.posthog.com/external_surveys/01984280-fc8a-0000-28a5-01078e2d553f?distinct_id=${
+                                                                                user?.email ?? 'john@acme.co'
+                                                                            }`}
                                                                             target="_blank"
-                                                                        >{`https://us.posthog.com/external_surveys/01984280-fc8a-0000-28a5-01078e2d553f?distinct_id=${user?.email ?? 'john@acme.co'}`}</Link>
+                                                                        >{`https://us.posthog.com/external_surveys/01984280-fc8a-0000-28a5-01078e2d553f?distinct_id=${
+                                                                            user?.email ?? 'john@acme.co'
+                                                                        }`}</Link>
                                                                     </li>
                                                                     <li>
                                                                         • Check more details about identifying
@@ -777,6 +812,12 @@ export default function SurveyEdit({ id }: { id: string }): JSX.Element {
                                                                             survey={survey}
                                                                             setSelectedPageIndex={setSelectedPageIndex}
                                                                             setSurveyValue={setSurveyValue}
+                                                                            translationValidationErrors={
+                                                                                translationValidationErrors
+                                                                            }
+                                                                            translationErrorsByQuestion={
+                                                                                translationErrorsByQuestion
+                                                                            }
                                                                         />
                                                                     ),
                                                                     content: (
@@ -795,248 +836,352 @@ export default function SurveyEdit({ id }: { id: string }): JSX.Element {
                                                                           header: (
                                                                               <div className="flex flex-row w-full items-center justify-between">
                                                                                   <b>Confirmation message</b>
-                                                                                  <LemonButton
-                                                                                      icon={<IconTrash />}
-                                                                                      data-attr="delete-survey-confirmation"
-                                                                                      size="xsmall"
-                                                                                      onClick={(e) => {
-                                                                                          const deleteConfirmationMessage =
-                                                                                              (): void => {
-                                                                                                  e.stopPropagation()
-                                                                                                  setSelectedPageIndex(
-                                                                                                      survey.questions
-                                                                                                          .length - 1
-                                                                                                  )
-                                                                                                  setSurveyValue(
-                                                                                                      'appearance',
-                                                                                                      {
-                                                                                                          ...survey.appearance,
-                                                                                                          displayThankYouMessage: false,
-                                                                                                      }
-                                                                                                  )
-                                                                                              }
+                                                                                  <div className="flex items-center gap-1">
+                                                                                      {(() => {
+                                                                                          const confirmationErrors =
+                                                                                              getConfirmationMessageErrors()
+                                                                                          return confirmationErrors >
+                                                                                              0 ? (
+                                                                                              <Tooltip
+                                                                                                  title={`${confirmationErrors} translation validation issue${
+                                                                                                      confirmationErrors >
+                                                                                                      1
+                                                                                                          ? 's'
+                                                                                                          : ''
+                                                                                                  }`}
+                                                                                              >
+                                                                                                  <IconWarning className="text-warning" />
+                                                                                              </Tooltip>
+                                                                                          ) : null
+                                                                                      })()}
+                                                                                      <LemonButton
+                                                                                          icon={<IconTrash />}
+                                                                                          data-attr="delete-survey-confirmation"
+                                                                                          size="xsmall"
+                                                                                          onClick={(e) => {
+                                                                                              const deleteConfirmationMessage =
+                                                                                                  (): void => {
+                                                                                                      e.stopPropagation()
+                                                                                                      setSelectedPageIndex(
+                                                                                                          survey
+                                                                                                              .questions
+                                                                                                              .length -
+                                                                                                              1
+                                                                                                      )
+                                                                                                      setSurveyValue(
+                                                                                                          'appearance',
+                                                                                                          {
+                                                                                                              ...survey.appearance,
+                                                                                                              displayThankYouMessage: false,
+                                                                                                          }
+                                                                                                      )
+                                                                                                  }
 
-                                                                                          if (hasBranchingLogic) {
-                                                                                              LemonDialog.open({
-                                                                                                  title: 'Your survey has active branching logic',
-                                                                                                  description: (
-                                                                                                      <p className="py-2">
-                                                                                                          Deleting the
-                                                                                                          confirmation
-                                                                                                          message will
-                                                                                                          remove your
-                                                                                                          branching
-                                                                                                          logic. Are you
-                                                                                                          sure you want
-                                                                                                          to continue?
-                                                                                                      </p>
-                                                                                                  ),
-                                                                                                  primaryButton: {
-                                                                                                      children:
-                                                                                                          'Continue',
-                                                                                                      status: 'danger',
-                                                                                                      onClick: () => {
-                                                                                                          deleteBranchingLogic()
-                                                                                                          deleteConfirmationMessage()
+                                                                                              if (hasBranchingLogic) {
+                                                                                                  LemonDialog.open({
+                                                                                                      title: 'Your survey has active branching logic',
+                                                                                                      description: (
+                                                                                                          <p className="py-2">
+                                                                                                              Deleting
+                                                                                                              the
+                                                                                                              confirmation
+                                                                                                              message
+                                                                                                              will
+                                                                                                              remove
+                                                                                                              your
+                                                                                                              branching
+                                                                                                              logic. Are
+                                                                                                              you sure
+                                                                                                              you want
+                                                                                                              to
+                                                                                                              continue?
+                                                                                                          </p>
+                                                                                                      ),
+                                                                                                      primaryButton: {
+                                                                                                          children:
+                                                                                                              'Continue',
+                                                                                                          status: 'danger',
+                                                                                                          onClick:
+                                                                                                              () => {
+                                                                                                                  deleteBranchingLogic()
+                                                                                                                  deleteConfirmationMessage()
+                                                                                                              },
                                                                                                       },
-                                                                                                  },
-                                                                                                  secondaryButton: {
-                                                                                                      children:
-                                                                                                          'Cancel',
-                                                                                                  },
-                                                                                              })
-                                                                                          } else {
-                                                                                              deleteConfirmationMessage()
-                                                                                          }
-                                                                                      }}
-                                                                                      tooltipPlacement="top-end"
-                                                                                  />
+                                                                                                      secondaryButton: {
+                                                                                                          children:
+                                                                                                              'Cancel',
+                                                                                                      },
+                                                                                                  })
+                                                                                              } else {
+                                                                                                  deleteConfirmationMessage()
+                                                                                              }
+                                                                                          }}
+                                                                                          tooltipPlacement="top-end"
+                                                                                      />
+                                                                                  </div>
                                                                               </div>
                                                                           ),
                                                                           content: (
                                                                               <>
                                                                                   <LemonField.Pure label="Thank you header">
-                                                                                      <LemonInput
-                                                                                          value={
-                                                                                              editingLanguage
-                                                                                                  ? (survey
-                                                                                                        .translations?.[
-                                                                                                        editingLanguage
-                                                                                                    ]
-                                                                                                        ?.thankYouMessageHeader ??
-                                                                                                    '')
-                                                                                                  : (survey.appearance
-                                                                                                        .thankYouMessageHeader ??
-                                                                                                    '')
-                                                                                          }
-                                                                                          onChange={(val) => {
-                                                                                              if (editingLanguage) {
-                                                                                                  setSurveyValue(
-                                                                                                      'translations',
-                                                                                                      {
-                                                                                                          ...survey.translations,
-                                                                                                          [editingLanguage]:
-                                                                                                              {
-                                                                                                                  ...survey
-                                                                                                                      .translations?.[
-                                                                                                                      editingLanguage
-                                                                                                                  ],
-                                                                                                                  thankYouMessageHeader:
-                                                                                                                      val,
-                                                                                                              },
+                                                                                      {(() => {
+                                                                                          const fieldError =
+                                                                                              getFieldError(
+                                                                                                  'thankYouMessageHeader'
+                                                                                              )
+                                                                                          return (
+                                                                                              <Tooltip
+                                                                                                  title={
+                                                                                                      fieldError?.error ||
+                                                                                                      ''
+                                                                                                  }
+                                                                                                  placement="top"
+                                                                                              >
+                                                                                                  <LemonInput
+                                                                                                      value={
+                                                                                                          editingLanguage
+                                                                                                              ? (survey
+                                                                                                                    .translations?.[
+                                                                                                                    editingLanguage
+                                                                                                                ]
+                                                                                                                    ?.thankYouMessageHeader ??
+                                                                                                                '')
+                                                                                                              : (survey
+                                                                                                                    .appearance
+                                                                                                                    .thankYouMessageHeader ??
+                                                                                                                '')
                                                                                                       }
-                                                                                                  )
-                                                                                              } else {
-                                                                                                  setSurveyValue(
-                                                                                                      'appearance',
-                                                                                                      {
-                                                                                                          ...survey.appearance,
-                                                                                                          thankYouMessageHeader:
-                                                                                                              val,
+                                                                                                      onChange={(
+                                                                                                          val
+                                                                                                      ) => {
+                                                                                                          if (
+                                                                                                              editingLanguage
+                                                                                                          ) {
+                                                                                                              setSurveyValue(
+                                                                                                                  'translations',
+                                                                                                                  {
+                                                                                                                      ...survey.translations,
+                                                                                                                      [editingLanguage]:
+                                                                                                                          {
+                                                                                                                              ...survey
+                                                                                                                                  .translations?.[
+                                                                                                                                  editingLanguage
+                                                                                                                              ],
+                                                                                                                              thankYouMessageHeader:
+                                                                                                                                  val,
+                                                                                                                          },
+                                                                                                                  }
+                                                                                                              )
+                                                                                                          } else {
+                                                                                                              setSurveyValue(
+                                                                                                                  'appearance',
+                                                                                                                  {
+                                                                                                                      ...survey.appearance,
+                                                                                                                      thankYouMessageHeader:
+                                                                                                                          val,
+                                                                                                                  }
+                                                                                                              )
+                                                                                                          }
+                                                                                                      }}
+                                                                                                      placeholder={
+                                                                                                          editingLanguage
+                                                                                                              ? survey
+                                                                                                                    .appearance
+                                                                                                                    .thankYouMessageHeader
+                                                                                                              : 'ex: Thank you for your feedback!'
                                                                                                       }
-                                                                                                  )
-                                                                                              }
-                                                                                          }}
-                                                                                          placeholder={
-                                                                                              editingLanguage
-                                                                                                  ? survey.appearance
-                                                                                                        .thankYouMessageHeader
-                                                                                                  : 'ex: Thank you for your feedback!'
-                                                                                          }
-                                                                                      />
+                                                                                                      className={getFieldErrorClass(
+                                                                                                          'thankYouMessageHeader'
+                                                                                                      )}
+                                                                                                  />
+                                                                                              </Tooltip>
+                                                                                          )
+                                                                                      })()}
                                                                                   </LemonField.Pure>
                                                                                   <LemonField.Pure
                                                                                       label="Thank you description"
                                                                                       className="mt-3"
                                                                                   >
-                                                                                      <HTMLEditor
-                                                                                          value={
-                                                                                              editingLanguage
-                                                                                                  ? (survey
-                                                                                                        .translations?.[
-                                                                                                        editingLanguage
-                                                                                                    ]
-                                                                                                        ?.thankYouMessageDescription ??
-                                                                                                    '')
-                                                                                                  : (survey.appearance
-                                                                                                        .thankYouMessageDescription ??
-                                                                                                    '')
-                                                                                          }
-                                                                                          onChange={(val) => {
-                                                                                              if (editingLanguage) {
-                                                                                                  setSurveyValue(
-                                                                                                      'translations',
-                                                                                                      {
-                                                                                                          ...survey.translations,
-                                                                                                          [editingLanguage]:
-                                                                                                              {
-                                                                                                                  ...survey
-                                                                                                                      .translations?.[
-                                                                                                                      editingLanguage
-                                                                                                                  ],
-                                                                                                                  thankYouMessageDescription:
-                                                                                                                      val,
-                                                                                                              },
+                                                                                      {(() => {
+                                                                                          const fieldError =
+                                                                                              getFieldError(
+                                                                                                  'thankYouMessageDescription'
+                                                                                              )
+                                                                                          return (
+                                                                                              <Tooltip
+                                                                                                  title={
+                                                                                                      fieldError?.error ||
+                                                                                                      ''
+                                                                                                  }
+                                                                                                  placement="top"
+                                                                                              >
+                                                                                                  <HTMLEditor
+                                                                                                      value={
+                                                                                                          editingLanguage
+                                                                                                              ? (survey
+                                                                                                                    .translations?.[
+                                                                                                                    editingLanguage
+                                                                                                                ]
+                                                                                                                    ?.thankYouMessageDescription ??
+                                                                                                                '')
+                                                                                                              : (survey
+                                                                                                                    .appearance
+                                                                                                                    .thankYouMessageDescription ??
+                                                                                                                '')
                                                                                                       }
-                                                                                                  )
-                                                                                              } else {
-                                                                                                  setSurveyValue(
-                                                                                                      'appearance',
-                                                                                                      {
-                                                                                                          ...survey.appearance,
-                                                                                                          thankYouMessageDescription:
-                                                                                                              val,
-                                                                                                          thankYouMessageDescriptionContentType,
+                                                                                                      onChange={(
+                                                                                                          val
+                                                                                                      ) => {
+                                                                                                          if (
+                                                                                                              editingLanguage
+                                                                                                          ) {
+                                                                                                              setSurveyValue(
+                                                                                                                  'translations',
+                                                                                                                  {
+                                                                                                                      ...survey.translations,
+                                                                                                                      [editingLanguage]:
+                                                                                                                          {
+                                                                                                                              ...survey
+                                                                                                                                  .translations?.[
+                                                                                                                                  editingLanguage
+                                                                                                                              ],
+                                                                                                                              thankYouMessageDescription:
+                                                                                                                                  val,
+                                                                                                                          },
+                                                                                                                  }
+                                                                                                              )
+                                                                                                          } else {
+                                                                                                              setSurveyValue(
+                                                                                                                  'appearance',
+                                                                                                                  {
+                                                                                                                      ...survey.appearance,
+                                                                                                                      thankYouMessageDescription:
+                                                                                                                          val,
+                                                                                                                      thankYouMessageDescriptionContentType,
+                                                                                                                  }
+                                                                                                              )
+                                                                                                          }
+                                                                                                      }}
+                                                                                                      onTabChange={
+                                                                                                          editingLanguage
+                                                                                                              ? undefined
+                                                                                                              : (
+                                                                                                                    key
+                                                                                                                ) => {
+                                                                                                                    const updatedAppearance =
+                                                                                                                        {
+                                                                                                                            ...survey.appearance,
+                                                                                                                            thankYouMessageDescriptionContentType:
+                                                                                                                                key ===
+                                                                                                                                'html'
+                                                                                                                                    ? 'html'
+                                                                                                                                    : 'text',
+                                                                                                                        }
+                                                                                                                    setSurveyValue(
+                                                                                                                        'appearance',
+                                                                                                                        updatedAppearance
+                                                                                                                    )
+                                                                                                                }
                                                                                                       }
-                                                                                                  )
-                                                                                              }
-                                                                                          }}
-                                                                                          onTabChange={
-                                                                                              editingLanguage
-                                                                                                  ? undefined
-                                                                                                  : (key) => {
-                                                                                                        const updatedAppearance =
-                                                                                                            {
-                                                                                                                ...survey.appearance,
-                                                                                                                thankYouMessageDescriptionContentType:
-                                                                                                                    key ===
-                                                                                                                    'html'
-                                                                                                                        ? 'html'
-                                                                                                                        : 'text',
-                                                                                                            }
-                                                                                                        setSurveyValue(
-                                                                                                            'appearance',
-                                                                                                            updatedAppearance
-                                                                                                        )
-                                                                                                    }
-                                                                                          }
-                                                                                          activeTab={
-                                                                                              thankYouMessageDescriptionContentType ??
-                                                                                              'text'
-                                                                                          }
-                                                                                          textPlaceholder={
-                                                                                              editingLanguage
-                                                                                                  ? survey.appearance
-                                                                                                        .thankYouMessageDescription
-                                                                                                  : 'ex: We really appreciate it.'
-                                                                                          }
-                                                                                          disableTabSwitching={
-                                                                                              !!editingLanguage
-                                                                                          }
-                                                                                      />
+                                                                                                      activeTab={
+                                                                                                          thankYouMessageDescriptionContentType ??
+                                                                                                          'text'
+                                                                                                      }
+                                                                                                      textPlaceholder={
+                                                                                                          editingLanguage
+                                                                                                              ? survey
+                                                                                                                    .appearance
+                                                                                                                    .thankYouMessageDescription
+                                                                                                              : 'ex: We really appreciate it.'
+                                                                                                      }
+                                                                                                      disableTabSwitching={
+                                                                                                          !!editingLanguage
+                                                                                                      }
+                                                                                                      className={getFieldErrorClass(
+                                                                                                          'thankYouMessageDescription'
+                                                                                                      )}
+                                                                                                  />
+                                                                                              </Tooltip>
+                                                                                          )
+                                                                                      })()}
                                                                                   </LemonField.Pure>
                                                                                   <LemonField.Pure
                                                                                       className="mt-2"
                                                                                       label="Button text"
                                                                                   >
-                                                                                      <LemonInput
-                                                                                          value={
-                                                                                              editingLanguage
-                                                                                                  ? (survey
-                                                                                                        .translations?.[
-                                                                                                        editingLanguage
-                                                                                                    ]
-                                                                                                        ?.thankYouMessageCloseButtonText ??
-                                                                                                    '')
-                                                                                                  : (survey.appearance
-                                                                                                        .thankYouMessageCloseButtonText ??
-                                                                                                    '')
-                                                                                          }
-                                                                                          onChange={(val) => {
-                                                                                              if (editingLanguage) {
-                                                                                                  setSurveyValue(
-                                                                                                      'translations',
-                                                                                                      {
-                                                                                                          ...survey.translations,
-                                                                                                          [editingLanguage]:
-                                                                                                              {
-                                                                                                                  ...survey
-                                                                                                                      .translations?.[
-                                                                                                                      editingLanguage
-                                                                                                                  ],
-                                                                                                                  thankYouMessageCloseButtonText:
-                                                                                                                      val,
-                                                                                                              },
+                                                                                      {(() => {
+                                                                                          const fieldError =
+                                                                                              getFieldError(
+                                                                                                  'thankYouMessageCloseButtonText'
+                                                                                              )
+                                                                                          return (
+                                                                                              <Tooltip
+                                                                                                  title={
+                                                                                                      fieldError?.error ||
+                                                                                                      ''
+                                                                                                  }
+                                                                                                  placement="top"
+                                                                                              >
+                                                                                                  <LemonInput
+                                                                                                      value={
+                                                                                                          editingLanguage
+                                                                                                              ? (survey
+                                                                                                                    .translations?.[
+                                                                                                                    editingLanguage
+                                                                                                                ]
+                                                                                                                    ?.thankYouMessageCloseButtonText ??
+                                                                                                                '')
+                                                                                                              : (survey
+                                                                                                                    .appearance
+                                                                                                                    .thankYouMessageCloseButtonText ??
+                                                                                                                '')
                                                                                                       }
-                                                                                                  )
-                                                                                              } else {
-                                                                                                  setSurveyValue(
-                                                                                                      'appearance',
-                                                                                                      {
-                                                                                                          ...survey.appearance,
-                                                                                                          thankYouMessageCloseButtonText:
-                                                                                                              val,
+                                                                                                      onChange={(
+                                                                                                          val
+                                                                                                      ) => {
+                                                                                                          if (
+                                                                                                              editingLanguage
+                                                                                                          ) {
+                                                                                                              setSurveyValue(
+                                                                                                                  'translations',
+                                                                                                                  {
+                                                                                                                      ...survey.translations,
+                                                                                                                      [editingLanguage]:
+                                                                                                                          {
+                                                                                                                              ...survey
+                                                                                                                                  .translations?.[
+                                                                                                                                  editingLanguage
+                                                                                                                              ],
+                                                                                                                              thankYouMessageCloseButtonText:
+                                                                                                                                  val,
+                                                                                                                          },
+                                                                                                                  }
+                                                                                                              )
+                                                                                                          } else {
+                                                                                                              setSurveyValue(
+                                                                                                                  'appearance',
+                                                                                                                  {
+                                                                                                                      ...survey.appearance,
+                                                                                                                      thankYouMessageCloseButtonText:
+                                                                                                                          val,
+                                                                                                                  }
+                                                                                                              )
+                                                                                                          }
+                                                                                                      }}
+                                                                                                      placeholder={
+                                                                                                          editingLanguage
+                                                                                                              ? survey
+                                                                                                                    .appearance
+                                                                                                                    .thankYouMessageCloseButtonText
+                                                                                                              : 'example: Close'
                                                                                                       }
-                                                                                                  )
-                                                                                              }
-                                                                                          }}
-                                                                                          placeholder={
-                                                                                              editingLanguage
-                                                                                                  ? survey.appearance
-                                                                                                        .thankYouMessageCloseButtonText
-                                                                                                  : 'example: Close'
-                                                                                          }
-                                                                                      />
+                                                                                                      className={getFieldErrorClass(
+                                                                                                          'thankYouMessageCloseButtonText'
+                                                                                                      )}
+                                                                                                  />
+                                                                                              </Tooltip>
+                                                                                          )
+                                                                                      })()}
                                                                                   </LemonField.Pure>
                                                                                   <LemonField.Pure className="mt-2">
                                                                                       <Tooltip
@@ -1620,7 +1765,9 @@ export default function SurveyEdit({ id }: { id: string }): JSX.Element {
                                                               <LemonField.Pure label="Properties">
                                                                   <BindLogic
                                                                       logic={featureFlagLogic}
-                                                                      props={{ id: survey.targeting_flag?.id || 'new' }}
+                                                                      props={{
+                                                                          id: survey.targeting_flag?.id || 'new',
+                                                                      }}
                                                                   >
                                                                       {!targetingFlagFilters && (
                                                                           <LemonButton
@@ -1726,7 +1873,9 @@ export default function SurveyEdit({ id }: { id: string }): JSX.Element {
                     </div>
                     <div className="h-full">
                         <div
-                            className={`sticky ${editingLanguage || hasTranslationValidationErrors ? 'top-28' : 'top-16'}`}
+                            className={`sticky ${
+                                editingLanguage || hasTranslationValidationErrors ? 'top-28' : 'top-16'
+                            }`}
                         >
                             <SurveyFormAppearance
                                 previewPageIndex={selectedPageIndex || 0}

--- a/frontend/src/scenes/surveys/SurveyEdit.tsx
+++ b/frontend/src/scenes/surveys/SurveyEdit.tsx
@@ -43,9 +43,9 @@ import { SurveyActionTrigger } from 'scenes/surveys/SurveyActionTrigger'
 import { SurveyCancelEventTrigger, SurveyEventTrigger } from 'scenes/surveys/SurveyEventTrigger'
 import { SurveyRepeatSchedule } from 'scenes/surveys/SurveyRepeatSchedule'
 import { SurveyResponsesCollection } from 'scenes/surveys/SurveyResponsesCollection'
-import { COMMON_LANGUAGES, SurveyTranslations } from 'scenes/surveys/SurveyTranslations'
+import { SurveyTranslations } from 'scenes/surveys/SurveyTranslations'
 import { SurveyWidgetCustomization } from 'scenes/surveys/SurveyWidgetCustomization'
-import { sanitizeSurveyAppearance } from 'scenes/surveys/utils'
+import { sanitizeSurveyAppearance, validateSurveyAppearance } from 'scenes/surveys/utils'
 import { urls } from 'scenes/urls'
 
 import { SceneContent } from '~/layout/scenes/components/SceneContent'
@@ -64,6 +64,8 @@ import {
     SurveyType,
 } from '~/types'
 
+import { SurveyBranchingFlowModal } from './branching-flow/SurveyBranchingFlowModal'
+import { SURVEY_TYPE_LABEL_MAP, SurveyMatchTypeLabels, defaultSurveyFieldValues } from './constants'
 import { SurveyAPIEditor } from './SurveyAPIEditor'
 import { SurveyAppearancePreview } from './SurveyAppearancePreview'
 import { HTMLEditor, PresentationTypeCard } from './SurveyAppearanceUtils'
@@ -72,8 +74,7 @@ import { SurveyFormAppearance } from './SurveyFormAppearance'
 import { DataCollectionType, SurveyEditSection, surveyLogic } from './surveyLogic'
 import { surveysLogic } from './surveysLogic'
 import { canUseSurveyWizard } from './utils'
-import { SurveyBranchingFlowModal } from './branching-flow/SurveyBranchingFlowModal'
-import { SURVEY_TYPE_LABEL_MAP, SurveyMatchTypeLabels, defaultSurveyFieldValues } from './constants'
+import { COMMON_LANGUAGES } from './SurveyTranslations'
 
 function SurveyCompletionConditions(): JSX.Element {
     const { survey, dataCollectionType, isAdaptiveLimitFFEnabled } = useValues(surveyLogic)
@@ -283,6 +284,7 @@ export default function SurveyEdit({ id }: { id: string }): JSX.Element {
         setEditingLanguage,
         setFlagPropertyErrors,
         deleteBranchingLogic,
+        setSurveyManualErrors,
         editingSurvey,
         loadSurvey,
     } = useActions(surveyLogic)
@@ -466,90 +468,113 @@ export default function SurveyEdit({ id }: { id: string }): JSX.Element {
                     }
                 />
                 <div className="sticky top-[34px] z-[100] bg-bg-3000">
-                    {hasTranslationValidationErrors ? (
-                        <LemonCollapse
-                            embedded
-                            className="my-2 bg-warning-highlight rounded"
-                            panels={[
-                                {
-                                    key: 'validation-errors',
-                                    header: {
-                                        children: (
-                                            <span className="text-sm">
-                                                ⚠️ Translation validation issues ({translationValidationErrors.length})
-                                            </span>
-                                        ),
-                                        className: 'bg-warning-highlight',
-                                    },
-                                    content: (
-                                        <div className="text-sm">
-                                            {(() => {
-                                                // Group errors by language
-                                                const errorsByLanguage = translationValidationErrors.reduce(
-                                                    (acc, error) => {
-                                                        const lang = error.language
-                                                        if (!acc[lang]) {
-                                                            acc[lang] = []
-                                                        }
-                                                        acc[lang].push(error)
-                                                        return acc
-                                                    },
-                                                    {} as Record<string, typeof translationValidationErrors>
-                                                )
+                    {(() => {
+                        // Only show translation validation errors if the survey actually has translations
+                        const hasActualTranslations = !!(
+                            (survey.translations && Object.keys(survey.translations).length > 0) ||
+                            (survey.questions &&
+                                survey.questions.some((q) => q.translations && Object.keys(q.translations).length > 0))
+                        )
+                        const shouldShowValidationErrors = hasTranslationValidationErrors && hasActualTranslations
 
-                                                return Object.entries(errorsByLanguage).map(([lang, errors]) => (
-                                                    <div key={lang} className="mb-2">
-                                                        <button
-                                                            onClick={(e) => {
-                                                                e.preventDefault()
-                                                                setEditingLanguage(lang === 'default' ? null : lang)
-                                                            }}
-                                                            className="font-semibold hover:underline cursor-pointer"
-                                                        >
-                                                            {lang === 'default'
-                                                                ? 'Default language'
-                                                                : COMMON_LANGUAGES.find((l) => l.value === lang)
-                                                                      ?.label || lang}
-                                                        </button>
-                                                        :
-                                                        <ul className="ml-4 list-disc">
-                                                            {errors.map((error, idx) => (
-                                                                <li key={idx}>
-                                                                    {error.questionIndex >= 0
-                                                                        ? `Question ${error.questionIndex + 1}`
-                                                                        : 'Survey'}{' '}
-                                                                    - {error.field}: {error.error}
-                                                                </li>
-                                                            ))}
-                                                        </ul>
-                                                    </div>
-                                                ))
-                                            })()}
-                                        </div>
-                                    ),
-                                    className: 'bg-warning-highlight',
-                                },
-                            ]}
-                        />
-                    ) : editingLanguage ? (
-                    <div className="px-4 py-2 mt-1 mb-1.5 bg-warning-highlight rounded border border-warning">
-                        <span className="text-sm">
-                            Editing translation for{' '}
-                            <strong>
-                                {COMMON_LANGUAGES.find((l) => l.value === editingLanguage)?.label || editingLanguage}
-                            </strong>
-                            . Only user-facing text can be translated - all other fields are editable in the{' '}
-                            <button
-                                onClick={() => setEditingLanguage(null)}
-                                className="font-semibold hover:underline cursor-pointer"
-                            >
-                                default language
-                            </button>{' '}
-                            only.
-                        </span>
-                    </div>
-                ) : null}
-            </div>
+                        if (shouldShowValidationErrors) {
+                            return (
+                                <LemonCollapse
+                                    embedded
+                                    className="my-2 bg-warning-highlight rounded"
+                                    panels={[
+                                        {
+                                            key: 'validation-errors',
+                                            header: {
+                                                children: (
+                                                    <span className="text-sm">
+                                                        ⚠️ Translation validation issues (
+                                                        {translationValidationErrors.length})
+                                                    </span>
+                                                ),
+                                                className: 'bg-warning-highlight',
+                                            },
+                                            content: (
+                                                <div className="text-sm">
+                                                    {(() => {
+                                                        const errorsByLanguage = translationValidationErrors.reduce(
+                                                            (acc, error) => {
+                                                                const lang = error.language
+                                                                if (!acc[lang]) {
+                                                                    acc[lang] = []
+                                                                }
+                                                                acc[lang].push(error)
+                                                                return acc
+                                                            },
+                                                            {} as Record<string, typeof translationValidationErrors>
+                                                        )
+
+                                                        return Object.entries(errorsByLanguage).map(
+                                                            ([lang, errors]) => (
+                                                                <div key={lang} className="mb-2">
+                                                                    <button
+                                                                        onClick={(e) => {
+                                                                            e.preventDefault()
+                                                                            setEditingLanguage(
+                                                                                lang === 'default' ? null : lang
+                                                                            )
+                                                                        }}
+                                                                        className="font-semibold hover:underline cursor-pointer"
+                                                                    >
+                                                                        {lang === 'default'
+                                                                            ? 'Default language'
+                                                                            : COMMON_LANGUAGES.find(
+                                                                                  (l) => l.value === lang
+                                                                              )?.label || lang}
+                                                                    </button>
+                                                                    :
+                                                                    <ul className="ml-4 list-disc">
+                                                                        {errors.map((error, idx) => (
+                                                                            <li key={idx}>
+                                                                                {error.questionIndex >= 0
+                                                                                    ? `Question ${error.questionIndex + 1}`
+                                                                                    : 'Survey'}{' '}
+                                                                                - {formatFieldName(error.field)}:{' '}
+                                                                                {error.error}
+                                                                            </li>
+                                                                        ))}
+                                                                    </ul>
+                                                                </div>
+                                                            )
+                                                        )
+                                                    })()}
+                                                </div>
+                                            ),
+                                            className: 'bg-warning-highlight',
+                                        },
+                                    ]}
+                                />
+                            )
+                        } else if (editingLanguage) {
+                            return (
+                                <div className="px-4 py-2 mt-1 mb-1.5 bg-warning-highlight rounded border border-warning">
+                                    <span className="text-sm">
+                                        Editing translation for{' '}
+                                        <strong>
+                                            {COMMON_LANGUAGES.find((l) => l.value === editingLanguage)?.label ||
+                                                editingLanguage}
+                                        </strong>
+                                        . Only user-facing text can be translated - all other fields are editable in the{' '}
+                                        <button
+                                            onClick={() => setEditingLanguage(null)}
+                                            className="font-semibold hover:underline cursor-pointer"
+                                        >
+                                            default language
+                                        </button>{' '}
+                                        only.
+                                    </span>
+                                </div>
+                            )
+                        }
+
+                        return null
+                    })()}
+                </div>
                 <div className="flex flex-col xl:grid xl:grid-cols-[1fr_400px] gap-x-4 h-full">
                     <div className="flex flex-col gap-2 flex-1 SurveyForm">
                         <LemonCollapse
@@ -681,950 +706,1037 @@ export default function SurveyEdit({ id }: { id: string }): JSX.Element {
                                         </LemonField>
                                     ),
                                 },
-                            {
-                                key: SurveyEditSection.Steps,
-                                header: 'Steps',
-                                content: (
-                                    <>
-                                        <DndContext
-                                            onDragEnd={({ active, over }) => {
-                                                if (over && active.id !== over.id) {
-                                                    const finishDrag = (): void =>
-                                                        onSortEnd({
-                                                            oldIndex: sortedItemIds.indexOf(active.id.toString()),
-                                                            newIndex: sortedItemIds.indexOf(over.id.toString()),
-                                                        })
-
-                                                    if (hasBranchingLogic) {
-                                                        LemonDialog.open({
-                                                            title: 'Your survey has active branching logic',
-                                                            description: (
-                                                                <p className="py-2">
-                                                                    Rearranging questions will remove your branching
-                                                                    logic. Are you sure you want to continue?
-                                                                </p>
-                                                            ),
-
-                                                            primaryButton: {
-                                                                children: 'Continue',
-                                                                status: 'danger',
-                                                                onClick: () => {
-                                                                    deleteBranchingLogic()
-                                                                    finishDrag()
-                                                                },
-                                                            },
-                                                            secondaryButton: {
-                                                                children: 'Cancel',
-                                                            },
-                                                        })
-                                                    } else {
-                                                        finishDrag()
-                                                    }
-                                                }
-                                            }}
-                                        >
-                                            <SortableContext
-                                                disabled={survey.questions.length <= 1}
-                                                items={sortedItemIds}
-                                                strategy={verticalListSortingStrategy}
-                                            >
-                                                <LemonCollapse
-                                                    activeKey={
-                                                        selectedPageIndex === null ? undefined : selectedPageIndex
-                                                    }
-                                                    onChange={(index) => {
-                                                        setSelectedPageIndex(index)
-                                                    }}
-                                                    panels={[
-                                                        ...survey.questions.map(
-                                                            (
-                                                                question:
-                                                                    | LinkSurveyQuestion
-                                                                    | SurveyQuestion
-                                                                    | RatingSurveyQuestion,
-                                                                index: number
-                                                            ) => ({
-                                                                key: index,
-                                                                dataAttr: `survey-question-panel-${index}`,
-                                                                header: (
-                                                                    <SurveyEditQuestionHeader
-                                                                        index={index}
-                                                                        survey={survey}
-                                                                        setSelectedPageIndex={setSelectedPageIndex}
-                                                                        setSurveyValue={setSurveyValue}
-                                                                    />
-                                                                ),
-                                                                content: (
-                                                                    <SurveyEditQuestionGroup
-                                                                        index={index}
-                                                                        key={index}
-                                                                        question={question}
-                                                                    />
-                                                                ),
+                                {
+                                    key: SurveyEditSection.Steps,
+                                    header: 'Steps',
+                                    content: (
+                                        <>
+                                            <DndContext
+                                                onDragEnd={({ active, over }) => {
+                                                    if (over && active.id !== over.id) {
+                                                        const finishDrag = (): void =>
+                                                            onSortEnd({
+                                                                oldIndex: sortedItemIds.indexOf(active.id.toString()),
+                                                                newIndex: sortedItemIds.indexOf(over.id.toString()),
                                                             })
-                                                        ),
-                                                        ...(survey.appearance?.displayThankYouMessage
-                                                            ? [
-                                                                  {
-                                                                      key: survey.questions.length,
-                                                                      header: (
-                                                                          <div className="flex flex-row w-full items-center justify-between">
-                                                                              <b>Confirmation message</b>
-                                                                              <LemonButton
-                                                                                  icon={<IconTrash />}
-                                                                                  data-attr="delete-survey-confirmation"
-                                                                                  size="xsmall"
-                                                                                  onClick={(e) => {
-                                                                                      const deleteConfirmationMessage =
-                                                                                          (): void => {
-                                                                                              e.stopPropagation()
-                                                                                              setSelectedPageIndex(
-                                                                                                  survey.questions
-                                                                                                      .length - 1
-                                                                                              )
-                                                                                              setSurveyValue(
-                                                                                                  'appearance',
-                                                                                                  {
-                                                                                                      ...survey.appearance,
-                                                                                                      displayThankYouMessage: false,
-                                                                                                  }
-                                                                                              )
-                                                                                          }
 
-                                                                                      if (hasBranchingLogic) {
-                                                                                          LemonDialog.open({
-                                                                                              title: 'Your survey has active branching logic',
-                                                                                              description: (
-                                                                                                  <p className="py-2">
-                                                                                                      Deleting the
-                                                                                                      confirmation
-                                                                                                      message will
-                                                                                                      remove your
-                                                                                                      branching logic.
-                                                                                                      Are you sure you
-                                                                                                      want to continue?
-                                                                                                  </p>
-                                                                                              ),
-                                                                                              primaryButton: {
-                                                                                                  children: 'Continue',
-                                                                                                  status: 'danger',
-                                                                                                  onClick: () => {
-                                                                                                      deleteBranchingLogic()
-                                                                                                      deleteConfirmationMessage()
-                                                                                                  },
-                                                                                              },
-                                                                                              secondaryButton: {
-                                                                                                  children: 'Cancel',
-                                                                                              },
-                                                                                          })
-                                                                                      } else {
-                                                                                          deleteConfirmationMessage()
-                                                                                      }
-                                                                                  }}
-                                                                                  tooltipPlacement="top-end"
-                                                                              />
-                                                                          </div>
-                                                                      ),
-                                                                      content: (
-                                                                          <>
-                                                                              <LemonField.Pure label="Thank you header">
-                                                                                  <LemonInput
-                                                                                      value={
-                                                                                          editingLanguage
-                                                                                              ? (survey.translations?.[
-                                                                                                    editingLanguage
-                                                                                                ]
-                                                                                                    ?.thankYouMessageHeader ??
-                                                                                                '')
-                                                                                              : (survey.appearance
-                                                                                                    .thankYouMessageHeader ??
-                                                                                                '')
-                                                                                      }
-                                                                                      onChange={(val) => {
-                                                                                          if (editingLanguage) {
-                                                                                              setSurveyValue(
-                                                                                                  'translations',
-                                                                                                  {
-                                                                                                      ...survey.translations,
-                                                                                                      [editingLanguage]:
-                                                                                                          {
-                                                                                                              ...survey
-                                                                                                                  .translations?.[
-                                                                                                                  editingLanguage
-                                                                                                              ],
-                                                                                                              thankYouMessageHeader:
-                                                                                                                  val,
-                                                                                                          },
-                                                                                                  }
-                                                                                              )
-                                                                                          } else {
-                                                                                              setSurveyValue(
-                                                                                                  'appearance',
-                                                                                                  {
-                                                                                                      ...survey.appearance,
-                                                                                                      thankYouMessageHeader:
-                                                                                                          val,
-                                                                                                  }
-                                                                                              )
-                                                                                          }
-                                                                                      }}
-                                                                                      placeholder={
-                                                                                          editingLanguage
-                                                                                              ? survey.appearance
-                                                                                                    .thankYouMessageHeader
-                                                                                              : 'ex: Thank you for your feedback!'
-                                                                                      }
-                                                                                  />
-                                                                              </LemonField.Pure>
-                                                                              <LemonField.Pure
-                                                                                  label="Thank you description"
-                                                                                  className="mt-3"
-                                                                              >
-                                                                                  <HTMLEditor
-                                                                                      value={
-                                                                                          editingLanguage
-                                                                                              ? (survey.translations?.[
-                                                                                                    editingLanguage
-                                                                                                ]
-                                                                                                    ?.thankYouMessageDescription ??
-                                                                                                '')
-                                                                                              : (survey.appearance
-                                                                                                    .thankYouMessageDescription ??
-                                                                                                '')
-                                                                                      }
-                                                                                      onChange={(val) => {
-                                                                                          if (editingLanguage) {
-                                                                                              setSurveyValue(
-                                                                                                  'translations',
-                                                                                                  {
-                                                                                                      ...survey.translations,
-                                                                                                      [editingLanguage]:
-                                                                                                          {
-                                                                                                              ...survey
-                                                                                                                  .translations?.[
-                                                                                                                  editingLanguage
-                                                                                                              ],
-                                                                                                              thankYouMessageDescription:
-                                                                                                                  val,
-                                                                                                          },
-                                                                                                  }
-                                                                                              )
-                                                                                          } else {
-                                                                                              setSurveyValue(
-                                                                                                  'appearance',
-                                                                                                  {
-                                                                                                      ...survey.appearance,
-                                                                                                      thankYouMessageDescription:
-                                                                                                          val,
-                                                                                                      thankYouMessageDescriptionContentType,
-                                                                                                  }
-                                                                                              )
-                                                                                          }
-                                                                                      }}
-                                                                                      onTabChange={
-                                                                                          editingLanguage
-                                                                                              ? undefined
-                                                                                              : (key) => {
-                                                                                                    const updatedAppearance =
-                                                                                                        {
-                                                                                                            ...survey.appearance,
-                                                                                                            thankYouMessageDescriptionContentType:
-                                                                                                                key ===
-                                                                                                                'html'
-                                                                                                                    ? 'html'
-                                                                                                                    : 'text',
-                                                                                                        }
-                                                                                                    setSurveyValue(
-                                                                                                        'appearance',
-                                                                                                        updatedAppearance
-                                                                                                    )
-                                                                                                }
-                                                                                      }
-                                                                                      activeTab={
-                                                                                          thankYouMessageDescriptionContentType ??
-                                                                                          'text'
-                                                                                      }
-                                                                                      textPlaceholder={
-                                                                                          editingLanguage
-                                                                                              ? survey.appearance
-                                                                                                    .thankYouMessageDescription
-                                                                                              : 'ex: We really appreciate it.'
-                                                                                      }
-                                                                                      disableTabSwitching={
-                                                                                          !!editingLanguage
-                                                                                      }
-                                                                                  />
-                                                                              </LemonField.Pure>
-                                                                              <LemonField.Pure
-                                                                                  className="mt-2"
-                                                                                  label="Button text"
-                                                                              >
-                                                                                  <LemonInput
-                                                                                      value={
-                                                                                          editingLanguage
-                                                                                              ? (survey.translations?.[
-                                                                                                    editingLanguage
-                                                                                                ]
-                                                                                                    ?.thankYouMessageCloseButtonText ??
-                                                                                                '')
-                                                                                              : (survey.appearance
-                                                                                                    .thankYouMessageCloseButtonText ??
-                                                                                                '')
-                                                                                      }
-                                                                                      onChange={(val) => {
-                                                                                          if (editingLanguage) {
-                                                                                              setSurveyValue(
-                                                                                                  'translations',
-                                                                                                  {
-                                                                                                      ...survey.translations,
-                                                                                                      [editingLanguage]:
-                                                                                                          {
-                                                                                                              ...survey
-                                                                                                                  .translations?.[
-                                                                                                                  editingLanguage
-                                                                                                              ],
-                                                                                                              thankYouMessageCloseButtonText:
-                                                                                                                  val,
-                                                                                                          },
-                                                                                                  }
-                                                                                              )
-                                                                                          } else {
-                                                                                              setSurveyValue(
-                                                                                                  'appearance',
-                                                                                                  {
-                                                                                                      ...survey.appearance,
-                                                                                                      thankYouMessageCloseButtonText:
-                                                                                                          val,
-                                                                                                  }
-                                                                                              )
-                                                                                          }
-                                                                                      }}
-                                                                                      placeholder={
-                                                                                          editingLanguage
-                                                                                              ? survey.appearance
-                                                                                                    .thankYouMessageCloseButtonText
-                                                                                              : 'example: Close'
-                                                                                      }
-                                                                                  />
-                                                                              </LemonField.Pure>
-                                                                              <LemonField.Pure className="mt-2">
-                                                                                  <LemonCheckbox
-                                                                                      checked={
-                                                                                          !!survey.appearance
-                                                                                              .autoDisappear
-                                                                                      }
-                                                                                      label="Auto disappear"
-                                                                                      onChange={(checked) =>
-                                                                                          setSurveyValue('appearance', {
-                                                                                              ...survey.appearance,
-                                                                                              autoDisappear: checked,
-                                                                                          })
-                                                                                      }
-                                                                                  />
-                                                                              </LemonField.Pure>
-                                                                          </>
-                                                                      ),
-                                                                  },
-                                                              ]
-                                                            : []),
-                                                    ]}
-                                                />
-                                            </SortableContext>
-                                        </DndContext>
-                                        <div className="flex gap-2">
-                                            <div className="flex items-center gap-2 mt-2">
-                                                <LemonButton
-                                                    data-attr="add-question"
-                                                    type="secondary"
-                                                    className="w-max"
-                                                    icon={<IconPlus />}
-                                                    onClick={() => {
-                                                        setSurveyValue('questions', [
-                                                            ...survey.questions,
-                                                            { ...defaultSurveyFieldValues.open.questions[0] },
-                                                        ])
-                                                        setSelectedPageIndex(survey.questions.length)
-                                                    }}
+                                                        if (hasBranchingLogic) {
+                                                            LemonDialog.open({
+                                                                title: 'Your survey has active branching logic',
+                                                                description: (
+                                                                    <p className="py-2">
+                                                                        Rearranging questions will remove your branching
+                                                                        logic. Are you sure you want to continue?
+                                                                    </p>
+                                                                ),
+
+                                                                primaryButton: {
+                                                                    children: 'Continue',
+                                                                    status: 'danger',
+                                                                    onClick: () => {
+                                                                        deleteBranchingLogic()
+                                                                        finishDrag()
+                                                                    },
+                                                                },
+                                                                secondaryButton: {
+                                                                    children: 'Cancel',
+                                                                },
+                                                            })
+                                                        } else {
+                                                            finishDrag()
+                                                        }
+                                                    }
+                                                }}
+                                            >
+                                                <SortableContext
+                                                    disabled={survey.questions.length <= 1}
+                                                    items={sortedItemIds}
+                                                    strategy={verticalListSortingStrategy}
                                                 >
-                                                    Add question
-                                                </LemonButton>
-                                                {hasBranchingLogic && (
+                                                    <LemonCollapse
+                                                        activeKey={
+                                                            selectedPageIndex === null ? undefined : selectedPageIndex
+                                                        }
+                                                        onChange={(index) => {
+                                                            setSelectedPageIndex(index)
+                                                        }}
+                                                        panels={[
+                                                            ...survey.questions.map(
+                                                                (
+                                                                    question:
+                                                                        | LinkSurveyQuestion
+                                                                        | SurveyQuestion
+                                                                        | RatingSurveyQuestion,
+                                                                    index: number
+                                                                ) => ({
+                                                                    key: index,
+                                                                    dataAttr: `survey-question-panel-${index}`,
+                                                                    header: (
+                                                                        <SurveyEditQuestionHeader
+                                                                            index={index}
+                                                                            survey={survey}
+                                                                            setSelectedPageIndex={setSelectedPageIndex}
+                                                                            setSurveyValue={setSurveyValue}
+                                                                        />
+                                                                    ),
+                                                                    content: (
+                                                                        <SurveyEditQuestionGroup
+                                                                            index={index}
+                                                                            key={index}
+                                                                            question={question}
+                                                                        />
+                                                                    ),
+                                                                })
+                                                            ),
+                                                            ...(survey.appearance?.displayThankYouMessage
+                                                                ? [
+                                                                      {
+                                                                          key: survey.questions.length,
+                                                                          header: (
+                                                                              <div className="flex flex-row w-full items-center justify-between">
+                                                                                  <b>Confirmation message</b>
+                                                                                  <LemonButton
+                                                                                      icon={<IconTrash />}
+                                                                                      data-attr="delete-survey-confirmation"
+                                                                                      size="xsmall"
+                                                                                      onClick={(e) => {
+                                                                                          const deleteConfirmationMessage =
+                                                                                              (): void => {
+                                                                                                  e.stopPropagation()
+                                                                                                  setSelectedPageIndex(
+                                                                                                      survey.questions
+                                                                                                          .length - 1
+                                                                                                  )
+                                                                                                  setSurveyValue(
+                                                                                                      'appearance',
+                                                                                                      {
+                                                                                                          ...survey.appearance,
+                                                                                                          displayThankYouMessage: false,
+                                                                                                      }
+                                                                                                  )
+                                                                                              }
+
+                                                                                          if (hasBranchingLogic) {
+                                                                                              LemonDialog.open({
+                                                                                                  title: 'Your survey has active branching logic',
+                                                                                                  description: (
+                                                                                                      <p className="py-2">
+                                                                                                          Deleting the
+                                                                                                          confirmation
+                                                                                                          message will
+                                                                                                          remove your
+                                                                                                          branching
+                                                                                                          logic. Are you
+                                                                                                          sure you want
+                                                                                                          to continue?
+                                                                                                      </p>
+                                                                                                  ),
+                                                                                                  primaryButton: {
+                                                                                                      children:
+                                                                                                          'Continue',
+                                                                                                      status: 'danger',
+                                                                                                      onClick: () => {
+                                                                                                          deleteBranchingLogic()
+                                                                                                          deleteConfirmationMessage()
+                                                                                                      },
+                                                                                                  },
+                                                                                                  secondaryButton: {
+                                                                                                      children:
+                                                                                                          'Cancel',
+                                                                                                  },
+                                                                                              })
+                                                                                          } else {
+                                                                                              deleteConfirmationMessage()
+                                                                                          }
+                                                                                      }}
+                                                                                      tooltipPlacement="top-end"
+                                                                                  />
+                                                                              </div>
+                                                                          ),
+                                                                          content: (
+                                                                              <>
+                                                                                  <LemonField.Pure label="Thank you header">
+                                                                                      <LemonInput
+                                                                                          value={
+                                                                                              editingLanguage
+                                                                                                  ? (survey
+                                                                                                        .translations?.[
+                                                                                                        editingLanguage
+                                                                                                    ]
+                                                                                                        ?.thankYouMessageHeader ??
+                                                                                                    '')
+                                                                                                  : (survey.appearance
+                                                                                                        .thankYouMessageHeader ??
+                                                                                                    '')
+                                                                                          }
+                                                                                          onChange={(val) => {
+                                                                                              if (editingLanguage) {
+                                                                                                  setSurveyValue(
+                                                                                                      'translations',
+                                                                                                      {
+                                                                                                          ...survey.translations,
+                                                                                                          [editingLanguage]:
+                                                                                                              {
+                                                                                                                  ...survey
+                                                                                                                      .translations?.[
+                                                                                                                      editingLanguage
+                                                                                                                  ],
+                                                                                                                  thankYouMessageHeader:
+                                                                                                                      val,
+                                                                                                              },
+                                                                                                      }
+                                                                                                  )
+                                                                                              } else {
+                                                                                                  setSurveyValue(
+                                                                                                      'appearance',
+                                                                                                      {
+                                                                                                          ...survey.appearance,
+                                                                                                          thankYouMessageHeader:
+                                                                                                              val,
+                                                                                                      }
+                                                                                                  )
+                                                                                              }
+                                                                                          }}
+                                                                                          placeholder={
+                                                                                              editingLanguage
+                                                                                                  ? survey.appearance
+                                                                                                        .thankYouMessageHeader
+                                                                                                  : 'ex: Thank you for your feedback!'
+                                                                                          }
+                                                                                      />
+                                                                                  </LemonField.Pure>
+                                                                                  <LemonField.Pure
+                                                                                      label="Thank you description"
+                                                                                      className="mt-3"
+                                                                                  >
+                                                                                      <HTMLEditor
+                                                                                          value={
+                                                                                              editingLanguage
+                                                                                                  ? (survey
+                                                                                                        .translations?.[
+                                                                                                        editingLanguage
+                                                                                                    ]
+                                                                                                        ?.thankYouMessageDescription ??
+                                                                                                    '')
+                                                                                                  : (survey.appearance
+                                                                                                        .thankYouMessageDescription ??
+                                                                                                    '')
+                                                                                          }
+                                                                                          onChange={(val) => {
+                                                                                              if (editingLanguage) {
+                                                                                                  setSurveyValue(
+                                                                                                      'translations',
+                                                                                                      {
+                                                                                                          ...survey.translations,
+                                                                                                          [editingLanguage]:
+                                                                                                              {
+                                                                                                                  ...survey
+                                                                                                                      .translations?.[
+                                                                                                                      editingLanguage
+                                                                                                                  ],
+                                                                                                                  thankYouMessageDescription:
+                                                                                                                      val,
+                                                                                                              },
+                                                                                                      }
+                                                                                                  )
+                                                                                              } else {
+                                                                                                  setSurveyValue(
+                                                                                                      'appearance',
+                                                                                                      {
+                                                                                                          ...survey.appearance,
+                                                                                                          thankYouMessageDescription:
+                                                                                                              val,
+                                                                                                          thankYouMessageDescriptionContentType,
+                                                                                                      }
+                                                                                                  )
+                                                                                              }
+                                                                                          }}
+                                                                                          onTabChange={
+                                                                                              editingLanguage
+                                                                                                  ? undefined
+                                                                                                  : (key) => {
+                                                                                                        const updatedAppearance =
+                                                                                                            {
+                                                                                                                ...survey.appearance,
+                                                                                                                thankYouMessageDescriptionContentType:
+                                                                                                                    key ===
+                                                                                                                    'html'
+                                                                                                                        ? 'html'
+                                                                                                                        : 'text',
+                                                                                                            }
+                                                                                                        setSurveyValue(
+                                                                                                            'appearance',
+                                                                                                            updatedAppearance
+                                                                                                        )
+                                                                                                    }
+                                                                                          }
+                                                                                          activeTab={
+                                                                                              thankYouMessageDescriptionContentType ??
+                                                                                              'text'
+                                                                                          }
+                                                                                          textPlaceholder={
+                                                                                              editingLanguage
+                                                                                                  ? survey.appearance
+                                                                                                        .thankYouMessageDescription
+                                                                                                  : 'ex: We really appreciate it.'
+                                                                                          }
+                                                                                          disableTabSwitching={
+                                                                                              !!editingLanguage
+                                                                                          }
+                                                                                      />
+                                                                                  </LemonField.Pure>
+                                                                                  <LemonField.Pure
+                                                                                      className="mt-2"
+                                                                                      label="Button text"
+                                                                                  >
+                                                                                      <LemonInput
+                                                                                          value={
+                                                                                              editingLanguage
+                                                                                                  ? (survey
+                                                                                                        .translations?.[
+                                                                                                        editingLanguage
+                                                                                                    ]
+                                                                                                        ?.thankYouMessageCloseButtonText ??
+                                                                                                    '')
+                                                                                                  : (survey.appearance
+                                                                                                        .thankYouMessageCloseButtonText ??
+                                                                                                    '')
+                                                                                          }
+                                                                                          onChange={(val) => {
+                                                                                              if (editingLanguage) {
+                                                                                                  setSurveyValue(
+                                                                                                      'translations',
+                                                                                                      {
+                                                                                                          ...survey.translations,
+                                                                                                          [editingLanguage]:
+                                                                                                              {
+                                                                                                                  ...survey
+                                                                                                                      .translations?.[
+                                                                                                                      editingLanguage
+                                                                                                                  ],
+                                                                                                                  thankYouMessageCloseButtonText:
+                                                                                                                      val,
+                                                                                                              },
+                                                                                                      }
+                                                                                                  )
+                                                                                              } else {
+                                                                                                  setSurveyValue(
+                                                                                                      'appearance',
+                                                                                                      {
+                                                                                                          ...survey.appearance,
+                                                                                                          thankYouMessageCloseButtonText:
+                                                                                                              val,
+                                                                                                      }
+                                                                                                  )
+                                                                                              }
+                                                                                          }}
+                                                                                          placeholder={
+                                                                                              editingLanguage
+                                                                                                  ? survey.appearance
+                                                                                                        .thankYouMessageCloseButtonText
+                                                                                                  : 'example: Close'
+                                                                                          }
+                                                                                      />
+                                                                                  </LemonField.Pure>
+                                                                                  <LemonField.Pure className="mt-2">
+                                                                                      <Tooltip
+                                                                                          title={
+                                                                                              editingLanguage
+                                                                                                  ? 'Auto disappear can only be changed in the default language'
+                                                                                                  : undefined
+                                                                                          }
+                                                                                      >
+                                                                                          <LemonCheckbox
+                                                                                              checked={
+                                                                                                  !!survey.appearance
+                                                                                                      .autoDisappear
+                                                                                              }
+                                                                                              label="Auto disappear"
+                                                                                              disabled={
+                                                                                                  editingLanguage !==
+                                                                                                  null
+                                                                                              }
+                                                                                              onChange={(checked) =>
+                                                                                                  setSurveyValue(
+                                                                                                      'appearance',
+                                                                                                      {
+                                                                                                          ...survey.appearance,
+                                                                                                          autoDisappear:
+                                                                                                              checked,
+                                                                                                      }
+                                                                                                  )
+                                                                                              }
+                                                                                          />
+                                                                                      </Tooltip>
+                                                                                  </LemonField.Pure>
+                                                                              </>
+                                                                          ),
+                                                                      },
+                                                                  ]
+                                                                : []),
+                                                        ]}
+                                                    />
+                                                </SortableContext>
+                                            </DndContext>
+                                            <div className="flex gap-2">
+                                                <div className="flex items-center gap-2 mt-2">
                                                     <LemonButton
-                                                        data-attr="preview-survey-branching"
+                                                        data-attr="add-question"
                                                         type="secondary"
                                                         className="w-max"
-                                                        icon={<IconGitBranch />}
-                                                        onClick={() => setShowFlowModal(true)}
+                                                        icon={<IconPlus />}
+                                                        disabled={editingLanguage !== null}
+                                                        disabledReason={
+                                                            editingLanguage
+                                                                ? 'Cannot add questions while editing a translation'
+                                                                : undefined
+                                                        }
+                                                        onClick={() => {
+                                                            const newQuestion = {
+                                                                ...defaultSurveyFieldValues.open.questions[0],
+                                                            } as any
+
+                                                            // Initialize translations for all existing languages
+                                                            const existingLanguages = Object.keys(
+                                                                survey.translations || {}
+                                                            )
+                                                            if (existingLanguages.length > 0) {
+                                                                newQuestion.translations = {}
+                                                                existingLanguages.forEach((lang) => {
+                                                                    newQuestion.translations[lang] = {
+                                                                        question: newQuestion.question || '',
+                                                                        description: newQuestion.description || '',
+                                                                        buttonText: newQuestion.buttonText || '',
+                                                                    }
+                                                                })
+                                                            }
+
+                                                            setSurveyValue('questions', [
+                                                                ...survey.questions,
+                                                                newQuestion,
+                                                            ])
+                                                            setSelectedPageIndex(survey.questions.length)
+                                                        }}
                                                     >
-                                                        Preview branching flow
+                                                        Add question
+                                                    </LemonButton>
+                                                    {hasBranchingLogic && (
+                                                        <LemonButton
+                                                            data-attr="preview-survey-branching"
+                                                            type="secondary"
+                                                            className="w-max"
+                                                            icon={<IconGitBranch />}
+                                                            onClick={() => setShowFlowModal(true)}
+                                                        >
+                                                            Preview branching flow
+                                                        </LemonButton>
+                                                    )}
+                                                </div>
+                                                {!survey.appearance?.displayThankYouMessage && (
+                                                    <LemonButton
+                                                        type="secondary"
+                                                        className="w-max mt-2"
+                                                        icon={<IconPlus />}
+                                                        onClick={() => {
+                                                            setSurveyValue('appearance', {
+                                                                ...survey.appearance,
+                                                                displayThankYouMessage: true,
+                                                            })
+                                                            setSelectedPageIndex(survey.questions.length)
+                                                        }}
+                                                    >
+                                                        Add confirmation message
                                                     </LemonButton>
                                                 )}
                                             </div>
-                                            {!survey.appearance?.displayThankYouMessage && (
-                                                <LemonButton
-                                                    type="secondary"
-                                                    className="w-max mt-2"
-                                                    icon={<IconPlus />}
-                                                    onClick={() => {
-                                                        setSurveyValue('appearance', {
-                                                            ...survey.appearance,
-                                                            displayThankYouMessage: true,
-                                                        })
-                                                        setSelectedPageIndex(survey.questions.length)
-                                                    }}
-                                                >
-                                                    Add confirmation message
-                                                </LemonButton>
-                                            )}
-                                        </div>
-                                    </>
-                                ),
-                            },
-                            {
-                                key: SurveyEditSection.Translations,
-                                header: 'Translations',
-                                content: <SurveyTranslations />,
-                            },
-                            ...(survey.type !== SurveyType.API
-                                ? [
-                                      {
-                                          key: SurveyEditSection.Customization,
-                                          header: 'Customization',
-                                          content: (
-                                              <LemonField name="appearance" label="">
-                                                  {({ onChange }) => (
-                                                      <Customization
-                                                          survey={survey}
-                                                          hasBranchingLogic={hasBranchingLogic}
-                                                          deleteBranchingLogic={deleteBranchingLogic}
-                                                          hasRatingButtons={survey.questions.some(
-                                                              (question) => question.type === SurveyQuestionType.Rating
-                                                          )}
-                                                          hasPlaceholderText={survey.questions.some(
-                                                              (question) => question.type === SurveyQuestionType.Open
-                                                          )}
-                                                          onAppearanceChange={(appearance) => {
-                                                              const newAppearance = sanitizeSurveyAppearance({
-                                                                  ...survey.appearance,
-                                                                  ...appearance,
-                                                              })
-                                                              onChange(newAppearance)
-                                                              if (
-                                                                  'surveyPopupDelaySeconds' in appearance &&
-                                                                  !appearance.surveyPopupDelaySeconds &&
-                                                                  survey.conditions?.cancelEvents?.values?.length
-                                                              ) {
-                                                                  setSurveyValue('conditions', {
-                                                                      ...survey.conditions,
-                                                                      cancelEvents: undefined,
+                                        </>
+                                    ),
+                                },
+                                {
+                                    key: SurveyEditSection.Translations,
+                                    header: 'Translations',
+                                    content: <SurveyTranslations />,
+                                },
+                                ...(survey.type !== SurveyType.API
+                                    ? [
+                                          {
+                                              key: SurveyEditSection.Customization,
+                                              header: 'Customization',
+                                              content: (
+                                                  <LemonField name="appearance" label="">
+                                                      {({ onChange }) => (
+                                                          <Customization
+                                                              survey={survey}
+                                                              hasBranchingLogic={hasBranchingLogic}
+                                                              deleteBranchingLogic={deleteBranchingLogic}
+                                                              hasRatingButtons={survey.questions.some(
+                                                                  (question) =>
+                                                                      question.type === SurveyQuestionType.Rating
+                                                              )}
+                                                              hasPlaceholderText={survey.questions.some(
+                                                                  (question) =>
+                                                                      question.type === SurveyQuestionType.Open
+                                                              )}
+                                                              onAppearanceChange={(appearance) => {
+                                                                  const newAppearance = sanitizeSurveyAppearance({
+                                                                      ...survey.appearance,
+                                                                      ...appearance,
                                                                   })
+                                                                  onChange(newAppearance)
+                                                                  if (newAppearance) {
+                                                                      setSurveyManualErrors(
+                                                                          validateSurveyAppearance(
+                                                                              newAppearance,
+                                                                              true,
+                                                                              survey.type
+                                                                          )
+                                                                      )
+                                                                  }
+                                                                  if (
+                                                                      'surveyPopupDelaySeconds' in appearance &&
+                                                                      !appearance.surveyPopupDelaySeconds &&
+                                                                      survey.conditions?.cancelEvents?.values?.length
+                                                                  ) {
+                                                                      setSurveyValue('conditions', {
+                                                                          ...survey.conditions,
+                                                                          cancelEvents: undefined,
+                                                                      })
+                                                                  }
+                                                              }}
+                                                              validationErrors={surveyErrors?.appearance}
+                                                          />
+                                                      )}
+                                                  </LemonField>
+                                              ),
+                                          },
+                                      ]
+                                    : []),
+                                ...(survey.type !== SurveyType.ExternalSurvey
+                                    ? [
+                                          {
+                                              key: SurveyEditSection.DisplayConditions,
+                                              header: 'Display conditions',
+                                              dataAttr: 'survey-display-conditions',
+                                              content: (
+                                                  <LemonField.Pure>
+                                                      <LemonSelect
+                                                          onChange={(value) => {
+                                                              if (value) {
+                                                                  resetTargeting()
+                                                              } else {
+                                                                  // TRICKY: When attempting to set user match conditions
+                                                                  // we want a proxy value to be set so that the user
+                                                                  // can then edit these, or decide to go back to all user targeting
+                                                                  setSurveyValue('conditions', { url: '' })
                                                               }
                                                           }}
-                                                          validationErrors={surveyErrors?.appearance}
+                                                          value={!hasTargetingSet}
+                                                          options={[
+                                                              { label: 'All users', value: true },
+                                                              {
+                                                                  label: 'Users who match all of the following...',
+                                                                  value: false,
+                                                                  'data-attr': 'survey-display-conditions-select-users',
+                                                              },
+                                                          ]}
+                                                          data-attr="survey-display-conditions-select"
                                                       />
-                                                  )}
-                                              </LemonField>
-                                          ),
-                                      },
-                                  ]
-                                : []),
-                            ...(survey.type !== SurveyType.ExternalSurvey
-                                ? [
-                                      {
-                                          key: SurveyEditSection.DisplayConditions,
-                                          header: 'Display conditions',
-                                          dataAttr: 'survey-display-conditions',
-                                          content: (
-                                              <LemonField.Pure>
-                                                  <LemonSelect
-                                                      onChange={(value) => {
-                                                          if (value) {
-                                                              resetTargeting()
-                                                          } else {
-                                                              // TRICKY: When attempting to set user match conditions
-                                                              // we want a proxy value to be set so that the user
-                                                              // can then edit these, or decide to go back to all user targeting
-                                                              setSurveyValue('conditions', { url: '' })
-                                                          }
-                                                      }}
-                                                      value={!hasTargetingSet}
-                                                      options={[
-                                                          { label: 'All users', value: true },
-                                                          {
-                                                              label: 'Users who match all of the following...',
-                                                              value: false,
-                                                              'data-attr': 'survey-display-conditions-select-users',
-                                                          },
-                                                      ]}
-                                                      data-attr="survey-display-conditions-select"
-                                                  />
-                                                  {!hasTargetingSet ? (
-                                                      <span className="text-secondary">
-                                                          Survey <b>will be released to everyone</b>
-                                                      </span>
-                                                  ) : (
-                                                      <>
-                                                          <LemonField
-                                                              name="linked_flag_id"
-                                                              label="Link feature flag (optional)"
-                                                              info={
-                                                                  <>
-                                                                      Connecting to a feature flag will automatically
-                                                                      enable this survey for everyone in the feature
-                                                                      flag.
-                                                                  </>
-                                                              }
-                                                          >
-                                                              {({ value, onChange }) => (
-                                                                  <div
-                                                                      className="flex"
-                                                                      data-attr="survey-display-conditions-linked-flag"
-                                                                  >
-                                                                      <FlagSelector
-                                                                          value={value}
-                                                                          onChange={(id, _key, flag) => {
-                                                                              onChange(id)
-                                                                              if (
-                                                                                  survey.linked_flag_id &&
-                                                                                  !survey.linked_flag
-                                                                              ) {
-                                                                                  api.featureFlags
-                                                                                      .get(survey.linked_flag_id)
-                                                                                      .then((flag) => {
-                                                                                          setSurveyValue(
-                                                                                              'linked_flag',
-                                                                                              flag
-                                                                                          )
-                                                                                      })
-                                                                                      .catch(() => {
-                                                                                          // If flag doesn't exist anymore, clear the linked_flag_id
-                                                                                          setSurveyValue(
-                                                                                              'linked_flag_id',
-                                                                                              null
-                                                                                          )
-                                                                                          // Reset variant selection when flag changes
-                                                                                          const {
-                                                                                              linkedFlagVariant,
-                                                                                              ...conditions
-                                                                                          } = survey.conditions || {}
-                                                                                          setSurveyValue('conditions', {
-                                                                                              ...conditions,
+                                                      {!hasTargetingSet ? (
+                                                          <span className="text-secondary">
+                                                              Survey <b>will be released to everyone</b>
+                                                          </span>
+                                                      ) : (
+                                                          <>
+                                                              <LemonField
+                                                                  name="linked_flag_id"
+                                                                  label="Link feature flag (optional)"
+                                                                  info={
+                                                                      <>
+                                                                          Connecting to a feature flag will
+                                                                          automatically enable this survey for everyone
+                                                                          in the feature flag.
+                                                                      </>
+                                                                  }
+                                                              >
+                                                                  {({ value, onChange }) => (
+                                                                      <div
+                                                                          className="flex"
+                                                                          data-attr="survey-display-conditions-linked-flag"
+                                                                      >
+                                                                          <FlagSelector
+                                                                              value={value}
+                                                                              onChange={(id, _key, flag) => {
+                                                                                  onChange(id)
+                                                                                  if (
+                                                                                      survey.linked_flag_id &&
+                                                                                      !survey.linked_flag
+                                                                                  ) {
+                                                                                      api.featureFlags
+                                                                                          .get(survey.linked_flag_id)
+                                                                                          .then((flag) => {
+                                                                                              setSurveyValue(
+                                                                                                  'linked_flag',
+                                                                                                  flag
+                                                                                              )
                                                                                           })
+                                                                                          .catch(() => {
+                                                                                              // If flag doesn't exist anymore, clear the linked_flag_id
+                                                                                              setSurveyValue(
+                                                                                                  'linked_flag_id',
+                                                                                                  null
+                                                                                              )
+                                                                                              // Reset variant selection when flag changes
+                                                                                              const {
+                                                                                                  linkedFlagVariant,
+                                                                                                  ...conditions
+                                                                                              } =
+                                                                                                  survey.conditions ||
+                                                                                                  {}
+                                                                                              setSurveyValue(
+                                                                                                  'conditions',
+                                                                                                  {
+                                                                                                      ...conditions,
+                                                                                                  }
+                                                                                              )
+                                                                                          })
+                                                                                  } else {
+                                                                                      setSurveyValue(
+                                                                                          'linked_flag',
+                                                                                          flag
+                                                                                      )
+                                                                                      // Reset variant selection when flag changes
+                                                                                      const {
+                                                                                          linkedFlagVariant,
+                                                                                          ...conditions
+                                                                                      } = survey.conditions || {}
+                                                                                      setSurveyValue('conditions', {
+                                                                                          ...conditions,
                                                                                       })
-                                                                              } else {
-                                                                                  setSurveyValue('linked_flag', flag)
-                                                                                  // Reset variant selection when flag changes
-                                                                                  const {
-                                                                                      linkedFlagVariant,
-                                                                                      ...conditions
-                                                                                  } = survey.conditions || {}
-                                                                                  setSurveyValue('conditions', {
-                                                                                      ...conditions,
-                                                                                  })
+                                                                                  }
+                                                                              }}
+                                                                          />
+                                                                          {value && (
+                                                                              <LemonButton
+                                                                                  className="ml-2"
+                                                                                  icon={<IconCancel />}
+                                                                                  size="small"
+                                                                                  onClick={() => {
+                                                                                      onChange(null)
+                                                                                      setSurveyValue(
+                                                                                          'linked_flag',
+                                                                                          null
+                                                                                      )
+                                                                                      const {
+                                                                                          linkedFlagVariant,
+                                                                                          ...conditions
+                                                                                      } = survey.conditions || {}
+                                                                                      setSurveyValue('conditions', {
+                                                                                          ...conditions,
+                                                                                      })
+                                                                                  }}
+                                                                                  aria-label="close"
+                                                                              />
+                                                                          )}
+                                                                      </div>
+                                                                  )}
+                                                              </LemonField>
+                                                              {survey.linked_flag?.filters.multivariate && (
+                                                                  <LemonField.Pure
+                                                                      label="Link to a specific flag variant"
+                                                                      info="Choose which variant of the feature flag to link to this survey.
+                                                              Requires posthog-js v1.259.0 or greater or posthog-react-native v4.4.0 or greater"
+                                                                  >
+                                                                      <div className="flex flex-col gap-2">
+                                                                          <LemonSegmentedButton
+                                                                              className="min-w-1/3"
+                                                                              value={
+                                                                                  survey.conditions
+                                                                                      ?.linkedFlagVariant ?? ANY_VARIANT
                                                                               }
-                                                                          }}
-                                                                      />
-                                                                      {value && (
-                                                                          <LemonButton
-                                                                              className="ml-2"
-                                                                              icon={<IconCancel />}
-                                                                              size="small"
-                                                                              onClick={() => {
-                                                                                  onChange(null)
-                                                                                  setSurveyValue('linked_flag', null)
-                                                                                  const {
-                                                                                      linkedFlagVariant,
-                                                                                      ...conditions
-                                                                                  } = survey.conditions || {}
+                                                                              options={variantOptions(
+                                                                                  survey.linked_flag?.filters
+                                                                                      .multivariate || undefined
+                                                                              )}
+                                                                              onChange={(variant) => {
                                                                                   setSurveyValue('conditions', {
-                                                                                      ...conditions,
+                                                                                      ...survey.conditions,
+                                                                                      linkedFlagVariant:
+                                                                                          variant === ANY_VARIANT
+                                                                                              ? null
+                                                                                              : variant,
                                                                                   })
                                                                               }}
-                                                                              aria-label="close"
                                                                           />
-                                                                      )}
-                                                                  </div>
+                                                                          <p className="text-sm text-secondary">
+                                                                              This is a multi-variant flag. You can link
+                                                                              to "any" variant of the flag, and the
+                                                                              survey will be shown whenever the flag is
+                                                                              enabled for a user. Alternatively, you can
+                                                                              link to a specific variant of the flag,
+                                                                              and the survey will only be shown when the
+                                                                              user has that specific variant enabled.
+                                                                          </p>
+                                                                      </div>
+                                                                  </LemonField.Pure>
                                                               )}
-                                                          </LemonField>
-                                                          {survey.linked_flag?.filters.multivariate && (
-                                                              <LemonField.Pure
-                                                                  label="Link to a specific flag variant"
-                                                                  info="Choose which variant of the feature flag to link to this survey.
-                                                              Requires posthog-js v1.259.0 or greater or posthog-react-native v4.4.0 or greater"
-                                                              >
-                                                                  <div className="flex flex-col gap-2">
-                                                                      <LemonSegmentedButton
-                                                                          className="min-w-1/3"
-                                                                          value={
-                                                                              survey.conditions?.linkedFlagVariant ??
-                                                                              ANY_VARIANT
-                                                                          }
-                                                                          options={variantOptions(
-                                                                              survey.linked_flag?.filters
-                                                                                  .multivariate || undefined
-                                                                          )}
-                                                                          onChange={(variant) => {
-                                                                              setSurveyValue('conditions', {
-                                                                                  ...survey.conditions,
-                                                                                  linkedFlagVariant:
-                                                                                      variant === ANY_VARIANT
-                                                                                          ? null
-                                                                                          : variant,
-                                                                              })
-                                                                          }}
-                                                                      />
-                                                                      <p className="text-sm text-secondary">
-                                                                          This is a multi-variant flag. You can link to
-                                                                          "any" variant of the flag, and the survey will
-                                                                          be shown whenever the flag is enabled for a
-                                                                          user. Alternatively, you can link to a
-                                                                          specific variant of the flag, and the survey
-                                                                          will only be shown when the user has that
-                                                                          specific variant enabled.
-                                                                      </p>
-                                                                  </div>
-                                                              </LemonField.Pure>
-                                                          )}
-                                                          <LemonField name="conditions">
-                                                              {({ value, onChange }) => (
-                                                                  <>
-                                                                      <LemonField.Pure
-                                                                          label="URL targeting"
-                                                                          error={urlMatchTypeValidationError}
-                                                                          info="Targeting by regex or exact match requires at least version 1.82 of posthog-js"
-                                                                      >
-                                                                          <div className="flex flex-row gap-2 items-center">
-                                                                              URL
-                                                                              <LemonSelect
-                                                                                  value={
-                                                                                      value?.urlMatchType ||
-                                                                                      SurveyMatchType.Contains
-                                                                                  }
-                                                                                  onChange={(matchTypeVal) => {
-                                                                                      onChange({
-                                                                                          ...value,
-                                                                                          urlMatchType: matchTypeVal,
-                                                                                      })
-                                                                                  }}
-                                                                                  data-attr="survey-url-matching-type"
-                                                                                  options={(
-                                                                                      Object.keys(
-                                                                                          SurveyMatchTypeLabels
-                                                                                      ) as Array<
-                                                                                          ValueOf<
-                                                                                              typeof SurveyMatchType
-                                                                                          >
-                                                                                      >
-                                                                                  ).map((key) => ({
-                                                                                      label: SurveyMatchTypeLabels[key],
-                                                                                      value: key,
-                                                                                  }))}
-                                                                              />
-                                                                              <LemonInput
-                                                                                  value={value?.url}
-                                                                                  onChange={(urlVal) =>
-                                                                                      onChange({
-                                                                                          ...value,
-                                                                                          url: urlVal,
-                                                                                      })
-                                                                                  }
-                                                                                  placeholder="ex: https://app.posthog.com"
-                                                                                  fullWidth
-                                                                              />
-                                                                          </div>
-                                                                      </LemonField.Pure>
-                                                                      <LemonField.Pure
-                                                                          label="Device Types"
-                                                                          error={deviceTypesMatchTypeValidationError}
-                                                                          info={
-                                                                              <>
-                                                                                  Add the device types to show the
-                                                                                  survey on. Possible values: 'Desktop',
-                                                                                  'Mobile', 'Tablet'. For the full list
-                                                                                  and caveats,{' '}
-                                                                                  <Link to="https://posthog.com/docs/surveys/creating-surveys#display-conditions">
-                                                                                      check the documentation here
-                                                                                  </Link>
-                                                                                  . Requires at least version 1.214 of
-                                                                                  posthog-js
-                                                                              </>
-                                                                          }
-                                                                      >
-                                                                          <div className="flex flex-row gap-2 items-center">
-                                                                              Device Types
-                                                                              <LemonSelect
-                                                                                  value={
-                                                                                      value?.deviceTypesMatchType ||
-                                                                                      SurveyMatchType.Contains
-                                                                                  }
-                                                                                  onChange={(matchTypeVal) => {
-                                                                                      onChange({
-                                                                                          ...value,
-                                                                                          deviceTypesMatchType:
-                                                                                              matchTypeVal,
-                                                                                      })
-                                                                                  }}
-                                                                                  data-attr="survey-device-types-matching-type"
-                                                                                  options={(
-                                                                                      Object.keys(
-                                                                                          SurveyMatchTypeLabels
-                                                                                      ) as Array<
-                                                                                          ValueOf<
-                                                                                              typeof SurveyMatchType
-                                                                                          >
-                                                                                      >
-                                                                                  ).map((key) => ({
-                                                                                      label: SurveyMatchTypeLabels[key],
-                                                                                      value: key,
-                                                                                  }))}
-                                                                              />
-                                                                              {[
-                                                                                  SurveyMatchType.Regex,
-                                                                                  SurveyMatchType.NotRegex,
-                                                                              ].includes(
-                                                                                  value?.deviceTypesMatchType ||
-                                                                                      SurveyMatchType.Contains
-                                                                              ) ? (
-                                                                                  <LemonInput
-                                                                                      value={value?.deviceTypes?.join(
-                                                                                          '|'
-                                                                                      )}
-                                                                                      onChange={(deviceTypesVal) =>
-                                                                                          onChange({
-                                                                                              ...value,
-                                                                                              deviceTypes: [
-                                                                                                  deviceTypesVal,
-                                                                                              ],
-                                                                                          })
+                                                              <LemonField name="conditions">
+                                                                  {({ value, onChange }) => (
+                                                                      <>
+                                                                          <LemonField.Pure
+                                                                              label="URL targeting"
+                                                                              error={urlMatchTypeValidationError}
+                                                                              info="Targeting by regex or exact match requires at least version 1.82 of posthog-js"
+                                                                          >
+                                                                              <div className="flex flex-row gap-2 items-center">
+                                                                                  URL
+                                                                                  <LemonSelect
+                                                                                      value={
+                                                                                          value?.urlMatchType ||
+                                                                                          SurveyMatchType.Contains
                                                                                       }
-                                                                                      // regex placeholder for device type
-                                                                                      className="flex-1"
-                                                                                      placeholder="ex: Desktop|Mobile"
-                                                                                  />
-                                                                              ) : (
-                                                                                  <PropertyValue
-                                                                                      propertyKey={getPropertyKey(
-                                                                                          'Device Type',
-                                                                                          TaxonomicFilterGroupType.EventProperties
-                                                                                      )}
-                                                                                      type={PropertyFilterType.Event}
-                                                                                      onSet={(
-                                                                                          deviceTypes: string | string[]
-                                                                                      ) => {
+                                                                                      onChange={(matchTypeVal) => {
                                                                                           onChange({
                                                                                               ...value,
-                                                                                              deviceTypes:
-                                                                                                  Array.isArray(
-                                                                                                      deviceTypes
-                                                                                                  )
-                                                                                                      ? deviceTypes
-                                                                                                      : [deviceTypes],
+                                                                                              urlMatchType:
+                                                                                                  matchTypeVal,
                                                                                           })
                                                                                       }}
-                                                                                      operator={PropertyOperator.Exact}
-                                                                                      value={value?.deviceTypes}
-                                                                                      inputClassName="flex-1"
+                                                                                      data-attr="survey-url-matching-type"
+                                                                                      options={(
+                                                                                          Object.keys(
+                                                                                              SurveyMatchTypeLabels
+                                                                                          ) as Array<
+                                                                                              ValueOf<
+                                                                                                  typeof SurveyMatchType
+                                                                                              >
+                                                                                          >
+                                                                                      ).map((key) => ({
+                                                                                          label: SurveyMatchTypeLabels[
+                                                                                              key
+                                                                                          ],
+                                                                                          value: key,
+                                                                                      }))}
                                                                                   />
-                                                                              )}
-                                                                          </div>
-                                                                      </LemonField.Pure>
-                                                                      <LemonField.Pure label="CSS selector matches:">
-                                                                          <LemonInput
-                                                                              value={value?.selector}
-                                                                              onChange={(selectorVal) =>
-                                                                                  onChange({
-                                                                                      ...value,
-                                                                                      selector: selectorVal,
-                                                                                  })
+                                                                                  <LemonInput
+                                                                                      value={value?.url}
+                                                                                      onChange={(urlVal) =>
+                                                                                          onChange({
+                                                                                              ...value,
+                                                                                              url: urlVal,
+                                                                                          })
+                                                                                      }
+                                                                                      placeholder="ex: https://app.posthog.com"
+                                                                                      fullWidth
+                                                                                  />
+                                                                              </div>
+                                                                          </LemonField.Pure>
+                                                                          <LemonField.Pure
+                                                                              label="Device Types"
+                                                                              error={
+                                                                                  deviceTypesMatchTypeValidationError
                                                                               }
-                                                                              placeholder="ex: .className or #id"
-                                                                          />
-                                                                      </LemonField.Pure>
-                                                                      <LemonField.Pure
-                                                                          label="Survey wait period"
-                                                                          info="Note that this condition will only apply reliably for identified users within a single browser session. Anonymous users or users who switch browsers, use incognito sessions, or log out and log back in may see the survey again. Additionally, responses submitted while a user is anonymous may be associated with their account if they log in during the same session."
-                                                                      >
-                                                                          <div className="flex flex-row gap-2 items-center">
-                                                                              <LemonCheckbox
-                                                                                  checked={
-                                                                                      !!value?.seenSurveyWaitPeriodInDays
-                                                                                  }
-                                                                                  onChange={(checked) => {
-                                                                                      if (checked) {
-                                                                                          onChange({
-                                                                                              ...value,
-                                                                                              seenSurveyWaitPeriodInDays:
-                                                                                                  value?.seenSurveyWaitPeriodInDays ||
-                                                                                                  30,
-                                                                                          })
-                                                                                      } else {
-                                                                                          const {
-                                                                                              seenSurveyWaitPeriodInDays,
-                                                                                              ...rest
-                                                                                          } = value || {}
-                                                                                          onChange(rest)
-                                                                                      }
-                                                                                  }}
-                                                                              />
-                                                                              Don't show to users who saw any survey in
-                                                                              the last
-                                                                              <LemonInput
-                                                                                  type="number"
-                                                                                  size="xsmall"
-                                                                                  min={0}
-                                                                                  value={
-                                                                                      value?.seenSurveyWaitPeriodInDays ||
-                                                                                      NaN
-                                                                                  }
-                                                                                  onChange={(val) => {
-                                                                                      if (
-                                                                                          val !== undefined &&
-                                                                                          val > 0
-                                                                                      ) {
-                                                                                          onChange({
-                                                                                              ...value,
-                                                                                              seenSurveyWaitPeriodInDays:
-                                                                                                  val,
-                                                                                          })
-                                                                                      } else {
-                                                                                          onChange({
-                                                                                              ...value,
-                                                                                              seenSurveyWaitPeriodInDays:
-                                                                                                  null,
-                                                                                          })
-                                                                                      }
-                                                                                  }}
-                                                                                  className="w-12"
-                                                                                  id="survey-wait-period-input"
-                                                                              />{' '}
-                                                                              {value?.seenSurveyWaitPeriodInDays ===
-                                                                              1 ? (
-                                                                                  <span>day.</span>
-                                                                              ) : (
-                                                                                  <span>days.</span>
-                                                                              )}
-                                                                          </div>
-                                                                      </LemonField.Pure>
-                                                                  </>
-                                                              )}
-                                                          </LemonField>
-                                                          <LemonField.Pure label="Properties">
-                                                              <BindLogic
-                                                                  logic={featureFlagLogic}
-                                                                  props={{ id: survey.targeting_flag?.id || 'new' }}
-                                                              >
-                                                                  {!targetingFlagFilters && (
-                                                                      <LemonButton
-                                                                          type="secondary"
-                                                                          className="w-max"
-                                                                          onClick={() => {
-                                                                              setSurveyValue('targeting_flag_filters', {
-                                                                                  groups: [
-                                                                                      {
-                                                                                          properties: [],
-                                                                                          rollout_percentage: 100,
-                                                                                          variant: null,
-                                                                                      },
-                                                                                  ],
-                                                                                  multivariate: null,
-                                                                                  payloads: {},
-                                                                              })
-                                                                              setSurveyValue(
-                                                                                  'remove_targeting_flag',
-                                                                                  false
-                                                                              )
-                                                                          }}
-                                                                      >
-                                                                          Add property targeting
-                                                                      </LemonButton>
-                                                                  )}
-                                                                  {targetingFlagFilters && (
-                                                                      <>
-                                                                          <div className="mt-2">
-                                                                              <FeatureFlagReleaseConditions
-                                                                                  id={
-                                                                                      String(
-                                                                                          survey.targeting_flag?.id
-                                                                                      ) || 'new'
-                                                                                  }
-                                                                                  excludeTitle={true}
-                                                                                  filters={targetingFlagFilters}
-                                                                                  onChange={(filters, errors) => {
-                                                                                      setFlagPropertyErrors(errors)
-                                                                                      setSurveyValue(
-                                                                                          'targeting_flag_filters',
-                                                                                          filters
-                                                                                      )
-                                                                                  }}
-                                                                                  showTrashIconWithOneCondition
-                                                                                  removedLastConditionCallback={
-                                                                                      removeTargetingFlagFilters
-                                                                                  }
-                                                                              />
-                                                                          </div>
-                                                                          <LemonButton
-                                                                              type="secondary"
-                                                                              status="danger"
-                                                                              className="w-max"
-                                                                              onClick={removeTargetingFlagFilters}
+                                                                              info={
+                                                                                  <>
+                                                                                      Add the device types to show the
+                                                                                      survey on. Possible values:
+                                                                                      'Desktop', 'Mobile', 'Tablet'. For
+                                                                                      the full list and caveats,{' '}
+                                                                                      <Link to="https://posthog.com/docs/surveys/creating-surveys#display-conditions">
+                                                                                          check the documentation here
+                                                                                      </Link>
+                                                                                      . Requires at least version 1.214
+                                                                                      of posthog-js
+                                                                                  </>
+                                                                              }
                                                                           >
-                                                                              Remove all property targeting
-                                                                          </LemonButton>
+                                                                              <div className="flex flex-row gap-2 items-center">
+                                                                                  Device Types
+                                                                                  <LemonSelect
+                                                                                      value={
+                                                                                          value?.deviceTypesMatchType ||
+                                                                                          SurveyMatchType.Contains
+                                                                                      }
+                                                                                      onChange={(matchTypeVal) => {
+                                                                                          onChange({
+                                                                                              ...value,
+                                                                                              deviceTypesMatchType:
+                                                                                                  matchTypeVal,
+                                                                                          })
+                                                                                      }}
+                                                                                      data-attr="survey-device-types-matching-type"
+                                                                                      options={(
+                                                                                          Object.keys(
+                                                                                              SurveyMatchTypeLabels
+                                                                                          ) as Array<
+                                                                                              ValueOf<
+                                                                                                  typeof SurveyMatchType
+                                                                                              >
+                                                                                          >
+                                                                                      ).map((key) => ({
+                                                                                          label: SurveyMatchTypeLabels[
+                                                                                              key
+                                                                                          ],
+                                                                                          value: key,
+                                                                                      }))}
+                                                                                  />
+                                                                                  {[
+                                                                                      SurveyMatchType.Regex,
+                                                                                      SurveyMatchType.NotRegex,
+                                                                                  ].includes(
+                                                                                      value?.deviceTypesMatchType ||
+                                                                                          SurveyMatchType.Contains
+                                                                                  ) ? (
+                                                                                      <LemonInput
+                                                                                          value={value?.deviceTypes?.join(
+                                                                                              '|'
+                                                                                          )}
+                                                                                          onChange={(deviceTypesVal) =>
+                                                                                              onChange({
+                                                                                                  ...value,
+                                                                                                  deviceTypes: [
+                                                                                                      deviceTypesVal,
+                                                                                                  ],
+                                                                                              })
+                                                                                          }
+                                                                                          // regex placeholder for device type
+                                                                                          className="flex-1"
+                                                                                          placeholder="ex: Desktop|Mobile"
+                                                                                      />
+                                                                                  ) : (
+                                                                                      <PropertyValue
+                                                                                          propertyKey={getPropertyKey(
+                                                                                              'Device Type',
+                                                                                              TaxonomicFilterGroupType.EventProperties
+                                                                                          )}
+                                                                                          type={
+                                                                                              PropertyFilterType.Event
+                                                                                          }
+                                                                                          onSet={(
+                                                                                              deviceTypes:
+                                                                                                  | string
+                                                                                                  | string[]
+                                                                                          ) => {
+                                                                                              onChange({
+                                                                                                  ...value,
+                                                                                                  deviceTypes:
+                                                                                                      Array.isArray(
+                                                                                                          deviceTypes
+                                                                                                      )
+                                                                                                          ? deviceTypes
+                                                                                                          : [
+                                                                                                                deviceTypes,
+                                                                                                            ],
+                                                                                              })
+                                                                                          }}
+                                                                                          operator={
+                                                                                              PropertyOperator.Exact
+                                                                                          }
+                                                                                          value={value?.deviceTypes}
+                                                                                          inputClassName="flex-1"
+                                                                                      />
+                                                                                  )}
+                                                                              </div>
+                                                                          </LemonField.Pure>
+                                                                          <LemonField.Pure label="CSS selector matches:">
+                                                                              <LemonInput
+                                                                                  value={value?.selector}
+                                                                                  onChange={(selectorVal) =>
+                                                                                      onChange({
+                                                                                          ...value,
+                                                                                          selector: selectorVal,
+                                                                                      })
+                                                                                  }
+                                                                                  placeholder="ex: .className or #id"
+                                                                              />
+                                                                          </LemonField.Pure>
+                                                                          <LemonField.Pure
+                                                                              label="Survey wait period"
+                                                                              info="Note that this condition will only apply reliably for identified users within a single browser session. Anonymous users or users who switch browsers, use incognito sessions, or log out and log back in may see the survey again. Additionally, responses submitted while a user is anonymous may be associated with their account if they log in during the same session."
+                                                                          >
+                                                                              <div className="flex flex-row gap-2 items-center">
+                                                                                  <LemonCheckbox
+                                                                                      checked={
+                                                                                          !!value?.seenSurveyWaitPeriodInDays
+                                                                                      }
+                                                                                      onChange={(checked) => {
+                                                                                          if (checked) {
+                                                                                              onChange({
+                                                                                                  ...value,
+                                                                                                  seenSurveyWaitPeriodInDays:
+                                                                                                      value?.seenSurveyWaitPeriodInDays ||
+                                                                                                      30,
+                                                                                              })
+                                                                                          } else {
+                                                                                              const {
+                                                                                                  seenSurveyWaitPeriodInDays,
+                                                                                                  ...rest
+                                                                                              } = value || {}
+                                                                                              onChange(rest)
+                                                                                          }
+                                                                                      }}
+                                                                                  />
+                                                                                  Don't show to users who saw any survey
+                                                                                  in the last
+                                                                                  <LemonInput
+                                                                                      type="number"
+                                                                                      size="xsmall"
+                                                                                      min={0}
+                                                                                      value={
+                                                                                          value?.seenSurveyWaitPeriodInDays ||
+                                                                                          NaN
+                                                                                      }
+                                                                                      onChange={(val) => {
+                                                                                          if (
+                                                                                              val !== undefined &&
+                                                                                              val > 0
+                                                                                          ) {
+                                                                                              onChange({
+                                                                                                  ...value,
+                                                                                                  seenSurveyWaitPeriodInDays:
+                                                                                                      val,
+                                                                                              })
+                                                                                          } else {
+                                                                                              onChange({
+                                                                                                  ...value,
+                                                                                                  seenSurveyWaitPeriodInDays:
+                                                                                                      null,
+                                                                                              })
+                                                                                          }
+                                                                                      }}
+                                                                                      className="w-12"
+                                                                                      id="survey-wait-period-input"
+                                                                                  />{' '}
+                                                                                  {value?.seenSurveyWaitPeriodInDays ===
+                                                                                  1 ? (
+                                                                                      <span>day.</span>
+                                                                                  ) : (
+                                                                                      <span>days.</span>
+                                                                                  )}
+                                                                              </div>
+                                                                          </LemonField.Pure>
                                                                       </>
                                                                   )}
-                                                              </BindLogic>
-                                                          </LemonField.Pure>
-                                                          {featureFlags[FEATURE_FLAGS.SURVEYS_ACTIONS] ? (
-                                                              <LemonField.Pure
-                                                                  label="Activation triggers"
-                                                                  info="Survey will activate when any of these conditions are met"
-                                                              >
-                                                                  <div className="border rounded p-3 space-y-3">
-                                                                      <SurveyEventTrigger />
-                                                                      <div className="flex items-center gap-2">
-                                                                          <div className="flex-1 border-t border-dashed" />
-                                                                          <span className="text-xs font-semibold text-muted uppercase">
-                                                                              or
-                                                                          </span>
-                                                                          <div className="flex-1 border-t border-dashed" />
-                                                                      </div>
-                                                                      <SurveyActionTrigger />
-                                                                  </div>
+                                                              </LemonField>
+                                                              <LemonField.Pure label="Properties">
+                                                                  <BindLogic
+                                                                      logic={featureFlagLogic}
+                                                                      props={{ id: survey.targeting_flag?.id || 'new' }}
+                                                                  >
+                                                                      {!targetingFlagFilters && (
+                                                                          <LemonButton
+                                                                              type="secondary"
+                                                                              className="w-max"
+                                                                              onClick={() => {
+                                                                                  setSurveyValue(
+                                                                                      'targeting_flag_filters',
+                                                                                      {
+                                                                                          groups: [
+                                                                                              {
+                                                                                                  properties: [],
+                                                                                                  rollout_percentage: 100,
+                                                                                                  variant: null,
+                                                                                              },
+                                                                                          ],
+                                                                                          multivariate: null,
+                                                                                          payloads: {},
+                                                                                      }
+                                                                                  )
+                                                                                  setSurveyValue(
+                                                                                      'remove_targeting_flag',
+                                                                                      false
+                                                                                  )
+                                                                              }}
+                                                                          >
+                                                                              Add property targeting
+                                                                          </LemonButton>
+                                                                      )}
+                                                                      {targetingFlagFilters && (
+                                                                          <>
+                                                                              <div className="mt-2">
+                                                                                  <FeatureFlagReleaseConditions
+                                                                                      id={
+                                                                                          String(
+                                                                                              survey.targeting_flag?.id
+                                                                                          ) || 'new'
+                                                                                      }
+                                                                                      excludeTitle={true}
+                                                                                      filters={targetingFlagFilters}
+                                                                                      onChange={(filters, errors) => {
+                                                                                          setFlagPropertyErrors(errors)
+                                                                                          setSurveyValue(
+                                                                                              'targeting_flag_filters',
+                                                                                              filters
+                                                                                          )
+                                                                                      }}
+                                                                                      showTrashIconWithOneCondition
+                                                                                      removedLastConditionCallback={
+                                                                                          removeTargetingFlagFilters
+                                                                                      }
+                                                                                  />
+                                                                              </div>
+                                                                              <LemonButton
+                                                                                  type="secondary"
+                                                                                  status="danger"
+                                                                                  className="w-max"
+                                                                                  onClick={removeTargetingFlagFilters}
+                                                                              >
+                                                                                  Remove all property targeting
+                                                                              </LemonButton>
+                                                                          </>
+                                                                      )}
+                                                                  </BindLogic>
                                                               </LemonField.Pure>
-                                                          ) : (
-                                                              <SurveyEventTrigger />
-                                                          )}
-                                                          {!!survey.appearance?.surveyPopupDelaySeconds && (
-                                                              <SurveyCancelEventTrigger />
-                                                          )}
-                                                      </>
-                                                  )}
-                                              </LemonField.Pure>
-                                          ),
-                                      },
-                                  ]
-                                : []),
-                            {
-                                key: SurveyEditSection.CompletionConditions,
-                                header: 'Completion conditions',
-                                content: <SurveyCompletionConditions />,
-                            },
-                        ]}
-                    />
-                </div>
-                <div className="h-full">
-                    <div
-                        className={`sticky ${editingLanguage || hasTranslationValidationErrors ? 'top-28' : 'top-16'}`}
-                    >
-                        <SurveyFormAppearance
-                            previewPageIndex={selectedPageIndex || 0}
-                            survey={previewSurvey}
-                            handleSetSelectedPageIndex={(pageIndex) => setSelectedPageIndex(pageIndex)}
-                            isEditingSurvey={isEditingSurvey}
+                                                              {featureFlags[FEATURE_FLAGS.SURVEYS_ACTIONS] ? (
+                                                                  <LemonField.Pure
+                                                                      label="Activation triggers"
+                                                                      info="Survey will activate when any of these conditions are met"
+                                                                  >
+                                                                      <div className="border rounded p-3 space-y-3">
+                                                                          <SurveyEventTrigger />
+                                                                          <div className="flex items-center gap-2">
+                                                                              <div className="flex-1 border-t border-dashed" />
+                                                                              <span className="text-xs font-semibold text-muted uppercase">
+                                                                                  or
+                                                                              </span>
+                                                                              <div className="flex-1 border-t border-dashed" />
+                                                                          </div>
+                                                                          <SurveyActionTrigger />
+                                                                      </div>
+                                                                  </LemonField.Pure>
+                                                              ) : (
+                                                                  <SurveyEventTrigger />
+                                                              )}
+                                                              {!!survey.appearance?.surveyPopupDelaySeconds && (
+                                                                  <SurveyCancelEventTrigger />
+                                                              )}
+                                                          </>
+                                                      )}
+                                                  </LemonField.Pure>
+                                              ),
+                                          },
+                                      ]
+                                    : []),
+                                {
+                                    key: SurveyEditSection.CompletionConditions,
+                                    header: 'Completion conditions',
+                                    content: <SurveyCompletionConditions />,
+                                },
+                            ]}
                         />
                     </div>
+                    <div className="h-full">
+                        <div
+                            className={`sticky ${editingLanguage || hasTranslationValidationErrors ? 'top-28' : 'top-16'}`}
+                        >
+                            <SurveyFormAppearance
+                                previewPageIndex={selectedPageIndex || 0}
+                                survey={previewSurvey}
+                                handleSetSelectedPageIndex={(pageIndex) => setSelectedPageIndex(pageIndex)}
+                                isEditingSurvey={isEditingSurvey}
+                            />
+                        </div>
+                    </div>
                 </div>
-            </div>
             </div>
             <SurveyBranchingFlowModal survey={survey} isOpen={showFlowModal} onClose={() => setShowFlowModal(false)} />
         </SceneContent>

--- a/frontend/src/scenes/surveys/SurveyEdit.tsx
+++ b/frontend/src/scenes/surveys/SurveyEdit.tsx
@@ -71,6 +71,9 @@ import { SurveyAppearancePreview } from './SurveyAppearancePreview'
 import { HTMLEditor, PresentationTypeCard } from './SurveyAppearanceUtils'
 import { SurveyEditQuestionGroup, SurveyEditQuestionHeader } from './SurveyEditQuestionRow'
 import { SurveyFormAppearance } from './SurveyFormAppearance'
+import { SurveyBranchingFlowModal } from './branching-flow/SurveyBranchingFlowModal'
+import { COMMON_LANGUAGES } from './SurveyTranslations'
+import { SURVEY_TYPE_LABEL_MAP, SurveyMatchTypeLabels, defaultSurveyFieldValues } from './constants'
 import { DataCollectionType, SurveyEditSection, surveyLogic } from './surveyLogic'
 import { surveysLogic } from './surveysLogic'
 import { canUseSurveyWizard } from './utils'
@@ -254,6 +257,7 @@ export default function SurveyEdit({ id }: { id: string }): JSX.Element {
         resetTargeting,
         setSelectedPageIndex,
         setSelectedSection,
+        setEditingLanguage,
         setFlagPropertyErrors,
         deleteBranchingLogic,
         editingSurvey,
@@ -304,9 +308,9 @@ export default function SurveyEdit({ id }: { id: string }): JSX.Element {
 
     const [showFlowModal, setShowFlowModal] = useState(false)
 
-    // Auto-expand Steps panel when a language is selected for translation
+    // Auto-expand Steps panel when a language is selected for translation or when returning to default
     useEffect(() => {
-        if (editingLanguage) {
+        if (editingLanguage !== undefined) {
             setSelectedSection(SurveyEditSection.Steps)
         }
     }, [editingLanguage, setSelectedSection])
@@ -419,10 +423,20 @@ export default function SurveyEdit({ id }: { id: string }): JSX.Element {
                     }
                 />
                 {editingLanguage && (
-                    <div className="flex items-center gap-2 px-4 py-2 bg-warning-highlight rounded border border-warning">
-                        <IconInfo className="text-warning" />
+                    <div className="px-4 py-2 bg-warning-highlight rounded border border-warning sticky top-0 z-[9999] mb-2">
                         <span className="text-sm">
-                            Editing translation for <strong>{editingLanguage}</strong>
+                            Editing translation for{' '}
+                            <strong>
+                                {COMMON_LANGUAGES.find((l) => l.value === editingLanguage)?.label || editingLanguage}
+                            </strong>
+                            . Only user-facing text can be translated - all other fields are editable in the{' '}
+                            <button
+                                onClick={() => setEditingLanguage(null)}
+                                className="font-semibold hover:underline cursor-pointer"
+                            >
+                                default language
+                            </button>{' '}
+                            only.
                         </span>
                     </div>
                 )}

--- a/frontend/src/scenes/surveys/SurveyEdit.tsx
+++ b/frontend/src/scenes/surveys/SurveyEdit.tsx
@@ -4,7 +4,7 @@ import { DndContext } from '@dnd-kit/core'
 import { SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable'
 import { BindLogic, useActions, useMountedLogic, useValues } from 'kea'
 import { router } from 'kea-router'
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 
 import { IconGitBranch, IconInfo, IconPlus, IconTrash } from '@posthog/icons'
 import {
@@ -304,6 +304,13 @@ export default function SurveyEdit({ id }: { id: string }): JSX.Element {
 
     const [showFlowModal, setShowFlowModal] = useState(false)
 
+    // Auto-expand Steps panel when a language is selected for translation
+    useEffect(() => {
+        if (editingLanguage) {
+            setSelectedSection(SurveyEditSection.Steps)
+        }
+    }, [editingLanguage, setSelectedSection])
+
     const handleCancelClick = (): void => {
         editingSurvey(false)
         if (id === 'new') {
@@ -411,6 +418,14 @@ export default function SurveyEdit({ id }: { id: string }): JSX.Element {
                         </>
                     }
                 />
+                {editingLanguage && (
+                    <div className="flex items-center gap-2 px-4 py-2 bg-warning-highlight rounded border border-warning">
+                        <IconInfo className="text-warning" />
+                        <span className="text-sm">
+                            Editing translation for <strong>{editingLanguage}</strong>
+                        </span>
+                    </div>
+                )}
             </div>
             <div className="flex flex-col xl:grid xl:grid-cols-[1fr_400px] gap-x-4 h-full">
                 <div className="flex flex-col gap-2 flex-1 SurveyForm">
@@ -831,6 +846,11 @@ export default function SurveyEdit({ id }: { id: string }): JSX.Element {
                                     </>
                                 ),
                             },
+                            {
+                                key: SurveyEditSection.Translations,
+                                header: 'Translations',
+                                content: <SurveyTranslations />,
+                            },
                             ...(survey.type !== SurveyType.API
                                 ? [
                                       {
@@ -874,11 +894,6 @@ export default function SurveyEdit({ id }: { id: string }): JSX.Element {
                                       },
                                   ]
                                 : []),
-                            {
-                                key: SurveyEditSection.Translations,
-                                header: 'Translations',
-                                content: <SurveyTranslations />,
-                            },
                             ...(survey.type !== SurveyType.ExternalSurvey
                                 ? [
                                       {

--- a/frontend/src/scenes/surveys/SurveyEdit.tsx
+++ b/frontend/src/scenes/surveys/SurveyEdit.tsx
@@ -251,8 +251,8 @@ export default function SurveyEdit({ id }: { id: string }): JSX.Element {
         surveyErrors,
         user,
         surveyLoading,
-        choicesMismatchedLanguages,
-        hasChoicesMismatch,
+        translationValidationErrors,
+        hasTranslationValidationErrors,
     } = useValues(surveyLogic)
     const {
         setSurveyValue,
@@ -434,8 +434,8 @@ export default function SurveyEdit({ id }: { id: string }): JSX.Element {
                                 form="survey"
                                 size="small"
                                 disabledReason={
-                                    hasChoicesMismatch
-                                        ? `Cannot save: choices translations don't match. Please update translations for: ${choicesMismatchedLanguages.join(', ')}`
+                                    hasTranslationValidationErrors
+                                        ? 'Cannot save: please fix translation validation errors below'
                                         : undefined
                                 }
                             >
@@ -462,22 +462,69 @@ export default function SurveyEdit({ id }: { id: string }): JSX.Element {
                         </span>
                     </div>
                 )}
-                {hasChoicesMismatch && (
-                    <div className="px-4 py-2 bg-danger-highlight rounded border border-danger mt-4">
-                        <span className="text-sm">
-                            ⚠️ Choices were modified in the default language. Please update choices translations for:{' '}
-                            {choicesMismatchedLanguages.map((lang, index) => (
-                                <span key={lang}>
-                                    {index > 0 && ', '}
-                                    <button
-                                        onClick={() => setEditingLanguage(lang)}
-                                        className="font-bold hover:underline cursor-pointer text-danger"
-                                    >
-                                        {COMMON_LANGUAGES.find((l) => l.value === lang)?.label || lang}
-                                    </button>
-                                </span>
-                            ))}
-                        </span>
+                {hasTranslationValidationErrors && (
+                    <div className="px-4 py-2 bg-warning-highlight rounded border border-warning mt-4">
+                        <LemonCollapse
+                            embedded
+                            defaultActiveKey="validation-errors"
+                            panels={[
+                                {
+                                    key: 'validation-errors',
+                                    header: {
+                                        children: (
+                                            <span className="text-sm font-semibold">
+                                                ⚠️ Translation validation issues ({translationValidationErrors.length})
+                                            </span>
+                                        ),
+                                    },
+                                    content: (
+                                        <div className="text-sm">
+                                            {(() => {
+                                                // Group errors by language
+                                                const errorsByLanguage = translationValidationErrors.reduce(
+                                                    (acc, error) => {
+                                                        const lang = error.language
+                                                        if (!acc[lang]) {
+                                                            acc[lang] = []
+                                                        }
+                                                        acc[lang].push(error)
+                                                        return acc
+                                                    },
+                                                    {} as Record<string, typeof translationValidationErrors>
+                                                )
+
+                                                return Object.entries(errorsByLanguage).map(([lang, errors]) => (
+                                                    <div key={lang} className="mb-2">
+                                                        <button
+                                                            onClick={() =>
+                                                                setEditingLanguage(lang === 'default' ? null : lang)
+                                                            }
+                                                            className="font-semibold hover:underline cursor-pointer"
+                                                        >
+                                                            {lang === 'default'
+                                                                ? 'Default language'
+                                                                : COMMON_LANGUAGES.find((l) => l.value === lang)
+                                                                      ?.label || lang}
+                                                        </button>
+                                                        :
+                                                        <ul className="ml-4 list-disc">
+                                                            {errors.map((error, idx) => (
+                                                                <li key={idx}>
+                                                                    {error.questionIndex >= 0
+                                                                        ? `Question ${error.questionIndex + 1}`
+                                                                        : 'Survey'}{' '}
+                                                                    - {error.field}: {error.error}
+                                                                </li>
+                                                            ))}
+                                                        </ul>
+                                                    </div>
+                                                ))
+                                            })()}
+                                        </div>
+                                    ),
+                                },
+                            ]}
+                        />
                     </div>
                 )}
             </div>

--- a/frontend/src/scenes/surveys/SurveyEdit.tsx
+++ b/frontend/src/scenes/surveys/SurveyEdit.tsx
@@ -44,6 +44,7 @@ import { SurveyCancelEventTrigger, SurveyEventTrigger } from 'scenes/surveys/Sur
 import { SurveyRepeatSchedule } from 'scenes/surveys/SurveyRepeatSchedule'
 import { SurveyResponsesCollection } from 'scenes/surveys/SurveyResponsesCollection'
 import { SurveyTranslations } from 'scenes/surveys/SurveyTranslations'
+import { getSurveyWithTranslatedContent } from 'scenes/surveys/surveyTranslationUtils'
 import { SurveyWidgetCustomization } from 'scenes/surveys/SurveyWidgetCustomization'
 import { sanitizeSurveyAppearance, validateSurveyAppearance } from 'scenes/surveys/utils'
 import { urls } from 'scenes/urls'
@@ -302,55 +303,10 @@ export default function SurveyEdit({ id }: { id: string }): JSX.Element {
     const hasActiveTranslationValidationErrors = surveyTranslationsEnabled && hasTranslationValidationErrors
     const activeTranslationValidationErrors = surveyTranslationsEnabled ? translationValidationErrors : []
     const hasVisibleTranslationValidationErrors = hasActiveTranslationValidationErrors && hasActualTranslations
-    const previewSurvey = useMemo(() => {
-        if (!activeEditingLanguage || !survey.translations?.[activeEditingLanguage]) {
-            return survey
-        }
-
-        const processed = { ...survey }
-        const translation = survey.translations[activeEditingLanguage]
-
-        if (translation.name) {
-            processed.name = translation.name
-        }
-        if (
-            translation.thankYouMessageHeader ||
-            translation.thankYouMessageDescription ||
-            translation.thankYouMessageCloseButtonText
-        ) {
-            processed.appearance = {
-                ...survey.appearance,
-                ...(translation.thankYouMessageHeader && {
-                    thankYouMessageHeader: translation.thankYouMessageHeader,
-                }),
-                ...(translation.thankYouMessageDescription && {
-                    thankYouMessageDescription: translation.thankYouMessageDescription,
-                }),
-                ...(translation.thankYouMessageCloseButtonText && {
-                    thankYouMessageCloseButtonText: translation.thankYouMessageCloseButtonText,
-                }),
-            }
-        }
-
-        processed.questions = survey.questions.map((q) => {
-            const qTrans = q.translations?.[activeEditingLanguage]
-            if (qTrans) {
-                return {
-                    ...q,
-                    question: qTrans.question || q.question,
-                    description: qTrans.description || q.description,
-                    choices: qTrans.choices || q.choices,
-                    buttonText: qTrans.buttonText || q.buttonText,
-                    link: qTrans.link || q.link,
-                    lowerBoundLabel: qTrans.lowerBoundLabel || q.lowerBoundLabel,
-                    upperBoundLabel: qTrans.upperBoundLabel || q.upperBoundLabel,
-                }
-            }
-            return q
-        })
-
-        return processed
-    }, [survey, activeEditingLanguage])
+    const previewSurvey = useMemo(
+        () => getSurveyWithTranslatedContent(survey, activeEditingLanguage),
+        [survey, activeEditingLanguage]
+    )
     const sortedItemIds = survey.questions.map((_, idx) => idx.toString())
     const { thankYouMessageDescriptionContentType = null } = survey.appearance ?? {}
     useMountedLogic(actionsModel)
@@ -1067,27 +1023,28 @@ export default function SurveyEdit({ id }: { id: string }): JSX.Element {
                                                                                                               )
                                                                                                           }
                                                                                                       }}
-                                                                                                      onTabChange={
-                                                                                                          activeEditingLanguage
-                                                                                                              ? undefined
-                                                                                                              : (
-                                                                                                                    key
-                                                                                                                ) => {
-                                                                                                                    const updatedAppearance =
-                                                                                                                        {
-                                                                                                                            ...survey.appearance,
-                                                                                                                            thankYouMessageDescriptionContentType:
-                                                                                                                                key ===
-                                                                                                                                'html'
-                                                                                                                                    ? 'html'
-                                                                                                                                    : 'text',
-                                                                                                                        }
-                                                                                                                    setSurveyValue(
-                                                                                                                        'appearance',
-                                                                                                                        updatedAppearance
-                                                                                                                    )
-                                                                                                                }
-                                                                                                      }
+                                                                                                      onTabChange={(
+                                                                                                          key
+                                                                                                      ) => {
+                                                                                                          if (
+                                                                                                              activeEditingLanguage
+                                                                                                          ) {
+                                                                                                              return
+                                                                                                          }
+                                                                                                          const updatedAppearance =
+                                                                                                              {
+                                                                                                                  ...survey.appearance,
+                                                                                                                  thankYouMessageDescriptionContentType:
+                                                                                                                      key ===
+                                                                                                                      'html'
+                                                                                                                          ? 'html'
+                                                                                                                          : 'text',
+                                                                                                              }
+                                                                                                          setSurveyValue(
+                                                                                                              'appearance',
+                                                                                                              updatedAppearance
+                                                                                                          )
+                                                                                                      }}
                                                                                                       activeTab={
                                                                                                           thankYouMessageDescriptionContentType ??
                                                                                                           'text'

--- a/frontend/src/scenes/surveys/SurveyEdit.tsx
+++ b/frontend/src/scenes/surveys/SurveyEdit.tsx
@@ -281,6 +281,23 @@ export default function SurveyEdit({ id }: { id: string }): JSX.Element {
             processed.description = translation.description
         }
 
+        if (
+            translation.thankYouMessageHeader ||
+            translation.thankYouMessageDescription ||
+            translation.thankYouMessageCloseButtonText
+        ) {
+            processed.appearance = {
+                ...survey.appearance,
+                ...(translation.thankYouMessageHeader && { thankYouMessageHeader: translation.thankYouMessageHeader }),
+                ...(translation.thankYouMessageDescription && {
+                    thankYouMessageDescription: translation.thankYouMessageDescription,
+                }),
+                ...(translation.thankYouMessageCloseButtonText && {
+                    thankYouMessageCloseButtonText: translation.thankYouMessageCloseButtonText,
+                }),
+            }
+        }
+
         processed.questions = survey.questions.map((q) => {
             const qTrans = q.translations?.[editingLanguage]
             if (qTrans) {
@@ -289,8 +306,6 @@ export default function SurveyEdit({ id }: { id: string }): JSX.Element {
                     question: qTrans.question || q.question,
                     description: qTrans.description || q.description,
                     choices: qTrans.choices || q.choices,
-                    thankYouMessageHeader: qTrans.thankYouMessageHeader || q.thankYouMessageHeader,
-                    thankYouMessageDescription: qTrans.thankYouMessageDescription || q.thankYouMessageDescription,
                     buttonText: qTrans.buttonText || q.buttonText,
                     link: qTrans.link || q.link,
                     lowerBoundLabel: qTrans.lowerBoundLabel || q.lowerBoundLabel,
@@ -718,17 +733,50 @@ export default function SurveyEdit({ id }: { id: string }): JSX.Element {
                                                                               <LemonField.Pure label="Thank you header">
                                                                                   <LemonInput
                                                                                       value={
-                                                                                          survey.appearance
-                                                                                              .thankYouMessageHeader
+                                                                                          editingLanguage
+                                                                                              ? (survey.translations?.[
+                                                                                                    editingLanguage
+                                                                                                ]
+                                                                                                    ?.thankYouMessageHeader ??
+                                                                                                '')
+                                                                                              : (survey.appearance
+                                                                                                    .thankYouMessageHeader ??
+                                                                                                '')
                                                                                       }
-                                                                                      onChange={(val) =>
-                                                                                          setSurveyValue('appearance', {
-                                                                                              ...survey.appearance,
-                                                                                              thankYouMessageHeader:
-                                                                                                  val,
-                                                                                          })
+                                                                                      onChange={(val) => {
+                                                                                          if (editingLanguage) {
+                                                                                              setSurveyValue(
+                                                                                                  'translations',
+                                                                                                  {
+                                                                                                      ...survey.translations,
+                                                                                                      [editingLanguage]:
+                                                                                                          {
+                                                                                                              ...survey
+                                                                                                                  .translations?.[
+                                                                                                                  editingLanguage
+                                                                                                              ],
+                                                                                                              thankYouMessageHeader:
+                                                                                                                  val,
+                                                                                                          },
+                                                                                                  }
+                                                                                              )
+                                                                                          } else {
+                                                                                              setSurveyValue(
+                                                                                                  'appearance',
+                                                                                                  {
+                                                                                                      ...survey.appearance,
+                                                                                                      thankYouMessageHeader:
+                                                                                                          val,
+                                                                                                  }
+                                                                                              )
+                                                                                          }
+                                                                                      }}
+                                                                                      placeholder={
+                                                                                          editingLanguage
+                                                                                              ? survey.appearance
+                                                                                                    .thankYouMessageHeader
+                                                                                              : 'ex: Thank you for your feedback!'
                                                                                       }
-                                                                                      placeholder="ex: Thank you for your feedback!"
                                                                                   />
                                                                               </LemonField.Pure>
                                                                               <LemonField.Pure
@@ -737,35 +785,77 @@ export default function SurveyEdit({ id }: { id: string }): JSX.Element {
                                                                               >
                                                                                   <HTMLEditor
                                                                                       value={
-                                                                                          survey.appearance
-                                                                                              .thankYouMessageDescription
+                                                                                          editingLanguage
+                                                                                              ? (survey.translations?.[
+                                                                                                    editingLanguage
+                                                                                                ]
+                                                                                                    ?.thankYouMessageDescription ??
+                                                                                                '')
+                                                                                              : (survey.appearance
+                                                                                                    .thankYouMessageDescription ??
+                                                                                                '')
                                                                                       }
-                                                                                      onChange={(val) =>
-                                                                                          setSurveyValue('appearance', {
-                                                                                              ...survey.appearance,
-                                                                                              thankYouMessageDescription:
-                                                                                                  val,
-                                                                                              thankYouMessageDescriptionContentType,
-                                                                                          })
-                                                                                      }
-                                                                                      onTabChange={(key) => {
-                                                                                          const updatedAppearance = {
-                                                                                              ...survey.appearance,
-                                                                                              thankYouMessageDescriptionContentType:
-                                                                                                  key === 'html'
-                                                                                                      ? 'html'
-                                                                                                      : 'text',
+                                                                                      onChange={(val) => {
+                                                                                          if (editingLanguage) {
+                                                                                              setSurveyValue(
+                                                                                                  'translations',
+                                                                                                  {
+                                                                                                      ...survey.translations,
+                                                                                                      [editingLanguage]:
+                                                                                                          {
+                                                                                                              ...survey
+                                                                                                                  .translations?.[
+                                                                                                                  editingLanguage
+                                                                                                              ],
+                                                                                                              thankYouMessageDescription:
+                                                                                                                  val,
+                                                                                                          },
+                                                                                                  }
+                                                                                              )
+                                                                                          } else {
+                                                                                              setSurveyValue(
+                                                                                                  'appearance',
+                                                                                                  {
+                                                                                                      ...survey.appearance,
+                                                                                                      thankYouMessageDescription:
+                                                                                                          val,
+                                                                                                      thankYouMessageDescriptionContentType,
+                                                                                                  }
+                                                                                              )
                                                                                           }
-                                                                                          setSurveyValue(
-                                                                                              'appearance',
-                                                                                              updatedAppearance
-                                                                                          )
                                                                                       }}
+                                                                                      onTabChange={
+                                                                                          editingLanguage
+                                                                                              ? undefined
+                                                                                              : (key) => {
+                                                                                                    const updatedAppearance =
+                                                                                                        {
+                                                                                                            ...survey.appearance,
+                                                                                                            thankYouMessageDescriptionContentType:
+                                                                                                                key ===
+                                                                                                                'html'
+                                                                                                                    ? 'html'
+                                                                                                                    : 'text',
+                                                                                                        }
+                                                                                                    setSurveyValue(
+                                                                                                        'appearance',
+                                                                                                        updatedAppearance
+                                                                                                    )
+                                                                                                }
+                                                                                      }
                                                                                       activeTab={
                                                                                           thankYouMessageDescriptionContentType ??
                                                                                           'text'
                                                                                       }
-                                                                                      textPlaceholder="ex: We really appreciate it."
+                                                                                      textPlaceholder={
+                                                                                          editingLanguage
+                                                                                              ? survey.appearance
+                                                                                                    .thankYouMessageDescription
+                                                                                              : 'ex: We really appreciate it.'
+                                                                                      }
+                                                                                      disableTabSwitching={
+                                                                                          !!editingLanguage
+                                                                                      }
                                                                                   />
                                                                               </LemonField.Pure>
                                                                               <LemonField.Pure
@@ -774,17 +864,50 @@ export default function SurveyEdit({ id }: { id: string }): JSX.Element {
                                                                               >
                                                                                   <LemonInput
                                                                                       value={
-                                                                                          survey.appearance
-                                                                                              .thankYouMessageCloseButtonText
+                                                                                          editingLanguage
+                                                                                              ? (survey.translations?.[
+                                                                                                    editingLanguage
+                                                                                                ]
+                                                                                                    ?.thankYouMessageCloseButtonText ??
+                                                                                                '')
+                                                                                              : (survey.appearance
+                                                                                                    .thankYouMessageCloseButtonText ??
+                                                                                                '')
                                                                                       }
-                                                                                      onChange={(val) =>
-                                                                                          setSurveyValue('appearance', {
-                                                                                              ...survey.appearance,
-                                                                                              thankYouMessageCloseButtonText:
-                                                                                                  val,
-                                                                                          })
+                                                                                      onChange={(val) => {
+                                                                                          if (editingLanguage) {
+                                                                                              setSurveyValue(
+                                                                                                  'translations',
+                                                                                                  {
+                                                                                                      ...survey.translations,
+                                                                                                      [editingLanguage]:
+                                                                                                          {
+                                                                                                              ...survey
+                                                                                                                  .translations?.[
+                                                                                                                  editingLanguage
+                                                                                                              ],
+                                                                                                              thankYouMessageCloseButtonText:
+                                                                                                                  val,
+                                                                                                          },
+                                                                                                  }
+                                                                                              )
+                                                                                          } else {
+                                                                                              setSurveyValue(
+                                                                                                  'appearance',
+                                                                                                  {
+                                                                                                      ...survey.appearance,
+                                                                                                      thankYouMessageCloseButtonText:
+                                                                                                          val,
+                                                                                                  }
+                                                                                              )
+                                                                                          }
+                                                                                      }}
+                                                                                      placeholder={
+                                                                                          editingLanguage
+                                                                                              ? survey.appearance
+                                                                                                    .thankYouMessageCloseButtonText
+                                                                                              : 'example: Close'
                                                                                       }
-                                                                                      placeholder="example: Close"
                                                                                   />
                                                                               </LemonField.Pure>
                                                                               <LemonField.Pure className="mt-2">

--- a/frontend/src/scenes/surveys/SurveyEdit.tsx
+++ b/frontend/src/scenes/surveys/SurveyEdit.tsx
@@ -234,6 +234,30 @@ function SurveyCompletionConditions(): JSX.Element {
     )
 }
 
+// Helper to format field names for display
+function formatFieldName(field: string): string {
+    const fieldNameMap: Record<string, string> = {
+        name: 'Survey name',
+        description: 'Survey description',
+        thankYouMessageHeader: 'Thank you message header',
+        thankYouMessageDescription: 'Thank you message description',
+        thankYouMessageCloseButtonText: 'Thank you close button text',
+        question: 'Question text',
+        buttonText: 'Button text',
+        lowerBoundLabel: 'Lower bound label',
+        upperBoundLabel: 'Upper bound label',
+        link: 'Link URL',
+    }
+
+    // Handle choices[n] format
+    const choiceMatch = field.match(/^choices\[(\d+)\]$/)
+    if (choiceMatch) {
+        return `Choice ${parseInt(choiceMatch[1]) + 1}`
+    }
+
+    return fieldNameMap[field] || field
+}
+
 export default function SurveyEdit({ id }: { id: string }): JSX.Element {
     const {
         survey,
@@ -444,19 +468,19 @@ export default function SurveyEdit({ id }: { id: string }): JSX.Element {
                 />
                 <div className="sticky top-[34px] z-[100] bg-bg-3000">
                     {hasTranslationValidationErrors ? (
-                        <div className="px-4 py-2 mt-1 mb-1.5 bg-warning-highlight rounded border border-warning">
                         <LemonCollapse
                             embedded
-                            defaultActiveKey="validation-errors"
+                            className="my-2 bg-warning-highlight rounded"
                             panels={[
                                 {
                                     key: 'validation-errors',
                                     header: {
                                         children: (
-                                            <span className="text-sm font-semibold">
+                                            <span className="text-sm">
                                                 ⚠️ Translation validation issues ({translationValidationErrors.length})
                                             </span>
                                         ),
+                                        className: 'bg-warning-highlight',
                                     },
                                     content: (
                                         <div className="text-sm">
@@ -477,9 +501,10 @@ export default function SurveyEdit({ id }: { id: string }): JSX.Element {
                                                 return Object.entries(errorsByLanguage).map(([lang, errors]) => (
                                                     <div key={lang} className="mb-2">
                                                         <button
-                                                            onClick={() =>
+                                                            onClick={(e) => {
+                                                                e.preventDefault()
                                                                 setEditingLanguage(lang === 'default' ? null : lang)
-                                                            }
+                                                            }}
                                                             className="font-semibold hover:underline cursor-pointer"
                                                         >
                                                             {lang === 'default'
@@ -503,11 +528,11 @@ export default function SurveyEdit({ id }: { id: string }): JSX.Element {
                                             })()}
                                         </div>
                                     ),
+                                    className: 'bg-warning-highlight',
                                 },
                             ]}
                         />
-                    </div>
-                ) : editingLanguage ? (
+                    ) : editingLanguage ? (
                     <div className="px-4 py-2 mt-1 mb-1.5 bg-warning-highlight rounded border border-warning">
                         <span className="text-sm">
                             Editing translation for{' '}

--- a/frontend/src/scenes/surveys/SurveyEdit.tsx
+++ b/frontend/src/scenes/surveys/SurveyEdit.tsx
@@ -43,7 +43,7 @@ import { SurveyActionTrigger } from 'scenes/surveys/SurveyActionTrigger'
 import { SurveyCancelEventTrigger, SurveyEventTrigger } from 'scenes/surveys/SurveyEventTrigger'
 import { SurveyRepeatSchedule } from 'scenes/surveys/SurveyRepeatSchedule'
 import { SurveyResponsesCollection } from 'scenes/surveys/SurveyResponsesCollection'
-import { SurveyTranslations } from 'scenes/surveys/SurveyTranslations'
+import { COMMON_LANGUAGES, SurveyTranslations } from 'scenes/surveys/SurveyTranslations'
 import { SurveyWidgetCustomization } from 'scenes/surveys/SurveyWidgetCustomization'
 import { sanitizeSurveyAppearance } from 'scenes/surveys/utils'
 import { urls } from 'scenes/urls'
@@ -64,17 +64,16 @@ import {
     SurveyType,
 } from '~/types'
 
-import { SurveyBranchingFlowModal } from './branching-flow/SurveyBranchingFlowModal'
-import { SURVEY_TYPE_LABEL_MAP, SurveyMatchTypeLabels, defaultSurveyFieldValues } from './constants'
 import { SurveyAPIEditor } from './SurveyAPIEditor'
 import { SurveyAppearancePreview } from './SurveyAppearancePreview'
 import { HTMLEditor, PresentationTypeCard } from './SurveyAppearanceUtils'
 import { SurveyEditQuestionGroup, SurveyEditQuestionHeader } from './SurveyEditQuestionRow'
 import { SurveyFormAppearance } from './SurveyFormAppearance'
-import { COMMON_LANGUAGES } from './SurveyTranslations'
 import { DataCollectionType, SurveyEditSection, surveyLogic } from './surveyLogic'
 import { surveysLogic } from './surveysLogic'
 import { canUseSurveyWizard } from './utils'
+import { SurveyBranchingFlowModal } from './branching-flow/SurveyBranchingFlowModal'
+import { SURVEY_TYPE_LABEL_MAP, SurveyMatchTypeLabels, defaultSurveyFieldValues } from './constants'
 
 function SurveyCompletionConditions(): JSX.Element {
     const { survey, dataCollectionType, isAdaptiveLimitFFEnabled } = useValues(surveyLogic)

--- a/frontend/src/scenes/surveys/SurveyEdit.tsx
+++ b/frontend/src/scenes/surveys/SurveyEdit.tsx
@@ -71,9 +71,7 @@ import { SurveyAppearancePreview } from './SurveyAppearancePreview'
 import { HTMLEditor, PresentationTypeCard } from './SurveyAppearanceUtils'
 import { SurveyEditQuestionGroup, SurveyEditQuestionHeader } from './SurveyEditQuestionRow'
 import { SurveyFormAppearance } from './SurveyFormAppearance'
-import { SurveyBranchingFlowModal } from './branching-flow/SurveyBranchingFlowModal'
 import { COMMON_LANGUAGES } from './SurveyTranslations'
-import { SURVEY_TYPE_LABEL_MAP, SurveyMatchTypeLabels, defaultSurveyFieldValues } from './constants'
 import { DataCollectionType, SurveyEditSection, surveyLogic } from './surveyLogic'
 import { surveysLogic } from './surveysLogic'
 import { canUseSurveyWizard } from './utils'
@@ -267,7 +265,7 @@ export default function SurveyEdit({ id }: { id: string }): JSX.Element {
     } = useActions(surveyLogic)
     const { setPreferredEditor } = useActions(surveysLogic)
     const { featureFlags } = useValues(enabledFeaturesLogic)
-    const { guidedEditorEnabled } = useValues(surveysLogic)
+    const { guidedEditorEnabled } = useValues(surveyLogic)
     const previewSurvey = useMemo(() => {
         if (!editingLanguage || !survey.translations?.[editingLanguage]) {
             return survey
@@ -364,7 +362,7 @@ export default function SurveyEdit({ id }: { id: string }): JSX.Element {
 
     return (
         <SceneContent>
-            <div className="flex flex-col gap-y-4">
+            <div className={`flex flex-col gap-y-4 ${editingLanguage || hasTranslationValidationErrors ? 'mt-1' : ''}`}>
                 <SceneTitleSection
                     name={editingLanguage ? (survey.translations?.[editingLanguage]?.name ?? '') : survey.name}
                     description={
@@ -444,26 +442,9 @@ export default function SurveyEdit({ id }: { id: string }): JSX.Element {
                         </>
                     }
                 />
-                {editingLanguage && (
-                    <div className="px-4 py-2 bg-warning-highlight rounded border border-warning sticky top-0 z-[9999] mb-2">
-                        <span className="text-sm">
-                            Editing translation for{' '}
-                            <strong>
-                                {COMMON_LANGUAGES.find((l) => l.value === editingLanguage)?.label || editingLanguage}
-                            </strong>
-                            . Only user-facing text can be translated - all other fields are editable in the{' '}
-                            <button
-                                onClick={() => setEditingLanguage(null)}
-                                className="font-semibold hover:underline cursor-pointer"
-                            >
-                                default language
-                            </button>{' '}
-                            only.
-                        </span>
-                    </div>
-                )}
-                {hasTranslationValidationErrors && (
-                    <div className="px-4 py-2 bg-warning-highlight rounded border border-warning mt-4">
+                <div className="sticky top-[34px] z-[100] bg-bg-3000">
+                    {hasTranslationValidationErrors ? (
+                        <div className="px-4 py-2 mt-1 mb-1.5 bg-warning-highlight rounded border border-warning">
                         <LemonCollapse
                             embedded
                             defaultActiveKey="validation-errors"
@@ -526,136 +507,156 @@ export default function SurveyEdit({ id }: { id: string }): JSX.Element {
                             ]}
                         />
                     </div>
-                )}
+                ) : editingLanguage ? (
+                    <div className="px-4 py-2 mt-1 mb-1.5 bg-warning-highlight rounded border border-warning">
+                        <span className="text-sm">
+                            Editing translation for{' '}
+                            <strong>
+                                {COMMON_LANGUAGES.find((l) => l.value === editingLanguage)?.label || editingLanguage}
+                            </strong>
+                            . Only user-facing text can be translated - all other fields are editable in the{' '}
+                            <button
+                                onClick={() => setEditingLanguage(null)}
+                                className="font-semibold hover:underline cursor-pointer"
+                            >
+                                default language
+                            </button>{' '}
+                            only.
+                        </span>
+                    </div>
+                ) : null}
             </div>
-            <div className="flex flex-col xl:grid xl:grid-cols-[1fr_400px] gap-x-4 h-full">
-                <div className="flex flex-col gap-2 flex-1 SurveyForm">
-                    <LemonCollapse
-                        activeKey={selectedSection || undefined}
-                        onChange={(section) => {
-                            setSelectedSection(section)
-                        }}
-                        className="bg-surface-primary"
-                        panels={[
-                            {
-                                key: SurveyEditSection.Presentation,
-                                header: 'Presentation',
-                                content: (
-                                    <LemonField name="type">
-                                        {({ onChange, value }) => {
-                                            return (
-                                                <div className="flex flex-col gap-2">
-                                                    <div className="grid grid-cols-2 2xl:grid-cols-4 gap-4">
-                                                        <PresentationTypeCard
-                                                            active={value === SurveyType.Popover}
-                                                            onClick={() => {
-                                                                onChange(SurveyType.Popover)
-                                                                if (survey.schedule === SurveySchedule.Always) {
-                                                                    setSurveyValue('schedule', SurveySchedule.Once)
-                                                                }
-                                                            }}
-                                                            title={SURVEY_TYPE_LABEL_MAP[SurveyType.Popover]}
-                                                            description="Automatically appears when PostHog JS is installed"
-                                                            value={SurveyType.Popover}
-                                                        >
-                                                            <div className="scale-[0.8] absolute -top-4 -left-4">
-                                                                <SurveyAppearancePreview
-                                                                    survey={survey}
-                                                                    previewPageIndex={0}
-                                                                />
-                                                            </div>
-                                                        </PresentationTypeCard>
-                                                        <PresentationTypeCard
-                                                            active={value === SurveyType.API}
-                                                            onClick={() => {
-                                                                onChange(SurveyType.API)
-                                                                if (survey.schedule === SurveySchedule.Always) {
-                                                                    setSurveyValue('schedule', SurveySchedule.Once)
-                                                                }
-                                                            }}
-                                                            title={SURVEY_TYPE_LABEL_MAP[SurveyType.API]}
-                                                            description="Use the PostHog API to show/hide your survey programmatically"
-                                                            value={SurveyType.API}
-                                                        >
-                                                            <div className="absolute left-4 w-[350px]">
-                                                                <SurveyAPIEditor survey={survey} />
-                                                            </div>
-                                                        </PresentationTypeCard>
-                                                        <PresentationTypeCard
-                                                            active={value === SurveyType.Widget}
-                                                            onClick={() => onChange(SurveyType.Widget)}
-                                                            title={SURVEY_TYPE_LABEL_MAP[SurveyType.Widget]}
-                                                            description="Set up a survey based on your own custom button or our prebuilt feedback tab"
-                                                            value={SurveyType.Widget}
-                                                        >
-                                                            <button className="bg-black py-2 px-3 min-w-[40px] absolute right-3 -bottom-16 text-white opacity-30 rounded scale-[2]">
-                                                                Feedback
-                                                            </button>
-                                                        </PresentationTypeCard>
-                                                        <PresentationTypeCard
-                                                            active={value === SurveyType.ExternalSurvey}
-                                                            onClick={() => onChange(SurveyType.ExternalSurvey)}
-                                                            title={SURVEY_TYPE_LABEL_MAP[SurveyType.ExternalSurvey]}
-                                                            description="Collect responses via an external link, hosted on PostHog. If you are already using surveys, make sure to upgrade posthog-js to at least v1.258.1."
-                                                            value={SurveyType.ExternalSurvey}
-                                                        >
-                                                            <LemonTag type="warning">BETA</LemonTag>
-                                                        </PresentationTypeCard>
-                                                    </div>
-                                                    {survey.type === SurveyType.Widget && <SurveyWidgetCustomization />}
-                                                    {survey.type === SurveyType.ExternalSurvey && (
-                                                        <>
-                                                            <Tooltip title="Enable this to embed the survey in tools like Framer, Webflow, or other website builders that use iframes.">
-                                                                <LemonSwitch
-                                                                    checked={!!survey.enable_iframe_embedding}
-                                                                    onChange={(checked) =>
-                                                                        setSurveyValue(
-                                                                            'enable_iframe_embedding',
-                                                                            checked
-                                                                        )
+                <div className="flex flex-col xl:grid xl:grid-cols-[1fr_400px] gap-x-4 h-full">
+                    <div className="flex flex-col gap-2 flex-1 SurveyForm">
+                        <LemonCollapse
+                            activeKey={selectedSection || undefined}
+                            onChange={(section) => {
+                                setSelectedSection(section)
+                            }}
+                            className="bg-surface-primary"
+                            panels={[
+                                {
+                                    key: SurveyEditSection.Presentation,
+                                    header: 'Presentation',
+                                    content: (
+                                        <LemonField name="type">
+                                            {({ onChange, value }) => {
+                                                return (
+                                                    <div className="flex flex-col gap-2">
+                                                        <div className="grid grid-cols-2 2xl:grid-cols-4 gap-4">
+                                                            <PresentationTypeCard
+                                                                active={value === SurveyType.Popover}
+                                                                onClick={() => {
+                                                                    onChange(SurveyType.Popover)
+                                                                    if (survey.schedule === SurveySchedule.Always) {
+                                                                        setSurveyValue('schedule', SurveySchedule.Once)
                                                                     }
-                                                                    label="Allow embedding in iframes"
-                                                                    bordered
-                                                                />
-                                                            </Tooltip>
-                                                            <div className="font-semibold">
-                                                                How hosted surveys work:
-                                                            </div>
-                                                            <ul className="space-y-2 text-sm">
-                                                                <li>
-                                                                    • The survey will be hosted by PostHog and you can
-                                                                    share the URL with your customers
-                                                                </li>
-                                                                <li>
-                                                                    • To identify respondents, add the{' '}
-                                                                    <code className="bg-surface-tertiary px-1 rounded">
-                                                                        distinct_id
-                                                                    </code>{' '}
-                                                                    query parameter to the URL. Here's an example:{'\n'}
-                                                                    <Link
-                                                                        to={`https://us.posthog.com/external_surveys/01984280-fc8a-0000-28a5-01078e2d553f?distinct_id=${user?.email ?? 'john@acme.co'}`}
-                                                                        target="_blank"
-                                                                    >{`https://us.posthog.com/external_surveys/01984280-fc8a-0000-28a5-01078e2d553f?distinct_id=${user?.email ?? 'john@acme.co'}`}</Link>
-                                                                </li>
-                                                                <li>
-                                                                    • Check more details about identifying respondents
-                                                                    in the{' '}
-                                                                    <Link
-                                                                        to="https://posthog.com/docs/surveys/creating-surveys#identifying-respondents-on-hosted-surveys"
-                                                                        target="_blank"
-                                                                    >
-                                                                        documentation
-                                                                    </Link>
-                                                                </li>
-                                                            </ul>
-                                                        </>
-                                                    )}
-                                                </div>
-                                            )
-                                        }}
-                                    </LemonField>
-                                ),
-                            },
+                                                                }}
+                                                                title={SURVEY_TYPE_LABEL_MAP[SurveyType.Popover]}
+                                                                description="Automatically appears when PostHog JS is installed"
+                                                                value={SurveyType.Popover}
+                                                            >
+                                                                <div className="scale-[0.8] absolute -top-4 -left-4">
+                                                                    <SurveyAppearancePreview
+                                                                        survey={survey}
+                                                                        previewPageIndex={0}
+                                                                    />
+                                                                </div>
+                                                            </PresentationTypeCard>
+                                                            <PresentationTypeCard
+                                                                active={value === SurveyType.API}
+                                                                onClick={() => {
+                                                                    onChange(SurveyType.API)
+                                                                    if (survey.schedule === SurveySchedule.Always) {
+                                                                        setSurveyValue('schedule', SurveySchedule.Once)
+                                                                    }
+                                                                }}
+                                                                title={SURVEY_TYPE_LABEL_MAP[SurveyType.API]}
+                                                                description="Use the PostHog API to show/hide your survey programmatically"
+                                                                value={SurveyType.API}
+                                                            >
+                                                                <div className="absolute left-4 w-[350px]">
+                                                                    <SurveyAPIEditor survey={survey} />
+                                                                </div>
+                                                            </PresentationTypeCard>
+                                                            <PresentationTypeCard
+                                                                active={value === SurveyType.Widget}
+                                                                onClick={() => onChange(SurveyType.Widget)}
+                                                                title={SURVEY_TYPE_LABEL_MAP[SurveyType.Widget]}
+                                                                description="Set up a survey based on your own custom button or our prebuilt feedback tab"
+                                                                value={SurveyType.Widget}
+                                                            >
+                                                                <button className="bg-black py-2 px-3 min-w-[40px] absolute right-3 -bottom-16 text-white opacity-30 rounded scale-[2]">
+                                                                    Feedback
+                                                                </button>
+                                                            </PresentationTypeCard>
+                                                            <PresentationTypeCard
+                                                                active={value === SurveyType.ExternalSurvey}
+                                                                onClick={() => onChange(SurveyType.ExternalSurvey)}
+                                                                title={SURVEY_TYPE_LABEL_MAP[SurveyType.ExternalSurvey]}
+                                                                description="Collect responses via an external link, hosted on PostHog. If you are already using surveys, make sure to upgrade posthog-js to at least v1.258.1."
+                                                                value={SurveyType.ExternalSurvey}
+                                                            >
+                                                                <LemonTag type="warning">BETA</LemonTag>
+                                                            </PresentationTypeCard>
+                                                        </div>
+                                                        {survey.type === SurveyType.Widget && (
+                                                            <SurveyWidgetCustomization />
+                                                        )}
+                                                        {survey.type === SurveyType.ExternalSurvey && (
+                                                            <>
+                                                                <Tooltip title="Enable this to embed the survey in tools like Framer, Webflow, or other website builders that use iframes.">
+                                                                    <LemonSwitch
+                                                                        checked={!!survey.enable_iframe_embedding}
+                                                                        onChange={(checked) =>
+                                                                            setSurveyValue(
+                                                                                'enable_iframe_embedding',
+                                                                                checked
+                                                                            )
+                                                                        }
+                                                                        label="Allow embedding in iframes"
+                                                                        bordered
+                                                                    />
+                                                                </Tooltip>
+                                                                <div className="font-semibold">
+                                                                    How hosted surveys work:
+                                                                </div>
+                                                                <ul className="space-y-2 text-sm">
+                                                                    <li>
+                                                                        • The survey will be hosted by PostHog and you
+                                                                        can share the URL with your customers
+                                                                    </li>
+                                                                    <li>
+                                                                        • To identify respondents, add the{' '}
+                                                                        <code className="bg-surface-tertiary px-1 rounded">
+                                                                            distinct_id
+                                                                        </code>{' '}
+                                                                        query parameter to the URL. Here's an example:
+                                                                        {'\n'}
+                                                                        <Link
+                                                                            to={`https://us.posthog.com/external_surveys/01984280-fc8a-0000-28a5-01078e2d553f?distinct_id=${user?.email ?? 'john@acme.co'}`}
+                                                                            target="_blank"
+                                                                        >{`https://us.posthog.com/external_surveys/01984280-fc8a-0000-28a5-01078e2d553f?distinct_id=${user?.email ?? 'john@acme.co'}`}</Link>
+                                                                    </li>
+                                                                    <li>
+                                                                        • Check more details about identifying
+                                                                        respondents in the{' '}
+                                                                        <Link
+                                                                            to="https://posthog.com/docs/surveys/creating-surveys#identifying-respondents-on-hosted-surveys"
+                                                                            target="_blank"
+                                                                        >
+                                                                            documentation
+                                                                        </Link>
+                                                                    </li>
+                                                                </ul>
+                                                            </>
+                                                        )}
+                                                    </div>
+                                                )
+                                            }}
+                                        </LemonField>
+                                    ),
+                                },
                             {
                                 key: SurveyEditSection.Steps,
                                 header: 'Steps',
@@ -1588,7 +1589,9 @@ export default function SurveyEdit({ id }: { id: string }): JSX.Element {
                     />
                 </div>
                 <div className="h-full">
-                    <div className="sticky top-16">
+                    <div
+                        className={`sticky ${editingLanguage || hasTranslationValidationErrors ? 'top-28' : 'top-16'}`}
+                    >
                         <SurveyFormAppearance
                             previewPageIndex={selectedPageIndex || 0}
                             survey={previewSurvey}
@@ -1597,6 +1600,7 @@ export default function SurveyEdit({ id }: { id: string }): JSX.Element {
                         />
                     </div>
                 </div>
+            </div>
             </div>
             <SurveyBranchingFlowModal survey={survey} isOpen={showFlowModal} onClose={() => setShowFlowModal(false)} />
         </SceneContent>

--- a/frontend/src/scenes/surveys/SurveyEdit.tsx
+++ b/frontend/src/scenes/surveys/SurveyEdit.tsx
@@ -251,6 +251,8 @@ export default function SurveyEdit({ id }: { id: string }): JSX.Element {
         surveyErrors,
         user,
         surveyLoading,
+        choicesMismatchedLanguages,
+        hasChoicesMismatch,
     } = useValues(surveyLogic)
     const {
         setSurveyValue,
@@ -431,6 +433,11 @@ export default function SurveyEdit({ id }: { id: string }): JSX.Element {
                                 loading={surveyLoading}
                                 form="survey"
                                 size="small"
+                                disabledReason={
+                                    hasChoicesMismatch
+                                        ? `Cannot save: choices translations don't match. Please update translations for: ${choicesMismatchedLanguages.join(', ')}`
+                                        : undefined
+                                }
                             >
                                 {id === 'new' ? 'Save as draft' : 'Save'}
                             </LemonButton>
@@ -452,6 +459,24 @@ export default function SurveyEdit({ id }: { id: string }): JSX.Element {
                                 default language
                             </button>{' '}
                             only.
+                        </span>
+                    </div>
+                )}
+                {hasChoicesMismatch && (
+                    <div className="px-4 py-2 bg-danger-highlight rounded border border-danger mt-4">
+                        <span className="text-sm">
+                            ⚠️ Choices were modified in the default language. Please update choices translations for:{' '}
+                            {choicesMismatchedLanguages.map((lang, index) => (
+                                <span key={lang}>
+                                    {index > 0 && ', '}
+                                    <button
+                                        onClick={() => setEditingLanguage(lang)}
+                                        className="font-bold hover:underline cursor-pointer text-danger"
+                                    >
+                                        {COMMON_LANGUAGES.find((l) => l.value === lang)?.label || lang}
+                                    </button>
+                                </span>
+                            ))}
                         </span>
                     </div>
                 )}

--- a/frontend/src/scenes/surveys/SurveyEdit.tsx
+++ b/frontend/src/scenes/surveys/SurveyEdit.tsx
@@ -4,7 +4,7 @@ import { DndContext } from '@dnd-kit/core'
 import { SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable'
 import { BindLogic, useActions, useMountedLogic, useValues } from 'kea'
 import { router } from 'kea-router'
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 
 import { IconGitBranch, IconInfo, IconPlus, IconTrash } from '@posthog/icons'
 import {
@@ -43,6 +43,7 @@ import { SurveyActionTrigger } from 'scenes/surveys/SurveyActionTrigger'
 import { SurveyCancelEventTrigger, SurveyEventTrigger } from 'scenes/surveys/SurveyEventTrigger'
 import { SurveyRepeatSchedule } from 'scenes/surveys/SurveyRepeatSchedule'
 import { SurveyResponsesCollection } from 'scenes/surveys/SurveyResponsesCollection'
+import { SurveyTranslations } from 'scenes/surveys/SurveyTranslations'
 import { SurveyWidgetCustomization } from 'scenes/surveys/SurveyWidgetCustomization'
 import { sanitizeSurveyAppearance } from 'scenes/surveys/utils'
 import { urls } from 'scenes/urls'
@@ -235,6 +236,7 @@ function SurveyCompletionConditions(): JSX.Element {
 export default function SurveyEdit({ id }: { id: string }): JSX.Element {
     const {
         survey,
+        editingLanguage,
         urlMatchTypeValidationError,
         hasTargetingSet,
         selectedPageIndex,
@@ -259,6 +261,43 @@ export default function SurveyEdit({ id }: { id: string }): JSX.Element {
     } = useActions(surveyLogic)
     const { setPreferredEditor } = useActions(surveysLogic)
     const { featureFlags } = useValues(enabledFeaturesLogic)
+    const { guidedEditorEnabled } = useValues(surveysLogic)
+    const previewSurvey = useMemo(() => {
+        if (!editingLanguage || !survey.translations?.[editingLanguage]) {
+            return survey
+        }
+
+        const processed = { ...survey }
+        const translation = survey.translations[editingLanguage]
+
+        if (translation.name) {
+            processed.name = translation.name
+        }
+        if (translation.description) {
+            processed.description = translation.description
+        }
+
+        processed.questions = survey.questions.map((q) => {
+            const qTrans = q.translations?.[editingLanguage]
+            if (qTrans) {
+                return {
+                    ...q,
+                    question: qTrans.question || q.question,
+                    description: qTrans.description || q.description,
+                    choices: qTrans.choices || q.choices,
+                    thankYouMessageHeader: qTrans.thankYouMessageHeader || q.thankYouMessageHeader,
+                    thankYouMessageDescription: qTrans.thankYouMessageDescription || q.thankYouMessageDescription,
+                    buttonText: qTrans.buttonText || q.buttonText,
+                    link: qTrans.link || q.link,
+                    lowerBoundLabel: qTrans.lowerBoundLabel || q.lowerBoundLabel,
+                    upperBoundLabel: qTrans.upperBoundLabel || q.upperBoundLabel,
+                }
+            }
+            return q
+        })
+
+        return processed
+    }, [survey, editingLanguage])
     const sortedItemIds = survey.questions.map((_, idx) => idx.toString())
     const { thankYouMessageDescriptionContentType = null } = survey.appearance ?? {}
     useMountedLogic(actionsModel)
@@ -299,14 +338,42 @@ export default function SurveyEdit({ id }: { id: string }): JSX.Element {
         <SceneContent>
             <div className="flex flex-col gap-y-4">
                 <SceneTitleSection
-                    name={survey.name}
-                    description={survey.description}
+                    name={editingLanguage ? (survey.translations?.[editingLanguage]?.name ?? '') : survey.name}
+                    description={
+                        editingLanguage
+                            ? (survey.translations?.[editingLanguage]?.description ?? '')
+                            : survey.description
+                    }
                     resourceType={{
                         type: 'survey',
                     }}
                     canEdit
-                    onNameChange={(name) => setSurveyValue('name', name)}
-                    onDescriptionChange={(description) => setSurveyValue('description', description)}
+                    onNameChange={(name) => {
+                        if (editingLanguage) {
+                            setSurveyValue('translations', {
+                                ...survey.translations,
+                                [editingLanguage]: {
+                                    ...survey.translations?.[editingLanguage],
+                                    name,
+                                },
+                            })
+                        } else {
+                            setSurveyValue('name', name)
+                        }
+                    }}
+                    onDescriptionChange={(description) => {
+                        if (editingLanguage) {
+                            setSurveyValue('translations', {
+                                ...survey.translations,
+                                [editingLanguage]: {
+                                    ...survey.translations?.[editingLanguage],
+                                    description,
+                                },
+                            })
+                        } else {
+                            setSurveyValue('description', description)
+                        }
+                    }}
                     renameDebounceMs={0}
                     forceEdit
                     actions={
@@ -807,6 +874,11 @@ export default function SurveyEdit({ id }: { id: string }): JSX.Element {
                                       },
                                   ]
                                 : []),
+                            {
+                                key: SurveyEditSection.Translations,
+                                header: 'Translations',
+                                content: <SurveyTranslations />,
+                            },
                             ...(survey.type !== SurveyType.ExternalSurvey
                                 ? [
                                       {
@@ -1295,7 +1367,7 @@ export default function SurveyEdit({ id }: { id: string }): JSX.Element {
                     <div className="sticky top-16">
                         <SurveyFormAppearance
                             previewPageIndex={selectedPageIndex || 0}
-                            survey={survey}
+                            survey={previewSurvey}
                             handleSetSelectedPageIndex={(pageIndex) => setSelectedPageIndex(pageIndex)}
                             isEditingSurvey={isEditingSurvey}
                         />

--- a/frontend/src/scenes/surveys/SurveyEdit.tsx
+++ b/frontend/src/scenes/surveys/SurveyEdit.tsx
@@ -294,8 +294,14 @@ export default function SurveyEdit({ id }: { id: string }): JSX.Element {
     const { featureFlags } = useValues(enabledFeaturesLogic)
     const surveyTranslationsEnabled = !!featureFlags[FEATURE_FLAGS.SURVEYS_TRANSLATIONS]
     const activeEditingLanguage = surveyTranslationsEnabled ? editingLanguage : null
+    const surveyTranslations = survey.translations ?? {}
+    const hasActualTranslations = !!(
+        (survey.translations && Object.keys(survey.translations).length > 0) ||
+        (survey.questions && survey.questions.some((q) => q.translations && Object.keys(q.translations).length > 0))
+    )
     const hasActiveTranslationValidationErrors = surveyTranslationsEnabled && hasTranslationValidationErrors
     const activeTranslationValidationErrors = surveyTranslationsEnabled ? translationValidationErrors : []
+    const hasVisibleTranslationValidationErrors = hasActiveTranslationValidationErrors && hasActualTranslations
     const previewSurvey = useMemo(() => {
         if (!activeEditingLanguage || !survey.translations?.[activeEditingLanguage]) {
             return survey
@@ -422,7 +428,7 @@ export default function SurveyEdit({ id }: { id: string }): JSX.Element {
         <SceneContent>
             <div
                 className={`flex flex-col gap-y-4 ${
-                    activeEditingLanguage || hasActiveTranslationValidationErrors ? 'mt-1' : ''
+                    activeEditingLanguage || hasVisibleTranslationValidationErrors ? 'mt-1' : ''
                 }`}
             >
                 <SceneTitleSection
@@ -437,7 +443,7 @@ export default function SurveyEdit({ id }: { id: string }): JSX.Element {
                     onNameChange={(name) => {
                         if (activeEditingLanguage) {
                             setSurveyValue('translations', {
-                                ...survey.translations,
+                                ...surveyTranslations,
                                 [activeEditingLanguage]: {
                                     ...survey.translations?.[activeEditingLanguage],
                                     name,
@@ -482,7 +488,7 @@ export default function SurveyEdit({ id }: { id: string }): JSX.Element {
                                 form="survey"
                                 size="small"
                                 disabledReason={
-                                    hasActiveTranslationValidationErrors
+                                    hasVisibleTranslationValidationErrors
                                         ? 'Cannot save: please fix translation validation errors below'
                                         : undefined
                                 }
@@ -494,14 +500,7 @@ export default function SurveyEdit({ id }: { id: string }): JSX.Element {
                 />
                 <div className="sticky top-[34px] z-[100] bg-bg-3000">
                     {(() => {
-                        // Only show translation validation errors if the survey actually has translations
-                        const hasActualTranslations = !!(
-                            (survey.translations && Object.keys(survey.translations).length > 0) ||
-                            (survey.questions &&
-                                survey.questions.some((q) => q.translations && Object.keys(q.translations).length > 0))
-                        )
-                        const shouldShowValidationErrors =
-                            surveyTranslationsEnabled && hasActiveTranslationValidationErrors && hasActualTranslations
+                        const shouldShowValidationErrors = hasVisibleTranslationValidationErrors
 
                         if (shouldShowValidationErrors) {
                             return (
@@ -543,6 +542,7 @@ export default function SurveyEdit({ id }: { id: string }): JSX.Element {
                                                             ([lang, errors]) => (
                                                                 <div key={lang} className="mb-2">
                                                                     <button
+                                                                        type="button"
                                                                         onClick={(e) => {
                                                                             e.preventDefault()
                                                                             setEditingLanguage(
@@ -593,6 +593,7 @@ export default function SurveyEdit({ id }: { id: string }): JSX.Element {
                                         </strong>
                                         . Only user-facing text can be translated - all other fields are editable in the{' '}
                                         <button
+                                            type="button"
                                             onClick={() => setEditingLanguage(null)}
                                             className="font-semibold hover:underline cursor-pointer"
                                         >
@@ -667,7 +668,10 @@ export default function SurveyEdit({ id }: { id: string }): JSX.Element {
                                                                 description="Set up a survey based on your own custom button or our prebuilt feedback tab"
                                                                 value={SurveyType.Widget}
                                                             >
-                                                                <button className="bg-black py-2 px-3 min-w-[40px] absolute right-3 -bottom-16 text-white opacity-30 rounded scale-[2]">
+                                                                <button
+                                                                    type="button"
+                                                                    className="bg-black py-2 px-3 min-w-[40px] absolute right-3 -bottom-16 text-white opacity-30 rounded scale-[2]"
+                                                                >
                                                                     Feedback
                                                                 </button>
                                                             </PresentationTypeCard>
@@ -961,7 +965,7 @@ export default function SurveyEdit({ id }: { id: string }): JSX.Element {
                                                                                                               setSurveyValue(
                                                                                                                   'translations',
                                                                                                                   {
-                                                                                                                      ...survey.translations,
+                                                                                                                      ...surveyTranslations,
                                                                                                                       [activeEditingLanguage]:
                                                                                                                           {
                                                                                                                               ...survey
@@ -1039,7 +1043,7 @@ export default function SurveyEdit({ id }: { id: string }): JSX.Element {
                                                                                                               setSurveyValue(
                                                                                                                   'translations',
                                                                                                                   {
-                                                                                                                      ...survey.translations,
+                                                                                                                      ...surveyTranslations,
                                                                                                                       [activeEditingLanguage]:
                                                                                                                           {
                                                                                                                               ...survey
@@ -1146,7 +1150,7 @@ export default function SurveyEdit({ id }: { id: string }): JSX.Element {
                                                                                                               setSurveyValue(
                                                                                                                   'translations',
                                                                                                                   {
-                                                                                                                      ...survey.translations,
+                                                                                                                      ...surveyTranslations,
                                                                                                                       [activeEditingLanguage]:
                                                                                                                           {
                                                                                                                               ...survey
@@ -1879,7 +1883,7 @@ export default function SurveyEdit({ id }: { id: string }): JSX.Element {
                     <div className="h-full">
                         <div
                             className={`sticky ${
-                                activeEditingLanguage || hasActiveTranslationValidationErrors ? 'top-28' : 'top-16'
+                                activeEditingLanguage || hasVisibleTranslationValidationErrors ? 'top-28' : 'top-16'
                             }`}
                         >
                             <SurveyFormAppearance

--- a/frontend/src/scenes/surveys/SurveyEditQuestionRow.tsx
+++ b/frontend/src/scenes/surveys/SurveyEditQuestionRow.tsx
@@ -213,7 +213,10 @@ export function SurveyEditQuestionGroup({ index, question }: { index: number; qu
             const trans = updatedTranslations[lang]
             if (trans.choices) {
                 const oldChoices = trans.choices
-                const newTransChoices = [...newChoices].map((_, idx) => oldChoices[idx] || '')
+                // Use default text if available, otherwise use placeholder
+                const newTransChoices = [...newChoices].map(
+                    (defaultChoice, idx) => oldChoices[idx] || defaultChoice || '[Translation needed]'
+                )
                 updatedTranslations[lang] = {
                     ...trans,
                     choices: newTransChoices,

--- a/frontend/src/scenes/surveys/SurveyEditQuestionRow.tsx
+++ b/frontend/src/scenes/surveys/SurveyEditQuestionRow.tsx
@@ -13,6 +13,7 @@ import { QuestionBranchingInput } from 'scenes/surveys/components/question-branc
 
 import {
     BasicSurveyQuestion,
+    LinkSurveyQuestion,
     MultipleSurveyQuestion,
     RatingSurveyQuestion,
     Survey,
@@ -220,6 +221,7 @@ export function SurveyEditQuestionGroup({ index, question }: { index: number; qu
             <div className="flex flex-col gap-2">
                 <LemonField name="type" label="Question type" className="max-w-60">
                     <LemonSelect
+                        disabled={!!editingLanguage}
                         data-attr={`survey-question-type-${index}`}
                         onSelect={(newType) => {
                             const isCurrentMultipleChoice =
@@ -272,7 +274,11 @@ export function SurveyEditQuestionGroup({ index, question }: { index: number; qu
                     />
                 </LemonField>
                 <LemonField name={getFieldName('question')} label="Label">
-                    <LemonInput data-attr={`survey-question-label-${index}`} value={displayQuestion.question || ''} />
+                    <LemonInput
+                        data-attr={`survey-question-label-${index}`}
+                        value={displayQuestion.question || ''}
+                        placeholder={editingLanguage ? question.question : undefined}
+                    />
                 </LemonField>
                 <LemonField name={getFieldName('description')} label="Description (optional)">
                     {({ value, onChange }) => (
@@ -288,8 +294,8 @@ export function SurveyEditQuestionGroup({ index, question }: { index: number; qu
                     )}
                 </LemonField>
                 {survey.questions.length > 1 && (
-                    <LemonField name="optional">
-                        <LemonCheckbox label="Optional" checked={!!question.optional} />
+                    <LemonField name="optional" className="my-2">
+                        <LemonCheckbox label="Optional" checked={!!question.optional} disabled={!!editingLanguage} />
                     </LemonField>
                 )}
                 {question.type === SurveyQuestionType.Open && (
@@ -308,7 +314,10 @@ export function SurveyEditQuestionGroup({ index, question }: { index: number; qu
                         label="Link"
                         info="Only https:// or mailto: links are supported."
                     >
-                        <LemonInput value={displayQuestion.link || ''} placeholder="https://posthog.com" />
+                        <LemonInput
+                            value={displayQuestion.link || ''}
+                            placeholder={editingLanguage ? question.link || 'https://posthog.com' : 'https://posthog.com'}
+                        />
                     </LemonField>
                 )}
                 {question.type === SurveyQuestionType.Rating && (
@@ -316,6 +325,7 @@ export function SurveyEditQuestionGroup({ index, question }: { index: number; qu
                         <div className="flex flex-row gap-4">
                             <LemonField name="display" label="Display type" className="w-1/2">
                                 <LemonSelect
+                                    disabled={!!editingLanguage}
                                     options={[
                                         { label: 'Number', value: 'number' },
                                         { label: 'Emoji', value: 'emoji' },
@@ -339,6 +349,7 @@ export function SurveyEditQuestionGroup({ index, question }: { index: number; qu
                             </LemonField>
                             <LemonField name="scale" label="Scale" className="w-1/2">
                                 <LemonSelect
+                                    disabled={!!editingLanguage}
                                     options={question.display === 'emoji' ? SCALE_OPTIONS.EMOJI : SCALE_OPTIONS.NUMBER}
                                     onChange={(val) => {
                                         const newQuestion = { ...survey.questions[index], scale: val }
@@ -352,11 +363,17 @@ export function SurveyEditQuestionGroup({ index, question }: { index: number; qu
                         </div>
                         {!isThumbQuestion(question) && (
                             <div className="flex flex-row gap-4">
-                                <LemonField name="lowerBoundLabel" label="Lower bound label" className="w-1/2">
-                                    <LemonInput value={question.lowerBoundLabel || ''} />
+                                <LemonField name={getFieldName('lowerBoundLabel')} label="Lower bound label" className="w-1/2">
+                                    <LemonInput
+                                        value={displayQuestion.lowerBoundLabel || ''}
+                                        placeholder={editingLanguage ? question.lowerBoundLabel : undefined}
+                                    />
                                 </LemonField>
-                                <LemonField name="upperBoundLabel" label="Upper bound label" className="w-1/2">
-                                    <LemonInput value={question.upperBoundLabel || ''} />
+                                <LemonField name={getFieldName('upperBoundLabel')} label="Upper bound label" className="w-1/2">
+                                    <LemonInput
+                                        value={displayQuestion.upperBoundLabel || ''}
+                                        placeholder={editingLanguage ? question.upperBoundLabel : undefined}
+                                    />
                                 </LemonField>
                             </div>
                         )}
@@ -367,6 +384,7 @@ export function SurveyEditQuestionGroup({ index, question }: { index: number; qu
                                         label="This is an NPS question"
                                         info="If checked, we'll calculate and display NPS on the survey results page."
                                         checked={isNpsQuestion !== false}
+                                        disabled={!!editingLanguage}
                                         onChange={toggleIsNpsQuestion}
                                     />
                                 )}
@@ -384,6 +402,7 @@ export function SurveyEditQuestionGroup({ index, question }: { index: number; qu
                                         <div className="flex flex-col gap-2">
                                             {(value || []).map((choice: string, index: number) => {
                                                 const isOpenChoice = hasOpenChoice && index === value?.length - 1
+                                                const originalChoices = (question.choices || []) as string[]
                                                 return (
                                                     <div className="flex flex-row gap-2 relative" key={index}>
                                                         <LemonInput
@@ -394,6 +413,9 @@ export function SurveyEditQuestionGroup({ index, question }: { index: number; qu
                                                                 newChoices[index] = val
                                                                 onChange(newChoices)
                                                             }}
+                                                            placeholder={
+                                                                editingLanguage ? originalChoices[index] : undefined
+                                                            }
                                                             suffix={
                                                                 isOpenChoice && (
                                                                     <LemonTag type="highlight">open-ended</LemonTag>
@@ -424,6 +446,11 @@ export function SurveyEditQuestionGroup({ index, question }: { index: number; qu
                                                             icon={<IconPlusSmall />}
                                                             type="secondary"
                                                             fullWidth={false}
+                                                            disabledReason={
+                                                                editingLanguage
+                                                                    ? 'Cannot modify choices while translating'
+                                                                    : undefined
+                                                            }
                                                             onClick={() => {
                                                                 if (!value) {
                                                                     onChange([''])
@@ -444,6 +471,11 @@ export function SurveyEditQuestionGroup({ index, question }: { index: number; qu
                                                                 icon={<IconPlusSmall />}
                                                                 type="secondary"
                                                                 fullWidth={false}
+                                                                disabledReason={
+                                                                    editingLanguage
+                                                                        ? 'Cannot modify choices while translating'
+                                                                        : undefined
+                                                                }
                                                                 onClick={() => {
                                                                     if (!value) {
                                                                         onChange(['Other'])
@@ -464,6 +496,7 @@ export function SurveyEditQuestionGroup({ index, question }: { index: number; qu
                                                                 <LemonCheckbox
                                                                     checked={!!shuffleOptions}
                                                                     label="Shuffle options"
+                                                                    disabled={!!editingLanguage}
                                                                     onChange={(checked) =>
                                                                         toggleShuffleOptions(checked)
                                                                     }
@@ -494,11 +527,16 @@ export function SurveyEditQuestionGroup({ index, question }: { index: number; qu
                         {(!canSkipSubmitButton || (canSkipSubmitButton && !question.skipSubmitButton)) && (
                             <LemonInput
                                 value={
-                                    question.buttonText === undefined
+                                    displayQuestion.buttonText === undefined
                                         ? (survey.appearance?.submitButtonText ?? 'Submit')
-                                        : question.buttonText
+                                        : displayQuestion.buttonText
                                 }
                                 onChange={(val) => handleQuestionValueChange('buttonText', val)}
+                                placeholder={
+                                    editingLanguage
+                                        ? (question.buttonText ?? survey.appearance?.submitButtonText ?? 'Submit')
+                                        : undefined
+                                }
                             />
                         )}
                         {canSkipSubmitButton && (

--- a/frontend/src/scenes/surveys/SurveyEditQuestionRow.tsx
+++ b/frontend/src/scenes/surveys/SurveyEditQuestionRow.tsx
@@ -200,6 +200,35 @@ export function SurveyEditQuestionGroup({ index, question }: { index: number; qu
     const shouldShowNpsCheckbox =
         question.type === SurveyQuestionType.Rating && question.scale === SURVEY_RATING_SCALE.NPS_10_POINT
 
+    const hasTranslations = question.translations && Object.keys(question.translations).length > 0
+
+    // Helper to synchronize choices in all translations when default choices change
+    const syncChoicesInTranslations = (newChoices: string[]): void => {
+        if (!hasTranslations || !question.translations) {
+            return
+        }
+
+        const updatedTranslations = { ...question.translations }
+        Object.keys(updatedTranslations).forEach((lang) => {
+            const trans = updatedTranslations[lang]
+            if (trans.choices) {
+                const oldChoices = trans.choices
+                const newTransChoices = [...newChoices].map((_, idx) => oldChoices[idx] || '')
+                updatedTranslations[lang] = {
+                    ...trans,
+                    choices: newTransChoices,
+                }
+            }
+        })
+
+        // Update question with synced translations
+        setSurveyValue('questions', [
+            ...survey.questions.slice(0, index),
+            { ...question, translations: updatedTranslations },
+            ...survey.questions.slice(index + 1),
+        ])
+    }
+
     const confirmQuestionTypeChange = (
         index: number,
         question: MultipleSurveyQuestion,
@@ -211,7 +240,44 @@ export function SurveyEditQuestionGroup({ index, question }: { index: number; qu
         LemonDialog.open({
             title: 'Changing question type',
             description: (
-                <p className="py-2">The choices you have configured will be removed. Would you like to proceed?</p>
+                <p className="py-2">
+                    {hasTranslations ? (
+                        <>
+                            This question has translations. Changing the question type will remove the choices you have
+                            configured and incompatible translation fields.
+                        </>
+                    ) : (
+                        'The choices you have configured will be removed.'
+                    )}{' '}
+                    Would you like to proceed?
+                </p>
+            ),
+            primaryButton: {
+                children: 'Continue',
+                status: 'danger',
+                onClick: () => {
+                    setDefaultForQuestionType(index, question, newType)
+                    resetBranchingForQuestion(index)
+                },
+            },
+            secondaryButton: {
+                children: 'Cancel',
+            },
+        })
+    }
+
+    const confirmQuestionTypeChangeWithTranslations = (
+        index: number,
+        question: SurveyQuestion,
+        newType: SurveyQuestionType
+    ): void => {
+        LemonDialog.open({
+            title: 'Changing question type',
+            description: (
+                <p className="py-2">
+                    This question has translations. Changing the question type will remove incompatible translation
+                    fields. Would you like to proceed?
+                </p>
             ),
             primaryButton: {
                 children: 'Continue',
@@ -253,6 +319,11 @@ export function SurveyEditQuestionGroup({ index, question }: { index: number; qu
                             }
                             if (isCurrentMultipleChoice && !isNewMultipleChoice) {
                                 confirmQuestionTypeChange(index, question, newType)
+                                return
+                            }
+                            // Check if question has translations
+                            if (hasTranslations) {
+                                confirmQuestionTypeChangeWithTranslations(index, question, newType)
                                 return
                             }
                             setDefaultForQuestionType(index, question, newType)
@@ -446,75 +517,59 @@ export function SurveyEditQuestionGroup({ index, question }: { index: number; qu
                         <LemonField name="hasOpenChoice">
                             {({ value: hasOpenChoice, onChange: toggleHasOpenChoice }) => (
                                 <LemonField name={getFieldName('choices')} label="Choices">
-                                    {({ value, onChange }) => (
-                                        <div className="flex flex-col gap-2">
-                                            {(value || []).map((choice: string, index: number) => {
-                                                const isOpenChoice = hasOpenChoice && index === value?.length - 1
-                                                const originalChoices = (question.choices || []) as string[]
-                                                return (
-                                                    <div className="flex flex-row gap-2 relative" key={index}>
-                                                        <LemonInput
-                                                            value={choice}
-                                                            fullWidth
-                                                            onChange={(val) => {
-                                                                const newChoices = [...value]
-                                                                newChoices[index] = val
-                                                                onChange(newChoices)
-                                                            }}
-                                                            placeholder={
-                                                                editingLanguage ? originalChoices[index] : undefined
-                                                            }
-                                                            suffix={
-                                                                isOpenChoice && (
-                                                                    <LemonTag type="highlight">open-ended</LemonTag>
-                                                                )
-                                                            }
-                                                        />
-                                                        <LemonButton
-                                                            icon={<IconTrash />}
-                                                            size="xsmall"
-                                                            noPadding
-                                                            onClick={() => {
-                                                                const newChoices = [...value]
-                                                                newChoices.splice(index, 1)
-                                                                onChange(newChoices)
-                                                                if (isOpenChoice) {
-                                                                    toggleHasOpenChoice(false)
+                                    {({ value, onChange }) => {
+                                        // Wrap onChange to sync translations
+                                        const handleChoicesChange = (newChoices: string[]): void => {
+                                            onChange(newChoices)
+                                            if (!editingLanguage) {
+                                                syncChoicesInTranslations(newChoices)
+                                            }
+                                        }
+
+                                        return (
+                                            <div className="flex flex-col gap-2">
+                                                {(value || []).map((choice: string, index: number) => {
+                                                    const isOpenChoice = hasOpenChoice && index === value?.length - 1
+                                                    const originalChoices = (question.choices || []) as string[]
+                                                    return (
+                                                        <div className="flex flex-row gap-2 relative" key={index}>
+                                                            <LemonInput
+                                                                value={choice}
+                                                                fullWidth
+                                                                onChange={(val) => {
+                                                                    const newChoices = [...value]
+                                                                    newChoices[index] = val
+                                                                    handleChoicesChange(newChoices)
+                                                                }}
+                                                                placeholder={
+                                                                    editingLanguage ? originalChoices[index] : undefined
                                                                 }
-                                                            }}
-                                                        />
-                                                    </div>
-                                                )
-                                            })}
-                                            <div className="w-fit flex flex-row flex-wrap gap-2">
-                                                {((value || []).length < MAX_NUMBER_OF_OPTIONS ||
-                                                    survey.type != SurveyType.Popover) && (
-                                                    <>
-                                                        <LemonButton
-                                                            icon={<IconPlusSmall />}
-                                                            type="secondary"
-                                                            fullWidth={false}
-                                                            disabledReason={
-                                                                editingLanguage
-                                                                    ? 'Cannot modify choices while translating'
-                                                                    : undefined
-                                                            }
-                                                            onClick={() => {
-                                                                if (!value) {
-                                                                    onChange([''])
-                                                                } else if (hasOpenChoice) {
-                                                                    const newChoices = value.slice(0, -1)
-                                                                    newChoices.push('')
-                                                                    newChoices.push(value[value.length - 1])
-                                                                    onChange(newChoices)
-                                                                } else {
-                                                                    onChange([...value, ''])
+                                                                suffix={
+                                                                    isOpenChoice && (
+                                                                        <LemonTag type="highlight">open-ended</LemonTag>
+                                                                    )
                                                                 }
-                                                            }}
-                                                        >
-                                                            Add choice
-                                                        </LemonButton>
-                                                        {!hasOpenChoice && (
+                                                            />
+                                                            <LemonButton
+                                                                icon={<IconTrash />}
+                                                                size="xsmall"
+                                                                noPadding
+                                                                onClick={() => {
+                                                                    const newChoices = [...value]
+                                                                    newChoices.splice(index, 1)
+                                                                    handleChoicesChange(newChoices)
+                                                                    if (isOpenChoice) {
+                                                                        toggleHasOpenChoice(false)
+                                                                    }
+                                                                }}
+                                                            />
+                                                        </div>
+                                                    )
+                                                })}
+                                                <div className="w-fit flex flex-row flex-wrap gap-2">
+                                                    {((value || []).length < MAX_NUMBER_OF_OPTIONS ||
+                                                        survey.type != SurveyType.Popover) && (
+                                                        <>
                                                             <LemonButton
                                                                 icon={<IconPlusSmall />}
                                                                 type="secondary"
@@ -526,41 +581,67 @@ export function SurveyEditQuestionGroup({ index, question }: { index: number; qu
                                                                 }
                                                                 onClick={() => {
                                                                     if (!value) {
-                                                                        onChange(['Other'])
+                                                                        handleChoicesChange([''])
+                                                                    } else if (hasOpenChoice) {
+                                                                        const newChoices = value.slice(0, -1)
+                                                                        newChoices.push('')
+                                                                        newChoices.push(value[value.length - 1])
+                                                                        handleChoicesChange(newChoices)
                                                                     } else {
-                                                                        onChange([...value, 'Other'])
+                                                                        handleChoicesChange([...value, ''])
                                                                     }
-                                                                    toggleHasOpenChoice(true)
                                                                 }}
                                                             >
-                                                                Add open-ended choice
+                                                                Add choice
                                                             </LemonButton>
-                                                        )}
-                                                        <LemonField name="shuffleOptions" className="mt-2">
-                                                            {({
-                                                                value: shuffleOptions,
-                                                                onChange: toggleShuffleOptions,
-                                                            }) => (
-                                                                <LemonCheckbox
-                                                                    checked={!!shuffleOptions}
-                                                                    label="Shuffle options"
-                                                                    disabled={!!editingLanguage}
+                                                            {!hasOpenChoice && (
+                                                                <LemonButton
+                                                                    icon={<IconPlusSmall />}
+                                                                    type="secondary"
+                                                                    fullWidth={false}
                                                                     disabledReason={
                                                                         editingLanguage
-                                                                            ? 'Shuffle options can only be changed in the default language'
+                                                                            ? 'Cannot modify choices while translating'
                                                                             : undefined
                                                                     }
-                                                                    onChange={(checked) =>
-                                                                        toggleShuffleOptions(checked)
-                                                                    }
-                                                                />
+                                                                    onClick={() => {
+                                                                        if (!value) {
+                                                                            handleChoicesChange(['Other'])
+                                                                        } else {
+                                                                            handleChoicesChange([...value, 'Other'])
+                                                                        }
+                                                                        toggleHasOpenChoice(true)
+                                                                    }}
+                                                                >
+                                                                    Add open-ended choice
+                                                                </LemonButton>
                                                             )}
-                                                        </LemonField>
-                                                    </>
-                                                )}
+                                                            <LemonField name="shuffleOptions" className="mt-2">
+                                                                {({
+                                                                    value: shuffleOptions,
+                                                                    onChange: toggleShuffleOptions,
+                                                                }) => (
+                                                                    <LemonCheckbox
+                                                                        checked={!!shuffleOptions}
+                                                                        label="Shuffle options"
+                                                                        disabled={!!editingLanguage}
+                                                                        disabledReason={
+                                                                            editingLanguage
+                                                                                ? 'Shuffle options can only be changed in the default language'
+                                                                                : undefined
+                                                                        }
+                                                                        onChange={(checked) =>
+                                                                            toggleShuffleOptions(checked)
+                                                                        }
+                                                                    />
+                                                                )}
+                                                            </LemonField>
+                                                        </>
+                                                    )}
+                                                </div>
                                             </div>
-                                        </div>
-                                    )}
+                                        )
+                                    }}
                                 </LemonField>
                             )}
                         </LemonField>

--- a/frontend/src/scenes/surveys/SurveyEditQuestionRow.tsx
+++ b/frontend/src/scenes/surveys/SurveyEditQuestionRow.tsx
@@ -13,6 +13,7 @@ import { QuestionBranchingInput } from 'scenes/surveys/components/question-branc
 
 import {
     BasicSurveyQuestion,
+    LinkSurveyQuestion,
     MultipleSurveyQuestion,
     RatingSurveyQuestion,
     Survey,
@@ -40,6 +41,15 @@ type SurveyQuestionHeaderProps = {
 }
 
 const MAX_NUMBER_OF_OPTIONS = 15
+
+const isChoiceQuestion = (question: SurveyQuestion): question is MultipleSurveyQuestion =>
+    question.type === SurveyQuestionType.SingleChoice || question.type === SurveyQuestionType.MultipleChoice
+
+const isLinkQuestion = (question: SurveyQuestion): question is LinkSurveyQuestion =>
+    question.type === SurveyQuestionType.Link
+
+const isRatingQuestion = (question: SurveyQuestion): question is RatingSurveyQuestion =>
+    question.type === SurveyQuestionType.Rating
 
 export function SurveyEditQuestionHeader({
     index,
@@ -226,10 +236,7 @@ export function SurveyEditQuestionGroup({ index, question }: { index: number; qu
               ...question.translations?.[editingLanguage],
               choices:
                   question.translations?.[editingLanguage]?.choices ||
-                  (question.type === SurveyQuestionType.SingleChoice ||
-                  question.type === SurveyQuestionType.MultipleChoice
-                      ? question.choices || []
-                      : undefined),
+                  (isChoiceQuestion(question) ? question.choices || [] : undefined),
           }
         : question
 
@@ -241,7 +248,7 @@ export function SurveyEditQuestionGroup({ index, question }: { index: number; qu
 
     // Helper to synchronize choices in all translations when default choices change
     const syncChoicesInTranslations = (newChoices: string[]): void => {
-        if (!hasTranslations || !question.translations) {
+        if (!hasTranslations || !question.translations || !isChoiceQuestion(question)) {
             return
         }
 
@@ -432,7 +439,7 @@ export function SurveyEditQuestionGroup({ index, question }: { index: number; qu
                         return (
                             <Tooltip title={fieldError?.error || ''} placement="top">
                                 <HTMLEditor
-                                    value={displayQuestion.description}
+                                    value={displayQuestion.description ?? undefined}
                                     onChange={(val) => {
                                         handleQuestionValueChange('description', val)
                                     }}
@@ -486,7 +493,7 @@ export function SurveyEditQuestionGroup({ index, question }: { index: number; qu
                         )}
                     </LemonField>
                 )}
-                {question.type === SurveyQuestionType.Link && (
+                {isLinkQuestion(question) && (
                     <LemonField
                         name={getFieldName('link')}
                         label="Link"
@@ -497,7 +504,7 @@ export function SurveyEditQuestionGroup({ index, question }: { index: number; qu
                             return (
                                 <Tooltip title={fieldError?.error || ''} placement="top">
                                     <LemonInput
-                                        value={displayQuestion.link || ''}
+                                        value={(displayQuestion as LinkSurveyQuestion).link || ''}
                                         placeholder={
                                             editingLanguage
                                                 ? question.link || 'https://posthog.com'
@@ -511,7 +518,7 @@ export function SurveyEditQuestionGroup({ index, question }: { index: number; qu
                         })()}
                     </LemonField>
                 )}
-                {question.type === SurveyQuestionType.Rating && (
+                {isRatingQuestion(question) && (
                     <div className="flex flex-col gap-2">
                         <div className="flex flex-row gap-4">
                             <LemonField name="display" label="Display type" className="w-1/2">
@@ -574,7 +581,9 @@ export function SurveyEditQuestionGroup({ index, question }: { index: number; qu
                                         return (
                                             <Tooltip title={fieldError?.error || ''} placement="top">
                                                 <LemonInput
-                                                    value={displayQuestion.lowerBoundLabel || ''}
+                                                    value={
+                                                        (displayQuestion as RatingSurveyQuestion).lowerBoundLabel || ''
+                                                    }
                                                     placeholder={editingLanguage ? question.lowerBoundLabel : undefined}
                                                     onChange={(val) =>
                                                         handleQuestionValueChange('lowerBoundLabel', val)
@@ -595,7 +604,9 @@ export function SurveyEditQuestionGroup({ index, question }: { index: number; qu
                                         return (
                                             <Tooltip title={fieldError?.error || ''} placement="top">
                                                 <LemonInput
-                                                    value={displayQuestion.upperBoundLabel || ''}
+                                                    value={
+                                                        (displayQuestion as RatingSurveyQuestion).upperBoundLabel || ''
+                                                    }
                                                     placeholder={editingLanguage ? question.upperBoundLabel : undefined}
                                                     onChange={(val) =>
                                                         handleQuestionValueChange('upperBoundLabel', val)
@@ -628,8 +639,7 @@ export function SurveyEditQuestionGroup({ index, question }: { index: number; qu
                         )}
                     </div>
                 )}
-                {(question.type === SurveyQuestionType.SingleChoice ||
-                    question.type === SurveyQuestionType.MultipleChoice) && (
+                {isChoiceQuestion(question) && (
                     <div className="flex flex-col gap-2">
                         <LemonField name="hasOpenChoice">
                             {({ value: hasOpenChoice, onChange: toggleHasOpenChoice }) => (
@@ -646,7 +656,7 @@ export function SurveyEditQuestionGroup({ index, question }: { index: number; qu
                                             <div className="flex flex-col gap-2">
                                                 {(value || []).map((choice: string, index: number) => {
                                                     const isOpenChoice = hasOpenChoice && index === value?.length - 1
-                                                    const originalChoices = (question.choices || []) as string[]
+                                                    const originalChoices = question.choices || []
                                                     const choiceError = getChoiceError(index)
                                                     return (
                                                         <div className="flex flex-row gap-2 relative" key={index}>

--- a/frontend/src/scenes/surveys/SurveyEditQuestionRow.tsx
+++ b/frontend/src/scenes/surveys/SurveyEditQuestionRow.tsx
@@ -358,180 +358,164 @@ export function SurveyEditQuestionGroup({
                 question.type === SurveyQuestionType.SingleChoice;
               const isNewMultipleChoice =
                 newType === SurveyQuestionType.MultipleChoice ||
-                newType === SurveyQuestionType.SingleChoice;
+                newType === SurveyQuestionType.SingleChoice
 
-              // Same multiple choice type - just update type
-              if (isCurrentMultipleChoice && isNewMultipleChoice) {
-                setMultipleSurveyQuestion(index, question, newType);
-                resetBranchingForQuestion(index);
-                return;
-              }
-              if (isCurrentMultipleChoice && !isNewMultipleChoice) {
-                confirmQuestionTypeChange(index, question, newType);
-                return;
-              }
-              // Check if question has translations
-              if (hasTranslations) {
-                confirmQuestionTypeChangeWithTranslations(
-                  index,
-                  question,
-                  newType
-                );
-                return;
-              }
-              setDefaultForQuestionType(index, question, newType);
-              resetBranchingForQuestion(index);
-            }}
-            options={[
-              {
-                label: SurveyQuestionLabel[SurveyQuestionType.Open],
-                value: SurveyQuestionType.Open,
-                "data-attr": `survey-question-type-${index}-${SurveyQuestionType.Open}`,
-              },
-              {
-                label: "Link/Notification",
-                value: SurveyQuestionType.Link,
-                "data-attr": `survey-question-type-${index}-${SurveyQuestionType.Link}`,
-              },
-              {
-                label: "Rating",
-                value: SurveyQuestionType.Rating,
-                "data-attr": `survey-question-type-${index}-${SurveyQuestionType.Rating}`,
-              },
-              {
-                label: "Single choice select",
-                value: SurveyQuestionType.SingleChoice,
-                "data-attr": `survey-question-type-${index}-${SurveyQuestionType.SingleChoice}`,
-              },
-              {
-                label: "Multiple choice select",
-                value: SurveyQuestionType.MultipleChoice,
-                "data-attr": `survey-question-type-${index}-${SurveyQuestionType.MultipleChoice}`,
-              },
-            ]}
-          />
-        </LemonField>
-        <LemonField name={getFieldName("question")} label="Label">
-          <LemonInput
-            data-attr={`survey-question-label-${index}`}
-            value={displayQuestion.question || ""}
-            placeholder={editingLanguage ? question.question : undefined}
-          />
-        </LemonField>
-        <LemonField
-          name={getFieldName("description")}
-          label="Description (optional)"
-        >
-          {({ value, onChange }) => (
-            <HTMLEditor
-              value={value}
-              onChange={(val) => {
-                onChange(val);
-                handleQuestionValueChange("description", val);
-              }}
-              onTabChange={handleTabChange}
-              activeTab={initialDescriptionContentType}
-            />
-          )}
-        </LemonField>
-        {survey.questions.length > 1 && (
-          <LemonField name="optional" className="my-2">
-            <LemonCheckbox
-              label="Optional"
-              checked={!!question.optional}
-              disabled={!!editingLanguage}
-              disabledReason={
-                editingLanguage
-                  ? "Question settings can only be changed in the default language"
-                  : undefined
-              }
-            />
-          </LemonField>
-        )}
-        {question.type === SurveyQuestionType.Open && (
-          <LemonField name="validation">
-            {({ value, onChange }) => (
-              <ValidationRulesEditor
-                value={(question as BasicSurveyQuestion).validation ?? value}
-                onChange={onChange}
-              />
-            )}
-          </LemonField>
-        )}
-        {question.type === SurveyQuestionType.Link && (
-          <LemonField
-            name={getFieldName("link")}
-            label="Link"
-            info="Only https:// or mailto: links are supported."
-          >
-            <LemonInput
-              value={displayQuestion.link || ""}
-              placeholder={
-                editingLanguage
-                  ? question.link || "https://posthog.com"
-                  : "https://posthog.com"
-              }
-            />
-          </LemonField>
-        )}
-        {question.type === SurveyQuestionType.Rating && (
-          <div className="flex flex-col gap-2">
-            <div className="flex flex-row gap-4">
-              <LemonField name="display" label="Display type" className="w-1/2">
-                <LemonSelect
-                  disabled={!!editingLanguage}
-                  disabledReason={
-                    editingLanguage
-                      ? "Display type can only be changed in the default language"
-                      : undefined
-                  }
-                  options={[
-                    { label: "Number", value: "number" },
-                    { label: "Emoji", value: "emoji" },
-                  ]}
-                  onChange={(val) => {
-                    const newQuestion = {
-                      ...survey.questions[index],
-                      display: val,
-                      scale: SURVEY_RATING_SCALE.LIKERT_5_POINT,
-                    };
-                    const newQuestions = [...survey.questions];
-                    newQuestions[index] = newQuestion;
-                    setSurveyValue("questions", newQuestions);
-                    setSurveyValue(
-                      "appearance.ratingButtonColor",
-                      val === "emoji" ? "#939393" : "white"
-                    );
-                    resetBranchingForQuestion(index);
-                  }}
-                />
-              </LemonField>
-              <LemonField name="scale" label="Scale" className="w-1/2">
-                <LemonSelect
-                  disabled={!!editingLanguage}
-                  disabledReason={
-                    editingLanguage
-                      ? "Rating scale can only be changed in the default language"
-                      : undefined
-                  }
-                  options={
-                    question.display === "emoji"
-                      ? SCALE_OPTIONS.EMOJI
-                      : SCALE_OPTIONS.NUMBER
-                  }
-                  onChange={(val) => {
-                    const newQuestion = {
-                      ...survey.questions[index],
-                      scale: val,
-                    };
-                    const newQuestions = [...survey.questions];
-                    newQuestions[index] = newQuestion;
-                    setSurveyValue("questions", newQuestions);
-                    resetBranchingForQuestion(index);
-                  }}
-                />
-              </LemonField>
-            </div>
+                            // Same multiple choice type - just update type
+                            if (isCurrentMultipleChoice && isNewMultipleChoice) {
+                                setMultipleSurveyQuestion(index, question, newType)
+                                resetBranchingForQuestion(index)
+                                return
+                            }
+                            if (isCurrentMultipleChoice && !isNewMultipleChoice) {
+                                confirmQuestionTypeChange(index, question, newType)
+                                return
+                            }
+                            // Check if question has translations
+                            if (hasTranslations) {
+                                confirmQuestionTypeChangeWithTranslations(index, question, newType)
+                                return
+                            }
+                            setDefaultForQuestionType(index, question, newType)
+                            resetBranchingForQuestion(index)
+                        }}
+                        options={[
+                            {
+                                label: SurveyQuestionLabel[SurveyQuestionType.Open],
+                                value: SurveyQuestionType.Open,
+                                'data-attr': `survey-question-type-${index}-${SurveyQuestionType.Open}`,
+                            },
+                            {
+                                label: 'Link/Notification',
+                                value: SurveyQuestionType.Link,
+                                'data-attr': `survey-question-type-${index}-${SurveyQuestionType.Link}`,
+                            },
+                            {
+                                label: 'Rating',
+                                value: SurveyQuestionType.Rating,
+                                'data-attr': `survey-question-type-${index}-${SurveyQuestionType.Rating}`,
+                            },
+                            {
+                                label: 'Single choice select',
+                                value: SurveyQuestionType.SingleChoice,
+                                'data-attr': `survey-question-type-${index}-${SurveyQuestionType.SingleChoice}`,
+                            },
+                            {
+                                label: 'Multiple choice select',
+                                value: SurveyQuestionType.MultipleChoice,
+                                'data-attr': `survey-question-type-${index}-${SurveyQuestionType.MultipleChoice}`,
+                            },
+                        ]}
+                    />
+                </LemonField>
+                <LemonField name={getFieldName('question')} label="Label">
+                    <LemonInput
+                        data-attr={`survey-question-label-${index}`}
+                        value={displayQuestion.question || ''}
+                        placeholder={editingLanguage ? question.question : undefined}
+                    />
+                </LemonField>
+                <LemonField name={getFieldName('description')} label="Description (optional)">
+                    {({ value, onChange }) => (
+                        <HTMLEditor
+                            value={value}
+                            onChange={(val) => {
+                                onChange(val)
+                                handleQuestionValueChange('description', val)
+                            }}
+                            onTabChange={handleTabChange}
+                            activeTab={initialDescriptionContentType}
+                        />
+                    )}
+                </LemonField>
+                {survey.questions.length > 1 && (
+                    <LemonField name="optional" className="my-2">
+                        <LemonCheckbox
+                            label="Optional"
+                            checked={!!question.optional}
+                            disabled={!!editingLanguage}
+                            disabledReason={
+                                editingLanguage
+                                    ? 'Question settings can only be changed in the default language'
+                                    : undefined
+                            }
+                        />
+                    </LemonField>
+                )}
+                {question.type === SurveyQuestionType.Open && (
+                    <LemonField name="validation">
+                        {({ value, onChange }) => (
+                            <ValidationRulesEditor
+                                value={(question as BasicSurveyQuestion).validation ?? value}
+                                onChange={onChange}
+                            />
+                        )}
+                    </LemonField>
+                )}
+                {question.type === SurveyQuestionType.Link && (
+                    <LemonField
+                        name={getFieldName('link')}
+                        label="Link"
+                        info="Only https:// or mailto: links are supported."
+                    >
+                        <LemonInput
+                            value={displayQuestion.link || ''}
+                            placeholder={
+                                editingLanguage ? question.link || 'https://posthog.com' : 'https://posthog.com'
+                            }
+                        />
+                    </LemonField>
+                )}
+                {question.type === SurveyQuestionType.Rating && (
+                    <div className="flex flex-col gap-2">
+                        <div className="flex flex-row gap-4">
+                            <LemonField name="display" label="Display type" className="w-1/2">
+                                <LemonSelect
+                                    disabled={!!editingLanguage}
+                                    disabledReason={
+                                        editingLanguage
+                                            ? 'Display type can only be changed in the default language'
+                                            : undefined
+                                    }
+                                    options={[
+                                        { label: 'Number', value: 'number' },
+                                        { label: 'Emoji', value: 'emoji' },
+                                    ]}
+                                    onChange={(val) => {
+                                        const newQuestion = {
+                                            ...survey.questions[index],
+                                            display: val,
+                                            scale: SURVEY_RATING_SCALE.LIKERT_5_POINT,
+                                        }
+                                        const newQuestions = [...survey.questions]
+                                        newQuestions[index] = newQuestion
+                                        setSurveyValue('questions', newQuestions)
+                                        setSurveyValue(
+                                            'appearance.ratingButtonColor',
+                                            val === 'emoji' ? '#939393' : 'white'
+                                        )
+                                        resetBranchingForQuestion(index)
+                                    }}
+                                />
+                            </LemonField>
+                            <LemonField name="scale" label="Scale" className="w-1/2">
+                                <LemonSelect
+                                    disabled={!!editingLanguage}
+                                    disabledReason={
+                                        editingLanguage
+                                            ? 'Rating scale can only be changed in the default language'
+                                            : undefined
+                                    }
+                                    options={question.display === 'emoji' ? SCALE_OPTIONS.EMOJI : SCALE_OPTIONS.NUMBER}
+                                    onChange={(val) => {
+                                        const newQuestion = { ...survey.questions[index], scale: val }
+                                        const newQuestions = [...survey.questions]
+                                        newQuestions[index] = newQuestion
+                                        setSurveyValue('questions', newQuestions)
+                                        resetBranchingForQuestion(index)
+                                    }}
+                                />
+                            </LemonField>
+                        </div>
             {!isThumbQuestion(question) && (
               <div className="flex flex-row gap-4">
                 <LemonField

--- a/frontend/src/scenes/surveys/SurveyEditQuestionRow.tsx
+++ b/frontend/src/scenes/surveys/SurveyEditQuestionRow.tsx
@@ -182,6 +182,13 @@ export function SurveyEditQuestionGroup({ index, question }: { index: number; qu
         ? {
               ...question,
               ...question.translations?.[editingLanguage],
+              // Ensure choices array exists for translations by using original choices if translation is empty
+              choices:
+                  question.translations?.[editingLanguage]?.choices ||
+                  (question.type === SurveyQuestionType.SingleChoice ||
+                  question.type === SurveyQuestionType.MultipleChoice
+                      ? question.choices || []
+                      : undefined),
           }
         : question
 
@@ -222,6 +229,9 @@ export function SurveyEditQuestionGroup({ index, question }: { index: number; qu
                 <LemonField name="type" label="Question type" className="max-w-60">
                     <LemonSelect
                         disabled={!!editingLanguage}
+                        disabledReason={
+                            editingLanguage ? 'Question type can only be changed in the default language' : undefined
+                        }
                         data-attr={`survey-question-type-${index}`}
                         onSelect={(newType) => {
                             const isCurrentMultipleChoice =
@@ -295,7 +305,16 @@ export function SurveyEditQuestionGroup({ index, question }: { index: number; qu
                 </LemonField>
                 {survey.questions.length > 1 && (
                     <LemonField name="optional" className="my-2">
-                        <LemonCheckbox label="Optional" checked={!!question.optional} disabled={!!editingLanguage} />
+                        <LemonCheckbox
+                            label="Optional"
+                            checked={!!question.optional}
+                            disabled={!!editingLanguage}
+                            disabledReason={
+                                editingLanguage
+                                    ? 'Question settings can only be changed in the default language'
+                                    : undefined
+                            }
+                        />
                     </LemonField>
                 )}
                 {question.type === SurveyQuestionType.Open && (
@@ -316,7 +335,9 @@ export function SurveyEditQuestionGroup({ index, question }: { index: number; qu
                     >
                         <LemonInput
                             value={displayQuestion.link || ''}
-                            placeholder={editingLanguage ? question.link || 'https://posthog.com' : 'https://posthog.com'}
+                            placeholder={
+                                editingLanguage ? question.link || 'https://posthog.com' : 'https://posthog.com'
+                            }
                         />
                     </LemonField>
                 )}
@@ -326,6 +347,11 @@ export function SurveyEditQuestionGroup({ index, question }: { index: number; qu
                             <LemonField name="display" label="Display type" className="w-1/2">
                                 <LemonSelect
                                     disabled={!!editingLanguage}
+                                    disabledReason={
+                                        editingLanguage
+                                            ? 'Display type can only be changed in the default language'
+                                            : undefined
+                                    }
                                     options={[
                                         { label: 'Number', value: 'number' },
                                         { label: 'Emoji', value: 'emoji' },
@@ -350,6 +376,11 @@ export function SurveyEditQuestionGroup({ index, question }: { index: number; qu
                             <LemonField name="scale" label="Scale" className="w-1/2">
                                 <LemonSelect
                                     disabled={!!editingLanguage}
+                                    disabledReason={
+                                        editingLanguage
+                                            ? 'Rating scale can only be changed in the default language'
+                                            : undefined
+                                    }
                                     options={question.display === 'emoji' ? SCALE_OPTIONS.EMOJI : SCALE_OPTIONS.NUMBER}
                                     onChange={(val) => {
                                         const newQuestion = { ...survey.questions[index], scale: val }
@@ -363,13 +394,21 @@ export function SurveyEditQuestionGroup({ index, question }: { index: number; qu
                         </div>
                         {!isThumbQuestion(question) && (
                             <div className="flex flex-row gap-4">
-                                <LemonField name={getFieldName('lowerBoundLabel')} label="Lower bound label" className="w-1/2">
+                                <LemonField
+                                    name={getFieldName('lowerBoundLabel')}
+                                    label="Lower bound label"
+                                    className="w-1/2"
+                                >
                                     <LemonInput
                                         value={displayQuestion.lowerBoundLabel || ''}
                                         placeholder={editingLanguage ? question.lowerBoundLabel : undefined}
                                     />
                                 </LemonField>
-                                <LemonField name={getFieldName('upperBoundLabel')} label="Upper bound label" className="w-1/2">
+                                <LemonField
+                                    name={getFieldName('upperBoundLabel')}
+                                    label="Upper bound label"
+                                    className="w-1/2"
+                                >
                                     <LemonInput
                                         value={displayQuestion.upperBoundLabel || ''}
                                         placeholder={editingLanguage ? question.upperBoundLabel : undefined}
@@ -385,6 +424,11 @@ export function SurveyEditQuestionGroup({ index, question }: { index: number; qu
                                         info="If checked, we'll calculate and display NPS on the survey results page."
                                         checked={isNpsQuestion !== false}
                                         disabled={!!editingLanguage}
+                                        disabledReason={
+                                            editingLanguage
+                                                ? 'Question settings can only be changed in the default language'
+                                                : undefined
+                                        }
                                         onChange={toggleIsNpsQuestion}
                                     />
                                 )}
@@ -397,7 +441,7 @@ export function SurveyEditQuestionGroup({ index, question }: { index: number; qu
                     <div className="flex flex-col gap-2">
                         <LemonField name="hasOpenChoice">
                             {({ value: hasOpenChoice, onChange: toggleHasOpenChoice }) => (
-                                <LemonField name="choices" label="Choices">
+                                <LemonField name={getFieldName('choices')} label="Choices">
                                     {({ value, onChange }) => (
                                         <div className="flex flex-col gap-2">
                                             {(value || []).map((choice: string, index: number) => {
@@ -497,6 +541,11 @@ export function SurveyEditQuestionGroup({ index, question }: { index: number; qu
                                                                     checked={!!shuffleOptions}
                                                                     label="Shuffle options"
                                                                     disabled={!!editingLanguage}
+                                                                    disabledReason={
+                                                                        editingLanguage
+                                                                            ? 'Shuffle options can only be changed in the default language'
+                                                                            : undefined
+                                                                    }
                                                                     onChange={(checked) =>
                                                                         toggleShuffleOptions(checked)
                                                                     }
@@ -555,6 +604,12 @@ export function SurveyEditQuestionGroup({ index, question }: { index: number; qu
                                         label="Automatically submit on selection"
                                         checked={!!skipSubmitButtonValue}
                                         onChange={onSkipSubmitButtonChange}
+                                        disabled={!!editingLanguage}
+                                        disabledReason={
+                                            editingLanguage
+                                                ? 'Submit settings can only be changed in the default language'
+                                                : undefined
+                                        }
                                     />
                                 )}
                             </LemonField>

--- a/frontend/src/scenes/surveys/SurveyEditQuestionRow.tsx
+++ b/frontend/src/scenes/surveys/SurveyEditQuestionRow.tsx
@@ -1,711 +1,798 @@
-import './EditSurvey.scss'
+import "./EditSurvey.scss";
 
-import { useSortable } from '@dnd-kit/sortable'
-import { CSS } from '@dnd-kit/utilities'
-import { useActions, useValues } from 'kea'
-import { Group } from 'kea-forms'
+import { useSortable } from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import { useActions, useValues } from "kea";
+import { Group } from "kea-forms";
 
-import { IconPlusSmall, IconTrash } from '@posthog/icons'
-import { LemonButton, LemonCheckbox, LemonDialog, LemonInput, LemonSelect, LemonTag } from '@posthog/lemon-ui'
+import { IconPlusSmall, IconTrash } from "@posthog/icons";
+import {
+  LemonButton,
+  LemonCheckbox,
+  LemonDialog,
+  LemonInput,
+  LemonSelect,
+  LemonTag,
+} from "@posthog/lemon-ui";
 
-import { LemonField } from 'lib/lemon-ui/LemonField'
-import { QuestionBranchingInput } from 'scenes/surveys/components/question-branching/QuestionBranchingInput'
+import { LemonField } from "lib/lemon-ui/LemonField";
+import { QuestionBranchingInput } from "scenes/surveys/components/question-branching/QuestionBranchingInput";
 
 import {
-    BasicSurveyQuestion,
-    LinkSurveyQuestion,
-    MultipleSurveyQuestion,
-    RatingSurveyQuestion,
-    Survey,
-    SurveyQuestion,
-    SurveyQuestionType,
-    SurveyType,
-} from '~/types'
+  BasicSurveyQuestion,
+  LinkSurveyQuestion,
+  MultipleSurveyQuestion,
+  RatingSurveyQuestion,
+  Survey,
+  SurveyQuestion,
+  SurveyQuestionType,
+  SurveyType,
+} from "~/types";
 
-import { ValidationRulesEditor } from './components/ValidationRulesEditor'
-import { NewSurvey, SCALE_OPTIONS, SURVEY_RATING_SCALE, SurveyQuestionLabel } from './constants'
-import { HTMLEditor } from './SurveyAppearanceUtils'
-import { SurveyDragHandle } from './SurveyDragHandle'
-import { surveyLogic } from './surveyLogic'
-import { isThumbQuestion } from './utils'
+import { ValidationRulesEditor } from "./components/ValidationRulesEditor";
+import {
+  NewSurvey,
+  SCALE_OPTIONS,
+  SURVEY_RATING_SCALE,
+  SurveyQuestionLabel,
+} from "./constants";
+import { HTMLEditor } from "./SurveyAppearanceUtils";
+import { SurveyDragHandle } from "./SurveyDragHandle";
+import { surveyLogic } from "./surveyLogic";
+import { isThumbQuestion } from "./utils";
 
 type SurveyQuestionHeaderProps = {
-    index: number
-    survey: Survey | NewSurvey
-    setSelectedPageIndex: (index: number) => void
-    setSurveyValue: (key: string, value: any) => void
-}
+  index: number;
+  survey: Survey | NewSurvey;
+  setSelectedPageIndex: (index: number) => void;
+  setSurveyValue: (key: string, value: any) => void;
+};
 
-const MAX_NUMBER_OF_OPTIONS = 15
+const MAX_NUMBER_OF_OPTIONS = 15;
 
 export function SurveyEditQuestionHeader({
-    index,
-    survey,
-    setSelectedPageIndex,
-    setSurveyValue,
+  index,
+  survey,
+  setSelectedPageIndex,
+  setSurveyValue,
 }: SurveyQuestionHeaderProps): JSX.Element {
-    const { hasBranchingLogic, editingLanguage } = useValues(surveyLogic)
-    const { deleteBranchingLogic } = useActions(surveyLogic)
-    const { setNodeRef, attributes, transform, transition, listeners, isDragging } = useSortable({
-        id: index.toString(),
-    })
+  const { hasBranchingLogic, editingLanguage } = useValues(surveyLogic);
+  const { deleteBranchingLogic } = useActions(surveyLogic);
+  const {
+    setNodeRef,
+    attributes,
+    transform,
+    transition,
+    listeners,
+    isDragging,
+  } = useSortable({
+    id: index.toString(),
+  });
 
-    return (
-        <div
-            className="flex flex-row w-full items-center justify-between relative"
-            ref={setNodeRef}
-            {...attributes}
-            // eslint-disable-next-line react/forbid-dom-props
-            style={{
-                zIndex: isDragging ? 1 : undefined,
-                transform: CSS.Translate.toString(transform),
-                transition,
-            }}
-        >
-            <div className="flex flex-row gap-2 items-center">
-                <SurveyDragHandle listeners={listeners} hasMultipleQuestions={survey.questions.length > 1} />
+  return (
+    <div
+      className="flex flex-row w-full items-center justify-between relative"
+      ref={setNodeRef}
+      {...attributes}
+      // eslint-disable-next-line react/forbid-dom-props
+      style={{
+        zIndex: isDragging ? 1 : undefined,
+        transform: CSS.Translate.toString(transform),
+        transition,
+      }}
+    >
+      <div className="flex flex-row gap-2 items-center">
+        <SurveyDragHandle
+          listeners={listeners}
+          hasMultipleQuestions={survey.questions.length > 1}
+        />
 
-                <b>
-                    Question {index + 1}.{' '}
-                    {editingLanguage
-                        ? (survey.questions[index].translations?.[editingLanguage]?.question ??
-                          survey.questions[index].question)
-                        : survey.questions[index].question}
-                </b>
-            </div>
-            {survey.questions.length > 1 && (
-                <LemonButton
-                    icon={<IconTrash />}
-                    size="xsmall"
-                    data-attr={`delete-survey-question-${index}`}
-                    onClick={(e) => {
-                        const deleteQuestion = (): void => {
-                            e.stopPropagation()
-                            setSelectedPageIndex(index <= 0 ? 0 : index - 1)
-                            setSurveyValue(
-                                'questions',
-                                survey.questions.filter((_, i) => i !== index)
-                            )
-                        }
+        <b>
+          Question {index + 1}.{" "}
+          {editingLanguage
+            ? survey.questions[index].translations?.[editingLanguage]
+                ?.question ?? survey.questions[index].question
+            : survey.questions[index].question}
+        </b>
+      </div>
+      {survey.questions.length > 1 && (
+        <LemonButton
+          icon={<IconTrash />}
+          size="xsmall"
+          data-attr={`delete-survey-question-${index}`}
+          onClick={(e) => {
+            const deleteQuestion = (): void => {
+              e.stopPropagation();
+              setSelectedPageIndex(index <= 0 ? 0 : index - 1);
+              setSurveyValue(
+                "questions",
+                survey.questions.filter((_, i) => i !== index)
+              );
+            };
 
-                        if (hasBranchingLogic) {
-                            LemonDialog.open({
-                                title: 'Your survey has active branching logic',
-                                description: (
-                                    <p className="py-2">
-                                        Deleting the question will remove your branching logic. Are you sure you want to
-                                        continue?
-                                    </p>
-                                ),
-                                primaryButton: {
-                                    children: 'Continue',
-                                    status: 'danger',
-                                    onClick: () => {
-                                        deleteBranchingLogic()
-                                        deleteQuestion()
-                                    },
-                                },
-                                secondaryButton: {
-                                    children: 'Cancel',
-                                },
-                            })
-                        } else {
-                            deleteQuestion()
-                        }
-                    }}
-                    tooltipPlacement="top-end"
-                />
-            )}
-        </div>
-    )
+            if (hasBranchingLogic) {
+              LemonDialog.open({
+                title: "Your survey has active branching logic",
+                description: (
+                  <p className="py-2">
+                    Deleting the question will remove your branching logic. Are
+                    you sure you want to continue?
+                  </p>
+                ),
+                primaryButton: {
+                  children: "Continue",
+                  status: "danger",
+                  onClick: () => {
+                    deleteBranchingLogic();
+                    deleteQuestion();
+                  },
+                },
+                secondaryButton: {
+                  children: "Cancel",
+                },
+              });
+            } else {
+              deleteQuestion();
+            }
+          }}
+          tooltipPlacement="top-end"
+        />
+      )}
+    </div>
+  );
 }
 
 function canQuestionSkipSubmitButton(
-    question: SurveyQuestion
+  question: SurveyQuestion
 ): question is RatingSurveyQuestion | MultipleSurveyQuestion {
-    return (
-        question.type === SurveyQuestionType.Rating ||
-        (question.type === SurveyQuestionType.SingleChoice && !question.hasOpenChoice)
-    )
+  return (
+    question.type === SurveyQuestionType.Rating ||
+    (question.type === SurveyQuestionType.SingleChoice &&
+      !question.hasOpenChoice)
+  );
 }
 
-export function SurveyEditQuestionGroup({ index, question }: { index: number; question: SurveyQuestion }): JSX.Element {
-    const { survey, descriptionContentType, editingLanguage } = useValues(surveyLogic)
-    const { setDefaultForQuestionType, setSurveyValue, resetBranchingForQuestion, setMultipleSurveyQuestion } =
-        useActions(surveyLogic)
+export function SurveyEditQuestionGroup({
+  index,
+  question,
+}: {
+  index: number;
+  question: SurveyQuestion;
+}): JSX.Element {
+  const { survey, descriptionContentType, editingLanguage } =
+    useValues(surveyLogic);
+  const {
+    setDefaultForQuestionType,
+    setSurveyValue,
+    resetBranchingForQuestion,
+    setMultipleSurveyQuestion,
+  } = useActions(surveyLogic);
 
-    const initialDescriptionContentType = descriptionContentType(index) ?? 'text'
+  const initialDescriptionContentType = descriptionContentType(index) ?? "text";
 
-    const handleQuestionValueChange = (key: string, val: string): void => {
-        if (
-            editingLanguage &&
-            ['question', 'description', 'buttonText', 'choices', 'link', 'lowerBoundLabel', 'upperBoundLabel'].includes(
-                key
-            )
-        ) {
-            const updatedQuestion = survey.questions.map((q, idx) => {
-                if (index === idx) {
-                    const currentTranslations = q.translations || {}
-                    const currentLangTrans = currentTranslations[editingLanguage] || {}
-                    return {
-                        ...q,
-                        translations: {
-                            ...currentTranslations,
-                            [editingLanguage]: {
-                                ...currentLangTrans,
-                                [key]: val,
-                            },
-                        },
-                    }
-                }
-                return q
-            })
-            setSurveyValue('questions', updatedQuestion)
-        } else {
-            const updatedQuestion = survey.questions.map((question, idx) => {
-                if (index === idx) {
-                    return {
-                        ...question,
-                        [key]: val,
-                    }
-                }
-                return question
-            })
-            setSurveyValue('questions', updatedQuestion)
+  const handleQuestionValueChange = (key: string, val: string): void => {
+    if (
+      editingLanguage &&
+      [
+        "question",
+        "description",
+        "buttonText",
+        "choices",
+        "link",
+        "lowerBoundLabel",
+        "upperBoundLabel",
+      ].includes(key)
+    ) {
+      const updatedQuestion = survey.questions.map((q, idx) => {
+        if (index === idx) {
+          const currentTranslations = q.translations || {};
+          const currentLangTrans = currentTranslations[editingLanguage] || {};
+          return {
+            ...q,
+            translations: {
+              ...currentTranslations,
+              [editingLanguage]: {
+                ...currentLangTrans,
+                [key]: val,
+              },
+            },
+          };
         }
+        return q;
+      });
+      setSurveyValue("questions", updatedQuestion);
+    } else {
+      const updatedQuestion = survey.questions.map((question, idx) => {
+        if (index === idx) {
+          return {
+            ...question,
+            [key]: val,
+          };
+        }
+        return question;
+      });
+      setSurveyValue("questions", updatedQuestion);
+    }
+  };
+
+  const handleTabChange = (key: string): void => {
+    handleQuestionValueChange("descriptionContentType", key);
+  };
+
+  const getFieldName = (key: string): string =>
+    editingLanguage === null ? key : `translations.${editingLanguage}.${key}`;
+
+  const displayQuestion = editingLanguage
+    ? {
+        ...question,
+        ...question.translations?.[editingLanguage],
+        // Ensure choices array exists for translations by using original choices if translation is empty
+        choices:
+          question.translations?.[editingLanguage]?.choices ||
+          (question.type === SurveyQuestionType.SingleChoice ||
+          question.type === SurveyQuestionType.MultipleChoice
+            ? question.choices || []
+            : undefined),
+      }
+    : question;
+
+  const canSkipSubmitButton = canQuestionSkipSubmitButton(question);
+  const shouldShowNpsCheckbox =
+    question.type === SurveyQuestionType.Rating &&
+    question.scale === SURVEY_RATING_SCALE.NPS_10_POINT;
+
+  const hasTranslations =
+    question.translations && Object.keys(question.translations).length > 0;
+
+  // Helper to synchronize choices in all translations when default choices change
+  const syncChoicesInTranslations = (newChoices: string[]): void => {
+    if (!hasTranslations || !question.translations) {
+      return;
     }
 
-    const handleTabChange = (key: string): void => {
-        handleQuestionValueChange('descriptionContentType', key)
-    }
+    const updatedTranslations = { ...question.translations };
+    Object.keys(updatedTranslations).forEach((lang) => {
+      const trans = updatedTranslations[lang];
+      if (trans.choices) {
+        const oldChoices = trans.choices;
+        // Use default text if available, otherwise use placeholder
+        const newTransChoices = [...newChoices].map(
+          (defaultChoice, idx) =>
+            oldChoices[idx] || defaultChoice || "[Translation needed]"
+        );
+        updatedTranslations[lang] = {
+          ...trans,
+          choices: newTransChoices,
+        };
+      }
+    });
 
-    const getFieldName = (key: string): string =>
-        editingLanguage === null ? key : `translations.${editingLanguage}.${key}`
+    // Update question with synced translations
+    setSurveyValue("questions", [
+      ...survey.questions.slice(0, index),
+      { ...question, translations: updatedTranslations },
+      ...survey.questions.slice(index + 1),
+    ]);
+  };
 
-    const displayQuestion = editingLanguage
-        ? {
-              ...question,
-              ...question.translations?.[editingLanguage],
-              // Ensure choices array exists for translations by using original choices if translation is empty
-              choices:
-                  question.translations?.[editingLanguage]?.choices ||
-                  (question.type === SurveyQuestionType.SingleChoice ||
-                  question.type === SurveyQuestionType.MultipleChoice
-                      ? question.choices || []
-                      : undefined),
-          }
-        : question
+  const confirmQuestionTypeChange = (
+    index: number,
+    question: MultipleSurveyQuestion,
+    newType: SurveyQuestionType
+  ): void => {
+    // Reset to current type first (because onSelect has already changed it)
+    setMultipleSurveyQuestion(index, question, question.type);
 
-    const canSkipSubmitButton = canQuestionSkipSubmitButton(question)
-    const shouldShowNpsCheckbox =
-        question.type === SurveyQuestionType.Rating && question.scale === SURVEY_RATING_SCALE.NPS_10_POINT
+    LemonDialog.open({
+      title: "Changing question type",
+      description: (
+        <p className="py-2">
+          {hasTranslations ? (
+            <>
+              This question has translations. Changing the question type will
+              remove the choices you have configured and incompatible
+              translation fields.
+            </>
+          ) : (
+            "The choices you have configured will be removed."
+          )}{" "}
+          Would you like to proceed?
+        </p>
+      ),
+      primaryButton: {
+        children: "Continue",
+        status: "danger",
+        onClick: () => {
+          setDefaultForQuestionType(index, question, newType);
+          resetBranchingForQuestion(index);
+        },
+      },
+      secondaryButton: {
+        children: "Cancel",
+      },
+    });
+  };
 
-    const hasTranslations = question.translations && Object.keys(question.translations).length > 0
+  const confirmQuestionTypeChangeWithTranslations = (
+    index: number,
+    question: SurveyQuestion,
+    newType: SurveyQuestionType
+  ): void => {
+    LemonDialog.open({
+      title: "Changing question type",
+      description: (
+        <p className="py-2">
+          This question has translations. Changing the question type will remove
+          incompatible translation fields. Would you like to proceed?
+        </p>
+      ),
+      primaryButton: {
+        children: "Continue",
+        status: "danger",
+        onClick: () => {
+          setDefaultForQuestionType(index, question, newType);
+          resetBranchingForQuestion(index);
+        },
+      },
+      secondaryButton: {
+        children: "Cancel",
+      },
+    });
+  };
 
-    // Helper to synchronize choices in all translations when default choices change
-    const syncChoicesInTranslations = (newChoices: string[]): void => {
-        if (!hasTranslations || !question.translations) {
-            return
-        }
-
-        const updatedTranslations = { ...question.translations }
-        Object.keys(updatedTranslations).forEach((lang) => {
-            const trans = updatedTranslations[lang]
-            if (trans.choices) {
-                const oldChoices = trans.choices
-                // Use default text if available, otherwise use placeholder
-                const newTransChoices = [...newChoices].map(
-                    (defaultChoice, idx) => oldChoices[idx] || defaultChoice || '[Translation needed]'
-                )
-                updatedTranslations[lang] = {
-                    ...trans,
-                    choices: newTransChoices,
-                }
+  return (
+    <Group name={`questions.${index}`} key={index}>
+      <div className="flex flex-col gap-2">
+        <LemonField name="type" label="Question type" className="max-w-60">
+          <LemonSelect
+            disabled={!!editingLanguage}
+            disabledReason={
+              editingLanguage
+                ? "Question type can only be changed in the default language"
+                : undefined
             }
-        })
+            data-attr={`survey-question-type-${index}`}
+            onSelect={(newType) => {
+              const isCurrentMultipleChoice =
+                question.type === SurveyQuestionType.MultipleChoice ||
+                question.type === SurveyQuestionType.SingleChoice;
+              const isNewMultipleChoice =
+                newType === SurveyQuestionType.MultipleChoice ||
+                newType === SurveyQuestionType.SingleChoice;
 
-        // Update question with synced translations
-        setSurveyValue('questions', [
-            ...survey.questions.slice(0, index),
-            { ...question, translations: updatedTranslations },
-            ...survey.questions.slice(index + 1),
-        ])
-    }
-
-    const confirmQuestionTypeChange = (
-        index: number,
-        question: MultipleSurveyQuestion,
-        newType: SurveyQuestionType
-    ): void => {
-        // Reset to current type first (because onSelect has already changed it)
-        setMultipleSurveyQuestion(index, question, question.type)
-
-        LemonDialog.open({
-            title: 'Changing question type',
-            description: (
-                <p className="py-2">
-                    {hasTranslations ? (
-                        <>
-                            This question has translations. Changing the question type will remove the choices you have
-                            configured and incompatible translation fields.
-                        </>
-                    ) : (
-                        'The choices you have configured will be removed.'
-                    )}{' '}
-                    Would you like to proceed?
-                </p>
-            ),
-            primaryButton: {
-                children: 'Continue',
-                status: 'danger',
-                onClick: () => {
-                    setDefaultForQuestionType(index, question, newType)
-                    resetBranchingForQuestion(index)
-                },
-            },
-            secondaryButton: {
-                children: 'Cancel',
-            },
-        })
-    }
-
-    const confirmQuestionTypeChangeWithTranslations = (
-        index: number,
-        question: SurveyQuestion,
-        newType: SurveyQuestionType
-    ): void => {
-        LemonDialog.open({
-            title: 'Changing question type',
-            description: (
-                <p className="py-2">
-                    This question has translations. Changing the question type will remove incompatible translation
-                    fields. Would you like to proceed?
-                </p>
-            ),
-            primaryButton: {
-                children: 'Continue',
-                status: 'danger',
-                onClick: () => {
-                    setDefaultForQuestionType(index, question, newType)
-                    resetBranchingForQuestion(index)
-                },
-            },
-            secondaryButton: {
-                children: 'Cancel',
-            },
-        })
-    }
-
-    return (
-        <Group name={`questions.${index}`} key={index}>
-            <div className="flex flex-col gap-2">
-                <LemonField name="type" label="Question type" className="max-w-60">
-                    <LemonSelect
-                        disabled={!!editingLanguage}
-                        disabledReason={
-                            editingLanguage ? 'Question type can only be changed in the default language' : undefined
-                        }
-                        data-attr={`survey-question-type-${index}`}
-                        onSelect={(newType) => {
-                            const isCurrentMultipleChoice =
-                                question.type === SurveyQuestionType.MultipleChoice ||
-                                question.type === SurveyQuestionType.SingleChoice
-                            const isNewMultipleChoice =
-                                newType === SurveyQuestionType.MultipleChoice ||
-                                newType === SurveyQuestionType.SingleChoice
-
-                            // Same multiple choice type - just update type
-                            if (isCurrentMultipleChoice && isNewMultipleChoice) {
-                                setMultipleSurveyQuestion(index, question, newType)
-                                resetBranchingForQuestion(index)
-                                return
-                            }
-                            if (isCurrentMultipleChoice && !isNewMultipleChoice) {
-                                confirmQuestionTypeChange(index, question, newType)
-                                return
-                            }
-                            // Check if question has translations
-                            if (hasTranslations) {
-                                confirmQuestionTypeChangeWithTranslations(index, question, newType)
-                                return
-                            }
-                            setDefaultForQuestionType(index, question, newType)
-                            resetBranchingForQuestion(index)
-                        }}
-                        options={[
-                            {
-                                label: SurveyQuestionLabel[SurveyQuestionType.Open],
-                                value: SurveyQuestionType.Open,
-                                'data-attr': `survey-question-type-${index}-${SurveyQuestionType.Open}`,
-                            },
-                            {
-                                label: 'Link/Notification',
-                                value: SurveyQuestionType.Link,
-                                'data-attr': `survey-question-type-${index}-${SurveyQuestionType.Link}`,
-                            },
-                            {
-                                label: 'Rating',
-                                value: SurveyQuestionType.Rating,
-                                'data-attr': `survey-question-type-${index}-${SurveyQuestionType.Rating}`,
-                            },
-                            {
-                                label: 'Single choice select',
-                                value: SurveyQuestionType.SingleChoice,
-                                'data-attr': `survey-question-type-${index}-${SurveyQuestionType.SingleChoice}`,
-                            },
-                            {
-                                label: 'Multiple choice select',
-                                value: SurveyQuestionType.MultipleChoice,
-                                'data-attr': `survey-question-type-${index}-${SurveyQuestionType.MultipleChoice}`,
-                            },
-                        ]}
-                    />
-                </LemonField>
-                <LemonField name={getFieldName('question')} label="Label">
-                    <LemonInput
-                        data-attr={`survey-question-label-${index}`}
-                        value={displayQuestion.question || ''}
-                        placeholder={editingLanguage ? question.question : undefined}
-                    />
-                </LemonField>
-                <LemonField name={getFieldName('description')} label="Description (optional)">
-                    {({ value, onChange }) => (
-                        <HTMLEditor
-                            value={value}
-                            onChange={(val) => {
-                                onChange(val)
-                                handleQuestionValueChange('description', val)
-                            }}
-                            onTabChange={handleTabChange}
-                            activeTab={initialDescriptionContentType}
-                        />
-                    )}
-                </LemonField>
-                {survey.questions.length > 1 && (
-                    <LemonField name="optional" className="my-2">
-                        <LemonCheckbox
-                            label="Optional"
-                            checked={!!question.optional}
-                            disabled={!!editingLanguage}
-                            disabledReason={
-                                editingLanguage
-                                    ? 'Question settings can only be changed in the default language'
-                                    : undefined
-                            }
-                        />
-                    </LemonField>
-                )}
-                {question.type === SurveyQuestionType.Open && (
-                    <LemonField name="validation">
-                        {({ value, onChange }) => (
-                            <ValidationRulesEditor
-                                value={(question as BasicSurveyQuestion).validation ?? value}
-                                onChange={onChange}
-                            />
-                        )}
-                    </LemonField>
-                )}
-                {question.type === SurveyQuestionType.Link && (
-                    <LemonField
-                        name={getFieldName('link')}
-                        label="Link"
-                        info="Only https:// or mailto: links are supported."
-                    >
-                        <LemonInput
-                            value={displayQuestion.link || ''}
-                            placeholder={
-                                editingLanguage ? question.link || 'https://posthog.com' : 'https://posthog.com'
-                            }
-                        />
-                    </LemonField>
-                )}
-                {question.type === SurveyQuestionType.Rating && (
-                    <div className="flex flex-col gap-2">
-                        <div className="flex flex-row gap-4">
-                            <LemonField name="display" label="Display type" className="w-1/2">
-                                <LemonSelect
-                                    disabled={!!editingLanguage}
-                                    disabledReason={
-                                        editingLanguage
-                                            ? 'Display type can only be changed in the default language'
-                                            : undefined
-                                    }
-                                    options={[
-                                        { label: 'Number', value: 'number' },
-                                        { label: 'Emoji', value: 'emoji' },
-                                    ]}
-                                    onChange={(val) => {
-                                        const newQuestion = {
-                                            ...survey.questions[index],
-                                            display: val,
-                                            scale: SURVEY_RATING_SCALE.LIKERT_5_POINT,
-                                        }
-                                        const newQuestions = [...survey.questions]
-                                        newQuestions[index] = newQuestion
-                                        setSurveyValue('questions', newQuestions)
-                                        setSurveyValue(
-                                            'appearance.ratingButtonColor',
-                                            val === 'emoji' ? '#939393' : 'white'
-                                        )
-                                        resetBranchingForQuestion(index)
-                                    }}
-                                />
-                            </LemonField>
-                            <LemonField name="scale" label="Scale" className="w-1/2">
-                                <LemonSelect
-                                    disabled={!!editingLanguage}
-                                    disabledReason={
-                                        editingLanguage
-                                            ? 'Rating scale can only be changed in the default language'
-                                            : undefined
-                                    }
-                                    options={question.display === 'emoji' ? SCALE_OPTIONS.EMOJI : SCALE_OPTIONS.NUMBER}
-                                    onChange={(val) => {
-                                        const newQuestion = { ...survey.questions[index], scale: val }
-                                        const newQuestions = [...survey.questions]
-                                        newQuestions[index] = newQuestion
-                                        setSurveyValue('questions', newQuestions)
-                                        resetBranchingForQuestion(index)
-                                    }}
-                                />
-                            </LemonField>
-                        </div>
-                        {!isThumbQuestion(question) && (
-                            <div className="flex flex-row gap-4">
-                                <LemonField
-                                    name={getFieldName('lowerBoundLabel')}
-                                    label="Lower bound label"
-                                    className="w-1/2"
-                                >
-                                    <LemonInput
-                                        value={displayQuestion.lowerBoundLabel || ''}
-                                        placeholder={editingLanguage ? question.lowerBoundLabel : undefined}
-                                    />
-                                </LemonField>
-                                <LemonField
-                                    name={getFieldName('upperBoundLabel')}
-                                    label="Upper bound label"
-                                    className="w-1/2"
-                                >
-                                    <LemonInput
-                                        value={displayQuestion.upperBoundLabel || ''}
-                                        placeholder={editingLanguage ? question.upperBoundLabel : undefined}
-                                    />
-                                </LemonField>
-                            </div>
-                        )}
-                        {shouldShowNpsCheckbox && (
-                            <LemonField name="isNpsQuestion">
-                                {({ value: isNpsQuestion, onChange: toggleIsNpsQuestion }) => (
-                                    <LemonCheckbox
-                                        label="This is an NPS question"
-                                        info="If checked, we'll calculate and display NPS on the survey results page."
-                                        checked={isNpsQuestion !== false}
-                                        disabled={!!editingLanguage}
-                                        disabledReason={
-                                            editingLanguage
-                                                ? 'Question settings can only be changed in the default language'
-                                                : undefined
-                                        }
-                                        onChange={toggleIsNpsQuestion}
-                                    />
-                                )}
-                            </LemonField>
-                        )}
-                    </div>
-                )}
-                {(question.type === SurveyQuestionType.SingleChoice ||
-                    question.type === SurveyQuestionType.MultipleChoice) && (
-                    <div className="flex flex-col gap-2">
-                        <LemonField name="hasOpenChoice">
-                            {({ value: hasOpenChoice, onChange: toggleHasOpenChoice }) => (
-                                <LemonField name={getFieldName('choices')} label="Choices">
-                                    {({ value, onChange }) => {
-                                        // Wrap onChange to sync translations
-                                        const handleChoicesChange = (newChoices: string[]): void => {
-                                            onChange(newChoices)
-                                            if (!editingLanguage) {
-                                                syncChoicesInTranslations(newChoices)
-                                            }
-                                        }
-
-                                        return (
-                                            <div className="flex flex-col gap-2">
-                                                {(value || []).map((choice: string, index: number) => {
-                                                    const isOpenChoice = hasOpenChoice && index === value?.length - 1
-                                                    const originalChoices = (question.choices || []) as string[]
-                                                    return (
-                                                        <div className="flex flex-row gap-2 relative" key={index}>
-                                                            <LemonInput
-                                                                value={choice}
-                                                                fullWidth
-                                                                onChange={(val) => {
-                                                                    const newChoices = [...value]
-                                                                    newChoices[index] = val
-                                                                    handleChoicesChange(newChoices)
-                                                                }}
-                                                                placeholder={
-                                                                    editingLanguage ? originalChoices[index] : undefined
-                                                                }
-                                                                suffix={
-                                                                    isOpenChoice && (
-                                                                        <LemonTag type="highlight">open-ended</LemonTag>
-                                                                    )
-                                                                }
-                                                            />
-                                                            <LemonButton
-                                                                icon={<IconTrash />}
-                                                                size="xsmall"
-                                                                noPadding
-                                                                onClick={() => {
-                                                                    const newChoices = [...value]
-                                                                    newChoices.splice(index, 1)
-                                                                    handleChoicesChange(newChoices)
-                                                                    if (isOpenChoice) {
-                                                                        toggleHasOpenChoice(false)
-                                                                    }
-                                                                }}
-                                                            />
-                                                        </div>
-                                                    )
-                                                })}
-                                                <div className="w-fit flex flex-row flex-wrap gap-2">
-                                                    {((value || []).length < MAX_NUMBER_OF_OPTIONS ||
-                                                        survey.type != SurveyType.Popover) && (
-                                                        <>
-                                                            <LemonButton
-                                                                icon={<IconPlusSmall />}
-                                                                type="secondary"
-                                                                fullWidth={false}
-                                                                disabledReason={
-                                                                    editingLanguage
-                                                                        ? 'Cannot modify choices while translating'
-                                                                        : undefined
-                                                                }
-                                                                onClick={() => {
-                                                                    if (!value) {
-                                                                        handleChoicesChange([''])
-                                                                    } else if (hasOpenChoice) {
-                                                                        const newChoices = value.slice(0, -1)
-                                                                        newChoices.push('')
-                                                                        newChoices.push(value[value.length - 1])
-                                                                        handleChoicesChange(newChoices)
-                                                                    } else {
-                                                                        handleChoicesChange([...value, ''])
-                                                                    }
-                                                                }}
-                                                            >
-                                                                Add choice
-                                                            </LemonButton>
-                                                            {!hasOpenChoice && (
-                                                                <LemonButton
-                                                                    icon={<IconPlusSmall />}
-                                                                    type="secondary"
-                                                                    fullWidth={false}
-                                                                    disabledReason={
-                                                                        editingLanguage
-                                                                            ? 'Cannot modify choices while translating'
-                                                                            : undefined
-                                                                    }
-                                                                    onClick={() => {
-                                                                        if (!value) {
-                                                                            handleChoicesChange(['Other'])
-                                                                        } else {
-                                                                            handleChoicesChange([...value, 'Other'])
-                                                                        }
-                                                                        toggleHasOpenChoice(true)
-                                                                    }}
-                                                                >
-                                                                    Add open-ended choice
-                                                                </LemonButton>
-                                                            )}
-                                                            <LemonField name="shuffleOptions" className="mt-2">
-                                                                {({
-                                                                    value: shuffleOptions,
-                                                                    onChange: toggleShuffleOptions,
-                                                                }) => (
-                                                                    <LemonCheckbox
-                                                                        checked={!!shuffleOptions}
-                                                                        label="Shuffle options"
-                                                                        disabled={!!editingLanguage}
-                                                                        disabledReason={
-                                                                            editingLanguage
-                                                                                ? 'Shuffle options can only be changed in the default language'
-                                                                                : undefined
-                                                                        }
-                                                                        onChange={(checked) =>
-                                                                            toggleShuffleOptions(checked)
-                                                                        }
-                                                                    />
-                                                                )}
-                                                            </LemonField>
-                                                        </>
-                                                    )}
-                                                </div>
-                                            </div>
-                                        )
-                                    }}
-                                </LemonField>
-                            )}
-                        </LemonField>
-                    </div>
-                )}
-                <LemonField
-                    name="buttonText"
-                    label="Submit button text"
-                    className="flex-1 flex gap-1 justify-center"
-                    info={
-                        canSkipSubmitButton
-                            ? "When the 'Automatically submit on selection' option is enabled, users won't need to click a submit button - their response will be submitted immediately after selecting an option. The submit button will be hidden. Requires at least version 1.244.0 of posthog-js. Not available for the mobile SDKs at the moment."
-                            : undefined
-                    }
-                >
-                    <>
-                        {(!canSkipSubmitButton || (canSkipSubmitButton && !question.skipSubmitButton)) && (
-                            <LemonInput
-                                value={
-                                    displayQuestion.buttonText === undefined
-                                        ? (survey.appearance?.submitButtonText ?? 'Submit')
-                                        : displayQuestion.buttonText
-                                }
-                                onChange={(val) => handleQuestionValueChange('buttonText', val)}
-                                placeholder={
-                                    editingLanguage
-                                        ? (question.buttonText ?? survey.appearance?.submitButtonText ?? 'Submit')
-                                        : undefined
-                                }
-                            />
-                        )}
-                        {canSkipSubmitButton && (
-                            <LemonField
-                                name="skipSubmitButton"
-                                info={
-                                    <>
-                                        If enabled, the survey will submit immediately after the user makes a selection
-                                        (for single-choice without open-ended, or rating questions), and the submit
-                                        button will be hidden/text ignored.
-                                    </>
-                                }
-                            >
-                                {({ value: skipSubmitButtonValue, onChange: onSkipSubmitButtonChange }) => (
-                                    <LemonCheckbox
-                                        label="Automatically submit on selection"
-                                        checked={!!skipSubmitButtonValue}
-                                        onChange={onSkipSubmitButtonChange}
-                                        disabled={!!editingLanguage}
-                                        disabledReason={
-                                            editingLanguage
-                                                ? 'Submit settings can only be changed in the default language'
-                                                : undefined
-                                        }
-                                    />
-                                )}
-                            </LemonField>
-                        )}
-                    </>
-                </LemonField>
-                <QuestionBranchingInput questionIndex={index} question={question} />
+              // Same multiple choice type - just update type
+              if (isCurrentMultipleChoice && isNewMultipleChoice) {
+                setMultipleSurveyQuestion(index, question, newType);
+                resetBranchingForQuestion(index);
+                return;
+              }
+              if (isCurrentMultipleChoice && !isNewMultipleChoice) {
+                confirmQuestionTypeChange(index, question, newType);
+                return;
+              }
+              // Check if question has translations
+              if (hasTranslations) {
+                confirmQuestionTypeChangeWithTranslations(
+                  index,
+                  question,
+                  newType
+                );
+                return;
+              }
+              setDefaultForQuestionType(index, question, newType);
+              resetBranchingForQuestion(index);
+            }}
+            options={[
+              {
+                label: SurveyQuestionLabel[SurveyQuestionType.Open],
+                value: SurveyQuestionType.Open,
+                "data-attr": `survey-question-type-${index}-${SurveyQuestionType.Open}`,
+              },
+              {
+                label: "Link/Notification",
+                value: SurveyQuestionType.Link,
+                "data-attr": `survey-question-type-${index}-${SurveyQuestionType.Link}`,
+              },
+              {
+                label: "Rating",
+                value: SurveyQuestionType.Rating,
+                "data-attr": `survey-question-type-${index}-${SurveyQuestionType.Rating}`,
+              },
+              {
+                label: "Single choice select",
+                value: SurveyQuestionType.SingleChoice,
+                "data-attr": `survey-question-type-${index}-${SurveyQuestionType.SingleChoice}`,
+              },
+              {
+                label: "Multiple choice select",
+                value: SurveyQuestionType.MultipleChoice,
+                "data-attr": `survey-question-type-${index}-${SurveyQuestionType.MultipleChoice}`,
+              },
+            ]}
+          />
+        </LemonField>
+        <LemonField name={getFieldName("question")} label="Label">
+          <LemonInput
+            data-attr={`survey-question-label-${index}`}
+            value={displayQuestion.question || ""}
+            placeholder={editingLanguage ? question.question : undefined}
+          />
+        </LemonField>
+        <LemonField
+          name={getFieldName("description")}
+          label="Description (optional)"
+        >
+          {({ value, onChange }) => (
+            <HTMLEditor
+              value={value}
+              onChange={(val) => {
+                onChange(val);
+                handleQuestionValueChange("description", val);
+              }}
+              onTabChange={handleTabChange}
+              activeTab={initialDescriptionContentType}
+            />
+          )}
+        </LemonField>
+        {survey.questions.length > 1 && (
+          <LemonField name="optional" className="my-2">
+            <LemonCheckbox
+              label="Optional"
+              checked={!!question.optional}
+              disabled={!!editingLanguage}
+              disabledReason={
+                editingLanguage
+                  ? "Question settings can only be changed in the default language"
+                  : undefined
+              }
+            />
+          </LemonField>
+        )}
+        {question.type === SurveyQuestionType.Open && (
+          <LemonField name="validation">
+            {({ value, onChange }) => (
+              <ValidationRulesEditor
+                value={(question as BasicSurveyQuestion).validation ?? value}
+                onChange={onChange}
+              />
+            )}
+          </LemonField>
+        )}
+        {question.type === SurveyQuestionType.Link && (
+          <LemonField
+            name={getFieldName("link")}
+            label="Link"
+            info="Only https:// or mailto: links are supported."
+          >
+            <LemonInput
+              value={displayQuestion.link || ""}
+              placeholder={
+                editingLanguage
+                  ? question.link || "https://posthog.com"
+                  : "https://posthog.com"
+              }
+            />
+          </LemonField>
+        )}
+        {question.type === SurveyQuestionType.Rating && (
+          <div className="flex flex-col gap-2">
+            <div className="flex flex-row gap-4">
+              <LemonField name="display" label="Display type" className="w-1/2">
+                <LemonSelect
+                  disabled={!!editingLanguage}
+                  disabledReason={
+                    editingLanguage
+                      ? "Display type can only be changed in the default language"
+                      : undefined
+                  }
+                  options={[
+                    { label: "Number", value: "number" },
+                    { label: "Emoji", value: "emoji" },
+                  ]}
+                  onChange={(val) => {
+                    const newQuestion = {
+                      ...survey.questions[index],
+                      display: val,
+                      scale: SURVEY_RATING_SCALE.LIKERT_5_POINT,
+                    };
+                    const newQuestions = [...survey.questions];
+                    newQuestions[index] = newQuestion;
+                    setSurveyValue("questions", newQuestions);
+                    setSurveyValue(
+                      "appearance.ratingButtonColor",
+                      val === "emoji" ? "#939393" : "white"
+                    );
+                    resetBranchingForQuestion(index);
+                  }}
+                />
+              </LemonField>
+              <LemonField name="scale" label="Scale" className="w-1/2">
+                <LemonSelect
+                  disabled={!!editingLanguage}
+                  disabledReason={
+                    editingLanguage
+                      ? "Rating scale can only be changed in the default language"
+                      : undefined
+                  }
+                  options={
+                    question.display === "emoji"
+                      ? SCALE_OPTIONS.EMOJI
+                      : SCALE_OPTIONS.NUMBER
+                  }
+                  onChange={(val) => {
+                    const newQuestion = {
+                      ...survey.questions[index],
+                      scale: val,
+                    };
+                    const newQuestions = [...survey.questions];
+                    newQuestions[index] = newQuestion;
+                    setSurveyValue("questions", newQuestions);
+                    resetBranchingForQuestion(index);
+                  }}
+                />
+              </LemonField>
             </div>
-        </Group>
-    )
+            {!isThumbQuestion(question) && (
+              <div className="flex flex-row gap-4">
+                <LemonField
+                  name={getFieldName("lowerBoundLabel")}
+                  label="Lower bound label"
+                  className="w-1/2"
+                >
+                  <LemonInput
+                    value={displayQuestion.lowerBoundLabel || ""}
+                    placeholder={
+                      editingLanguage ? question.lowerBoundLabel : undefined
+                    }
+                  />
+                </LemonField>
+                <LemonField
+                  name={getFieldName("upperBoundLabel")}
+                  label="Upper bound label"
+                  className="w-1/2"
+                >
+                  <LemonInput
+                    value={displayQuestion.upperBoundLabel || ""}
+                    placeholder={
+                      editingLanguage ? question.upperBoundLabel : undefined
+                    }
+                  />
+                </LemonField>
+              </div>
+            )}
+            {shouldShowNpsCheckbox && (
+              <LemonField name="isNpsQuestion">
+                {({ value: isNpsQuestion, onChange: toggleIsNpsQuestion }) => (
+                  <LemonCheckbox
+                    label="This is an NPS question"
+                    info="If checked, we'll calculate and display NPS on the survey results page."
+                    checked={isNpsQuestion !== false}
+                    disabled={!!editingLanguage}
+                    disabledReason={
+                      editingLanguage
+                        ? "Question settings can only be changed in the default language"
+                        : undefined
+                    }
+                    onChange={toggleIsNpsQuestion}
+                  />
+                )}
+              </LemonField>
+            )}
+          </div>
+        )}
+        {(question.type === SurveyQuestionType.SingleChoice ||
+          question.type === SurveyQuestionType.MultipleChoice) && (
+          <div className="flex flex-col gap-2">
+            <LemonField name="hasOpenChoice">
+              {({ value: hasOpenChoice, onChange: toggleHasOpenChoice }) => (
+                <LemonField name={getFieldName("choices")} label="Choices">
+                  {({ value, onChange }) => {
+                    // Wrap onChange to sync translations
+                    const handleChoicesChange = (
+                      newChoices: string[]
+                    ): void => {
+                      onChange(newChoices);
+                      if (!editingLanguage) {
+                        syncChoicesInTranslations(newChoices);
+                      }
+                    };
+
+                    return (
+                      <div className="flex flex-col gap-2">
+                        {(value || []).map((choice: string, index: number) => {
+                          const isOpenChoice =
+                            hasOpenChoice && index === value?.length - 1;
+                          const originalChoices = (question.choices ||
+                            []) as string[];
+                          return (
+                            <div
+                              className="flex flex-row gap-2 relative"
+                              key={index}
+                            >
+                              <LemonInput
+                                value={choice}
+                                fullWidth
+                                onChange={(val) => {
+                                  const newChoices = [...value];
+                                  newChoices[index] = val;
+                                  handleChoicesChange(newChoices);
+                                }}
+                                placeholder={
+                                  editingLanguage
+                                    ? originalChoices[index]
+                                    : undefined
+                                }
+                                suffix={
+                                  isOpenChoice && (
+                                    <LemonTag type="highlight">
+                                      open-ended
+                                    </LemonTag>
+                                  )
+                                }
+                              />
+                              <LemonButton
+                                icon={<IconTrash />}
+                                size="xsmall"
+                                noPadding
+                                onClick={() => {
+                                  const newChoices = [...value];
+                                  newChoices.splice(index, 1);
+                                  handleChoicesChange(newChoices);
+                                  if (isOpenChoice) {
+                                    toggleHasOpenChoice(false);
+                                  }
+                                }}
+                              />
+                            </div>
+                          );
+                        })}
+                        <div className="w-fit flex flex-row flex-wrap gap-2">
+                          {((value || []).length < MAX_NUMBER_OF_OPTIONS ||
+                            survey.type != SurveyType.Popover) && (
+                            <>
+                              <LemonButton
+                                icon={<IconPlusSmall />}
+                                type="secondary"
+                                fullWidth={false}
+                                disabledReason={
+                                  editingLanguage
+                                    ? "Cannot modify choices while translating"
+                                    : undefined
+                                }
+                                onClick={() => {
+                                  if (!value) {
+                                    handleChoicesChange([""]);
+                                  } else if (hasOpenChoice) {
+                                    const newChoices = value.slice(0, -1);
+                                    newChoices.push("");
+                                    newChoices.push(value[value.length - 1]);
+                                    handleChoicesChange(newChoices);
+                                  } else {
+                                    handleChoicesChange([...value, ""]);
+                                  }
+                                }}
+                              >
+                                Add choice
+                              </LemonButton>
+                              {!hasOpenChoice && (
+                                <LemonButton
+                                  icon={<IconPlusSmall />}
+                                  type="secondary"
+                                  fullWidth={false}
+                                  disabledReason={
+                                    editingLanguage
+                                      ? "Cannot modify choices while translating"
+                                      : undefined
+                                  }
+                                  onClick={() => {
+                                    if (!value) {
+                                      handleChoicesChange(["Other"]);
+                                    } else {
+                                      handleChoicesChange([...value, "Other"]);
+                                    }
+                                    toggleHasOpenChoice(true);
+                                  }}
+                                >
+                                  Add open-ended choice
+                                </LemonButton>
+                              )}
+                              <LemonField
+                                name="shuffleOptions"
+                                className="mt-2"
+                              >
+                                {({
+                                  value: shuffleOptions,
+                                  onChange: toggleShuffleOptions,
+                                }) => (
+                                  <LemonCheckbox
+                                    checked={!!shuffleOptions}
+                                    label="Shuffle options"
+                                    disabled={!!editingLanguage}
+                                    disabledReason={
+                                      editingLanguage
+                                        ? "Shuffle options can only be changed in the default language"
+                                        : undefined
+                                    }
+                                    onChange={(checked) =>
+                                      toggleShuffleOptions(checked)
+                                    }
+                                  />
+                                )}
+                              </LemonField>
+                            </>
+                          )}
+                        </div>
+                      </div>
+                    );
+                  }}
+                </LemonField>
+              )}
+            </LemonField>
+          </div>
+        )}
+        <LemonField
+          name="buttonText"
+          label="Submit button text"
+          className="flex-1 flex gap-1 justify-center"
+          info={
+            canSkipSubmitButton
+              ? "When the 'Automatically submit on selection' option is enabled, users won't need to click a submit button - their response will be submitted immediately after selecting an option. The submit button will be hidden. Requires at least version 1.244.0 of posthog-js. Not available for the mobile SDKs at the moment."
+              : undefined
+          }
+        >
+          <>
+            {(!canSkipSubmitButton ||
+              (canSkipSubmitButton && !question.skipSubmitButton)) && (
+              <LemonInput
+                value={
+                  displayQuestion.buttonText === undefined
+                    ? survey.appearance?.submitButtonText ?? "Submit"
+                    : displayQuestion.buttonText
+                }
+                onChange={(val) => handleQuestionValueChange("buttonText", val)}
+                placeholder={
+                  editingLanguage
+                    ? question.buttonText ??
+                      survey.appearance?.submitButtonText ??
+                      "Submit"
+                    : undefined
+                }
+              />
+            )}
+            {canSkipSubmitButton && (
+              <LemonField
+                name="skipSubmitButton"
+                info={
+                  <>
+                    If enabled, the survey will submit immediately after the
+                    user makes a selection (for single-choice without
+                    open-ended, or rating questions), and the submit button will
+                    be hidden/text ignored.
+                  </>
+                }
+              >
+                {({
+                  value: skipSubmitButtonValue,
+                  onChange: onSkipSubmitButtonChange,
+                }) => (
+                  <LemonCheckbox
+                    label="Automatically submit on selection"
+                    checked={!!skipSubmitButtonValue}
+                    onChange={onSkipSubmitButtonChange}
+                    disabled={!!editingLanguage}
+                    disabledReason={
+                      editingLanguage
+                        ? "Submit settings can only be changed in the default language"
+                        : undefined
+                    }
+                  />
+                )}
+              </LemonField>
+            )}
+          </>
+        </LemonField>
+        <QuestionBranchingInput questionIndex={index} question={question} />
+      </div>
+    </Group>
+  );
 }

--- a/frontend/src/scenes/surveys/SurveyEditQuestionRow.tsx
+++ b/frontend/src/scenes/surveys/SurveyEditQuestionRow.tsx
@@ -6,14 +6,13 @@ import { useActions, useValues } from 'kea'
 import { Group } from 'kea-forms'
 
 import { IconPlusSmall, IconTrash } from '@posthog/icons'
-import { LemonButton, LemonCheckbox, LemonDialog, LemonInput, LemonSelect, LemonTag } from '@posthog/lemon-ui'
+import { LemonButton, LemonCheckbox, LemonDialog, LemonInput, LemonSelect, LemonTag, Tooltip } from '@posthog/lemon-ui'
 
 import { LemonField } from 'lib/lemon-ui/LemonField'
 import { QuestionBranchingInput } from 'scenes/surveys/components/question-branching/QuestionBranchingInput'
 
 import {
     BasicSurveyQuestion,
-    LinkSurveyQuestion,
     MultipleSurveyQuestion,
     RatingSurveyQuestion,
     Survey,
@@ -207,18 +206,24 @@ export function SurveyEditQuestionGroup({ index, question }: { index: number; qu
             return
         }
 
+        const oldChoices = question.choices || []
         const updatedTranslations = { ...question.translations }
+
         Object.keys(updatedTranslations).forEach((lang) => {
             const trans = updatedTranslations[lang]
-            if (trans.choices) {
-                const oldChoices = trans.choices
-                const newTransChoices = [...newChoices].map((defaultChoice, idx) => {
-                    const existingChoice = oldChoices[idx]
-                    if (existingChoice !== undefined && existingChoice !== null) {
-                        return existingChoice
+            const transChoices = trans.choices && Array.isArray(trans.choices) ? trans.choices : []
+            if (trans.choices && Array.isArray(trans.choices)) {
+                // Sync choices by index: keep translation from same index in old choices
+                // This way if user deletes choice at index 2, we delete index 2 in all languages
+                const newTransChoices = newChoices.map((newChoice, newIndex) => {
+                    // Check if this choice existed at this same position in old choices
+                    if (oldChoices[newIndex] === newChoice && transChoices[newIndex] !== undefined) {
+                        // Same choice at same position, keep the translation
+                        return transChoices[newIndex]
                     }
-                    if (defaultChoice !== undefined && defaultChoice !== null && defaultChoice !== '') {
-                        return defaultChoice
+                    // This is a new/modified choice, initialize with the default or placeholder
+                    if (newChoice !== '' && newChoice !== undefined) {
+                        return newChoice
                     }
                     return '[Translation needed]'
                 })
@@ -404,12 +409,30 @@ export function SurveyEditQuestionGroup({ index, question }: { index: number; qu
                     </LemonField>
                 )}
                 {question.type === SurveyQuestionType.Open && (
-                    <LemonField name="validation">
+                    <LemonField
+                        name="validation"
+                        info={
+                            editingLanguage
+                                ? 'Validation settings can only be changed in the default language'
+                                : undefined
+                        }
+                    >
                         {({ value, onChange }) => (
-                            <ValidationRulesEditor
-                                value={(question as BasicSurveyQuestion).validation ?? value}
-                                onChange={onChange}
-                            />
+                            <Tooltip
+                                title={
+                                    editingLanguage
+                                        ? 'Validation settings can only be changed in the default language'
+                                        : undefined
+                                }
+                            >
+                                <div className={editingLanguage ? 'cursor-not-allowed opacity-60' : ''}>
+                                    <ValidationRulesEditor
+                                        value={(question as BasicSurveyQuestion).validation ?? value}
+                                        onChange={editingLanguage ? () => {} : onChange}
+                                        disabled={!!editingLanguage}
+                                    />
+                                </div>
+                            </Tooltip>
                         )}
                     </LemonField>
                 )}
@@ -560,19 +583,31 @@ export function SurveyEditQuestionGroup({ index, question }: { index: number; qu
                                                                     )
                                                                 }
                                                             />
-                                                            <LemonButton
-                                                                icon={<IconTrash />}
-                                                                size="xsmall"
-                                                                noPadding
-                                                                onClick={() => {
-                                                                    const newChoices = [...value]
-                                                                    newChoices.splice(index, 1)
-                                                                    handleChoicesChange(newChoices)
-                                                                    if (isOpenChoice) {
-                                                                        toggleHasOpenChoice(false)
-                                                                    }
-                                                                }}
-                                                            />
+                                                            <Tooltip
+                                                                title={
+                                                                    editingLanguage
+                                                                        ? 'Choices can only be modified in the default language'
+                                                                        : undefined
+                                                                }
+                                                            >
+                                                                <LemonButton
+                                                                    icon={<IconTrash />}
+                                                                    size="xsmall"
+                                                                    className="px-1"
+                                                                    disabled={editingLanguage !== null}
+                                                                    onClick={() => {
+                                                                        if (editingLanguage) {
+                                                                            return
+                                                                        }
+                                                                        const newChoices = [...value]
+                                                                        newChoices.splice(index, 1)
+                                                                        handleChoicesChange(newChoices)
+                                                                        if (isOpenChoice) {
+                                                                            toggleHasOpenChoice(false)
+                                                                        }
+                                                                    }}
+                                                                />
+                                                            </Tooltip>
                                                         </div>
                                                     )
                                                 })}

--- a/frontend/src/scenes/surveys/SurveyEditQuestionRow.tsx
+++ b/frontend/src/scenes/surveys/SurveyEditQuestionRow.tsx
@@ -125,28 +125,64 @@ function canQuestionSkipSubmitButton(
 }
 
 export function SurveyEditQuestionGroup({ index, question }: { index: number; question: SurveyQuestion }): JSX.Element {
-    const { survey, descriptionContentType } = useValues(surveyLogic)
+    const { survey, descriptionContentType, editingLanguage } = useValues(surveyLogic)
     const { setDefaultForQuestionType, setSurveyValue, resetBranchingForQuestion, setMultipleSurveyQuestion } =
         useActions(surveyLogic)
 
     const initialDescriptionContentType = descriptionContentType(index) ?? 'text'
 
     const handleQuestionValueChange = (key: string, val: string): void => {
-        const updatedQuestion = survey.questions.map((question, idx) => {
-            if (index === idx) {
-                return {
-                    ...question,
-                    [key]: val,
+        if (
+            editingLanguage &&
+            ['question', 'description', 'buttonText', 'choices', 'link', 'lowerBoundLabel', 'upperBoundLabel'].includes(
+                key
+            )
+        ) {
+            const updatedQuestion = survey.questions.map((q, idx) => {
+                if (index === idx) {
+                    const currentTranslations = q.translations || {}
+                    const currentLangTrans = currentTranslations[editingLanguage] || {}
+                    return {
+                        ...q,
+                        translations: {
+                            ...currentTranslations,
+                            [editingLanguage]: {
+                                ...currentLangTrans,
+                                [key]: val,
+                            },
+                        },
+                    }
                 }
-            }
-            return question
-        })
-        setSurveyValue('questions', updatedQuestion)
+                return q
+            })
+            setSurveyValue('questions', updatedQuestion)
+        } else {
+            const updatedQuestion = survey.questions.map((question, idx) => {
+                if (index === idx) {
+                    return {
+                        ...question,
+                        [key]: val,
+                    }
+                }
+                return question
+            })
+            setSurveyValue('questions', updatedQuestion)
+        }
     }
 
     const handleTabChange = (key: string): void => {
         handleQuestionValueChange('descriptionContentType', key)
     }
+
+    const getFieldName = (key: string): string =>
+        editingLanguage === null ? key : `translations.${editingLanguage}.${key}`
+
+    const displayQuestion = editingLanguage
+        ? {
+              ...question,
+              ...question.translations?.[editingLanguage],
+          }
+        : question
 
     const canSkipSubmitButton = canQuestionSkipSubmitButton(question)
     const shouldShowNpsCheckbox =
@@ -235,10 +271,10 @@ export function SurveyEditQuestionGroup({ index, question }: { index: number; qu
                         ]}
                     />
                 </LemonField>
-                <LemonField name="question" label="Label">
-                    <LemonInput data-attr={`survey-question-label-${index}`} value={question.question} />
+                <LemonField name={getFieldName('question')} label="Label">
+                    <LemonInput data-attr={`survey-question-label-${index}`} value={displayQuestion.question || ''} />
                 </LemonField>
-                <LemonField name="description" label="Description (optional)">
+                <LemonField name={getFieldName('description')} label="Description (optional)">
                     {({ value, onChange }) => (
                         <HTMLEditor
                             value={value}
@@ -267,8 +303,12 @@ export function SurveyEditQuestionGroup({ index, question }: { index: number; qu
                     </LemonField>
                 )}
                 {question.type === SurveyQuestionType.Link && (
-                    <LemonField name="link" label="Link" info="Only https:// or mailto: links are supported.">
-                        <LemonInput value={question.link || ''} placeholder="https://posthog.com" />
+                    <LemonField
+                        name={getFieldName('link')}
+                        label="Link"
+                        info="Only https:// or mailto: links are supported."
+                    >
+                        <LemonInput value={displayQuestion.link || ''} placeholder="https://posthog.com" />
                     </LemonField>
                 )}
                 {question.type === SurveyQuestionType.Rating && (

--- a/frontend/src/scenes/surveys/SurveyEditQuestionRow.tsx
+++ b/frontend/src/scenes/surveys/SurveyEditQuestionRow.tsx
@@ -1,411 +1,373 @@
-import "./EditSurvey.scss";
+import './EditSurvey.scss'
 
-import { useSortable } from "@dnd-kit/sortable";
-import { CSS } from "@dnd-kit/utilities";
-import { useActions, useValues } from "kea";
-import { Group } from "kea-forms";
+import { useSortable } from '@dnd-kit/sortable'
+import { CSS } from '@dnd-kit/utilities'
+import { useActions, useValues } from 'kea'
+import { Group } from 'kea-forms'
 
-import { IconPlusSmall, IconTrash } from "@posthog/icons";
-import {
-  LemonButton,
-  LemonCheckbox,
-  LemonDialog,
-  LemonInput,
-  LemonSelect,
-  LemonTag,
-} from "@posthog/lemon-ui";
+import { IconPlusSmall, IconTrash } from '@posthog/icons'
+import { LemonButton, LemonCheckbox, LemonDialog, LemonInput, LemonSelect, LemonTag } from '@posthog/lemon-ui'
 
-import { LemonField } from "lib/lemon-ui/LemonField";
-import { QuestionBranchingInput } from "scenes/surveys/components/question-branching/QuestionBranchingInput";
+import { LemonField } from 'lib/lemon-ui/LemonField'
+import { QuestionBranchingInput } from 'scenes/surveys/components/question-branching/QuestionBranchingInput'
 
 import {
-  BasicSurveyQuestion,
-  LinkSurveyQuestion,
-  MultipleSurveyQuestion,
-  RatingSurveyQuestion,
-  Survey,
-  SurveyQuestion,
-  SurveyQuestionType,
-  SurveyType,
-} from "~/types";
+    BasicSurveyQuestion,
+    LinkSurveyQuestion,
+    MultipleSurveyQuestion,
+    RatingSurveyQuestion,
+    Survey,
+    SurveyQuestion,
+    SurveyQuestionType,
+    SurveyType,
+} from '~/types'
 
-import { ValidationRulesEditor } from "./components/ValidationRulesEditor";
-import {
-  NewSurvey,
-  SCALE_OPTIONS,
-  SURVEY_RATING_SCALE,
-  SurveyQuestionLabel,
-} from "./constants";
-import { HTMLEditor } from "./SurveyAppearanceUtils";
-import { SurveyDragHandle } from "./SurveyDragHandle";
-import { surveyLogic } from "./surveyLogic";
-import { isThumbQuestion } from "./utils";
+import { ValidationRulesEditor } from './components/ValidationRulesEditor'
+import { NewSurvey, SCALE_OPTIONS, SURVEY_RATING_SCALE, SurveyQuestionLabel } from './constants'
+import { HTMLEditor } from './SurveyAppearanceUtils'
+import { SurveyDragHandle } from './SurveyDragHandle'
+import { surveyLogic } from './surveyLogic'
+import { isThumbQuestion } from './utils'
 
 type SurveyQuestionHeaderProps = {
-  index: number;
-  survey: Survey | NewSurvey;
-  setSelectedPageIndex: (index: number) => void;
-  setSurveyValue: (key: string, value: any) => void;
-};
+    index: number
+    survey: Survey | NewSurvey
+    setSelectedPageIndex: (index: number) => void
+    setSurveyValue: (key: string, value: any) => void
+}
 
-const MAX_NUMBER_OF_OPTIONS = 15;
+const MAX_NUMBER_OF_OPTIONS = 15
 
 export function SurveyEditQuestionHeader({
-  index,
-  survey,
-  setSelectedPageIndex,
-  setSurveyValue,
+    index,
+    survey,
+    setSelectedPageIndex,
+    setSurveyValue,
 }: SurveyQuestionHeaderProps): JSX.Element {
-  const { hasBranchingLogic, editingLanguage } = useValues(surveyLogic);
-  const { deleteBranchingLogic } = useActions(surveyLogic);
-  const {
-    setNodeRef,
-    attributes,
-    transform,
-    transition,
-    listeners,
-    isDragging,
-  } = useSortable({
-    id: index.toString(),
-  });
+    const { hasBranchingLogic, editingLanguage } = useValues(surveyLogic)
+    const { deleteBranchingLogic } = useActions(surveyLogic)
+    const { setNodeRef, attributes, transform, transition, listeners, isDragging } = useSortable({
+        id: index.toString(),
+    })
 
-  return (
-    <div
-      className="flex flex-row w-full items-center justify-between relative"
-      ref={setNodeRef}
-      {...attributes}
-      // eslint-disable-next-line react/forbid-dom-props
-      style={{
-        zIndex: isDragging ? 1 : undefined,
-        transform: CSS.Translate.toString(transform),
-        transition,
-      }}
-    >
-      <div className="flex flex-row gap-2 items-center">
-        <SurveyDragHandle
-          listeners={listeners}
-          hasMultipleQuestions={survey.questions.length > 1}
-        />
+    return (
+        <div
+            className="flex flex-row w-full items-center justify-between relative"
+            ref={setNodeRef}
+            {...attributes}
+            // eslint-disable-next-line react/forbid-dom-props
+            style={{
+                zIndex: isDragging ? 1 : undefined,
+                transform: CSS.Translate.toString(transform),
+                transition,
+            }}
+        >
+            <div className="flex flex-row gap-2 items-center">
+                <SurveyDragHandle listeners={listeners} hasMultipleQuestions={survey.questions.length > 1} />
 
-        <b>
-          Question {index + 1}.{" "}
-          {editingLanguage
-            ? survey.questions[index].translations?.[editingLanguage]
-                ?.question ?? survey.questions[index].question
-            : survey.questions[index].question}
-        </b>
-      </div>
-      {survey.questions.length > 1 && (
-        <LemonButton
-          icon={<IconTrash />}
-          size="xsmall"
-          data-attr={`delete-survey-question-${index}`}
-          onClick={(e) => {
-            const deleteQuestion = (): void => {
-              e.stopPropagation();
-              setSelectedPageIndex(index <= 0 ? 0 : index - 1);
-              setSurveyValue(
-                "questions",
-                survey.questions.filter((_, i) => i !== index)
-              );
-            };
+                <b>
+                    Question {index + 1}.{' '}
+                    {editingLanguage
+                        ? (survey.questions[index].translations?.[editingLanguage]?.question ??
+                          survey.questions[index].question)
+                        : survey.questions[index].question}
+                </b>
+            </div>
+            {survey.questions.length > 1 && (
+                <LemonButton
+                    icon={<IconTrash />}
+                    size="xsmall"
+                    data-attr={`delete-survey-question-${index}`}
+                    onClick={(e) => {
+                        const deleteQuestion = (): void => {
+                            e.stopPropagation()
+                            setSelectedPageIndex(index <= 0 ? 0 : index - 1)
+                            setSurveyValue(
+                                'questions',
+                                survey.questions.filter((_, i) => i !== index)
+                            )
+                        }
 
-            if (hasBranchingLogic) {
-              LemonDialog.open({
-                title: "Your survey has active branching logic",
-                description: (
-                  <p className="py-2">
-                    Deleting the question will remove your branching logic. Are
-                    you sure you want to continue?
-                  </p>
-                ),
-                primaryButton: {
-                  children: "Continue",
-                  status: "danger",
-                  onClick: () => {
-                    deleteBranchingLogic();
-                    deleteQuestion();
-                  },
-                },
-                secondaryButton: {
-                  children: "Cancel",
-                },
-              });
-            } else {
-              deleteQuestion();
-            }
-          }}
-          tooltipPlacement="top-end"
-        />
-      )}
-    </div>
-  );
+                        if (hasBranchingLogic) {
+                            LemonDialog.open({
+                                title: 'Your survey has active branching logic',
+                                description: (
+                                    <p className="py-2">
+                                        Deleting the question will remove your branching logic. Are you sure you want to
+                                        continue?
+                                    </p>
+                                ),
+                                primaryButton: {
+                                    children: 'Continue',
+                                    status: 'danger',
+                                    onClick: () => {
+                                        deleteBranchingLogic()
+                                        deleteQuestion()
+                                    },
+                                },
+                                secondaryButton: {
+                                    children: 'Cancel',
+                                },
+                            })
+                        } else {
+                            deleteQuestion()
+                        }
+                    }}
+                    tooltipPlacement="top-end"
+                />
+            )}
+        </div>
+    )
 }
 
 function canQuestionSkipSubmitButton(
-  question: SurveyQuestion
+    question: SurveyQuestion
 ): question is RatingSurveyQuestion | MultipleSurveyQuestion {
-  return (
-    question.type === SurveyQuestionType.Rating ||
-    (question.type === SurveyQuestionType.SingleChoice &&
-      !question.hasOpenChoice)
-  );
+    return (
+        question.type === SurveyQuestionType.Rating ||
+        (question.type === SurveyQuestionType.SingleChoice && !question.hasOpenChoice)
+    )
 }
 
-export function SurveyEditQuestionGroup({
-  index,
-  question,
-}: {
-  index: number;
-  question: SurveyQuestion;
-}): JSX.Element {
-  const { survey, descriptionContentType, editingLanguage } =
-    useValues(surveyLogic);
-  const {
-    setDefaultForQuestionType,
-    setSurveyValue,
-    resetBranchingForQuestion,
-    setMultipleSurveyQuestion,
-  } = useActions(surveyLogic);
+export function SurveyEditQuestionGroup({ index, question }: { index: number; question: SurveyQuestion }): JSX.Element {
+    const { survey, descriptionContentType, editingLanguage } = useValues(surveyLogic)
+    const { setDefaultForQuestionType, setSurveyValue, resetBranchingForQuestion, setMultipleSurveyQuestion } =
+        useActions(surveyLogic)
 
-  const initialDescriptionContentType = descriptionContentType(index) ?? "text";
+    const initialDescriptionContentType = descriptionContentType(index) ?? 'text'
 
-  const handleQuestionValueChange = (key: string, val: string): void => {
-    if (
-      editingLanguage &&
-      [
-        "question",
-        "description",
-        "buttonText",
-        "choices",
-        "link",
-        "lowerBoundLabel",
-        "upperBoundLabel",
-      ].includes(key)
-    ) {
-      const updatedQuestion = survey.questions.map((q, idx) => {
-        if (index === idx) {
-          const currentTranslations = q.translations || {};
-          const currentLangTrans = currentTranslations[editingLanguage] || {};
-          return {
-            ...q,
-            translations: {
-              ...currentTranslations,
-              [editingLanguage]: {
-                ...currentLangTrans,
-                [key]: val,
-              },
-            },
-          };
+    const handleQuestionValueChange = (key: string, val: string): void => {
+        if (
+            editingLanguage &&
+            ['question', 'description', 'buttonText', 'choices', 'link', 'lowerBoundLabel', 'upperBoundLabel'].includes(
+                key
+            )
+        ) {
+            const updatedQuestion = survey.questions.map((q, idx) => {
+                if (index === idx) {
+                    const currentTranslations = q.translations || {}
+                    const currentLangTrans = currentTranslations[editingLanguage] || {}
+                    return {
+                        ...q,
+                        translations: {
+                            ...currentTranslations,
+                            [editingLanguage]: {
+                                ...currentLangTrans,
+                                [key]: val,
+                            },
+                        },
+                    }
+                }
+                return q
+            })
+            setSurveyValue('questions', updatedQuestion)
+        } else {
+            const updatedQuestion = survey.questions.map((question, idx) => {
+                if (index === idx) {
+                    return {
+                        ...question,
+                        [key]: val,
+                    }
+                }
+                return question
+            })
+            setSurveyValue('questions', updatedQuestion)
         }
-        return q;
-      });
-      setSurveyValue("questions", updatedQuestion);
-    } else {
-      const updatedQuestion = survey.questions.map((question, idx) => {
-        if (index === idx) {
-          return {
-            ...question,
-            [key]: val,
-          };
-        }
-        return question;
-      });
-      setSurveyValue("questions", updatedQuestion);
-    }
-  };
-
-  const handleTabChange = (key: string): void => {
-    handleQuestionValueChange("descriptionContentType", key);
-  };
-
-  const getFieldName = (key: string): string =>
-    editingLanguage === null ? key : `translations.${editingLanguage}.${key}`;
-
-  const displayQuestion = editingLanguage
-    ? {
-        ...question,
-        ...question.translations?.[editingLanguage],
-        // Ensure choices array exists for translations by using original choices if translation is empty
-        choices:
-          question.translations?.[editingLanguage]?.choices ||
-          (question.type === SurveyQuestionType.SingleChoice ||
-          question.type === SurveyQuestionType.MultipleChoice
-            ? question.choices || []
-            : undefined),
-      }
-    : question;
-
-  const canSkipSubmitButton = canQuestionSkipSubmitButton(question);
-  const shouldShowNpsCheckbox =
-    question.type === SurveyQuestionType.Rating &&
-    question.scale === SURVEY_RATING_SCALE.NPS_10_POINT;
-
-  const hasTranslations =
-    question.translations && Object.keys(question.translations).length > 0;
-
-  // Helper to synchronize choices in all translations when default choices change
-  const syncChoicesInTranslations = (newChoices: string[]): void => {
-    if (!hasTranslations || !question.translations) {
-      return;
     }
 
-    const updatedTranslations = { ...question.translations };
-    Object.keys(updatedTranslations).forEach((lang) => {
-      const trans = updatedTranslations[lang];
-      if (trans.choices) {
-        const oldChoices = trans.choices;
-        // Use default text if available, otherwise use placeholder
-        const newTransChoices = [...newChoices].map(
-          (defaultChoice, idx) =>
-            oldChoices[idx] || defaultChoice || "[Translation needed]"
-        );
-        updatedTranslations[lang] = {
-          ...trans,
-          choices: newTransChoices,
-        };
-      }
-    });
+    const handleTabChange = (key: string): void => {
+        handleQuestionValueChange('descriptionContentType', key)
+    }
 
-    // Update question with synced translations
-    setSurveyValue("questions", [
-      ...survey.questions.slice(0, index),
-      { ...question, translations: updatedTranslations },
-      ...survey.questions.slice(index + 1),
-    ]);
-  };
+    const getFieldName = (key: string): string =>
+        editingLanguage === null ? key : `translations.${editingLanguage}.${key}`
 
-  const confirmQuestionTypeChange = (
-    index: number,
-    question: MultipleSurveyQuestion,
-    newType: SurveyQuestionType
-  ): void => {
-    // Reset to current type first (because onSelect has already changed it)
-    setMultipleSurveyQuestion(index, question, question.type);
+    const displayQuestion = editingLanguage
+        ? {
+              ...question,
+              ...question.translations?.[editingLanguage],
+              choices:
+                  question.translations?.[editingLanguage]?.choices ||
+                  (question.type === SurveyQuestionType.SingleChoice ||
+                  question.type === SurveyQuestionType.MultipleChoice
+                      ? question.choices || []
+                      : undefined),
+          }
+        : question
 
-    LemonDialog.open({
-      title: "Changing question type",
-      description: (
-        <p className="py-2">
-          {hasTranslations ? (
-            <>
-              This question has translations. Changing the question type will
-              remove the choices you have configured and incompatible
-              translation fields.
-            </>
-          ) : (
-            "The choices you have configured will be removed."
-          )}{" "}
-          Would you like to proceed?
-        </p>
-      ),
-      primaryButton: {
-        children: "Continue",
-        status: "danger",
-        onClick: () => {
-          setDefaultForQuestionType(index, question, newType);
-          resetBranchingForQuestion(index);
-        },
-      },
-      secondaryButton: {
-        children: "Cancel",
-      },
-    });
-  };
+    const canSkipSubmitButton = canQuestionSkipSubmitButton(question)
+    const shouldShowNpsCheckbox =
+        question.type === SurveyQuestionType.Rating && question.scale === SURVEY_RATING_SCALE.NPS_10_POINT
 
-  const confirmQuestionTypeChangeWithTranslations = (
-    index: number,
-    question: SurveyQuestion,
-    newType: SurveyQuestionType
-  ): void => {
-    LemonDialog.open({
-      title: "Changing question type",
-      description: (
-        <p className="py-2">
-          This question has translations. Changing the question type will remove
-          incompatible translation fields. Would you like to proceed?
-        </p>
-      ),
-      primaryButton: {
-        children: "Continue",
-        status: "danger",
-        onClick: () => {
-          setDefaultForQuestionType(index, question, newType);
-          resetBranchingForQuestion(index);
-        },
-      },
-      secondaryButton: {
-        children: "Cancel",
-      },
-    });
-  };
+    const hasTranslations = question.translations && Object.keys(question.translations).length > 0
 
-  return (
-    <Group name={`questions.${index}`} key={index}>
-      <div className="flex flex-col gap-2">
-        <LemonField name="type" label="Question type" className="max-w-60">
-          <LemonSelect
-            disabled={!!editingLanguage}
-            disabledReason={
-              editingLanguage
-                ? "Question type can only be changed in the default language"
-                : undefined
+    // Helper to synchronize choices in all translations when default choices change
+    const syncChoicesInTranslations = (newChoices: string[]): void => {
+        if (!hasTranslations || !question.translations) {
+            return
+        }
+
+        const updatedTranslations = { ...question.translations }
+        Object.keys(updatedTranslations).forEach((lang) => {
+            const trans = updatedTranslations[lang]
+            if (trans.choices) {
+                const oldChoices = trans.choices
+                const newTransChoices = [...newChoices].map((defaultChoice, idx) => {
+                    const existingChoice = oldChoices[idx]
+                    if (existingChoice !== undefined && existingChoice !== null) {
+                        return existingChoice
+                    }
+                    if (defaultChoice !== undefined && defaultChoice !== null && defaultChoice !== '') {
+                        return defaultChoice
+                    }
+                    return '[Translation needed]'
+                })
+                updatedTranslations[lang] = {
+                    ...trans,
+                    choices: newTransChoices,
+                }
             }
-            data-attr={`survey-question-type-${index}`}
-            onSelect={(newType) => {
-              const isCurrentMultipleChoice =
-                question.type === SurveyQuestionType.MultipleChoice ||
-                question.type === SurveyQuestionType.SingleChoice;
-              const isNewMultipleChoice =
-                newType === SurveyQuestionType.MultipleChoice ||
-                newType === SurveyQuestionType.SingleChoice
+        })
 
-                            // Same multiple choice type - just update type
-                            if (isCurrentMultipleChoice && isNewMultipleChoice) {
-                                setMultipleSurveyQuestion(index, question, newType)
+        setSurveyValue('questions', [
+            ...survey.questions.slice(0, index),
+            { ...question, choices: newChoices, translations: updatedTranslations },
+            ...survey.questions.slice(index + 1),
+        ])
+    }
+
+    const confirmQuestionTypeChange = (
+        index: number,
+        question: MultipleSurveyQuestion,
+        newType: SurveyQuestionType
+    ): void => {
+        LemonDialog.open({
+            title: 'Changing question type',
+            description: (
+                <p className="py-2">
+                    {hasTranslations ? (
+                        <>
+                            This question has translations. Changing the question type will remove the choices you have
+                            configured and incompatible translation fields.
+                        </>
+                    ) : (
+                        'The choices you have configured will be removed.'
+                    )}{' '}
+                    Would you like to proceed?
+                </p>
+            ),
+            primaryButton: {
+                children: 'Continue',
+                status: 'danger',
+                onClick: () => {
+                    setDefaultForQuestionType(index, question, newType)
+                    resetBranchingForQuestion(index)
+                },
+            },
+            secondaryButton: {
+                children: 'Cancel',
+                onClick: () => {
+                    // Revert the question type back to original
+                    setMultipleSurveyQuestion(index, question, question.type)
+                },
+            },
+        })
+    }
+
+    const confirmQuestionTypeChangeWithTranslations = (
+        index: number,
+        question: SurveyQuestion,
+        newType: SurveyQuestionType
+    ): void => {
+        LemonDialog.open({
+            title: 'Changing question type',
+            description: (
+                <p className="py-2">
+                    This question has translations. Changing the question type will remove incompatible translation
+                    fields. Would you like to proceed?
+                </p>
+            ),
+            primaryButton: {
+                children: 'Continue',
+                status: 'danger',
+                onClick: () => {
+                    setDefaultForQuestionType(index, question, newType)
+                    resetBranchingForQuestion(index)
+                },
+            },
+            secondaryButton: {
+                children: 'Cancel',
+            },
+        })
+    }
+
+    return (
+        <Group name={`questions.${index}`} key={index}>
+            <div className="flex flex-col gap-2">
+                <LemonField name="type" label="Question type" className="max-w-60">
+                    {({ value: currentType }) => (
+                        <LemonSelect
+                            value={currentType}
+                            disabled={!!editingLanguage}
+                            disabledReason={
+                                editingLanguage
+                                    ? 'Question type can only be changed in the default language'
+                                    : undefined
+                            }
+                            data-attr={`survey-question-type-${index}`}
+                            onSelect={(newType) => {
+                                const isCurrentMultipleChoice =
+                                    question.type === SurveyQuestionType.MultipleChoice ||
+                                    question.type === SurveyQuestionType.SingleChoice
+                                const isNewMultipleChoice =
+                                    newType === SurveyQuestionType.MultipleChoice ||
+                                    newType === SurveyQuestionType.SingleChoice
+
+                                if (isCurrentMultipleChoice && isNewMultipleChoice) {
+                                    setMultipleSurveyQuestion(index, question, newType)
+                                    resetBranchingForQuestion(index)
+                                    return
+                                }
+                                if (isCurrentMultipleChoice && !isNewMultipleChoice) {
+                                    confirmQuestionTypeChange(index, question, newType)
+                                    return
+                                }
+                                if (hasTranslations) {
+                                    confirmQuestionTypeChangeWithTranslations(index, question, newType)
+                                    return
+                                }
+                                setDefaultForQuestionType(index, question, newType)
                                 resetBranchingForQuestion(index)
-                                return
-                            }
-                            if (isCurrentMultipleChoice && !isNewMultipleChoice) {
-                                confirmQuestionTypeChange(index, question, newType)
-                                return
-                            }
-                            // Check if question has translations
-                            if (hasTranslations) {
-                                confirmQuestionTypeChangeWithTranslations(index, question, newType)
-                                return
-                            }
-                            setDefaultForQuestionType(index, question, newType)
-                            resetBranchingForQuestion(index)
-                        }}
-                        options={[
-                            {
-                                label: SurveyQuestionLabel[SurveyQuestionType.Open],
-                                value: SurveyQuestionType.Open,
-                                'data-attr': `survey-question-type-${index}-${SurveyQuestionType.Open}`,
-                            },
-                            {
-                                label: 'Link/Notification',
-                                value: SurveyQuestionType.Link,
-                                'data-attr': `survey-question-type-${index}-${SurveyQuestionType.Link}`,
-                            },
-                            {
-                                label: 'Rating',
-                                value: SurveyQuestionType.Rating,
-                                'data-attr': `survey-question-type-${index}-${SurveyQuestionType.Rating}`,
-                            },
-                            {
-                                label: 'Single choice select',
-                                value: SurveyQuestionType.SingleChoice,
-                                'data-attr': `survey-question-type-${index}-${SurveyQuestionType.SingleChoice}`,
-                            },
-                            {
-                                label: 'Multiple choice select',
-                                value: SurveyQuestionType.MultipleChoice,
-                                'data-attr': `survey-question-type-${index}-${SurveyQuestionType.MultipleChoice}`,
-                            },
-                        ]}
-                    />
+                            }}
+                            options={[
+                                {
+                                    label: SurveyQuestionLabel[SurveyQuestionType.Open],
+                                    value: SurveyQuestionType.Open,
+                                    'data-attr': `survey-question-type-${index}-${SurveyQuestionType.Open}`,
+                                },
+                                {
+                                    label: 'Link/Notification',
+                                    value: SurveyQuestionType.Link,
+                                    'data-attr': `survey-question-type-${index}-${SurveyQuestionType.Link}`,
+                                },
+                                {
+                                    label: 'Rating',
+                                    value: SurveyQuestionType.Rating,
+                                    'data-attr': `survey-question-type-${index}-${SurveyQuestionType.Rating}`,
+                                },
+                                {
+                                    label: 'Single choice select',
+                                    value: SurveyQuestionType.SingleChoice,
+                                    'data-attr': `survey-question-type-${index}-${SurveyQuestionType.SingleChoice}`,
+                                },
+                                {
+                                    label: 'Multiple choice select',
+                                    value: SurveyQuestionType.MultipleChoice,
+                                    'data-attr': `survey-question-type-${index}-${SurveyQuestionType.MultipleChoice}`,
+                                },
+                            ]}
+                        />
+                    )}
                 </LemonField>
                 <LemonField name={getFieldName('question')} label="Label">
                     <LemonInput
@@ -516,267 +478,241 @@ export function SurveyEditQuestionGroup({
                                 />
                             </LemonField>
                         </div>
-            {!isThumbQuestion(question) && (
-              <div className="flex flex-row gap-4">
-                <LemonField
-                  name={getFieldName("lowerBoundLabel")}
-                  label="Lower bound label"
-                  className="w-1/2"
-                >
-                  <LemonInput
-                    value={displayQuestion.lowerBoundLabel || ""}
-                    placeholder={
-                      editingLanguage ? question.lowerBoundLabel : undefined
-                    }
-                  />
-                </LemonField>
-                <LemonField
-                  name={getFieldName("upperBoundLabel")}
-                  label="Upper bound label"
-                  className="w-1/2"
-                >
-                  <LemonInput
-                    value={displayQuestion.upperBoundLabel || ""}
-                    placeholder={
-                      editingLanguage ? question.upperBoundLabel : undefined
-                    }
-                  />
-                </LemonField>
-              </div>
-            )}
-            {shouldShowNpsCheckbox && (
-              <LemonField name="isNpsQuestion">
-                {({ value: isNpsQuestion, onChange: toggleIsNpsQuestion }) => (
-                  <LemonCheckbox
-                    label="This is an NPS question"
-                    info="If checked, we'll calculate and display NPS on the survey results page."
-                    checked={isNpsQuestion !== false}
-                    disabled={!!editingLanguage}
-                    disabledReason={
-                      editingLanguage
-                        ? "Question settings can only be changed in the default language"
-                        : undefined
-                    }
-                    onChange={toggleIsNpsQuestion}
-                  />
-                )}
-              </LemonField>
-            )}
-          </div>
-        )}
-        {(question.type === SurveyQuestionType.SingleChoice ||
-          question.type === SurveyQuestionType.MultipleChoice) && (
-          <div className="flex flex-col gap-2">
-            <LemonField name="hasOpenChoice">
-              {({ value: hasOpenChoice, onChange: toggleHasOpenChoice }) => (
-                <LemonField name={getFieldName("choices")} label="Choices">
-                  {({ value, onChange }) => {
-                    // Wrap onChange to sync translations
-                    const handleChoicesChange = (
-                      newChoices: string[]
-                    ): void => {
-                      onChange(newChoices);
-                      if (!editingLanguage) {
-                        syncChoicesInTranslations(newChoices);
-                      }
-                    };
-
-                    return (
-                      <div className="flex flex-col gap-2">
-                        {(value || []).map((choice: string, index: number) => {
-                          const isOpenChoice =
-                            hasOpenChoice && index === value?.length - 1;
-                          const originalChoices = (question.choices ||
-                            []) as string[];
-                          return (
-                            <div
-                              className="flex flex-row gap-2 relative"
-                              key={index}
-                            >
-                              <LemonInput
-                                value={choice}
-                                fullWidth
-                                onChange={(val) => {
-                                  const newChoices = [...value];
-                                  newChoices[index] = val;
-                                  handleChoicesChange(newChoices);
-                                }}
-                                placeholder={
-                                  editingLanguage
-                                    ? originalChoices[index]
-                                    : undefined
-                                }
-                                suffix={
-                                  isOpenChoice && (
-                                    <LemonTag type="highlight">
-                                      open-ended
-                                    </LemonTag>
-                                  )
-                                }
-                              />
-                              <LemonButton
-                                icon={<IconTrash />}
-                                size="xsmall"
-                                noPadding
-                                onClick={() => {
-                                  const newChoices = [...value];
-                                  newChoices.splice(index, 1);
-                                  handleChoicesChange(newChoices);
-                                  if (isOpenChoice) {
-                                    toggleHasOpenChoice(false);
-                                  }
-                                }}
-                              />
-                            </div>
-                          );
-                        })}
-                        <div className="w-fit flex flex-row flex-wrap gap-2">
-                          {((value || []).length < MAX_NUMBER_OF_OPTIONS ||
-                            survey.type != SurveyType.Popover) && (
-                            <>
-                              <LemonButton
-                                icon={<IconPlusSmall />}
-                                type="secondary"
-                                fullWidth={false}
-                                disabledReason={
-                                  editingLanguage
-                                    ? "Cannot modify choices while translating"
-                                    : undefined
-                                }
-                                onClick={() => {
-                                  if (!value) {
-                                    handleChoicesChange([""]);
-                                  } else if (hasOpenChoice) {
-                                    const newChoices = value.slice(0, -1);
-                                    newChoices.push("");
-                                    newChoices.push(value[value.length - 1]);
-                                    handleChoicesChange(newChoices);
-                                  } else {
-                                    handleChoicesChange([...value, ""]);
-                                  }
-                                }}
-                              >
-                                Add choice
-                              </LemonButton>
-                              {!hasOpenChoice && (
-                                <LemonButton
-                                  icon={<IconPlusSmall />}
-                                  type="secondary"
-                                  fullWidth={false}
-                                  disabledReason={
-                                    editingLanguage
-                                      ? "Cannot modify choices while translating"
-                                      : undefined
-                                  }
-                                  onClick={() => {
-                                    if (!value) {
-                                      handleChoicesChange(["Other"]);
-                                    } else {
-                                      handleChoicesChange([...value, "Other"]);
-                                    }
-                                    toggleHasOpenChoice(true);
-                                  }}
+                        {!isThumbQuestion(question) && (
+                            <div className="flex flex-row gap-4">
+                                <LemonField
+                                    name={getFieldName('lowerBoundLabel')}
+                                    label="Lower bound label"
+                                    className="w-1/2"
                                 >
-                                  Add open-ended choice
-                                </LemonButton>
-                              )}
-                              <LemonField
-                                name="shuffleOptions"
-                                className="mt-2"
-                              >
-                                {({
-                                  value: shuffleOptions,
-                                  onChange: toggleShuffleOptions,
-                                }) => (
-                                  <LemonCheckbox
-                                    checked={!!shuffleOptions}
-                                    label="Shuffle options"
-                                    disabled={!!editingLanguage}
-                                    disabledReason={
-                                      editingLanguage
-                                        ? "Shuffle options can only be changed in the default language"
-                                        : undefined
-                                    }
-                                    onChange={(checked) =>
-                                      toggleShuffleOptions(checked)
-                                    }
-                                  />
+                                    <LemonInput
+                                        value={displayQuestion.lowerBoundLabel || ''}
+                                        placeholder={editingLanguage ? question.lowerBoundLabel : undefined}
+                                    />
+                                </LemonField>
+                                <LemonField
+                                    name={getFieldName('upperBoundLabel')}
+                                    label="Upper bound label"
+                                    className="w-1/2"
+                                >
+                                    <LemonInput
+                                        value={displayQuestion.upperBoundLabel || ''}
+                                        placeholder={editingLanguage ? question.upperBoundLabel : undefined}
+                                    />
+                                </LemonField>
+                            </div>
+                        )}
+                        {shouldShowNpsCheckbox && (
+                            <LemonField name="isNpsQuestion">
+                                {({ value: isNpsQuestion, onChange: toggleIsNpsQuestion }) => (
+                                    <LemonCheckbox
+                                        label="This is an NPS question"
+                                        info="If checked, we'll calculate and display NPS on the survey results page."
+                                        checked={isNpsQuestion !== false}
+                                        disabled={!!editingLanguage}
+                                        disabledReason={
+                                            editingLanguage
+                                                ? 'Question settings can only be changed in the default language'
+                                                : undefined
+                                        }
+                                        onChange={toggleIsNpsQuestion}
+                                    />
                                 )}
-                              </LemonField>
-                            </>
-                          )}
-                        </div>
-                      </div>
-                    );
-                  }}
-                </LemonField>
-              )}
-            </LemonField>
-          </div>
-        )}
-        <LemonField
-          name="buttonText"
-          label="Submit button text"
-          className="flex-1 flex gap-1 justify-center"
-          info={
-            canSkipSubmitButton
-              ? "When the 'Automatically submit on selection' option is enabled, users won't need to click a submit button - their response will be submitted immediately after selecting an option. The submit button will be hidden. Requires at least version 1.244.0 of posthog-js. Not available for the mobile SDKs at the moment."
-              : undefined
-          }
-        >
-          <>
-            {(!canSkipSubmitButton ||
-              (canSkipSubmitButton && !question.skipSubmitButton)) && (
-              <LemonInput
-                value={
-                  displayQuestion.buttonText === undefined
-                    ? survey.appearance?.submitButtonText ?? "Submit"
-                    : displayQuestion.buttonText
-                }
-                onChange={(val) => handleQuestionValueChange("buttonText", val)}
-                placeholder={
-                  editingLanguage
-                    ? question.buttonText ??
-                      survey.appearance?.submitButtonText ??
-                      "Submit"
-                    : undefined
-                }
-              />
-            )}
-            {canSkipSubmitButton && (
-              <LemonField
-                name="skipSubmitButton"
-                info={
-                  <>
-                    If enabled, the survey will submit immediately after the
-                    user makes a selection (for single-choice without
-                    open-ended, or rating questions), and the submit button will
-                    be hidden/text ignored.
-                  </>
-                }
-              >
-                {({
-                  value: skipSubmitButtonValue,
-                  onChange: onSkipSubmitButtonChange,
-                }) => (
-                  <LemonCheckbox
-                    label="Automatically submit on selection"
-                    checked={!!skipSubmitButtonValue}
-                    onChange={onSkipSubmitButtonChange}
-                    disabled={!!editingLanguage}
-                    disabledReason={
-                      editingLanguage
-                        ? "Submit settings can only be changed in the default language"
-                        : undefined
-                    }
-                  />
+                            </LemonField>
+                        )}
+                    </div>
                 )}
-              </LemonField>
-            )}
-          </>
-        </LemonField>
-        <QuestionBranchingInput questionIndex={index} question={question} />
-      </div>
-    </Group>
-  );
+                {(question.type === SurveyQuestionType.SingleChoice ||
+                    question.type === SurveyQuestionType.MultipleChoice) && (
+                    <div className="flex flex-col gap-2">
+                        <LemonField name="hasOpenChoice">
+                            {({ value: hasOpenChoice, onChange: toggleHasOpenChoice }) => (
+                                <LemonField name={getFieldName('choices')} label="Choices">
+                                    {({ value, onChange }) => {
+                                        const handleChoicesChange = (newChoices: string[]): void => {
+                                            onChange(newChoices)
+                                            if (!editingLanguage) {
+                                                syncChoicesInTranslations(newChoices)
+                                            }
+                                        }
+
+                                        return (
+                                            <div className="flex flex-col gap-2">
+                                                {(value || []).map((choice: string, index: number) => {
+                                                    const isOpenChoice = hasOpenChoice && index === value?.length - 1
+                                                    const originalChoices = (question.choices || []) as string[]
+                                                    return (
+                                                        <div className="flex flex-row gap-2 relative" key={index}>
+                                                            <LemonInput
+                                                                value={choice}
+                                                                fullWidth
+                                                                onChange={(val) => {
+                                                                    const newChoices = [...value]
+                                                                    newChoices[index] = val
+                                                                    handleChoicesChange(newChoices)
+                                                                }}
+                                                                placeholder={
+                                                                    editingLanguage ? originalChoices[index] : undefined
+                                                                }
+                                                                suffix={
+                                                                    isOpenChoice && (
+                                                                        <LemonTag type="highlight">open-ended</LemonTag>
+                                                                    )
+                                                                }
+                                                            />
+                                                            <LemonButton
+                                                                icon={<IconTrash />}
+                                                                size="xsmall"
+                                                                noPadding
+                                                                onClick={() => {
+                                                                    const newChoices = [...value]
+                                                                    newChoices.splice(index, 1)
+                                                                    handleChoicesChange(newChoices)
+                                                                    if (isOpenChoice) {
+                                                                        toggleHasOpenChoice(false)
+                                                                    }
+                                                                }}
+                                                            />
+                                                        </div>
+                                                    )
+                                                })}
+                                                <div className="w-fit flex flex-row flex-wrap gap-2">
+                                                    {((value || []).length < MAX_NUMBER_OF_OPTIONS ||
+                                                        survey.type != SurveyType.Popover) && (
+                                                        <>
+                                                            <LemonButton
+                                                                icon={<IconPlusSmall />}
+                                                                type="secondary"
+                                                                fullWidth={false}
+                                                                disabledReason={
+                                                                    editingLanguage
+                                                                        ? 'Cannot modify choices while translating'
+                                                                        : undefined
+                                                                }
+                                                                onClick={() => {
+                                                                    if (!value) {
+                                                                        handleChoicesChange([''])
+                                                                    } else if (hasOpenChoice) {
+                                                                        const newChoices = value.slice(0, -1)
+                                                                        newChoices.push('')
+                                                                        newChoices.push(value[value.length - 1])
+                                                                        handleChoicesChange(newChoices)
+                                                                    } else {
+                                                                        handleChoicesChange([...value, ''])
+                                                                    }
+                                                                }}
+                                                            >
+                                                                Add choice
+                                                            </LemonButton>
+                                                            {!hasOpenChoice && (
+                                                                <LemonButton
+                                                                    icon={<IconPlusSmall />}
+                                                                    type="secondary"
+                                                                    fullWidth={false}
+                                                                    disabledReason={
+                                                                        editingLanguage
+                                                                            ? 'Cannot modify choices while translating'
+                                                                            : undefined
+                                                                    }
+                                                                    onClick={() => {
+                                                                        if (!value) {
+                                                                            handleChoicesChange(['Other'])
+                                                                        } else {
+                                                                            handleChoicesChange([...value, 'Other'])
+                                                                        }
+                                                                        toggleHasOpenChoice(true)
+                                                                    }}
+                                                                >
+                                                                    Add open-ended choice
+                                                                </LemonButton>
+                                                            )}
+                                                            <LemonField name="shuffleOptions" className="mt-2">
+                                                                {({
+                                                                    value: shuffleOptions,
+                                                                    onChange: toggleShuffleOptions,
+                                                                }) => (
+                                                                    <LemonCheckbox
+                                                                        checked={!!shuffleOptions}
+                                                                        label="Shuffle options"
+                                                                        disabled={!!editingLanguage}
+                                                                        disabledReason={
+                                                                            editingLanguage
+                                                                                ? 'Shuffle options can only be changed in the default language'
+                                                                                : undefined
+                                                                        }
+                                                                        onChange={(checked) =>
+                                                                            toggleShuffleOptions(checked)
+                                                                        }
+                                                                    />
+                                                                )}
+                                                            </LemonField>
+                                                        </>
+                                                    )}
+                                                </div>
+                                            </div>
+                                        )
+                                    }}
+                                </LemonField>
+                            )}
+                        </LemonField>
+                    </div>
+                )}
+                <LemonField
+                    name="buttonText"
+                    label="Submit button text"
+                    className="flex-1 flex gap-1 justify-center"
+                    info={
+                        canSkipSubmitButton
+                            ? "When the 'Automatically submit on selection' option is enabled, users won't need to click a submit button - their response will be submitted immediately after selecting an option. The submit button will be hidden. Requires at least version 1.244.0 of posthog-js. Not available for the mobile SDKs at the moment."
+                            : undefined
+                    }
+                >
+                    <>
+                        {(!canSkipSubmitButton || (canSkipSubmitButton && !question.skipSubmitButton)) && (
+                            <LemonInput
+                                value={
+                                    displayQuestion.buttonText === undefined
+                                        ? (survey.appearance?.submitButtonText ?? 'Submit')
+                                        : displayQuestion.buttonText
+                                }
+                                onChange={(val) => handleQuestionValueChange('buttonText', val)}
+                                placeholder={
+                                    editingLanguage
+                                        ? (question.buttonText ?? survey.appearance?.submitButtonText ?? 'Submit')
+                                        : undefined
+                                }
+                            />
+                        )}
+                        {canSkipSubmitButton && (
+                            <LemonField
+                                name="skipSubmitButton"
+                                info={
+                                    <>
+                                        If enabled, the survey will submit immediately after the user makes a selection
+                                        (for single-choice without open-ended, or rating questions), and the submit
+                                        button will be hidden/text ignored.
+                                    </>
+                                }
+                            >
+                                {({ value: skipSubmitButtonValue, onChange: onSkipSubmitButtonChange }) => (
+                                    <LemonCheckbox
+                                        label="Automatically submit on selection"
+                                        checked={!!skipSubmitButtonValue}
+                                        onChange={onSkipSubmitButtonChange}
+                                        disabled={!!editingLanguage}
+                                        disabledReason={
+                                            editingLanguage
+                                                ? 'Submit settings can only be changed in the default language'
+                                                : undefined
+                                        }
+                                    />
+                                )}
+                            </LemonField>
+                        )}
+                    </>
+                </LemonField>
+                <QuestionBranchingInput questionIndex={index} question={question} />
+            </div>
+        </Group>
+    )
 }

--- a/frontend/src/scenes/surveys/SurveyEditQuestionRow.tsx
+++ b/frontend/src/scenes/surveys/SurveyEditQuestionRow.tsx
@@ -44,7 +44,7 @@ export function SurveyEditQuestionHeader({
     setSelectedPageIndex,
     setSurveyValue,
 }: SurveyQuestionHeaderProps): JSX.Element {
-    const { hasBranchingLogic } = useValues(surveyLogic)
+    const { hasBranchingLogic, editingLanguage } = useValues(surveyLogic)
     const { deleteBranchingLogic } = useActions(surveyLogic)
     const { setNodeRef, attributes, transform, transition, listeners, isDragging } = useSortable({
         id: index.toString(),
@@ -66,7 +66,11 @@ export function SurveyEditQuestionHeader({
                 <SurveyDragHandle listeners={listeners} hasMultipleQuestions={survey.questions.length > 1} />
 
                 <b>
-                    Question {index + 1}. {survey.questions[index].question}
+                    Question {index + 1}.{' '}
+                    {editingLanguage
+                        ? (survey.questions[index].translations?.[editingLanguage]?.question ??
+                          survey.questions[index].question)
+                        : survey.questions[index].question}
                 </b>
             </div>
             {survey.questions.length > 1 && (

--- a/frontend/src/scenes/surveys/SurveyEditQuestionRow.tsx
+++ b/frontend/src/scenes/surveys/SurveyEditQuestionRow.tsx
@@ -260,10 +260,7 @@ export function SurveyEditQuestionGroup({ index, question }: { index: number; qu
                         // Same choice at same position, keep the translation
                         return transChoices[newIndex]
                     }
-                    // This is a new/modified choice, initialize with the default or placeholder
-                    if (newChoice !== '' && newChoice !== undefined) {
-                        return newChoice
-                    }
+                    // New or modified choices must be translated explicitly.
                     return '[Translation needed]'
                 })
                 updatedTranslations[lang] = {

--- a/frontend/src/scenes/surveys/SurveyEditQuestionRow.tsx
+++ b/frontend/src/scenes/surveys/SurveyEditQuestionRow.tsx
@@ -5,7 +5,7 @@ import { CSS } from '@dnd-kit/utilities'
 import { useActions, useValues } from 'kea'
 import { Group } from 'kea-forms'
 
-import { IconPlusSmall, IconTrash } from '@posthog/icons'
+import { IconPlusSmall, IconTrash, IconWarning } from '@posthog/icons'
 import { LemonButton, LemonCheckbox, LemonDialog, LemonInput, LemonSelect, LemonTag, Tooltip } from '@posthog/lemon-ui'
 
 import { LemonField } from 'lib/lemon-ui/LemonField'
@@ -33,6 +33,10 @@ type SurveyQuestionHeaderProps = {
     survey: Survey | NewSurvey
     setSelectedPageIndex: (index: number) => void
     setSurveyValue: (key: string, value: any) => void
+    translationValidationErrors?: Array<{ language: string; questionIndex: number; field: string; error: string }>
+    translationErrorsByQuestion?: (
+        questionIndex: number
+    ) => Array<{ language: string; questionIndex: number; field: string; error: string }>
 }
 
 const MAX_NUMBER_OF_OPTIONS = 15
@@ -42,12 +46,16 @@ export function SurveyEditQuestionHeader({
     survey,
     setSelectedPageIndex,
     setSurveyValue,
+    translationErrorsByQuestion,
 }: SurveyQuestionHeaderProps): JSX.Element {
     const { hasBranchingLogic, editingLanguage } = useValues(surveyLogic)
     const { deleteBranchingLogic } = useActions(surveyLogic)
     const { setNodeRef, attributes, transform, transition, listeners, isDragging } = useSortable({
         id: index.toString(),
     })
+
+    // Get errors for this specific question in current language
+    const questionErrors = translationErrorsByQuestion ? translationErrorsByQuestion(index) : []
 
     return (
         <div
@@ -72,49 +80,58 @@ export function SurveyEditQuestionHeader({
                         : survey.questions[index].question}
                 </b>
             </div>
-            {survey.questions.length > 1 && (
-                <LemonButton
-                    icon={<IconTrash />}
-                    size="xsmall"
-                    data-attr={`delete-survey-question-${index}`}
-                    onClick={(e) => {
-                        const deleteQuestion = (): void => {
-                            e.stopPropagation()
-                            setSelectedPageIndex(index <= 0 ? 0 : index - 1)
-                            setSurveyValue(
-                                'questions',
-                                survey.questions.filter((_, i) => i !== index)
-                            )
-                        }
+            <div className="flex items-center gap-1">
+                {questionErrors.length > 0 && (
+                    <Tooltip
+                        title={`${questionErrors.length} translation validation issue${questionErrors.length > 1 ? 's' : ''}`}
+                    >
+                        <IconWarning className="text-warning" />
+                    </Tooltip>
+                )}
+                {survey.questions.length > 1 && (
+                    <LemonButton
+                        icon={<IconTrash />}
+                        size="xsmall"
+                        data-attr={`delete-survey-question-${index}`}
+                        onClick={(e) => {
+                            const deleteQuestion = (): void => {
+                                e.stopPropagation()
+                                setSelectedPageIndex(index <= 0 ? 0 : index - 1)
+                                setSurveyValue(
+                                    'questions',
+                                    survey.questions.filter((_, i) => i !== index)
+                                )
+                            }
 
-                        if (hasBranchingLogic) {
-                            LemonDialog.open({
-                                title: 'Your survey has active branching logic',
-                                description: (
-                                    <p className="py-2">
-                                        Deleting the question will remove your branching logic. Are you sure you want to
-                                        continue?
-                                    </p>
-                                ),
-                                primaryButton: {
-                                    children: 'Continue',
-                                    status: 'danger',
-                                    onClick: () => {
-                                        deleteBranchingLogic()
-                                        deleteQuestion()
+                            if (hasBranchingLogic) {
+                                LemonDialog.open({
+                                    title: 'Your survey has active branching logic',
+                                    description: (
+                                        <p className="py-2">
+                                            Deleting the question will remove your branching logic. Are you sure you
+                                            want to continue?
+                                        </p>
+                                    ),
+                                    primaryButton: {
+                                        children: 'Continue',
+                                        status: 'danger',
+                                        onClick: () => {
+                                            deleteBranchingLogic()
+                                            deleteQuestion()
+                                        },
                                     },
-                                },
-                                secondaryButton: {
-                                    children: 'Cancel',
-                                },
-                            })
-                        } else {
-                            deleteQuestion()
-                        }
-                    }}
-                    tooltipPlacement="top-end"
-                />
-            )}
+                                    secondaryButton: {
+                                        children: 'Cancel',
+                                    },
+                                })
+                            } else {
+                                deleteQuestion()
+                            }
+                        }}
+                        tooltipPlacement="top-end"
+                    />
+                )}
+            </div>
         </div>
     )
 }
@@ -129,7 +146,7 @@ function canQuestionSkipSubmitButton(
 }
 
 export function SurveyEditQuestionGroup({ index, question }: { index: number; question: SurveyQuestion }): JSX.Element {
-    const { survey, descriptionContentType, editingLanguage } = useValues(surveyLogic)
+    const { survey, descriptionContentType, editingLanguage, translationErrorsForField } = useValues(surveyLogic)
     const { setDefaultForQuestionType, setSurveyValue, resetBranchingForQuestion, setMultipleSurveyQuestion } =
         useActions(surveyLogic)
 
@@ -180,6 +197,28 @@ export function SurveyEditQuestionGroup({ index, question }: { index: number; qu
 
     const getFieldName = (key: string): string =>
         editingLanguage === null ? key : `translations.${editingLanguage}.${key}`
+
+    const getFieldError = (
+        fieldKey: string
+    ): { language: string; questionIndex: number; field: string; error: string } | undefined => {
+        return translationErrorsForField ? translationErrorsForField(index, fieldKey) : undefined
+    }
+
+    const getChoiceError = (
+        choiceIndex: number
+    ): { language: string; questionIndex: number; field: string; error: string } | undefined => {
+        return translationErrorsForField ? translationErrorsForField(index, `choices[${choiceIndex}]`) : undefined
+    }
+
+    const getFieldErrorClass = (fieldKey: string): string => {
+        const fieldError = getFieldError(fieldKey)
+        return fieldError ? 'border border-warning hover:border-primary' : ''
+    }
+
+    const getChoiceErrorClass = (choiceIndex: number): string => {
+        const choiceError = getChoiceError(choiceIndex)
+        return choiceError ? 'border border-warning hover:border-primary' : ''
+    }
 
     const displayQuestion = editingLanguage
         ? {
@@ -375,24 +414,38 @@ export function SurveyEditQuestionGroup({ index, question }: { index: number; qu
                     )}
                 </LemonField>
                 <LemonField name={getFieldName('question')} label="Label">
-                    <LemonInput
-                        data-attr={`survey-question-label-${index}`}
-                        value={displayQuestion.question || ''}
-                        placeholder={editingLanguage ? question.question : undefined}
-                    />
+                    {(() => {
+                        const fieldError = getFieldError('question')
+                        return (
+                            <Tooltip title={fieldError?.error || ''} placement="top">
+                                <LemonInput
+                                    data-attr={`survey-question-label-${index}`}
+                                    value={displayQuestion.question || ''}
+                                    placeholder={editingLanguage ? question.question : undefined}
+                                    onChange={(val) => handleQuestionValueChange('question', val)}
+                                    className={getFieldErrorClass('question')}
+                                />
+                            </Tooltip>
+                        )
+                    })()}
                 </LemonField>
                 <LemonField name={getFieldName('description')} label="Description (optional)">
-                    {({ value, onChange }) => (
-                        <HTMLEditor
-                            value={value}
-                            onChange={(val) => {
-                                onChange(val)
-                                handleQuestionValueChange('description', val)
-                            }}
-                            onTabChange={handleTabChange}
-                            activeTab={initialDescriptionContentType}
-                        />
-                    )}
+                    {(() => {
+                        const fieldError = getFieldError('description')
+                        return (
+                            <Tooltip title={fieldError?.error || ''} placement="top">
+                                <HTMLEditor
+                                    value={displayQuestion.description}
+                                    onChange={(val) => {
+                                        handleQuestionValueChange('description', val)
+                                    }}
+                                    onTabChange={handleTabChange}
+                                    activeTab={initialDescriptionContentType}
+                                    className={getFieldErrorClass('description')}
+                                />
+                            </Tooltip>
+                        )
+                    })()}
                 </LemonField>
                 {survey.questions.length > 1 && (
                     <LemonField name="optional" className="my-2">
@@ -442,12 +495,23 @@ export function SurveyEditQuestionGroup({ index, question }: { index: number; qu
                         label="Link"
                         info="Only https:// or mailto: links are supported."
                     >
-                        <LemonInput
-                            value={displayQuestion.link || ''}
-                            placeholder={
-                                editingLanguage ? question.link || 'https://posthog.com' : 'https://posthog.com'
-                            }
-                        />
+                        {(() => {
+                            const fieldError = getFieldError('link')
+                            return (
+                                <Tooltip title={fieldError?.error || ''} placement="top">
+                                    <LemonInput
+                                        value={displayQuestion.link || ''}
+                                        placeholder={
+                                            editingLanguage
+                                                ? question.link || 'https://posthog.com'
+                                                : 'https://posthog.com'
+                                        }
+                                        onChange={(val) => handleQuestionValueChange('link', val)}
+                                        className={getFieldErrorClass('link')}
+                                    />
+                                </Tooltip>
+                            )
+                        })()}
                     </LemonField>
                 )}
                 {question.type === SurveyQuestionType.Rating && (
@@ -508,20 +572,42 @@ export function SurveyEditQuestionGroup({ index, question }: { index: number; qu
                                     label="Lower bound label"
                                     className="w-1/2"
                                 >
-                                    <LemonInput
-                                        value={displayQuestion.lowerBoundLabel || ''}
-                                        placeholder={editingLanguage ? question.lowerBoundLabel : undefined}
-                                    />
+                                    {(() => {
+                                        const fieldError = getFieldError('lowerBoundLabel')
+                                        return (
+                                            <Tooltip title={fieldError?.error || ''} placement="top">
+                                                <LemonInput
+                                                    value={displayQuestion.lowerBoundLabel || ''}
+                                                    placeholder={editingLanguage ? question.lowerBoundLabel : undefined}
+                                                    onChange={(val) =>
+                                                        handleQuestionValueChange('lowerBoundLabel', val)
+                                                    }
+                                                    className={getFieldErrorClass('lowerBoundLabel')}
+                                                />
+                                            </Tooltip>
+                                        )
+                                    })()}
                                 </LemonField>
                                 <LemonField
                                     name={getFieldName('upperBoundLabel')}
                                     label="Upper bound label"
                                     className="w-1/2"
                                 >
-                                    <LemonInput
-                                        value={displayQuestion.upperBoundLabel || ''}
-                                        placeholder={editingLanguage ? question.upperBoundLabel : undefined}
-                                    />
+                                    {(() => {
+                                        const fieldError = getFieldError('upperBoundLabel')
+                                        return (
+                                            <Tooltip title={fieldError?.error || ''} placement="top">
+                                                <LemonInput
+                                                    value={displayQuestion.upperBoundLabel || ''}
+                                                    placeholder={editingLanguage ? question.upperBoundLabel : undefined}
+                                                    onChange={(val) =>
+                                                        handleQuestionValueChange('upperBoundLabel', val)
+                                                    }
+                                                    className={getFieldErrorClass('upperBoundLabel')}
+                                                />
+                                            </Tooltip>
+                                        )
+                                    })()}
                                 </LemonField>
                             </div>
                         )}
@@ -564,25 +650,33 @@ export function SurveyEditQuestionGroup({ index, question }: { index: number; qu
                                                 {(value || []).map((choice: string, index: number) => {
                                                     const isOpenChoice = hasOpenChoice && index === value?.length - 1
                                                     const originalChoices = (question.choices || []) as string[]
+                                                    const choiceError = getChoiceError(index)
                                                     return (
                                                         <div className="flex flex-row gap-2 relative" key={index}>
-                                                            <LemonInput
-                                                                value={choice}
-                                                                fullWidth
-                                                                onChange={(val) => {
-                                                                    const newChoices = [...value]
-                                                                    newChoices[index] = val
-                                                                    handleChoicesChange(newChoices)
-                                                                }}
-                                                                placeholder={
-                                                                    editingLanguage ? originalChoices[index] : undefined
-                                                                }
-                                                                suffix={
-                                                                    isOpenChoice && (
-                                                                        <LemonTag type="highlight">open-ended</LemonTag>
-                                                                    )
-                                                                }
-                                                            />
+                                                            <Tooltip title={choiceError?.error || ''} placement="top">
+                                                                <LemonInput
+                                                                    value={choice}
+                                                                    fullWidth
+                                                                    onChange={(val) => {
+                                                                        const newChoices = [...value]
+                                                                        newChoices[index] = val
+                                                                        handleChoicesChange(newChoices)
+                                                                    }}
+                                                                    placeholder={
+                                                                        editingLanguage
+                                                                            ? originalChoices[index]
+                                                                            : undefined
+                                                                    }
+                                                                    className={getChoiceErrorClass(index)}
+                                                                    suffix={
+                                                                        isOpenChoice && (
+                                                                            <LemonTag type="highlight">
+                                                                                open-ended
+                                                                            </LemonTag>
+                                                                        )
+                                                                    }
+                                                                />
+                                                            </Tooltip>
                                                             <Tooltip
                                                                 title={
                                                                     editingLanguage
@@ -703,21 +797,30 @@ export function SurveyEditQuestionGroup({ index, question }: { index: number; qu
                     }
                 >
                     <>
-                        {(!canSkipSubmitButton || (canSkipSubmitButton && !question.skipSubmitButton)) && (
-                            <LemonInput
-                                value={
-                                    displayQuestion.buttonText === undefined
-                                        ? (survey.appearance?.submitButtonText ?? 'Submit')
-                                        : displayQuestion.buttonText
-                                }
-                                onChange={(val) => handleQuestionValueChange('buttonText', val)}
-                                placeholder={
-                                    editingLanguage
-                                        ? (question.buttonText ?? survey.appearance?.submitButtonText ?? 'Submit')
-                                        : undefined
-                                }
-                            />
-                        )}
+                        {(!canSkipSubmitButton || (canSkipSubmitButton && !question.skipSubmitButton)) &&
+                            (() => {
+                                const fieldError = getFieldError('buttonText')
+                                return (
+                                    <Tooltip title={fieldError?.error || ''} placement="top">
+                                        <LemonInput
+                                            value={
+                                                displayQuestion.buttonText === undefined
+                                                    ? (survey.appearance?.submitButtonText ?? 'Submit')
+                                                    : displayQuestion.buttonText
+                                            }
+                                            onChange={(val) => handleQuestionValueChange('buttonText', val)}
+                                            placeholder={
+                                                editingLanguage
+                                                    ? (question.buttonText ??
+                                                      survey.appearance?.submitButtonText ??
+                                                      'Submit')
+                                                    : undefined
+                                            }
+                                            className={getFieldErrorClass('buttonText')}
+                                        />
+                                    </Tooltip>
+                                )
+                            })()}
                         {canSkipSubmitButton && (
                             <LemonField
                                 name="skipSubmitButton"

--- a/frontend/src/scenes/surveys/SurveyTranslations.tsx
+++ b/frontend/src/scenes/surveys/SurveyTranslations.tsx
@@ -51,25 +51,30 @@ export function SurveyTranslations(): JSX.Element {
             return
         }
 
-        // Initialize translation with empty choices arrays for multiple choice questions
-        const initialTranslation: Record<string, any> = {}
-        survey.questions?.forEach((question, index) => {
+        // Initialize each question's translation with choices arrays for multiple choice questions
+        const updatedQuestions = survey.questions.map((question) => {
             if (
                 question.type === SurveyQuestionType.SingleChoice ||
                 question.type === SurveyQuestionType.MultipleChoice
             ) {
-                if (!initialTranslation.questions) {
-                    initialTranslation.questions = []
-                }
-                initialTranslation.questions[index] = {
-                    choices: question.choices || [],
+                return {
+                    ...question,
+                    translations: {
+                        ...question.translations,
+                        [lang]: {
+                            ...question.translations?.[lang],
+                            choices: question.choices || [],
+                        },
+                    },
                 }
             }
+            return question
         })
 
+        setSurveyValue('questions', updatedQuestions)
         setSurveyValue('translations', {
             ...currentTranslations,
-            [lang]: initialTranslation,
+            [lang]: {},
         })
         setEditingLanguage(lang)
     }

--- a/frontend/src/scenes/surveys/SurveyTranslations.tsx
+++ b/frontend/src/scenes/surveys/SurveyTranslations.tsx
@@ -1,0 +1,136 @@
+import { useActions, useValues } from 'kea'
+
+import { IconTrash } from '@posthog/icons'
+import { LemonButton, LemonInputSelect } from '@posthog/lemon-ui'
+
+import { surveyLogic } from './surveyLogic'
+
+const COMMON_LANGUAGES = [
+    { value: 'en', label: 'English (en)' },
+    { value: 'en-US', label: 'English - US (en-US)' },
+    { value: 'en-GB', label: 'English - UK (en-GB)' },
+    { value: 'es', label: 'Spanish (es)' },
+    { value: 'es-ES', label: 'Spanish - Spain (es-ES)' },
+    { value: 'es-MX', label: 'Spanish - Mexico (es-MX)' },
+    { value: 'fr', label: 'French (fr)' },
+    { value: 'fr-FR', label: 'French - France (fr-FR)' },
+    { value: 'fr-CA', label: 'French - Canada (fr-CA)' },
+    { value: 'de', label: 'German (de)' },
+    { value: 'de-DE', label: 'German - Germany (de-DE)' },
+    { value: 'pt', label: 'Portuguese (pt)' },
+    { value: 'pt-BR', label: 'Portuguese - Brazil (pt-BR)' },
+    { value: 'pt-PT', label: 'Portuguese - Portugal (pt-PT)' },
+    { value: 'zh', label: 'Chinese (zh)' },
+    { value: 'zh-CN', label: 'Chinese - Simplified (zh-CN)' },
+    { value: 'zh-TW', label: 'Chinese - Traditional (zh-TW)' },
+    { value: 'ja', label: 'Japanese (ja)' },
+    { value: 'ko', label: 'Korean (ko)' },
+    { value: 'ru', label: 'Russian (ru)' },
+    { value: 'ar', label: 'Arabic (ar)' },
+    { value: 'hi', label: 'Hindi (hi)' },
+    { value: 'it', label: 'Italian (it)' },
+    { value: 'nl', label: 'Dutch (nl)' },
+    { value: 'pl', label: 'Polish (pl)' },
+    { value: 'tr', label: 'Turkish (tr)' },
+]
+
+export function SurveyTranslations(): JSX.Element {
+    const { survey, editingLanguage } = useValues(surveyLogic)
+    const { setSurveyValue, setEditingLanguage } = useActions(surveyLogic)
+
+    const addedLanguages = Object.keys(survey.translations || {})
+
+    const addLanguage = (lang: string): void => {
+        if (!lang) {
+            return
+        }
+        const currentTranslations = survey.translations || {}
+        if (currentTranslations[lang]) {
+            return
+        }
+
+        setSurveyValue('translations', {
+            ...currentTranslations,
+            [lang]: {},
+        })
+        setEditingLanguage(lang)
+    }
+
+    const removeLanguage = (lang: string): void => {
+        const currentTranslations = { ...survey.translations }
+        delete currentTranslations[lang]
+        setSurveyValue('translations', currentTranslations)
+        if (editingLanguage === lang) {
+            setEditingLanguage(null)
+        }
+    }
+
+    return (
+        <div className="flex flex-col gap-4">
+            <div className="flex gap-2">
+                <LemonInputSelect
+                    mode="single"
+                    options={COMMON_LANGUAGES.filter((l) => !addedLanguages.includes(l.value)).map((l) => ({
+                        key: l.value,
+                        label: l.label,
+                    }))}
+                    onChange={(values) => {
+                        const lang = values[0]
+                        if (lang) {
+                            addLanguage(lang)
+                        }
+                    }}
+                    placeholder="Add a language (e.g., 'fr', 'French', 'fr-CA')"
+                    className="grow"
+                    allowCustomValues
+                    value={[]}
+                />
+            </div>
+
+            <div className="space-y-2">
+                <div
+                    className={`flex items-center justify-between p-2 border rounded cursor-pointer ${editingLanguage === null ? 'border-primary-500 bg-primary-highlight' : 'border-border'}`}
+                    onClick={() => setEditingLanguage(null)}
+                >
+                    <span className="font-semibold">Default (Original)</span>
+                </div>
+
+                {addedLanguages.map((lang) => (
+                    <div
+                        key={lang}
+                        className={`flex items-center justify-between p-2 border rounded cursor-pointer ${editingLanguage === lang ? 'border-primary-500 bg-primary-highlight' : 'border-border'}`}
+                        onClick={() => setEditingLanguage(lang)}
+                    >
+                        <div className="flex items-center gap-2">
+                            <span>{COMMON_LANGUAGES.find((l) => l.value === lang)?.label || lang}</span>
+                            <span className="text-muted-alt text-xs">({lang})</span>
+                        </div>
+                        <LemonButton
+                            icon={<IconTrash />}
+                            status="danger"
+                            size="small"
+                            onClick={(e) => {
+                                e.stopPropagation()
+                                removeLanguage(lang)
+                            }}
+                        />
+                    </div>
+                ))}
+            </div>
+
+            <div className="mt-4 border-t pt-4">
+                {editingLanguage ? (
+                    <p className="text-muted-alt">
+                        Currently editing:{' '}
+                        <b>{COMMON_LANGUAGES.find((l) => l.value === editingLanguage)?.label || editingLanguage}</b>.
+                        All text fields in the editor will save to this language.
+                    </p>
+                ) : (
+                    <p className="text-muted-alt">
+                        Currently editing: <b>Default</b>. This is the fallback content.
+                    </p>
+                )}
+            </div>
+        </div>
+    )
+}

--- a/frontend/src/scenes/surveys/SurveyTranslations.tsx
+++ b/frontend/src/scenes/surveys/SurveyTranslations.tsx
@@ -118,18 +118,13 @@ export function SurveyTranslations(): JSX.Element {
                 ))}
             </div>
 
-            <div className="mt-4 border-t pt-4">
-                {editingLanguage ? (
-                    <p className="text-muted-alt">
-                        Currently editing:{' '}
-                        <b>{COMMON_LANGUAGES.find((l) => l.value === editingLanguage)?.label || editingLanguage}</b>.
-                        All text fields in the editor will save to this language.
-                    </p>
-                ) : (
-                    <p className="text-muted-alt">
-                        Currently editing: <b>Default</b>. This is the fallback content.
-                    </p>
-                )}
+            <div className="mt-4 border-t pt-4 text-muted-alt text-sm">
+                Editing:{' '}
+                <b>
+                    {editingLanguage
+                        ? COMMON_LANGUAGES.find((l) => l.value === editingLanguage)?.label || editingLanguage
+                        : 'Default'}
+                </b>
             </div>
         </div>
     )

--- a/frontend/src/scenes/surveys/SurveyTranslations.tsx
+++ b/frontend/src/scenes/surveys/SurveyTranslations.tsx
@@ -1,7 +1,7 @@
 import { useActions, useValues } from 'kea'
 
 import { IconTrash } from '@posthog/icons'
-import { LemonButton, LemonInputSelect } from '@posthog/lemon-ui'
+import { LemonButton, LemonDialog, LemonInputSelect } from '@posthog/lemon-ui'
 
 import { SurveyQuestionType } from '~/types'
 
@@ -136,7 +136,26 @@ export function SurveyTranslations(): JSX.Element {
                             size="xsmall"
                             onClick={(e) => {
                                 e.stopPropagation()
-                                removeLanguage(lang)
+                                LemonDialog.open({
+                                    title: 'Delete translation',
+                                    description: (
+                                        <p className="py-2">
+                                            Are you sure you want to delete the translation for{' '}
+                                            <strong>
+                                                {COMMON_LANGUAGES.find((l) => l.value === lang)?.label || lang}
+                                            </strong>
+                                            ? This action cannot be undone.
+                                        </p>
+                                    ),
+                                    primaryButton: {
+                                        children: 'Delete',
+                                        status: 'danger',
+                                        onClick: () => removeLanguage(lang),
+                                    },
+                                    secondaryButton: {
+                                        children: 'Cancel',
+                                    },
+                                })
                             }}
                         />
                     </div>

--- a/frontend/src/scenes/surveys/SurveyTranslations.tsx
+++ b/frontend/src/scenes/surveys/SurveyTranslations.tsx
@@ -74,7 +74,10 @@ export function SurveyTranslations(): JSX.Element {
         setSurveyValue('questions', updatedQuestions)
         setSurveyValue('translations', {
             ...currentTranslations,
-            [lang]: {},
+            [lang]: {
+                name: survey.name || '',
+                description: survey.description || '',
+            },
         })
         setEditingLanguage(lang)
     }
@@ -160,7 +163,7 @@ export function SurveyTranslations(): JSX.Element {
                                             <strong>
                                                 {COMMON_LANGUAGES.find((l) => l.value === lang)?.label || lang}
                                             </strong>
-                                            ? This action cannot be undone.
+                                            ? All translated content for this language will be permanently lost.
                                         </p>
                                     ),
                                     primaryButton: {

--- a/frontend/src/scenes/surveys/SurveyTranslations.tsx
+++ b/frontend/src/scenes/surveys/SurveyTranslations.tsx
@@ -109,7 +109,7 @@ export function SurveyTranslations(): JSX.Element {
             <div className="space-y-2">
                 {addedLanguages.length > 0 && (
                     <div
-                        className={`flex items-center justify-between px-2 py-1 border rounded cursor-pointer ${editingLanguage === null ? 'border-warning bg-warning-highlight' : 'border-border'}`}
+                        className={`flex items-center justify-between px-2 py-1.5 border rounded cursor-pointer ${editingLanguage === null ? 'border-warning bg-warning-highlight' : 'border-border'}`}
                         onClick={() => setEditingLanguage(null)}
                     >
                         <span>Default (Original)</span>

--- a/frontend/src/scenes/surveys/SurveyTranslations.tsx
+++ b/frontend/src/scenes/surveys/SurveyTranslations.tsx
@@ -80,9 +80,25 @@ export function SurveyTranslations(): JSX.Element {
     }
 
     const removeLanguage = (lang: string): void => {
+        // Remove survey-level translations
         const currentTranslations = { ...survey.translations }
         delete currentTranslations[lang]
         setSurveyValue('translations', currentTranslations)
+
+        // Remove question-level translations
+        const updatedQuestions = survey.questions.map((question) => {
+            if (question.translations && question.translations[lang]) {
+                const questionTranslations = { ...question.translations }
+                delete questionTranslations[lang]
+                return {
+                    ...question,
+                    translations: questionTranslations,
+                }
+            }
+            return question
+        })
+        setSurveyValue('questions', updatedQuestions)
+
         if (editingLanguage === lang) {
             setEditingLanguage(null)
         }

--- a/frontend/src/scenes/surveys/SurveyTranslations.tsx
+++ b/frontend/src/scenes/surveys/SurveyTranslations.tsx
@@ -1,4 +1,5 @@
 import { useActions, useValues } from 'kea'
+import type { KeyboardEvent } from 'react'
 
 import { IconTrash } from '@posthog/icons'
 import { LemonButton, LemonDialog, LemonInputSelect } from '@posthog/lemon-ui'
@@ -40,19 +41,32 @@ export function SurveyTranslations(): JSX.Element {
     const { survey, editingLanguage } = useValues(surveyLogic)
     const { setSurveyValue, setEditingLanguage } = useActions(surveyLogic)
 
-    const addedLanguages = Object.keys(survey.translations || {})
+    const surveyTranslations = survey.translations ?? {}
+    const addedLanguages = Object.keys(surveyTranslations)
+    const getLanguageLabel = (lang: string): string => COMMON_LANGUAGES.find((l) => l.value === lang)?.label || lang
+    const selectLanguage = (lang: string | null): void => setEditingLanguage(lang)
+    const onLanguageKeyDown = (event: KeyboardEvent<HTMLDivElement>, lang: string | null): void => {
+        if (event.currentTarget !== event.target) {
+            return
+        }
+        if (event.key === 'Enter' || event.key === ' ') {
+            event.preventDefault()
+            selectLanguage(lang)
+        }
+    }
 
     const addLanguage = (lang: string): void => {
         if (!lang) {
             return
         }
-        const currentTranslations = survey.translations || {}
+        const currentTranslations = surveyTranslations
         if (currentTranslations[lang]) {
             return
         }
 
         // Initialize each question's translation with all translatable fields from defaults
         const updatedQuestions = survey.questions.map((question) => {
+            const questionTranslations = question.translations ?? {}
             const baseTranslation = {
                 question: question.question || '',
                 description: question.description || '',
@@ -72,9 +86,9 @@ export function SurveyTranslations(): JSX.Element {
             return {
                 ...question,
                 translations: {
-                    ...question.translations,
+                    ...questionTranslations,
                     [lang]: {
-                        ...question.translations?.[lang],
+                        ...questionTranslations[lang],
                         ...newTranslation,
                     },
                 },
@@ -96,7 +110,7 @@ export function SurveyTranslations(): JSX.Element {
 
     const removeLanguage = (lang: string): void => {
         // Remove survey-level translations
-        const currentTranslations = { ...survey.translations }
+        const currentTranslations = { ...surveyTranslations }
         delete currentTranslations[lang]
         setSurveyValue('translations', currentTranslations)
 
@@ -145,26 +159,34 @@ export function SurveyTranslations(): JSX.Element {
             <div className="space-y-2">
                 {addedLanguages.length > 0 && (
                     <div
+                        role="button"
+                        tabIndex={0}
                         className={`flex items-center justify-between px-2 py-1.5 border rounded cursor-pointer ${editingLanguage === null ? 'border-warning bg-warning-highlight' : 'border-border'}`}
-                        onClick={() => setEditingLanguage(null)}
+                        onClick={() => selectLanguage(null)}
+                        onKeyDown={(event) => onLanguageKeyDown(event, null)}
                     >
-                        <span>Default (Original)</span>
+                        <span>Default (original)</span>
                     </div>
                 )}
 
                 {addedLanguages.map((lang) => (
                     <div
                         key={lang}
+                        role="button"
+                        tabIndex={0}
                         className={`flex items-center justify-between px-2 py-1 border rounded cursor-pointer ${editingLanguage === lang ? 'border-warning bg-warning-highlight' : 'border-border'}`}
-                        onClick={() => setEditingLanguage(lang)}
+                        onClick={() => selectLanguage(lang)}
+                        onKeyDown={(event) => onLanguageKeyDown(event, lang)}
                     >
                         <div className="flex items-center gap-2">
-                            <span>{COMMON_LANGUAGES.find((l) => l.value === lang)?.label || lang}</span>
+                            <span>{getLanguageLabel(lang)}</span>
                         </div>
                         <LemonButton
                             icon={<IconTrash />}
                             status="danger"
                             size="xsmall"
+                            aria-label={`Delete translation for ${getLanguageLabel(lang)}`}
+                            title={`Delete translation for ${getLanguageLabel(lang)}`}
                             onClick={(e) => {
                                 e.stopPropagation()
                                 LemonDialog.open({
@@ -172,10 +194,8 @@ export function SurveyTranslations(): JSX.Element {
                                     description: (
                                         <p className="py-2">
                                             Are you sure you want to delete the translation for{' '}
-                                            <strong>
-                                                {COMMON_LANGUAGES.find((l) => l.value === lang)?.label || lang}
-                                            </strong>
-                                            ? All translated content for this language will be permanently lost.
+                                            <strong>{getLanguageLabel(lang)}</strong>? All translated content for this
+                                            language will be permanently lost.
                                         </p>
                                     ),
                                     primaryButton: {

--- a/frontend/src/scenes/surveys/SurveyTranslations.tsx
+++ b/frontend/src/scenes/surveys/SurveyTranslations.tsx
@@ -86,7 +86,6 @@ export function SurveyTranslations(): JSX.Element {
             ...currentTranslations,
             [lang]: {
                 name: survey.name || '',
-                description: survey.description || '',
                 thankYouMessageHeader: survey.appearance?.thankYouMessageHeader || '',
                 thankYouMessageDescription: survey.appearance?.thankYouMessageDescription || '',
                 thankYouMessageCloseButtonText: survey.appearance?.thankYouMessageCloseButtonText || '',

--- a/frontend/src/scenes/surveys/SurveyTranslations.tsx
+++ b/frontend/src/scenes/surveys/SurveyTranslations.tsx
@@ -51,24 +51,34 @@ export function SurveyTranslations(): JSX.Element {
             return
         }
 
-        // Initialize each question's translation with choices arrays for multiple choice questions
+        // Initialize each question's translation with all translatable fields from defaults
         const updatedQuestions = survey.questions.map((question) => {
-            if (
-                question.type === SurveyQuestionType.SingleChoice ||
-                question.type === SurveyQuestionType.MultipleChoice
-            ) {
-                return {
-                    ...question,
-                    translations: {
-                        ...question.translations,
-                        [lang]: {
-                            ...question.translations?.[lang],
-                            choices: question.choices || [],
-                        },
-                    },
-                }
+            const baseTranslation = {
+                question: question.question || '',
+                description: question.description || '',
+                buttonText: question.buttonText || '',
+                lowerBoundLabel: question.lowerBoundLabel || '',
+                upperBoundLabel: question.upperBoundLabel || '',
             }
-            return question
+
+            const newTranslation =
+                question.type === SurveyQuestionType.SingleChoice || question.type === SurveyQuestionType.MultipleChoice
+                    ? {
+                          ...baseTranslation,
+                          choices: question.choices || [],
+                      }
+                    : baseTranslation
+
+            return {
+                ...question,
+                translations: {
+                    ...question.translations,
+                    [lang]: {
+                        ...question.translations?.[lang],
+                        ...newTranslation,
+                    },
+                },
+            }
         })
 
         setSurveyValue('questions', updatedQuestions)
@@ -77,6 +87,9 @@ export function SurveyTranslations(): JSX.Element {
             [lang]: {
                 name: survey.name || '',
                 description: survey.description || '',
+                thankYouMessageHeader: survey.appearance?.thankYouMessageHeader || '',
+                thankYouMessageDescription: survey.appearance?.thankYouMessageDescription || '',
+                thankYouMessageCloseButtonText: survey.appearance?.thankYouMessageCloseButtonText || '',
             },
         })
         setEditingLanguage(lang)

--- a/frontend/src/scenes/surveys/SurveyTranslations.tsx
+++ b/frontend/src/scenes/surveys/SurveyTranslations.tsx
@@ -4,7 +4,7 @@ import type { KeyboardEvent } from 'react'
 import { IconTrash } from '@posthog/icons'
 import { LemonButton, LemonDialog, LemonInputSelect } from '@posthog/lemon-ui'
 
-import { SurveyQuestionType } from '~/types'
+import { MultipleSurveyQuestion, SurveyQuestion, SurveyQuestionType } from '~/types'
 
 import { surveyLogic } from './surveyLogic'
 
@@ -36,6 +36,9 @@ export const COMMON_LANGUAGES = [
     { value: 'pl', label: 'Polish (pl)' },
     { value: 'tr', label: 'Turkish (tr)' },
 ]
+
+const isChoiceQuestion = (question: SurveyQuestion): question is MultipleSurveyQuestion =>
+    question.type === SurveyQuestionType.SingleChoice || question.type === SurveyQuestionType.MultipleChoice
 
 export function SurveyTranslations(): JSX.Element {
     const { survey, editingLanguage } = useValues(surveyLogic)
@@ -71,17 +74,19 @@ export function SurveyTranslations(): JSX.Element {
                 question: question.question || '',
                 description: question.description || '',
                 buttonText: question.buttonText || '',
-                lowerBoundLabel: question.lowerBoundLabel || '',
-                upperBoundLabel: question.upperBoundLabel || '',
             }
 
-            const newTranslation =
-                question.type === SurveyQuestionType.SingleChoice || question.type === SurveyQuestionType.MultipleChoice
+            const newTranslation = {
+                ...baseTranslation,
+                ...(question.type === SurveyQuestionType.Rating
                     ? {
-                          ...baseTranslation,
-                          choices: question.choices || [],
+                          lowerBoundLabel: question.lowerBoundLabel || '',
+                          upperBoundLabel: question.upperBoundLabel || '',
                       }
-                    : baseTranslation
+                    : {}),
+                ...(isChoiceQuestion(question) ? { choices: question.choices || [] } : {}),
+                ...(question.type === SurveyQuestionType.Link ? { link: question.link || '' } : {}),
+            }
 
             return {
                 ...question,

--- a/frontend/src/scenes/surveys/components/LinkToSurveyFormSection.tsx
+++ b/frontend/src/scenes/surveys/components/LinkToSurveyFormSection.tsx
@@ -18,6 +18,7 @@ const defaultLabels: Record<SurveyEditSection, string> = {
     [SurveyEditSection.DisplayConditions]: 'display conditions section',
     [SurveyEditSection.Scheduling]: 'scheduling section',
     [SurveyEditSection.CompletionConditions]: 'completion conditions section',
+    [SurveyEditSection.Translations]: 'translations section',
 }
 
 export function LinkToSurveyFormSection({ section, label }: Props): JSX.Element {

--- a/frontend/src/scenes/surveys/components/ValidationRulesEditor.tsx
+++ b/frontend/src/scenes/surveys/components/ValidationRulesEditor.tsx
@@ -5,9 +5,10 @@ import { SurveyValidationRule, SurveyValidationType } from '~/types'
 interface ValidationRulesEditorProps {
     value: SurveyValidationRule[] | undefined
     onChange: (rules: SurveyValidationRule[] | undefined) => void
+    disabled?: boolean
 }
 
-export function ValidationRulesEditor({ value, onChange }: ValidationRulesEditorProps): JSX.Element {
+export function ValidationRulesEditor({ value, onChange, disabled }: ValidationRulesEditorProps): JSX.Element {
     const rules = value || []
 
     const minLengthRule = rules.find((r) => r.type === SurveyValidationType.MinLength)
@@ -15,10 +16,15 @@ export function ValidationRulesEditor({ value, onChange }: ValidationRulesEditor
     const hasLengthLimit = !!minLengthRule || !!maxLengthRule
 
     const updateRules = (newRules: SurveyValidationRule[]): void => {
-        onChange(newRules.length > 0 ? newRules : undefined)
+        if (!disabled) {
+            onChange(newRules.length > 0 ? newRules : undefined)
+        }
     }
 
     const toggleLengthLimit = (enabled: boolean): void => {
+        if (disabled) {
+            return
+        }
         if (enabled) {
             const filtered = rules.filter(
                 (r) => r.type !== SurveyValidationType.MinLength && r.type !== SurveyValidationType.MaxLength
@@ -34,6 +40,9 @@ export function ValidationRulesEditor({ value, onChange }: ValidationRulesEditor
     }
 
     const setMinLength = (val: number | undefined): void => {
+        if (disabled) {
+            return
+        }
         const filtered = rules.filter((r) => r.type !== SurveyValidationType.MinLength)
         if (val !== undefined && val > 0) {
             updateRules([...filtered, { type: SurveyValidationType.MinLength, value: val }])
@@ -43,6 +52,9 @@ export function ValidationRulesEditor({ value, onChange }: ValidationRulesEditor
     }
 
     const setMaxLength = (val: number | undefined): void => {
+        if (disabled) {
+            return
+        }
         const filtered = rules.filter((r) => r.type !== SurveyValidationType.MaxLength)
         if (val !== undefined && val > 0) {
             updateRules([...filtered, { type: SurveyValidationType.MaxLength, value: val }])
@@ -53,7 +65,12 @@ export function ValidationRulesEditor({ value, onChange }: ValidationRulesEditor
 
     return (
         <div className="flex flex-row items-center gap-2">
-            <LemonCheckbox label="Validate message length" checked={hasLengthLimit} onChange={toggleLengthLimit} />
+            <LemonCheckbox
+                label="Validate message length"
+                checked={hasLengthLimit}
+                onChange={toggleLengthLimit}
+                disabled={disabled}
+            />
             <LemonInput
                 type="number"
                 min={1}
@@ -62,6 +79,7 @@ export function ValidationRulesEditor({ value, onChange }: ValidationRulesEditor
                 value={minLengthRule?.value}
                 onChange={setMinLength}
                 className="w-16"
+                disabled={disabled}
             />
             <span className="text-secondary">to</span>
             <LemonInput
@@ -71,6 +89,7 @@ export function ValidationRulesEditor({ value, onChange }: ValidationRulesEditor
                 value={maxLengthRule?.value}
                 onChange={setMaxLength}
                 className="w-16"
+                disabled={disabled}
             />
         </div>
     )

--- a/frontend/src/scenes/surveys/components/question-branching/QuestionBranchingInput.tsx
+++ b/frontend/src/scenes/surveys/components/question-branching/QuestionBranchingInput.tsx
@@ -45,7 +45,7 @@ export function QuestionBranchingInput({
     questionIndex: number
     question: SurveyQuestion
 }): JSX.Element {
-    const { survey, getBranchingDropdownValue } = useValues(surveyLogic)
+    const { survey, getBranchingDropdownValue, editingLanguage } = useValues(surveyLogic)
     const { setQuestionBranchingType, setSurveyValue } = useActions(surveyLogic)
 
     const availableQuestions = getAvailableQuestionOptions(survey.questions, questionIndex)
@@ -126,6 +126,10 @@ export function QuestionBranchingInput({
                     data-attr={`survey-question-${questionIndex}-branching-select`}
                     onSelect={handleBranchingSelection}
                     options={dropdownOptions}
+                    disabled={!!editingLanguage}
+                    disabledReason={
+                        editingLanguage ? 'Question branching can only be edited in the default language' : undefined
+                    }
                 />
             </LemonField>
             {/* Show response-based branching UI when that option is selected */}

--- a/frontend/src/scenes/surveys/constants.tsx
+++ b/frontend/src/scenes/surveys/constants.tsx
@@ -88,6 +88,7 @@ export const defaultSurveyAppearance = {
     borderRadius: '10px',
     shuffleQuestions: false,
     surveyPopupDelaySeconds: undefined,
+    autoDetectLanguage: true,
 } as const satisfies SurveyAppearance
 
 export const defaultSurveyFieldValues = {

--- a/frontend/src/scenes/surveys/constants.tsx
+++ b/frontend/src/scenes/surveys/constants.tsx
@@ -88,7 +88,6 @@ export const defaultSurveyAppearance = {
     borderRadius: '10px',
     shuffleQuestions: false,
     surveyPopupDelaySeconds: undefined,
-    autoDetectLanguage: true,
 } as const satisfies SurveyAppearance
 
 export const defaultSurveyFieldValues = {

--- a/frontend/src/scenes/surveys/constants.tsx
+++ b/frontend/src/scenes/surveys/constants.tsx
@@ -200,6 +200,7 @@ export interface NewSurvey extends Pick<
     | 'headline_summary'
     | 'headline_response_count'
     | 'form_content'
+    | 'translations'
 > {
     id: 'new'
     linked_flag_id: number | null

--- a/frontend/src/scenes/surveys/surveyLogic.test.ts
+++ b/frontend/src/scenes/surveys/surveyLogic.test.ts
@@ -18,6 +18,7 @@ import {
     AnyPropertyFilter,
     ChoiceQuestionProcessedResponses,
     EventPropertyFilter,
+    LinkSurveyQuestion,
     OpenQuestionProcessedResponses,
     PropertyFilterType,
     PropertyOperator,
@@ -99,6 +100,19 @@ const createPersistedSurvey = (): Survey => ({
     ],
 })
 
+const createSurveyWithLinkQuestion = (questionOverrides: Partial<LinkSurveyQuestion> = {}): Survey => ({
+    ...createPersistedSurvey(),
+    questions: [
+        {
+            type: SurveyQuestionType.Link,
+            question: 'Open the documentation',
+            description: '',
+            link: 'https://posthog.com/docs',
+            ...questionOverrides,
+        },
+    ],
+})
+
 describe('editor sync', () => {
     beforeEach(() => {
         initKeaTests()
@@ -157,6 +171,96 @@ describe('editor sync', () => {
         await expectLogic(logic).toFinishAllListeners()
 
         expect(logic.values.survey.name).toBe('Unsaved tabbed name')
+    })
+})
+
+describe('translation validation', () => {
+    let logic: ReturnType<typeof surveyLogic.build>
+
+    beforeEach(() => {
+        initKeaTests()
+        logic = surveyLogic({ id: 'new' })
+        logic.mount()
+    })
+
+    it('validates placeholders and translated link URLs', async () => {
+        const survey = createSurveyWithLinkQuestion({
+            translations: {
+                fr: { question: 'Ouvrir la documentation', link: 'https:not-valid' },
+                es: { question: 'Abrir la documentacion', link: '' },
+                de: { question: 'Dokumentation offnen', link: 'https://posthog.com/docs' },
+                it: { question: '[Translation needed]' },
+            },
+        })
+
+        await expectLogic(logic, () => {
+            logic.actions.loadSurveySuccess(survey)
+        }).toMatchValues({
+            translationValidationErrors: expect.arrayContaining([
+                {
+                    language: 'fr',
+                    questionIndex: 0,
+                    field: 'link',
+                    error: 'Must start with https:// or mailto:',
+                },
+                {
+                    language: 'es',
+                    questionIndex: 0,
+                    field: 'link',
+                    error: 'Cannot be empty',
+                },
+                {
+                    language: 'it',
+                    questionIndex: 0,
+                    field: 'question',
+                    error: 'Contains placeholder "[Translation needed]"',
+                },
+            ]),
+        })
+
+        expect(
+            logic.values.translationValidationErrors.some((error) => error.language === 'de' && error.field === 'link')
+        ).toBe(false)
+    })
+
+    it('validates default link URLs without requiring translations', async () => {
+        const survey = createSurveyWithLinkQuestion({ link: 'https:not-valid' })
+
+        await expectLogic(logic, () => {
+            logic.actions.loadSurveySuccess(survey)
+        }).toMatchValues({
+            translationValidationErrors: [
+                {
+                    language: 'default',
+                    questionIndex: 0,
+                    field: 'link',
+                    error: 'Must start with https:// or mailto:',
+                },
+            ],
+        })
+    })
+
+    it('does not validate survey root description translations', async () => {
+        const survey = {
+            ...createPersistedSurvey(),
+            description: '',
+            translations: {
+                fr: {
+                    name: 'Enquete',
+                    description: 'Description traduite',
+                },
+            },
+        } as Survey
+
+        await expectLogic(logic, () => {
+            logic.actions.loadSurveySuccess(survey)
+        })
+
+        expect(
+            logic.values.translationValidationErrors.some(
+                (error) => error.questionIndex === -1 && error.field === 'description'
+            )
+        ).toBe(false)
     })
 })
 

--- a/frontend/src/scenes/surveys/surveyLogic.tsx
+++ b/frontend/src/scenes/surveys/surveyLogic.tsx
@@ -1392,6 +1392,18 @@ export const surveyLogic = kea<surveyLogicType>([
                                       delete cleanedTrans.upperBoundLabel
                                   }
 
+                                  // Initialize choices for new single/multiple choice questions
+                                  if (
+                                      (type === SurveyQuestionType.SingleChoice ||
+                                          type === SurveyQuestionType.MultipleChoice) &&
+                                      !cleanedTrans.choices
+                                  ) {
+                                      const defaultChoices =
+                                          (defaultSurveyFieldValues[type].questions[0] as MultipleSurveyQuestion)
+                                              .choices || []
+                                      cleanedTrans.choices = defaultChoices
+                                  }
+
                                   acc[lang] = cleanedTrans
                                   return acc
                               },
@@ -2158,13 +2170,15 @@ export const surveyLogic = kea<surveyLogicType>([
                         ]
                         fieldChecks.forEach(({ key, defaultValue }) => {
                             const value = trans[key]
-                            const defaultIsEmpty =
-                                !defaultValue || typeof defaultValue !== 'string' || defaultValue.trim() === ''
+                            // Only check if default is explicitly empty (not undefined)
+                            const defaultIsExplicitlyEmpty =
+                                defaultValue !== undefined &&
+                                (typeof defaultValue !== 'string' || defaultValue.trim() === '')
                             const translationHasValue =
                                 value !== undefined && typeof value === 'string' && value.trim() !== ''
 
-                            // Track fields with translations but empty defaults
-                            if (defaultIsEmpty && translationHasValue) {
+                            // Track fields with translations but explicitly empty defaults
+                            if (defaultIsExplicitlyEmpty && translationHasValue) {
                                 fieldsWithEmptyDefaults.add(key)
                             }
                         })
@@ -2187,9 +2201,10 @@ export const surveyLogic = kea<surveyLogicType>([
                         },
                     ]
                     fieldChecks.forEach(({ key, defaultValue }) => {
-                        const defaultIsEmpty =
-                            !defaultValue || typeof defaultValue !== 'string' || defaultValue.trim() === ''
-                        if (defaultIsEmpty && fieldsWithEmptyDefaults.has(key)) {
+                        const defaultIsExplicitlyEmpty =
+                            defaultValue !== undefined &&
+                            (typeof defaultValue !== 'string' || defaultValue.trim() === '')
+                        if (defaultIsExplicitlyEmpty && fieldsWithEmptyDefaults.has(key)) {
                             errors.push({
                                 language: 'default',
                                 questionIndex: -1,
@@ -2280,13 +2295,15 @@ export const surveyLogic = kea<surveyLogicType>([
                         ]
                         textFieldChecks.forEach(({ key, defaultValue }) => {
                             const value = trans[key]
-                            const defaultIsEmpty =
-                                !defaultValue || typeof defaultValue !== 'string' || defaultValue.trim() === ''
+                            // Only check if default is explicitly empty (not undefined)
+                            const defaultIsExplicitlyEmpty =
+                                defaultValue !== undefined &&
+                                (typeof defaultValue !== 'string' || defaultValue.trim() === '')
                             const translationHasValue =
                                 value !== undefined && typeof value === 'string' && value.trim() !== ''
 
-                            // Track fields with translations but empty defaults
-                            if (defaultIsEmpty && translationHasValue) {
+                            // Track fields with translations but explicitly empty defaults
+                            if (defaultIsExplicitlyEmpty && translationHasValue) {
                                 fieldsWithEmptyDefaults.add(key)
                             }
                         })
@@ -2302,9 +2319,10 @@ export const surveyLogic = kea<surveyLogicType>([
                             { key: 'upperBoundLabel', defaultValue: question.upperBoundLabel },
                         ]
                         textFieldChecks.forEach(({ key, defaultValue }) => {
-                            const defaultIsEmpty =
-                                !defaultValue || typeof defaultValue !== 'string' || defaultValue.trim() === ''
-                            if (defaultIsEmpty && fieldsWithEmptyDefaults.has(key)) {
+                            const defaultIsExplicitlyEmpty =
+                                defaultValue !== undefined &&
+                                (typeof defaultValue !== 'string' || defaultValue.trim() === '')
+                            if (defaultIsExplicitlyEmpty && fieldsWithEmptyDefaults.has(key)) {
                                 errors.push({
                                     language: 'default',
                                     questionIndex: qIndex,

--- a/frontend/src/scenes/surveys/surveyLogic.tsx
+++ b/frontend/src/scenes/surveys/surveyLogic.tsx
@@ -1292,6 +1292,8 @@ export const surveyLogic = kea<surveyLogicType>([
             null as string | null,
             {
                 setEditingLanguage: (_, { language }) => language,
+                resetSurvey: () => null,
+                loadSurveySuccess: () => null,
             },
         ],
         showArchivedResponses: [
@@ -2136,32 +2138,109 @@ export const surveyLogic = kea<surveyLogicType>([
                     }
                 })
 
+                // First collect fields that have translations but empty defaults
+                const fieldsWithEmptyDefaults = new Set<string>()
+                languages.forEach((lang) => {
+                    const trans = survey.translations?.[lang]
+                    if (trans) {
+                        const fieldChecks = [
+                            { key: 'name', defaultValue: survey.name },
+                            { key: 'description', defaultValue: survey.description },
+                            { key: 'thankYouMessageHeader', defaultValue: survey.appearance?.thankYouMessageHeader },
+                            {
+                                key: 'thankYouMessageDescription',
+                                defaultValue: survey.appearance?.thankYouMessageDescription,
+                            },
+                            {
+                                key: 'thankYouMessageCloseButtonText',
+                                defaultValue: survey.appearance?.thankYouMessageCloseButtonText,
+                            },
+                        ]
+                        fieldChecks.forEach(({ key, defaultValue }) => {
+                            const value = trans[key]
+                            const defaultIsEmpty =
+                                !defaultValue || typeof defaultValue !== 'string' || defaultValue.trim() === ''
+                            const translationHasValue =
+                                value !== undefined && typeof value === 'string' && value.trim() !== ''
+
+                            // Track fields with translations but empty defaults
+                            if (defaultIsEmpty && translationHasValue) {
+                                fieldsWithEmptyDefaults.add(key)
+                            }
+                        })
+                    }
+                })
+
+                // Add errors for empty default fields that have translations
+                if (fieldsWithEmptyDefaults.size > 0) {
+                    const fieldChecks = [
+                        { key: 'name', defaultValue: survey.name },
+                        { key: 'description', defaultValue: survey.description },
+                        { key: 'thankYouMessageHeader', defaultValue: survey.appearance?.thankYouMessageHeader },
+                        {
+                            key: 'thankYouMessageDescription',
+                            defaultValue: survey.appearance?.thankYouMessageDescription,
+                        },
+                        {
+                            key: 'thankYouMessageCloseButtonText',
+                            defaultValue: survey.appearance?.thankYouMessageCloseButtonText,
+                        },
+                    ]
+                    fieldChecks.forEach(({ key, defaultValue }) => {
+                        const defaultIsEmpty =
+                            !defaultValue || typeof defaultValue !== 'string' || defaultValue.trim() === ''
+                        if (defaultIsEmpty && fieldsWithEmptyDefaults.has(key)) {
+                            errors.push({
+                                language: 'default',
+                                questionIndex: -1,
+                                field: key,
+                                error: 'Cannot be empty (has translation)',
+                            })
+                        }
+                    })
+                }
+
                 // Validate survey-level translations
                 languages.forEach((lang) => {
                     const trans = survey.translations?.[lang]
                     if (trans) {
-                        const fields = [
-                            'name',
-                            'description',
-                            'thankYouMessageHeader',
-                            'thankYouMessageDescription',
-                            'thankYouMessageCloseButtonText',
+                        const fieldChecks = [
+                            { key: 'name', defaultValue: survey.name },
+                            { key: 'description', defaultValue: survey.description },
+                            { key: 'thankYouMessageHeader', defaultValue: survey.appearance?.thankYouMessageHeader },
+                            {
+                                key: 'thankYouMessageDescription',
+                                defaultValue: survey.appearance?.thankYouMessageDescription,
+                            },
+                            {
+                                key: 'thankYouMessageCloseButtonText',
+                                defaultValue: survey.appearance?.thankYouMessageCloseButtonText,
+                            },
                         ]
-                        fields.forEach((field) => {
-                            const value = trans[field]
+                        fieldChecks.forEach(({ key, defaultValue }) => {
+                            const value = trans[key]
+                            const defaultHasValue =
+                                defaultValue && typeof defaultValue === 'string' && defaultValue.trim() !== ''
+
                             if (value === '[Translation needed]') {
                                 errors.push({
                                     language: lang,
                                     questionIndex: -1,
-                                    field,
+                                    field: key,
                                     error: 'Contains placeholder "[Translation needed]"',
                                 })
                             }
-                            if (typeof value === 'string' && value.trim() === '') {
+                            // Only validate empty translation strings if default has a value
+                            if (
+                                defaultHasValue &&
+                                value !== undefined &&
+                                typeof value === 'string' &&
+                                value.trim() === ''
+                            ) {
                                 errors.push({
                                     language: lang,
                                     questionIndex: -1,
-                                    field,
+                                    field: key,
                                     error: 'Cannot be empty',
                                 })
                             }
@@ -2171,34 +2250,104 @@ export const surveyLogic = kea<surveyLogicType>([
 
                 // Validate question-level translations
                 survey.questions.forEach((question, qIndex) => {
+                    // Validate default choices for empty strings
+                    if (question.choices && Array.isArray(question.choices)) {
+                        question.choices.forEach((choice, choiceIndex) => {
+                            if (typeof choice === 'string' && choice.trim() === '') {
+                                errors.push({
+                                    language: 'default',
+                                    questionIndex: qIndex,
+                                    field: `choices[${choiceIndex}]`,
+                                    error: 'Cannot be empty',
+                                })
+                            }
+                        })
+                    }
+
                     if (!question.translations) {
                         return
                     }
 
+                    // First collect fields that have translations but empty defaults
+                    const fieldsWithEmptyDefaults = new Set<string>()
+                    Object.values(question.translations).forEach((trans) => {
+                        const textFieldChecks = [
+                            { key: 'question', defaultValue: question.question },
+                            { key: 'description', defaultValue: question.description },
+                            { key: 'buttonText', defaultValue: question.buttonText },
+                            { key: 'lowerBoundLabel', defaultValue: question.lowerBoundLabel },
+                            { key: 'upperBoundLabel', defaultValue: question.upperBoundLabel },
+                        ]
+                        textFieldChecks.forEach(({ key, defaultValue }) => {
+                            const value = trans[key]
+                            const defaultIsEmpty =
+                                !defaultValue || typeof defaultValue !== 'string' || defaultValue.trim() === ''
+                            const translationHasValue =
+                                value !== undefined && typeof value === 'string' && value.trim() !== ''
+
+                            // Track fields with translations but empty defaults
+                            if (defaultIsEmpty && translationHasValue) {
+                                fieldsWithEmptyDefaults.add(key)
+                            }
+                        })
+                    })
+
+                    // Add errors for empty default fields that have translations
+                    if (fieldsWithEmptyDefaults.size > 0) {
+                        const textFieldChecks = [
+                            { key: 'question', defaultValue: question.question },
+                            { key: 'description', defaultValue: question.description },
+                            { key: 'buttonText', defaultValue: question.buttonText },
+                            { key: 'lowerBoundLabel', defaultValue: question.lowerBoundLabel },
+                            { key: 'upperBoundLabel', defaultValue: question.upperBoundLabel },
+                        ]
+                        textFieldChecks.forEach(({ key, defaultValue }) => {
+                            const defaultIsEmpty =
+                                !defaultValue || typeof defaultValue !== 'string' || defaultValue.trim() === ''
+                            if (defaultIsEmpty && fieldsWithEmptyDefaults.has(key)) {
+                                errors.push({
+                                    language: 'default',
+                                    questionIndex: qIndex,
+                                    field: key,
+                                    error: 'Cannot be empty (has translation)',
+                                })
+                            }
+                        })
+                    }
+
                     Object.entries(question.translations).forEach(([lang, trans]) => {
                         // Check text fields
-                        const textFields = [
-                            'question',
-                            'description',
-                            'buttonText',
-                            'lowerBoundLabel',
-                            'upperBoundLabel',
+                        const textFieldChecks = [
+                            { key: 'question', defaultValue: question.question },
+                            { key: 'description', defaultValue: question.description },
+                            { key: 'buttonText', defaultValue: question.buttonText },
+                            { key: 'lowerBoundLabel', defaultValue: question.lowerBoundLabel },
+                            { key: 'upperBoundLabel', defaultValue: question.upperBoundLabel },
                         ]
-                        textFields.forEach((field) => {
-                            const value = trans[field]
+                        textFieldChecks.forEach(({ key, defaultValue }) => {
+                            const value = trans[key]
+                            const defaultHasValue =
+                                defaultValue && typeof defaultValue === 'string' && defaultValue.trim() !== ''
+
                             if (value === '[Translation needed]') {
                                 errors.push({
                                     language: lang,
                                     questionIndex: qIndex,
-                                    field,
+                                    field: key,
                                     error: 'Contains placeholder "[Translation needed]"',
                                 })
                             }
-                            if (typeof value === 'string' && value.trim() === '') {
+                            // Only validate empty translation strings if default has a value
+                            if (
+                                defaultHasValue &&
+                                value !== undefined &&
+                                typeof value === 'string' &&
+                                value.trim() === ''
+                            ) {
                                 errors.push({
                                     language: lang,
                                     questionIndex: qIndex,
-                                    field,
+                                    field: key,
                                     error: 'Cannot be empty',
                                 })
                             }

--- a/frontend/src/scenes/surveys/surveyLogic.tsx
+++ b/frontend/src/scenes/surveys/surveyLogic.tsx
@@ -51,6 +51,7 @@ import {
     FeatureFlagFilters,
     HogFunctionType,
     IntervalType,
+    LinkSurveyQuestion,
     MultipleSurveyQuestion,
     OpenQuestionProcessedResponses,
     OpenQuestionResponseData,
@@ -110,6 +111,20 @@ import {
 export type SurveyBaseStatTuple = [string, number, number, string | null, string | null] // [event_name, total_count, unique_persons, first_seen, last_seen]
 export type SurveyBaseStatsResult = SurveyBaseStatTuple[] | null
 export type DismissedAndSentCountResult = number | null
+export type TranslationValidationError = {
+    language: string
+    questionIndex: number
+    field: string
+    error: string
+}
+
+type SurveyTranslationField = keyof NonNullable<Survey['translations']>[string]
+type QuestionTranslation = NonNullable<SurveyQuestion['translations']>[string]
+type QuestionTextTranslationField = Exclude<keyof QuestionTranslation, 'choices'>
+type TranslationFieldCheck<T extends string> = {
+    key: T
+    defaultValue?: string | null
+}
 
 const SURVEY_QUERY_TAG_BASE = { scene: 'Survey' as const, productKey: 'surveys' as const }
 
@@ -122,6 +137,15 @@ const SURVEY_QUERY_TAGS = {
     aggregateResults: { ...SURVEY_QUERY_TAG_BASE, name: 'survey_results_aggregate' as const },
     openEndedResults: { ...SURVEY_QUERY_TAG_BASE, name: 'survey_results_open_ended' as const },
 }
+
+const isChoiceSurveyQuestion = (question: SurveyQuestion): question is MultipleSurveyQuestion =>
+    question.type === SurveyQuestionType.SingleChoice || question.type === SurveyQuestionType.MultipleChoice
+
+const isLinkSurveyQuestion = (question: SurveyQuestion): question is LinkSurveyQuestion =>
+    question.type === SurveyQuestionType.Link
+
+const isRatingSurveyQuestion = (question: SurveyQuestion): question is RatingSurveyQuestion =>
+    question.type === SurveyQuestionType.Rating
 
 const DEFAULT_OPERATORS: Record<SurveyQuestionType, { label: string; value: PropertyOperator }> = {
     [SurveyQuestionType.Open]: {
@@ -1422,14 +1446,17 @@ export const surveyLogic = kea<surveyLogicType>([
                           )
                         : cleanedTranslations
 
-                    newQuestions[idx] = {
+                    const nextQuestion = {
                         ...q,
                         ...newQuestionDefaults,
                         question,
                         description,
-                        choices: newChoices, // Ensure choices are set for choice-based questions
                         translations: choicesInitializedTranslations,
                     }
+                    newQuestions[idx] =
+                        type === SurveyQuestionType.SingleChoice || type === SurveyQuestionType.MultipleChoice
+                            ? ({ ...nextQuestion, choices: newChoices } as SurveyQuestion)
+                            : (nextQuestion as SurveyQuestion)
                     return {
                         ...state,
                         questions: newQuestions,
@@ -2148,9 +2175,9 @@ export const surveyLogic = kea<surveyLogicType>([
         ],
         translationValidationErrors: [
             (s) => [s.survey],
-            (survey): Array<{ language: string; questionIndex: number; field: string; error: string }> => {
-                const errors: Array<{ language: string; questionIndex: number; field: string; error: string }> = []
-                const surveyLevelFieldChecks = [
+            (survey): TranslationValidationError[] => {
+                const errors: TranslationValidationError[] = []
+                const surveyLevelFieldChecks: TranslationFieldCheck<SurveyTranslationField>[] = [
                     { key: 'name', defaultValue: survey.name },
                     { key: 'thankYouMessageHeader', defaultValue: survey.appearance?.thankYouMessageHeader },
                     {
@@ -2251,7 +2278,7 @@ export const surveyLogic = kea<surveyLogicType>([
                 // Validate question-level translations
                 survey.questions.forEach((question, qIndex) => {
                     // Validate default choices for empty strings
-                    if (question.choices && Array.isArray(question.choices)) {
+                    if (isChoiceSurveyQuestion(question) && question.choices && Array.isArray(question.choices)) {
                         question.choices.forEach((choice, choiceIndex) => {
                             if (typeof choice === 'string' && choice.trim() === '') {
                                 errors.push({
@@ -2268,12 +2295,16 @@ export const surveyLogic = kea<surveyLogicType>([
                         return
                     }
 
-                    const textFieldChecks = [
+                    const textFieldChecks: TranslationFieldCheck<QuestionTextTranslationField>[] = [
                         { key: 'question', defaultValue: question.question },
                         { key: 'description', defaultValue: question.description },
                         { key: 'buttonText', defaultValue: question.buttonText },
-                        { key: 'lowerBoundLabel', defaultValue: question.lowerBoundLabel },
-                        { key: 'upperBoundLabel', defaultValue: question.upperBoundLabel },
+                        ...(isRatingSurveyQuestion(question)
+                            ? [
+                                  { key: 'lowerBoundLabel' as const, defaultValue: question.lowerBoundLabel },
+                                  { key: 'upperBoundLabel' as const, defaultValue: question.upperBoundLabel },
+                              ]
+                            : []),
                     ]
 
                     // First collect fields that have translations but empty defaults
@@ -2344,7 +2375,7 @@ export const surveyLogic = kea<surveyLogicType>([
                         })
 
                         // Check link field
-                        if ('link' in trans) {
+                        if (isLinkSurveyQuestion(question) && 'link' in trans) {
                             const linkDefaultHasValue = typeof question.link === 'string' && question.link.trim() !== ''
                             const linkValue = trans.link
 
@@ -2377,7 +2408,7 @@ export const surveyLogic = kea<surveyLogicType>([
                         }
 
                         // Check choices array
-                        if (trans.choices && Array.isArray(trans.choices)) {
+                        if (isChoiceSurveyQuestion(question) && trans.choices && Array.isArray(trans.choices)) {
                             trans.choices.forEach((choice, choiceIndex) => {
                                 if (choice === '[Translation needed]') {
                                     errors.push({
@@ -2402,7 +2433,7 @@ export const surveyLogic = kea<surveyLogicType>([
 
                 // Also validate default question links
                 survey.questions.forEach((question, qIndex) => {
-                    const link = typeof question.link === 'string' ? question.link.trim() : ''
+                    const link = isLinkSurveyQuestion(question) && question.link ? question.link.trim() : ''
                     if (link && !link.match(/^(https:\/\/|mailto:)/)) {
                         errors.push({
                             language: 'default',
@@ -2423,9 +2454,9 @@ export const surveyLogic = kea<surveyLogicType>([
         translationErrorsByQuestion: [
             (s) => [s.translationValidationErrors, s.editingLanguage],
             (
-                errors: Array<{ language: string; questionIndex: number; field: string; error: string }>,
+                errors: TranslationValidationError[],
                 editingLanguage: string | null
-            ): ((questionIndex: number) => typeof errors) => {
+            ): ((questionIndex: number) => TranslationValidationError[]) => {
                 return (questionIndex: number) => {
                     const targetLanguage = editingLanguage === null ? 'default' : editingLanguage
                     return errors.filter((e) => e.questionIndex === questionIndex && e.language === targetLanguage)
@@ -2435,9 +2466,9 @@ export const surveyLogic = kea<surveyLogicType>([
         translationErrorsForField: [
             (s) => [s.translationValidationErrors, s.editingLanguage],
             (
-                errors: Array<{ language: string; questionIndex: number; field: string; error: string }>,
+                errors: TranslationValidationError[],
                 editingLanguage: string | null
-            ): ((questionIndex: number, fieldPath: string) => (typeof errors)[0] | undefined) => {
+            ): ((questionIndex: number, fieldPath: string) => TranslationValidationError | undefined) => {
                 return (questionIndex: number, fieldPath: string) => {
                     const targetLanguage = editingLanguage === null ? 'default' : editingLanguage
                     return errors.find(

--- a/frontend/src/scenes/surveys/surveyLogic.tsx
+++ b/frontend/src/scenes/surveys/surveyLogic.tsx
@@ -157,6 +157,7 @@ export enum SurveyEditSection {
     DisplayConditions = 'DisplayConditions',
     Scheduling = 'scheduling',
     CompletionConditions = 'CompletionConditions',
+    Translations = 'translations',
 }
 export interface SurveyLogicProps {
     /** Either a UUID or 'new'. */
@@ -502,6 +503,7 @@ export const surveyLogic = kea<surveyLogicType>([
         ],
     })),
     actions({
+        setEditingLanguage: (language: string | null) => ({ language }),
         setSurveyMissing: true,
         editingSurvey: (editing: boolean) => ({ editing }),
         setDefaultForQuestionType: (idx: number, surveyQuestion: SurveyQuestion, type: SurveyQuestionType) => ({
@@ -1284,6 +1286,12 @@ export const surveyLogic = kea<surveyLogicType>([
             {} as Record<string, string>,
             {
                 setPersonNames: (state, { personNames }) => ({ ...state, ...personNames }),
+            },
+        ],
+        editingLanguage: [
+            null as string | null,
+            {
+                setEditingLanguage: (_, { language }) => language,
             },
         ],
         showArchivedResponses: [

--- a/frontend/src/scenes/surveys/surveyLogic.tsx
+++ b/frontend/src/scenes/surveys/surveyLogic.tsx
@@ -1392,18 +1392,6 @@ export const surveyLogic = kea<surveyLogicType>([
                                       delete cleanedTrans.upperBoundLabel
                                   }
 
-                                  // Initialize choices for new single/multiple choice questions
-                                  if (
-                                      (type === SurveyQuestionType.SingleChoice ||
-                                          type === SurveyQuestionType.MultipleChoice) &&
-                                      !cleanedTrans.choices
-                                  ) {
-                                      const defaultChoices =
-                                          (defaultSurveyFieldValues[type].questions[0] as MultipleSurveyQuestion)
-                                              .choices || []
-                                      cleanedTrans.choices = defaultChoices
-                                  }
-
                                   acc[lang] = cleanedTrans
                                   return acc
                               },
@@ -1411,12 +1399,36 @@ export const surveyLogic = kea<surveyLogicType>([
                           )
                         : undefined
 
+                    // Get the new question with default values for the new type
+                    const newQuestionDefaults = defaultSurveyFieldValues[type].questions[0] as SurveyQuestionBase
+                    const newChoices = (newQuestionDefaults as MultipleSurveyQuestion).choices || []
+
+                    // Initialize choices for new single/multiple choice questions in translations
+                    const choicesInitializedTranslations = cleanedTranslations
+                        ? Object.entries(cleanedTranslations).reduce(
+                              (acc, [lang, trans]) => {
+                                  const cleanedTrans = { ...trans }
+                                  if (
+                                      (type === SurveyQuestionType.SingleChoice ||
+                                          type === SurveyQuestionType.MultipleChoice) &&
+                                      !cleanedTrans.choices
+                                  ) {
+                                      cleanedTrans.choices = newChoices
+                                  }
+                                  acc[lang] = cleanedTrans
+                                  return acc
+                              },
+                              {} as Record<string, any>
+                          )
+                        : cleanedTranslations
+
                     newQuestions[idx] = {
                         ...q,
-                        ...(defaultSurveyFieldValues[type].questions[0] as SurveyQuestionBase),
+                        ...newQuestionDefaults,
                         question,
                         description,
-                        translations: cleanedTranslations,
+                        choices: newChoices, // Ensure choices are set for choice-based questions
+                        translations: choicesInitializedTranslations,
                     }
                     return {
                         ...state,

--- a/frontend/src/scenes/surveys/surveyLogic.tsx
+++ b/frontend/src/scenes/surveys/surveyLogic.tsx
@@ -2445,6 +2445,33 @@ export const surveyLogic = kea<surveyLogicType>([
             (s) => [s.translationValidationErrors],
             (errors): boolean => errors.length > 0,
         ],
+        translationErrorsByQuestion: [
+            (s) => [s.translationValidationErrors, s.editingLanguage],
+            (
+                errors: Array<{ language: string; questionIndex: number; field: string; error: string }>,
+                editingLanguage: string | null
+            ): ((questionIndex: number) => typeof errors) => {
+                return (questionIndex: number) => {
+                    const targetLanguage = editingLanguage === null ? 'default' : editingLanguage
+                    return errors.filter((e) => e.questionIndex === questionIndex && e.language === targetLanguage)
+                }
+            },
+        ],
+        translationErrorsForField: [
+            (s) => [s.translationValidationErrors, s.editingLanguage],
+            (
+                errors: Array<{ language: string; questionIndex: number; field: string; error: string }>,
+                editingLanguage: string | null
+            ): ((questionIndex: number, fieldPath: string) => (typeof errors)[0] | undefined) => {
+                return (questionIndex: number, fieldPath: string) => {
+                    const targetLanguage = editingLanguage === null ? 'default' : editingLanguage
+                    return errors.find(
+                        (e) =>
+                            e.questionIndex === questionIndex && e.field === fieldPath && e.language === targetLanguage
+                    )
+                }
+            },
+        ],
         surveyAsInsightURL: [
             (s) => [s.survey],
             (survey) => {

--- a/frontend/src/scenes/surveys/surveyLogic.tsx
+++ b/frontend/src/scenes/surveys/surveyLogic.tsx
@@ -2150,6 +2150,18 @@ export const surveyLogic = kea<surveyLogicType>([
             (s) => [s.survey],
             (survey): Array<{ language: string; questionIndex: number; field: string; error: string }> => {
                 const errors: Array<{ language: string; questionIndex: number; field: string; error: string }> = []
+                const surveyLevelFieldChecks = [
+                    { key: 'name', defaultValue: survey.name },
+                    { key: 'thankYouMessageHeader', defaultValue: survey.appearance?.thankYouMessageHeader },
+                    {
+                        key: 'thankYouMessageDescription',
+                        defaultValue: survey.appearance?.thankYouMessageDescription,
+                    },
+                    {
+                        key: 'thankYouMessageCloseButtonText',
+                        defaultValue: survey.appearance?.thankYouMessageCloseButtonText,
+                    },
+                ]
 
                 // Get all languages
                 const languages = new Set<string>()
@@ -2167,20 +2179,7 @@ export const surveyLogic = kea<surveyLogicType>([
                 languages.forEach((lang) => {
                     const trans = survey.translations?.[lang]
                     if (trans) {
-                        const fieldChecks = [
-                            { key: 'name', defaultValue: survey.name },
-                            { key: 'description', defaultValue: survey.description },
-                            { key: 'thankYouMessageHeader', defaultValue: survey.appearance?.thankYouMessageHeader },
-                            {
-                                key: 'thankYouMessageDescription',
-                                defaultValue: survey.appearance?.thankYouMessageDescription,
-                            },
-                            {
-                                key: 'thankYouMessageCloseButtonText',
-                                defaultValue: survey.appearance?.thankYouMessageCloseButtonText,
-                            },
-                        ]
-                        fieldChecks.forEach(({ key, defaultValue }) => {
+                        surveyLevelFieldChecks.forEach(({ key, defaultValue }) => {
                             const value = trans[key]
                             // Only check if default is explicitly empty (not undefined)
                             const defaultIsExplicitlyEmpty =
@@ -2199,20 +2198,7 @@ export const surveyLogic = kea<surveyLogicType>([
 
                 // Add errors for empty default fields that have translations
                 if (fieldsWithEmptyDefaults.size > 0) {
-                    const fieldChecks = [
-                        { key: 'name', defaultValue: survey.name },
-                        { key: 'description', defaultValue: survey.description },
-                        { key: 'thankYouMessageHeader', defaultValue: survey.appearance?.thankYouMessageHeader },
-                        {
-                            key: 'thankYouMessageDescription',
-                            defaultValue: survey.appearance?.thankYouMessageDescription,
-                        },
-                        {
-                            key: 'thankYouMessageCloseButtonText',
-                            defaultValue: survey.appearance?.thankYouMessageCloseButtonText,
-                        },
-                    ]
-                    fieldChecks.forEach(({ key, defaultValue }) => {
+                    surveyLevelFieldChecks.forEach(({ key, defaultValue }) => {
                         const defaultIsExplicitlyEmpty =
                             defaultValue !== undefined &&
                             (typeof defaultValue !== 'string' || defaultValue.trim() === '')
@@ -2231,20 +2217,7 @@ export const surveyLogic = kea<surveyLogicType>([
                 languages.forEach((lang) => {
                     const trans = survey.translations?.[lang]
                     if (trans) {
-                        const fieldChecks = [
-                            { key: 'name', defaultValue: survey.name },
-                            { key: 'description', defaultValue: survey.description },
-                            { key: 'thankYouMessageHeader', defaultValue: survey.appearance?.thankYouMessageHeader },
-                            {
-                                key: 'thankYouMessageDescription',
-                                defaultValue: survey.appearance?.thankYouMessageDescription,
-                            },
-                            {
-                                key: 'thankYouMessageCloseButtonText',
-                                defaultValue: survey.appearance?.thankYouMessageCloseButtonText,
-                            },
-                        ]
-                        fieldChecks.forEach(({ key, defaultValue }) => {
+                        surveyLevelFieldChecks.forEach(({ key, defaultValue }) => {
                             const value = trans[key]
                             const defaultHasValue =
                                 defaultValue && typeof defaultValue === 'string' && defaultValue.trim() !== ''
@@ -2295,16 +2268,17 @@ export const surveyLogic = kea<surveyLogicType>([
                         return
                     }
 
+                    const textFieldChecks = [
+                        { key: 'question', defaultValue: question.question },
+                        { key: 'description', defaultValue: question.description },
+                        { key: 'buttonText', defaultValue: question.buttonText },
+                        { key: 'lowerBoundLabel', defaultValue: question.lowerBoundLabel },
+                        { key: 'upperBoundLabel', defaultValue: question.upperBoundLabel },
+                    ]
+
                     // First collect fields that have translations but empty defaults
                     const fieldsWithEmptyDefaults = new Set<string>()
                     Object.values(question.translations).forEach((trans) => {
-                        const textFieldChecks = [
-                            { key: 'question', defaultValue: question.question },
-                            { key: 'description', defaultValue: question.description },
-                            { key: 'buttonText', defaultValue: question.buttonText },
-                            { key: 'lowerBoundLabel', defaultValue: question.lowerBoundLabel },
-                            { key: 'upperBoundLabel', defaultValue: question.upperBoundLabel },
-                        ]
                         textFieldChecks.forEach(({ key, defaultValue }) => {
                             const value = trans[key]
                             // Only check if default is explicitly empty (not undefined)
@@ -2323,13 +2297,6 @@ export const surveyLogic = kea<surveyLogicType>([
 
                     // Add errors for empty default fields that have translations
                     if (fieldsWithEmptyDefaults.size > 0) {
-                        const textFieldChecks = [
-                            { key: 'question', defaultValue: question.question },
-                            { key: 'description', defaultValue: question.description },
-                            { key: 'buttonText', defaultValue: question.buttonText },
-                            { key: 'lowerBoundLabel', defaultValue: question.lowerBoundLabel },
-                            { key: 'upperBoundLabel', defaultValue: question.upperBoundLabel },
-                        ]
                         textFieldChecks.forEach(({ key, defaultValue }) => {
                             const defaultIsExplicitlyEmpty =
                                 defaultValue !== undefined &&
@@ -2347,13 +2314,6 @@ export const surveyLogic = kea<surveyLogicType>([
 
                     Object.entries(question.translations).forEach(([lang, trans]) => {
                         // Check text fields
-                        const textFieldChecks = [
-                            { key: 'question', defaultValue: question.question },
-                            { key: 'description', defaultValue: question.description },
-                            { key: 'buttonText', defaultValue: question.buttonText },
-                            { key: 'lowerBoundLabel', defaultValue: question.lowerBoundLabel },
-                            { key: 'upperBoundLabel', defaultValue: question.upperBoundLabel },
-                        ]
                         textFieldChecks.forEach(({ key, defaultValue }) => {
                             const value = trans[key]
                             const defaultHasValue =
@@ -2392,7 +2352,7 @@ export const surveyLogic = kea<surveyLogicType>([
                                     field: 'link',
                                     error: 'Contains placeholder "[Translation needed]"',
                                 })
-                            } else if (!trans.link.match(/^(https:|mailto:)/)) {
+                            } else if (!trans.link.match(/^(https:\/\/|mailto:)/)) {
                                 errors.push({
                                     language: lang,
                                     questionIndex: qIndex,
@@ -2428,7 +2388,7 @@ export const surveyLogic = kea<surveyLogicType>([
 
                 // Also validate default question links
                 survey.questions.forEach((question, qIndex) => {
-                    if (question.link && !question.link.match(/^(https:|mailto:)/)) {
+                    if (question.link && !question.link.match(/^(https:\/\/|mailto:)/)) {
                         errors.push({
                             language: 'default',
                             questionIndex: qIndex,

--- a/frontend/src/scenes/surveys/surveyLogic.tsx
+++ b/frontend/src/scenes/surveys/surveyLogic.tsx
@@ -2344,21 +2344,35 @@ export const surveyLogic = kea<surveyLogicType>([
                         })
 
                         // Check link field
-                        if (trans.link) {
-                            if (trans.link === '[Translation needed]') {
+                        if ('link' in trans) {
+                            const linkDefaultHasValue = typeof question.link === 'string' && question.link.trim() !== ''
+                            const linkValue = trans.link
+
+                            if (linkValue === '[Translation needed]') {
                                 errors.push({
                                     language: lang,
                                     questionIndex: qIndex,
                                     field: 'link',
                                     error: 'Contains placeholder "[Translation needed]"',
                                 })
-                            } else if (!trans.link.match(/^(https:\/\/|mailto:)/)) {
-                                errors.push({
-                                    language: lang,
-                                    questionIndex: qIndex,
-                                    field: 'link',
-                                    error: 'Must start with https:// or mailto:',
-                                })
+                            } else if (typeof linkValue === 'string') {
+                                const trimmedLink = linkValue.trim()
+
+                                if (linkDefaultHasValue && trimmedLink === '') {
+                                    errors.push({
+                                        language: lang,
+                                        questionIndex: qIndex,
+                                        field: 'link',
+                                        error: 'Cannot be empty',
+                                    })
+                                } else if (trimmedLink !== '' && !trimmedLink.match(/^(https:\/\/|mailto:)/)) {
+                                    errors.push({
+                                        language: lang,
+                                        questionIndex: qIndex,
+                                        field: 'link',
+                                        error: 'Must start with https:// or mailto:',
+                                    })
+                                }
                             }
                         }
 
@@ -2388,7 +2402,8 @@ export const surveyLogic = kea<surveyLogicType>([
 
                 // Also validate default question links
                 survey.questions.forEach((question, qIndex) => {
-                    if (question.link && !question.link.match(/^(https:\/\/|mailto:)/)) {
+                    const link = typeof question.link === 'string' ? question.link.trim() : ''
+                    if (link && !link.match(/^(https:\/\/|mailto:)/)) {
                         errors.push({
                             language: 'default',
                             questionIndex: qIndex,

--- a/frontend/src/scenes/surveys/surveyLogic.tsx
+++ b/frontend/src/scenes/surveys/surveyLogic.tsx
@@ -1368,11 +1368,41 @@ export const surveyLogic = kea<surveyLogicType>([
                     if (q.type === SurveyQuestionType.MultipleChoice || q.type === SurveyQuestionType.SingleChoice) {
                         delete q.hasOpenChoice
                     }
+
+                    // Clean up translations when question type changes
+                    const cleanedTranslations = q.translations
+                        ? Object.entries(q.translations).reduce(
+                              (acc, [lang, trans]) => {
+                                  const cleanedTrans = { ...trans }
+
+                                  // Remove fields that don't apply to the new type
+                                  if (
+                                      type !== SurveyQuestionType.SingleChoice &&
+                                      type !== SurveyQuestionType.MultipleChoice
+                                  ) {
+                                      delete cleanedTrans.choices
+                                  }
+                                  if (type !== SurveyQuestionType.Link) {
+                                      delete cleanedTrans.link
+                                  }
+                                  if (type !== SurveyQuestionType.Rating) {
+                                      delete cleanedTrans.lowerBoundLabel
+                                      delete cleanedTrans.upperBoundLabel
+                                  }
+
+                                  acc[lang] = cleanedTrans
+                                  return acc
+                              },
+                              {} as Record<string, any>
+                          )
+                        : undefined
+
                     newQuestions[idx] = {
                         ...q,
                         ...(defaultSurveyFieldValues[type].questions[0] as SurveyQuestionBase),
                         question,
                         description,
+                        translations: cleanedTranslations,
                     }
                     return {
                         ...state,

--- a/frontend/src/scenes/surveys/surveyLogic.tsx
+++ b/frontend/src/scenes/surveys/surveyLogic.tsx
@@ -2120,6 +2120,33 @@ export const surveyLogic = kea<surveyLogicType>([
             (survey) =>
                 survey.questions.some((question) => question.branching && Object.keys(question.branching).length > 0),
         ],
+        choicesMismatchedLanguages: [
+            (s) => [s.survey],
+            (survey): string[] => {
+                const mismatchedLanguages = new Set<string>()
+
+                survey.questions.forEach((question) => {
+                    const originalChoices = question.choices || []
+                    if (
+                        question.translations &&
+                        (question.type === SurveyQuestionType.SingleChoice ||
+                            question.type === SurveyQuestionType.MultipleChoice)
+                    ) {
+                        Object.entries(question.translations).forEach(([lang, trans]) => {
+                            if (trans.choices && trans.choices.length !== originalChoices.length) {
+                                mismatchedLanguages.add(lang)
+                            }
+                        })
+                    }
+                })
+
+                return Array.from(mismatchedLanguages)
+            },
+        ],
+        hasChoicesMismatch: [
+            (s) => [s.choicesMismatchedLanguages],
+            (mismatchedLanguages): boolean => mismatchedLanguages.length > 0,
+        ],
         surveyAsInsightURL: [
             (s) => [s.survey],
             (survey) => {

--- a/frontend/src/scenes/surveys/surveyLogic.tsx
+++ b/frontend/src/scenes/surveys/surveyLogic.tsx
@@ -2120,32 +2120,151 @@ export const surveyLogic = kea<surveyLogicType>([
             (survey) =>
                 survey.questions.some((question) => question.branching && Object.keys(question.branching).length > 0),
         ],
-        choicesMismatchedLanguages: [
+        translationValidationErrors: [
             (s) => [s.survey],
-            (survey): string[] => {
-                const mismatchedLanguages = new Set<string>()
+            (survey): Array<{ language: string; questionIndex: number; field: string; error: string }> => {
+                const errors: Array<{ language: string; questionIndex: number; field: string; error: string }> = []
 
-                survey.questions.forEach((question) => {
-                    const originalChoices = question.choices || []
-                    if (
-                        question.translations &&
-                        (question.type === SurveyQuestionType.SingleChoice ||
-                            question.type === SurveyQuestionType.MultipleChoice)
-                    ) {
-                        Object.entries(question.translations).forEach(([lang, trans]) => {
-                            if (trans.choices && trans.choices.length !== originalChoices.length) {
-                                mismatchedLanguages.add(lang)
+                // Get all languages
+                const languages = new Set<string>()
+                if (survey.translations) {
+                    Object.keys(survey.translations).forEach((lang) => languages.add(lang))
+                }
+                survey.questions.forEach((q) => {
+                    if (q.translations) {
+                        Object.keys(q.translations).forEach((lang) => languages.add(lang))
+                    }
+                })
+
+                // Validate survey-level translations
+                languages.forEach((lang) => {
+                    const trans = survey.translations?.[lang]
+                    if (trans) {
+                        const fields = [
+                            'name',
+                            'description',
+                            'thankYouMessageHeader',
+                            'thankYouMessageDescription',
+                            'thankYouMessageCloseButtonText',
+                        ]
+                        fields.forEach((field) => {
+                            const value = trans[field]
+                            if (value === '[Translation needed]') {
+                                errors.push({
+                                    language: lang,
+                                    questionIndex: -1,
+                                    field,
+                                    error: 'Contains placeholder "[Translation needed]"',
+                                })
+                            }
+                            if (typeof value === 'string' && value.trim() === '') {
+                                errors.push({
+                                    language: lang,
+                                    questionIndex: -1,
+                                    field,
+                                    error: 'Cannot be empty',
+                                })
                             }
                         })
                     }
                 })
 
-                return Array.from(mismatchedLanguages)
+                // Validate question-level translations
+                survey.questions.forEach((question, qIndex) => {
+                    if (!question.translations) {
+                        return
+                    }
+
+                    Object.entries(question.translations).forEach(([lang, trans]) => {
+                        // Check text fields
+                        const textFields = [
+                            'question',
+                            'description',
+                            'buttonText',
+                            'lowerBoundLabel',
+                            'upperBoundLabel',
+                        ]
+                        textFields.forEach((field) => {
+                            const value = trans[field]
+                            if (value === '[Translation needed]') {
+                                errors.push({
+                                    language: lang,
+                                    questionIndex: qIndex,
+                                    field,
+                                    error: 'Contains placeholder "[Translation needed]"',
+                                })
+                            }
+                            if (typeof value === 'string' && value.trim() === '') {
+                                errors.push({
+                                    language: lang,
+                                    questionIndex: qIndex,
+                                    field,
+                                    error: 'Cannot be empty',
+                                })
+                            }
+                        })
+
+                        // Check link field
+                        if (trans.link) {
+                            if (trans.link === '[Translation needed]') {
+                                errors.push({
+                                    language: lang,
+                                    questionIndex: qIndex,
+                                    field: 'link',
+                                    error: 'Contains placeholder "[Translation needed]"',
+                                })
+                            } else if (!trans.link.match(/^(https:|mailto:)/)) {
+                                errors.push({
+                                    language: lang,
+                                    questionIndex: qIndex,
+                                    field: 'link',
+                                    error: 'Must start with https:// or mailto:',
+                                })
+                            }
+                        }
+
+                        // Check choices array
+                        if (trans.choices && Array.isArray(trans.choices)) {
+                            trans.choices.forEach((choice, choiceIndex) => {
+                                if (choice === '[Translation needed]') {
+                                    errors.push({
+                                        language: lang,
+                                        questionIndex: qIndex,
+                                        field: `choices[${choiceIndex}]`,
+                                        error: 'Contains placeholder "[Translation needed]"',
+                                    })
+                                }
+                                if (typeof choice === 'string' && choice.trim() === '') {
+                                    errors.push({
+                                        language: lang,
+                                        questionIndex: qIndex,
+                                        field: `choices[${choiceIndex}]`,
+                                        error: 'Cannot be empty',
+                                    })
+                                }
+                            })
+                        }
+                    })
+                })
+
+                // Also validate default question links
+                survey.questions.forEach((question, qIndex) => {
+                    if (question.link && !question.link.match(/^(https:|mailto:)/)) {
+                        errors.push({
+                            language: 'default',
+                            questionIndex: qIndex,
+                            field: 'link',
+                            error: 'Must start with https:// or mailto:',
+                        })
+                    }
+                })
+
+                return errors
             },
         ],
-        hasChoicesMismatch: [
-            (s) => [s.choicesMismatchedLanguages],
-            (mismatchedLanguages): boolean => mismatchedLanguages.length > 0,
+        hasTranslationValidationErrors: [
+            (s) => [s.translationValidationErrors],
+            (errors): boolean => errors.length > 0,
         ],
         surveyAsInsightURL: [
             (s) => [s.survey],

--- a/frontend/src/scenes/surveys/surveyTranslationUtils.test.ts
+++ b/frontend/src/scenes/surveys/surveyTranslationUtils.test.ts
@@ -1,0 +1,103 @@
+import {
+    AccessControlLevel,
+    MultipleSurveyQuestion,
+    RatingSurveyQuestion,
+    Survey,
+    SurveyPosition,
+    SurveyQuestionType,
+    SurveySchedule,
+    SurveyType,
+} from '~/types'
+
+import { getSurveyWithTranslatedContent } from './surveyTranslationUtils'
+
+const createSurvey = (): Survey => ({
+    id: 'test-survey',
+    name: 'Customer feedback',
+    description: '',
+    type: SurveyType.Popover,
+    linked_flag: null,
+    linked_flag_id: null,
+    targeting_flag: null,
+    questions: [
+        {
+            type: SurveyQuestionType.SingleChoice,
+            question: 'How was onboarding?',
+            description: 'Pick the closest answer',
+            choices: ['Great', 'Okay'],
+            translations: {
+                fr: {
+                    question: "Comment s'est passee l'integration ?",
+                    description: 'Choisissez la reponse la plus proche',
+                    choices: ['Super', 'Correct'],
+                },
+            },
+        },
+        {
+            type: SurveyQuestionType.Rating,
+            question: 'How likely are you to recommend us?',
+            display: 'number',
+            scale: 10,
+            lowerBoundLabel: 'Unlikely',
+            upperBoundLabel: 'Very likely',
+            translations: {
+                fr: {
+                    question: 'Quelle est la probabilite de nous recommander ?',
+                    lowerBoundLabel: 'Peu probable',
+                    upperBoundLabel: 'Tres probable',
+                },
+            },
+        },
+    ],
+    conditions: null,
+    appearance: {
+        position: SurveyPosition.Right,
+        displayThankYouMessage: true,
+        thankYouMessageHeader: 'Thank you',
+        thankYouMessageDescription: 'We appreciate your feedback.',
+    },
+    translations: {
+        fr: {
+            name: 'Avis client',
+            thankYouMessageHeader: 'Merci',
+            thankYouMessageDescription: 'Merci pour votre retour.',
+        },
+    },
+    created_at: '2026-01-01T00:00:00.000Z',
+    created_by: null,
+    start_date: null,
+    end_date: null,
+    archived: false,
+    targeting_flag_filters: undefined,
+    responses_limit: null,
+    schedule: SurveySchedule.Once,
+    user_access_level: AccessControlLevel.Editor,
+})
+
+describe('getSurveyWithTranslatedContent', () => {
+    it('applies survey, question, choice, and appearance translations for previews', () => {
+        const survey = createSurvey()
+
+        const translatedSurvey = getSurveyWithTranslatedContent(survey, 'fr')
+        const translatedChoiceQuestion = translatedSurvey.questions[0] as MultipleSurveyQuestion
+        const translatedRatingQuestion = translatedSurvey.questions[1] as RatingSurveyQuestion
+
+        expect(translatedSurvey.name).toBe('Avis client')
+        expect(translatedSurvey.appearance?.thankYouMessageHeader).toBe('Merci')
+        expect(translatedSurvey.appearance?.thankYouMessageDescription).toBe('Merci pour votre retour.')
+        expect(translatedChoiceQuestion.question).toBe("Comment s'est passee l'integration ?")
+        expect(translatedChoiceQuestion.description).toBe('Choisissez la reponse la plus proche')
+        expect(translatedChoiceQuestion.choices).toEqual(['Super', 'Correct'])
+        expect(translatedRatingQuestion.question).toBe('Quelle est la probabilite de nous recommander ?')
+        expect(translatedRatingQuestion.lowerBoundLabel).toBe('Peu probable')
+        expect(translatedRatingQuestion.upperBoundLabel).toBe('Tres probable')
+        expect(survey.questions[0].question).toBe('How was onboarding?')
+    })
+
+    it('returns the original survey when the language has no root translation', () => {
+        const survey = createSurvey()
+
+        expect(getSurveyWithTranslatedContent(survey, 'es')).toBe(survey)
+        expect(getSurveyWithTranslatedContent(survey, null)).toBe(survey)
+    })
+})

--- a/frontend/src/scenes/surveys/surveyTranslationUtils.ts
+++ b/frontend/src/scenes/surveys/surveyTranslationUtils.ts
@@ -1,0 +1,84 @@
+import { Survey, SurveyAppearance, SurveyQuestion, SurveyQuestionType } from '~/types'
+
+import { NewSurvey } from './constants'
+
+export function getSurveyWithTranslatedContent<TSurvey extends Survey | NewSurvey>(
+    survey: TSurvey,
+    language: string | null
+): TSurvey {
+    const translation = language ? survey.translations?.[language] : null
+
+    if (!language || !translation) {
+        return survey
+    }
+
+    const appearanceUpdates: Partial<SurveyAppearance> = {}
+    if (translation.thankYouMessageHeader) {
+        appearanceUpdates.thankYouMessageHeader = translation.thankYouMessageHeader
+    }
+    if (translation.thankYouMessageDescription) {
+        appearanceUpdates.thankYouMessageDescription = translation.thankYouMessageDescription
+    }
+    if (translation.thankYouMessageCloseButtonText) {
+        appearanceUpdates.thankYouMessageCloseButtonText = translation.thankYouMessageCloseButtonText
+    }
+
+    return {
+        ...survey,
+        ...(translation.name ? { name: translation.name } : {}),
+        ...(Object.keys(appearanceUpdates).length > 0
+            ? {
+                  appearance: {
+                      ...survey.appearance,
+                      ...appearanceUpdates,
+                  },
+              }
+            : {}),
+        questions: survey.questions.map((question): SurveyQuestion => {
+            const questionTranslation = question.translations?.[language]
+
+            if (!questionTranslation) {
+                return question
+            }
+
+            const translatedFields = {
+                question: questionTranslation.question || question.question,
+                description: questionTranslation.description || question.description,
+                buttonText: questionTranslation.buttonText || question.buttonText,
+            }
+
+            if (
+                question.type === SurveyQuestionType.SingleChoice ||
+                question.type === SurveyQuestionType.MultipleChoice
+            ) {
+                return {
+                    ...question,
+                    ...translatedFields,
+                    choices: questionTranslation.choices || question.choices,
+                }
+            }
+
+            if (question.type === SurveyQuestionType.Link) {
+                return {
+                    ...question,
+                    ...translatedFields,
+                    link: questionTranslation.link || question.link,
+                }
+            }
+
+            if (question.type === SurveyQuestionType.Rating) {
+                return {
+                    ...question,
+                    ...translatedFields,
+                    lowerBoundLabel: questionTranslation.lowerBoundLabel || question.lowerBoundLabel,
+                    upperBoundLabel: questionTranslation.upperBoundLabel || question.upperBoundLabel,
+                }
+            }
+
+            return {
+                ...question,
+                ...translatedFields,
+            }
+        }),
+    } as TSurvey
+}

--- a/frontend/src/scenes/surveys/wizard/SurveyWizard.test.tsx
+++ b/frontend/src/scenes/surveys/wizard/SurveyWizard.test.tsx
@@ -1,12 +1,49 @@
 import '@testing-library/jest-dom'
 
-import { render, screen, waitFor } from '@testing-library/react'
+import { cleanup, render, screen } from '@testing-library/react'
 import { router } from 'kea-router'
+
+import { FEATURE_FLAGS } from 'lib/constants'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 
 import { useMocks } from '~/mocks/jest'
 import { initKeaTests } from '~/test/init'
+import { AccessControlLevel, Survey, SurveyPosition, SurveyQuestionType, SurveySchedule, SurveyType } from '~/types'
 
 import { SurveyWizardComponent } from './SurveyWizard'
+
+const createGuidedSurvey = (): Survey => ({
+    id: 'test-survey',
+    name: 'Test survey',
+    description: '',
+    type: SurveyType.Popover,
+    linked_flag: null,
+    linked_flag_id: null,
+    targeting_flag: null,
+    questions: [
+        {
+            type: SurveyQuestionType.Open,
+            question: 'What do you think?',
+            description: '',
+            buttonText: 'Submit',
+        },
+    ],
+    conditions: null,
+    appearance: {
+        position: SurveyPosition.Right,
+        displayThankYouMessage: true,
+        thankYouMessageHeader: 'Thank you',
+    },
+    created_at: '2026-01-01T00:00:00.000Z',
+    created_by: null,
+    start_date: null,
+    end_date: null,
+    archived: false,
+    targeting_flag_filters: undefined,
+    responses_limit: null,
+    schedule: SurveySchedule.Once,
+    user_access_level: AccessControlLevel.Editor,
+})
 
 describe('SurveyWizard', () => {
     beforeEach(() => {
@@ -17,6 +54,7 @@ describe('SurveyWizard', () => {
         useMocks({
             get: {
                 '/api/projects/:team/surveys/': () => [200, { count: 0, results: [], next: null, previous: null }],
+                '/api/projects/:team/surveys/test-survey/': () => [200, createGuidedSurvey()],
                 '/api/projects/:team/surveys/responses_count': () => [200, {}],
             },
             patch: {
@@ -28,6 +66,8 @@ describe('SurveyWizard', () => {
     })
 
     afterEach(() => {
+        cleanup()
+        featureFlagLogic.unmount()
         jest.restoreAllMocks()
     })
 
@@ -38,10 +78,21 @@ describe('SurveyWizard', () => {
 
         render(<SurveyWizardComponent id="new" />)
 
-        await waitFor(() => {
-            expect(screen.getByText('Choose a survey template')).toBeInTheDocument()
-        })
+        expect(await screen.findByText('Choose a survey template')).toBeInTheDocument()
 
         expect(replaceSpy).not.toHaveBeenCalled()
+    })
+
+    it('shows the translations section in the guided form when the feature flag is enabled', async () => {
+        featureFlagLogic.mount()
+        featureFlagLogic.actions.setFeatureFlags([FEATURE_FLAGS.SURVEYS_TRANSLATIONS], {
+            [FEATURE_FLAGS.SURVEYS_TRANSLATIONS]: true,
+        })
+        router.actions.push('/surveys/guided/test-survey')
+
+        render(<SurveyWizardComponent id="test-survey" />)
+
+        expect(await screen.findByText('Translations')).toBeInTheDocument()
+        expect(screen.getByPlaceholderText('Add a language')).toBeInTheDocument()
     })
 })

--- a/frontend/src/scenes/surveys/wizard/SurveyWizard.tsx
+++ b/frontend/src/scenes/surveys/wizard/SurveyWizard.tsx
@@ -8,7 +8,9 @@ import { IconArrowLeft, IconChevronLeft, IconChevronRight } from '@posthog/icons
 import { LemonButton, LemonDialog } from '@posthog/lemon-ui'
 
 import { EditableField } from 'lib/components/EditableField/EditableField'
+import { FEATURE_FLAGS } from 'lib/constants'
 import { LemonSkeleton } from 'lib/lemon-ui/LemonSkeleton'
+import { featureFlagLogic as enabledFeaturesLogic } from 'lib/logic/featureFlagLogic'
 import { useMaxTool } from 'scenes/max/useMaxTool'
 import { SceneExport } from 'scenes/sceneTypes'
 import { teamLogic } from 'scenes/teamLogic'
@@ -23,6 +25,7 @@ import { SurveyAppearancePreview } from '../SurveyAppearancePreview'
 import { getEventPropertyFilterCount } from '../SurveyEventTrigger'
 import { surveyLogic } from '../surveyLogic'
 import { surveysLogic } from '../surveysLogic'
+import { getSurveyWithTranslatedContent } from '../surveyTranslationUtils'
 import { canUseSurveyWizard, doesSurveyHaveDisplayConditions, getSurveyAudienceSummaryValue } from '../utils'
 import { MaxTip } from './MaxTip'
 import { AppearanceStep } from './steps/AppearanceStep'
@@ -69,6 +72,8 @@ function SurveyWizard({ id }: SurveyWizardLogicProps): JSX.Element {
     const { setSurveyValue, loadSurvey } = useActions(surveyLogic)
 
     const { setPreferredEditor } = useActions(surveysLogic)
+    const { featureFlags } = useValues(enabledFeaturesLogic)
+    const surveyTranslationsEnabled = !!featureFlags[FEATURE_FLAGS.SURVEYS_TRANSLATIONS]
 
     // Redirect existing surveys that use wizard-unsupported fields to the full
     // editor. Brand-new surveys should always start on template selection,
@@ -100,6 +105,8 @@ function SurveyWizard({ id }: SurveyWizardLogicProps): JSX.Element {
     const { isDarkModeOn } = useValues(themeLogic)
 
     const [previewPageIndex, setPreviewPageIndex] = useState(0)
+    const [guidedEditingLanguage, setGuidedEditingLanguage] = useState<string | null>(null)
+    const activeEditingLanguage = surveyTranslationsEnabled ? guidedEditingLanguage : null
 
     const maxPreviewIndex = survey.appearance?.displayThankYouMessage
         ? survey.questions.length
@@ -108,6 +115,12 @@ function SurveyWizard({ id }: SurveyWizardLogicProps): JSX.Element {
     useEffect(() => {
         setPreviewPageIndex((current) => (current > maxPreviewIndex ? Math.max(0, maxPreviewIndex) : current))
     }, [maxPreviewIndex])
+
+    useEffect(() => {
+        if (!surveyTranslationsEnabled && guidedEditingLanguage !== null) {
+            setGuidedEditingLanguage(null)
+        }
+    }, [guidedEditingLanguage, surveyTranslationsEnabled])
 
     const handleCustomizeMore = (): void => {
         setPreferredEditor('full')
@@ -146,7 +159,7 @@ function SurveyWizard({ id }: SurveyWizardLogicProps): JSX.Element {
     }
 
     const previewSurvey: NewSurvey = {
-        ...survey,
+        ...getSurveyWithTranslatedContent(survey, activeEditingLanguage),
         id,
     } as NewSurvey
 
@@ -370,7 +383,12 @@ function SurveyWizard({ id }: SurveyWizardLogicProps): JSX.Element {
                     {/* Left: Form */}
                     <div className="space-y-5 lg:col-span-3">
                         <div>
-                            {currentStep === 'questions' && <QuestionsStep />}
+                            {currentStep === 'questions' && (
+                                <QuestionsStep
+                                    editingLanguage={guidedEditingLanguage}
+                                    setEditingLanguage={setGuidedEditingLanguage}
+                                />
+                            )}
                             {currentStep === 'where' && <WhereStep onOpenFullEditor={handleCustomizeMore} />}
                             {currentStep === 'when' && <WhenStep />}
                         </div>

--- a/frontend/src/scenes/surveys/wizard/steps/QuestionsStep.tsx
+++ b/frontend/src/scenes/surveys/wizard/steps/QuestionsStep.tsx
@@ -10,7 +10,9 @@ import { IconEmoji, IconPlusSmall, IconRevert, IconTrash } from '@posthog/icons'
 import { LemonButton, LemonCheckbox, LemonInput, LemonSegmentedButton, LemonSwitch, LemonTag } from '@posthog/lemon-ui'
 
 import { EditableField } from 'lib/components/EditableField/EditableField'
+import { FEATURE_FLAGS } from 'lib/constants'
 import { SortableDragIcon } from 'lib/lemon-ui/icons'
+import { featureFlagLogic as enabledFeaturesLogic } from 'lib/logic/featureFlagLogic'
 
 import {
     LinkSurveyQuestion,
@@ -29,6 +31,7 @@ import { AddQuestionButton } from '../AddQuestionButton'
 import { QuestionTypeChip } from '../QuestionTypeChip'
 import { surveyWizardLogic } from '../surveyWizardLogic'
 import { WizardSection, WizardStepLayout } from '../WizardLayout'
+import { TranslationsSection } from './TranslationsSection'
 
 const MAX_CHOICES = 10
 
@@ -487,13 +490,20 @@ function SortableQuestionCard({
     )
 }
 
-export function QuestionsStep(): JSX.Element {
+interface QuestionsStepProps {
+    editingLanguage: string | null
+    setEditingLanguage: (language: string | null) => void
+}
+
+export function QuestionsStep({ editingLanguage, setEditingLanguage }: QuestionsStepProps): JSX.Element {
     const { survey } = useValues(surveyLogic)
     const { setSurveyValue } = useActions(surveyLogic)
     const { selectedTemplate } = useValues(surveyWizardLogic)
     const { restoreDefaultQuestions } = useActions(surveyWizardLogic)
 
     const [activeId, setActiveId] = useState<string | null>(null)
+    const { featureFlags } = useValues(enabledFeaturesLogic)
+    const surveyTranslationsEnabled = !!featureFlags[FEATURE_FLAGS.SURVEYS_TRANSLATIONS]
 
     const questions = survey.questions as SurveyQuestion[]
     const sortedItemIds = questions.map((_, index) => index.toString())
@@ -616,6 +626,10 @@ export function QuestionsStep(): JSX.Element {
                 appearance={{ ...defaultSurveyAppearance, ...survey.appearance }}
                 onUpdate={(updates) => setSurveyValue('appearance', { ...survey.appearance, ...updates })}
             />
+
+            {surveyTranslationsEnabled ? (
+                <TranslationsSection editingLanguage={editingLanguage} setEditingLanguage={setEditingLanguage} />
+            ) : null}
         </WizardStepLayout>
     )
 }

--- a/frontend/src/scenes/surveys/wizard/steps/TranslationsSection.tsx
+++ b/frontend/src/scenes/surveys/wizard/steps/TranslationsSection.tsx
@@ -1,0 +1,413 @@
+import { useActions, useValues } from 'kea'
+
+import { IconTrash } from '@posthog/icons'
+import { LemonButton, LemonDialog, LemonInput, LemonInputSelect, LemonTextArea } from '@posthog/lemon-ui'
+
+import { LemonField } from 'lib/lemon-ui/LemonField'
+
+import {
+    LinkSurveyQuestion,
+    MultipleSurveyQuestion,
+    RatingSurveyQuestion,
+    SurveyQuestion,
+    SurveyQuestionType,
+} from '~/types'
+
+import { defaultSurveyAppearance } from '../../constants'
+import { surveyLogic } from '../../surveyLogic'
+import { COMMON_LANGUAGES } from '../../SurveyTranslations'
+import { WizardPanel, WizardSection } from '../WizardLayout'
+
+type QuestionTranslation = NonNullable<SurveyQuestion['translations']>[string]
+
+function getLanguageLabel(language: string): string {
+    return COMMON_LANGUAGES.find((commonLanguage) => commonLanguage.value === language)?.label || language
+}
+
+function isChoiceQuestion(question: SurveyQuestion): question is MultipleSurveyQuestion {
+    return question.type === SurveyQuestionType.SingleChoice || question.type === SurveyQuestionType.MultipleChoice
+}
+
+function isRatingQuestion(question: SurveyQuestion): question is RatingSurveyQuestion {
+    return question.type === SurveyQuestionType.Rating
+}
+
+function isLinkQuestion(question: SurveyQuestion): question is LinkSurveyQuestion {
+    return question.type === SurveyQuestionType.Link
+}
+
+function GuidedTranslationInput({
+    label,
+    value,
+    source,
+    onChange,
+    multiline = false,
+}: {
+    label: string
+    value: string
+    source?: string | null
+    onChange: (value: string) => void
+    multiline?: boolean
+}): JSX.Element {
+    return (
+        <LemonField.Pure label={label} className="gap-1">
+            {multiline ? (
+                <LemonTextArea value={value} onChange={onChange} placeholder={source || undefined} minRows={2} />
+            ) : (
+                <LemonInput value={value} onChange={onChange} placeholder={source || undefined} fullWidth />
+            )}
+        </LemonField.Pure>
+    )
+}
+
+interface TranslationsSectionProps {
+    editingLanguage: string | null
+    setEditingLanguage: (language: string | null) => void
+}
+
+export function TranslationsSection({ editingLanguage, setEditingLanguage }: TranslationsSectionProps): JSX.Element {
+    const { survey } = useValues(surveyLogic)
+    const { setSurveyValue } = useActions(surveyLogic)
+
+    const translations = survey.translations ?? {}
+    const addedLanguages = Object.keys(translations)
+    const activeLanguage = editingLanguage && translations[editingLanguage] ? editingLanguage : null
+    const appearance = { ...defaultSurveyAppearance, ...survey.appearance }
+
+    const addLanguage = (language: string): void => {
+        if (!language || translations[language]) {
+            return
+        }
+
+        setSurveyValue('translations', {
+            ...translations,
+            [language]: {
+                thankYouMessageHeader: appearance.thankYouMessageHeader || '',
+                thankYouMessageDescription: appearance.thankYouMessageDescription || '',
+                thankYouMessageCloseButtonText: appearance.thankYouMessageCloseButtonText || '',
+            },
+        })
+        setSurveyValue(
+            'questions',
+            survey.questions.map((question) => {
+                const questionTranslations = question.translations ?? {}
+
+                return {
+                    ...question,
+                    translations: {
+                        ...questionTranslations,
+                        [language]: {
+                            question: question.question || '',
+                            description: question.description || '',
+                            buttonText: question.buttonText || '',
+                            ...(isChoiceQuestion(question) ? { choices: question.choices || [] } : {}),
+                            ...(isRatingQuestion(question)
+                                ? {
+                                      lowerBoundLabel: question.lowerBoundLabel || '',
+                                      upperBoundLabel: question.upperBoundLabel || '',
+                                  }
+                                : {}),
+                            ...(isLinkQuestion(question) ? { link: question.link || '' } : {}),
+                        },
+                    },
+                }
+            })
+        )
+        setEditingLanguage(language)
+    }
+
+    const removeLanguage = (language: string): void => {
+        const nextTranslations = { ...translations }
+        delete nextTranslations[language]
+
+        setSurveyValue('translations', nextTranslations)
+        setSurveyValue(
+            'questions',
+            survey.questions.map((question) => {
+                if (!question.translations?.[language]) {
+                    return question
+                }
+
+                const nextQuestionTranslations = { ...question.translations }
+                delete nextQuestionTranslations[language]
+
+                return {
+                    ...question,
+                    translations: nextQuestionTranslations,
+                }
+            })
+        )
+
+        if (editingLanguage === language) {
+            setEditingLanguage(null)
+        }
+    }
+
+    const updateSurveyTranslation = (updates: Partial<NonNullable<(typeof survey)['translations']>[string]>): void => {
+        if (!activeLanguage) {
+            return
+        }
+
+        setSurveyValue('translations', {
+            ...translations,
+            [activeLanguage]: {
+                ...translations[activeLanguage],
+                ...updates,
+            },
+        })
+    }
+
+    const updateQuestionTranslation = (questionIndex: number, updates: Partial<QuestionTranslation>): void => {
+        if (!activeLanguage) {
+            return
+        }
+
+        setSurveyValue(
+            'questions',
+            survey.questions.map((question, index) => {
+                if (index !== questionIndex) {
+                    return question
+                }
+
+                const questionTranslations = question.translations ?? {}
+
+                return {
+                    ...question,
+                    translations: {
+                        ...questionTranslations,
+                        [activeLanguage]: {
+                            ...question.translations?.[activeLanguage],
+                            ...updates,
+                        },
+                    },
+                }
+            })
+        )
+    }
+
+    const updateChoiceTranslation = (questionIndex: number, choiceIndex: number, value: string): void => {
+        const question = survey.questions[questionIndex]
+        if (!activeLanguage || !isChoiceQuestion(question)) {
+            return
+        }
+
+        const translatedChoices = [...(question.translations?.[activeLanguage]?.choices || question.choices || [])]
+        translatedChoices[choiceIndex] = value
+        updateQuestionTranslation(questionIndex, { choices: translatedChoices })
+    }
+
+    return (
+        <WizardSection
+            title="Translations"
+            description="Translate the respondent-facing copy. Targeting, scheduling, and branching stay shared across languages."
+            descriptionClassName="text-sm"
+        >
+            <WizardPanel className="space-y-4">
+                <LemonInputSelect
+                    mode="single"
+                    options={COMMON_LANGUAGES.filter((language) => !addedLanguages.includes(language.value)).map(
+                        (language) => ({
+                            key: language.value,
+                            label: language.label,
+                        })
+                    )}
+                    onChange={(values) => {
+                        const language = values[0]
+                        if (language) {
+                            addLanguage(language)
+                        }
+                    }}
+                    placeholder="Add a language"
+                    allowCustomValues
+                    value={[]}
+                />
+
+                {addedLanguages.length > 0 ? (
+                    <div className="flex flex-wrap gap-2">
+                        <LemonButton
+                            size="small"
+                            type={activeLanguage === null ? 'primary' : 'secondary'}
+                            onClick={() => setEditingLanguage(null)}
+                        >
+                            Original
+                        </LemonButton>
+                        {addedLanguages.map((language) => (
+                            <LemonButton
+                                key={language}
+                                size="small"
+                                type={activeLanguage === language ? 'primary' : 'secondary'}
+                                onClick={() => setEditingLanguage(language)}
+                            >
+                                {getLanguageLabel(language)}
+                            </LemonButton>
+                        ))}
+                    </div>
+                ) : null}
+
+                {activeLanguage ? (
+                    <div className="space-y-4 border-t border-border pt-4">
+                        <div className="flex items-center justify-between gap-3">
+                            <div>
+                                <h3 className="m-0 text-sm font-semibold">{getLanguageLabel(activeLanguage)}</h3>
+                                <p className="m-0 text-xs text-secondary">The preview uses this language.</p>
+                            </div>
+                            <LemonButton
+                                icon={<IconTrash />}
+                                type="tertiary"
+                                status="danger"
+                                size="small"
+                                onClick={() => {
+                                    LemonDialog.open({
+                                        title: 'Delete translation',
+                                        description: (
+                                            <p className="py-2">
+                                                Delete the translation for{' '}
+                                                <strong>{getLanguageLabel(activeLanguage)}</strong>?
+                                            </p>
+                                        ),
+                                        primaryButton: {
+                                            children: 'Delete',
+                                            status: 'danger',
+                                            onClick: () => removeLanguage(activeLanguage),
+                                        },
+                                        secondaryButton: {
+                                            children: 'Cancel',
+                                        },
+                                    })
+                                }}
+                            >
+                                Delete
+                            </LemonButton>
+                        </div>
+
+                        <div className="space-y-3">
+                            {survey.questions.map((question, questionIndex) => {
+                                const questionTranslation = question.translations?.[activeLanguage] ?? {}
+                                const ratingQuestion = isRatingQuestion(question) ? question : null
+                                const linkQuestion = isLinkQuestion(question) ? question : null
+
+                                return (
+                                    <div
+                                        key={questionIndex}
+                                        className="space-y-3 rounded-lg border border-border bg-bg-light p-3"
+                                    >
+                                        <div className="text-xs font-semibold text-secondary">
+                                            Question {questionIndex + 1}
+                                        </div>
+                                        <GuidedTranslationInput
+                                            label="Question"
+                                            value={questionTranslation.question || ''}
+                                            source={question.question}
+                                            onChange={(questionText) =>
+                                                updateQuestionTranslation(questionIndex, { question: questionText })
+                                            }
+                                        />
+                                        {question.description ? (
+                                            <GuidedTranslationInput
+                                                label="Description"
+                                                value={questionTranslation.description || ''}
+                                                source={question.description}
+                                                onChange={(description) =>
+                                                    updateQuestionTranslation(questionIndex, { description })
+                                                }
+                                                multiline
+                                            />
+                                        ) : null}
+                                        {question.buttonText ? (
+                                            <GuidedTranslationInput
+                                                label="Button text"
+                                                value={questionTranslation.buttonText || ''}
+                                                source={question.buttonText}
+                                                onChange={(buttonText) =>
+                                                    updateQuestionTranslation(questionIndex, { buttonText })
+                                                }
+                                            />
+                                        ) : null}
+                                        {ratingQuestion ? (
+                                            <div className="grid gap-3 sm:grid-cols-2">
+                                                <GuidedTranslationInput
+                                                    label="Lower label"
+                                                    value={questionTranslation.lowerBoundLabel || ''}
+                                                    source={ratingQuestion.lowerBoundLabel}
+                                                    onChange={(lowerBoundLabel) =>
+                                                        updateQuestionTranslation(questionIndex, { lowerBoundLabel })
+                                                    }
+                                                />
+                                                <GuidedTranslationInput
+                                                    label="Upper label"
+                                                    value={questionTranslation.upperBoundLabel || ''}
+                                                    source={ratingQuestion.upperBoundLabel}
+                                                    onChange={(upperBoundLabel) =>
+                                                        updateQuestionTranslation(questionIndex, { upperBoundLabel })
+                                                    }
+                                                />
+                                            </div>
+                                        ) : null}
+                                        {isChoiceQuestion(question) ? (
+                                            <div className="grid gap-2 sm:grid-cols-2">
+                                                {question.choices.map((choice, choiceIndex) => (
+                                                    <GuidedTranslationInput
+                                                        key={choiceIndex}
+                                                        label={`Choice ${choiceIndex + 1}`}
+                                                        value={questionTranslation.choices?.[choiceIndex] || ''}
+                                                        source={choice}
+                                                        onChange={(value) =>
+                                                            updateChoiceTranslation(questionIndex, choiceIndex, value)
+                                                        }
+                                                    />
+                                                ))}
+                                            </div>
+                                        ) : null}
+                                        {linkQuestion ? (
+                                            <GuidedTranslationInput
+                                                label="Link URL"
+                                                value={questionTranslation.link || ''}
+                                                source={linkQuestion.link}
+                                                onChange={(link) => updateQuestionTranslation(questionIndex, { link })}
+                                            />
+                                        ) : null}
+                                    </div>
+                                )
+                            })}
+                        </div>
+
+                        {appearance.displayThankYouMessage ? (
+                            <div className="space-y-3 rounded-lg border border-border bg-bg-light p-3">
+                                <div className="text-xs font-semibold text-secondary">Confirmation screen</div>
+                                <GuidedTranslationInput
+                                    label="Header"
+                                    value={translations[activeLanguage]?.thankYouMessageHeader || ''}
+                                    source={appearance.thankYouMessageHeader}
+                                    onChange={(thankYouMessageHeader) =>
+                                        updateSurveyTranslation({ thankYouMessageHeader })
+                                    }
+                                />
+                                {appearance.thankYouMessageDescription ? (
+                                    <GuidedTranslationInput
+                                        label="Description"
+                                        value={translations[activeLanguage]?.thankYouMessageDescription || ''}
+                                        source={appearance.thankYouMessageDescription}
+                                        onChange={(thankYouMessageDescription) =>
+                                            updateSurveyTranslation({ thankYouMessageDescription })
+                                        }
+                                        multiline
+                                    />
+                                ) : null}
+                                {appearance.thankYouMessageCloseButtonText ? (
+                                    <GuidedTranslationInput
+                                        label="Close button"
+                                        value={translations[activeLanguage]?.thankYouMessageCloseButtonText || ''}
+                                        source={appearance.thankYouMessageCloseButtonText}
+                                        onChange={(thankYouMessageCloseButtonText) =>
+                                            updateSurveyTranslation({ thankYouMessageCloseButtonText })
+                                        }
+                                    />
+                                ) : null}
+                            </div>
+                        ) : null}
+                    </div>
+                ) : null}
+            </WizardPanel>
+        </WizardSection>
+    )
+}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -3870,8 +3870,6 @@ export interface SurveyAppearance {
     disabledButtonOpacity?: string
     maxWidth?: string
     textSubtleColor?: string
-    autoDetectLanguage?: boolean
-    surveyLanguageProperty?: string
     inputBackground?: string
     // Optional override for input and rating button text color. If not set, auto-calculated from inputBackground.
     inputTextColor?: string

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -3787,7 +3787,16 @@ export interface Survey extends WithAccessControl {
     headline_summary?: string | null
     headline_response_count?: number | null
     form_content?: Record<string, unknown> | null
-    translations?: Record<string, { name?: string; description?: string }> | null
+    translations?: Record<
+        string,
+        {
+            name?: string
+            description?: string
+            thankYouMessageHeader?: string
+            thankYouMessageDescription?: string
+            thankYouMessageCloseButtonText?: string
+        }
+    > | null
 }
 
 export enum SurveyMatchType {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -3791,7 +3791,6 @@ export interface Survey extends WithAccessControl {
         string,
         {
             name?: string
-            description?: string
             thankYouMessageHeader?: string
             thankYouMessageDescription?: string
             thankYouMessageCloseButtonText?: string

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -3787,6 +3787,7 @@ export interface Survey extends WithAccessControl {
     headline_summary?: string | null
     headline_response_count?: number | null
     form_content?: Record<string, unknown> | null
+    translations?: Record<string, { name?: string; description?: string }> | null
 }
 
 export enum SurveyMatchType {
@@ -3869,6 +3870,8 @@ export interface SurveyAppearance {
     disabledButtonOpacity?: string
     maxWidth?: string
     textSubtleColor?: string
+    autoDetectLanguage?: boolean
+    surveyLanguageProperty?: string
     inputBackground?: string
     // Optional override for input and rating button text color. If not set, auto-calculated from inputBackground.
     inputTextColor?: string
@@ -3892,6 +3895,18 @@ export interface SurveyQuestionBase {
         | ConfirmationMessageBranching
         | ResponseBasedBranching
         | SpecificQuestionBranching
+    translations?: Record<
+        string,
+        {
+            question?: string
+            description?: string
+            buttonText?: string
+            lowerBoundLabel?: string
+            upperBoundLabel?: string
+            choices?: string[]
+            link?: string
+        }
+    > | null
 }
 
 export interface BasicSurveyQuestion extends SurveyQuestionBase {


### PR DESCRIPTION
## Problem
Original (https://github.com/PostHog/posthog/pull/45281)

So here's the situation: teams running global products need to collect feedback from users who speak different languages. Right now, our surveys only support one language per survey, which means they're stuck with some pretty bad options:

- **Create duplicate surveys for each language** - maintenance nightmare, fragmented data, and analytics get split across surveys (maintenance headaches too)
- **Use English-only surveys** - which tanks response rates from non-English speakers  

This PR implements the frontend UI for multi-language survey support. Now customers can add translations for any language they want, and the end users automatically see the correct version based on their language property. Much cleaner!

It's dependent on the backend support from https://github.com/PostHog/posthog/pull/45096

Closes #42154 

## Changes

### The Core Features

**1. Translations Management UI** (`SurveyTranslations.tsx`)

Added a new "Translations" tab/panel in the survey editor. We get:
- Language dropdown with 26 common languages pre-populated (but it accepts any language code we throw at it - custom keys)
- Full support for regional variants - think en-US vs en-GB, fr-FR vs fr-CA, es-ES vs es-MX
- Add/remove languages with confirmation dialogs (so you don't accidentally nuke someone's translation work)
- Click any language to enter translation edit mode

**2. Language Editing Mode** (`SurveyEdit.tsx`)

When editing a translation, there's a yellow sticky banner that makes it super clear which language we're working on. It says "Only user-facing text can be translated - all other fields are editable in the default language only" to prevent confusion.

We can quickly switch back to default language with an inline link.

**3. Comprehensive Pre-Save Validation** (`surveyLogic.tsx`)

This one's important for preventing nasty errors. Added a new `translationValidationErrors` selector that catches:

- **Empty strings**: These cause backend validation errors, so we block them entirely
- **Translation placeholders**: Fields still marked `[Translation needed]` need to be actually translated
- **Link URL security**: All link fields must start with `https://` or `mailto:` - this prevents XSS attacks via `javascript:` or `data:` URIs (keeping it in sync with backend's validation too)

The validation runs for both the default language and all translations. When there are issues, we get:
- Yellow collapsible warning banner (sticky, so it stays visible while you scroll)
- Errors grouped by language with clickable language names to jump directly to the problem
- Save button disabled with a clear tooltip explaining what needs fixing
- Banner auto-dismisses when you fix the issues (reactive validation FTW)

**4. Auto-Synchronization of Choices** (`SurveyEditQuestionRow.tsx`)

This was quite fun to solve too. When managing multiple choice or single choice questions:

- Add a choice in default language → All translations automatically get a `[Translation needed]` placeholder
- Remove a choice → It's deleted from all translations
- Reorder choices → Order syncs across all languages
- **We literally cannot create mismatched choice arrays** - it's impossible by design

This prevents a whole class of errors where choice counts don't match, which would break everything from frontend rendering to backend validation.

**5. Smart Banner Priority System** (`SurveyEdit.tsx`)

Only one banner shows at a time to avoid clutter:

1. **Priority 1**: Validation errors (critical - blocks save)
2. **Priority 2**: Language editing context (helpful guidance)

Both banners are sticky and stay visible while you scroll. The survey title/description scroll normally though - we don't want the entire header stuck to the top!

### UX Improvements

**Intelligent Placeholder Behavior**
- Empty translation fields show the default language text as a greyed-out placeholder - visual hint without actually saving placeholder data
- New choices auto-fill with `[Translation needed]` instead of empty strings (prevents save errors)
- Language switcher clearly shows "Default (Original)" so you always know where you are

**Translation Field Detection**
- Only user-facing text fields are editable when you're in translation mode
- Non-translatable fields are view-only
- Prevents customers from accidentally modifying settings that shouldn't be language-specific
- And probably more importantly, I think it helps customers work easier + declutter the mind (maybe?) when they know fully in their head they are only going to be updating user-facing content when the yellow sticky banner appears 

**Smooth Workflow**
- Adding a language auto-switches to that language for immediate translation
- Deleting a language returns to default view
- Validation errors let us click language names to quickly switch and fix

### Security Stuff

**XSS Prevention**
- Link field validation requires `https://` or `mailto:` prefix (matching backend's restriction/validation)
- Blocks `javascript:`, `data:`, and other sketchy URI schemes
- Validation enforced in both frontend and backend (defense in depth)
- All translation text is sanitized on render

**Data Integrity**
- Empty string validation prevents backend from crashing on missing required fields
- Choice synchronization prevents data structure mismatches
- Placeholder detection ensures incomplete translations don't accidentally ship

## Implementation Details

### Data Structure

```typescript
interface Survey {
  // Survey-level translations
  translations?: {
    [languageCode: string]: {
      name?: string
      description?: string
      thankYouMessageHeader?: string
      thankYouMessageDescription?: string
      thankYouMessageCloseButtonText?: string
    }
  }
  
  questions: Array<{
    // Question-level translations
    translations?: {
      [languageCode: string]: {
        question?: string
        description?: string
        buttonText?: string
        link?: string
        choices?: string[]
        lowerBoundLabel?: string
        upperBoundLabel?: string
      }
    }
  }>
}
```

### Key Selectors

**`translationValidationErrors`** - Does all the heavy lifting for validation:
- Scans all languages in survey and question translations
- Checks each translatable field against our validation rules
- Returns structured error array: `{ language, questionIndex, field, error }`
- Powers both the save button disable state and the validation banner

**`hasTranslationValidationErrors`** - Simple boolean gate:
- Derived from `translationValidationErrors.length > 0`
- Used to show/hide validation banner and disable save button

## Design Decisions (and why)

**Why sticky banners?**
Validation errors are critical - they should always be visible. The language context banner prevents confusion when you're scrolling through a long survey. We kept the scene title/description non-sticky though, so normal document flow still works.

**Why the banner priority system?**
Showing both banners at once creates visual clutter and increases cognitive load. Validation errors are more critical (they block save), so they take priority. When there are no errors, the language context banner shows to help you stay oriented.

**Why `[Translation needed]` instead of empty strings?**
Empty strings cause backend validation errors due to database constraints. Using a visible placeholder makes incomplete translations obvious, and our pre-save validation can detect and block them.

**Why auto-sync choices?**
This prevents a whole category of bugs where choice arrays have mismatched lengths between languages. It reduces cognitive load for translators (they don't have to manage array lengths), and makes it literally impossible to create invalid state.

**Why validate link format?**
Of course, security (and then the backend also blocks this as well). We need to prevent XSS attacks via `javascript:` or `data:` URIs. We allow `mailto:` for contact links though. The validation provides clear error messages to guide users to the correct format.

**Why disable non-translatable fields during translation mode?**
So for this, when editing a translation, we restrict customers to only editing user-facing text fields. Here's why:

*What could go wrong if we allowed it:*
- **Question type chaos**: Imagine changing a multiple choice question to a rating question while in French mode. Now we've got French translations with incompatible field structures (choices array vs rating labels).
- **Data integrity**: Adding/removing questions in translation mode would create orphaned translations or missing question mappings.
- **Better UX + Clarity**: Customers can easily keep track of the flow that they update survey's structure or add new changes in default language, then go back to translate the new content for other languages (and nothing more)

*What we allow instead:*
- Only user-facing text fields are editable: question text, description, choices, button labels, etc.
- All structural changes (question types,  adding/removing questions/choices etc) must be done in the default language
- The yellow banner makes this crystal clear: "Only user-facing text can be translated" and customers can instantly jump back to default language (without having to scroll down to the Translations tab/panel)

This prevents a whole category of bugs and keeps the survey structure consistent across all languages. When there's need to change structure, we switch back to default, make the change, and it applies to all languages. Then we go back and translate the new content. Feels like a kind of unidirectional flow that can't be easily mistaken

**Why validate empty choices in the default language?**
This one's subtle but important. When you add a new choice while translations exist, the system creates a placeholder `[Translation needed]` in all translations. But what if the user forgets to fill in the default choice itself?

*The problem:*
- User has French and Spanish translations active
- User adds a new choice to a multiple choice question
- User fills in the French translation: "Oui"
- User fills in the Spanish translation: "Sí"  
- User forgets to fill in the default (English) choice - it stays as empty string
- Backend throws validation error or prevents save because choices cannot be empty

*The fix:*
We also validate choices in the default language before checking translations. Empty string choices are never allowed - whether you're using translations or not. This ensures consistency:
- If a choice is empty in default → Validation error, save blocked
- If a choice is empty in translation → Validation error, save blocked
- If a choice has text in translation but empty in default → Validation error (because default needs a value)

**Why validate that default fields cannot be empty when translations exist (reverse validation)?**
This is the flip side of the coin - it prevents us from translating content that doesn't exist in the default language.

*The problem:*
- User creates a survey with a rating question
- User adds French translation
- User gets excited and fills in the French question text: "Que pensez-vous de notre produit?"
- User forgets to fill in the default (English) question text - leaves it empty
- Without reverse validation, this saves successfully
- But now you have a broken default language version - English end-users see no question text!
- Even worse, the survey might fail backend validation because required fields are empty

*The fix:*
When a default field is empty but translations have values, we show an error on the DEFAULT language: "Cannot be empty (has translation)". This makes it clear:
- You cannot translate something that doesn't exist in the source
- The default language is the source of truth - it must be complete first
- Fill in the default field, THEN translate it

*And then why do we  put the error on default instead of translation?*
Because the problem IS in the default! The translation itself is perfectly valid - the issue is that we're trying to translate from nothing. By putting the error on the default language, we guide customers to fix the root cause: fill in the default content first, then go translate it.

This enforces a healthy workflow: "translate FROM complete default" rather than allowing "translate TO without FROM". The default language must always be complete and valid, regardless of how many translations exist. We can think of it as protecting the integrity of our source content!

## How did you test this code

### Core workflow (Steps 1–3)
[surveys-translation-demo.webm](https://github.com/user-attachments/assets/0cb9a82d-d5fc-4776-b716-20f35d0c6204)

This video demonstrates the core translation workflow:

**Step 1: Create base survey (default language)**
- Created "Product Satisfaction Q1 2026" survey with beta feedback template
- Added three questions: rating question (satisfied/not satisfied), multiple choice question (5 feature choices), and open text question with description
- Filled in thank you message (header, description, close button text)

**Step 2: Add French translation**
- Clicked Translations tab → added French (fr)
- Sticky yellow banner appeared: "Editing translation for French. Only user-facing text can be translated..."
- Language switcher showed "Default (Original)" | "French (fr)"
- Translatable fields showed default English text as placeholders
- Translated all content: survey name, description, all question fields, choices, thank you message
- Verified choices automatically showed default text as placeholders
- Confirmed non-translatable fields (question types and other 'structural' fields) were disabled

**Step 3: Add Spanish translation**
- Added custom language key (spanish-es) from language dropdown
- Translated all content to Spanish
- Demonstrated that custom language key (spanish-es) works

### Validation & UX polish

[survey-translations-validatinos-and-ux-polish-demo.mp4](https://github.com/user-attachments/assets/d6a0e002-8558-494a-b4ff-51536d0e8560)


**Validation features**
- Empty string validation: clear Question 1 text → "Cannot be empty" error on default
- Translation placeholder validation: leave `[Translation needed]` in French → validation error, collapsible banner, save disabled
- Link URL security: try `javascript:alert('xss')` → blocked with "Must start with https:// or mailto:" error
- Choice synchronization: add/remove choices in default → auto-sync with `[Translation needed]` placeholders in translations, deleted choices in default are reflected in other languages
- Reverse validation: empty default question but filled French translation → error on default: "Cannot be empty (has translation)"
- Banner priority: validation banner (yellow, sticky) takes priority over language editing banner

**Some UX polish features demoed**
- Reordering survey questions reflect in translations
- Smart field restrictions: question type dropdown disabled in translation mode
- Question type change cleanup: translations automatically clean up incompatible fields when question type changes. E.g from Multiple choice select → Link/Notification. Likewise, switching between similar structures Multiple choice select → Single choice select retains compatible fields like choices
- Language switcher clarity: highlighted active language or faulty one (in validation messages), e.g "Default (Original)" label, click to jump
- Intelligent placeholders: default text shown as greyed placeholders, new choices show `[Translation needed]`
- Sticky banner behavior: validation/language banners stick while scrolling, title/description scroll normally
- Delete confirmation: trash icon → confirmation dialog prevents accidental deletion

[surveys-translation-deletion-demo.webm](https://github.com/user-attachments/assets/66b3c17a-9610-41dd-a80d-4d1f2408515c)

## ⚠️ The Missing Piece - What's Left

Okay, so here's the thing - **this PR gets us 90% of the way there, but there's one critical piece missing**: the actual rendering logic in `posthog-js`.

Right now:
- ✅ Creators can add translations in PostHog UI
- ✅ Backend stores and validates translations
- ❌ **End users still see English** - the JS SDK doesn't know how to render translations yet!

**What needs to happen:**

The `posthog-js` SDK needs to:
1. Detect the user's language from person properties (e.g., `language: 'fr'`)
2. Merge translated fields with default survey fields
3. Render the translated version

Without this last piece, end users will always see the default language no matter what translations exist. So we'll need a companion PR in `posthog-js` to complete this epic! **(Good news: We have one already drafted here: [PostHog/posthog-js#3004](https://github.com/PostHog/posthog-js/pull/3004))**

## Changelog

Yes, I guess...