### PR TITLE
fix(logs): dont filter out empty timeseries values for logs sparkline

### DIFF
--- a/products/logs/frontend/components/LogsViewer/data/logsViewerDataLogic.ts
+++ b/products/logs/frontend/components/LogsViewer/data/logsViewerDataLogic.ts
@@ -426,7 +426,6 @@ export const logsViewerDataLogic = kea<logsViewerDataLogicType>([
                                       trace: 'muted-alt',
                                   }[name],
                     }))
-                    .filter((series) => series.values.reduce((a, b) => a + b) > 0)
 
                 return { data, labels, dates }
             },


### PR DESCRIPTION
## Problem

the sparkline stopped abruptly if there were no more values past a certain point, behaving differently to gaps earlier in the series

## Changes

make the full sparkline width always render, with "no entries" in the empty columns instead of being completely blank:

old:
<img width="1053" height="387" alt="image" src="https://github.com/user-attachments/assets/5b2667ae-1b6a-47cc-8158-375461e4d727" />


new: 
<img width="1045" height="367" alt="image" src="https://github.com/user-attachments/assets/60173168-f8ef-4918-a273-d8822a936371" />

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
n/a
<!-- Briefly describe the steps you took, and what steps reviewers must take to get to where changes are, and what is the expected behavior. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
no
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
