### PR TITLE
fix(llma): fix Z-Score normalization saturation and simulation data shortfall

### DIFF
--- a/posthog/tasks/alerts/detector.py
+++ b/posthog/tasks/alerts/detector.py
@@ -340,13 +340,29 @@ def simulate_detector_on_insight(
     detector_type_str = detector_config.get("type", "zscore")
     min_samples = _compute_min_samples_for_detector(detector_config)
 
+    # +1 because _drop_incomplete_current_interval removes the last point
+    min_samples_with_padding = min_samples + 1
+    min_date_from = _date_range_override_for_detector(trends_query, min_samples_with_padding)
+
     is_non_time_series = _is_non_time_series_trend(trends_query)
     if is_non_time_series:
         filters_override = None
     elif date_from:
-        filters_override = {"date_from": date_from}
+        # Use whichever goes further back: the user's range or the detector minimum.
+        # We parse both to absolute datetimes and pick the earlier one.
+        from zoneinfo import ZoneInfo
+
+        from posthog.utils import relative_date_parse
+
+        utc = ZoneInfo("UTC")
+        user_dt = relative_date_parse(date_from, utc)
+        min_dt = relative_date_parse(min_date_from["date_from"], utc) if min_date_from else None
+        if min_dt and min_dt < user_dt:
+            filters_override = min_date_from
+        else:
+            filters_override = {"date_from": date_from}
     else:
-        filters_override = _date_range_override_for_detector(trends_query, min_samples)
+        filters_override = min_date_from
 
     execution_mode = ExecutionMode.RECENT_CACHE_CALCULATE_BLOCKING_IF_STALE
     if trends_query.interval == IntervalType.HOUR:

--- a/posthog/tasks/alerts/detectors/statistical/zscore.py
+++ b/posthog/tasks/alerts/detectors/statistical/zscore.py
@@ -1,5 +1,4 @@
 import numpy as np
-from scipy.special import erf
 
 from posthog.schema import DetectorType
 
@@ -10,18 +9,17 @@ from posthog.tasks.alerts.detectors.registry import register_detector
 def _zscore_to_probability(z_score: float, window_zscores: np.ndarray) -> float:
     """Normalize a z-score to a [0, 1] anomaly probability.
 
-    Uses pyod's 'unify' approach: standardize the raw z-score against the
-    distribution of z-scores observed in the training window, then apply erf.
-    This asks "how unusual is this z-score compared to what we normally see?"
-    rather than mapping the raw z-score directly (which produces a fixed ~5%
-    false-positive rate regardless of data stability).
+    Uses min-max normalization against the training window z-scores,
+    consistent with PyOD's default ``linear`` method. The score represents
+    where the current z-score falls relative to the range observed in the
+    training window: 0 means at or below the minimum, 1 means at or above
+    the maximum.
     """
-    mean_z = float(window_zscores.mean())
-    std_z = float(window_zscores.std())
-    if std_z == 0:
-        return 1.0 if z_score > mean_z else 0.0
-    standardized = (z_score - mean_z) / std_z
-    return float(np.clip(erf(standardized / np.sqrt(2)), 0.0, 1.0))
+    min_z = float(window_zscores.min())
+    max_z = float(window_zscores.max())
+    if max_z == min_z:
+        return 1.0 if z_score > max_z else 0.0
+    return float(np.clip((z_score - min_z) / (max_z - min_z), 0.0, 1.0))
 
 
 @register_detector(DetectorType.ZSCORE)
@@ -32,8 +30,9 @@ class ZScoreDetector(BaseDetector):
     Detects anomalies by calculating how many standard deviations
     a value is from the rolling mean.
 
-    Scores are normalized to [0, 1] probabilities using pyod's 'unify'
-    approach (standardize against training window z-scores, then erf).
+    Scores are normalized to [0, 1] using min-max normalization against
+    the training window z-scores (consistent with PyOD's default ``linear``
+    method).
 
     Config:
         threshold: float - Anomaly probability threshold (default: 0.95)

--- a/posthog/tasks/alerts/detectors/test/test_detectors.py
+++ b/posthog/tasks/alerts/detectors/test/test_detectors.py
@@ -604,7 +604,7 @@ class TestRealisticScoreBehavior:
 
     @parameterized.expand(
         [
-            ("zscore", ZScoreDetector({"threshold": 0.95, "window": 168})),
+            ("zscore", ZScoreDetector({"threshold": 0.95, "window": 168, "preprocessing": {"diffs_n": 1}})),
             ("iqr", IQRDetector({"threshold": 0.95, "multiplier": 1.5, "window": 168})),
         ]
     )
@@ -616,7 +616,7 @@ class TestRealisticScoreBehavior:
 
     @parameterized.expand(
         [
-            ("zscore", ZScoreDetector({"threshold": 0.95, "window": 168})),
+            ("zscore", ZScoreDetector({"threshold": 0.95, "window": 168, "preprocessing": {"diffs_n": 1}})),
             ("iqr", IQRDetector({"threshold": 0.95, "multiplier": 1.5, "window": 168})),
         ]
     )
@@ -633,7 +633,7 @@ class TestRealisticScoreBehavior:
     def test_zscore_and_iforest_both_low_on_stable_data(self) -> None:
         """zscore and IsolationForest should both score low on stable data
         so that ensemble OR/AND logic behaves predictably."""
-        zr = ZScoreDetector({"threshold": 0.95, "window": 168}).detect(STABLE_HOURLY)
+        zr = ZScoreDetector({"threshold": 0.95, "window": 168, "preprocessing": {"diffs_n": 1}}).detect(STABLE_HOURLY)
         ir = IsolationForestDetector({"threshold": 0.95}).detect(STABLE_HOURLY)
 
         assert zr.score is not None and ir.score is not None


### PR DESCRIPTION
## Problem

Two issues with the Z-Score anomaly detection alerts:

1. **Scores always show ~100%**: The erf-based probability normalization (reimplemented from PyOD's `unify` method) saturates extremely fast above the threshold. Any z-score above ~2 maps to 95%+, and above ~2.5 rounds to 100%. This makes scores uninformative for triggered alerts.

2. **Simulation shows no scores**: When the user-selected simulation range (e.g. "Last 7d" = 168 hours) matches the detector window size (168), the detector's `min_length=window+1` validation fails because `_drop_incomplete_current_interval` removes one data point, leaving exactly `window` points instead of the required `window+1`.

## Changes

**Z-Score normalization** (`zscore.py`):
- Replace erf-based "unify" normalization with min-max normalization against training window z-scores
- Consistent with PyOD's default `linear` method used by all other PyOD-backed detectors in `base_pyod.py`
- Removes `scipy.special.erf` dependency

**Simulation date range** (`detector.py`):
- When user provides a custom `date_from`, compare it against the detector's minimum sample requirement (with +1 padding for dropped incomplete interval)
- Use whichever range goes further back, ensuring the detector always has enough data

**Tests** (`test_detectors.py`):
- Updated 3 realistic behavior tests to use `preprocessing: {"diffs_n": 1}` on z-score detectors, matching real-world config where differencing is always enabled

## How did you test this code?

- All 126 detector unit tests pass
- Verified min-max normalization produces score=0.39 (well below 0.95 threshold) on stable diurnal data with preprocessing, vs erf's ~0.79
- Verified batch FP rate drops to 1.2% (from ~5% with erf) on preprocessed stable data
- Verified obvious anomaly spikes still fire correctly

## Publish to changelog?

no