### PR TITLE
chore(error-tracking): increase max retries

### DIFF
--- a/nodejs/src/ingestion/error-tracking/error-tracking-pipeline.test.ts
+++ b/nodejs/src/ingestion/error-tracking/error-tracking-pipeline.test.ts
@@ -25,6 +25,12 @@ import {
     runErrorTrackingPipeline,
 } from './error-tracking-pipeline'
 
+// Skip retry sleeps so tests run instantly
+jest.mock('~/utils/utils', () => ({
+    ...jest.requireActual('~/utils/utils'),
+    sleep: jest.fn().mockResolvedValue(undefined),
+}))
+
 // Suppress logger output during tests
 jest.mock('~/utils/logger', () => ({
     logger: {
@@ -627,12 +633,12 @@ describe('ErrorTrackingPipeline', () => {
 
             const pipeline = createErrorTrackingPipeline(pipelineConfig)
 
-            // Cymbal errors are retried 3 times (pipeline default), then propagate
+            // Cymbal errors are retried 10 times (pipeline default), then propagate
             // so Kafka doesn't commit and retries the batch
             await expect(runErrorTrackingPipeline(pipeline, [message])).rejects.toThrow('Cymbal unavailable')
 
-            // Cymbal was called 3 times (initial + 2 retries) before giving up
-            expect(mockCymbalClient.processExceptions).toHaveBeenCalledTimes(3)
+            // Cymbal was called 10 times (initial + 9 retries) before giving up
+            expect(mockCymbalClient.processExceptions).toHaveBeenCalledTimes(10)
             expect(mockHogTransformer.transformEventAndProduceMessages).not.toHaveBeenCalled()
         })
 

--- a/nodejs/src/ingestion/error-tracking/error-tracking-pipeline.ts
+++ b/nodejs/src/ingestion/error-tracking/error-tracking-pipeline.ts
@@ -180,8 +180,10 @@ export function createErrorTrackingPipeline(
                                     // Process through Cymbal as a batch (before enrichment - Cymbal only
                                     // needs raw exception data, not person/geoip/group data).
                                     // Retry on transient failures (5xx, timeout, network errors).
+                                    // 10 tries with 100ms base sleep and 2x backoff (capped at 10s)
+                                    // gives ~30s total budget to ride out a Cymbal restart.
                                     .pipeBatchWithRetry(createCymbalProcessingStep(cymbalClient), {
-                                        tries: 3,
+                                        tries: 10,
                                         sleepMs: 100,
                                     })
                                     // Enrich, prepare, create, and emit events


### PR DESCRIPTION
## Problem

10 retries is a lot - but when cymbal crashes all at once, 3 isn't enough and the ingestion pipeline then crashes too. this gives us breathing room to wait for cymbal to be available again - with the existing backoff logic, this should cap out around 30s.