### PR TITLE
chore(cymbal): don't panic on kafka broker disconnect

### DIFF
--- a/rust/cymbal/src/consumer.rs
+++ b/rust/cymbal/src/consumer.rs
@@ -40,7 +40,13 @@ pub async fn start_consumer(config: &Config, context: Arc<AppContext>) {
                     offsets.push(offset);
                 }
                 Err(RecvErr::Kafka(e)) => {
-                    panic!("Kafka error: {e}")
+                    // Kafka-level errors (broker disconnect, rebalance, coordinator change)
+                    // don't correspond to a specific message — no offset was created, so no
+                    // data is skipped. librdkafka handles reconnection internally, and the
+                    // next loop iteration will retry from the same position.
+                    metrics::counter!(ERRORS, "cause" => "kafka_error").increment(1);
+                    error!("Kafka error receiving message: {:?}", e);
+                    continue;
                 }
                 Err(err) => {
                     // If we failed to parse the message, or it was empty, just log and continue, our


### PR DESCRIPTION
## Problem

when cymbal experiences intermittent disconnects from kafka, it throws a panic and kills the service. rdkafka will already try to reconnect, so instead of panicking we should return an error and try again on the next loop. in monitoring the new error tracking ingestion pipeline i saw all pods dying at once because all cymbal pods were due to a disconnect (i think there were some broker restarts today) - i'm adding a more flexible retry policy on that end but i think it'd be good to be more flexible here too. 

this will currently immediately retry - i wanted to keep this simple, but happy to add a retry policy with a backoff here if we think that'd be better.