### PR TITLE
refactor(funnels): replace filters with queries in funnel tests

### DIFF
--- a/posthog/hogql_queries/insights/funnels/test/test_funnel.py
+++ b/posthog/hogql_queries/insights/funnels/test/test_funnel.py
@@ -1,6 +1,5 @@
 import uuid
 from datetime import datetime
-from typing import cast
 
 from freezegun import freeze_time
 from posthog.test.base import (
@@ -30,6 +29,7 @@ from posthog.schema import (
     EventsNode,
     FilterLogicalOperator,
     FunnelConversionWindowTimeUnit,
+    FunnelExclusionActionsNode,
     FunnelExclusionEventsNode,
     FunnelMathType,
     FunnelsActorsQuery,
@@ -48,7 +48,7 @@ from posthog.hogql.modifiers import create_default_modifiers_for_team
 
 from posthog.api.instance_settings import get_instance_setting
 from posthog.clickhouse.client.execute import sync_execute
-from posthog.constants import INSIGHT_FUNNELS, FunnelOrderType, FunnelVizType
+from posthog.constants import FunnelOrderType, FunnelVizType
 from posthog.hogql_queries.actors_query_runner import ActorsQueryRunner
 from posthog.hogql_queries.insights.funnels.funnel import FunnelUDF
 from posthog.hogql_queries.insights.funnels.funnel_query_context import FunnelQueryContext
@@ -59,7 +59,6 @@ from posthog.hogql_queries.insights.funnels.test.breakdown_cases import (
     funnel_breakdown_test_factory,
 )
 from posthog.hogql_queries.insights.funnels.test.conversion_time_cases import funnel_conversion_time_test_factory
-from posthog.hogql_queries.legacy_compatibility.filter_to_query import filter_to_query
 from posthog.models import Action, Element
 from posthog.models.cohort.cohort import Cohort
 from posthog.models.group.util import create_group
@@ -96,10 +95,9 @@ class TestFunnelConversionTimeUDF(
 class TestFOSSFunnelUDF(ClickhouseTestMixin, APIBaseTest):
     maxDiff = None
 
-    def _get_actor_ids_at_step(self, filters, funnelStep, funnelStepBreakdown=None):
-        funnels_query = cast(FunnelsQuery, filter_to_query(filters))
+    def _get_actor_ids_at_step(self, query, funnelStep, funnelStepBreakdown=None):
         funnel_actors_query = FunnelsActorsQuery(
-            source=funnels_query, funnelStep=funnelStep, funnelStepBreakdown=funnelStepBreakdown
+            source=query, funnelStep=funnelStep, funnelStepBreakdown=funnelStepBreakdown
         )
         actors_query = ActorsQuery(source=funnel_actors_query)
         response = ActorsQueryRunner(query=actors_query, team=self.team).calculate()
@@ -164,7 +162,7 @@ class TestFOSSFunnelUDF(ClickhouseTestMixin, APIBaseTest):
             properties={},
         )
 
-    def _basic_funnel(self, properties=None, filters=None):
+    def _basic_funnel(self, query: FunnelsQuery | None = None, properties=None):
         action_credit_card = Action.objects.create(
             team=self.team,
             name="paid",
@@ -188,22 +186,40 @@ class TestFOSSFunnelUDF(ClickhouseTestMixin, APIBaseTest):
             ],
         )
 
-        if filters is None:
-            filters = {
-                "events": [{"id": "user signed up", "type": "events", "order": 0}],
-                "actions": [
-                    {"id": action_credit_card.pk, "type": "actions", "order": 1},
-                    {"id": action_play_movie.pk, "type": "actions", "order": 2},
+        if query is None:
+            query = FunnelsQuery(
+                series=[
+                    EventsNode(
+                        event="user signed up",
+                        name="user signed up",
+                    ),
+                    ActionsNode(id=action_credit_card.pk),
+                    ActionsNode(id=action_play_movie.pk),
                 ],
-                "funnel_window_days": 14,
-            }
+            )
 
         if properties is not None:
-            filters.update({"properties": properties})
+            query = FunnelsQuery(
+                **query.model_dump(exclude_defaults=True, exclude_none=True, mode="json"),
+                properties={
+                    "type": "AND",
+                    "values": [
+                        {
+                            "type": "AND",
+                            "values": [
+                                {
+                                    "key": key,
+                                    "operator": "exact",
+                                    "type": "event",
+                                    "value": value,
+                                }
+                                for key, value in properties.items()
+                            ],
+                        }
+                    ],
+                },
+            )
 
-        filters["insight"] = INSIGHT_FUNNELS
-
-        query = cast(FunnelsQuery, filter_to_query(filters))
         return FunnelsQueryRunner(query=query, team=self.team)
 
     def test_funnel_events(self):
@@ -330,11 +346,17 @@ class TestFOSSFunnelUDF(ClickhouseTestMixin, APIBaseTest):
         )
 
         funnel = self._basic_funnel(
-            filters={
-                "events": [{"id": "user signed up", "type": "events", "order": 0}],
-                "actions": [{"id": action_play_movie.pk, "type": "actions", "order": 2}],
-                "funnel_window_days": 14,
-            }
+            query=FunnelsQuery(
+                series=[
+                    EventsNode(
+                        event="user signed up",
+                        name="user signed up",
+                    ),
+                    ActionsNode(
+                        id=action_play_movie.pk,
+                    ),
+                ],
+            )
         )
 
         # events
@@ -368,14 +390,19 @@ class TestFOSSFunnelUDF(ClickhouseTestMixin, APIBaseTest):
 
     def test_funnel_with_any_event(self):
         funnel = self._basic_funnel(
-            filters={
-                "events": [
-                    {"id": None, "type": "events", "order": 0},
-                    {"id": None, "type": "events", "order": 1},
-                    {"id": None, "type": "events", "order": 2},
+            query=FunnelsQuery(
+                series=[
+                    EventsNode(
+                        name="All events",
+                    ),
+                    EventsNode(
+                        name="All events",
+                    ),
+                    EventsNode(
+                        name="All events",
+                    ),
                 ],
-                "funnel_window_days": 14,
-            }
+            )
         )
 
         # events
@@ -423,15 +450,17 @@ class TestFOSSFunnelUDF(ClickhouseTestMixin, APIBaseTest):
         )
 
         funnel = self._basic_funnel(
-            filters={
-                "events": [{"id": "user signed up", "type": "events", "order": 1}],
-                "actions": [{"id": action_play_movie.pk, "type": "actions", "order": 2}],
-                "new_entities": [
-                    {"id": "first", "type": "new_entity", "order": 0},
-                    {"id": "last", "type": "new_entity", "order": 3},
+            query=FunnelsQuery(
+                series=[
+                    EventsNode(
+                        event="user signed up",
+                        name="user signed up",
+                    ),
+                    ActionsNode(
+                        id=action_play_movie.pk,
+                    ),
                 ],
-                "funnel_window_days": 14,
-            }
+            )
         )
 
         # events
@@ -521,39 +550,44 @@ class TestFOSSFunnelUDF(ClickhouseTestMixin, APIBaseTest):
                 }
             ],
         )
-        filters = {
-            "events": [
-                {
-                    "id": "user signed up",
-                    "type": "events",
-                    "order": 0,
-                    "properties": [
-                        {"key": "$browser", "value": "Safari"},
+        query = FunnelsQuery(
+            series=[
+                EventsNode(
+                    event="user signed up",
+                    name="user signed up",
+                    properties=[
+                        {
+                            "key": "$browser",
+                            "value": "Safari",
+                        },
                         {
                             "key": "$browser",
                             "operator": "is_not",
                             "value": "Chrome",
                         },
                     ],
-                }
+                ),
+                ActionsNode(
+                    id=action_credit_card.pk,
+                    properties=[
+                        {
+                            "key": "$browser",
+                            "value": "Safari",
+                        },
+                    ],
+                ),
+                ActionsNode(
+                    id=action_play_movie.pk,
+                    properties=[
+                        {
+                            "key": "$browser",
+                            "value": "Firefox",
+                        },
+                    ],
+                ),
             ],
-            "actions": [
-                {
-                    "id": action_credit_card.pk,
-                    "type": "actions",
-                    "order": 1,
-                    "properties": [{"key": "$browser", "value": "Safari"}],
-                },
-                {
-                    "id": action_play_movie.pk,
-                    "type": "actions",
-                    "order": 2,
-                    "properties": [{"key": "$browser", "value": "Firefox"}],
-                },
-            ],
-            "funnel_window_days": 14,
-        }
-        funnel = self._basic_funnel(filters=filters)
+        )
+        funnel = self._basic_funnel(query)
 
         # events
         _create_person(
@@ -606,28 +640,29 @@ class TestFOSSFunnelUDF(ClickhouseTestMixin, APIBaseTest):
                 }
             ],
         )
-        filters = {
-            "events": [
-                {
-                    "id": "user signed up",
-                    "type": "events",
-                    "order": 0,
-                    "properties": [
+        query = FunnelsQuery(
+            series=[
+                EventsNode(
+                    event="user signed up",
+                    name="user signed up",
+                    properties=[
                         {
                             "key": "email",
-                            "value": "hello@posthog.com",
+                            "operator": "exact",
                             "type": "person",
-                        }
+                            "value": "hello@posthog.com",
+                        },
                     ],
-                }
+                ),
+                ActionsNode(
+                    id=action_credit_card.pk,
+                ),
+                ActionsNode(
+                    id=action_play_movie.pk,
+                ),
             ],
-            "actions": [
-                {"id": action_credit_card.pk, "type": "actions", "order": 1},
-                {"id": action_play_movie.pk, "type": "actions", "order": 2},
-            ],
-            "funnel_window_days": 14,
-        }
-        funnel = self._basic_funnel(filters=filters)
+        )
+        funnel = self._basic_funnel(query)
 
         # events
         _create_person(
@@ -679,16 +714,20 @@ class TestFOSSFunnelUDF(ClickhouseTestMixin, APIBaseTest):
             ],
         )
 
-        filters = {
-            "events": [{"id": "event1", "order": 0}],
-            "actions": [
-                {"id": action1.pk, "order": 1},
-                {"id": action2.pk, "order": 2},
+        query = FunnelsQuery(
+            series=[
+                EventsNode(
+                    event="event1",
+                    name="event1",
+                ),
+                ActionsNode(
+                    id=action1.pk,
+                ),
+                ActionsNode(
+                    id=action2.pk,
+                ),
             ],
-            "insight": INSIGHT_FUNNELS,
-            "funnel_window_days": 14,
-        }
-        query = cast(FunnelsQuery, filter_to_query(filters))
+        )
         results = FunnelsQueryRunner(query=query, team=self.team).calculate().results
 
         self.assertEqual(results[0]["count"], 1)
@@ -706,13 +745,19 @@ class TestFOSSFunnelUDF(ClickhouseTestMixin, APIBaseTest):
         _create_event(distinct_id="person1", event="event1", team=self.team)
         _create_event(distinct_id="person2", event="event1", team=self.team)
 
-        filters = {
-            "events": [{"id": "event1", "order": 0}, {"id": "event1", "order": 1}],
-            "insight": INSIGHT_FUNNELS,
-            "filter_test_accounts": True,
-            "funnel_window_days": 14,
-        }
-        query = cast(FunnelsQuery, filter_to_query(filters))
+        query = FunnelsQuery(
+            filterTestAccounts=True,
+            series=[
+                EventsNode(
+                    event="event1",
+                    name="event1",
+                ),
+                EventsNode(
+                    event="event1",
+                    name="event1",
+                ),
+            ],
+        )
         results = FunnelsQueryRunner(query=query, team=self.team).calculate().results
 
         self.assertEqual(results[0]["count"], 1)
@@ -734,26 +779,25 @@ class TestFOSSFunnelUDF(ClickhouseTestMixin, APIBaseTest):
         _create_event(distinct_id="person2", event="event1", team=self.team)
         _create_event(distinct_id="person3", event="event1", team=self.team)
 
-        filters = {
-            "events": [
-                {
-                    "id": "event1",
-                    "order": 0,
-                    "properties": [
+        query = FunnelsQuery(
+            series=[
+                EventsNode(
+                    event="event1",
+                    name="event1",
+                    properties=[
                         {
                             "key": "email",
-                            "value": "is_set",
                             "operator": "is_set",
                             "type": "person",
-                        }
+                            "value": "is_set",
+                        },
                     ],
-                },
-                {"id": None, "order": 1},
+                ),
+                EventsNode(
+                    name="All events",
+                ),
             ],
-            "insight": INSIGHT_FUNNELS,
-            "funnel_window_days": 14,
-        }
-        query = cast(FunnelsQuery, filter_to_query(filters))
+        )
         results = FunnelsQueryRunner(query=query, team=self.team).calculate().results
 
         self.assertEqual(results[0]["count"], 2)
@@ -793,29 +837,37 @@ class TestFOSSFunnelUDF(ClickhouseTestMixin, APIBaseTest):
             ],
         )
 
