### PR TITLE
fix(experiments): metrics using action nodes correcly display the action name.

### DIFF
--- a/ee/clickhouse/views/experiment_saved_metrics.py
+++ b/ee/clickhouse/views/experiment_saved_metrics.py
@@ -9,6 +9,7 @@ from posthog.api.tagged_item import TaggedItemSerializerMixin
 from posthog.rbac.user_access_control import UserAccessControlSerializerMixin
 
 from products.experiments.backend.experiment_saved_metric_service import ExperimentSavedMetricService
+from products.experiments.backend.metric_utils import refresh_action_names_in_metric
 from products.experiments.backend.models.experiment import ExperimentSavedMetric, ExperimentToSavedMetric
 
 from ee.api.rbac.access_control import AccessControlViewSetMixin
@@ -33,6 +34,13 @@ class ExperimentToSavedMetricSerializer(serializers.ModelSerializer):
             "id",
             "created_at",
         ]
+
+    def to_representation(self, instance: ExperimentToSavedMetric):
+        data = super().to_representation(instance)
+        # Refresh action names to show current names instead of stale cached values
+        team = instance.experiment.team
+        data["query"] = refresh_action_names_in_metric(data.get("query"), team)
+        return data
 
 
 class ExperimentSavedMetricSerializer(
@@ -60,6 +68,13 @@ class ExperimentSavedMetricSerializer(
             "updated_at",
             "user_access_level",
         ]
+
+    def to_representation(self, instance: ExperimentSavedMetric):
+        data = super().to_representation(instance)
+        # Refresh action names to show current names instead of stale cached values
+        team = self.context["get_team"]()
+        data["query"] = refresh_action_names_in_metric(data.get("query"), team)
+        return data
 
     def create(self, validated_data):
         tags = validated_data.pop("tags", None)

--- a/ee/clickhouse/views/experiments.py
+++ b/ee/clickhouse/views/experiments.py
@@ -142,13 +142,10 @@ class ExperimentSerializer(UserAccessControlSerializerMixin, serializers.ModelSe
                 if metric.get("funnels_query", {}).get("dateRange"):
                     metric["funnels_query"]["dateRange"] = new_date_range
 
-        # Refresh action names in saved metrics
+        # Update date ranges in saved metrics
+        # Note: Action name refresh is handled by ExperimentToSavedMetricSerializer.to_representation
         for saved_metric in data.get("saved_metrics", []):
             if saved_metric.get("query"):
-                # Refresh action names (already done by ExperimentToSavedMetricSerializer.to_representation,
-                # but do it here too for consistency and in case saved_metrics are prefetched)
-                saved_metric["query"] = refresh_action_names_in_metric(saved_metric["query"], instance.team)
-
                 if saved_metric["query"].get("count_query", {}).get("dateRange"):
                     saved_metric["query"]["count_query"]["dateRange"] = new_date_range
                 if saved_metric["query"].get("funnels_query", {}).get("dateRange"):

--- a/ee/clickhouse/views/experiments.py
+++ b/ee/clickhouse/views/experiments.py
@@ -31,6 +31,7 @@ from posthog.temporal.common.client import sync_connect
 from posthog.temporal.experiments.models import ExperimentTimeseriesRecalculationWorkflowInputs
 
 from products.experiments.backend.experiment_service import ExperimentService
+from products.experiments.backend.metric_utils import refresh_action_names_in_metric
 from products.experiments.backend.models.experiment import (
     Experiment,
     ExperimentHoldout,
@@ -126,22 +127,35 @@ class ExperimentSerializer(UserAccessControlSerializerMixin, serializers.ModelSe
             "date_to": data["end_date"] if data["end_date"] else "",
             "explicitDate": True,
         }
+
+        # Refresh action names in inline metrics (metrics and metrics_secondary)
         for metrics_list in [data.get("metrics", []), data.get("metrics_secondary", [])]:
-            for metric in metrics_list:
+            for i, metric in enumerate(metrics_list):
+                # Refresh action names to show current names instead of stale cached values
+                refreshed_metric = refresh_action_names_in_metric(metric, instance.team)
+                if refreshed_metric:
+                    metrics_list[i] = refreshed_metric
+                    metric = refreshed_metric
+
                 if metric.get("count_query", {}).get("dateRange"):
                     metric["count_query"]["dateRange"] = new_date_range
                 if metric.get("funnels_query", {}).get("dateRange"):
                     metric["funnels_query"]["dateRange"] = new_date_range
 
+        # Refresh action names in saved metrics
         for saved_metric in data.get("saved_metrics", []):
-            if saved_metric.get("query", {}).get("count_query", {}).get("dateRange"):
-                saved_metric["query"]["count_query"]["dateRange"] = new_date_range
-            if saved_metric.get("query", {}).get("funnels_query", {}).get("dateRange"):
-                saved_metric["query"]["funnels_query"]["dateRange"] = new_date_range
-
-            # Add fingerprint to saved metric returned from API
-            # so that frontend knows what timeseries records to query
             if saved_metric.get("query"):
+                # Refresh action names (already done by ExperimentToSavedMetricSerializer.to_representation,
+                # but do it here too for consistency and in case saved_metrics are prefetched)
+                saved_metric["query"] = refresh_action_names_in_metric(saved_metric["query"], instance.team)
+
+                if saved_metric["query"].get("count_query", {}).get("dateRange"):
+                    saved_metric["query"]["count_query"]["dateRange"] = new_date_range
+                if saved_metric["query"].get("funnels_query", {}).get("dateRange"):
+                    saved_metric["query"]["funnels_query"]["dateRange"] = new_date_range
+
+                # Add fingerprint to saved metric returned from API
+                # so that frontend knows what timeseries records to query
                 saved_metric["query"]["fingerprint"] = compute_metric_fingerprint(
                     saved_metric["query"],
                     instance.start_date,

--- a/ee/clickhouse/views/test/test_experiment_saved_metrics.py
+++ b/ee/clickhouse/views/test/test_experiment_saved_metrics.py
@@ -784,3 +784,82 @@ class TestExperimentSavedMetricsCRUD(APILicensedTest):
         )
         self.assertIn("query", saved_metrics[0])
         self.assertEqual(saved_metrics[0]["query"]["kind"], "ExperimentMetric")
+
+    def test_saved_metric_refreshes_action_names(self):
+        """Test that saved metrics show current action names when actions are renamed."""
+        from posthog.models.action.action import Action
+
+        # Create an action
+        action = Action.objects.create(team=self.team, name="Original Action Name")
+
+        # Create a saved metric using the action
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/experiment_saved_metrics/",
+            {
+                "name": "Test Metric with Action",
+                "query": {
+                    "kind": "ExperimentMetric",
+                    "metric_type": "mean",
+                    "source": {
+                        "kind": "ActionsNode",
+                        "id": action.id,
+                        "name": "Original Action Name",  # Stale name
+                    },
+                },
+            },
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        saved_metric_id = response.json()["id"]
+
+        # Rename the action
+        action.name = "Renamed Action"
+        action.save()
+
+        # Fetch the saved metric
+        response = self.client.get(f"/api/projects/{self.team.id}/experiment_saved_metrics/{saved_metric_id}/")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        # Verify the action name was refreshed
+        self.assertEqual(response.json()["query"]["source"]["name"], "Renamed Action")
+        self.assertEqual(response.json()["query"]["source"]["id"], action.id)
+
+    def test_saved_metric_preserves_name_for_deleted_action(self):
+        """Test that saved metrics preserve old names when actions are deleted."""
+        from posthog.models.action.action import Action
+
+        # Create an action
+        action = Action.objects.create(team=self.team, name="Action to Delete")
+        action_id = action.id
+
+        # Create a saved metric using the action
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/experiment_saved_metrics/",
+            {
+                "name": "Test Metric with Deleted Action",
+                "query": {
+                    "kind": "ExperimentMetric",
+                    "metric_type": "mean",
+                    "source": {
+                        "kind": "ActionsNode",
+                        "id": action_id,
+                        "name": "Action to Delete",
+                    },
+                },
+            },
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        saved_metric_id = response.json()["id"]
+
+        # Delete the action
+        action.deleted = True
+        action.save()
+
+        # Fetch the saved metric
+        response = self.client.get(f"/api/projects/{self.team.id}/experiment_saved_metrics/{saved_metric_id}/")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        # Verify the old name is preserved
+        self.assertEqual(response.json()["query"]["source"]["name"], "Action to Delete")
+        self.assertEqual(response.json()["query"]["source"]["id"], action_id)

--- a/products/experiments/backend/metric_utils.py
+++ b/products/experiments/backend/metric_utils.py
@@ -1,0 +1,90 @@
+"""Utility functions for working with experiment metrics."""
+
+import copy
+import logging
+from typing import Any
+
+from posthog.models.action.action import Action
+from posthog.models.team.team import Team
+
+logger = logging.getLogger(__name__)
+
+
+def refresh_action_names_in_metric(query: dict[str, Any] | None, team: Team) -> dict[str, Any] | None:
+    """
+    Update ActionsNode names in a metric query to reflect current action names.
+
+    This ensures that if an action is renamed, metrics display the latest name
+    instead of the stale name that was stored when the metric was created.
+
+    This function is defensive:
+    - If an action is deleted, the old name is preserved
+    - If there's an error fetching actions, the original query is returned unchanged
+    - The original query is never mutated
+
+    Args:
+        query: The metric query dictionary (ExperimentMetric)
+        team: The team to fetch actions for
+
+    Returns:
+        Updated query dict with refreshed action names, or original query if errors occur
+    """
+    if not query or query.get("kind") != "ExperimentMetric":
+        return query
+
+    try:
+        # Create a copy to avoid mutating the original
+        query = copy.deepcopy(query)
+
+        # Collect all action IDs that need to be fetched
+        action_ids: set[int] = set()
+        _collect_action_ids(query, action_ids)
+
+        if not action_ids:
+            return query
+
+        # Fetch all actions in a single query
+        # Only include actions that still exist (not deleted)
+        actions_by_id = {
+            action.id: action.name for action in Action.objects.filter(id__in=action_ids, team=team, deleted=False)
+        }
+
+        # Update action names throughout the query
+        # If an action was deleted, its ID won't be in actions_by_id and the old name will be preserved
+        _update_action_names(query, actions_by_id)
+
+        return query
+    except Exception as e:
+        # Be defensive - if anything goes wrong, return the original query unchanged
+        logger.warning(
+            f"Error refreshing action names in metric query: {e}",
+            exc_info=True,
+            extra={"team_id": team.id, "query_kind": query.get("kind") if query else None},
+        )
+        return query
+
+
+def _collect_action_ids(obj: Any, action_ids: set[int]) -> None:
+    """Recursively collect all action IDs from ActionsNode objects in the query."""
+    if isinstance(obj, dict):
+        if obj.get("kind") == "ActionsNode" and "id" in obj:
+            action_ids.add(obj["id"])
+        for value in obj.values():
+            _collect_action_ids(value, action_ids)
+    elif isinstance(obj, list):
+        for item in obj:
+            _collect_action_ids(item, action_ids)
+
+
+def _update_action_names(obj: Any, actions_by_id: dict[int, str]) -> None:
+    """Recursively update all ActionsNode name fields with current action names."""
+    if isinstance(obj, dict):
+        if obj.get("kind") == "ActionsNode" and "id" in obj:
+            action_id = obj["id"]
+            if action_id in actions_by_id:
+                obj["name"] = actions_by_id[action_id]
+        for value in obj.values():
+            _update_action_names(value, actions_by_id)
+    elif isinstance(obj, list):
+        for item in obj:
+            _update_action_names(item, actions_by_id)

--- a/products/experiments/backend/metric_utils.py
+++ b/products/experiments/backend/metric_utils.py
@@ -68,7 +68,11 @@ def _collect_action_ids(obj: Any, action_ids: set[int]) -> None:
     """Recursively collect all action IDs from ActionsNode objects in the query."""
     if isinstance(obj, dict):
         if obj.get("kind") == "ActionsNode" and "id" in obj:
-            action_ids.add(obj["id"])
+            # Convert to int in case it's stored as a string
+            try:
+                action_ids.add(int(obj["id"]))
+            except (ValueError, TypeError):
+                logger.warning(f"Invalid action ID in ActionsNode: {obj['id']}")
         for value in obj.values():
             _collect_action_ids(value, action_ids)
     elif isinstance(obj, list):
@@ -80,7 +84,13 @@ def _update_action_names(obj: Any, actions_by_id: dict[int, str]) -> None:
     """Recursively update all ActionsNode name fields with current action names."""
     if isinstance(obj, dict):
         if obj.get("kind") == "ActionsNode" and "id" in obj:
-            action_id = obj["id"]
+            # Convert to int in case it's stored as a string
+            try:
+                action_id = int(obj["id"])
+            except (ValueError, TypeError):
+                logger.warning(f"Invalid action ID in ActionsNode: {obj['id']}")
+                return
+
             if action_id in actions_by_id:
                 obj["name"] = actions_by_id[action_id]
         for value in obj.values():

--- a/products/experiments/backend/metric_utils.py
+++ b/products/experiments/backend/metric_utils.py
@@ -57,7 +57,8 @@ def refresh_action_names_in_metric(query: dict[str, Any] | None, team: Team) -> 
     except Exception as e:
         # Be defensive - if anything goes wrong, return the original query unchanged
         logger.warning(
-            f"Error refreshing action names in metric query: {e}",
+            "Error refreshing action names in metric query: %s",
+            e,
             exc_info=True,
             extra={"team_id": team.id, "query_kind": query.get("kind") if query else None},
         )
@@ -72,7 +73,7 @@ def _collect_action_ids(obj: Any, action_ids: set[int]) -> None:
             try:
                 action_ids.add(int(obj["id"]))
             except (ValueError, TypeError):
-                logger.warning(f"Invalid action ID in ActionsNode: {obj['id']}")
+                logger.warning("Invalid action ID in ActionsNode: %s", obj["id"])
         for value in obj.values():
             _collect_action_ids(value, action_ids)
     elif isinstance(obj, list):
@@ -88,7 +89,7 @@ def _update_action_names(obj: Any, actions_by_id: dict[int, str]) -> None:
             try:
                 action_id = int(obj["id"])
             except (ValueError, TypeError):
-                logger.warning(f"Invalid action ID in ActionsNode: {obj['id']}")
+                logger.warning("Invalid action ID in ActionsNode: %s", obj["id"])
                 return
 
             if action_id in actions_by_id:

--- a/products/experiments/backend/test/test_metric_utils.py
+++ b/products/experiments/backend/test/test_metric_utils.py
@@ -1,0 +1,283 @@
+"""Tests for experiment metric utilities."""
+
+from posthog.test.base import BaseTest
+
+from parameterized import parameterized
+
+from posthog.models.action.action import Action
+
+from products.experiments.backend.metric_utils import refresh_action_names_in_metric
+
+
+class TestRefreshActionNamesInMetric(BaseTest):
+    """Test that action names are refreshed in experiment metrics."""
+
+    def setUp(self):
+        super().setUp()
+        # Create test actions
+        self.action1 = Action.objects.create(team=self.team, name="Original Action 1")
+        self.action2 = Action.objects.create(team=self.team, name="Original Action 2")
+        self.action3 = Action.objects.create(team=self.team, name="Original Action 3")
+
+    @parameterized.expand(
+        [
+            ("mean", "source"),
+        ]
+    )
+    def test_refresh_action_names_in_single_field_metric(self, metric_type: str, field_name: str):
+        """Test refreshing action names in metrics with a single ActionsNode field."""
+        query = {
+            "kind": "ExperimentMetric",
+            "metric_type": metric_type,
+            field_name: {
+                "kind": "ActionsNode",
+                "id": self.action1.id,
+                "name": "Original Action 1",
+            },
+        }
+
+        # Rename the action
+        self.action1.name = "Renamed Action 1"
+        self.action1.save()
+
+        # Refresh action names
+        updated_query = refresh_action_names_in_metric(query, self.team)
+
+        # Verify the name was updated
+        assert updated_query[field_name]["name"] == "Renamed Action 1"
+        assert updated_query[field_name]["id"] == self.action1.id
+        assert updated_query[field_name]["kind"] == "ActionsNode"
+
+    def test_refresh_action_names_in_funnel_metric(self):
+        """Test refreshing action names in a funnel metric with multiple steps."""
+        query = {
+            "kind": "ExperimentMetric",
+            "metric_type": "funnel",
+            "series": [
+                {
+                    "kind": "ActionsNode",
+                    "id": self.action1.id,
+                    "name": "Original Action 1",
+                },
+                {
+                    "kind": "EventsNode",
+                    "event": "pageview",
+                    "name": "Pageview",
+                },
+                {
+                    "kind": "ActionsNode",
+                    "id": self.action2.id,
+                    "name": "Original Action 2",
+                },
+            ],
+        }
+
+        # Rename both actions
+        self.action1.name = "Renamed Action 1"
+        self.action1.save()
+        self.action2.name = "Renamed Action 2"
+        self.action2.save()
+
+        # Refresh action names
+        updated_query = refresh_action_names_in_metric(query, self.team)
+
+        # Verify action names were updated but event name was not changed
+        assert updated_query["series"][0]["name"] == "Renamed Action 1"
+        assert updated_query["series"][1]["name"] == "Pageview"  # EventsNode unchanged
+        assert updated_query["series"][2]["name"] == "Renamed Action 2"
+
+    @parameterized.expand(
+        [
+            ("ratio", "numerator", "denominator"),
+            ("retention", "start_event", "completion_event"),
+        ]
+    )
+    def test_refresh_action_names_in_dual_field_metric(self, metric_type: str, field1: str, field2: str):
+        """Test refreshing action names in metrics with two ActionsNode fields."""
+        query = {
+            "kind": "ExperimentMetric",
+            "metric_type": metric_type,
+            field1: {
+                "kind": "ActionsNode",
+                "id": self.action1.id,
+                "name": "Original Action 1",
+            },
+            field2: {
+                "kind": "ActionsNode",
+                "id": self.action2.id,
+                "name": "Original Action 2",
+            },
+        }
+
+        # Rename the actions
+        self.action1.name = "Renamed Action 1"
+        self.action1.save()
+        self.action2.name = "Renamed Action 2"
+        self.action2.save()
+
+        # Refresh action names
+        updated_query = refresh_action_names_in_metric(query, self.team)
+
+        # Verify both names were updated
+        assert updated_query[field1]["name"] == "Renamed Action 1"
+        assert updated_query[field2]["name"] == "Renamed Action 2"
+
+    def test_does_not_modify_events_node(self):
+        """Test that EventsNode names are not modified."""
+        query = {
+            "kind": "ExperimentMetric",
+            "metric_type": "mean",
+            "source": {
+                "kind": "EventsNode",
+                "event": "pageview",
+                "name": "Custom Pageview Name",
+            },
+        }
+
+        # Refresh action names
+        updated_query = refresh_action_names_in_metric(query, self.team)
+
+        # Verify EventsNode name was not changed
+        assert updated_query["source"]["name"] == "Custom Pageview Name"
+
+    @parameterized.expand(
+        [
+            ("missing", False),
+            ("deleted", True),
+        ]
+    )
+    def test_handles_nonexistent_action(self, scenario: str, action_exists: bool):
+        """Test that missing or deleted actions don't cause errors."""
+        if action_exists:
+            action_id = self.action1.id
+            self.action1.delete()
+        else:
+            action_id = 99999
+
+        query = {
+            "kind": "ExperimentMetric",
+            "metric_type": "mean",
+            "source": {
+                "kind": "ActionsNode",
+                "id": action_id,
+                "name": "Original Name",
+            },
+        }
+
+        # Refresh action names (should not crash)
+        updated_query = refresh_action_names_in_metric(query, self.team)
+
+        # Verify the name remains unchanged when action doesn't exist
+        assert updated_query["source"]["name"] == "Original Name"
+
+    @parameterized.expand(
+        [
+            # Legacy query format
+            (
+                "legacy",
+                {
+                    "kind": "ExperimentTrendsQuery",
+                    "series": [{"kind": "ActionsNode", "id": 1, "name": "Old Name"}],
+                },
+            ),
+            # Empty query
+            ("empty", {}),
+            # None
+            ("none", None),
+        ]
+    )
+    def test_non_experiment_metric_query_unchanged(self, _name: str, query: dict | None):
+        """Test that non-ExperimentMetric queries are returned unchanged."""
+        updated_query = refresh_action_names_in_metric(query, self.team)
+        assert updated_query == query
+
+    def test_query_not_mutated(self):
+        """Test that the original query is not mutated."""
+        original_query = {
+            "kind": "ExperimentMetric",
+            "metric_type": "mean",
+            "source": {
+                "kind": "ActionsNode",
+                "id": self.action1.id,
+                "name": "Original Action 1",
+            },
+        }
+
+        # Rename the action
+        self.action1.name = "Renamed Action 1"
+        self.action1.save()
+
+        # Store original name
+        original_name = original_query["source"]["name"]
+
+        # Refresh action names
+        updated_query = refresh_action_names_in_metric(original_query, self.team)
+
+        # Verify original query was not mutated
+        assert original_query["source"]["name"] == original_name
+        assert updated_query["source"]["name"] == "Renamed Action 1"
+
+    def test_handles_nested_structures(self):
+        """Test that deeply nested ActionsNode structures are handled."""
+        query = {
+            "kind": "ExperimentMetric",
+            "metric_type": "funnel",
+            "series": [
+                {
+                    "kind": "ActionsNode",
+                    "id": self.action1.id,
+                    "name": "Original Action 1",
+                    "properties": [
+                        {
+                            "type": "event",
+                            "key": "some_property",
+                        }
+                    ],
+                }
+            ],
+            "breakdownFilter": {
+                "breakdown": "country",
+            },
+        }
+
+        # Rename the action
+        self.action1.name = "Renamed Action 1"
+        self.action1.save()
+
+        # Refresh action names
+        updated_query = refresh_action_names_in_metric(query, self.team)
+
+        # Verify the action name was updated
+        assert updated_query["series"][0]["name"] == "Renamed Action 1"
+        # Verify other properties remain intact
+        assert updated_query["series"][0]["properties"][0]["key"] == "some_property"
+        assert updated_query["breakdownFilter"]["breakdown"] == "country"
+
+    def test_batch_fetching_actions(self):
+        """Test that multiple actions are fetched in a single query."""
+        query = {
+            "kind": "ExperimentMetric",
+            "metric_type": "funnel",
+            "series": [
+                {"kind": "ActionsNode", "id": self.action1.id, "name": "Original Action 1"},
+                {"kind": "ActionsNode", "id": self.action2.id, "name": "Original Action 2"},
+                {"kind": "ActionsNode", "id": self.action3.id, "name": "Original Action 3"},
+            ],
+        }
+
+        # Rename all actions
+        self.action1.name = "Renamed Action 1"
+        self.action1.save()
+        self.action2.name = "Renamed Action 2"
+        self.action2.save()
+        self.action3.name = "Renamed Action 3"
+        self.action3.save()
+
+        # Count queries executed
+        with self.assertNumQueries(1):  # Should be a single query to fetch all actions
+            updated_query = refresh_action_names_in_metric(query, self.team)
+
+        # Verify all names were updated
+        assert updated_query["series"][0]["name"] == "Renamed Action 1"
+        assert updated_query["series"][1]["name"] == "Renamed Action 2"
+        assert updated_query["series"][2]["name"] == "Renamed Action 3"

--- a/products/experiments/backend/test/test_metric_utils.py
+++ b/products/experiments/backend/test/test_metric_utils.py
@@ -19,17 +19,12 @@ class TestRefreshActionNamesInMetric(BaseTest):
         self.action2 = Action.objects.create(team=self.team, name="Original Action 2")
         self.action3 = Action.objects.create(team=self.team, name="Original Action 3")
 
-    @parameterized.expand(
-        [
-            ("mean", "source"),
-        ]
-    )
-    def test_refresh_action_names_in_single_field_metric(self, metric_type: str, field_name: str):
-        """Test refreshing action names in metrics with a single ActionsNode field."""
+    def test_refresh_action_names_in_mean_metric(self):
+        """Test refreshing action names in a mean metric."""
         query = {
             "kind": "ExperimentMetric",
-            "metric_type": metric_type,
-            field_name: {
+            "metric_type": "mean",
+            "source": {
                 "kind": "ActionsNode",
                 "id": self.action1.id,
                 "name": "Original Action 1",
@@ -45,9 +40,9 @@ class TestRefreshActionNamesInMetric(BaseTest):
 
         # Verify the name was updated
         assert updated_query is not None
-        assert updated_query[field_name]["name"] == "Renamed Action 1"
-        assert updated_query[field_name]["id"] == self.action1.id
-        assert updated_query[field_name]["kind"] == "ActionsNode"
+        assert updated_query["source"]["name"] == "Renamed Action 1"
+        assert updated_query["source"]["id"] == self.action1.id
+        assert updated_query["source"]["kind"] == "ActionsNode"
 
     def test_refresh_action_names_in_funnel_metric(self):
         """Test refreshing action names in a funnel metric with multiple steps."""
@@ -154,7 +149,8 @@ class TestRefreshActionNamesInMetric(BaseTest):
         """Test that missing or deleted actions don't cause errors."""
         if action_exists:
             action_id = self.action1.id
-            self.action1.delete()
+            self.action1.deleted = True
+            self.action1.save()
         else:
             action_id = 99999
 

--- a/products/experiments/backend/test/test_metric_utils.py
+++ b/products/experiments/backend/test/test_metric_utils.py
@@ -44,6 +44,7 @@ class TestRefreshActionNamesInMetric(BaseTest):
         updated_query = refresh_action_names_in_metric(query, self.team)
 
         # Verify the name was updated
+        assert updated_query is not None
         assert updated_query[field_name]["name"] == "Renamed Action 1"
         assert updated_query[field_name]["id"] == self.action1.id
         assert updated_query[field_name]["kind"] == "ActionsNode"
@@ -82,6 +83,7 @@ class TestRefreshActionNamesInMetric(BaseTest):
         updated_query = refresh_action_names_in_metric(query, self.team)
 
         # Verify action names were updated but event name was not changed
+        assert updated_query is not None
         assert updated_query["series"][0]["name"] == "Renamed Action 1"
         assert updated_query["series"][1]["name"] == "Pageview"  # EventsNode unchanged
         assert updated_query["series"][2]["name"] == "Renamed Action 2"
@@ -119,6 +121,7 @@ class TestRefreshActionNamesInMetric(BaseTest):
         updated_query = refresh_action_names_in_metric(query, self.team)
 
         # Verify both names were updated
+        assert updated_query is not None
         assert updated_query[field1]["name"] == "Renamed Action 1"
         assert updated_query[field2]["name"] == "Renamed Action 2"
 
@@ -138,6 +141,7 @@ class TestRefreshActionNamesInMetric(BaseTest):
         updated_query = refresh_action_names_in_metric(query, self.team)
 
         # Verify EventsNode name was not changed
+        assert updated_query is not None
         assert updated_query["source"]["name"] == "Custom Pageview Name"
 
     @parameterized.expand(
@@ -168,6 +172,7 @@ class TestRefreshActionNamesInMetric(BaseTest):
         updated_query = refresh_action_names_in_metric(query, self.team)
 
         # Verify the name remains unchanged when action doesn't exist
+        assert updated_query is not None
         assert updated_query["source"]["name"] == "Original Name"
 
     @parameterized.expand(
@@ -193,7 +198,9 @@ class TestRefreshActionNamesInMetric(BaseTest):
 
     def test_query_not_mutated(self):
         """Test that the original query is not mutated."""
-        original_query = {
+        from typing import Any
+
+        original_query: dict[str, Any] = {
             "kind": "ExperimentMetric",
             "metric_type": "mean",
             "source": {
@@ -215,6 +222,8 @@ class TestRefreshActionNamesInMetric(BaseTest):
 
         # Verify original query was not mutated
         assert original_query["source"]["name"] == original_name
+        assert updated_query is not None
+        assert isinstance(updated_query, dict)
         assert updated_query["source"]["name"] == "Renamed Action 1"
 
     def test_handles_nested_structures(self):
@@ -248,6 +257,8 @@ class TestRefreshActionNamesInMetric(BaseTest):
         updated_query = refresh_action_names_in_metric(query, self.team)
 
         # Verify the action name was updated
+        assert updated_query is not None
+        assert isinstance(updated_query, dict)
         assert updated_query["series"][0]["name"] == "Renamed Action 1"
         # Verify other properties remain intact
         assert updated_query["series"][0]["properties"][0]["key"] == "some_property"
@@ -278,6 +289,7 @@ class TestRefreshActionNamesInMetric(BaseTest):
             updated_query = refresh_action_names_in_metric(query, self.team)
 
         # Verify all names were updated
+        assert updated_query is not None
         assert updated_query["series"][0]["name"] == "Renamed Action 1"
         assert updated_query["series"][1]["name"] == "Renamed Action 2"
         assert updated_query["series"][2]["name"] == "Renamed Action 3"


### PR DESCRIPTION
## Problem

When an experiment metric uses  and _action_, we store the `name` on the metrics JSON field

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Added code to intercept the metrics array and replace if with the correct values for actions from the `actions` table.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

```bash
pytest ee/clickhouse/views/test/test_experiment_saved_metrics.py -v
pytest ee/clickhouse/views/test/test_experiments_action_names.py -v
pnpm turbo run backend:test --filter=@posthog/products-experiments
```

![cat-type](https://github.com/user-attachments/assets/731f0766-46c9-4a14-92a4-daca10870b6d)


<!-- Briefly describe the steps you took, and what steps reviewers must take to get to where changes are, and what is the expected behavior. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

do not publish to changelog

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
