### PR TITLE
chore: skip sending shutdown command to Chrome

### DIFF
--- a/mypy-baseline.txt
+++ b/mypy-baseline.txt
@@ -538,6 +538,7 @@ posthog/tasks/alerts/test/test_alert_checks.py:0: error: Value of type "Any | No
 posthog/tasks/email.py:0: error: Argument "email" to "add_recipient" of "EmailMessage" has incompatible type "str | None"; expected "str"  [arg-type]
 posthog/tasks/email.py:0: error: Incompatible types in assignment (expression has type "Team | None", variable has type "Team")  [assignment]
 posthog/tasks/email.py:0: error: Item "None" of "User | None" has no attribute "first_name"  [union-attr]
+posthog/tasks/exports/image_exporter.py:0: error: Cannot assign to a method  [method-assign]
 posthog/tasks/exports/test/test_csv_exporter.py:0: error: Argument 1 to "BytesIO" has incompatible type "bytes | memoryview[int] | None"; expected "Buffer"  [arg-type]
 posthog/tasks/exports/test/test_csv_exporter.py:0: error: Argument 1 to "read" has incompatible type "str | None"; expected "str"  [arg-type]
 posthog/tasks/exports/test/test_csv_exporter.py:0: error: Argument 1 to "read" has incompatible type "str | None"; expected "str"  [arg-type]

--- a/posthog/tasks/exports/image_exporter.py
+++ b/posthog/tasks/exports/image_exporter.py
@@ -105,12 +105,20 @@ def get_driver() -> webdriver.Chrome:
 
     if os.environ.get("CHROMEDRIVER_BIN"):
         service = webdriver.ChromeService(executable_path=os.environ["CHROMEDRIVER_BIN"])
-        return webdriver.Chrome(service=service, options=options)
+        driver = webdriver.Chrome(service=service, options=options)
+    else:
+        driver = webdriver.Chrome(
+            service=Service(ChromeDriverManager(chrome_type=ChromeType.GOOGLE).install()),
+            options=options,
+        )
 
-    return webdriver.Chrome(
-        service=Service(ChromeDriverManager(chrome_type=ChromeType.GOOGLE).install()),
-        options=options,
-    )
+    # Selenium's Service.send_remote_shutdown_command() uses urllib.request.urlopen()
+    # which routes through HTTP_PROXY. The egress proxy blocks this localhost request,
+    # but it doesn't matter — Service.stop() always calls _terminate_process() (SIGTERM)
+    # right after, so the HTTP shutdown is redundant.
+    driver.service.send_remote_shutdown_command = lambda: None
+
+    return driver
 
 
 def _export_to_png(


### PR DESCRIPTION
The shutdown command will be blocked by our egress proxy. Disabling use of the proxy for this specific command isn't straightforward, and we send a SIGTERM to the process immediately after this anyway, so there's no point in accumulating these blocked requests in our egress proxy's logs.
