### PR TITLE
fix(ci): consolidate dorny paths-filter calls for temporal workers

### DIFF
--- a/.github/workflows/container-images-cd.yml
+++ b/.github/workflows/container-images-cd.yml
@@ -411,21 +411,28 @@ jobs:
                         "timestamp": "${{ github.event.head_commit.timestamp }}"
                       }
 
-            - name: Check for changes that affect health check temporal worker
+            - name: Check for changes that affect temporal workers (dorny)
               uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
-              id: check_changes_health_check_temporal_worker
+              id: check_temporal_worker_changes
               with:
                   filters: |
-                      shouldRun:
+                      healthCheck:
                         - 'posthog/temporal/health_checks/**'
                         - 'products/.*/backend/temporal/health_checks/**'
                         - 'posthog/temporal/common/**'
                         - 'posthog/management/commands/start_temporal_worker.py'
                         - pyproject.toml
                         - bin/temporal-django-worker
+                      logsAlerting:
+                        - 'posthog/temporal/logs_alerting/**'
+                        - 'products/logs/backend/**'
+                        - 'posthog/temporal/common/**'
+                        - 'posthog/management/commands/start_temporal_worker.py'
+                        - pyproject.toml
+                        - bin/temporal-django-worker
 
             - name: Trigger Health Check Temporal Worker Cloud deployment
-              if: steps.check_changes_health_check_temporal_worker.outputs.shouldRun == 'true'
+              if: steps.check_temporal_worker_changes.outputs.healthCheck == 'true'
               uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4.0.1
               with:
                   token: ${{ steps.deployer.outputs.token }}
@@ -495,21 +502,8 @@ jobs:
                         "timestamp": "${{ github.event.head_commit.timestamp }}"
                       }
 
-            - name: Check for changes that affect logs alerting temporal worker
-              uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
-              id: check_changes_logs_alerting_temporal_worker
-              with:
-                  filters: |
-                      shouldRun:
-                        - 'posthog/temporal/logs_alerting/**'
-                        - 'products/logs/backend/**'
-                        - 'posthog/temporal/common/**'
-                        - 'posthog/management/commands/start_temporal_worker.py'
-                        - pyproject.toml
-                        - bin/temporal-django-worker
-
             - name: Trigger Logs Alerting Temporal Worker Cloud deployment
-              if: steps.check_changes_logs_alerting_temporal_worker.outputs.shouldRun == 'true'
+              if: steps.check_temporal_worker_changes.outputs.logsAlerting == 'true'
               uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4.0.1
               with:
                   token: ${{ steps.deployer.outputs.token }}


### PR DESCRIPTION
## Problem

#52858 added a second `dorny/paths-filter` action for the logs alerting temporal worker, but there was already one in use for the health check worker. Two separate calls means two redundant git diff operations.

## Changes

Merge both into a single `dorny/paths-filter` call with named filter sets (`healthCheck`, `logsAlerting`). Functionally identical, just fewer redundant steps.

## How did you test this code?

Follows existing pattern. dorny/paths-filter supports multiple named filters in one call — each gets its own output.

## Publish to changelog?

No

## 🤖 LLM context

Agent-authored cleanup of #52858.