### PR TITLE
feat(sql-editor): hierarchy of views

### DIFF
--- a/frontend/src/lib/components/TablePreview/databaseTablePreviewLogic.ts
+++ b/frontend/src/lib/components/TablePreview/databaseTablePreviewLogic.ts
@@ -3,7 +3,7 @@ import { loaders } from 'kea-loaders'
 import posthog from 'posthog-js'
 
 import { hogqlQuery } from '~/queries/query'
-import { hogql } from '~/queries/utils'
+import { escapeHogQLQualifiedIdentifier, hogql } from '~/queries/utils'
 
 import type { databaseTablePreviewLogicType } from './databaseTablePreviewLogicType'
 import type { TablePreviewExpressionColumn } from './types'
@@ -45,8 +45,8 @@ export const databaseTablePreviewLogic = kea<databaseTablePreviewLogicType>([
                     try {
                         const response = await hogqlQuery(
                             trimmedWhereClause
-                                ? hogql`SELECT *${hogql.raw(previewExpressionSelectClause)} FROM ${hogql.identifier(props.tableName)} WHERE ${hogql.raw(trimmedWhereClause)} LIMIT ${previewLimit}`
-                                : hogql`SELECT *${hogql.raw(previewExpressionSelectClause)} FROM ${hogql.identifier(props.tableName)} LIMIT ${previewLimit}`
+                                ? hogql`SELECT *${hogql.raw(previewExpressionSelectClause)} FROM ${hogql.raw(escapeHogQLQualifiedIdentifier(props.tableName))} WHERE ${hogql.raw(trimmedWhereClause)} LIMIT ${previewLimit}`
+                                : hogql`SELECT *${hogql.raw(previewExpressionSelectClause)} FROM ${hogql.raw(escapeHogQLQualifiedIdentifier(props.tableName))} LIMIT ${previewLimit}`
                         )
                         return (response.results || []).map((row: any[]) =>
                             Object.fromEntries(

--- a/frontend/src/lib/components/TablePreview/databaseTablePreviewLogic.ts
+++ b/frontend/src/lib/components/TablePreview/databaseTablePreviewLogic.ts
@@ -3,7 +3,7 @@ import { loaders } from 'kea-loaders'
 import posthog from 'posthog-js'
 
 import { hogqlQuery } from '~/queries/query'
-import { escapeHogQLQualifiedIdentifier, hogql } from '~/queries/utils'
+import { hogql } from '~/queries/utils'
 
 import type { databaseTablePreviewLogicType } from './databaseTablePreviewLogicType'
 import type { TablePreviewExpressionColumn } from './types'
@@ -45,8 +45,8 @@ export const databaseTablePreviewLogic = kea<databaseTablePreviewLogicType>([
                     try {
                         const response = await hogqlQuery(
                             trimmedWhereClause
-                                ? hogql`SELECT *${hogql.raw(previewExpressionSelectClause)} FROM ${hogql.raw(escapeHogQLQualifiedIdentifier(props.tableName))} WHERE ${hogql.raw(trimmedWhereClause)} LIMIT ${previewLimit}`
-                                : hogql`SELECT *${hogql.raw(previewExpressionSelectClause)} FROM ${hogql.raw(escapeHogQLQualifiedIdentifier(props.tableName))} LIMIT ${previewLimit}`
+                                ? hogql`SELECT *${hogql.raw(previewExpressionSelectClause)} FROM ${hogql.qualifiedIdentifier(props.tableName)} WHERE ${hogql.raw(trimmedWhereClause)} LIMIT ${previewLimit}`
+                                : hogql`SELECT *${hogql.raw(previewExpressionSelectClause)} FROM ${hogql.qualifiedIdentifier(props.tableName)} LIMIT ${previewLimit}`
                         )
                         return (response.results || []).map((row: any[]) =>
                             Object.fromEntries(

--- a/frontend/src/queries/utils.test.ts
+++ b/frontend/src/queries/utils.test.ts
@@ -29,6 +29,12 @@ describe('hogql tag', () => {
         )
     })
 
+    it('properly returns query with qualified identifier substitution', () => {
+        expect(hogql`SELECT * FROM ${hogql.qualifiedIdentifier('my schema.odd table')}`).toEqual(
+            'SELECT * FROM "my schema"."odd table"'
+        )
+    })
+
     it('properly returns query with string and number substitutions', () => {
         expect(hogql`SELECT * FROM events WHERE properties.foo = ${'bar'} AND properties.baz = ${3}`).toEqual(
             "SELECT * FROM events WHERE properties.foo = 'bar' AND properties.baz = 3"

--- a/frontend/src/queries/utils.ts
+++ b/frontend/src/queries/utils.ts
@@ -755,6 +755,10 @@ function hogQLRaw(raw: string): HogQLRaw {
     }
 }
 
+function hogQLQualifiedIdentifier(identifier: string): HogQLRaw {
+    return hogQLRaw(escapeHogQLQualifiedIdentifier(identifier))
+}
+
 function isHogQLRaw(value: any): value is HogQLRaw {
     return !!value?.__hogql_raw
 }
@@ -814,6 +818,7 @@ export function hogql(strings: TemplateStringsArray, ...values: any[]): HogQLQue
     ) as unknown as HogQLQueryString
 }
 hogql.identifier = hogQLIdentifier
+hogql.qualifiedIdentifier = hogQLQualifiedIdentifier
 hogql.raw = hogQLRaw
 
 /**

--- a/frontend/src/queries/utils.ts
+++ b/frontend/src/queries/utils.ts
@@ -660,6 +660,11 @@ export function escapePropertyAsHogQLIdentifier(identifier: string): string {
     return !identifier.includes('"') ? `"${identifier}"` : `\`${identifier}\``
 }
 
+// Formats qualified identifiers like schema.table or dotted view names by escaping each segment separately.
+export function escapeHogQLQualifiedIdentifier(identifier: string): string {
+    return identifier.split('.').map(escapePropertyAsHogQLIdentifier).join('.')
+}
+
 export function taxonomicEventFilterToHogQL(
     groupType: TaxonomicFilterGroupType,
     value: TaxonomicFilterValue

--- a/frontend/src/scenes/data-warehouse/editor/SQLEditor.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/SQLEditor.tsx
@@ -209,6 +209,7 @@ export function SQLEditor({
 function SQLEditorSceneTitle(): JSX.Element | null {
     const {
         queryInput,
+        activeTab,
         editingView,
         editingInsight,
         insightLoading,
@@ -350,6 +351,7 @@ function SQLEditorSceneTitle(): JSX.Element | null {
                                     onClick={() =>
                                         updateView({
                                             id: editingView.id,
+                                            name: activeTab?.name ?? editingView.name,
                                             query: {
                                                 ...sourceQuery.source,
                                                 query: queryInput ?? '',

--- a/frontend/src/scenes/data-warehouse/editor/sidebar/QueryDatabase.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/sidebar/QueryDatabase.tsx
@@ -31,7 +31,7 @@ import { urls } from 'scenes/urls'
 
 import { SearchHighlightMultiple } from '~/layout/navigation-3000/components/SearchHighlight'
 import { DatabaseSerializedFieldType } from '~/queries/schema/schema-general'
-import { escapePropertyAsHogQLIdentifier } from '~/queries/utils'
+import { escapeHogQLQualifiedIdentifier } from '~/queries/utils'
 
 import { draftsLogic } from '../draftsLogic'
 import { renderTableCount } from '../editorSceneLogic'
@@ -426,7 +426,7 @@ export const QueryDatabase = (): JSX.Element => {
                             ? getEndpointUrl(item)
                             : urls.sqlEditor({ view_id: item.record?.view.id })
                     const table = item.record?.tableName || item.name
-                    const selectAllQuery = `SELECT * FROM ${escapePropertyAsHogQLIdentifier(table)} LIMIT 100`
+                    const selectAllQuery = `SELECT * FROM ${escapeHogQLQualifiedIdentifier(table)} LIMIT 100`
                     const nextConnectionId =
                         connectionId && connectionId !== POSTHOG_WAREHOUSE ? connectionId : undefined
 

--- a/frontend/src/scenes/data-warehouse/editor/sidebar/queryDatabaseLogic.test.ts
+++ b/frontend/src/scenes/data-warehouse/editor/sidebar/queryDatabaseLogic.test.ts
@@ -1,0 +1,37 @@
+import { TreeDataItem } from 'lib/lemon-ui/LemonTree/LemonTree'
+
+import { createDottedViewTree } from './queryDatabaseLogic'
+
+describe('createDottedViewTree', () => {
+    it('groups dotted views into folders and creates an index node when a folder is also a view', () => {
+        const items: TreeDataItem[] = [
+            {
+                id: 'view-ab',
+                name: 'a.b',
+                type: 'node',
+                record: { type: 'view' },
+                children: [],
+            },
+            {
+                id: 'view-abc',
+                name: 'a.b.c',
+                type: 'node',
+                record: { type: 'view' },
+                children: [],
+            },
+        ]
+
+        const tree = createDottedViewTree(items)
+
+        expect(tree).toHaveLength(1)
+        expect(tree[0].name).toBe('a')
+        expect(tree[0].record?.type).toBe('view-folder')
+
+        const bFolder = tree[0].children?.[0]
+        expect(bFolder?.name).toBe('b')
+        expect(bFolder?.record?.type).toBe('view-folder')
+        expect(bFolder?.children?.map((child) => child.name)).toEqual(['index', 'c'])
+        expect(bFolder?.children?.[0].record?.type).toBe('view')
+        expect(bFolder?.children?.[1].record?.type).toBe('view')
+    })
+})

--- a/frontend/src/scenes/data-warehouse/editor/sidebar/queryDatabaseLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/sidebar/queryDatabaseLogic.tsx
@@ -1021,6 +1021,81 @@ const createTopLevelFolderNode = (
     }
 }
 
+type DotPathTreeNode = {
+    item?: TreeDataItem
+    children: Map<string, DotPathTreeNode>
+}
+
+const cloneTreeItemWithName = (item: TreeDataItem, name: string, idSuffix = ''): TreeDataItem => ({
+    ...item,
+    id: idSuffix ? `${item.id}-${idSuffix}` : item.id,
+    name,
+})
+
+const createDotPathIndexNode = (item: TreeDataItem): TreeDataItem => cloneTreeItemWithName(item, 'index', 'index')
+
+const insertDotPathTreeNode = (root: DotPathTreeNode, item: TreeDataItem): void => {
+    const segments = item.name.split('.')
+    let currentNode = root
+
+    segments.forEach((segment) => {
+        if (!currentNode.children.has(segment)) {
+            currentNode.children.set(segment, { children: new Map() })
+        }
+        currentNode = currentNode.children.get(segment)!
+    })
+
+    currentNode.item = item
+}
+
+const materializeDotPathTreeNode = (
+    segment: string,
+    node: DotPathTreeNode,
+    parentPath: string[] = [],
+    isSearch = false
+): TreeDataItem | null => {
+    const fullPath = [...parentPath, segment].join('.')
+    const children = Array.from(node.children.entries())
+        .map(([childSegment, childNode]) =>
+            materializeDotPathTreeNode(childSegment, childNode, [...parentPath, segment], isSearch)
+        )
+        .filter((child): child is TreeDataItem => child !== null)
+        .sort((a, b) => a.name.localeCompare(b.name))
+
+    if (children.length === 0) {
+        return node.item ? cloneTreeItemWithName(node.item, segment) : null
+    }
+
+    return {
+        id: `${isSearch ? 'search-' : ''}view-folder-${fullPath}/`,
+        name: segment,
+        type: 'node',
+        record: {
+            type: 'view-folder',
+            path: fullPath,
+        },
+        children: [...(node.item ? [createDotPathIndexNode(node.item)] : []), ...children],
+    }
+}
+
+export const createDottedViewTree = (items: TreeDataItem[], isSearch = false): TreeDataItem[] => {
+    const root: DotPathTreeNode = { children: new Map() }
+
+    items.forEach((item) => insertDotPathTreeNode(root, item))
+
+    return Array.from(root.children.entries())
+        .map(([segment, node]) => materializeDotPathTreeNode(segment, node, [], isSearch))
+        .filter((item): item is TreeDataItem => item !== null)
+        .sort((a, b) => a.name.localeCompare(b.name))
+}
+
+const collectTreeFolderIds = (items: TreeDataItem[]): string[] => {
+    return items.flatMap((item) => {
+        const nestedFolderIds = item.children?.length ? collectTreeFolderIds(item.children) : []
+        return item.record?.type === 'view-folder' ? [item.id, ...nestedFolderIds] : nestedFolderIds
+    })
+}
+
 export const queryDatabaseLogic = kea<queryDatabaseLogicType>([
     path(['scenes', 'data-warehouse', 'editor', 'queryDatabaseLogic']),
     actions({
@@ -1419,7 +1494,9 @@ export const queryDatabaseLogic = kea<queryDatabaseLogicType>([
 
                 if (viewsChildren.length > 0) {
                     expandedIds.push('search-views')
-                    searchResults.push(createTopLevelFolderNode('views', viewsChildren, true))
+                    const groupedViewsChildren = createDottedViewTree(viewsChildren, true)
+                    expandedIds.push(...collectTreeFolderIds(groupedViewsChildren))
+                    searchResults.push(createTopLevelFolderNode('views', groupedViewsChildren, true))
                 }
 
                 if (managedViewsChildren.length > 0 && !featureFlags[FEATURE_FLAGS.MANAGED_VIEWSETS]) {
@@ -1595,7 +1672,7 @@ export const queryDatabaseLogic = kea<queryDatabaseLogicType>([
                     })
                 }
 
-                viewsChildren.sort((a, b) => a.name.localeCompare(b.name))
+                const groupedViewsChildren = createDottedViewTree(viewsChildren)
                 managedViewsChildren.sort((a, b) => a.name.localeCompare(b.name))
 
                 const states = queryTabState?.state?.editorModelsStateKey
@@ -1676,7 +1753,7 @@ export const queryDatabaseLogic = kea<queryDatabaseLogicType>([
                               } as TreeDataItem,
                           ]
                         : []),
-                    createTopLevelFolderNode('views', viewsChildren),
+                    createTopLevelFolderNode('views', groupedViewsChildren),
                     ...(featureFlags[FEATURE_FLAGS.MANAGED_VIEWSETS]
                         ? []
                         : [createTopLevelFolderNode('managed-views', managedViewsChildren)]),

--- a/frontend/src/scenes/data-warehouse/editor/sql-utils.test.ts
+++ b/frontend/src/scenes/data-warehouse/editor/sql-utils.test.ts
@@ -1,0 +1,20 @@
+import { buildQueryForColumnClick } from './sql-utils'
+
+describe('buildQueryForColumnClick', () => {
+    it('renders dotted table names as qualified identifiers instead of quoting the full path', () => {
+        expect(buildQueryForColumnClick(null, 'this.is.sparta', 'SPARTA')).toBe(
+            'SELECT SPARTA FROM this.is.sparta LIMIT 100'
+        )
+    })
+
+    it('toggles columns against dotted table names without rewriting the table path', () => {
+        const firstQuery = buildQueryForColumnClick(null, 'this.is.sparta', 'SPARTA')
+        expect(firstQuery).toBe('SELECT SPARTA FROM this.is.sparta LIMIT 100')
+
+        const secondQuery = buildQueryForColumnClick(firstQuery, 'this.is.sparta', 'SPARTA')
+        expect(secondQuery).toBe('SELECT * FROM this.is.sparta LIMIT 100')
+
+        const thirdQuery = buildQueryForColumnClick(secondQuery, 'this.is.sparta', 'SPARTA')
+        expect(thirdQuery).toBe('SELECT SPARTA FROM this.is.sparta LIMIT 100')
+    })
+})

--- a/frontend/src/scenes/data-warehouse/editor/sql-utils.ts
+++ b/frontend/src/scenes/data-warehouse/editor/sql-utils.ts
@@ -1,4 +1,4 @@
-import { escapePropertyAsHogQLIdentifier } from '~/queries/utils'
+import { escapeHogQLQualifiedIdentifier, escapePropertyAsHogQLIdentifier } from '~/queries/utils'
 
 export const normalizeIdentifier = (identifier: string): string => {
     return identifier.replace(/^[`"']|[`"']$/g, '').toLowerCase()
@@ -11,13 +11,17 @@ const parseSelectedColumns = (selectedColumns: string): string[] => {
         .filter((column) => column.length > 0)
 }
 
+const formatSelectedColumn = (column: string): string => {
+    return column === '*' ? column : escapePropertyAsHogQLIdentifier(column)
+}
+
 export const buildQueryForColumnClick = (
     currentQuery: string | null,
     tableName: string,
     columnName: string
 ): string => {
     const limitOffsetClause = currentQuery ? extractLimitOffsetClause(currentQuery) : null
-    const baseQuery = `SELECT ${columnName} FROM ${escapePropertyAsHogQLIdentifier(tableName)} ${limitOffsetClause ?? 'LIMIT 100'}`
+    const baseQuery = `SELECT ${columnName} FROM ${escapeHogQLQualifiedIdentifier(tableName)} ${limitOffsetClause ?? 'LIMIT 100'}`
 
     if (!currentQuery) {
         return baseQuery
@@ -57,7 +61,7 @@ export const buildQueryForColumnClick = (
         columns = ['*']
     }
 
-    return `SELECT ${columns.map(escapePropertyAsHogQLIdentifier).join(', ')} FROM ${tableName} ${limitOffsetClause ?? 'LIMIT 100'}`
+    return `SELECT ${columns.map(formatSelectedColumn).join(', ')} FROM ${escapeHogQLQualifiedIdentifier(tableName)} ${limitOffsetClause ?? 'LIMIT 100'}`
 }
 
 const normalizeKeywordSpacing = (query: string): string => {

--- a/frontend/src/scenes/data-warehouse/editor/sqlEditorLogic.test.ts
+++ b/frontend/src/scenes/data-warehouse/editor/sqlEditorLogic.test.ts
@@ -15,7 +15,7 @@ import { initKeaTests } from '~/test/init'
 import { ChartDisplayType, InsightShortId, QueryBasedInsightModel } from '~/types'
 
 import { OutputTab } from './outputPaneLogic'
-import { getDisplayTypeToSaveInsight, sqlEditorLogic } from './sqlEditorLogic'
+import { getDisplayTypeToSaveInsight, isValidViewName, sqlEditorLogic } from './sqlEditorLogic'
 
 // endpointLogic uses permanentlyMount() with a keyed logic, which crashes in
 // tests without the full React component tree — disable auto-mounting
@@ -220,6 +220,19 @@ describe('sqlEditorLogic', () => {
             expect(getDisplayTypeToSaveInsight(outputTab, sourceQueryDisplay, effectiveVisualizationType)).toEqual(
                 expected
             )
+        })
+    })
+
+    describe('isValidViewName', () => {
+        it.each([
+            ['simple_name', true],
+            ['folder.view_name', true],
+            ['folder.subfolder.view_name', true],
+            ['folder..view_name', false],
+            ['folder.bad-name', false],
+            ['1folder.view_name', false],
+        ])('validates %s', (name, expected) => {
+            expect(isValidViewName(name)).toBe(expected)
         })
     })
 

--- a/frontend/src/scenes/data-warehouse/editor/sqlEditorLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/sqlEditorLogic.tsx
@@ -142,6 +142,16 @@ export type UpdateViewPayload = Partial<DatabaseSchemaViewTable> & {
 
 type LegacyDataVisualizationNode = DataVisualizationNode & { connectionId?: string }
 
+export const VIEW_NAME_SEGMENT_REGEX = /^[A-Za-z_$][A-Za-z0-9_$]*$/
+
+export function isValidViewName(name?: string | null): boolean {
+    if (!name) {
+        return false
+    }
+
+    return name.split('.').every((segment) => VIEW_NAME_SEGMENT_REGEX.test(segment))
+}
+
 function normalizeRawQuerySource(source: HogQLQuery): HogQLQuery {
     return {
         ...source,
@@ -845,7 +855,7 @@ export const sqlEditorLogic = kea<sqlEditorLogicType>([
             LemonDialog.openForm({
                 title: 'Save as view',
                 initialValues: { viewName: values.activeTab?.name || '', isTest: false },
-                description: `View names can only contain letters, numbers, '_', or '$'. Spaces are not allowed.`,
+                description: `View names can only contain letters, numbers, '_', '$', or '.'. Spaces are not allowed.`,
                 content: (isLoading) =>
                     isLoading ? (
                         <div className="h-[37px] flex items-center">
@@ -884,8 +894,8 @@ export const sqlEditorLogic = kea<sqlEditorLogicType>([
                     viewName: (name) =>
                         !name
                             ? 'You must enter a name'
-                            : !/^[A-Za-z_$][A-Za-z0-9_$]*$/.test(name)
-                              ? 'Name must be valid'
+                            : !isValidViewName(name)
+                              ? 'Each dot-separated segment must be a valid name'
                               : undefined,
                 },
                 onSubmit: async ({ viewName, isTest }) => {
@@ -1302,9 +1312,9 @@ export const sqlEditorLogic = kea<sqlEditorLogicType>([
             },
         ],
         changesToSave: [
-            (s) => [s.editingView, s.queryInput],
-            (editingView, queryInput) => {
-                return editingView?.query?.query !== queryInput
+            (s) => [s.editingView, s.queryInput, s.activeTab],
+            (editingView, queryInput, activeTab) => {
+                return editingView?.query?.query !== queryInput || editingView?.name !== activeTab?.name
             },
         ],
         exportContext: [
@@ -1427,8 +1437,16 @@ export const sqlEditorLogic = kea<sqlEditorLogicType>([
             },
         ],
         titleSectionProps: [
-            (s) => [s.editingInsight, s.insightLoading, s.editingView, s.viewLoading, s.editorSource, s.dashboardId],
-            (editingInsight, insightLoading, editingView, viewLoading, editorSource, dashboardId) => {
+            (s) => [
+                s.editingInsight,
+                s.insightLoading,
+                s.editingView,
+                s.viewLoading,
+                s.editorSource,
+                s.dashboardId,
+                s.activeTab,
+            ],
+            (editingInsight, insightLoading, editingView, viewLoading, editorSource, dashboardId, activeTab) => {
                 if (editingInsight) {
                     const forceBackTo: Breadcrumb = dashboardId
                         ? {
@@ -1460,8 +1478,14 @@ export const sqlEditorLogic = kea<sqlEditorLogicType>([
 
                 if (editingView) {
                     return {
-                        name: editingView.name,
+                        name: activeTab?.name ?? editingView.name,
                         resourceType: { type: editingView.is_materialized ? 'matview' : 'view' },
+                        canEdit: true,
+                        onNameChange: (name: string) => {
+                            if (activeTab) {
+                                actions.updateTab({ ...activeTab, name })
+                            }
+                        },
                     }
                 }
 

--- a/frontend/src/scenes/data-warehouse/external/forms/SyncProgressStep.tsx
+++ b/frontend/src/scenes/data-warehouse/external/forms/SyncProgressStep.tsx
@@ -7,7 +7,7 @@ import { dataWarehouseSettingsLogic } from 'scenes/data-warehouse/settings/dataW
 import { urls } from 'scenes/urls'
 
 import { SceneSection } from '~/layout/scenes/components/SceneSection'
-import { escapePropertyAsHogQLIdentifier } from '~/queries/utils'
+import { escapeHogQLQualifiedIdentifier } from '~/queries/utils'
 import { ExternalDataSourceSchema } from '~/types'
 
 export const SyncProgressStep = (): JSX.Element => {
@@ -19,7 +19,7 @@ export const SyncProgressStep = (): JSX.Element => {
     const isDirectQuerySource = source?.access_method === 'direct'
 
     const getPreviewQuery = (tableName: string): string =>
-        `SELECT * FROM ${escapePropertyAsHogQLIdentifier(tableName)} LIMIT 100`
+        `SELECT * FROM ${escapeHogQLQualifiedIdentifier(tableName)} LIMIT 100`
 
     const getSyncStatus = (schema: ExternalDataSourceSchema): { status: string; tagType: LemonTagType } => {
         if (isDirectQuerySource) {

--- a/frontend/src/scenes/data-warehouse/settings/source/Schemas.tsx
+++ b/frontend/src/scenes/data-warehouse/settings/source/Schemas.tsx
@@ -31,7 +31,7 @@ import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
 
 import { ExternalDataSourceType, ProductIntentContext, ProductKey } from '~/queries/schema/schema-general'
-import { escapePropertyAsHogQLIdentifier } from '~/queries/utils'
+import { escapeHogQLQualifiedIdentifier } from '~/queries/utils'
 import {
     AccessControlLevel,
     AccessControlResourceType,
@@ -228,7 +228,7 @@ export const SchemaTable = ({ schemas, isLoading, isDirectQuerySource }: SchemaT
     }, [isLoading, initialLoad])
 
     const getPreviewQuery = useCallback(
-        (tableName: string): string => `SELECT * FROM ${escapePropertyAsHogQLIdentifier(tableName)} LIMIT 100`,
+        (tableName: string): string => `SELECT * FROM ${escapeHogQLQualifiedIdentifier(tableName)} LIMIT 100`,
         []
     )
 

--- a/frontend/src/scenes/data-warehouse/viewLinkLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/viewLinkLogic.tsx
@@ -9,7 +9,7 @@ import { databaseTableListLogic } from 'scenes/data-management/database/database
 
 import { hogqlQuery } from '~/queries/query'
 import { DatabaseSchemaField } from '~/queries/schema/schema-general'
-import { escapeHogQLQualifiedIdentifier, hogql } from '~/queries/utils'
+import { hogql } from '~/queries/utils'
 import { DataWarehouseViewLink } from '~/types'
 
 import { dataWarehouseJoinsLogic } from './external/dataWarehouseJoinsLogic'
@@ -470,9 +470,7 @@ async function loadTablePreviewData(
     setDataAction: (data: Record<string, any>[]) => void
 ): Promise<void> {
     try {
-        const response = await hogqlQuery(
-            hogql`SELECT * FROM ${hogql.raw(escapeHogQLQualifiedIdentifier(tableName))} LIMIT 10`
-        )
+        const response = await hogqlQuery(hogql`SELECT * FROM ${hogql.qualifiedIdentifier(tableName)} LIMIT 10`)
         const transformedData = (response.results || []).map((row: any[]) =>
             Object.fromEntries((response.columns || []).map((column: string, index: number) => [column, row[index]]))
         )

--- a/frontend/src/scenes/data-warehouse/viewLinkLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/viewLinkLogic.tsx
@@ -9,7 +9,7 @@ import { databaseTableListLogic } from 'scenes/data-management/database/database
 
 import { hogqlQuery } from '~/queries/query'
 import { DatabaseSchemaField } from '~/queries/schema/schema-general'
-import { hogql } from '~/queries/utils'
+import { escapeHogQLQualifiedIdentifier, hogql } from '~/queries/utils'
 import { DataWarehouseViewLink } from '~/types'
 
 import { dataWarehouseJoinsLogic } from './external/dataWarehouseJoinsLogic'
@@ -470,7 +470,9 @@ async function loadTablePreviewData(
     setDataAction: (data: Record<string, any>[]) => void
 ): Promise<void> {
     try {
-        const response = await hogqlQuery(hogql`SELECT * FROM ${hogql.identifier(tableName)} LIMIT 10`)
+        const response = await hogqlQuery(
+            hogql`SELECT * FROM ${hogql.raw(escapeHogQLQualifiedIdentifier(tableName))} LIMIT 10`
+        )
         const transformedData = (response.results || []).map((row: any[]) =>
             Object.fromEntries((response.columns || []).map((column: string, index: number) => [column, row[index]]))
         )


### PR DESCRIPTION
## Problem

Views are flat and we could use some hierarchy. 

## Changes

Let's try enabling dots and splitting by dots. The other idea is to create virtual categories and move views under them randomly. This PR doesn't prevent us from doing that --> if we add categories at a future date, you'll then be able to split by dot under them as well... 

![2026-04-01 00 34 10](https://github.com/user-attachments/assets/d9937f4c-f84e-42c8-a39b-2bc343386b56)


## How did you test this code?

<!-- Briefly describe the steps you took, and what steps reviewers must take to get to where changes are, and what is the expected behavior. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
