### PR TITLE
fix(docker): restore duckgres profile gate in dev compose

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -555,6 +555,7 @@ services:
         image: ghcr.io/posthog/duckgres:4b787d7a5c576cba92ff53d6e95f10c7b6464a39
         platform: arm64
         restart: on-failure
+        profiles: ['duckgres']
         ports:
             - '15432:15432'
         volumes:


### PR DESCRIPTION
**Problem**

#52838 removed `profiles: ['duckgres']` from `docker-compose.dev.yml` when centralizing profile definitions into the profiles overlay. But the dev compose file is frequently used standalone (mprocs, `wait-for-docker` default), so duckgres now starts unconditionally for every developer.

Unlike temporal, jaeger, etc. which were always-on in the dev file by design, duckgres was added with a profile gate from day one (#49685) — it was always opt-in.

Flagged by @webjunkie in https://github.com/PostHog/posthog/pull/52838#discussion_r3017407048.

**Changes**

Restore `profiles: ['duckgres']` in `docker-compose.dev.yml`. The overlay keeps its copy too, which is fine.

**How did you test this code?**

`docker compose -f docker-compose.dev.yml config --services` — duckgres absent unless `--profile duckgres` is passed.

No changelog, no docs update.

## 🤖 LLM context

One-line fix, agent-authored.