### PR TITLE
fix(phai): chat search

### DIFF
--- a/frontend/src/layout/panel-layout/ai-first/tabs/NavTabChat.tsx
+++ b/frontend/src/layout/panel-layout/ai-first/tabs/NavTabChat.tsx
@@ -80,6 +80,7 @@ export function NavTabChat({
         <div className="flex flex-col flex-1 overflow-hidden">
             <Combobox.Root
                 items={conversationGroups}
+                itemToStringLabel={(item: Conversation) => item?.title ?? ''}
                 itemToStringValue={(item: Conversation) => item?.title ?? ''}
                 open
                 autoHighlight
@@ -141,8 +142,12 @@ export function NavTabChat({
                                 <Combobox.List className="flex flex-col">
                                     {(group: ConversationGroup) => (
                                         <Collapsible
-                                            key={group.value}
-                                            defaultOpen={group.value === 'Today' || conversationGroups.length === 1}
+                                            key={`${group.value}-${!!inputValue}`}
+                                            defaultOpen={
+                                                !!inputValue ||
+                                                group.value === 'Today' ||
+                                                conversationGroups.length === 1
+                                            }
                                         >
                                             <Combobox.Group items={group.items}>
                                                 <Combobox.GroupLabel

--- a/frontend/src/scenes/max/components/ChatHistoryPanel.tsx
+++ b/frontend/src/scenes/max/components/ChatHistoryPanel.tsx
@@ -130,52 +130,46 @@ export const ChatHistoryPanel = memo(function ChatHistoryPanel({ tabId }: ChatHi
                             ) : (
                                 <>
                                     <Autocomplete.List className="flex flex-col gap-1 -mx-1">
-                                        <Autocomplete.Group items={conversationHistory}>
-                                            <Autocomplete.Collection>
-                                                {(conversation: ConversationDetail) => (
-                                                    <AiChatListItem.Root>
-                                                        <AiChatListItem.Group>
-                                                            <Autocomplete.Item
-                                                                key={conversation.id}
-                                                                value={conversation}
-                                                                onClick={(e) => {
-                                                                    e.preventDefault()
-                                                                    openConversation(conversation.id)
+                                        {(conversation: ConversationDetail) => (
+                                            <AiChatListItem.Root>
+                                                <AiChatListItem.Group>
+                                                    <Autocomplete.Item
+                                                        key={conversation.id}
+                                                        value={conversation}
+                                                        onClick={(e) => {
+                                                            e.preventDefault()
+                                                            openConversation(conversation.id)
+                                                        }}
+                                                        render={
+                                                            <Link
+                                                                to={AiChatListItem.getHref(conversation.id)}
+                                                                buttonProps={{
+                                                                    active: conversation.id === conversationId,
+                                                                    fullWidth: true,
+                                                                    className: 'pr-0',
                                                                 }}
-                                                                render={
-                                                                    <Link
-                                                                        to={AiChatListItem.getHref(conversation.id)}
-                                                                        buttonProps={{
-                                                                            active: conversation.id === conversationId,
-                                                                            fullWidth: true,
-                                                                            className: 'pr-0',
-                                                                        }}
-                                                                        tooltip={
-                                                                            conversation.title || 'view conversation'
-                                                                        }
-                                                                        tooltipPlacement="right"
-                                                                        extraContextMenuItems={
-                                                                            <AiChatListItem.ContextMenuAction
-                                                                                conversationId={conversation.id}
-                                                                            />
-                                                                        }
-                                                                    >
-                                                                        <AiChatListItem.Content
-                                                                            showIcon
-                                                                            title={conversation.title}
-                                                                            status={conversation.status}
-                                                                            updatedAt={conversation.updated_at}
-                                                                        />
-                                                                    </Link>
+                                                                tooltip={conversation.title || 'view conversation'}
+                                                                tooltipPlacement="right"
+                                                                extraContextMenuItems={
+                                                                    <AiChatListItem.ContextMenuAction
+                                                                        conversationId={conversation.id}
+                                                                    />
                                                                 }
-                                                            />
-                                                            <AiChatListItem.Trigger />
-                                                        </AiChatListItem.Group>
-                                                        <AiChatListItem.Actions conversationId={conversation.id} />
-                                                    </AiChatListItem.Root>
-                                                )}
-                                            </Autocomplete.Collection>
-                                        </Autocomplete.Group>
+                                                            >
+                                                                <AiChatListItem.Content
+                                                                    showIcon
+                                                                    title={conversation.title}
+                                                                    status={conversation.status}
+                                                                    updatedAt={conversation.updated_at}
+                                                                />
+                                                            </Link>
+                                                        }
+                                                    />
+                                                    <AiChatListItem.Trigger />
+                                                </AiChatListItem.Group>
+                                                <AiChatListItem.Actions conversationId={conversation.id} />
+                                            </AiChatListItem.Root>
+                                        )}
                                     </Autocomplete.List>
                                     <Autocomplete.Empty className="flex flex-col items-center justify-center text-center py-8 text-muted empty:hidden">
                                         <p className="text-sm mb-0">No chats found</p>


### PR DESCRIPTION
## Problem

- Search didn't work when `ai-first` flag was disabled
- Sections didn't automatically open when active in search
- Search didn't match strings correctly

## Changes

https://github.com/user-attachments/assets/e9775a38-ed85-4663-8766-4a6ab5c5c3c4

- Fixed the problems

## How did you test this code?

Tested locally

## Publish to changelog?

no

## Docs update

no