### PR TITLE
feat(dashboard): add AI-generated dashboard title and description

### DIFF
--- a/frontend/src/layout/scenes/components/SceneTitleSection.tsx
+++ b/frontend/src/layout/scenes/components/SceneTitleSection.tsx
@@ -195,9 +195,7 @@ type SceneMainTitleProps = {
      */
     className?: string
 
-    /**
-     * Optional callback to generate metadata (name, description) using AI
-     */
+    /** Optional callback to generate metadata (name + description) using AI — only shown on the title field. */
     onGenerateMetadata?: () => void
     /**
      * Whether metadata generation is currently in progress
@@ -388,6 +386,7 @@ export function SceneTitleSection({
                         renameDebounceMs={renameDebounceMs}
                         saveOnBlur={saveOnBlur}
                         maxLength={descriptionMaxLength}
+                        isGeneratingMetadata={isGeneratingMetadata}
                     />
                 </div>
             )}
@@ -454,7 +453,7 @@ export function SceneName({
         if (relatedTarget && containerRef.current && containerRef.current.contains(relatedTarget)) {
             return
         }
-        if (saveOnBlur && !forceEdit && name !== initialName) {
+        if (saveOnBlur && !forceEdit && !isGeneratingMetadata && name !== initialName) {
             debouncedOnBlurSave(name || '')
         }
         if (!forceEdit) {
@@ -473,6 +472,7 @@ export function SceneName({
                             variant="default"
                             name="name"
                             value={name || ''}
+                            readOnly={isGeneratingMetadata}
                             onChange={(e) => {
                                 setName(e.target.value)
                                 if (forceEdit) {
@@ -488,7 +488,8 @@ export function SceneName({
                                     className: `${textClasses} w-full hover:bg-fill-input py-0`,
                                     autoHeight: true,
                                 }),
-                                '[&_.LemonIcon]:size-4 input-like'
+                                '[&_.LemonIcon]:size-4 input-like',
+                                isGeneratingMetadata && 'cursor-not-allowed opacity-80'
                             )}
                             wrapperClassName="flex-1 min-w-0"
                             placeholder="Enter name"
@@ -522,7 +523,13 @@ export function SceneName({
                     </div>
                 ) : (
                     <Tooltip
-                        title={canEdit && !forceEdit ? 'Edit name' : undefined}
+                        title={
+                            isGeneratingMetadata
+                                ? 'Finish generating before editing'
+                                : canEdit && !forceEdit
+                                  ? 'Edit name'
+                                  : undefined
+                        }
                         placement="top-start"
                         arrowOffset={10}
                     >
@@ -531,7 +538,12 @@ export function SceneName({
                                 buttonPrimitiveVariants({ size: 'fit', className: textClasses }),
                                 'flex text-left [&_.LemonIcon]:size-4 focus-visible:z-50'
                             )}
-                            onClick={() => setIsEditing(true)}
+                            onClick={() => {
+                                if (!isGeneratingMetadata) {
+                                    setIsEditing(true)
+                                }
+                            }}
+                            disabled={isGeneratingMetadata}
                             truncate
                         >
                             <span className="truncate">{name || <span className="text-tertiary">Unnamed</span>}</span>
@@ -582,6 +594,8 @@ type SceneDescriptionProps = {
     renameDebounceMs?: number
     saveOnBlur?: boolean
     maxLength?: number
+    /** When true, description field is read-only (title AI control may be generating body copy too). */
+    isGeneratingMetadata?: boolean
 }
 
 function SceneDescription({
@@ -594,6 +608,7 @@ function SceneDescription({
     renameDebounceMs = 100,
     saveOnBlur = false,
     maxLength,
+    isGeneratingMetadata = false,
 }: SceneDescriptionProps): JSX.Element | null {
     const [description, setDescription] = useState(initialDescription)
     const [prevInitialDescription, setPrevInitialDescription] = useState(initialDescription)
@@ -625,7 +640,7 @@ function SceneDescription({
     }, renameDebounceMs)
 
     const handleBlur = (): void => {
-        if (saveOnBlur && !forceEdit && description !== initialDescription) {
+        if (saveOnBlur && !forceEdit && !isGeneratingMetadata && description !== initialDescription) {
             debouncedOnBlurSaveDescription(description || '')
         }
         if (!forceEdit) {
@@ -642,6 +657,7 @@ function SceneDescription({
                         name="description"
                         value={description || ''}
                         maxLength={maxLength}
+                        readOnly={isGeneratingMetadata}
                         onChange={(e) => {
                             setDescription(e.target.value)
                             if (forceEdit) {
@@ -657,7 +673,8 @@ function SceneDescription({
                                 className: `${textClasses} w-full hover:bg-fill-input px-[var(--button-padding-x-sm)]`,
                                 autoHeight: true,
                             }),
-                            '[&_.LemonIcon]:size-4 input-like'
+                            '[&_.LemonIcon]:size-4 input-like',
+                            isGeneratingMetadata && 'cursor-not-allowed opacity-80'
                         )}
                         wrapperClassName="w-full"
                         markdown={markdown}
@@ -667,12 +684,23 @@ function SceneDescription({
                     />
                 ) : (
                     <Tooltip
-                        title={canEdit && !forceEdit ? 'Edit description' : undefined}
+                        title={
+                            isGeneratingMetadata
+                                ? 'Finish generating before editing'
+                                : canEdit && !forceEdit
+                                  ? 'Edit description'
+                                  : undefined
+                        }
                         placement="bottom"
                         arrowOffset={10}
                     >
                         <ButtonPrimitive
-                            onClick={() => setIsEditing(true)}
+                            onClick={() => {
+                                if (!isGeneratingMetadata) {
+                                    setIsEditing(true)
+                                }
+                            }}
+                            disabled={isGeneratingMetadata}
                             className="flex text-start px-[var(--button-padding-x-sm)] py-[var(--button-padding-y-base)] [&_.LemonIcon]:size-4 focus-visible:z-50"
                             autoHeight
                             size="base"

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -3015,6 +3015,10 @@ const api = {
             return new ApiRequest().dashboardsDetail(id).get()
         },
 
+        async generateMetadata(id: number): Promise<{ name: string; description: string }> {
+            return await new ApiRequest().dashboardsDetail(id).withAction('generate_metadata').create({ data: {} })
+        },
+
         async createUnlistedDashboard(tag: string): Promise<DashboardType> {
             return new ApiRequest().dashboards().withAction('create_unlisted_dashboard').create({ data: { tag } })
         },

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -383,6 +383,7 @@ export const FEATURE_FLAGS = {
     PASSWORD_PROTECTED_SHARES: 'password-protected-shares', // owner: @aspicer
     DASHBOARD_AUTO_PREVIEW_LIMIT: 'dashboard-auto-preview-limit', // owner: @pauldambra #team-product-analytics
     DASHBOARD_QUICK_FILTERS_EXPERIMENT: 'dashboard-quick-filters-experiment', // owner: @vdekrijger #team-product-analytics multivariate=control,test
+    DASHBOARDS_AI_METADATA_GENERATION: 'dashboards-ai-metadata-generation', // owner: @mattp, #team-analytics-platform
     PRODUCT_ANALYTICS_DASHBOARD_MODAL_SMART_DEFAULTS: 'product-analytics-dashboard-modal-smart-defaults', // owner: @sam #team-product-analytics
     PRODUCT_TOURS: 'product-tours-2025', // owner: @adboio #team-surveys
     PRODUCT_TOURS_LOCALIZATION: 'product-tours-localization', // owner: @adboio #team-surveys

--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -268,6 +268,8 @@ export const eventUsageLogic = kea<eventUsageLogicType>([
         // insights
         reportInsightMetadataAiGenerated: (queryKind: NodeKind) => ({ queryKind }),
         reportInsightMetadataAiGenerationFailed: (queryKind: NodeKind) => ({ queryKind }),
+        reportDashboardMetadataAiGenerated: (payload: { dashboardId: number }) => payload,
+        reportDashboardMetadataAiGenerationFailed: (payload: { dashboardId: number }) => payload,
         reportInsightCreated: (query: Node | null) => ({ query }),
         reportInsightSaved: (
             insight: Partial<QueryBasedInsightModel> | null,
@@ -1079,6 +1081,12 @@ export const eventUsageLogic = kea<eventUsageLogicType>([
         },
         reportInsightMetadataAiGenerationFailed: async ({ queryKind }) => {
             posthog.capture('insight metadata ai generation failed', { query_kind: queryKind })
+        },
+        reportDashboardMetadataAiGenerated: async ({ dashboardId }) => {
+            posthog.capture('dashboard metadata ai generated', { dashboard_id: dashboardId })
+        },
+        reportDashboardMetadataAiGenerationFailed: async ({ dashboardId }) => {
+            posthog.capture('dashboard metadata ai generation failed', { dashboard_id: dashboardId })
         },
         reportInsightSaved: async ({ insight, query, isNewInsight }) => {
             // "insight saved" is a proxy for the new insight's results being valuable to the user

--- a/frontend/src/scenes/dashboard/DashboardHeader.tsx
+++ b/frontend/src/scenes/dashboard/DashboardHeader.tsx
@@ -1,6 +1,7 @@
 import { useActions, useValues } from 'kea'
 
 import { FullScreen } from 'lib/components/FullScreen'
+import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { DashboardEventSource } from 'lib/utils/eventUsageLogic'
 import { sceneConfigurations } from 'scenes/scenes'
 import { Scene } from 'scenes/sceneTypes'
@@ -19,9 +20,17 @@ export const DASHBOARD_CANNOT_EDIT_MESSAGE =
     "You don't have edit permissions for this dashboard. Ask a dashboard collaborator with edit access to add you."
 
 export function DashboardHeader(): JSX.Element | null {
-    const { dashboard, dashboardLoading, dashboardMode, canEditDashboard } = useValues(dashboardLogic)
-    const { setDashboardMode, loadDashboard } = useActions(dashboardLogic)
+    const {
+        dashboard,
+        dashboardLoading,
+        dashboardMode,
+        canEditDashboard,
+        canGenerateDashboardAiMetadata,
+        generatedDashboardMetadataLoading,
+    } = useValues(dashboardLogic)
+    const { setDashboardMode, loadDashboard, generateDashboardMetadata } = useActions(dashboardLogic)
     const { updateDashboard } = useActions(dashboardsModel)
+    const canAccessDashboardsAiMetadataGeneration = useFeatureFlag('DASHBOARDS_AI_METADATA_GENERATION')
 
     if (!dashboard && !dashboardLoading) {
         return null
@@ -49,6 +58,16 @@ export function DashboardHeader(): JSX.Element | null {
                 onDescriptionChange={(value) => {
                     updateDashboard({ id: dashboard?.id, description: value, allowUndo: true })
                 }}
+                onGenerateMetadata={
+                    canAccessDashboardsAiMetadataGeneration && canGenerateDashboardAiMetadata && dashboard
+                        ? generateDashboardMetadata
+                        : undefined
+                }
+                isGeneratingMetadata={
+                    canAccessDashboardsAiMetadataGeneration &&
+                    canGenerateDashboardAiMetadata &&
+                    generatedDashboardMetadataLoading
+                }
                 markdown
                 canEdit={canEditDashboard}
                 isLoading={dashboardLoading}

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -41,6 +41,7 @@ import { urls } from 'scenes/urls'
 import { userLogic } from 'scenes/userLogic'
 
 import { SIDE_PANEL_CONTEXT_KEY, SidePanelSceneContext } from '~/layout/navigation-3000/sidepanel/types'
+import { sceneLayoutLogic } from '~/layout/scenes/sceneLayoutLogic'
 import { dashboardsModel } from '~/models/dashboardsModel'
 import { insightsModel } from '~/models/insightsModel'
 import { variableDataLogic } from '~/queries/nodes/DataVisualization/Components/Variables/variableDataLogic'
@@ -622,6 +623,22 @@ export const dashboardLogic = kea<dashboardLogicType>([
                     }
 
                     return values.dashboard
+                },
+            },
+        ],
+        generatedDashboardMetadata: [
+            null as { name: string; description: string } | null,
+            {
+                generateDashboardMetadata: async () => {
+                    try {
+                        const response = await api.dashboards.generateMetadata(props.id)
+                        eventUsageLogic.actions.reportDashboardMetadataAiGenerated({ dashboardId: props.id })
+                        return { name: response.name, description: response.description }
+                    } catch (e) {
+                        eventUsageLogic.actions.reportDashboardMetadataAiGenerationFailed({ dashboardId: props.id })
+                        lemonToast.error('Failed to generate name and description')
+                        throw e
+                    }
                 },
             },
         ],
@@ -1549,6 +1566,33 @@ export const dashboardLogic = kea<dashboardLogicType>([
                     : false
             },
         ],
+        /** AI dashboard title/description: editor access, tiles present, main dashboard scene only, not shared/embed routes. */
+        canGenerateDashboardAiMetadata: [
+            (s) => [s.canEditDashboard, s.placement, s.dashboard, router.selectors.location],
+            (
+                canEditDashboard: boolean,
+                placement: DashboardPlacement,
+                dashboard: DashboardType<QueryBasedInsightModel> | null,
+                { pathname }: { pathname: string }
+            ): boolean => {
+                const tiles = dashboard?.tiles?.filter((t: DashboardTile<QueryBasedInsightModel>) => !t.deleted) ?? []
+                const hasInsightOrTextTile = tiles.some((t) => !!(t.insight || t.text))
+                if (!canEditDashboard || !hasInsightOrTextTile) {
+                    return false
+                }
+                if (placement !== DashboardPlacement.Dashboard) {
+                    return false
+                }
+                if (
+                    pathname.startsWith('/shared/') ||
+                    pathname.startsWith('/embedded/') ||
+                    pathname.startsWith('/shared_dashboard/')
+                ) {
+                    return false
+                }
+                return true
+            },
+        ],
         canRestrictDashboard: [
             // Sync conditions with backend can_user_restrict
             (s) => [s.dashboard, userLogic.selectors.user, teamLogic.selectors.currentTeam],
@@ -1747,6 +1791,19 @@ export const dashboardLogic = kea<dashboardLogicType>([
         },
     })),
     listeners(({ actions, values, cache, props, sharedListeners }) => ({
+        generateDashboardMetadataSuccess: ({ generatedDashboardMetadata }) => {
+            if (generatedDashboardMetadata && values.dashboard) {
+                dashboardsModel.actions.updateDashboard({
+                    id: values.dashboard.id,
+                    name: generatedDashboardMetadata.name,
+                    description: generatedDashboardMetadata.description,
+                    allowUndo: true,
+                })
+                if (generatedDashboardMetadata.description && !sceneLayoutLogic.values.showDescription) {
+                    sceneLayoutLogic.actions.toggleShowDescription()
+                }
+            }
+        },
         togglePinned: () => {
             if (values.dashboard) {
                 // Reducers have already run, so values.isPinned reflects the desired new state.

--- a/posthog/api/dashboard_metadata.py
+++ b/posthog/api/dashboard_metadata.py
@@ -1,0 +1,162 @@
+"""LLM-backed dashboard title and description generation from tile inventory."""
+
+import json
+from typing import Any, Optional
+
+import structlog
+
+from posthog.schema import InsightVizNode
+
+from posthog.hogql.ai import hit_openai
+
+from posthog.api.insight_suggestions import InsightMetadata, _summarize_query_for_naming
+from posthog.models import Team
+
+logger = structlog.get_logger(__name__)
+
+_DASHBOARD_METADATA_BODY_SHARED = """## Layout weighting (critical)
+- Tiles are listed in **visual layout order** (earlier = higher on the page / read first). Treat **top-of-dashboard content as higher priority** when deciding what matters.
+- Later or peripheral tiles may be **omitted** from the description if they add little beyond what the lead tiles already imply.
+
+## Audience
+Readers may have **no prior context**. Optimize for a quick skim: purpose, stakes, what to look at first.
+
+## Text cards (strong signal)
+- **User-authored**, often markdown. Usually explains goals or how to read the board—**weight heavily**, especially when the text card appears **early** in the tile list.
+- Mine text for intent; do not paste markdown verbatim into `description` unless a short phrase is clearly the canonical label.
+
+## Tone and terminology
+- **Plain language** over jargon, raw property names, or implementation terms—unless a tile is explicitly about that technical concept.
+- **No** numeric or opaque ids (user ids, PKs, etc.). Paraphrase; drop id-like tokens.
+
+## Concision overrides polish
+- Prefer **density and directness** over eloquence. Short phrases and **sentence fragments OK**; minor grammar tradeoffs acceptable if the line reads faster.
+
+## Description (`description`)
+- **Markdown allowed and expected** where it helps scanning: wrap **short phrases in bold** to **call out** what matters—key outcomes, risks, metrics, decisions, or what to watch. **Do not** bold whole sentences or stack bold on every clause; a few sharp callouts beat a wall of plain text.
+- **Extra-compact.** What to decide or watch, **outcomes or risks** when tiles imply it.
+- **Default: one cohesive block**—a few terse sentences or short lines of prose summarizing the **unified story** (top-weighted tiles). **No headings** unless splitting is clearly justified.
+- **Sections only when necessary:** `### Heading` plus a line or two, or a **bold lead-in** line with one line under—**only** if the dashboard has **clearly separate storylines** (e.g. unrelated domains) that would confuse readers in one paragraph. If one narrative fits, **stay single-block**. **Never** invent a section per graph or mirror tile order as a list of headers. When you do split, **prefer a single split** (two blocks); more only if the board is obviously multi-topic.
+- Collapse related charts into shared wording; **highest-impact points only**. Still avoid jargon and ids.
+
+## Input — dashboard tiles (layout order: earlier = higher on dashboard, higher inference priority; insight + text only; buttons excluded)
+{tiles_summary}
+
+## Output
+{output_instructions}
+"""
+
+
+def build_dashboard_tiles_naming_summary(dashboard: Any) -> str:
+    """Build a compact text description of insight and text tiles for AI naming (buttons omitted)."""
+    from products.dashboards.backend.models.dashboard_tile import DashboardTile
+
+    tiles_qs = DashboardTile.dashboard_queryset(dashboard.tiles.all())
+    sorted_tiles = DashboardTile.sort_tiles_by_layout(list(tiles_qs), "sm")
+    content_tiles = [t for t in sorted_tiles if t.insight_id or t.text_id]
+    if not content_tiles:
+        return "(No insight or text tiles on this dashboard.)"
+
+    blocks: list[str] = []
+    for i, tile in enumerate(content_tiles, 1):
+        if tile.insight is not None:
+            insight = tile.insight
+            title = (insight.name or insight.derived_name or "Untitled chart").strip()
+            block_lines = [f"Tile {i} (insight chart): {title}"]
+            if insight.query:
+                try:
+                    viz = InsightVizNode.model_validate(insight.query)
+                    block_lines.append(_summarize_query_for_naming(viz))
+                except Exception:
+                    qdict = insight.query if isinstance(insight.query, dict) else {}
+                    kind = qdict.get("kind", "unknown")
+                    block_lines.append(f"Visualization kind: {kind}")
+            blocks.append("\n".join(block_lines))
+        elif tile.text is not None:
+            body = (tile.text.body or "").strip()
+            # Longer excerpt: text cards are user-authored and often carry markdown context
+            excerpt_max = 3500
+            excerpt = body[:excerpt_max] + ("..." if len(body) > excerpt_max else "")
+            blocks.append(
+                f"Tile {i} (**text card — high priority**; user-written context, may include markdown):\n"
+                f"{excerpt or '(empty text card)'}"
+            )
+
+    return "\n\n".join(blocks)
+
+
+def generate_dashboard_metadata(
+    team: Team,
+    tiles_summary: str,
+    *,
+    current_name: Optional[str] = None,
+    current_description: Optional[str] = None,
+) -> InsightMetadata:
+    """Generate a concise name and description for a dashboard from a pre-built tile summary."""
+    try:
+        existing_lines: list[str] = []
+        if current_name:
+            existing_lines.append(f"- Current name: {current_name}")
+        if current_description:
+            existing_lines.append(f"- Current description: {current_description}")
+        existing_block = ""
+        if existing_lines:
+            existing_block = (
+                "## Existing dashboard metadata (foundational context)\n"
+                "Use this as grounding: extend, tighten, or replace if outdated—but **do not ignore** wording that still fits.\n"
+                + "\n".join(existing_lines)
+                + "\n\n"
+            )
+
+        task = """## Task
+Infer a dashboard **name** and **description** from the tile inventory below. Reflect what is actually on the dashboard (charts and **text cards**), not generic filler. **Do not** enumerate every tile or give **each chart its own subsection**—surface only the **few highest-signal themes**."""
+        output_instructions = """Return **only** valid JSON with exactly these string keys: `name`, `description`. No code fences, no commentary. `description` may include markdown (e.g. **bold** callouts). `name` is plain text only—**no markdown** in `name`. Escape strings so the JSON parses (newlines, quotes, backslashes inside `description`)."""
+        name_section = """## Name (`name`)
+- **One headline**, no newlines. Plain text only—**no markdown** in `name`.
+- **Overall theme** from the **weighted** tiles (top + text). Do not default to one chart title unless that tile clearly dominates.
+
+"""
+        prompt = f"""{task}
+
+{existing_block}{name_section}{
+            _DASHBOARD_METADATA_BODY_SHARED.format(
+                tiles_summary=tiles_summary,
+                output_instructions=output_instructions,
+            )
+        }"""
+
+        messages = [
+            {
+                "role": "system",
+                "content": (
+                    "You write terse dashboard titles and markdown descriptions: use **bold** sparingly for key callouts; "
+                    "one cohesive description by default; section breaks only when storylines are genuinely separate—not one section per chart. "
+                    'You output exactly one JSON object with keys "name" and "description" and no other text.'
+                ),
+            },
+            {"role": "user", "content": prompt},
+        ]
+
+        content, _, _ = hit_openai(
+            messages,
+            f"team/{team.id}/generate-dashboard-metadata",
+            posthog_properties={
+                "ai_product": "analytics_platform",
+                "ai_feature": "dashboard-ai-metadata-generation",
+            },
+        )
+
+        parsed = json.loads(content.strip())
+        name = parsed["name"].strip().strip('"').strip("'")
+        description = parsed["description"].strip()
+
+        if len(name) > 100:
+            name = name[:97] + "..."
+        if len(description) > 800:
+            description = description[:797] + "..."
+
+        return InsightMetadata(name=name, description=description)
+
+    except Exception:
+        logger.exception("ai_dashboard_metadata_generation_failed")
+        raise

--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -1097,7 +1097,6 @@ class InsightViewSet(
         """Validate that AI data processing is approved by the organization."""
         if not self.organization.is_ai_data_processing_approved:
             raise PermissionDenied("AI data processing must be approved by your organization")
-            raise PermissionDenied("AI data processing must be approved by your organization")
 
     @staticmethod
     def _is_mcp_request(request: Request) -> bool:

--- a/posthog/api/test/test_dashboard_metadata.py
+++ b/posthog/api/test/test_dashboard_metadata.py
@@ -37,7 +37,7 @@ class TestGenerateDashboardMetadata(APIBaseTest):
         ]
     )
     @patch(MOCK_PATH)
-    def test_returns_400_when_no_insight_or_text_tiles(self, mock_openai, _case_name):
+    def test_returns_400_when_no_insight_or_text_tiles(self, _case_name, mock_openai):
         if _case_name == "no_tiles":
             dashboard_id, _ = self.dashboard_api.create_dashboard({"name": "Empty"})
         else:

--- a/posthog/api/test/test_dashboard_metadata.py
+++ b/posthog/api/test/test_dashboard_metadata.py
@@ -1,0 +1,69 @@
+from posthog.test.base import APIBaseTest
+from unittest.mock import patch
+
+from parameterized import parameterized
+from rest_framework import status
+
+from posthog.api.test.dashboards import DashboardAPI
+
+MOCK_PATH = "posthog.api.dashboard_metadata.hit_openai"
+
+
+class TestGenerateDashboardMetadata(APIBaseTest):
+    def setUp(self):
+        super().setUp()
+        self.organization.is_ai_data_processing_approved = True
+        self.organization.save()
+        self.dashboard_api = DashboardAPI(self.client, self.team, self.assertEqual)
+
+    def _url(self, dashboard_id: int) -> str:
+        return f"/api/projects/{self.team.id}/dashboards/{dashboard_id}/generate_metadata/"
+
+    @patch(MOCK_PATH)
+    def test_returns_name_and_description(self, mock_openai):
+        dashboard_id, _ = self.dashboard_api.create_dashboard({"name": "d"})
+        _, _ = self.dashboard_api.create_insight({"dashboards": [dashboard_id], "name": "Pageviews"})
+        mock_openai.return_value = ('{"name": "Traffic overview", "description": "Key traffic metrics."}', 10, 20)
+        response = self.client.post(self._url(dashboard_id), {}, format="json")
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["name"] == "Traffic overview"
+        assert response.json()["description"] == "Key traffic metrics."
+
+    @parameterized.expand(
+        [
+            ("no_tiles",),
+            ("button_tiles_only",),
+        ]
+    )
+    @patch(MOCK_PATH)
+    def test_returns_400_when_no_insight_or_text_tiles(self, mock_openai, _case_name):
+        if _case_name == "no_tiles":
+            dashboard_id, _ = self.dashboard_api.create_dashboard({"name": "Empty"})
+        else:
+            dashboard_id, _ = self.dashboard_api.create_dashboard({"name": "d"})
+            _, _ = self.dashboard_api.create_button_tile(dashboard_id)
+        response = self.client.post(self._url(dashboard_id), {}, format="json")
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        err = response.json()["error"].lower()
+        assert "insight" in err or "text" in err
+        mock_openai.assert_not_called()
+
+    @patch(MOCK_PATH, side_effect=Exception("LLM API error"))
+    def test_llm_failure_returns_500(self, mock_openai):
+        dashboard_id, _ = self.dashboard_api.create_dashboard({"name": "d"})
+        _, _ = self.dashboard_api.create_insight({"dashboards": [dashboard_id], "name": "Pageviews"})
+        response = self.client.post(self._url(dashboard_id), {}, format="json")
+
+        assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+        assert "Failed" in response.json()["error"]
+
+    def test_ai_not_approved_returns_403(self):
+        self.organization.is_ai_data_processing_approved = False
+        self.organization.save()
+        dashboard_id, _ = self.dashboard_api.create_dashboard({"name": "d"})
+        _, _ = self.dashboard_api.create_insight({"dashboards": [dashboard_id], "name": "Pageviews"})
+        response = self.client.post(self._url(dashboard_id), {}, format="json")
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN

--- a/products/dashboards/backend/api/dashboard.py
+++ b/products/dashboards/backend/api/dashboard.py
@@ -32,6 +32,7 @@ from rest_framework.utils.serializer_helpers import ReturnDict
 
 from posthog.schema import InsightVizNode
 
+from posthog.api.dashboard_metadata import build_dashboard_tiles_naming_summary, generate_dashboard_metadata
 from posthog.api.forbid_destroy_model import ForbidDestroyModel
 from posthog.api.insight import DashboardTileBasicSerializer, InsightSerializer, InsightViewSet
 from posthog.api.insight_suggestions import summarize_insight_result
@@ -56,6 +57,11 @@ from posthog.models.quick_filter import QuickFilter
 from posthog.models.signals import model_activity_signal, mutable_receiver
 from posthog.models.tagged_item import TaggedItem
 from posthog.models.user import User
+from posthog.rate_limit import (
+    LLMAnalyticsSummarizationBurstThrottle,
+    LLMAnalyticsSummarizationDailyThrottle,
+    LLMAnalyticsSummarizationSustainedThrottle,
+)
 from posthog.rbac.access_control_api_mixin import AccessControlViewSetMixin
 from posthog.rbac.user_access_control import UserAccessControl, UserAccessControlSerializerMixin
 from posthog.renderers import SafeJSONRenderer, ServerSentEventRenderer
@@ -182,6 +188,11 @@ class DashboardSnapshotSerializer(serializers.Serializer):
         required=False,
         allow_null=True,
     )
+
+
+class DashboardGeneratedMetadataSerializer(serializers.Serializer):
+    name = serializers.CharField()
+    description = serializers.CharField()
 
 
 class TextSerializer(serializers.ModelSerializer):
@@ -918,6 +929,19 @@ class DashboardsViewSet(
 
     TEMPLATE_MAP = {"llm-analytics": get_llm_analytics_default_template}
 
+    def get_throttles(self):
+        if self.action == "generate_metadata":
+            return [
+                LLMAnalyticsSummarizationBurstThrottle(),
+                LLMAnalyticsSummarizationSustainedThrottle(),
+                LLMAnalyticsSummarizationDailyThrottle(),
+            ]
+        return super().get_throttles()
+
+    def _validate_ai_feature_access(self) -> None:
+        if not self.organization.is_ai_data_processing_approved:
+            raise exceptions.PermissionDenied("AI data processing must be approved by your organization")
+
     @tracer.start_as_current_span("DashboardViewSet.get_serializer_context")
     def get_serializer_context(self) -> dict[str, Any]:
         context = super().get_serializer_context()
@@ -1133,6 +1157,39 @@ class DashboardsViewSet(
             return Response({"result": "No significant changes detected in the dashboard data."})
 
         return Response({"result": analysis})
+
+    @extend_schema(
+        request=None,
+        responses={200: DashboardGeneratedMetadataSerializer},
+    )
+    @action(methods=["POST"], detail=True, required_scopes=["dashboard:write"])
+    def generate_metadata(self, request: Request, *args: Any, **kwargs: Any) -> Response:
+        """Generate an AI-suggested name and description from this dashboard's tiles."""
+        self._validate_ai_feature_access()
+        dashboard = self.get_object()
+        if not dashboard.tiles.filter(Q(insight__isnull=False) | Q(text__isnull=False)).exists():
+            return Response(
+                {
+                    "error": "Add at least one insight or text card before generating a title and description. "
+                    "Button tiles are not used for generation."
+                },
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        try:
+            summary = build_dashboard_tiles_naming_summary(dashboard)
+            metadata = generate_dashboard_metadata(
+                self.team,
+                summary,
+                current_name=(dashboard.name or "").strip() or None,
+                current_description=(dashboard.description or "").strip() or None,
+            )
+        except Exception:
+            logger.exception("dashboard_generate_metadata_failed", dashboard_id=dashboard.pk)
+            return Response(
+                {"error": "Failed to generate dashboard metadata. Please try again."},
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            )
+        return Response({"name": metadata.name, "description": metadata.description})
 
     # ******************************************
     # /projects/:id/dashboard/:id/stream_tiles

--- a/products/dashboards/frontend/generated/api.schemas.ts
+++ b/products/dashboards/frontend/generated/api.schemas.ts
@@ -443,6 +443,11 @@ export interface CopyDashboardTileRequestApi {
     tileId: number
 }
 
+export interface DashboardGeneratedMetadataApi {
+    name: string
+    description: string
+}
+
 export interface ReorderTilesRequestApi {
     /**
      * Array of tile IDs in the desired display order (top to bottom, left to right).
@@ -596,6 +601,18 @@ export type DashboardsCopyTileCreateFormat =
     (typeof DashboardsCopyTileCreateFormat)[keyof typeof DashboardsCopyTileCreateFormat]
 
 export const DashboardsCopyTileCreateFormat = {
+    Json: 'json',
+    Txt: 'txt',
+} as const
+
+export type DashboardsGenerateMetadataCreateParams = {
+    format?: DashboardsGenerateMetadataCreateFormat
+}
+
+export type DashboardsGenerateMetadataCreateFormat =
+    (typeof DashboardsGenerateMetadataCreateFormat)[keyof typeof DashboardsGenerateMetadataCreateFormat]
+
+export const DashboardsGenerateMetadataCreateFormat = {
     Json: 'json',
     Txt: 'txt',
 } as const

--- a/products/dashboards/frontend/generated/api.ts
+++ b/products/dashboards/frontend/generated/api.ts
@@ -12,6 +12,7 @@ import type {
     CopyDashboardTileRequestApi,
     DashboardApi,
     DashboardCollaboratorApi,
+    DashboardGeneratedMetadataApi,
     DashboardTemplateApi,
     DashboardTemplatesListParams,
     DashboardsAnalyzeRefreshResultCreateParams,
@@ -20,6 +21,7 @@ import type {
     DashboardsCreateParams,
     DashboardsCreateUnlistedDashboardCreateParams,
     DashboardsDestroyParams,
+    DashboardsGenerateMetadataCreateParams,
     DashboardsListParams,
     DashboardsMoveTilePartialUpdateParams,
     DashboardsPartialUpdateParams,
@@ -538,6 +540,41 @@ export const dashboardsCopyTileCreate = async (
         method: 'POST',
         headers: { 'Content-Type': 'application/json', ...options?.headers },
         body: JSON.stringify(copyDashboardTileRequestApi),
+    })
+}
+
+/**
+ * Generate an AI-suggested name and description from this dashboard's tiles.
+ */
+export const getDashboardsGenerateMetadataCreateUrl = (
+    projectId: string,
+    id: number,
+    params?: DashboardsGenerateMetadataCreateParams
+) => {
+    const normalizedParams = new URLSearchParams()
+
+    Object.entries(params || {}).forEach(([key, value]) => {
+        if (value !== undefined) {
+            normalizedParams.append(key, value === null ? 'null' : value.toString())
+        }
+    })
+
+    const stringifiedParams = normalizedParams.toString()
+
+    return stringifiedParams.length > 0
+        ? `/api/projects/${projectId}/dashboards/${id}/generate_metadata/?${stringifiedParams}`
+        : `/api/projects/${projectId}/dashboards/${id}/generate_metadata/`
+}
+
+export const dashboardsGenerateMetadataCreate = async (
+    projectId: string,
+    id: number,
+    params?: DashboardsGenerateMetadataCreateParams,
+    options?: RequestInit
+): Promise<DashboardGeneratedMetadataApi> => {
+    return apiMutator<DashboardGeneratedMetadataApi>(getDashboardsGenerateMetadataCreateUrl(projectId, id, params), {
+        ...options,
+        method: 'POST',
     })
 }
 

--- a/products/dashboards/mcp/tools.yaml
+++ b/products/dashboards/mcp/tools.yaml
@@ -190,3 +190,6 @@ tools:
     dashboards-copy-tile-create:
         operation: dashboards_copy_tile_create
         enabled: false
+    dashboards-generate-metadata-create:
+        operation: dashboards_generate_metadata_create
+        enabled: false

--- a/services/mcp/definitions/core.yaml
+++ b/services/mcp/definitions/core.yaml
@@ -602,3 +602,6 @@ tools:
     project-secret-api-keys-roll-create:
         operation: project_secret_api_keys_roll_create
         enabled: false
+    dashboards-generate-metadata-create:
+        operation: dashboards_generate_metadata_create
+        enabled: false

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -7906,6 +7906,11 @@ export namespace Schemas {
       properties?: (EventPropertyFilter | PersonPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | RevenueAnalyticsPropertyFilter)[] | null;
     }
 
+    export interface DashboardGeneratedMetadata {
+      name: string;
+      description: string;
+    }
+
     /**
      * * `team` - Only team
     * `global` - Global
@@ -29877,6 +29882,18 @@ export namespace Schemas {
       Txt: 'txt',
     } as const;
 
+    export type EnvironmentsDashboardsGenerateMetadataCreateParams = {
+    format?: EnvironmentsDashboardsGenerateMetadataCreateFormat;
+    };
+
+    export type EnvironmentsDashboardsGenerateMetadataCreateFormat = typeof EnvironmentsDashboardsGenerateMetadataCreateFormat[keyof typeof EnvironmentsDashboardsGenerateMetadataCreateFormat];
+
+
+    export const EnvironmentsDashboardsGenerateMetadataCreateFormat = {
+      Json: 'json',
+      Txt: 'txt',
+    } as const;
+
     export type EnvironmentsDashboardsMoveTilePartialUpdateParams = {
     format?: EnvironmentsDashboardsMoveTilePartialUpdateFormat;
     };
@@ -32509,6 +32526,18 @@ export namespace Schemas {
 
 
     export const DashboardsCopyTileCreateFormat = {
+      Json: 'json',
+      Txt: 'txt',
+    } as const;
+
+    export type DashboardsGenerateMetadataCreateParams = {
+    format?: DashboardsGenerateMetadataCreateFormat;
+    };
+
+    export type DashboardsGenerateMetadataCreateFormat = typeof DashboardsGenerateMetadataCreateFormat[keyof typeof DashboardsGenerateMetadataCreateFormat];
+
+
+    export const DashboardsGenerateMetadataCreateFormat = {
       Json: 'json',
       Txt: 'txt',
     } as const;


### PR DESCRIPTION
## Problem

Dashboards often ship with generic or empty titles and descriptions even when the board already contains strong signals (insight charts and user-authored text cards). Teams want a fast way to get a sensible **name** and **markdown-friendly description** without writing it from scratch as noted from survey responses

## Changes

Similar to Insights, behind a new feature flag.

Auto generates the title and description.

It factors in insight tiles + text cards and not button tiles. 

gives preference to elements first in the layout

Note:
I don't love how we initiate this at the moment, I'm still doodling on maybe a better ux.

https://github.com/user-attachments/assets/dc6cc59a-6c75-4f83-9ee6-e909e412a677


## How did you test this code?

Locally. New tests.

## Publish to changelog?

Do not publish to changelog (behind feature flag; announce when default-on or broadly rolled out).