-        filters = {
-            "actions": [
-                {"id": action.pk, "type": "actions", "order": 0},
-                {"id": action.pk, "type": "actions", "order": 1},
+        query = FunnelsQuery(
+            series=[
+                ActionsNode(
+                    id=action.pk,
+                ),
+                ActionsNode(
+                    id=action.pk,
+                ),
             ],
-            "insight": INSIGHT_FUNNELS,
-            "funnel_window_days": 14,
-        }
-        query = cast(FunnelsQuery, filter_to_query(filters))
+        )
         results = FunnelsQueryRunner(query=query, team=self.team).calculate().results
 
         self.assertEqual(results[0]["count"], 2)
 
     def test_basic_funnel_default_funnel_days(self):
-        filters = {
-            "events": [
-                {"id": "user signed up", "type": "events", "order": 0},
-                {"id": "paid", "type": "events", "order": 1},
+        query = FunnelsQuery(
+            dateRange=DateRange(
+                date_from="2020-01-01",
+                date_to="2020-01-14",
+            ),
+            series=[
+                EventsNode(
+                    event="user signed up",
+                    name="user signed up",
+                ),
+                EventsNode(
+                    event="paid",
+                    name="paid",
+                ),
             ],
-            "insight": INSIGHT_FUNNELS,
-            "date_from": "2020-01-01",
-            "date_to": "2020-01-14",
-        }
+        )
 
         # event
         _create_person(distinct_ids=["user_1"], team_id=self.team.pk)
@@ -832,7 +884,6 @@ class TestFOSSFunnelUDF(ClickhouseTestMixin, APIBaseTest):
             timestamp="2020-01-10T14:00:00Z",
         )
 
-        query = cast(FunnelsQuery, filter_to_query(filters))
         results = FunnelsQueryRunner(query=query, team=self.team).calculate().results
 
         self.assertEqual(results[0]["name"], "user signed up")
@@ -842,17 +893,26 @@ class TestFOSSFunnelUDF(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(results[1]["count"], 1)
 
     def test_basic_funnel_with_person_id_override_properties_joined_modifier_and_person_breakdown(self):
-        filters = {
-            "events": [
-                {"id": "user signed up", "type": "events", "order": 0},
-                {"id": "paid", "type": "events", "order": 1},
+        query = FunnelsQuery(
+            breakdownFilter=BreakdownFilter(
+                breakdown="$browser",
+                breakdown_type="person",
+            ),
+            dateRange=DateRange(
+                date_from="2020-01-01",
+                date_to="2020-01-14",
+            ),
+            series=[
+                EventsNode(
+                    event="user signed up",
+                    name="user signed up",
+                ),
+                EventsNode(
+                    event="paid",
+                    name="paid",
+                ),
             ],
-            "insight": INSIGHT_FUNNELS,
-            "date_from": "2020-01-01",
-            "date_to": "2020-01-14",
-            "breakdown": "$browser",
-            "breakdown_type": "person",
-        }
+        )
 
         # event
         _create_person(distinct_ids=["user_1"], team_id=self.team.pk)
@@ -869,7 +929,6 @@ class TestFOSSFunnelUDF(ClickhouseTestMixin, APIBaseTest):
             timestamp="2020-01-10T14:00:00Z",
         )
 
-        query = cast(FunnelsQuery, filter_to_query(filters))
         results = (
             FunnelsQueryRunner(
                 query=query,
@@ -890,14 +949,18 @@ class TestFOSSFunnelUDF(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(results[0][1]["count"], 1)
 
     def test_basic_funnel_with_repeat_steps(self):
-        filters = {
-            "events": [
-                {"id": "user signed up", "type": "events", "order": 0},
-                {"id": "user signed up", "type": "events", "order": 1},
+        query = FunnelsQuery(
+            series=[
+                EventsNode(
+                    event="user signed up",
+                    name="user signed up",
+                ),
+                EventsNode(
+                    event="user signed up",
+                    name="user signed up",
+                ),
             ],
-            "insight": INSIGHT_FUNNELS,
-            "funnel_window_days": 14,
-        }
+        )
 
         # event
         person1_stopped_after_two_signups = _create_person(distinct_ids=["stopped_after_signup1"], team_id=self.team.pk)
@@ -919,7 +982,6 @@ class TestFOSSFunnelUDF(ClickhouseTestMixin, APIBaseTest):
             distinct_id="stopped_after_signup2",
         )
 
-        query = cast(FunnelsQuery, filter_to_query(filters))
         results = FunnelsQueryRunner(query=query, team=self.team).calculate().results
 
         self.assertEqual(results[0]["name"], "user signed up")
@@ -928,7 +990,7 @@ class TestFOSSFunnelUDF(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(results[1]["count"], 1)
 
         self.assertCountEqual(
-            self._get_actor_ids_at_step(filters, 1),
+            self._get_actor_ids_at_step(query, 1),
             [
                 person1_stopped_after_two_signups.uuid,
                 person2_stopped_after_signup.uuid,
@@ -936,25 +998,30 @@ class TestFOSSFunnelUDF(ClickhouseTestMixin, APIBaseTest):
         )
 
         self.assertCountEqual(
-            self._get_actor_ids_at_step(filters, 2),
+            self._get_actor_ids_at_step(query, 2),
             [person1_stopped_after_two_signups.uuid],
         )
 
     @also_test_with_materialized_columns(["key"])
     def test_basic_funnel_with_derivative_steps(self):
-        filters = {
-            "events": [
-                {
-                    "id": "user signed up",
-                    "type": "events",
-                    "order": 0,
-                    "properties": {"key": "val"},
-                },
-                {"id": "user signed up", "type": "events", "order": 1},
+        query = FunnelsQuery(
+            series=[
+                EventsNode(
+                    event="user signed up",
+                    name="user signed up",
+                    properties=[
+                        {
+                            "key": "key",
+                            "value": "val",
+                        },
+                    ],
+                ),
+                EventsNode(
+                    event="user signed up",
+                    name="user signed up",
+                ),
             ],
-            "insight": INSIGHT_FUNNELS,
-            "funnel_window_days": 14,
-        }
+        )
 
         # event
         person1_stopped_after_two_signups = _create_person(distinct_ids=["stopped_after_signup1"], team_id=self.team.pk)
@@ -978,7 +1045,6 @@ class TestFOSSFunnelUDF(ClickhouseTestMixin, APIBaseTest):
             properties={"key": "val"},
         )
 
-        query = cast(FunnelsQuery, filter_to_query(filters))
         results = FunnelsQueryRunner(query=query, team=self.team).calculate().results
 
         self.assertEqual(results[0]["name"], "user signed up")
@@ -987,7 +1053,7 @@ class TestFOSSFunnelUDF(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(results[1]["count"], 1)
 
         self.assertCountEqual(
-            self._get_actor_ids_at_step(filters, 1),
+            self._get_actor_ids_at_step(query, 1),
             [
                 person1_stopped_after_two_signups.uuid,
                 person2_stopped_after_signup.uuid,
@@ -995,7 +1061,7 @@ class TestFOSSFunnelUDF(ClickhouseTestMixin, APIBaseTest):
         )
 
         self.assertCountEqual(
-            self._get_actor_ids_at_step(filters, 2),
+            self._get_actor_ids_at_step(query, 2),
             [person1_stopped_after_two_signups.uuid],
         )
 
@@ -1011,17 +1077,19 @@ class TestFOSSFunnelUDF(ClickhouseTestMixin, APIBaseTest):
             self.team,
         )
 
-        filters = {
-            "events": [
-                {"id": "user signed up", "type": "events", "order": 0},
-                {"id": "user signed up", "type": "events", "order": 1},
+        query = FunnelsQuery(
+            series=[
+                EventsNode(
+                    event="user signed up",
+                    name="user signed up",
+                ),
+                EventsNode(
+                    event="user signed up",
+                    name="user signed up",
+                ),
             ],
-            "insight": INSIGHT_FUNNELS,
-            "funnel_window_interval": 14,
-            "funnel_window_interval_unit": "day",
-        }
+        )
 
-        query = cast(FunnelsQuery, filter_to_query(filters))
         results = FunnelsQueryRunner(query=query, team=self.team).calculate().results
 
         self.assertEqual(results[0]["name"], "user signed up")
@@ -1030,7 +1098,7 @@ class TestFOSSFunnelUDF(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(results[1]["count"], 1)
 
         self.assertCountEqual(
-            self._get_actor_ids_at_step(filters, 1),
+            self._get_actor_ids_at_step(query, 1),
             [
                 people["stopped_after_signup1"].uuid,
                 people["stopped_after_signup2"].uuid,
@@ -1038,53 +1106,77 @@ class TestFOSSFunnelUDF(ClickhouseTestMixin, APIBaseTest):
         )
 
         self.assertCountEqual(
-            self._get_actor_ids_at_step(filters, 2),
+            self._get_actor_ids_at_step(query, 2),
             [people["stopped_after_signup1"].uuid],
         )
 
-        filters = {
-            "events": [
-                {"id": "user signed up", "type": "events", "order": 0},
-                {"id": "user signed up", "type": "events", "order": 1},
+        query = FunnelsQuery(
+            funnelsFilter=FunnelsFilter(
+                funnelWindowInterval=2,
+                funnelWindowIntervalUnit="week",
+            ),
+            series=[
+                EventsNode(
+                    event="user signed up",
+                    name="user signed up",
+                ),
+                EventsNode(
+                    event="user signed up",
+                    name="user signed up",
+                ),
             ],
-            "insight": INSIGHT_FUNNELS,
-            "funnel_window_days": 14,
-            "funnel_window_interval": 2,
-            "funnel_window_interval_unit": "week",
-        }
+        )
 
-        query = cast(FunnelsQuery, filter_to_query(filters))
         result2 = FunnelsQueryRunner(query=query, team=self.team).calculate().results
 
         assert_funnel_results_equal(results, result2)
 
-        filters = {
-            "events": [
-                {"id": "user signed up", "type": "events", "order": 0},
-                {"id": "user signed up", "type": "events", "order": 1},
+        query = FunnelsQuery(
+            funnelsFilter=FunnelsFilter(
+                funnelWindowInterval=1,
+                funnelWindowIntervalUnit="hour",
+            ),
+            series=[
+                EventsNode(
+                    event="user signed up",
+                    name="user signed up",
+                ),
+                EventsNode(
+                    event="user signed up",
+                    name="user signed up",
+                ),
             ],
-            "insight": INSIGHT_FUNNELS,
-            "funnel_window_days": 14,
-            "funnel_window_interval": 1,
-            "funnel_window_interval_unit": "hour",
-        }
+        )
 
-        query = cast(FunnelsQuery, filter_to_query(filters))
         result3 = FunnelsQueryRunner(query=query, team=self.team).calculate().results
 
         assert_funnel_results_equal(results, result3)
 
     def test_advanced_funnel_with_repeat_steps(self):
-        filters = {
-            "events": [
-                {"id": "user signed up", "type": "events", "order": 0},
-                {"id": "$pageview", "type": "events", "order": 1},
-                {"id": "$pageview", "type": "events", "order": 2},
-                {"id": "$pageview", "type": "events", "order": 3},
-                {"id": "$pageview", "type": "events", "order": 4},
+        query = FunnelsQuery(
+            series=[
+                EventsNode(
+                    event="user signed up",
+                    name="user signed up",
+                ),
+                EventsNode(
+                    event="$pageview",
+                    name="$pageview",
+                ),
+                EventsNode(
+                    event="$pageview",
+                    name="$pageview",
+                ),
+                EventsNode(
+                    event="$pageview",
+                    name="$pageview",
+                ),
+                EventsNode(
+                    event="$pageview",
+                    name="$pageview",
+                ),
             ],
-            "insight": INSIGHT_FUNNELS,
-        }
+        )
 
         people = journeys_for(
             {
@@ -1118,7 +1210,6 @@ class TestFOSSFunnelUDF(ClickhouseTestMixin, APIBaseTest):
             self.team,
         )
 
-        query = cast(FunnelsQuery, filter_to_query(filters))
         results = FunnelsQueryRunner(query=query, team=self.team).calculate().results
 
         self.assertEqual(results[0]["name"], "user signed up")
@@ -1136,7 +1227,7 @@ class TestFOSSFunnelUDF(ClickhouseTestMixin, APIBaseTest):
 
         # check ordering of people in every step
         self.assertCountEqual(
-            self._get_actor_ids_at_step(filters, 1),
+            self._get_actor_ids_at_step(query, 1),
             [
                 people["stopped_after_signup1"].uuid,
                 people["stopped_after_pageview1"].uuid,
@@ -1147,7 +1238,7 @@ class TestFOSSFunnelUDF(ClickhouseTestMixin, APIBaseTest):
         )
 
         self.assertCountEqual(
-            self._get_actor_ids_at_step(filters, 2),
+            self._get_actor_ids_at_step(query, 2),
             [
                 people["stopped_after_pageview1"].uuid,
                 people["stopped_after_pageview2"].uuid,
@@ -1157,7 +1248,7 @@ class TestFOSSFunnelUDF(ClickhouseTestMixin, APIBaseTest):
         )
 
         self.assertCountEqual(
-            self._get_actor_ids_at_step(filters, 3),
+            self._get_actor_ids_at_step(query, 3),
             [
                 people["stopped_after_pageview2"].uuid,
                 people["stopped_after_pageview3"].uuid,
@@ -1166,7 +1257,7 @@ class TestFOSSFunnelUDF(ClickhouseTestMixin, APIBaseTest):
         )
 
         self.assertCountEqual(
-            self._get_actor_ids_at_step(filters, 4),
+            self._get_actor_ids_at_step(query, 4),
             [
                 people["stopped_after_pageview3"].uuid,
                 people["stopped_after_pageview4"].uuid,
@@ -1174,22 +1265,35 @@ class TestFOSSFunnelUDF(ClickhouseTestMixin, APIBaseTest):
         )
 
         self.assertCountEqual(
-            self._get_actor_ids_at_step(filters, 5),
+            self._get_actor_ids_at_step(query, 5),
             [people["stopped_after_pageview4"].uuid],
         )
 
     def test_advanced_funnel_with_repeat_steps_out_of_order_events(self):
-        filters = {
-            "events": [
-                {"id": "user signed up", "type": "events", "order": 0},
-                {"id": "$pageview", "type": "events", "order": 1},
-                {"id": "$pageview", "type": "events", "order": 2},
-                {"id": "$pageview", "type": "events", "order": 3},
-                {"id": "$pageview", "type": "events", "order": 4},
+        query = FunnelsQuery(
+            series=[
+                EventsNode(
+                    event="user signed up",
+                    name="user signed up",
+                ),
+                EventsNode(
+                    event="$pageview",
+                    name="$pageview",
+                ),
+                EventsNode(
+                    event="$pageview",
+                    name="$pageview",
+                ),
+                EventsNode(
+                    event="$pageview",
+                    name="$pageview",
+                ),
+                EventsNode(
+                    event="$pageview",
+                    name="$pageview",
+                ),
             ],
-            "insight": INSIGHT_FUNNELS,
-            "funnel_window_days": 14,
-        }
+        )
 
         # event
         person1_stopped_after_signup = _create_person(
@@ -1279,7 +1383,6 @@ class TestFOSSFunnelUDF(ClickhouseTestMixin, APIBaseTest):
         _create_event(team=self.team, event="$pageview", distinct_id="stopped_after_pageview5")
         _create_event(team=self.team, event="$pageview", distinct_id="stopped_after_pageview5")
 
-        query = cast(FunnelsQuery, filter_to_query(filters))
         results = FunnelsQueryRunner(query=query, team=self.team).calculate().results
 
         self.assertEqual(results[0]["name"], "user signed up")
@@ -1297,7 +1400,7 @@ class TestFOSSFunnelUDF(ClickhouseTestMixin, APIBaseTest):
 
         # check ordering of people in every step
         self.assertCountEqual(
-            self._get_actor_ids_at_step(filters, 1),
+            self._get_actor_ids_at_step(query, 1),
             [
                 person1_stopped_after_signup.uuid,
                 person2_stopped_after_one_pageview.uuid,
@@ -1308,7 +1411,7 @@ class TestFOSSFunnelUDF(ClickhouseTestMixin, APIBaseTest):
         )
 
         self.assertCountEqual(
-            self._get_actor_ids_at_step(filters, 2),
+            self._get_actor_ids_at_step(query, 2),
             [
                 person2_stopped_after_one_pageview.uuid,
                 person3_stopped_after_two_pageview.uuid,
@@ -1318,17 +1421,17 @@ class TestFOSSFunnelUDF(ClickhouseTestMixin, APIBaseTest):
         )
 
         self.assertCountEqual(
-            self._get_actor_ids_at_step(filters, 3),
+            self._get_actor_ids_at_step(query, 3),
             [person5_stopped_after_many_pageview.uuid],
         )
 
         self.assertCountEqual(
-            self._get_actor_ids_at_step(filters, 4),
+            self._get_actor_ids_at_step(query, 4),
             [person5_stopped_after_many_pageview.uuid],
         )
 
         self.assertCountEqual(
-            self._get_actor_ids_at_step(filters, 5),
+            self._get_actor_ids_at_step(query, 5),
             [person5_stopped_after_many_pageview.uuid],
         )
 
@@ -1347,13 +1450,16 @@ class TestFOSSFunnelUDF(ClickhouseTestMixin, APIBaseTest):
             ],
         )
 
-        filters = {
-            "actions": [
-                {"id": sign_up_action.id, "math": "dau", "order": 0},
-                {"id": sign_up_action.id, "math": "weekly_active", "order": 1},
+        query = FunnelsQuery(
+            series=[
+                ActionsNode(
+                    id=sign_up_action.id,
+                ),
+                ActionsNode(
+                    id=sign_up_action.id,
+                ),
             ],
-            "insight": INSIGHT_FUNNELS,
-        }
+        )
 
         # event
         person1_stopped_after_two_signups = _create_person(distinct_ids=["stopped_after_signup1"], team_id=self.team.pk)
@@ -1378,7 +1484,6 @@ class TestFOSSFunnelUDF(ClickhouseTestMixin, APIBaseTest):
             properties={"key": "val"},
         )
 
-        query = cast(FunnelsQuery, filter_to_query(filters))
         results = FunnelsQueryRunner(query=query, team=self.team).calculate().results
 
         self.assertEqual(results[0]["name"], "sign up")
@@ -1388,7 +1493,7 @@ class TestFOSSFunnelUDF(ClickhouseTestMixin, APIBaseTest):
 
         # check ordering of people in first step
         self.assertCountEqual(
-            self._get_actor_ids_at_step(filters, 1),
+            self._get_actor_ids_at_step(query, 1),
             [
                 person1_stopped_after_two_signups.uuid,
                 person2_stopped_after_signup.uuid,
@@ -1396,7 +1501,7 @@ class TestFOSSFunnelUDF(ClickhouseTestMixin, APIBaseTest):
         )
 
         self.assertCountEqual(
-            self._get_actor_ids_at_step(filters, 2),
+            self._get_actor_ids_at_step(query, 2),
             [person1_stopped_after_two_signups.uuid],
         )
 
@@ -1414,13 +1519,21 @@ class TestFOSSFunnelUDF(ClickhouseTestMixin, APIBaseTest):
             ],
         )
 
-        filters = {
-            "actions": [{"id": sign_up_action.id, "order": 0}],
-            "events": [{"id": "$pageview", "order": 1}],
-            "insight": INSIGHT_FUNNELS,
-            "date_from": "2020-01-01",
-            "date_to": "2020-01-07",
-        }
+        query = FunnelsQuery(
+            dateRange=DateRange(
+                date_from="2020-01-01",
+                date_to="2020-01-07",
+            ),
+            series=[
+                ActionsNode(
+                    id=sign_up_action.id,
+                ),
+                EventsNode(
+                    event="$pageview",
+                    name="$pageview",
+                ),
+            ],
+        )
 
         with freeze_time("2020-01-03"):
             # event
@@ -1448,7 +1561,6 @@ class TestFOSSFunnelUDF(ClickhouseTestMixin, APIBaseTest):
                 properties={"key": "val"},
             )
 
-            query = cast(FunnelsQuery, filter_to_query(filters))
             results = FunnelsQueryRunner(query=query, team=self.team).calculate().results
 
             self.assertEqual(results[0]["name"], "sign up")
@@ -1458,7 +1570,7 @@ class TestFOSSFunnelUDF(ClickhouseTestMixin, APIBaseTest):
 
             # check ordering of people in first step
             self.assertCountEqual(
-                self._get_actor_ids_at_step(filters, 1),
+                self._get_actor_ids_at_step(query, 1),
                 [
                     person1_stopped_after_two_signups.uuid,
                     person2_stopped_after_signup.uuid,
@@ -1466,7 +1578,7 @@ class TestFOSSFunnelUDF(ClickhouseTestMixin, APIBaseTest):
             )
 
             self.assertCountEqual(
-                self._get_actor_ids_at_step(filters, 2),
+                self._get_actor_ids_at_step(query, 2),
                 [person1_stopped_after_two_signups.uuid],
             )
 
@@ -1484,13 +1596,16 @@ class TestFOSSFunnelUDF(ClickhouseTestMixin, APIBaseTest):
             ],
         )
 
-        filters = {
-            "actions": [
-                {"id": sign_up_action.id, "math": "dau", "order": 0},
-                {"id": sign_up_action.id, "math": "weekly_active", "order": 1},
+        query = FunnelsQuery(
+            series=[
+                ActionsNode(
+                    id=sign_up_action.id,
+                ),
+                ActionsNode(
+                    id=sign_up_action.id,
+                ),
             ],
-            "insight": INSIGHT_FUNNELS,
-        }
+        )
 
         # event
         person1_stopped_after_two_signups = _create_person(
@@ -1523,7 +1638,6 @@ class TestFOSSFunnelUDF(ClickhouseTestMixin, APIBaseTest):
             properties={"key": "val"},
         )
 
-        query = cast(FunnelsQuery, filter_to_query(filters))
         results = FunnelsQueryRunner(query=query, team=self.team).calculate().results
 
         self.assertEqual(results[0]["name"], "sign up")
@@ -1533,7 +1647,7 @@ class TestFOSSFunnelUDF(ClickhouseTestMixin, APIBaseTest):
 
         # check ordering of people in first step
         self.assertCountEqual(
-            self._get_actor_ids_at_step(filters, 1),
+            self._get_actor_ids_at_step(query, 1),
             [
                 person1_stopped_after_two_signups.uuid,
                 person2_stopped_after_signup.uuid,
@@ -1541,7 +1655,7 @@ class TestFOSSFunnelUDF(ClickhouseTestMixin, APIBaseTest):
         )
 
         self.assertCountEqual(
-            self._get_actor_ids_at_step(filters, 2),
+            self._get_actor_ids_at_step(query, 2),
             [person1_stopped_after_two_signups.uuid],
         )
 
@@ -1563,13 +1677,16 @@ class TestFOSSFunnelUDF(ClickhouseTestMixin, APIBaseTest):
             ],
         )
 
-        filters = {
-            "actions": [
-                {"id": sign_up_action.id, "math": "dau", "order": 0},
-                {"id": sign_up_action.id, "math": "weekly_active", "order": 1},
+        query = FunnelsQuery(
+            series=[
+                ActionsNode(
+                    id=sign_up_action.id,
+                ),
+                ActionsNode(
+                    id=sign_up_action.id,
+                ),
             ],
-            "insight": INSIGHT_FUNNELS,
-        }
+        )
 
         # event
         person1_stopped_after_two_signups = _create_person(
@@ -1617,7 +1734,6 @@ class TestFOSSFunnelUDF(ClickhouseTestMixin, APIBaseTest):
             person_id="00000000-0000-0000-0000-000000000000",
         )
 
-        query = cast(FunnelsQuery, filter_to_query(filters))
         results = FunnelsQueryRunner(query=query, team=self.team).calculate().results
 
         self.assertEqual(results[0]["name"], "sign up")
@@ -1627,7 +1743,7 @@ class TestFOSSFunnelUDF(ClickhouseTestMixin, APIBaseTest):
 
         # check ordering of people in first step
         self.assertCountEqual(
-            self._get_actor_ids_at_step(filters, 1),
+            self._get_actor_ids_at_step(query, 1),
             [
                 person1_stopped_after_two_signups.uuid,
                 person2_stopped_after_signup.uuid,
@@ -1635,35 +1751,54 @@ class TestFOSSFunnelUDF(ClickhouseTestMixin, APIBaseTest):
         )
 
         self.assertCountEqual(
-            self._get_actor_ids_at_step(filters, 2),
+            self._get_actor_ids_at_step(query, 2),
             [person1_stopped_after_two_signups.uuid],
         )
 
     @also_test_with_materialized_columns(["$current_url"])
     def test_funnel_with_matching_properties(self):
-        filters = {
-            "events": [
-                {"id": "user signed up", "order": 0},
-                {
-                    "id": "$pageview",
-                    "order": 1,
-                    "properties": {"$current_url": "aloha.com"},
-                },
-                {
-                    "id": "$pageview",
-                    "order": 2,
-                    "properties": {"$current_url": "aloha2.com"},
-                },  # different event to above
-                {
-                    "id": "$pageview",
-                    "order": 3,
-                    "properties": {"$current_url": "aloha2.com"},
-                },
-                {"id": "$pageview", "order": 4},
+        query = FunnelsQuery(
+            series=[
+                EventsNode(
+                    event="user signed up",
+                    name="user signed up",
+                ),
+                EventsNode(
+                    event="$pageview",
+                    name="$pageview",
+                    properties=[
+                        {
+                            "key": "$current_url",
+                            "value": "aloha.com",
+                        },
+                    ],
+                ),
+                EventsNode(
+                    event="$pageview",
+                    name="$pageview",
+                    properties=[
+                        {
+                            "key": "$current_url",
+                            "value": "aloha2.com",
+                        },
+                    ],
+                ),
+                EventsNode(
+                    event="$pageview",
+                    name="$pageview",
+                    properties=[
+                        {
+                            "key": "$current_url",
+                            "value": "aloha2.com",
+                        },
+                    ],
+                ),
+                EventsNode(
+                    event="$pageview",
+                    name="$pageview",
+                ),
             ],
-            "insight": INSIGHT_FUNNELS,
-            "funnel_window_days": 14,
-        }
+        )
 
         # event
         people = journeys_for(
@@ -1731,7 +1866,6 @@ class TestFOSSFunnelUDF(ClickhouseTestMixin, APIBaseTest):
             self.team,
         )
 
-        query = cast(FunnelsQuery, filter_to_query(filters))
         results = FunnelsQueryRunner(query=query, team=self.team).calculate().results
 
         self.assertEqual(results[0]["name"], "user signed up")
@@ -1744,7 +1878,7 @@ class TestFOSSFunnelUDF(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(results[4]["count"], 0)
         # check ordering of people in every step
         self.assertCountEqual(
-            self._get_actor_ids_at_step(filters, 1),
+            self._get_actor_ids_at_step(query, 1),
             [
                 people["stopped_after_signup1"].uuid,
                 people["stopped_after_pageview1"].uuid,
@@ -1755,7 +1889,7 @@ class TestFOSSFunnelUDF(ClickhouseTestMixin, APIBaseTest):
         )
 
         self.assertCountEqual(
-            self._get_actor_ids_at_step(filters, 2),
+            self._get_actor_ids_at_step(query, 2),
             [
                 people["stopped_after_pageview1"].uuid,
                 people["stopped_after_pageview2"].uuid,
@@ -1765,7 +1899,7 @@ class TestFOSSFunnelUDF(ClickhouseTestMixin, APIBaseTest):
         )
 
         self.assertCountEqual(
-            self._get_actor_ids_at_step(filters, 3),
+            self._get_actor_ids_at_step(query, 3),
             [
                 people["stopped_after_pageview2"].uuid,
                 people["stopped_after_pageview3"].uuid,
@@ -1774,14 +1908,14 @@ class TestFOSSFunnelUDF(ClickhouseTestMixin, APIBaseTest):
         )
 
         self.assertCountEqual(
-            self._get_actor_ids_at_step(filters, 4),
+            self._get_actor_ids_at_step(query, 4),
             [
                 people["stopped_after_pageview3"].uuid,
                 people["stopped_after_pageview4"].uuid,
             ],
         )
 
-        self.assertCountEqual(self._get_actor_ids_at_step(filters, 5), [])
+        self.assertCountEqual(self._get_actor_ids_at_step(query, 5), [])
 
     def test_funnel_conversion_window(self):
         ids_to_compare = []
@@ -1816,20 +1950,31 @@ class TestFOSSFunnelUDF(ClickhouseTestMixin, APIBaseTest):
                 timestamp="2021-05-10 00:00:00",
             )
 
-        filters = {
-            "insight": INSIGHT_FUNNELS,
-            "interval": "day",
-            "date_from": "2021-05-01 00:00:00",
-            "date_to": "2021-05-14 00:00:00",
-            "funnel_window_interval": 7,
-            "events": [
-                {"id": "step one", "order": 0},
-                {"id": "step two", "order": 1},
-                {"id": "step three", "order": 2},
+        query = FunnelsQuery(
+            dateRange=DateRange(
+                date_from="2021-05-01 00:00:00",
+                date_to="2021-05-14 00:00:00",
+            ),
+            funnelsFilter=FunnelsFilter(
+                funnelWindowInterval=7,
+            ),
+            interval="day",
+            series=[
+                EventsNode(
+                    event="step one",
+                    name="step one",
+                ),
+                EventsNode(
+                    event="step two",
+                    name="step two",
+                ),
+                EventsNode(
+                    event="step three",
+                    name="step three",
+                ),
             ],
-        }
+        )
 
-        query = cast(FunnelsQuery, filter_to_query(filters))
         results = FunnelsQueryRunner(query=query, team=self.team).calculate().results
 
         self.assertEqual(results[0]["count"], 25)
@@ -1837,7 +1982,7 @@ class TestFOSSFunnelUDF(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(results[2]["count"], 0)
 
         self.assertCountEqual(
-            [str(id) for id in self._get_actor_ids_at_step(filters, 2)],
+            [str(id) for id in self._get_actor_ids_at_step(query, 2)],
             ids_to_compare,
         )
 
@@ -1875,19 +2020,30 @@ class TestFOSSFunnelUDF(ClickhouseTestMixin, APIBaseTest):
                 timestamp="2021-05-01 00:00:20",
             )
 
-        filters = {
-            "insight": INSIGHT_FUNNELS,
-            "date_from": "2021-05-01 00:00:00",
-            "date_to": "2021-05-14 00:00:00",
-            "funnel_window_interval": 15,
-            "funnel_window_interval_unit": "second",
-            "events": [
-                {"id": "step one", "order": 0},
-                {"id": "step two", "order": 1},
-                {"id": "step three", "order": 2},
+        query = FunnelsQuery(
+            dateRange=DateRange(
+                date_from="2021-05-01 00:00:00",
+                date_to="2021-05-14 00:00:00",
+            ),
+            funnelsFilter=FunnelsFilter(
+                funnelWindowInterval=15,
+                funnelWindowIntervalUnit="second",
+            ),
+            series=[
+                EventsNode(
+                    event="step one",
+                    name="step one",
+                ),
+                EventsNode(
+                    event="step two",
+                    name="step two",
+                ),
+                EventsNode(
+                    event="step three",
+                    name="step three",
+                ),
             ],
-        }
-        query = cast(FunnelsQuery, filter_to_query(filters))
+        )
         results = FunnelsQueryRunner(query=query, team=self.team).calculate().results
 
         self.assertEqual(results[0]["count"], 25)
@@ -1895,94 +2051,152 @@ class TestFOSSFunnelUDF(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(results[2]["count"], 0)
 
         self.assertCountEqual(
-            [str(id) for id in self._get_actor_ids_at_step(filters, 2)],
+            [str(id) for id in self._get_actor_ids_at_step(query, 2)],
             ids_to_compare,
         )
 
     def test_funnel_exclusions_invalid_params(self):
-        filters = {
-            "events": [
-                {"id": "user signed up", "type": "events", "order": 0},
-                {"id": "paid", "type": "events", "order": 1},
+        query = FunnelsQuery(
+            dateRange=DateRange(
+                date_from="2021-05-01 00:00:00",
+                date_to="2021-05-14 00:00:00",
+            ),
+            funnelsFilter=FunnelsFilter(
+                exclusions=[
+                    FunnelExclusionEventsNode(
+                        event="x",
+                        funnelFromStep=1,
+                        funnelToStep=1,
+                        name="x",
+                    ),
+                ],
+            ),
+            series=[
+                EventsNode(
+                    event="user signed up",
+                    name="user signed up",
+                ),
+                EventsNode(
+                    event="paid",
+                    name="paid",
+                ),
             ],
-            "insight": INSIGHT_FUNNELS,
-            "funnel_window_days": 14,
-            "date_from": "2021-05-01 00:00:00",
-            "date_to": "2021-05-14 00:00:00",
-            "exclusions": [
-                {
-                    "id": "x",
-                    "type": "events",
-                    "funnel_from_step": 1,
-                    "funnel_to_step": 1,
-                }
-            ],
-        }
+        )
 
-        query = cast(FunnelsQuery, filter_to_query(filters))
         self.assertRaises(ValidationError, lambda: FunnelsQueryRunner(query=query, team=self.team).calculate())
 
-        filters = {
-            **filters,
-            "exclusions": [
-                {
-                    "id": "x",
-                    "type": "events",
-                    "funnel_from_step": 1,
-                    "funnel_to_step": 2,
-                }
+        query = FunnelsQuery(
+            dateRange=DateRange(
+                date_from="2021-05-01 00:00:00",
+                date_to="2021-05-14 00:00:00",
+            ),
+            funnelsFilter=FunnelsFilter(
+                exclusions=[
+                    FunnelExclusionEventsNode(
+                        event="x",
+                        funnelFromStep=1,
+                        funnelToStep=2,
+                        name="x",
+                    ),
+                ],
+            ),
+            series=[
+                EventsNode(
+                    event="user signed up",
+                    name="user signed up",
+                ),
+                EventsNode(
+                    event="paid",
+                    name="paid",
+                ),
             ],
-        }
-        query = cast(FunnelsQuery, filter_to_query(filters))
+        )
         self.assertRaises(ValidationError, lambda: FunnelsQueryRunner(query=query, team=self.team).calculate())
 
-        filters = {
-            **filters,
-            "exclusions": [
-                {
-                    "id": "x",
-                    "type": "events",
-                    "funnel_from_step": 2,
-                    "funnel_to_step": 1,
-                }
+        query = FunnelsQuery(
+            dateRange=DateRange(
+                date_from="2021-05-01 00:00:00",
+                date_to="2021-05-14 00:00:00",
+            ),
+            funnelsFilter=FunnelsFilter(
+                exclusions=[
+                    FunnelExclusionEventsNode(
+                        event="x",
+                        funnelFromStep=2,
+                        funnelToStep=1,
+                        name="x",
+                    ),
+                ],
+            ),
+            series=[
+                EventsNode(
+                    event="user signed up",
+                    name="user signed up",
+                ),
+                EventsNode(
+                    event="paid",
+                    name="paid",
+                ),
             ],
-        }
-        query = cast(FunnelsQuery, filter_to_query(filters))
+        )
         self.assertRaises(ValidationError, lambda: FunnelsQueryRunner(query=query, team=self.team).calculate())
 
-        filters = {
-            **filters,
-            "exclusions": [
-                {
-                    "id": "x",
-                    "type": "events",
-                    "funnel_from_step": 0,
-                    "funnel_to_step": 2,
-                }
+        query = FunnelsQuery(
+            dateRange=DateRange(
+                date_from="2021-05-01 00:00:00",
+                date_to="2021-05-14 00:00:00",
+            ),
+            funnelsFilter=FunnelsFilter(
+                exclusions=[
+                    FunnelExclusionEventsNode(
+                        event="x",
+                        funnelFromStep=0,
+                        funnelToStep=2,
+                        name="x",
+                    ),
+                ],
+            ),
+            series=[
+                EventsNode(
+                    event="user signed up",
+                    name="user signed up",
+                ),
+                EventsNode(
+                    event="paid",
+                    name="paid",
+                ),
             ],
-        }
-        query = cast(FunnelsQuery, filter_to_query(filters))
+        )
         self.assertRaises(ValidationError, lambda: FunnelsQueryRunner(query=query, team=self.team).calculate())
 
     def test_funnel_exclusion_no_end_event(self):
-        filters = {
-            "events": [
-                {"id": "user signed up", "type": "events", "order": 0},
-                {"id": "paid", "type": "events", "order": 1},
+        query = FunnelsQuery(
+            dateRange=DateRange(
+                date_from="2021-05-01 00:00:00",
+                date_to="2021-05-14 00:00:00",
+            ),
+            funnelsFilter=FunnelsFilter(
+                exclusions=[
+                    FunnelExclusionEventsNode(
+                        event="x",
+                        funnelFromStep=0,
+                        funnelToStep=1,
+                        name="x",
+                    ),
+                ],
+                funnelWindowInterval=1,
+            ),
+            series=[
+                EventsNode(
+                    event="user signed up",
+                    name="user signed up",
+                ),
+                EventsNode(
+                    event="paid",
+                    name="paid",
+                ),
             ],
-            "insight": INSIGHT_FUNNELS,
-            "funnel_window_interval": 1,
-            "date_from": "2021-05-01 00:00:00",
-            "date_to": "2021-05-14 00:00:00",
-            "exclusions": [
-                {
-                    "id": "x",
-                    "type": "events",
-                    "funnel_from_step": 0,
-                    "funnel_to_step": 1,
-                }
-            ],
-        }
+        )
 
         # person 1
         person1 = _create_person(distinct_ids=["person1"], team_id=self.team.pk)
@@ -2051,7 +2265,6 @@ class TestFOSSFunnelUDF(ClickhouseTestMixin, APIBaseTest):
             timestamp="2021-05-02 08:00:00",
         )
 
-        query = cast(FunnelsQuery, filter_to_query(filters))
         results = FunnelsQueryRunner(query=query, team=self.team).calculate().results
 
         self.assertEqual(len(results), 2)
@@ -2061,8 +2274,8 @@ class TestFOSSFunnelUDF(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(results[1]["name"], "paid")
         self.assertEqual(results[1]["count"], 1)
 
-        self.assertCountEqual(self._get_actor_ids_at_step(filters, 1), [person1.uuid, person4.uuid])
-        self.assertCountEqual(self._get_actor_ids_at_step(filters, 2), [person1.uuid])
+        self.assertCountEqual(self._get_actor_ids_at_step(query, 1), [person1.uuid, person4.uuid])
+        self.assertCountEqual(self._get_actor_ids_at_step(query, 2), [person1.uuid])
 
     def test_funnel_exclusion_multiple_possible_no_end_event1(self):
         journeys_for(
@@ -2085,29 +2298,36 @@ class TestFOSSFunnelUDF(ClickhouseTestMixin, APIBaseTest):
             self.team,
         )
 
-        filters = {
-            "insight": INSIGHT_FUNNELS,
-            "funnel_viz_type": "steps",
-            "interval": "day",
-            "date_from": "2021-05-01 00:00:00",
-            "date_to": "2021-05-13 23:59:59",
-            "funnel_window_interval": 10,
-            "funnel_window_interval_unit": "second",
-            "events": [
-                {"id": "step one", "order": 0},
-                {"id": "step two", "order": 1},
+        query = FunnelsQuery(
+            dateRange=DateRange(
+                date_from="2021-05-01 00:00:00",
+                date_to="2021-05-13 23:59:59",
+            ),
+            funnelsFilter=FunnelsFilter(
+                exclusions=[
+                    FunnelExclusionEventsNode(
+                        event="exclusion",
+                        funnelFromStep=0,
+                        funnelToStep=1,
+                        name="exclusion",
+                    ),
+                ],
+                funnelWindowInterval=10,
+                funnelWindowIntervalUnit="second",
+            ),
+            interval="day",
+            series=[
+                EventsNode(
+                    event="step one",
+                    name="step one",
+                ),
+                EventsNode(
+                    event="step two",
+                    name="step two",
+                ),
             ],
-            "exclusions": [
-                {
-                    "id": "exclusion",
-                    "type": "events",
-                    "funnel_from_step": 0,
-                    "funnel_to_step": 1,
-                }
-            ],
-        }
+        )
 
-        query = cast(FunnelsQuery, filter_to_query(filters))
         results = FunnelsQueryRunner(query=query, team=self.team).calculate().results
 
         self.assertEqual(len(results), 2)
@@ -2135,29 +2355,36 @@ class TestFOSSFunnelUDF(ClickhouseTestMixin, APIBaseTest):
             self.team,
         )
 
-        filters = {
-            "insight": INSIGHT_FUNNELS,
-            "funnel_viz_type": "steps",
-            "interval": "day",
-            "date_from": "2021-05-01 00:00:00",
-            "date_to": "2021-05-13 23:59:59",
-            "funnel_window_interval": 10,
-            "funnel_window_interval_unit": "second",
-            "events": [
-                {"id": "step one", "order": 0},
-                {"id": "step two", "order": 1},
+        query = FunnelsQuery(
+            dateRange=DateRange(
+                date_from="2021-05-01 00:00:00",
+                date_to="2021-05-13 23:59:59",
+            ),
+            funnelsFilter=FunnelsFilter(
+                exclusions=[
+                    FunnelExclusionEventsNode(
+                        event="exclusion",
+                        funnelFromStep=0,
+                        funnelToStep=1,
+                        name="exclusion",
+                    ),
+                ],
+                funnelWindowInterval=10,
+                funnelWindowIntervalUnit="second",
+            ),
+            interval="day",
+            series=[
+                EventsNode(
+                    event="step one",
+                    name="step one",
+                ),
+                EventsNode(
+                    event="step two",
+                    name="step two",
+                ),
             ],
-            "exclusions": [
-                {
-                    "id": "exclusion",
-                    "type": "events",
-                    "funnel_from_step": 0,
-                    "funnel_to_step": 1,
-                }
-            ],
-        }
+        )
 
-        query = cast(FunnelsQuery, filter_to_query(filters))
         results = FunnelsQueryRunner(query=query, team=self.team).calculate().results
 
         self.assertEqual(len(results), 2)
@@ -2185,29 +2412,36 @@ class TestFOSSFunnelUDF(ClickhouseTestMixin, APIBaseTest):
             self.team,
         )
 
-        filters = {
-            "insight": INSIGHT_FUNNELS,
-            "funnel_viz_type": "steps",
-            "interval": "day",
-            "date_from": "2021-05-01 00:00:00",
-            "date_to": "2021-05-13 23:59:59",
-            "funnel_window_interval": 10,
-            "funnel_window_interval_unit": "second",
-            "events": [
-                {"id": "step one", "order": 0},
-                {"id": "step two", "order": 1},
+        query = FunnelsQuery(
+            dateRange=DateRange(
+                date_from="2021-05-01 00:00:00",
+                date_to="2021-05-13 23:59:59",
+            ),
+            funnelsFilter=FunnelsFilter(
+                exclusions=[
+                    FunnelExclusionEventsNode(
+                        event="exclusion",
+                        funnelFromStep=0,
+                        funnelToStep=1,
+                        name="exclusion",
+                    ),
+                ],
+                funnelWindowInterval=10,
+                funnelWindowIntervalUnit="second",
+            ),
+            interval="day",
+            series=[
+                EventsNode(
+                    event="step one",
+                    name="step one",
+                ),
+                EventsNode(
+                    event="step two",
+                    name="step two",
+                ),
             ],
-            "exclusions": [
-                {
-                    "id": "exclusion",
-                    "type": "events",
-                    "funnel_from_step": 0,
-                    "funnel_to_step": 1,
-                }
-            ],
-        }
+        )
 
-        query = cast(FunnelsQuery, filter_to_query(filters))
         results = FunnelsQueryRunner(query=query, team=self.team).calculate().results
 
         # There should be no events. UDF funnels returns an empty array and says "no events"
@@ -2234,24 +2468,31 @@ class TestFOSSFunnelUDF(ClickhouseTestMixin, APIBaseTest):
             ],
         )
 
-        filters = {
-            "events": [
-                {"id": "user signed up", "type": "events", "order": 0},
-                {"id": "paid", "type": "events", "order": 1},
+        query = FunnelsQuery(
+            dateRange=DateRange(
+                date_from="2021-05-01 00:00:00",
+                date_to="2021-05-14 00:00:00",
+            ),
+            funnelsFilter=FunnelsFilter(
+                exclusions=[
+                    FunnelExclusionActionsNode(
+                        funnelFromStep=0,
+                        funnelToStep=1,
+                        id=sign_up_action.id,
+                    ),
+                ],
+            ),
+            series=[
+                EventsNode(
+                    event="user signed up",
+                    name="user signed up",
+                ),
+                EventsNode(
+                    event="paid",
+                    name="paid",
+                ),
             ],
-            "insight": INSIGHT_FUNNELS,
-            "funnel_window_days": 14,
-            "date_from": "2021-05-01 00:00:00",
-            "date_to": "2021-05-14 00:00:00",
-            "exclusions": [
-                {
-                    "id": sign_up_action.id,
-                    "type": "actions",
-                    "funnel_from_step": 0,
-                    "funnel_to_step": 1,
-                }
-            ],
-        }
+        )
 
         # event 1
         person1 = _create_person(distinct_ids=["person1"], team_id=self.team.pk)
@@ -2305,7 +2546,6 @@ class TestFOSSFunnelUDF(ClickhouseTestMixin, APIBaseTest):
             timestamp="2021-05-01 06:00:00",
         )
 
-        query = cast(FunnelsQuery, filter_to_query(filters))
         results = FunnelsQueryRunner(query=query, team=self.team).calculate().results
 
         self.assertEqual(len(results), 2)
@@ -2315,28 +2555,36 @@ class TestFOSSFunnelUDF(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(results[1]["name"], "paid")
         self.assertEqual(results[1]["count"], 2)
 
-        self.assertCountEqual(self._get_actor_ids_at_step(filters, 1), [person1.uuid, person3.uuid])
-        self.assertCountEqual(self._get_actor_ids_at_step(filters, 2), [person1.uuid, person3.uuid])
+        self.assertCountEqual(self._get_actor_ids_at_step(query, 1), [person1.uuid, person3.uuid])
+        self.assertCountEqual(self._get_actor_ids_at_step(query, 2), [person1.uuid, person3.uuid])
 
     def test_funnel_exclusions_full_window(self):
-        filters = {
-            "events": [
-                {"id": "user signed up", "type": "events", "order": 0},
-                {"id": "paid", "type": "events", "order": 1},
+        query = FunnelsQuery(
+            dateRange=DateRange(
+                date_from="2021-05-01 00:00:00",
+                date_to="2021-05-14 00:00:00",
+            ),
+            funnelsFilter=FunnelsFilter(
+                exclusions=[
+                    FunnelExclusionEventsNode(
+                        event="x 1 name with numbers 2",
+                        funnelFromStep=0,
+                        funnelToStep=1,
+                        name="x 1 name with numbers 2",
+                    ),
+                ],
+            ),
+            series=[
+                EventsNode(
+                    event="user signed up",
+                    name="user signed up",
+                ),
+                EventsNode(
+                    event="paid",
+                    name="paid",
+                ),
             ],
-            "insight": INSIGHT_FUNNELS,
-            "funnel_window_days": 14,
-            "date_from": "2021-05-01 00:00:00",
-            "date_to": "2021-05-14 00:00:00",
-            "exclusions": [
-                {
-                    "id": "x 1 name with numbers 2",
-                    "type": "events",
-                    "funnel_from_step": 0,
-                    "funnel_to_step": 1,
-                }
-            ],
-        }
+        )
 
         # person 1
         person1 = _create_person(distinct_ids=["person1"], team_id=self.team.pk)
@@ -2389,7 +2637,6 @@ class TestFOSSFunnelUDF(ClickhouseTestMixin, APIBaseTest):
             timestamp="2021-05-01 06:00:00",
         )
 
-        query = cast(FunnelsQuery, filter_to_query(filters))
         results = FunnelsQueryRunner(query=query, team=self.team).calculate().results
 
         self.assertEqual(len(results), 2)
@@ -2399,30 +2646,48 @@ class TestFOSSFunnelUDF(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(results[1]["name"], "paid")
         self.assertEqual(results[1]["count"], 2)
 
-        self.assertCountEqual(self._get_actor_ids_at_step(filters, 1), [person1.uuid, person3.uuid])
-        self.assertCountEqual(self._get_actor_ids_at_step(filters, 2), [person1.uuid, person3.uuid])
+        self.assertCountEqual(self._get_actor_ids_at_step(query, 1), [person1.uuid, person3.uuid])
+        self.assertCountEqual(self._get_actor_ids_at_step(query, 2), [person1.uuid, person3.uuid])
 
     def test_advanced_funnel_exclusions_between_steps(self):
-        filters = {
-            "events": [
-                {"id": "user signed up", "type": "events", "order": 0},
-                {"id": "$pageview", "type": "events", "order": 1},
-                {"id": "insight viewed", "type": "events", "order": 2},
-                {"id": "invite teammate", "type": "events", "order": 3},
-                {"id": "pageview2", "type": "events", "order": 4},
+        query = FunnelsQuery(
+            dateRange=DateRange(
+                date_from="2021-05-01 00:00:00",
+                date_to="2021-05-14 00:00:00",
+            ),
+            funnelsFilter=FunnelsFilter(
+                exclusions=[
+                    FunnelExclusionEventsNode(
+                        event="x",
+                        funnelFromStep=0,
+                        funnelToStep=1,
+                        name="x",
+                    ),
+                ],
+            ),
+            series=[
+                EventsNode(
+                    event="user signed up",
+                    name="user signed up",
+                ),
+                EventsNode(
+                    event="$pageview",
+                    name="$pageview",
+                ),
+                EventsNode(
+                    event="insight viewed",
+                    name="insight viewed",
+                ),
+                EventsNode(
+                    event="invite teammate",
+                    name="invite teammate",
+                ),
+                EventsNode(
+                    event="pageview2",
+                    name="pageview2",
+                ),
             ],
-            "date_from": "2021-05-01 00:00:00",
-            "date_to": "2021-05-14 00:00:00",
-            "insight": INSIGHT_FUNNELS,
-            "exclusions": [
-                {
-                    "id": "x",
-                    "type": "events",
-                    "funnel_from_step": 0,
-                    "funnel_to_step": 1,
-                }
-            ],
-        }
+        )
 
         person1 = _create_person(distinct_ids=["person1"], team_id=self.team.pk)
         # this dude is discarded when funnel_from_step = 1
@@ -2569,7 +2834,6 @@ class TestFOSSFunnelUDF(ClickhouseTestMixin, APIBaseTest):
             timestamp="2021-05-01 06:00:00",
         )
 
-        query = cast(FunnelsQuery, filter_to_query(filters))
         results = FunnelsQueryRunner(query=query, team=self.team).calculate().results
 
         self.assertEqual(results[0]["name"], "user signed up")
@@ -2577,20 +2841,46 @@ class TestFOSSFunnelUDF(ClickhouseTestMixin, APIBaseTest):
 
         self.assertEqual(results[4]["count"], 2)
 
-        self.assertCountEqual(self._get_actor_ids_at_step(filters, 1), [person1.uuid, person2.uuid])
+        self.assertCountEqual(self._get_actor_ids_at_step(query, 1), [person1.uuid, person2.uuid])
 
-        filters = {
-            **filters,
-            "exclusions": [
-                {
-                    "id": "x",
-                    "type": "events",
-                    "funnel_from_step": 1,
-                    "funnel_to_step": 2,
-                }
+        query = FunnelsQuery(
+            dateRange=DateRange(
+                date_from="2021-05-01 00:00:00",
+                date_to="2021-05-14 00:00:00",
+            ),
+            funnelsFilter=FunnelsFilter(
+                exclusions=[
+                    FunnelExclusionEventsNode(
+                        event="x",
+                        funnelFromStep=1,
+                        funnelToStep=2,
+                        name="x",
+                    ),
+                ],
+            ),
+            series=[
+                EventsNode(
+                    event="user signed up",
+                    name="user signed up",
+                ),
+                EventsNode(
+                    event="$pageview",
+                    name="$pageview",
+                ),
+                EventsNode(
+                    event="insight viewed",
+                    name="insight viewed",
+                ),
+                EventsNode(
+                    event="invite teammate",
+                    name="invite teammate",
+                ),
+                EventsNode(
+                    event="pageview2",
+                    name="pageview2",
+                ),
             ],
-        }
-        query = cast(FunnelsQuery, filter_to_query(filters))
+        )
         results = FunnelsQueryRunner(query=query, team=self.team).calculate().results
 
         self.assertEqual(results[0]["name"], "user signed up")
@@ -2598,20 +2888,46 @@ class TestFOSSFunnelUDF(ClickhouseTestMixin, APIBaseTest):
 
         self.assertEqual(results[4]["count"], 2)
 
-        self.assertCountEqual(self._get_actor_ids_at_step(filters, 1), [person2.uuid, person3.uuid])
+        self.assertCountEqual(self._get_actor_ids_at_step(query, 1), [person2.uuid, person3.uuid])
 
-        filters = {
-            **filters,
-            "exclusions": [
-                {
-                    "id": "x",
-                    "type": "events",
-                    "funnel_from_step": 2,
-                    "funnel_to_step": 3,
-                }
+        query = FunnelsQuery(
+            dateRange=DateRange(
+                date_from="2021-05-01 00:00:00",
+                date_to="2021-05-14 00:00:00",
+            ),
+            funnelsFilter=FunnelsFilter(
+                exclusions=[
+                    FunnelExclusionEventsNode(
+                        event="x",
+                        funnelFromStep=2,
+                        funnelToStep=3,
+                        name="x",
+                    ),
+                ],
+            ),
+            series=[
+                EventsNode(
+                    event="user signed up",
+                    name="user signed up",
+                ),
+                EventsNode(
+                    event="$pageview",
+                    name="$pageview",
+                ),
+                EventsNode(
+                    event="insight viewed",
+                    name="insight viewed",
+                ),
+                EventsNode(
+                    event="invite teammate",
+                    name="invite teammate",
+                ),
+                EventsNode(
+                    event="pageview2",
+                    name="pageview2",
+                ),
             ],
-        }
-        query = cast(FunnelsQuery, filter_to_query(filters))
+        )
         results = FunnelsQueryRunner(query=query, team=self.team).calculate().results
 
         self.assertEqual(results[0]["name"], "user signed up")
@@ -2619,20 +2935,46 @@ class TestFOSSFunnelUDF(ClickhouseTestMixin, APIBaseTest):
 
         self.assertEqual(results[4]["count"], 1)
 
-        self.assertCountEqual(self._get_actor_ids_at_step(filters, 1), [person3.uuid])
+        self.assertCountEqual(self._get_actor_ids_at_step(query, 1), [person3.uuid])
 
-        filters = {
-            **filters,
-            "exclusions": [
-                {
-                    "id": "x",
-                    "type": "events",
-                    "funnel_from_step": 3,
-                    "funnel_to_step": 4,
-                }
+        query = FunnelsQuery(
+            dateRange=DateRange(
+                date_from="2021-05-01 00:00:00",
+                date_to="2021-05-14 00:00:00",
+            ),
+            funnelsFilter=FunnelsFilter(
+                exclusions=[
+                    FunnelExclusionEventsNode(
+                        event="x",
+                        funnelFromStep=3,
+                        funnelToStep=4,
+                        name="x",
+                    ),
+                ],
+            ),
+            series=[
+                EventsNode(
+                    event="user signed up",
+                    name="user signed up",
+                ),
+                EventsNode(
+                    event="$pageview",
+                    name="$pageview",
+                ),
+                EventsNode(
+                    event="insight viewed",
+                    name="insight viewed",
+                ),
+                EventsNode(
+                    event="invite teammate",
+                    name="invite teammate",
+                ),
+                EventsNode(
+                    event="pageview2",
+                    name="pageview2",
+                ),
             ],
-        }
-        query = cast(FunnelsQuery, filter_to_query(filters))
+        )
         results = FunnelsQueryRunner(query=query, team=self.team).calculate().results
 
         # There should be no events. UDF funnels returns an empty array and says "no events"
@@ -2644,21 +2986,47 @@ class TestFOSSFunnelUDF(ClickhouseTestMixin, APIBaseTest):
             self.assertEqual(results[0]["count"], 0)
             self.assertEqual(results[4]["count"], 0)
 
-        self.assertCountEqual(self._get_actor_ids_at_step(filters, 1), [])
+        self.assertCountEqual(self._get_actor_ids_at_step(query, 1), [])
 
         #  bigger step window
-        filters = {
-            **filters,
-            "exclusions": [
-                {
-                    "id": "x",
-                    "type": "events",
-                    "funnel_from_step": 1,
-                    "funnel_to_step": 3,
-                }
+        query = FunnelsQuery(
+            dateRange=DateRange(
+                date_from="2021-05-01 00:00:00",
+                date_to="2021-05-14 00:00:00",
+            ),
+            funnelsFilter=FunnelsFilter(
+                exclusions=[
+                    FunnelExclusionEventsNode(
+                        event="x",
+                        funnelFromStep=1,
+                        funnelToStep=3,
+                        name="x",
+                    ),
+                ],
+            ),
+            series=[
+                EventsNode(
+                    event="user signed up",
+                    name="user signed up",
+                ),
+                EventsNode(
+                    event="$pageview",
+                    name="$pageview",
+                ),
+                EventsNode(
+                    event="insight viewed",
+                    name="insight viewed",
+                ),
+                EventsNode(
+                    event="invite teammate",
+                    name="invite teammate",
+                ),
+                EventsNode(
+                    event="pageview2",
+                    name="pageview2",
+                ),
             ],
-        }
-        query = cast(FunnelsQuery, filter_to_query(filters))
+        )
         results = FunnelsQueryRunner(query=query, team=self.team).calculate().results
 
         self.assertEqual(results[0]["name"], "user signed up")
@@ -2666,35 +3034,53 @@ class TestFOSSFunnelUDF(ClickhouseTestMixin, APIBaseTest):
 
         self.assertEqual(results[4]["count"], 1)
 
-        self.assertCountEqual(self._get_actor_ids_at_step(filters, 1), [person3.uuid])
+        self.assertCountEqual(self._get_actor_ids_at_step(query, 1), [person3.uuid])
 
     def test_advanced_funnel_multiple_exclusions_between_steps(self):
-        filters = {
-            "events": [
-                {"id": "user signed up", "type": "events", "order": 0},
-                {"id": "$pageview", "type": "events", "order": 1},
-                {"id": "insight viewed", "type": "events", "order": 2},
-                {"id": "invite teammate", "type": "events", "order": 3},
-                {"id": "pageview2", "type": "events", "order": 4},
+        query = FunnelsQuery(
+            dateRange=DateRange(
+                date_from="2021-05-01 00:00:00",
+                date_to="2021-05-14 00:00:00",
+            ),
+            funnelsFilter=FunnelsFilter(
+                exclusions=[
+                    FunnelExclusionEventsNode(
+                        event="x",
+                        funnelFromStep=0,
+                        funnelToStep=1,
+                        name="x",
+                    ),
+                    FunnelExclusionEventsNode(
+                        event="y",
+                        funnelFromStep=2,
+                        funnelToStep=3,
+                        name="y",
+                    ),
+                ],
+            ),
+            series=[
+                EventsNode(
+                    event="user signed up",
+                    name="user signed up",
+                ),
+                EventsNode(
+                    event="$pageview",
+                    name="$pageview",
+                ),
+                EventsNode(
+                    event="insight viewed",
+                    name="insight viewed",
+                ),
+                EventsNode(
+                    event="invite teammate",
+                    name="invite teammate",
+                ),
+                EventsNode(
+                    event="pageview2",
+                    name="pageview2",
+                ),
             ],
-            "date_from": "2021-05-01 00:00:00",
-            "date_to": "2021-05-14 00:00:00",
-            "insight": INSIGHT_FUNNELS,
-            "exclusions": [
-                {
-                    "id": "x",
-                    "type": "events",
-                    "funnel_from_step": 0,
-                    "funnel_to_step": 1,
-                },
-                {
-                    "id": "y",
-                    "type": "events",
-                    "funnel_from_step": 2,
-                    "funnel_to_step": 3,
-                },
-            ],
-        }
+        )
 
         _create_person(distinct_ids=["person1"], team_id=self.team.pk)
         _create_event(
@@ -2866,7 +3252,6 @@ class TestFOSSFunnelUDF(ClickhouseTestMixin, APIBaseTest):
             timestamp="2021-05-01 06:00:00",
         )
 
-        query = cast(FunnelsQuery, filter_to_query(filters))
         results = FunnelsQueryRunner(query=query, team=self.team).calculate().results
 
         self.assertEqual(results[0]["name"], "user signed up")
@@ -2874,27 +3259,53 @@ class TestFOSSFunnelUDF(ClickhouseTestMixin, APIBaseTest):
 
         self.assertEqual(results[4]["count"], 1)
 
-        self.assertCountEqual(self._get_actor_ids_at_step(filters, 1), [person4.uuid])
+        self.assertCountEqual(self._get_actor_ids_at_step(query, 1), [person4.uuid])
 
-        filters = {
-            **filters,
-            "exclusions": [
-                {
-                    "id": "x",
-                    "type": "events",
-                    "funnel_from_step": 0,
-                    "funnel_to_step": 1,
-                },
-                {
-                    "id": "y",
-                    "type": "events",
-                    "funnel_from_step": 0,
-                    "funnel_to_step": 1,
-                },
+        query = FunnelsQuery(
+            dateRange=DateRange(
+                date_from="2021-05-01 00:00:00",
+                date_to="2021-05-14 00:00:00",
+            ),
+            funnelsFilter=FunnelsFilter(
+                exclusions=[
+                    FunnelExclusionEventsNode(
+                        event="x",
+                        funnelFromStep=0,
+                        funnelToStep=1,
+                        name="x",
+                    ),
+                    FunnelExclusionEventsNode(
+                        event="y",
+                        funnelFromStep=0,
+                        funnelToStep=1,
+                        name="y",
+                    ),
+                ],
+            ),
+            series=[
+                EventsNode(
+                    event="user signed up",
+                    name="user signed up",
+                ),
+                EventsNode(
+                    event="$pageview",
+                    name="$pageview",
+                ),
+                EventsNode(
+                    event="insight viewed",
+                    name="insight viewed",
+                ),
+                EventsNode(
+                    event="invite teammate",
+                    name="invite teammate",
+                ),
+                EventsNode(
+                    event="pageview2",
+                    name="pageview2",
+                ),
             ],
-        }
+        )
 
-        query = cast(FunnelsQuery, filter_to_query(filters))
         results = FunnelsQueryRunner(query=query, team=self.team).calculate().results
 
         self.assertEqual(results[0]["name"], "user signed up")
@@ -2902,26 +3313,52 @@ class TestFOSSFunnelUDF(ClickhouseTestMixin, APIBaseTest):
 
         self.assertEqual(results[4]["count"], 1)
 
-        self.assertCountEqual(self._get_actor_ids_at_step(filters, 1), [person4.uuid])
+        self.assertCountEqual(self._get_actor_ids_at_step(query, 1), [person4.uuid])
 
-        filters = {
-            **filters,
-            "exclusions": [
-                {
-                    "id": "x",
-                    "type": "events",
-                    "funnel_from_step": 0,
-                    "funnel_to_step": 1,
-                },
-                {
-                    "id": "y",
-                    "type": "events",
-                    "funnel_from_step": 0,
-                    "funnel_to_step": 1,
-                },
+        query = FunnelsQuery(
+            dateRange=DateRange(
+                date_from="2021-05-01 00:00:00",
+                date_to="2021-05-14 00:00:00",
+            ),
+            funnelsFilter=FunnelsFilter(
+                exclusions=[
+                    FunnelExclusionEventsNode(
+                        event="x",
+                        funnelFromStep=0,
+                        funnelToStep=1,
+                        name="x",
+                    ),
+                    FunnelExclusionEventsNode(
+                        event="y",
+                        funnelFromStep=0,
+                        funnelToStep=1,
+                        name="y",
+                    ),
+                ],
+            ),
+            series=[
+                EventsNode(
+                    event="user signed up",
+                    name="user signed up",
+                ),
+                EventsNode(
+                    event="$pageview",
+                    name="$pageview",
+                ),
+                EventsNode(
+                    event="insight viewed",
+                    name="insight viewed",
+                ),
+                EventsNode(
+                    event="invite teammate",
+                    name="invite teammate",
+                ),
+                EventsNode(
+                    event="pageview2",
+                    name="pageview2",
+                ),
             ],
-        }
-        query = cast(FunnelsQuery, filter_to_query(filters))
+        )
         results = FunnelsQueryRunner(query=query, team=self.team).calculate().results
 
         self.assertEqual(results[0]["name"], "user signed up")
@@ -2929,26 +3366,52 @@ class TestFOSSFunnelUDF(ClickhouseTestMixin, APIBaseTest):
 
         self.assertEqual(results[4]["count"], 1)
 
-        self.assertCountEqual(self._get_actor_ids_at_step(filters, 1), [person4.uuid])
+        self.assertCountEqual(self._get_actor_ids_at_step(query, 1), [person4.uuid])
 
-        filters = {
-            **filters,
-            "exclusions": [
-                {
-                    "id": "x",
-                    "type": "events",
-                    "funnel_from_step": 0,
-                    "funnel_to_step": 4,
-                },
-                {
-                    "id": "y",
-                    "type": "events",
-                    "funnel_from_step": 0,
-                    "funnel_to_step": 4,
-                },
+        query = FunnelsQuery(
+            dateRange=DateRange(
+                date_from="2021-05-01 00:00:00",
+                date_to="2021-05-14 00:00:00",
+            ),
+            funnelsFilter=FunnelsFilter(
+                exclusions=[
+                    FunnelExclusionEventsNode(
+                        event="x",
+                        funnelFromStep=0,
+                        funnelToStep=4,
+                        name="x",
+                    ),
+                    FunnelExclusionEventsNode(
+                        event="y",
+                        funnelFromStep=0,
+                        funnelToStep=4,
+                        name="y",
+                    ),
+                ],
+            ),
+            series=[
+                EventsNode(
+                    event="user signed up",
+                    name="user signed up",
+                ),
+                EventsNode(
+                    event="$pageview",
+                    name="$pageview",
+                ),
+                EventsNode(
+                    event="insight viewed",
+                    name="insight viewed",
+                ),
+                EventsNode(
+                    event="invite teammate",
+                    name="invite teammate",
+                ),
+                EventsNode(
+                    event="pageview2",
+                    name="pageview2",
+                ),
             ],
-        }
-        query = cast(FunnelsQuery, filter_to_query(filters))
+        )
         results = FunnelsQueryRunner(query=query, team=self.team).calculate().results
 
         self.assertEqual(results[0]["name"], "user signed up")
@@ -2956,25 +3419,46 @@ class TestFOSSFunnelUDF(ClickhouseTestMixin, APIBaseTest):
 
         self.assertEqual(results[4]["count"], 1)
 
-        self.assertCountEqual(self._get_actor_ids_at_step(filters, 1), [person4.uuid])
+        self.assertCountEqual(self._get_actor_ids_at_step(query, 1), [person4.uuid])
 
     @also_test_with_materialized_columns(["test_prop"])
     def test_funnel_with_denormalised_properties(self):
-        filters = {
-            "events": [
-                {
-                    "id": "user signed up",
-                    "type": "events",
-                    "order": 0,
-                    "properties": [{"key": "test_prop", "value": "hi"}],
-                },
-                {"id": "paid", "type": "events", "order": 1},
+        query = FunnelsQuery(
+            dateRange=DateRange(
+                date_from="2020-01-01",
+                date_to="2020-01-14",
+            ),
+            properties={
+                "type": "AND",
+                "values": [
+                    {
+                        "type": "AND",
+                        "values": [
+                            {
+                                "key": "test_prop",
+                                "value": "hi",
+                            },
+                        ],
+                    },
+                ],
+            },
+            series=[
+                EventsNode(
+                    event="user signed up",
+                    name="user signed up",
+                    properties=[
+                        {
+                            "key": "test_prop",
+                            "value": "hi",
+                        },
+                    ],
+                ),
+                EventsNode(
+                    event="paid",
+                    name="paid",
+                ),
             ],
-            "insight": INSIGHT_FUNNELS,
-            "date_from": "2020-01-01",
-            "properties": [{"key": "test_prop", "value": "hi"}],
-            "date_to": "2020-01-14",
-        }
+        )
 
         # event
         _create_person(distinct_ids=["user_1"], team_id=self.team.pk)
@@ -2992,7 +3476,6 @@ class TestFOSSFunnelUDF(ClickhouseTestMixin, APIBaseTest):
             timestamp="2020-01-10T14:00:00Z",
         )
 
-        query = cast(FunnelsQuery, filter_to_query(filters))
         results = FunnelsQueryRunner(query=query, team=self.team).calculate().results
 
         self.assertEqual(results[0]["name"], "user signed up")
@@ -3005,18 +3488,23 @@ class TestFOSSFunnelUDF(ClickhouseTestMixin, APIBaseTest):
                 _create_event(team=self.team, event="step one", distinct_id="test")
         with freeze_time("2024-01-11T12:01:00"):
             _create_event(team=self.team, event="step two", distinct_id="test")
-        filters = {
-            "insight": INSIGHT_FUNNELS,
-            "funnel_viz_type": "steps",
-            "date_from": "2024-01-10 00:00:00",
-            "date_to": "2024-01-12 00:00:00",
-            "events": [
-                {"id": "step one", "order": 0},
-                {"id": "step two", "order": 1},
+        query = FunnelsQuery(
+            dateRange=DateRange(
+                date_from="2024-01-10 00:00:00",
+                date_to="2024-01-12 00:00:00",
+            ),
+            series=[
+                EventsNode(
+                    event="step one",
+                    name="step one",
+                ),
+                EventsNode(
+                    event="step two",
+                    name="step two",
+                ),
             ],
-        }
+        )
 
-        query = cast(FunnelsQuery, filter_to_query(filters))
         results = FunnelsQueryRunner(query=query, team=self.team).calculate().results
         self.assertEqual(results[-1]["count"], 1)
 
@@ -3035,28 +3523,29 @@ class TestFOSSFunnelUDF(ClickhouseTestMixin, APIBaseTest):
         _create_event(team=self.team, event="user signed up", distinct_id="test2")
 
         for tag_name in ["img", "svg"]:
-            filters = {
-                "events": [
-                    {"id": "user signed up", "type": "events", "order": 0},
-                    {
-                        "id": "$autocapture",
-                        "name": "$autocapture",
-                        "order": 1,
-                        "properties": [
+            query = FunnelsQuery(
+                series=[
+                    EventsNode(
+                        event="user signed up",
+                        name="user signed up",
+                    ),
+                    EventsNode(
+                        event="$autocapture",
+                        name="$autocapture",
+                        properties=[
                             {
                                 "key": "tag_name",
-                                "value": [tag_name],
                                 "operator": "exact",
                                 "type": "element",
-                            }
+                                "value": [
+                                    tag_name,
+                                ],
+                            },
                         ],
-                        "type": "events",
-                    },
+                    ),
                 ],
-                "insight": INSIGHT_FUNNELS,
-            }
+            )
 
-            query = cast(FunnelsQuery, filter_to_query(filters))
             results = FunnelsQueryRunner(query=query, team=self.team).calculate().results
 
             self.assertEqual(len(results), 2)
@@ -3066,8 +3555,8 @@ class TestFOSSFunnelUDF(ClickhouseTestMixin, APIBaseTest):
             self.assertEqual(results[1]["name"], "$autocapture")
             self.assertEqual(results[1]["count"], 1)
 
-            self.assertCountEqual(self._get_actor_ids_at_step(filters, 1), [person1.uuid, person2.uuid])
-            self.assertCountEqual(self._get_actor_ids_at_step(filters, 2), [person1.uuid])
+            self.assertCountEqual(self._get_actor_ids_at_step(query, 1), [person1.uuid, person2.uuid])
+            self.assertCountEqual(self._get_actor_ids_at_step(query, 2), [person1.uuid])
 
     # TODO: fix this test
     # @snapshot_clickhouse_queries
@@ -3130,13 +3619,9 @@ class TestFOSSFunnelUDF(ClickhouseTestMixin, APIBaseTest):
     #             },
     #             {"id": "paid", "type": "events", "order": 1},
     #         ],
-    #         "insight": INSIGHT_FUNNELS,
     #         "date_from": "2020-01-01",
     #         "date_to": "2020-01-14",
     #     }
-
-    #     query = cast(FunnelsQuery, filter_to_query(filters))
-    #     results = FunnelsQueryRunner(query=query, team=self.team).calculate().results
 
     #     self.assertEqual(results[0]["name"], "user signed up")
     #     self.assertEqual(results[0]["count"], 1)
@@ -3194,32 +3679,32 @@ class TestFOSSFunnelUDF(ClickhouseTestMixin, APIBaseTest):
             ],
         )
 
-        filters = {
-            "events": [
-                {
-                    "id": "user signed up",
-                    "type": "events",
-                    "order": 0,
-                    "properties": [
+        query = FunnelsQuery(
+            dateRange=DateRange(
+                date_from="2020-01-01",
+                date_to="2020-01-14",
+            ),
+            series=[
+                EventsNode(
+                    event="user signed up",
+                    name="user signed up",
+                    properties=[
                         {
-                            "type": "precalculated-cohort",
-                            "key": "id",
                             "value": cohort.pk,
-                        }
+                        },
                     ],
-                },
-                {"id": "paid", "type": "events", "order": 1},
+                ),
+                EventsNode(
+                    event="paid",
+                    name="paid",
+                ),
             ],
-            "insight": INSIGHT_FUNNELS,
-            "date_from": "2020-01-01",
-            "date_to": "2020-01-14",
-        }
+        )
 
         # converts to precalculated-cohort due to simplify filters
         cohort.calculate_people_ch(pending_version=0)
 
         with self.settings(USE_PRECALCULATED_CH_COHORT_PEOPLE=True):
-            query = cast(FunnelsQuery, filter_to_query(filters))
             results = FunnelsQueryRunner(query=query, team=self.team).calculate().results
             self.assertEqual(results[0]["name"], "user signed up")
             self.assertEqual(results[0]["count"], 1)
@@ -3264,22 +3749,28 @@ class TestFOSSFunnelUDF(ClickhouseTestMixin, APIBaseTest):
         cohort = Cohort.objects.create(team=self.team, groups=[], is_static=True)
         cohort.insert_users_by_list(["user_2", "rando"])
 
-        filters = {
-            "events": [
-                {
-                    "id": "user signed up",
-                    "type": "events",
-                    "order": 0,
-                    "properties": [{"type": "static-cohort", "key": "id", "value": cohort.pk}],
-                },
-                {"id": "paid", "type": "events", "order": 1},
+        query = FunnelsQuery(
+            dateRange=DateRange(
+                date_from="2020-01-01",
+                date_to="2020-01-14",
+            ),
+            series=[
+                EventsNode(
+                    event="user signed up",
+                    name="user signed up",
+                    properties=[
+                        {
+                            "value": cohort.pk,
+                        },
+                    ],
+                ),
+                EventsNode(
+                    event="paid",
+                    name="paid",
+                ),
             ],
-            "insight": INSIGHT_FUNNELS,
-            "date_from": "2020-01-01",
-            "date_to": "2020-01-14",
-        }
+        )
 
-        query = cast(FunnelsQuery, filter_to_query(filters))
         results = FunnelsQueryRunner(query=query, team=self.team).calculate().results
 
         self.assertEqual(results[0]["name"], "user signed up")
@@ -3291,25 +3782,12 @@ class TestFOSSFunnelUDF(ClickhouseTestMixin, APIBaseTest):
     @snapshot_clickhouse_queries
     @also_test_with_materialized_columns(["$current_url"], person_properties=["email", "age"])
     def test_funnel_with_property_groups(self):
-        filters = {
-            "date_from": "2020-01-01 00:00:00",
-            "date_to": "2020-07-01 00:00:00",
-            "events": [
-                {"id": "user signed up", "order": 0},
-                {
-                    "id": "$pageview",
-                    "order": 1,
-                    "properties": {"$current_url": "aloha.com"},
-                },
-                {
-                    "id": "$pageview",
-                    "order": 2,
-                    "properties": {"$current_url": "aloha2.com"},
-                },  # different event to above
-            ],
-            "insight": INSIGHT_FUNNELS,
-            "funnel_window_days": 14,
-            "properties": {
+        query = FunnelsQuery(
+            dateRange=DateRange(
+                date_from="2020-01-01 00:00:00",
+                date_to="2020-07-01 00:00:00",
+            ),
+            properties={
                 "type": "OR",
                 "values": [
                     {
@@ -3318,14 +3796,14 @@ class TestFOSSFunnelUDF(ClickhouseTestMixin, APIBaseTest):
                             {
                                 "key": "email",
                                 "operator": "icontains",
-                                "value": ".com",
                                 "type": "person",
+                                "value": ".com",
                             },
                             {
                                 "key": "age",
                                 "operator": "exact",
-                                "value": "20",
                                 "type": "person",
+                                "value": "20",
                             },
                         ],
                     },
@@ -3335,20 +3813,46 @@ class TestFOSSFunnelUDF(ClickhouseTestMixin, APIBaseTest):
                             {
                                 "key": "email",
                                 "operator": "icontains",
-                                "value": ".org",
                                 "type": "person",
+                                "value": ".org",
                             },
                             {
                                 "key": "age",
                                 "operator": "exact",
-                                "value": "28",
                                 "type": "person",
+                                "value": "28",
                             },
                         ],
                     },
                 ],
             },
-        }
+            series=[
+                EventsNode(
+                    event="user signed up",
+                    name="user signed up",
+                ),
+                EventsNode(
+                    event="$pageview",
+                    name="$pageview",
+                    properties=[
+                        {
+                            "key": "$current_url",
+                            "value": "aloha.com",
+                        },
+                    ],
+                ),
+                EventsNode(
+                    event="$pageview",
+                    name="$pageview",
+                    properties=[
+                        {
+                            "key": "$current_url",
+                            "value": "aloha2.com",
+                        },
+                    ],
+                ),
+            ],
+        )
 
         people = {}
         people["stopped_after_signup1"] = _create_person(
@@ -3442,7 +3946,6 @@ class TestFOSSFunnelUDF(ClickhouseTestMixin, APIBaseTest):
             create_people=False,
         )
 
-        query = cast(FunnelsQuery, filter_to_query(filters))
         results = FunnelsQueryRunner(query=query, team=self.team).calculate().results
 
         self.assertEqual(results[0]["name"], "user signed up")
@@ -3453,7 +3956,7 @@ class TestFOSSFunnelUDF(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(results[2]["count"], 1)
         # check ordering of people in every step
         self.assertCountEqual(
-            self._get_actor_ids_at_step(filters, 1),
+            self._get_actor_ids_at_step(query, 1),
             [
                 people["stopped_after_pageview1"].uuid,
                 people["stopped_after_pageview2"].uuid,
@@ -3462,7 +3965,7 @@ class TestFOSSFunnelUDF(ClickhouseTestMixin, APIBaseTest):
         )
 
         self.assertCountEqual(
-            self._get_actor_ids_at_step(filters, 2),
+            self._get_actor_ids_at_step(query, 2),
             [
                 people["stopped_after_pageview2"].uuid,
                 people["stopped_after_pageview3"].uuid,
@@ -3470,7 +3973,7 @@ class TestFOSSFunnelUDF(ClickhouseTestMixin, APIBaseTest):
         )
 
         self.assertCountEqual(
-            self._get_actor_ids_at_step(filters, 3),
+            self._get_actor_ids_at_step(query, 3),
             [people["stopped_after_pageview3"].uuid],
         )
 
@@ -3479,15 +3982,22 @@ class TestFOSSFunnelUDF(ClickhouseTestMixin, APIBaseTest):
         self.team.timezone = "US/Pacific"
         self.team.save()
 
-        filters = {
-            "events": [
-                {"id": "user signed up", "type": "events", "order": 0},
-                {"id": "paid", "type": "events", "order": 1},
+        query = FunnelsQuery(
+            dateRange=DateRange(
+                date_from="2020-01-01",
+                date_to="2020-01-14",
+            ),
+            series=[
+                EventsNode(
+                    event="user signed up",
+                    name="user signed up",
+                ),
+                EventsNode(
+                    event="paid",
+                    name="paid",
+                ),
             ],
-            "insight": INSIGHT_FUNNELS,
-            "date_from": "2020-01-01",
-            "date_to": "2020-01-14",
-        }
+        )
 
         # event
         _create_person(distinct_ids=["user_1"], team_id=self.team.pk)
@@ -3499,7 +4009,6 @@ class TestFOSSFunnelUDF(ClickhouseTestMixin, APIBaseTest):
             timestamp="2020-01-01T01:00:00Z",
         )
 
-        query = cast(FunnelsQuery, filter_to_query(filters))
         results = FunnelsQueryRunner(query=query, team=self.team).calculate().results
         # There should be no events. UDF funnels returns an empty array and says "no events"
         # Old style funnels returns a count of 0
@@ -3523,12 +4032,18 @@ class TestFOSSFunnelUDF(ClickhouseTestMixin, APIBaseTest):
         )
 
         funnel = self._basic_funnel(
-            filters={
-                "events": [{"id": "user signed up", "type": "events", "order": 0}],
-                "actions": [{"id": action_play_movie.pk, "type": "actions", "order": 2}],
-                "funnel_window_days": 14,
-                "sampling_factor": 1,
-            }
+            query=FunnelsQuery(
+                samplingFactor=1.0,
+                series=[
+                    EventsNode(
+                        event="user signed up",
+                        name="user signed up",
+                    ),
+                    ActionsNode(
+                        id=action_play_movie.pk,
+                    ),
+                ],
+            )
         )
 
         # events
@@ -3582,17 +4097,27 @@ class TestFOSSFunnelUDF(ClickhouseTestMixin, APIBaseTest):
         )
         self._signup_event(distinct_id="second", properties={"$session_id": "3"})
 
-        basic_filters = {
-            "events": [
-                {"id": "user signed up", "type": "events", "order": 0},
-                {"id": "added to cart", "type": "events", "order": 0},
-                {"id": "checked out", "type": "events", "order": 0},
-            ],
-            "funnel_window_days": 14,
-        }
+        basic_series = [
+            EventsNode(
+                event="user signed up",
+                name="user signed up",
+            ),
+            EventsNode(
+                event="added to cart",
+                name="added to cart",
+            ),
+            EventsNode(
+                event="checked out",
+                name="checked out",
+            ),
+        ]
+
+        basic_query = FunnelsQuery(
+            series=basic_series,
+        )
 
         # without hogql aggregation
-        results = self._basic_funnel(filters=basic_filters).calculate().results
+        results = self._basic_funnel(query=basic_query).calculate().results
         self.assertEqual(results[0]["name"], "user signed up")
         self.assertEqual(results[0]["count"], 2)
         self.assertEqual(results[1]["count"], 1)
@@ -3601,10 +4126,10 @@ class TestFOSSFunnelUDF(ClickhouseTestMixin, APIBaseTest):
         # properties.$session_id
         results = (
             self._basic_funnel(
-                filters={
-                    **basic_filters,
-                    "funnel_aggregate_by_hogql": "properties.$session_id",
-                }
+                query=FunnelsQuery(
+                    funnelsFilter=FunnelsFilter(funnelAggregateByHogQL="properties.$session_id"),
+                    series=basic_series,
+                )
             )
             .calculate()
             .results
@@ -3615,7 +4140,12 @@ class TestFOSSFunnelUDF(ClickhouseTestMixin, APIBaseTest):
 
         # distinct_id
         results = (
-            self._basic_funnel(filters={**basic_filters, "funnel_aggregate_by_hogql": "distinct_id"})
+            self._basic_funnel(
+                query=FunnelsQuery(
+                    funnelsFilter=FunnelsFilter(funnelAggregateByHogQL="distinct_id"),
+                    series=basic_series,
+                )
+            )
             .calculate()
             .results
         )
@@ -3625,14 +4155,26 @@ class TestFOSSFunnelUDF(ClickhouseTestMixin, APIBaseTest):
 
         # person_id
         results = (
-            self._basic_funnel(filters={**basic_filters, "funnel_aggregate_by_hogql": "person_id"}).calculate().results
+            self._basic_funnel(
+                query=FunnelsQuery(
+                    funnelsFilter=FunnelsFilter(funnelAggregateByHogQL="person_id"),
+                    series=basic_series,
+                )
+            )
+            .calculate()
+            .results
         )
         self.assertEqual(results[0]["count"], 2)
         self.assertEqual(results[1]["count"], 1)
         self.assertEqual(results[2]["count"], 1)
 
         result = (
-            self._basic_funnel(filters={**basic_filters, "funnel_aggregate_by_hogql": "person.properties.common_prop"})
+            self._basic_funnel(
+                query=FunnelsQuery(
+                    funnelsFilter=FunnelsFilter(funnelAggregateByHogQL="person.properties.common_prop"),
+                    series=basic_series,
+                )
+            )
             .calculate()
             .results
         )
@@ -3651,35 +4193,27 @@ class TestFOSSFunnelUDF(ClickhouseTestMixin, APIBaseTest):
             defaults={"property_type": "Boolean"},
         )
 
-        filters = {
-            "events": [
-                {
-                    "type": "events",
-                    "id": "user signed up",
-                    "order": 0,
-                    "name": "user signed up",
-                    "math": "total",
-                },
-                {
-                    "type": "events",
-                    "id": None,
-                    "order": 1,
-                    "name": "All events",
-                    "math": "total",
-                    "properties": [
+        query = FunnelsQuery(
+            series=[
+                EventsNode(
+                    event="user signed up",
+                    name="user signed up",
+                ),
+                EventsNode(
+                    name="All events",
+                    properties=[
                         {
                             "key": "is_saved",
-                            "value": ["true"],
-                            "operator": "exact",
-                            "type": "event",
-                        }
+                            "value": [
+                                "true",
+                            ],
+                        },
                     ],
-                },
+                ),
             ],
-            "funnel_window_days": 14,
-        }
+        )
 
-        results = self._basic_funnel(filters=filters).calculate().results
+        results = self._basic_funnel(query).calculate().results
 
         self.assertEqual(results[0]["count"], 1)
         self.assertEqual(results[1]["count"], 1)
@@ -3698,13 +4232,19 @@ class TestFOSSFunnelUDF(ClickhouseTestMixin, APIBaseTest):
             ],
         )
 
-        filters = {
-            "events": [{"id": "user signed up", "type": "events", "order": 0}],
-            "actions": [{"id": action_checkout_all.pk, "type": "actions", "order": 1}],
-            "funnel_window_days": 14,
-        }
+        query = FunnelsQuery(
+            series=[
+                EventsNode(
+                    event="user signed up",
+                    name="user signed up",
+                ),
+                ActionsNode(
+                    id=action_checkout_all.pk,
+                ),
+            ],
+        )
 
-        result = self._basic_funnel(filters=filters).calculate().results
+        result = self._basic_funnel(query).calculate().results
 
         self.assertEqual(result[0]["count"], 1)
         self.assertEqual(result[1]["count"], 1)
@@ -3818,29 +4358,29 @@ class TestFOSSFunnelUDF(ClickhouseTestMixin, APIBaseTest):
         journeys_for(events_by_person, self.team)
         cohort.calculate_people_ch(pending_version=0)
 
-        filters = {
-            "events": [
-                {
-                    "id": "user signed up",
-                    "type": "events",
-                    "order": 0,
-                    "properties": [
+        query = FunnelsQuery(
+            aggregation_group_type_index=0,
+            dateRange=DateRange(
+                date_from="2020-01-01",
+                date_to="2020-01-14",
+            ),
+            series=[
+                EventsNode(
+                    event="user signed up",
+                    name="user signed up",
+                    properties=[
                         {
-                            "type": "precalculated-cohort",
-                            "key": "id",
                             "value": cohort.pk,
-                        }
+                        },
                     ],
-                },
-                {"id": "paid", "type": "events", "order": 1},
+                ),
+                EventsNode(
+                    event="paid",
+                    name="paid",
+                ),
             ],
-            "insight": INSIGHT_FUNNELS,
-            "date_from": "2020-01-01",
-            "date_to": "2020-01-14",
-            "aggregation_group_type_index": 0,
-        }
+        )
 
-        query = cast(FunnelsQuery, filter_to_query(filters))
         results = FunnelsQueryRunner(query=query, team=self.team).calculate().results
 
         self.assertEqual(results[0]["name"], "user signed up")
@@ -3871,17 +4411,23 @@ class TestFOSSFunnelUDF(ClickhouseTestMixin, APIBaseTest):
         }
         journeys_for(events_by_person, self.team)
 
-        filters = {
-            "events": [
-                {"id": "$pageview", "type": "events", "order": 0},
-                {"id": "user signed up", "type": "events", "order": 1},
+        query = FunnelsQuery(
+            dateRange=DateRange(
+                date_from="2024-02-17",
+                date_to="2024-03-18",
+            ),
+            series=[
+                EventsNode(
+                    event="$pageview",
+                    name="$pageview",
+                ),
+                EventsNode(
+                    event="user signed up",
+                    name="user signed up",
+                ),
             ],
-            "insight": INSIGHT_FUNNELS,
-            "date_from": "2024-02-17",
-            "date_to": "2024-03-18",
-        }
+        )
 
-        query = cast(FunnelsQuery, filter_to_query(filters))
         results = FunnelsQueryRunner(query=query, team=self.team).calculate().results
 
         self.assertEqual(results[1]["name"], "user signed up")
@@ -3893,7 +4439,6 @@ class TestFOSSFunnelUDF(ClickhouseTestMixin, APIBaseTest):
         self.team.timezone = "US/Pacific"
         self.team.save()
 
-        query = cast(FunnelsQuery, filter_to_query(filters))
         results = FunnelsQueryRunner(query=query, team=self.team).calculate().results
 
         # we still should have the user here, as the conversion window should not be affected by DST
@@ -4217,54 +4762,80 @@ class TestFOSSFunnelUDF(ClickhouseTestMixin, APIBaseTest):
             _create_event(team=self.team, event="step two", distinct_id="test")
         with freeze_time("2024-01-10T12:02:00"):
             _create_event(team=self.team, event="step three", distinct_id="test")
-        filters = {
-            "insight": INSIGHT_FUNNELS,
-            "funnel_viz_type": "steps",
-            "date_from": "2024-01-10 00:00:00",
-            "date_to": "2024-01-12 00:00:00",
-            "events": [
-                {"id": "step zero", "order": 0},
-                {"id": "step one", "order": 1},
-                {"id": "step two", "order": 2},
-                {"id": "step three", "order": 3},
+        query = FunnelsQuery(
+            dateRange=DateRange(
+                date_from="2024-01-10 00:00:00",
+                date_to="2024-01-12 00:00:00",
+            ),
+            funnelsFilter=FunnelsFilter(
+                exclusions=[
+                    FunnelExclusionEventsNode(
+                        event="exclusion",
+                        funnelFromStep=0,
+                        funnelToStep=1,
+                        name="exclusion",
+                    ),
+                ],
+            ),
+            series=[
+                EventsNode(
+                    event="step zero",
+                    name="step zero",
+                ),
+                EventsNode(
+                    event="step one",
+                    name="step one",
+                ),
+                EventsNode(
+                    event="step two",
+                    name="step two",
+                ),
+                EventsNode(
+                    event="step three",
+                    name="step three",
+                ),
             ],
-            "exclusions": [
-                {
-                    "id": "exclusion",
-                    "type": "events",
-                    "funnel_from_step": 0,
-                    "funnel_to_step": 1,
-                }
-            ],
-        }
+        )
 
-        query = cast(FunnelsQuery, filter_to_query(filters))
         results = FunnelsQueryRunner(query=query, team=self.team).calculate().results
         self.assertEqual(4, len(results))
         self.assertEqual(1, results[-1]["count"])
 
-        filters = {
-            "insight": INSIGHT_FUNNELS,
-            "funnel_viz_type": "steps",
-            "date_from": "2024-01-10 00:00:00",
-            "date_to": "2024-01-12 00:00:00",
-            "events": [
-                {"id": "step zero", "order": 0},
-                {"id": "step one", "order": 1},
-                {"id": "step two", "order": 2},
-                {"id": "step three", "order": 3},
+        query = FunnelsQuery(
+            dateRange=DateRange(
+                date_from="2024-01-10 00:00:00",
+                date_to="2024-01-12 00:00:00",
+            ),
+            funnelsFilter=FunnelsFilter(
+                exclusions=[
+                    FunnelExclusionEventsNode(
+                        event="exclusion",
+                        funnelFromStep=1,
+                        funnelToStep=2,
+                        name="exclusion",
+                    ),
+                ],
+            ),
+            series=[
+                EventsNode(
+                    event="step zero",
+                    name="step zero",
+                ),
+                EventsNode(
+                    event="step one",
+                    name="step one",
+                ),
+                EventsNode(
+                    event="step two",
+                    name="step two",
+                ),
+                EventsNode(
+                    event="step three",
+                    name="step three",
+                ),
             ],
-            "exclusions": [
-                {
-                    "id": "exclusion",
-                    "type": "events",
-                    "funnel_from_step": 1,
-                    "funnel_to_step": 2,
-                }
-            ],
-        }
+        )
 
-        query = cast(FunnelsQuery, filter_to_query(filters))
         results = FunnelsQueryRunner(query=query, team=self.team).calculate().results
         self.assertEqual(4, len(results))
         self.assertEqual(1, results[-1]["count"])
@@ -4543,29 +5114,36 @@ class TestFOSSFunnelUDF(ClickhouseTestMixin, APIBaseTest):
             self.team,
         )
 
-        filters = {
-            "insight": INSIGHT_FUNNELS,
-            "funnel_viz_type": "steps",
-            "interval": "day",
-            "date_from": "2021-05-01 00:00:00",
-            "date_to": "2021-05-13 23:59:59",
-            "funnel_window_interval": 30,
-            "funnel_window_interval_unit": "second",
-            "events": [
-                {"id": "step one", "order": 0},
-                {"id": "step two", "order": 1},
+        query = FunnelsQuery(
+            dateRange=DateRange(
+                date_from="2021-05-01 00:00:00",
+                date_to="2021-05-13 23:59:59",
+            ),
+            funnelsFilter=FunnelsFilter(
+                exclusions=[
+                    FunnelExclusionEventsNode(
+                        event="exclusion",
+                        funnelFromStep=0,
+                        funnelToStep=1,
+                        name="exclusion",
+                    ),
+                ],
+                funnelWindowInterval=30,
+                funnelWindowIntervalUnit="second",
+            ),
+            interval="day",
+            series=[
+                EventsNode(
+                    event="step one",
+                    name="step one",
+                ),
+                EventsNode(
+                    event="step two",
+                    name="step two",
+                ),
             ],
-            "exclusions": [
-                {
-                    "id": "exclusion",
-                    "type": "events",
-                    "funnel_from_step": 0,
-                    "funnel_to_step": 1,
-                }
-            ],
-        }
+        )
 
-        query = cast(FunnelsQuery, filter_to_query(filters))
         results = FunnelsQueryRunner(query=query, team=self.team).calculate().results
 
         self.assertEqual(1, results[1]["count"])
@@ -4602,29 +5180,36 @@ class TestFOSSFunnelUDF(ClickhouseTestMixin, APIBaseTest):
             self.team,
         )
 
-        filters = {
-            "insight": INSIGHT_FUNNELS,
-            "funnel_viz_type": "steps",
-            "interval": "day",
-            "date_from": "2021-05-01 00:00:00",
-            "date_to": "2021-05-13 23:59:59",
-            "funnel_window_interval": 10,
-            "funnel_window_interval_unit": "second",
-            "events": [
-                {"id": "step one", "order": 0},
-                {"id": "step two", "order": 1},
+        query = FunnelsQuery(
+            dateRange=DateRange(
+                date_from="2021-05-01 00:00:00",
+                date_to="2021-05-13 23:59:59",
+            ),
+            funnelsFilter=FunnelsFilter(
+                exclusions=[
+                    FunnelExclusionEventsNode(
+                        event="exclusion",
+                        funnelFromStep=0,
+                        funnelToStep=1,
+                        name="exclusion",
+                    ),
+                ],
+                funnelWindowInterval=10,
+                funnelWindowIntervalUnit="second",
+            ),
+            interval="day",
+            series=[
+                EventsNode(
+                    event="step one",
+                    name="step one",
+                ),
+                EventsNode(
+                    event="step two",
+                    name="step two",
+                ),
             ],
-            "exclusions": [
-                {
-                    "id": "exclusion",
-                    "type": "events",
-                    "funnel_from_step": 0,
-                    "funnel_to_step": 1,
-                }
-            ],
-        }
+        )
 
-        query = cast(FunnelsQuery, filter_to_query(filters))
         results = FunnelsQueryRunner(query=query, team=self.team, just_summarize=True).calculate().results
 
         # There should be no events. UDF funnels returns an empty array and says "no events"
@@ -4786,23 +5371,40 @@ class TestFOSSFunnelUDF(ClickhouseTestMixin, APIBaseTest):
             self.team,
         )
 
-        filters = {
-            "insight": INSIGHT_FUNNELS,
-            "funnel_viz_type": "steps",
-            "date_from": "2021-05-01 00:00:00",
-            "date_to": "2021-05-02 23:59:59",
-            "funnel_window_interval": 30,
-            "funnel_window_interval_unit": "second",
-            "events": [
-                {"id": "step one", "order": 0},
-                {"id": "step two", "order": 1},
-                {"id": "step three", "order": 2},
-            ],
-            "breakdown_type": "event",
-            "breakdown": "$browser",
-        }
+        def make_breakdown_query(
+            *, breakdown_attribution_type: str | None = None, breakdown_attribution_value: int | None = None
+        ) -> FunnelsQuery:
+            return FunnelsQuery(
+                breakdownFilter=BreakdownFilter(
+                    breakdown="$browser",
+                ),
+                dateRange=DateRange(
+                    date_from="2021-05-01 00:00:00",
+                    date_to="2021-05-02 23:59:59",
+                ),
+                funnelsFilter=FunnelsFilter(
+                    breakdownAttributionType=breakdown_attribution_type,
+                    breakdownAttributionValue=breakdown_attribution_value,
+                    funnelWindowInterval=30,
+                    funnelWindowIntervalUnit="second",
+                ),
+                series=[
+                    EventsNode(
+                        event="step one",
+                        name="step one",
+                    ),
+                    EventsNode(
+                        event="step two",
+                        name="step two",
+                    ),
+                    EventsNode(
+                        event="step three",
+                        name="step three",
+                    ),
+                ],
+            )
 
-        query = cast(FunnelsQuery, filter_to_query(filters))
+        query = make_breakdown_query()
         results = FunnelsQueryRunner(query=query, team=self.team, just_summarize=True).calculate().results
         assert 1 == len(results)
         result = results[0]
@@ -4810,34 +5412,27 @@ class TestFOSSFunnelUDF(ClickhouseTestMixin, APIBaseTest):
         assert [x["count"] == 1 for x in result]
         assert [x["breakdown"] == ["Chrome"] for x in result]
 
-        filters["breakdown_attribution_type"] = "all_events"
-        query = cast(FunnelsQuery, filter_to_query(filters))
+        query = make_breakdown_query(breakdown_attribution_type="all_events")
         results = FunnelsQueryRunner(query=query, team=self.team, just_summarize=True).calculate().results
         assert 1 == len(results)
         result = results[0]
         assert [x["count"] for x in result] == [1, 1, 1]
         assert [x["breakdown"] == ["Chrome"] for x in result]
 
-        filters["breakdown_attribution_type"] = "step"
-        filters["breakdown_attribution_value"] = 0
-        query = cast(FunnelsQuery, filter_to_query(filters))
+        query = make_breakdown_query(breakdown_attribution_type="step", breakdown_attribution_value=0)
         results = FunnelsQueryRunner(query=query, team=self.team, just_summarize=True).calculate().results
         assert 1 == len(results)
         result = results[0]
         assert [x["count"] for x in result] == [1, 1, 1]
         assert [x["breakdown"] == ["Chrome"] for x in result]
 
-        filters["breakdown_attribution_type"] = "step"
-        filters["breakdown_attribution_value"] = 1
-        query = cast(FunnelsQuery, filter_to_query(filters))
+        query = make_breakdown_query(breakdown_attribution_type="step", breakdown_attribution_value=1)
         results = FunnelsQueryRunner(query=query, team=self.team, just_summarize=True).calculate().results
         assert 2 == len(results)
         for result in results:
             assert [x["count"] for x in result] == [1, 1, 1]
 
-        filters["breakdown_attribution_type"] = "step"
-        filters["breakdown_attribution_value"] = 2
-        query = cast(FunnelsQuery, filter_to_query(filters))
+        query = make_breakdown_query(breakdown_attribution_type="step", breakdown_attribution_value=2)
         results = FunnelsQueryRunner(query=query, team=self.team, just_summarize=True).calculate().results
         assert 1 == len(results)
         result = results[0]
@@ -4849,16 +5444,27 @@ class TestFOSSFunnelUDF(ClickhouseTestMixin, APIBaseTest):
         _create_person(distinct_ids=["only_second_step"], team_id=self.team.pk)
         self._add_to_cart_event(distinct_id="only_second_step", timestamp=datetime(2021, 5, 2, 0, 0, 0))
 
-        filters = {
-            "insight": INSIGHT_FUNNELS,
-            "date_from": "2021-05-01 00:00:00",
-            "date_to": "2021-05-08 23:59:59",
-            "events": [{"id": "user signed up", "order": 0}, {"id": "added to cart", "order": 1}],
-            "funnel_window_interval": 3122064000,
-            "funnel_window_interval_unit": "second",
-        }
+        query = FunnelsQuery(
+            dateRange=DateRange(
+                date_from="2021-05-01 00:00:00",
+                date_to="2021-05-08 23:59:59",
+            ),
+            funnelsFilter=FunnelsFilter(
+                funnelWindowInterval=3122064000,
+                funnelWindowIntervalUnit="second",
+            ),
+            series=[
+                EventsNode(
+                    event="user signed up",
+                    name="user signed up",
+                ),
+                EventsNode(
+                    event="added to cart",
+                    name="added to cart",
+                ),
+            ],
+        )
 
-        query = cast(FunnelsQuery, filter_to_query(filters))
         results = FunnelsQueryRunner(query=query, team=self.team, just_summarize=True).calculate().results
 
         if len(results) == 0:
@@ -5047,26 +5653,55 @@ class TestFOSSFunnelUDF(ClickhouseTestMixin, APIBaseTest):
             _create_event(team=self.team, event="step four, five, eight", distinct_id="test")
             _create_event(team=self.team, event="step six, nine", distinct_id="test")
             _create_event(team=self.team, event="step one, ten", distinct_id="test")
-        filters = {
-            "insight": INSIGHT_FUNNELS,
-            "funnel_viz_type": "steps",
-            "date_from": "2024-01-10 00:00:00",
-            "date_to": "2024-01-12 00:00:00",
-            "events": [
-                {"id": "step one, ten", "order": 0},
-                {"id": "step two, three, seven", "order": 1},
-                {"id": "step two, three, seven", "order": 2},
-                {"id": "step four, five, eight", "order": 3},
-                {"id": "step four, five, eight", "order": 4},
-                {"id": "step six, nine", "order": 5},
-                {"id": "step two, three, seven", "order": 6},
-                {"id": "step four, five, eight", "order": 7},
-                {"id": "step six, nine", "order": 8},
-                {"id": "step one, ten", "order": 9},
+        query = FunnelsQuery(
+            dateRange=DateRange(
+                date_from="2024-01-10 00:00:00",
+                date_to="2024-01-12 00:00:00",
+            ),
+            series=[
+                EventsNode(
+                    event="step one, ten",
+                    name="step one, ten",
+                ),
+                EventsNode(
+                    event="step two, three, seven",
+                    name="step two, three, seven",
+                ),
+                EventsNode(
+                    event="step two, three, seven",
+                    name="step two, three, seven",
+                ),
+                EventsNode(
+                    event="step four, five, eight",
+                    name="step four, five, eight",
+                ),
+                EventsNode(
+                    event="step four, five, eight",
+                    name="step four, five, eight",
+                ),
+                EventsNode(
+                    event="step six, nine",
+                    name="step six, nine",
+                ),
+                EventsNode(
+                    event="step two, three, seven",
+                    name="step two, three, seven",
+                ),
+                EventsNode(
+                    event="step four, five, eight",
+                    name="step four, five, eight",
+                ),
+                EventsNode(
+                    event="step six, nine",
+                    name="step six, nine",
+                ),
+                EventsNode(
+                    event="step one, ten",
+                    name="step one, ten",
+                ),
             ],
-        }
+        )
 
-        query = cast(FunnelsQuery, filter_to_query(filters))
         results = FunnelsQueryRunner(query=query, team=self.team).calculate().results
         self.assertEqual(1, results[-1]["count"])
 
@@ -5093,29 +5728,36 @@ class TestFOSSFunnelUDF(ClickhouseTestMixin, APIBaseTest):
             self.team,
         )
 
-        filters = {
-            "insight": INSIGHT_FUNNELS,
-            "funnel_viz_type": "steps",
-            "interval": "day",
-            "date_from": "2021-05-01 00:00:00",
-            "date_to": "2021-05-13 23:59:59",
-            "funnel_window_interval": 10,
-            "funnel_window_interval_unit": "second",
-            "events": [
-                {"id": "step one", "order": 0},
-                {"id": "step two", "order": 1},
+        query = FunnelsQuery(
+            dateRange=DateRange(
+                date_from="2021-05-01 00:00:00",
+                date_to="2021-05-13 23:59:59",
+            ),
+            funnelsFilter=FunnelsFilter(
+                exclusions=[
+                    FunnelExclusionEventsNode(
+                        event="exclusion",
+                        funnelFromStep=0,
+                        funnelToStep=1,
+                        name="exclusion",
+                    ),
+                ],
+                funnelWindowInterval=10,
+                funnelWindowIntervalUnit="second",
+            ),
+            interval="day",
+            series=[
+                EventsNode(
+                    event="step one",
+                    name="step one",
+                ),
+                EventsNode(
+                    event="step two",
+                    name="step two",
+                ),
             ],
-            "exclusions": [
-                {
-                    "id": "exclusion",
-                    "type": "events",
-                    "funnel_from_step": 0,
-                    "funnel_to_step": 1,
-                }
-            ],
-        }
+        )
 
-        query = cast(FunnelsQuery, filter_to_query(filters))
         results = FunnelsQueryRunner(query=query, team=self.team, just_summarize=True).calculate().results
 
         self.assertEqual(1, results[0]["count"])
@@ -5181,7 +5823,6 @@ class TestFOSSFunnelUDF(ClickhouseTestMixin, APIBaseTest):
                 date_from="2012-01-01 00:00:00",
                 date_to="2012-02-01 23:59:59",
             ),
-            funnelsFilter=FunnelsFilter(),
         )
 
         result = FunnelsQueryRunner(query=query, team=self.team).calculate().results
@@ -5249,7 +5890,6 @@ class TestFOSSFunnelUDF(ClickhouseTestMixin, APIBaseTest):
                 date_from="2012-01-01 00:00:00",
                 date_to="2012-02-01 23:59:59",
             ),
-            funnelsFilter=FunnelsFilter(),
         )
 
         result = FunnelsQueryRunner(query=query, team=self.team).calculate().results
@@ -5287,7 +5927,6 @@ class TestFOSSFunnelUDF(ClickhouseTestMixin, APIBaseTest):
                 EventsNode(event="$checkout"),
             ],
             dateRange=DateRange(date_from="2024-01-01", date_to="2024-01-02"),
-            funnelsFilter=FunnelsFilter(),
         )
         result = FunnelsQueryRunner(query=query, team=self.team).calculate().results
 
@@ -5315,7 +5954,6 @@ class TestFOSSFunnelUDF(ClickhouseTestMixin, APIBaseTest):
                 EventsNode(event="$checkout"),
             ],
             dateRange=DateRange(date_from="2024-01-01", date_to="2024-01-02"),
-            funnelsFilter=FunnelsFilter(),
         )
         result = FunnelsQueryRunner(query=query, team=self.team).calculate().results
 
@@ -5346,7 +5984,6 @@ class TestFOSSFunnelUDF(ClickhouseTestMixin, APIBaseTest):
                 EventsNode(event="$checkout"),
             ],
             dateRange=DateRange(date_from="2024-01-01", date_to="2024-01-02"),
-            funnelsFilter=FunnelsFilter(),
         )
         result = FunnelsQueryRunner(query=query, team=self.team).calculate().results
 
@@ -5395,7 +6032,6 @@ class TestFOSSFunnelUDF(ClickhouseTestMixin, APIBaseTest):
                 EventsNode(event="$checkout"),
             ],
             dateRange=DateRange(date_from="2024-01-01", date_to="2024-01-02"),
-            funnelsFilter=FunnelsFilter(),
         )
         result = FunnelsQueryRunner(query=query, team=self.team).calculate().results
 

--- a/posthog/hogql_queries/insights/funnels/test/test_funnel.py
+++ b/posthog/hogql_queries/insights/funnels/test/test_funnel.py
@@ -2055,7 +2055,15 @@ class TestFOSSFunnelUDF(ClickhouseTestMixin, APIBaseTest):
             ids_to_compare,
         )
 
-    def test_funnel_exclusions_invalid_params(self):
+    @parameterized.expand(
+        [
+            ("same_step", 1, 1),
+            ("end_step_out_of_range", 1, 2),
+            ("reversed_steps", 2, 1),
+            ("start_step_zero", 0, 2),
+        ],
+    )
+    def test_funnel_exclusions_invalid_params(self, _name: str, from_step: int, to_step: int):
         query = FunnelsQuery(
             dateRange=DateRange(
                 date_from="2021-05-01 00:00:00",
@@ -2065,8 +2073,8 @@ class TestFOSSFunnelUDF(ClickhouseTestMixin, APIBaseTest):
                 exclusions=[
                     FunnelExclusionEventsNode(
                         event="x",
-                        funnelFromStep=1,
-                        funnelToStep=1,
+                        funnelFromStep=from_step,
+                        funnelToStep=to_step,
                         name="x",
                     ),
                 ],
@@ -2083,90 +2091,6 @@ class TestFOSSFunnelUDF(ClickhouseTestMixin, APIBaseTest):
             ],
         )
 
-        self.assertRaises(ValidationError, lambda: FunnelsQueryRunner(query=query, team=self.team).calculate())
-
-        query = FunnelsQuery(
-            dateRange=DateRange(
-                date_from="2021-05-01 00:00:00",
-                date_to="2021-05-14 00:00:00",
-            ),
-            funnelsFilter=FunnelsFilter(
-                exclusions=[
-                    FunnelExclusionEventsNode(
-                        event="x",
-                        funnelFromStep=1,
-                        funnelToStep=2,
-                        name="x",
-                    ),
-                ],
-            ),
-            series=[
-                EventsNode(
-                    event="user signed up",
-                    name="user signed up",
-                ),
-                EventsNode(
-                    event="paid",
-                    name="paid",
-                ),
-            ],
-        )
-        self.assertRaises(ValidationError, lambda: FunnelsQueryRunner(query=query, team=self.team).calculate())
-
-        query = FunnelsQuery(
-            dateRange=DateRange(
-                date_from="2021-05-01 00:00:00",
-                date_to="2021-05-14 00:00:00",
-            ),
-            funnelsFilter=FunnelsFilter(
-                exclusions=[
-                    FunnelExclusionEventsNode(
-                        event="x",
-                        funnelFromStep=2,
-                        funnelToStep=1,
-                        name="x",
-                    ),
-                ],
-            ),
-            series=[
-                EventsNode(
-                    event="user signed up",
-                    name="user signed up",
-                ),
-                EventsNode(
-                    event="paid",
-                    name="paid",
-                ),
-            ],
-        )
-        self.assertRaises(ValidationError, lambda: FunnelsQueryRunner(query=query, team=self.team).calculate())
-
-        query = FunnelsQuery(
-            dateRange=DateRange(
-                date_from="2021-05-01 00:00:00",
-                date_to="2021-05-14 00:00:00",
-            ),
-            funnelsFilter=FunnelsFilter(
-                exclusions=[
-                    FunnelExclusionEventsNode(
-                        event="x",
-                        funnelFromStep=0,
-                        funnelToStep=2,
-                        name="x",
-                    ),
-                ],
-            ),
-            series=[
-                EventsNode(
-                    event="user signed up",
-                    name="user signed up",
-                ),
-                EventsNode(
-                    event="paid",
-                    name="paid",
-                ),
-            ],
-        )
         self.assertRaises(ValidationError, lambda: FunnelsQueryRunner(query=query, team=self.team).calculate())
 
     def test_funnel_exclusion_no_end_event(self):
@@ -2650,44 +2574,41 @@ class TestFOSSFunnelUDF(ClickhouseTestMixin, APIBaseTest):
         self.assertCountEqual(self._get_actor_ids_at_step(query, 2), [person1.uuid, person3.uuid])
 
     def test_advanced_funnel_exclusions_between_steps(self):
-        query = FunnelsQuery(
-            dateRange=DateRange(
-                date_from="2021-05-01 00:00:00",
-                date_to="2021-05-14 00:00:00",
-            ),
-            funnelsFilter=FunnelsFilter(
-                exclusions=[
-                    FunnelExclusionEventsNode(
-                        event="x",
-                        funnelFromStep=0,
-                        funnelToStep=1,
-                        name="x",
-                    ),
-                ],
-            ),
-            series=[
-                EventsNode(
-                    event="user signed up",
-                    name="user signed up",
-                ),
-                EventsNode(
-                    event="$pageview",
-                    name="$pageview",
-                ),
-                EventsNode(
-                    event="insight viewed",
-                    name="insight viewed",
-                ),
-                EventsNode(
-                    event="invite teammate",
-                    name="invite teammate",
-                ),
-                EventsNode(
-                    event="pageview2",
-                    name="pageview2",
-                ),
-            ],
+        date_range = DateRange(
+            date_from="2021-05-01 00:00:00",
+            date_to="2021-05-14 00:00:00",
         )
+        five_step_series = [
+            EventsNode(event="user signed up", name="user signed up"),
+            EventsNode(event="$pageview", name="$pageview"),
+            EventsNode(event="insight viewed", name="insight viewed"),
+            EventsNode(event="invite teammate", name="invite teammate"),
+            EventsNode(event="pageview2", name="pageview2"),
+        ]
+
+        def run_query(exclusions):
+            query = FunnelsQuery(
+                dateRange=date_range,
+                funnelsFilter=FunnelsFilter(exclusions=exclusions),
+                series=five_step_series,
+            )
+            return query, FunnelsQueryRunner(query=query, team=self.team).calculate().results
+
+        def assert_results(results, expected_count):
+            if expected_count == 0:
+                # There should be no events. UDF funnels returns an empty array and says "no events"
+                # Old style funnels returns a count of 0
+                try:
+                    self.assertEqual([], results)
+                except AssertionError:
+                    self.assertEqual(results[0]["name"], "user signed up")
+                    self.assertEqual(results[0]["count"], 0)
+                    self.assertEqual(results[4]["count"], 0)
+                return
+
+            self.assertEqual(results[0]["name"], "user signed up")
+            self.assertEqual(results[0]["count"], expected_count)
+            self.assertEqual(results[4]["count"], expected_count)
 
         person1 = _create_person(distinct_ids=["person1"], team_id=self.team.pk)
         # this dude is discarded when funnel_from_step = 1
@@ -2834,253 +2755,100 @@ class TestFOSSFunnelUDF(ClickhouseTestMixin, APIBaseTest):
             timestamp="2021-05-01 06:00:00",
         )
 
-        results = FunnelsQueryRunner(query=query, team=self.team).calculate().results
-
-        self.assertEqual(results[0]["name"], "user signed up")
-        self.assertEqual(results[0]["count"], 2)
-
-        self.assertEqual(results[4]["count"], 2)
-
-        self.assertCountEqual(self._get_actor_ids_at_step(query, 1), [person1.uuid, person2.uuid])
-
-        query = FunnelsQuery(
-            dateRange=DateRange(
-                date_from="2021-05-01 00:00:00",
-                date_to="2021-05-14 00:00:00",
-            ),
-            funnelsFilter=FunnelsFilter(
-                exclusions=[
-                    FunnelExclusionEventsNode(
-                        event="x",
-                        funnelFromStep=1,
-                        funnelToStep=2,
-                        name="x",
-                    ),
-                ],
-            ),
-            series=[
-                EventsNode(
-                    event="user signed up",
-                    name="user signed up",
-                ),
-                EventsNode(
-                    event="$pageview",
-                    name="$pageview",
-                ),
-                EventsNode(
-                    event="insight viewed",
-                    name="insight viewed",
-                ),
-                EventsNode(
-                    event="invite teammate",
-                    name="invite teammate",
-                ),
-                EventsNode(
-                    event="pageview2",
-                    name="pageview2",
-                ),
-            ],
-        )
-        results = FunnelsQueryRunner(query=query, team=self.team).calculate().results
-
-        self.assertEqual(results[0]["name"], "user signed up")
-        self.assertEqual(results[0]["count"], 2)
-
-        self.assertEqual(results[4]["count"], 2)
-
-        self.assertCountEqual(self._get_actor_ids_at_step(query, 1), [person2.uuid, person3.uuid])
-
-        query = FunnelsQuery(
-            dateRange=DateRange(
-                date_from="2021-05-01 00:00:00",
-                date_to="2021-05-14 00:00:00",
-            ),
-            funnelsFilter=FunnelsFilter(
-                exclusions=[
-                    FunnelExclusionEventsNode(
-                        event="x",
-                        funnelFromStep=2,
-                        funnelToStep=3,
-                        name="x",
-                    ),
-                ],
-            ),
-            series=[
-                EventsNode(
-                    event="user signed up",
-                    name="user signed up",
-                ),
-                EventsNode(
-                    event="$pageview",
-                    name="$pageview",
-                ),
-                EventsNode(
-                    event="insight viewed",
-                    name="insight viewed",
-                ),
-                EventsNode(
-                    event="invite teammate",
-                    name="invite teammate",
-                ),
-                EventsNode(
-                    event="pageview2",
-                    name="pageview2",
-                ),
-            ],
-        )
-        results = FunnelsQueryRunner(query=query, team=self.team).calculate().results
-
-        self.assertEqual(results[0]["name"], "user signed up")
-        self.assertEqual(results[0]["count"], 1)
-
-        self.assertEqual(results[4]["count"], 1)
-
-        self.assertCountEqual(self._get_actor_ids_at_step(query, 1), [person3.uuid])
-
-        query = FunnelsQuery(
-            dateRange=DateRange(
-                date_from="2021-05-01 00:00:00",
-                date_to="2021-05-14 00:00:00",
-            ),
-            funnelsFilter=FunnelsFilter(
-                exclusions=[
-                    FunnelExclusionEventsNode(
-                        event="x",
-                        funnelFromStep=3,
-                        funnelToStep=4,
-                        name="x",
-                    ),
-                ],
-            ),
-            series=[
-                EventsNode(
-                    event="user signed up",
-                    name="user signed up",
-                ),
-                EventsNode(
-                    event="$pageview",
-                    name="$pageview",
-                ),
-                EventsNode(
-                    event="insight viewed",
-                    name="insight viewed",
-                ),
-                EventsNode(
-                    event="invite teammate",
-                    name="invite teammate",
-                ),
-                EventsNode(
-                    event="pageview2",
-                    name="pageview2",
-                ),
-            ],
-        )
-        results = FunnelsQueryRunner(query=query, team=self.team).calculate().results
-
-        # There should be no events. UDF funnels returns an empty array and says "no events"
-        # Old style funnels returns a count of 0
-        try:
-            self.assertEqual([], results)
-        except AssertionError:
-            self.assertEqual(results[0]["name"], "user signed up")
-            self.assertEqual(results[0]["count"], 0)
-            self.assertEqual(results[4]["count"], 0)
-
-        self.assertCountEqual(self._get_actor_ids_at_step(query, 1), [])
-
-        #  bigger step window
-        query = FunnelsQuery(
-            dateRange=DateRange(
-                date_from="2021-05-01 00:00:00",
-                date_to="2021-05-14 00:00:00",
-            ),
-            funnelsFilter=FunnelsFilter(
-                exclusions=[
-                    FunnelExclusionEventsNode(
-                        event="x",
-                        funnelFromStep=1,
-                        funnelToStep=3,
-                        name="x",
-                    ),
-                ],
-            ),
-            series=[
-                EventsNode(
-                    event="user signed up",
-                    name="user signed up",
-                ),
-                EventsNode(
-                    event="$pageview",
-                    name="$pageview",
-                ),
-                EventsNode(
-                    event="insight viewed",
-                    name="insight viewed",
-                ),
-                EventsNode(
-                    event="invite teammate",
-                    name="invite teammate",
-                ),
-                EventsNode(
-                    event="pageview2",
-                    name="pageview2",
-                ),
-            ],
-        )
-        results = FunnelsQueryRunner(query=query, team=self.team).calculate().results
-
-        self.assertEqual(results[0]["name"], "user signed up")
-        self.assertEqual(results[0]["count"], 1)
-
-        self.assertEqual(results[4]["count"], 1)
-
-        self.assertCountEqual(self._get_actor_ids_at_step(query, 1), [person3.uuid])
-
-    def test_advanced_funnel_multiple_exclusions_between_steps(self):
-        query = FunnelsQuery(
-            dateRange=DateRange(
-                date_from="2021-05-01 00:00:00",
-                date_to="2021-05-14 00:00:00",
-            ),
-            funnelsFilter=FunnelsFilter(
-                exclusions=[
+        cases = [
+            (
+                "between steps 0 and 1",
+                [
                     FunnelExclusionEventsNode(
                         event="x",
                         funnelFromStep=0,
                         funnelToStep=1,
                         name="x",
-                    ),
+                    )
+                ],
+                2,
+                [person1.uuid, person2.uuid],
+            ),
+            (
+                "between steps 1 and 2",
+                [
                     FunnelExclusionEventsNode(
-                        event="y",
+                        event="x",
+                        funnelFromStep=1,
+                        funnelToStep=2,
+                        name="x",
+                    )
+                ],
+                2,
+                [person2.uuid, person3.uuid],
+            ),
+            (
+                "between steps 2 and 3",
+                [
+                    FunnelExclusionEventsNode(
+                        event="x",
                         funnelFromStep=2,
                         funnelToStep=3,
-                        name="y",
-                    ),
+                        name="x",
+                    )
                 ],
+                1,
+                [person3.uuid],
             ),
-            series=[
-                EventsNode(
-                    event="user signed up",
-                    name="user signed up",
-                ),
-                EventsNode(
-                    event="$pageview",
-                    name="$pageview",
-                ),
-                EventsNode(
-                    event="insight viewed",
-                    name="insight viewed",
-                ),
-                EventsNode(
-                    event="invite teammate",
-                    name="invite teammate",
-                ),
-                EventsNode(
-                    event="pageview2",
-                    name="pageview2",
-                ),
-            ],
+            (
+                "between steps 3 and 4",
+                [
+                    FunnelExclusionEventsNode(
+                        event="x",
+                        funnelFromStep=3,
+                        funnelToStep=4,
+                        name="x",
+                    )
+                ],
+                0,
+                [],
+            ),
+            (
+                "between steps 1 and 3",
+                [
+                    FunnelExclusionEventsNode(
+                        event="x",
+                        funnelFromStep=1,
+                        funnelToStep=3,
+                        name="x",
+                    )
+                ],
+                1,
+                [person3.uuid],
+            ),
+        ]
+
+        for label, exclusions, expected_count, expected_actor_ids in cases:
+            with self.subTest(label):
+                query, results = run_query(exclusions)
+                assert_results(results, expected_count)
+                self.assertCountEqual(self._get_actor_ids_at_step(query, 1), expected_actor_ids)
+
+    def test_advanced_funnel_multiple_exclusions_between_steps(self):
+        date_range = DateRange(
+            date_from="2021-05-01 00:00:00",
+            date_to="2021-05-14 00:00:00",
         )
+        five_step_series = [
+            EventsNode(event="user signed up", name="user signed up"),
+            EventsNode(event="$pageview", name="$pageview"),
+            EventsNode(event="insight viewed", name="insight viewed"),
+            EventsNode(event="invite teammate", name="invite teammate"),
+            EventsNode(event="pageview2", name="pageview2"),
+        ]
+
+        def run_query(exclusions):
+            query = FunnelsQuery(
+                dateRange=date_range,
+                funnelsFilter=FunnelsFilter(exclusions=exclusions),
+                series=five_step_series,
+            )
+            return query, FunnelsQueryRunner(query=query, team=self.team).calculate().results
 
         _create_person(distinct_ids=["person1"], team_id=self.team.pk)
         _create_event(
@@ -3252,174 +3020,57 @@ class TestFOSSFunnelUDF(ClickhouseTestMixin, APIBaseTest):
             timestamp="2021-05-01 06:00:00",
         )
 
-        results = FunnelsQueryRunner(query=query, team=self.team).calculate().results
-
-        self.assertEqual(results[0]["name"], "user signed up")
-        self.assertEqual(results[0]["count"], 1)
-
-        self.assertEqual(results[4]["count"], 1)
-
-        self.assertCountEqual(self._get_actor_ids_at_step(query, 1), [person4.uuid])
-
-        query = FunnelsQuery(
-            dateRange=DateRange(
-                date_from="2021-05-01 00:00:00",
-                date_to="2021-05-14 00:00:00",
-            ),
-            funnelsFilter=FunnelsFilter(
-                exclusions=[
-                    FunnelExclusionEventsNode(
-                        event="x",
-                        funnelFromStep=0,
-                        funnelToStep=1,
-                        name="x",
-                    ),
-                    FunnelExclusionEventsNode(
-                        event="y",
-                        funnelFromStep=0,
-                        funnelToStep=1,
-                        name="y",
-                    ),
-                ],
-            ),
-            series=[
-                EventsNode(
-                    event="user signed up",
-                    name="user signed up",
+        cases = [
+            [
+                FunnelExclusionEventsNode(
+                    event="x",
+                    funnelFromStep=0,
+                    funnelToStep=1,
+                    name="x",
                 ),
-                EventsNode(
-                    event="$pageview",
-                    name="$pageview",
-                ),
-                EventsNode(
-                    event="insight viewed",
-                    name="insight viewed",
-                ),
-                EventsNode(
-                    event="invite teammate",
-                    name="invite teammate",
-                ),
-                EventsNode(
-                    event="pageview2",
-                    name="pageview2",
+                FunnelExclusionEventsNode(
+                    event="y",
+                    funnelFromStep=2,
+                    funnelToStep=3,
+                    name="y",
                 ),
             ],
-        )
-
-        results = FunnelsQueryRunner(query=query, team=self.team).calculate().results
-
-        self.assertEqual(results[0]["name"], "user signed up")
-        self.assertEqual(results[0]["count"], 1)
-
-        self.assertEqual(results[4]["count"], 1)
-
-        self.assertCountEqual(self._get_actor_ids_at_step(query, 1), [person4.uuid])
-
-        query = FunnelsQuery(
-            dateRange=DateRange(
-                date_from="2021-05-01 00:00:00",
-                date_to="2021-05-14 00:00:00",
-            ),
-            funnelsFilter=FunnelsFilter(
-                exclusions=[
-                    FunnelExclusionEventsNode(
-                        event="x",
-                        funnelFromStep=0,
-                        funnelToStep=1,
-                        name="x",
-                    ),
-                    FunnelExclusionEventsNode(
-                        event="y",
-                        funnelFromStep=0,
-                        funnelToStep=1,
-                        name="y",
-                    ),
-                ],
-            ),
-            series=[
-                EventsNode(
-                    event="user signed up",
-                    name="user signed up",
+            [
+                FunnelExclusionEventsNode(
+                    event="x",
+                    funnelFromStep=0,
+                    funnelToStep=1,
+                    name="x",
                 ),
-                EventsNode(
-                    event="$pageview",
-                    name="$pageview",
-                ),
-                EventsNode(
-                    event="insight viewed",
-                    name="insight viewed",
-                ),
-                EventsNode(
-                    event="invite teammate",
-                    name="invite teammate",
-                ),
-                EventsNode(
-                    event="pageview2",
-                    name="pageview2",
+                FunnelExclusionEventsNode(
+                    event="y",
+                    funnelFromStep=0,
+                    funnelToStep=1,
+                    name="y",
                 ),
             ],
-        )
-        results = FunnelsQueryRunner(query=query, team=self.team).calculate().results
-
-        self.assertEqual(results[0]["name"], "user signed up")
-        self.assertEqual(results[0]["count"], 1)
-
-        self.assertEqual(results[4]["count"], 1)
-
-        self.assertCountEqual(self._get_actor_ids_at_step(query, 1), [person4.uuid])
-
-        query = FunnelsQuery(
-            dateRange=DateRange(
-                date_from="2021-05-01 00:00:00",
-                date_to="2021-05-14 00:00:00",
-            ),
-            funnelsFilter=FunnelsFilter(
-                exclusions=[
-                    FunnelExclusionEventsNode(
-                        event="x",
-                        funnelFromStep=0,
-                        funnelToStep=4,
-                        name="x",
-                    ),
-                    FunnelExclusionEventsNode(
-                        event="y",
-                        funnelFromStep=0,
-                        funnelToStep=4,
-                        name="y",
-                    ),
-                ],
-            ),
-            series=[
-                EventsNode(
-                    event="user signed up",
-                    name="user signed up",
+            [
+                FunnelExclusionEventsNode(
+                    event="x",
+                    funnelFromStep=0,
+                    funnelToStep=4,
+                    name="x",
                 ),
-                EventsNode(
-                    event="$pageview",
-                    name="$pageview",
-                ),
-                EventsNode(
-                    event="insight viewed",
-                    name="insight viewed",
-                ),
-                EventsNode(
-                    event="invite teammate",
-                    name="invite teammate",
-                ),
-                EventsNode(
-                    event="pageview2",
-                    name="pageview2",
+                FunnelExclusionEventsNode(
+                    event="y",
+                    funnelFromStep=0,
+                    funnelToStep=4,
+                    name="y",
                 ),
             ],
-        )
-        results = FunnelsQueryRunner(query=query, team=self.team).calculate().results
+        ]
 
-        self.assertEqual(results[0]["name"], "user signed up")
-        self.assertEqual(results[0]["count"], 1)
-
-        self.assertEqual(results[4]["count"], 1)
-
-        self.assertCountEqual(self._get_actor_ids_at_step(query, 1), [person4.uuid])
+        for exclusions in cases:
+            query, results = run_query(exclusions)
+            self.assertEqual(results[0]["name"], "user signed up")
+            self.assertEqual(results[0]["count"], 1)
+            self.assertEqual(results[4]["count"], 1)
+            self.assertCountEqual(self._get_actor_ids_at_step(query, 1), [person4.uuid])
 
     @also_test_with_materialized_columns(["test_prop"])
     def test_funnel_with_denormalised_properties(self):


### PR DESCRIPTION
## Problem

We want to get rid of legacy "filters".

## Changes

Replaces them in `posthog/hogql_queries/insights/funnels/test/test_funnel.py`.

## How did you test this code?

Tests still run