### PR TITLE
perf(max): load conversation messages on demand instead of in list

### DIFF
--- a/ee/api/test/test_conversation.py
+++ b/ee/api/test/test_conversation.py
@@ -522,8 +522,6 @@ class TestConversation(APIBaseTest):
         assert "status" in results[0]
 
     def test_list_conversations_only_returns_own_conversations(self):
-        """Test that listing conversations only returns the current user's conversations"""
-        # Create conversations for different users
         own_conversation = Conversation.objects.create(
             user=self.user, team=self.team, title="My conversation", type=Conversation.Type.ASSISTANT
         )
@@ -531,14 +529,13 @@ class TestConversation(APIBaseTest):
             user=self.other_user, team=self.team, title="Other user conversation", type=Conversation.Type.ASSISTANT
         )
 
-        with patch("langgraph.graph.state.CompiledStateGraph.aget_state", new_callable=AsyncMock):
-            response = self.client.get(f"/api/environments/{self.team.id}/conversations/")
-            assert response.status_code == status.HTTP_200_OK
+        response = self.client.get(f"/api/environments/{self.team.id}/conversations/")
+        assert response.status_code == status.HTTP_200_OK
 
-            results = response.json()["results"]
-            assert len(results) == 1
-            assert results[0]["id"] == str(own_conversation.id)
-            assert results[0]["title"] == "My conversation"
+        results = response.json()["results"]
+        assert len(results) == 1
+        assert results[0]["id"] == str(own_conversation.id)
+        assert results[0]["title"] == "My conversation"
 
     def test_retrieve_own_conversation_succeeds(self):
         """Test that user can retrieve their own conversation"""

--- a/frontend/src/scenes/max/Max.stories.tsx
+++ b/frontend/src/scenes/max/Max.stories.tsx
@@ -365,14 +365,17 @@ export const ThreadWithConversationLoading: StoryFn = () => {
     useStorybookMocks({
         get: {
             '/api/environments/:team_id/conversations/': (_req, _res, ctx) => [ctx.delay('infinite')],
+            [`/api/environments/:team_id/conversations/${CONVERSATION_ID}/`]: (_req, _res, ctx) => [
+                ctx.delay('infinite'),
+            ],
         },
     })
 
-    const { setConversationId } = useActions(maxLogic({ tabId: 'storybook' }))
+    const { openConversation } = useActions(maxLogic({ tabId: 'storybook' }))
 
     useEffect(() => {
-        setConversationId(CONVERSATION_ID)
-    }, [setConversationId])
+        openConversation(CONVERSATION_ID)
+    }, [openConversation])
 
     return <Template />
 }
@@ -386,14 +389,78 @@ export const ThreadWithEmptyConversation: StoryFn = () => {
     useStorybookMocks({
         get: {
             '/api/environments/:team_id/conversations/': () => [200, conversationList],
+            '/api/environments/:team_id/conversations/empty/': () => [
+                200,
+                {
+                    id: 'empty',
+                    status: 'idle',
+                    title: 'Counting users chatting from USA',
+                    created_at: '2025-04-29T17:44:21.654307Z',
+                    updated_at: '2025-04-29T17:44:29.184791Z',
+                    user: MOCK_DEFAULT_BASIC_USER,
+                    messages: [],
+                },
+            ],
         },
     })
 
-    const { setConversationId } = useActions(maxLogic({ tabId: 'storybook' }))
+    const { openConversation } = useActions(maxLogic({ tabId: 'storybook' }))
 
     useEffect(() => {
-        setConversationId('empty')
-    }, [setConversationId])
+        openConversation('empty')
+    }, [openConversation])
+
+    return <Template />
+}
+
+const POEM_CONVERSATION = {
+    id: 'poem',
+    status: 'idle',
+    title: 'Writing poems',
+    created_at: '2025-04-29T17:44:21.654307Z',
+    updated_at: '2025-04-29T17:44:29.184791Z',
+    user: MOCK_DEFAULT_BASIC_USER,
+    messages: [
+        { content: 'write a poem', id: 'human-1', type: 'human' },
+        {
+            content: 'In the world of data, where numbers dance,\nPostHog stands ready, to give insights a chance.',
+            id: 'ai-1',
+            meta: null,
+            tool_calls: [],
+            type: 'ai',
+        },
+        { content: 'write another poem', id: 'human-2', type: 'human' },
+        {
+            content: 'In the forest of files, where hedgehogs roam,\nA platform was born, a digital home.',
+            id: 'ai-2',
+            meta: null,
+            tool_calls: [],
+            type: 'ai',
+        },
+        { content: 'write another poem', id: 'human-3', type: 'human' },
+        {
+            content: 'So join the adventure, in this digital bog,\nWhere files find a home, with PostHog!',
+            id: 'ai-3',
+            meta: null,
+            tool_calls: [],
+            type: 'ai',
+        },
+    ],
+}
+
+export const ThreadOpenedFromHistory: StoryFn = () => {
+    useStorybookMocks({
+        get: {
+            '/api/environments/:team_id/conversations/': () => [200, conversationList],
+            '/api/environments/:team_id/conversations/poem/': () => [200, POEM_CONVERSATION],
+        },
+    })
+
+    const { openConversation } = useActions(maxLogic({ tabId: 'storybook' }))
+
+    useEffect(() => {
+        openConversation('poem')
+    }, [openConversation])
 
     return <Template />
 }
@@ -439,12 +506,11 @@ export const SharedThread: StoryFn = () => {
         },
     })
 
-    const { setConversationId } = useActions(maxLogic({ tabId: 'storybook' }))
+    const { openConversation } = useActions(maxLogic({ tabId: 'storybook' }))
 
     useEffect(() => {
-        // Simulate loading a shared conversation via URL parameter
-        setConversationId(sharedConversationId)
-    }, [setConversationId])
+        openConversation(sharedConversationId)
+    }, [openConversation])
 
     return <Template />
 }
@@ -462,11 +528,11 @@ export const ThreadWithInProgressConversation: StoryFn = () => {
         },
     })
 
-    const { setConversationId } = useActions(maxLogic({ tabId: 'storybook' }))
+    const { openConversation } = useActions(maxLogic({ tabId: 'storybook' }))
 
     useEffect(() => {
-        setConversationId('in_progress')
-    }, [setConversationId])
+        openConversation('in_progress')
+    }, [openConversation])
 
     return <Template sidePanel />
 }
@@ -637,6 +703,7 @@ export const ThreadScrollsToBottomOnNewMessages: StoryFn = () => {
     useStorybookMocks({
         get: {
             '/api/environments/:team_id/conversations/': () => [200, conversationList],
+            '/api/environments/:team_id/conversations/poem/': () => [200, POEM_CONVERSATION],
         },
         post: {
             '/api/environments/:team_id/conversations/': (_, res, ctx) =>
@@ -645,14 +712,14 @@ export const ThreadScrollsToBottomOnNewMessages: StoryFn = () => {
     })
 
     const { conversation } = useValues(maxLogic({ tabId: 'storybook' }))
-    const { setConversationId } = useActions(maxLogic({ tabId: 'storybook' }))
+    const { openConversation } = useActions(maxLogic({ tabId: 'storybook' }))
     const logic = maxThreadLogic({ conversationId: 'poem', conversation, tabId: 'storybook' })
     const { threadRaw } = useValues(logic)
     const { askMax } = useActions(logic)
 
     useEffect(() => {
-        setConversationId('poem')
-    }, [setConversationId])
+        openConversation('poem')
+    }, [openConversation])
 
     const messagesSet = threadRaw.length > 0
     useEffect(() => {


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
