### PR TITLE
fix: Inconsistent exports compared to UI

### DIFF
--- a/frontend/src/lib/components/Cards/InsightCard/InsightMeta.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/InsightMeta.tsx
@@ -550,6 +550,7 @@ export function InsightMeta({
                                             export_format: ExporterFormat.PNG,
                                             insight: insight.id,
                                             dashboard: insightLogicProps.dashboardId,
+                                            export_context: exportContext,
                                         },
                                         {
                                             export_format: ExporterFormat.CSV,

--- a/frontend/src/scenes/dashboard/DashboardScenePanel.tsx
+++ b/frontend/src/scenes/dashboard/DashboardScenePanel.tsx
@@ -145,7 +145,10 @@ export function DashboardScenePanel(): JSX.Element | null {
                                 {
                                     format: ExporterFormat.PNG,
                                     dashboard: dashboard.id,
-                                    context: { path: apiUrl() },
+                                    context: {
+                                        path: apiUrl(),
+                                        variables_override: effectiveDashboardVariableOverrides,
+                                    },
                                     dataAttr: `${RESOURCE_TYPE}-export-png`,
                                 },
                                 ...(user?.is_staff

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -5095,6 +5095,7 @@ export type ExportContext = (
 ) & {
     row_limit?: number // Some exports have different row limits, e.g. logs
     columns?: string[]
+    variables_override?: Record<string, any>
 }
 
 export interface ExportedAssetType {

--- a/mypy-baseline.txt
+++ b/mypy-baseline.txt
@@ -299,7 +299,6 @@ posthog/async_migrations/migrations/0010_move_old_partitions.py:0: error: Cannot
 posthog/async_migrations/test/test_runner.py:0: error: Item "None" of "datetime | None" has no attribute "day"  [union-attr]
 posthog/batch_exports/http.py:0: error: Incompatible return value type (got "Any | None", expected "str")  [return-value]
 posthog/cache_utils.py:0: error: Arguments not allowed after ParamSpec.args  [valid-type]
-posthog/caching/calculate_results.py:0: error: Argument 2 to "process_query_dict" has incompatible type "Any | None"; expected "dict[Any, Any]"  [arg-type]
 posthog/caching/insight_cache.py:0: error: Argument 2 to "process_query_dict" has incompatible type "Any | None"; expected "dict[Any, Any]"  [arg-type]
 posthog/caching/insight_caching_state.py:0: error: Argument "params" to "execute" of "CursorWrapper" has incompatible type "list[object]"; expected "Sequence[bool | int | float | Decimal | str | <6 more items> | None] | Mapping[str, bool | int | float | Decimal | str | <6 more items> | None] | None | None"  [arg-type]
 posthog/caching/warming.py:0: error: Argument 2 to "process_query_dict" has incompatible type "Any | None"; expected "dict[Any, Any]"  [arg-type]

--- a/posthog/caching/calculate_results.py
+++ b/posthog/caching/calculate_results.py
@@ -14,6 +14,7 @@ from posthog.event_usage import AnalyticsProps
 from posthog.hogql_queries.query_runner import get_query_runner_or_none
 from posthog.models import Insight, Team, User
 from posthog.models.insight import generate_insight_filters_hash
+from posthog.schema_migrations.upgrade import upgrade
 from posthog.schema_migrations.upgrade_manager import upgrade_query
 
 from products.dashboards.backend.models.dashboard import Dashboard
@@ -56,6 +57,7 @@ def calculate_for_query_based_insight(
     filters_override: Optional[dict] = None,
     variables_override: Optional[dict] = None,
     tile_filters_override: Optional[dict] = None,
+    query_override: Optional[dict] = None,
     analytics_props: Optional[AnalyticsProps] = None,
 ) -> "InsightResult":
     from posthog.caching.fetch_from_cache import InsightResult, NothingInCacheResult
@@ -77,9 +79,13 @@ def calculate_for_query_based_insight(
     if tile_filters_override is not None and tile_filters_override != {}:
         dashboard_filters_json = tile_filters_override
 
+    query_json: dict | None = upgrade(query_override) if query_override is not None else insight.query
+    if query_json is None:
+        raise ValueError("Insight has no query and no query_override was provided")
+
     response = process_response = process_query_dict(
         team,
-        insight.query,
+        query_json,
         dashboard_filters_json=dashboard_filters_json,
         variables_override_json=variables_override_json,
         execution_mode=execution_mode,

--- a/posthog/caching/calculate_results.py
+++ b/posthog/caching/calculate_results.py
@@ -14,7 +14,6 @@ from posthog.event_usage import AnalyticsProps
 from posthog.hogql_queries.query_runner import get_query_runner_or_none
 from posthog.models import Insight, Team, User
 from posthog.models.insight import generate_insight_filters_hash
-from posthog.schema_migrations.upgrade import upgrade
 from posthog.schema_migrations.upgrade_manager import upgrade_query
 
 from products.dashboards.backend.models.dashboard import Dashboard
@@ -79,7 +78,7 @@ def calculate_for_query_based_insight(
     if tile_filters_override is not None and tile_filters_override != {}:
         dashboard_filters_json = tile_filters_override
 
-    query_json: dict | None = upgrade(query_override) if query_override is not None else insight.query
+    query_json: dict | None = query_override if query_override is not None else insight.query
     if query_json is None:
         raise ValueError("Insight has no query and no query_override was provided")
 

--- a/posthog/tasks/exports/image_exporter.py
+++ b/posthog/tasks/exports/image_exporter.py
@@ -418,7 +418,12 @@ def export_image(
                     dashboard_id=exported_asset.dashboard.id if exported_asset.dashboard else None,
                 )
 
-                # When exporting a single insight from a dashboard, apply the tile's filter overrides and dashboard variables
+                # When export_context contains a source query, use it as the query for cache warming.
+                # This captures the user's full current state (variables, filters, date ranges, etc.).
+                # Falls back to the saved insight query for subscriptions and other server-initiated exports.
+                export_context = exported_asset.export_context or {}
+                query_override = export_context.get("source")
+
                 dashboard_variables = None
                 tile_filters_override = None
                 if exported_asset.dashboard:
@@ -432,7 +437,9 @@ def export_image(
                     if tile:
                         tile_filters_override = tile.filters_overrides
 
-                with upgrade_query(exported_asset.insight):
+                if query_override:
+                    # query_override is upgraded inside calculate_for_query_based_insight,
+                    # so we skip upgrade_query (which only upgrades insight.query we won't use)
                     result = calculate_for_query_based_insight(
                         exported_asset.insight,
                         team=exported_asset.team,
@@ -441,17 +448,33 @@ def export_image(
                         user=None,
                         variables_override=dashboard_variables,
                         tile_filters_override=tile_filters_override,
+                        query_override=query_override,
                         analytics_props=export_analytics_props,
                     )
-                    if result.cache_key:
-                        insight_cache_keys[exported_asset.insight.id] = result.cache_key
+                else:
+                    with upgrade_query(exported_asset.insight):
+                        result = calculate_for_query_based_insight(
+                            exported_asset.insight,
+                            team=exported_asset.team,
+                            dashboard=exported_asset.dashboard,
+                            execution_mode=ExecutionMode.CALCULATE_BLOCKING_ALWAYS,
+                            user=None,
+                            variables_override=dashboard_variables,
+                            tile_filters_override=tile_filters_override,
+                            analytics_props=export_analytics_props,
+                        )
+                if result.cache_key:
+                    insight_cache_keys[exported_asset.insight.id] = result.cache_key
             elif exported_asset.dashboard:
                 logger.info(
                     "export_image.calculate_dashboard_insights",
                     dashboard_id=exported_asset.dashboard.id,
                 )
-                dashboard_variables = None
-                if exported_asset.dashboard.variables:
+                # Use variable overrides from export_context (user's current unsaved selection),
+                # falling back to saved dashboard variables
+                export_context = exported_asset.export_context or {}
+                dashboard_variables = export_context.get("variables_override")
+                if not dashboard_variables and exported_asset.dashboard.variables:
                     variables = list(InsightVariable.objects.filter(team=exported_asset.team).all())
                     dashboard_variables = map_stale_to_latest(exported_asset.dashboard.variables, variables)
 

--- a/posthog/tasks/exports/image_exporter.py
+++ b/posthog/tasks/exports/image_exporter.py
@@ -439,14 +439,17 @@ def export_image(
 
                 if query_override:
                     # query_override is upgraded inside calculate_for_query_based_insight,
-                    # so we skip upgrade_query (which only upgrades insight.query we won't use)
+                    # so we skip upgrade_query (which only upgrades insight.query we won't use).
+                    # variables_override is None because query_override already encodes the
+                    # user's full current state — applying saved dashboard variables on top
+                    # would clobber unsaved variable selections.
                     result = calculate_for_query_based_insight(
                         exported_asset.insight,
                         team=exported_asset.team,
                         dashboard=exported_asset.dashboard,
                         execution_mode=ExecutionMode.CALCULATE_BLOCKING_ALWAYS,
                         user=None,
-                        variables_override=dashboard_variables,
+                        variables_override=None,
                         tile_filters_override=tile_filters_override,
                         query_override=query_override,
                         analytics_props=export_analytics_props,

--- a/posthog/tasks/exports/test/test_image_exporter.py
+++ b/posthog/tasks/exports/test/test_image_exporter.py
@@ -331,6 +331,22 @@ class TestImageExporter(APIBaseTest):
                 True,
             ),
             (
+                "source_vars_not_overridden_by_dashboard_vars",
+                {
+                    "source": {
+                        "kind": "HogQLQuery",
+                        "query": "SELECT 1",
+                        "variables": {"var_1": {"code_name": "eventName", "value": "$pageview"}},
+                    }
+                },
+                {
+                    "kind": "HogQLQuery",
+                    "query": "SELECT 1",
+                    "variables": {"var_1": {"code_name": "eventName", "value": "$pageview"}},
+                },
+                True,
+            ),
+            (
                 "without_export_context",
                 None,
                 None,
@@ -386,7 +402,11 @@ class TestImageExporter(APIBaseTest):
         else:
             assert "query_override" not in call_kwargs
 
-        if variable:
+        if expected_query_override is not None:
+            # When query_override is present, variables_override must be None —
+            # the user's current state is already embedded in query_override
+            assert call_kwargs["variables_override"] is None
+        elif variable:
             variable_id = str(variable.id)
             assert call_kwargs["variables_override"] == {
                 variable_id: {

--- a/posthog/tasks/exports/test/test_image_exporter.py
+++ b/posthog/tasks/exports/test/test_image_exporter.py
@@ -6,6 +6,7 @@ from unittest.mock import mock_open, patch
 
 from boto3 import resource
 from botocore.client import Config
+from parameterized import parameterized
 
 from posthog.api.insight_variable import map_stale_to_latest
 from posthog.caching.fetch_from_cache import InsightResult
@@ -315,183 +316,127 @@ class TestImageExporter(APIBaseTest):
                 "tile_filters_override should match tile filters"
             )
 
-    @patch("posthog.tasks.exports.image_exporter._screenshot_asset")
-    @patch("posthog.tasks.exports.image_exporter.open", new_callable=mock_open, read_data=b"image_data")
-    @patch("os.remove")
-    def test_export_context_source_passed_as_query_override(self, *args: Any) -> None:
-        """When export_context contains a source query, it should be passed as query_override
-        so the export reflects the user's current state (variables, filters, date ranges, etc.)."""
-        insight = Insight.objects.create(
-            team=self.team,
-            name="SQL Insight",
-            query={
-                "kind": "DataVisualizationNode",
-                "source": {
-                    "kind": "HogQLQuery",
-                    "query": "SELECT event FROM events WHERE event = {eventName}",
-                    "variables": {
-                        "var_1": {"variableId": "var_1", "code_name": "eventName", "value": "$pageleave"},
-                    },
-                },
-            },
-        )
-
-        user_source = {
-            "kind": "HogQLQuery",
-            "query": "SELECT event FROM events WHERE event = {eventName}",
-            "variables": {
-                "var_1": {"variableId": "var_1", "code_name": "eventName", "value": "$pageview"},
-            },
-        }
-        exported_asset = ExportedAsset.objects.create(
-            team=self.team,
-            export_format=ExportedAsset.ExportFormat.PNG,
-            insight=insight,
-            export_context={"source": user_source},
-        )
-
-        with patch("posthog.tasks.exports.image_exporter.calculate_for_query_based_insight") as mock_calculate:
-            mock_calculate.return_value = make_insight_result("test_key")
-
-            with self.settings(OBJECT_STORAGE_ENABLED=False):
-                image_exporter.export_image(exported_asset)
-
-            call_kwargs = mock_calculate.call_args[1]
-            assert call_kwargs["query_override"] == user_source
-
-    @patch("posthog.tasks.exports.image_exporter._screenshot_asset")
-    @patch("posthog.tasks.exports.image_exporter.open", new_callable=mock_open, read_data=b"image_data")
-    @patch("os.remove")
-    def test_export_context_source_with_dashboard_still_passes_dashboard_variables(self, *args: Any) -> None:
-        """When both export_context source and dashboard variables exist, both should be passed
-        so that query_override captures the user's query and dashboard variables are still applied."""
-        dashboard = Dashboard.objects.create(
-            team=self.team,
-            name="Dashboard",
-            variables={"var_1": {"code_name": "eventName", "value": "dashboard_value"}},
-        )
-
-        InsightVariable.objects.create(team=self.team, name="eventName", code_name="eventName", type="String")
+    @parameterized.expand(
+        [
+            (
+                "with_source_override",
+                {"source": {"kind": "HogQLQuery", "query": "SELECT 1"}},
+                {"kind": "HogQLQuery", "query": "SELECT 1"},
+                False,
+            ),
+            (
+                "with_source_and_dashboard_variables",
+                {"source": {"kind": "HogQLQuery", "query": "SELECT 1"}},
+                {"kind": "HogQLQuery", "query": "SELECT 1"},
+                True,
+            ),
+            (
+                "without_export_context",
+                None,
+                None,
+                False,
+            ),
+        ]
+    )
+    @patch("posthog.tasks.exports.image_exporter.calculate_for_query_based_insight")
+    def test_insight_export_query_override_routing(
+        self,
+        _name: str,
+        export_context: dict | None,
+        expected_query_override: dict | None,
+        with_dashboard: bool,
+        mock_calculate: Any,
+        *args: Any,
+    ) -> None:
+        dashboard = None
+        variable = None
+        if with_dashboard:
+            dashboard = Dashboard.objects.create(
+                team=self.team,
+                name="Dashboard",
+                variables={"var_1": {"code_name": "eventName", "value": "dashboard_value"}},
+            )
+            variable = InsightVariable.objects.create(
+                team=self.team, name="eventName", code_name="eventName", type="String"
+            )
 
         insight = Insight.objects.create(
             team=self.team,
             name="SQL Insight",
-            query={
-                "kind": "DataVisualizationNode",
-                "source": {"kind": "HogQLQuery", "query": "SELECT 1"},
-            },
+            query={"kind": "DataVisualizationNode", "source": {"kind": "HogQLQuery", "query": "SELECT 1"}},
         )
-        DashboardTile.objects.create(dashboard=dashboard, insight=insight)
+        if dashboard:
+            DashboardTile.objects.create(dashboard=dashboard, insight=insight)
 
-        user_source = {"kind": "HogQLQuery", "query": "SELECT 1"}
         exported_asset = ExportedAsset.objects.create(
             team=self.team,
             export_format=ExportedAsset.ExportFormat.PNG,
             insight=insight,
             dashboard=dashboard,
-            export_context={"source": user_source},
+            export_context=export_context,
         )
 
-        with patch("posthog.tasks.exports.image_exporter.calculate_for_query_based_insight") as mock_calculate:
-            mock_calculate.return_value = make_insight_result("test_key")
+        mock_calculate.return_value = make_insight_result("test_key")
+        with self.settings(OBJECT_STORAGE_ENABLED=False):
+            image_exporter.export_image(exported_asset)
 
-            with self.settings(OBJECT_STORAGE_ENABLED=False):
-                image_exporter.export_image(exported_asset)
-
-            call_kwargs = mock_calculate.call_args[1]
-            assert call_kwargs["query_override"] == user_source
-            variables = list(InsightVariable.objects.filter(team=self.team).all())
-            expected_vars = map_stale_to_latest(dashboard.variables or {}, variables)
-            assert call_kwargs["variables_override"] == expected_vars
-
-    @patch("posthog.tasks.exports.image_exporter._screenshot_asset")
-    @patch("posthog.tasks.exports.image_exporter.open", new_callable=mock_open, read_data=b"image_data")
-    @patch("os.remove")
-    def test_no_export_context_uses_saved_insight_query(self, *args: Any) -> None:
-        """Without export_context, query_override is not passed (uses saved insight query via upgrade_query)."""
-        insight = Insight.objects.create(
-            team=self.team,
-            name="SQL Insight",
-            query={
-                "kind": "DataVisualizationNode",
-                "source": {"kind": "HogQLQuery", "query": "SELECT 1"},
-            },
-        )
-
-        exported_asset = ExportedAsset.objects.create(
-            team=self.team,
-            export_format=ExportedAsset.ExportFormat.PNG,
-            insight=insight,
-        )
-
-        with patch("posthog.tasks.exports.image_exporter.calculate_for_query_based_insight") as mock_calculate:
-            mock_calculate.return_value = make_insight_result("test_key")
-
-            with self.settings(OBJECT_STORAGE_ENABLED=False):
-                image_exporter.export_image(exported_asset)
-
-            call_kwargs = mock_calculate.call_args[1]
+        call_kwargs = mock_calculate.call_args[1]
+        if expected_query_override is not None:
+            assert call_kwargs["query_override"] == expected_query_override
+        else:
             assert "query_override" not in call_kwargs
+
+        if variable:
+            variable_id = str(variable.id)
+            assert call_kwargs["variables_override"] == {
+                variable_id: {
+                    "code_name": "eventName",
+                    "value": "dashboard_value",
+                    "variableId": variable_id,
+                }
+            }
+        else:
             assert call_kwargs["variables_override"] is None
 
-    @patch("posthog.tasks.exports.image_exporter._screenshot_asset")
-    @patch("posthog.tasks.exports.image_exporter.open", new_callable=mock_open, read_data=b"image_data")
-    @patch("os.remove")
-    def test_dashboard_export_uses_export_context_variables_override(self, *args: Any) -> None:
-        """Full dashboard export should use variables_override from export_context (unsaved user selection)."""
+    @parameterized.expand(
+        [
+            (
+                "uses_export_context_override",
+                {
+                    "variables_override": {
+                        "var_1": {"variableId": "var_1", "code_name": "eventName", "value": "$pageview"}
+                    }
+                },
+                True,
+            ),
+            (
+                "falls_back_to_saved_variables",
+                None,
+                False,
+            ),
+        ]
+    )
+    @patch("posthog.tasks.exports.image_exporter.calculate_for_query_based_insight")
+    def test_dashboard_export_variables_routing(
+        self,
+        _name: str,
+        export_context: dict | None,
+        uses_context_directly: bool,
+        mock_calculate: Any,
+        *args: Any,
+    ) -> None:
         dashboard = Dashboard.objects.create(
             team=self.team,
             name="Dashboard",
             variables={"var_1": {"code_name": "eventName", "value": "saved_value"}},
         )
-
+        variable = InsightVariable.objects.create(
+            team=self.team, name="eventName", code_name="eventName", type="String"
+        )
         insight = Insight.objects.create(
             team=self.team,
             name="SQL Insight",
-            query={
-                "kind": "DataVisualizationNode",
-                "source": {"kind": "HogQLQuery", "query": "SELECT 1"},
-            },
-        )
-        DashboardTile.objects.create(dashboard=dashboard, insight=insight)
-
-        user_variables = {"var_1": {"variableId": "var_1", "code_name": "eventName", "value": "$pageview"}}
-        dashboard_asset = ExportedAsset.objects.create(
-            team=self.team,
-            export_format=ExportedAsset.ExportFormat.PNG,
-            dashboard=dashboard,
-            export_context={"variables_override": user_variables},
-        )
-
-        with patch("posthog.tasks.exports.image_exporter.calculate_for_query_based_insight") as mock_calculate:
-            mock_calculate.return_value = make_insight_result("test_key")
-
-            with self.settings(OBJECT_STORAGE_ENABLED=False):
-                image_exporter.export_image(dashboard_asset)
-
-            call_kwargs = mock_calculate.call_args[1]
-            assert call_kwargs["variables_override"] == user_variables
-
-    @patch("posthog.tasks.exports.image_exporter._screenshot_asset")
-    @patch("posthog.tasks.exports.image_exporter.open", new_callable=mock_open, read_data=b"image_data")
-    @patch("os.remove")
-    def test_dashboard_export_falls_back_to_saved_variables(self, *args: Any) -> None:
-        """Without export_context, full dashboard export should use saved dashboard.variables."""
-        dashboard = Dashboard.objects.create(
-            team=self.team,
-            name="Dashboard",
-            variables={"var_1": {"code_name": "eventName", "value": "saved_value"}},
-        )
-
-        InsightVariable.objects.create(team=self.team, name="eventName", code_name="eventName", type="String")
-
-        insight = Insight.objects.create(
-            team=self.team,
-            name="SQL Insight",
-            query={
-                "kind": "DataVisualizationNode",
-                "source": {"kind": "HogQLQuery", "query": "SELECT 1"},
-            },
+            query={"kind": "DataVisualizationNode", "source": {"kind": "HogQLQuery", "query": "SELECT 1"}},
         )
         DashboardTile.objects.create(dashboard=dashboard, insight=insight)
 
@@ -499,29 +444,37 @@ class TestImageExporter(APIBaseTest):
             team=self.team,
             export_format=ExportedAsset.ExportFormat.PNG,
             dashboard=dashboard,
+            export_context=export_context,
         )
 
-        with patch("posthog.tasks.exports.image_exporter.calculate_for_query_based_insight") as mock_calculate:
-            mock_calculate.return_value = make_insight_result("test_key")
+        mock_calculate.return_value = make_insight_result("test_key")
+        with self.settings(OBJECT_STORAGE_ENABLED=False):
+            image_exporter.export_image(dashboard_asset)
 
-            with self.settings(OBJECT_STORAGE_ENABLED=False):
-                image_exporter.export_image(dashboard_asset)
-
-            call_kwargs = mock_calculate.call_args[1]
-            variables = list(InsightVariable.objects.filter(team=self.team).all())
-            expected = map_stale_to_latest(dashboard.variables or {}, variables)
-            assert call_kwargs["variables_override"] == expected
+        call_kwargs = mock_calculate.call_args[1]
+        if uses_context_directly:
+            assert call_kwargs["variables_override"] == export_context["variables_override"]  # type: ignore[index]
+        else:
+            variable_id = str(variable.id)
+            assert call_kwargs["variables_override"] == {
+                variable_id: {
+                    "code_name": "eventName",
+                    "value": "saved_value",
+                    "variableId": variable_id,
+                }
+            }
 
 
 @patch("posthog.tasks.exports.image_exporter._screenshot_asset")
 @patch("posthog.tasks.exports.image_exporter.open", new_callable=mock_open, read_data=b"image_data")
 @patch("os.remove")
 class TestImageExporterQueryOverrideE2E(ClickhouseTestMixin, APIBaseTest):
-    """E2E tests that execute real HogQL queries against ClickHouse (only screenshot is mocked)."""
-
-    def test_query_override_produces_different_results_than_saved_query(self, *args: Any) -> None:
-        """Verify that export_context source with different variable values
-        actually produces different cached data than the saved insight query."""
+    def test_query_override_produces_different_results_than_saved_query(
+        self,
+        mock_remove: Any,
+        mock_open: Any,
+        mock_screenshot_asset: Any,
+    ) -> None:
         _create_event(distinct_id="user1", event="$pageview", team=self.team)
         _create_event(distinct_id="user1", event="$pageview", team=self.team)
         _create_event(distinct_id="user1", event="$pageleave", team=self.team)
@@ -545,7 +498,7 @@ class TestImageExporterQueryOverrideE2E(ClickhouseTestMixin, APIBaseTest):
             query={"kind": "DataVisualizationNode", "source": query_source},
         )
 
-        # Export with saved defaults ($pageleave) — no export_context
+        # Export with saved defaults ($pageleave)
         asset_default = ExportedAsset.objects.create(
             team=self.team,
             export_format=ExportedAsset.ExportFormat.PNG,
@@ -554,7 +507,7 @@ class TestImageExporterQueryOverrideE2E(ClickhouseTestMixin, APIBaseTest):
         with self.settings(OBJECT_STORAGE_ENABLED=False):
             image_exporter.export_image(asset_default)
 
-        # Export with user override ($pageview) — via export_context
+        # Export with user override ($pageview) via export_context
         override_source = {
             **query_source,
             "variables": {
@@ -570,16 +523,14 @@ class TestImageExporterQueryOverrideE2E(ClickhouseTestMixin, APIBaseTest):
         with self.settings(OBJECT_STORAGE_ENABLED=False):
             image_exporter.export_image(asset_override)
 
-        # Both produce images, but with different cache keys (different query = different results)
         assert asset_default.content is not None
         assert asset_override.content is not None
 
-        # The screenshot URL contains cache_keys — verify they differ
-        screenshot_calls = args[2].call_args_list  # _screenshot_asset mock
+        # Different variables should produce different screenshot URLs (different cache keys)
+        screenshot_calls = mock_screenshot_asset.call_args_list
         url_default = screenshot_calls[0][0][1]
         url_override = screenshot_calls[1][0][1]
 
         assert "cache_keys=" in url_default
         assert "cache_keys=" in url_override
-        # Different variables should produce different cache keys
         assert url_default != url_override

--- a/posthog/tasks/exports/test/test_image_exporter.py
+++ b/posthog/tasks/exports/test/test_image_exporter.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from typing import Any
 
-from posthog.test.base import APIBaseTest
+from posthog.test.base import APIBaseTest, ClickhouseTestMixin, _create_event, flush_persons_and_events
 from unittest.mock import mock_open, patch
 
 from boto3 import resource
@@ -314,3 +314,272 @@ class TestImageExporter(APIBaseTest):
             assert call_kwargs["tile_filters_override"] == tile_filters, (
                 "tile_filters_override should match tile filters"
             )
+
+    @patch("posthog.tasks.exports.image_exporter._screenshot_asset")
+    @patch("posthog.tasks.exports.image_exporter.open", new_callable=mock_open, read_data=b"image_data")
+    @patch("os.remove")
+    def test_export_context_source_passed_as_query_override(self, *args: Any) -> None:
+        """When export_context contains a source query, it should be passed as query_override
+        so the export reflects the user's current state (variables, filters, date ranges, etc.)."""
+        insight = Insight.objects.create(
+            team=self.team,
+            name="SQL Insight",
+            query={
+                "kind": "DataVisualizationNode",
+                "source": {
+                    "kind": "HogQLQuery",
+                    "query": "SELECT event FROM events WHERE event = {eventName}",
+                    "variables": {
+                        "var_1": {"variableId": "var_1", "code_name": "eventName", "value": "$pageleave"},
+                    },
+                },
+            },
+        )
+
+        user_source = {
+            "kind": "HogQLQuery",
+            "query": "SELECT event FROM events WHERE event = {eventName}",
+            "variables": {
+                "var_1": {"variableId": "var_1", "code_name": "eventName", "value": "$pageview"},
+            },
+        }
+        exported_asset = ExportedAsset.objects.create(
+            team=self.team,
+            export_format=ExportedAsset.ExportFormat.PNG,
+            insight=insight,
+            export_context={"source": user_source},
+        )
+
+        with patch("posthog.tasks.exports.image_exporter.calculate_for_query_based_insight") as mock_calculate:
+            mock_calculate.return_value = make_insight_result("test_key")
+
+            with self.settings(OBJECT_STORAGE_ENABLED=False):
+                image_exporter.export_image(exported_asset)
+
+            call_kwargs = mock_calculate.call_args[1]
+            assert call_kwargs["query_override"] == user_source
+
+    @patch("posthog.tasks.exports.image_exporter._screenshot_asset")
+    @patch("posthog.tasks.exports.image_exporter.open", new_callable=mock_open, read_data=b"image_data")
+    @patch("os.remove")
+    def test_export_context_source_with_dashboard_still_passes_dashboard_variables(self, *args: Any) -> None:
+        """When both export_context source and dashboard variables exist, both should be passed
+        so that query_override captures the user's query and dashboard variables are still applied."""
+        dashboard = Dashboard.objects.create(
+            team=self.team,
+            name="Dashboard",
+            variables={"var_1": {"code_name": "eventName", "value": "dashboard_value"}},
+        )
+
+        InsightVariable.objects.create(team=self.team, name="eventName", code_name="eventName", type="String")
+
+        insight = Insight.objects.create(
+            team=self.team,
+            name="SQL Insight",
+            query={
+                "kind": "DataVisualizationNode",
+                "source": {"kind": "HogQLQuery", "query": "SELECT 1"},
+            },
+        )
+        DashboardTile.objects.create(dashboard=dashboard, insight=insight)
+
+        user_source = {"kind": "HogQLQuery", "query": "SELECT 1"}
+        exported_asset = ExportedAsset.objects.create(
+            team=self.team,
+            export_format=ExportedAsset.ExportFormat.PNG,
+            insight=insight,
+            dashboard=dashboard,
+            export_context={"source": user_source},
+        )
+
+        with patch("posthog.tasks.exports.image_exporter.calculate_for_query_based_insight") as mock_calculate:
+            mock_calculate.return_value = make_insight_result("test_key")
+
+            with self.settings(OBJECT_STORAGE_ENABLED=False):
+                image_exporter.export_image(exported_asset)
+
+            call_kwargs = mock_calculate.call_args[1]
+            assert call_kwargs["query_override"] == user_source
+            variables = list(InsightVariable.objects.filter(team=self.team).all())
+            expected_vars = map_stale_to_latest(dashboard.variables or {}, variables)
+            assert call_kwargs["variables_override"] == expected_vars
+
+    @patch("posthog.tasks.exports.image_exporter._screenshot_asset")
+    @patch("posthog.tasks.exports.image_exporter.open", new_callable=mock_open, read_data=b"image_data")
+    @patch("os.remove")
+    def test_no_export_context_uses_saved_insight_query(self, *args: Any) -> None:
+        """Without export_context, query_override is not passed (uses saved insight query via upgrade_query)."""
+        insight = Insight.objects.create(
+            team=self.team,
+            name="SQL Insight",
+            query={
+                "kind": "DataVisualizationNode",
+                "source": {"kind": "HogQLQuery", "query": "SELECT 1"},
+            },
+        )
+
+        exported_asset = ExportedAsset.objects.create(
+            team=self.team,
+            export_format=ExportedAsset.ExportFormat.PNG,
+            insight=insight,
+        )
+
+        with patch("posthog.tasks.exports.image_exporter.calculate_for_query_based_insight") as mock_calculate:
+            mock_calculate.return_value = make_insight_result("test_key")
+
+            with self.settings(OBJECT_STORAGE_ENABLED=False):
+                image_exporter.export_image(exported_asset)
+
+            call_kwargs = mock_calculate.call_args[1]
+            assert "query_override" not in call_kwargs
+            assert call_kwargs["variables_override"] is None
+
+    @patch("posthog.tasks.exports.image_exporter._screenshot_asset")
+    @patch("posthog.tasks.exports.image_exporter.open", new_callable=mock_open, read_data=b"image_data")
+    @patch("os.remove")
+    def test_dashboard_export_uses_export_context_variables_override(self, *args: Any) -> None:
+        """Full dashboard export should use variables_override from export_context (unsaved user selection)."""
+        dashboard = Dashboard.objects.create(
+            team=self.team,
+            name="Dashboard",
+            variables={"var_1": {"code_name": "eventName", "value": "saved_value"}},
+        )
+
+        insight = Insight.objects.create(
+            team=self.team,
+            name="SQL Insight",
+            query={
+                "kind": "DataVisualizationNode",
+                "source": {"kind": "HogQLQuery", "query": "SELECT 1"},
+            },
+        )
+        DashboardTile.objects.create(dashboard=dashboard, insight=insight)
+
+        user_variables = {"var_1": {"variableId": "var_1", "code_name": "eventName", "value": "$pageview"}}
+        dashboard_asset = ExportedAsset.objects.create(
+            team=self.team,
+            export_format=ExportedAsset.ExportFormat.PNG,
+            dashboard=dashboard,
+            export_context={"variables_override": user_variables},
+        )
+
+        with patch("posthog.tasks.exports.image_exporter.calculate_for_query_based_insight") as mock_calculate:
+            mock_calculate.return_value = make_insight_result("test_key")
+
+            with self.settings(OBJECT_STORAGE_ENABLED=False):
+                image_exporter.export_image(dashboard_asset)
+
+            call_kwargs = mock_calculate.call_args[1]
+            assert call_kwargs["variables_override"] == user_variables
+
+    @patch("posthog.tasks.exports.image_exporter._screenshot_asset")
+    @patch("posthog.tasks.exports.image_exporter.open", new_callable=mock_open, read_data=b"image_data")
+    @patch("os.remove")
+    def test_dashboard_export_falls_back_to_saved_variables(self, *args: Any) -> None:
+        """Without export_context, full dashboard export should use saved dashboard.variables."""
+        dashboard = Dashboard.objects.create(
+            team=self.team,
+            name="Dashboard",
+            variables={"var_1": {"code_name": "eventName", "value": "saved_value"}},
+        )
+
+        InsightVariable.objects.create(team=self.team, name="eventName", code_name="eventName", type="String")
+
+        insight = Insight.objects.create(
+            team=self.team,
+            name="SQL Insight",
+            query={
+                "kind": "DataVisualizationNode",
+                "source": {"kind": "HogQLQuery", "query": "SELECT 1"},
+            },
+        )
+        DashboardTile.objects.create(dashboard=dashboard, insight=insight)
+
+        dashboard_asset = ExportedAsset.objects.create(
+            team=self.team,
+            export_format=ExportedAsset.ExportFormat.PNG,
+            dashboard=dashboard,
+        )
+
+        with patch("posthog.tasks.exports.image_exporter.calculate_for_query_based_insight") as mock_calculate:
+            mock_calculate.return_value = make_insight_result("test_key")
+
+            with self.settings(OBJECT_STORAGE_ENABLED=False):
+                image_exporter.export_image(dashboard_asset)
+
+            call_kwargs = mock_calculate.call_args[1]
+            variables = list(InsightVariable.objects.filter(team=self.team).all())
+            expected = map_stale_to_latest(dashboard.variables or {}, variables)
+            assert call_kwargs["variables_override"] == expected
+
+
+@patch("posthog.tasks.exports.image_exporter._screenshot_asset")
+@patch("posthog.tasks.exports.image_exporter.open", new_callable=mock_open, read_data=b"image_data")
+@patch("os.remove")
+class TestImageExporterQueryOverrideE2E(ClickhouseTestMixin, APIBaseTest):
+    """E2E tests that execute real HogQL queries against ClickHouse (only screenshot is mocked)."""
+
+    def test_query_override_produces_different_results_than_saved_query(self, *args: Any) -> None:
+        """Verify that export_context source with different variable values
+        actually produces different cached data than the saved insight query."""
+        _create_event(distinct_id="user1", event="$pageview", team=self.team)
+        _create_event(distinct_id="user1", event="$pageview", team=self.team)
+        _create_event(distinct_id="user1", event="$pageleave", team=self.team)
+        flush_persons_and_events()
+
+        variable = InsightVariable.objects.create(
+            team=self.team, name="eventName", code_name="eventName", type="String", default_value="$pageleave"
+        )
+        variable_id = str(variable.id)
+
+        query_source = {
+            "kind": "HogQLQuery",
+            "query": "SELECT event, count() AS total FROM events WHERE event = {variables.eventName} GROUP BY event",
+            "variables": {
+                variable_id: {"variableId": variable_id, "code_name": "eventName", "value": "$pageleave"},
+            },
+        }
+        insight = Insight.objects.create(
+            team=self.team,
+            name="SQL Insight",
+            query={"kind": "DataVisualizationNode", "source": query_source},
+        )
+
+        # Export with saved defaults ($pageleave) — no export_context
+        asset_default = ExportedAsset.objects.create(
+            team=self.team,
+            export_format=ExportedAsset.ExportFormat.PNG,
+            insight=insight,
+        )
+        with self.settings(OBJECT_STORAGE_ENABLED=False):
+            image_exporter.export_image(asset_default)
+
+        # Export with user override ($pageview) — via export_context
+        override_source = {
+            **query_source,
+            "variables": {
+                variable_id: {"variableId": variable_id, "code_name": "eventName", "value": "$pageview"},
+            },
+        }
+        asset_override = ExportedAsset.objects.create(
+            team=self.team,
+            export_format=ExportedAsset.ExportFormat.PNG,
+            insight=insight,
+            export_context={"source": override_source},
+        )
+        with self.settings(OBJECT_STORAGE_ENABLED=False):
+            image_exporter.export_image(asset_override)
+
+        # Both produce images, but with different cache keys (different query = different results)
+        assert asset_default.content is not None
+        assert asset_override.content is not None
+
+        # The screenshot URL contains cache_keys — verify they differ
+        screenshot_calls = args[2].call_args_list  # _screenshot_asset mock
+        url_default = screenshot_calls[0][0][1]
+        url_override = screenshot_calls[1][0][1]
+
+        assert "cache_keys=" in url_default
+        assert "cache_keys=" in url_override
+        # Different variables should produce different cache keys
+        assert url_default != url_override


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

A recently reported [papercut](https://posthog.slack.com/archives/C0ACRAMJUAG/p1774609223405439) mentioned that variables are not being passed correctly for SQL insights inside the PNG export flow. For xlsx and csv this is not an issue, but for the png export this does surface an issue. It is present both in the "insight detail" and the dashboard pages.

## Changes

Effectively for the "one-off" export flow we will have the frontend pass all query details (just like it does for csv exports) to the backend; the backend will then check _if_ they are present, and if so, update the insight rendering to use those variables / details. If they are not present (e.g. subscription flow) it will fall back to the original details.

- Added `export_context` parameter to PNG export options in InsightMeta component (matching the CSV / XLSX exports)
- Enhanced dashboard PNG export to include `variables_override` in the export context
- Extended `ExportContext` type to support `variables_override` field
- Modified `calculate_for_query_based_insight` to accept a `query_override` parameter that takes precedence over the saved insight query
- Updated image exporter to use export context source query as query override, preserving user's current state (variables, filters, date ranges)
- Added fallback logic for dashboard exports to use export context variables or saved dashboard variables

## How did you test this code?

:white_check_mark: New (and existing) unit tests are passing

:white_check_mark: A insight detail export with SQL variables exports correctly

**Old:**

![CleanShot 2026-04-02 at 15.07.49.png](https://app.graphite.com/user-attachments/assets/9397d185-8877-44af-8ad1-736e74fad883.png)

**New:**

![CleanShot 2026-04-02 at 15.00.21.png](https://app.graphite.com/user-attachments/assets/7d356039-c63e-44eb-a176-df95b03435b6.png)

:white_check_mark: A dashboard with SQL variables exports correctly:

**Old:**

![CleanShot 2026-04-02 at 15.07.09.png](https://app.graphite.com/user-attachments/assets/3562766b-115e-45d6-a780-9e7d6d277203.png)

**New:**

![CleanShot 2026-04-02 at 15.02.24.png](https://app.graphite.com/user-attachments/assets/5b969f2e-8338-4ca4-8756-2eda1ba69c7a.png)

:white_check_mark: "Normal" insight and dashboard exports still work as well (manually confirmed, but no screenshots to retain the focus on the fix)

## Publish to changelog?

Yes - Exporting now retains additional metadata (like variables)

## Docs update

No docs update needed - this is an internal bug fix for export functionality.

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->