### PR TITLE
feat(data-warehouse): add source schema debug logging to SQL sources

### DIFF
--- a/posthog/temporal/data_imports/sources/mssql/mssql.py
+++ b/posthog/temporal/data_imports/sources/mssql/mssql.py
@@ -497,6 +497,7 @@ def mssql_source(
 
                 primary_keys = _get_primary_keys(cursor, schema, table_name)
                 table = _get_table(cursor, schema, table_name)
+                logger.debug(f"Source schema: {table.to_arrow_schema()}")
                 rows_to_sync = _get_rows_to_sync(cursor, inner_query, inner_query_args, logger)
                 chunk_size = _get_table_chunk_size(
                     cursor,

--- a/posthog/temporal/data_imports/sources/mysql/mysql.py
+++ b/posthog/temporal/data_imports/sources/mysql/mysql.py
@@ -592,6 +592,7 @@ def mysql_source(
 
                 primary_keys = _get_primary_keys(cursor, schema, table_name)
                 table = _get_table(cursor, schema, table_name)
+                logger.debug(f"Source schema: {table.to_arrow_schema()}")
                 rows_to_sync = _get_rows_to_sync(cursor, inner_query, inner_query_args, logger)
                 # define chunk_size
                 chunk_size = _get_table_chunk_size(

--- a/posthog/temporal/data_imports/sources/postgres/postgres.py
+++ b/posthog/temporal/data_imports/sources/postgres/postgres.py
@@ -914,6 +914,7 @@ def postgres_source(
             with connection.cursor() as cursor:
                 logger.debug("Getting table types...")
                 table = _get_table(cursor, schema, table_name, logger)
+                logger.debug(f"Source schema: {table.to_arrow_schema()}")
 
                 inner_query_with_limit = _build_query(
                     schema,

--- a/posthog/temporal/data_imports/sources/redshift/redshift.py
+++ b/posthog/temporal/data_imports/sources/redshift/redshift.py
@@ -572,6 +572,7 @@ def redshift_source(
             with connection.cursor() as cursor:
                 logger.debug("Getting table types...")
                 table = _get_table(cursor, schema, table_name, logger)
+                logger.debug(f"Source schema: {table.to_arrow_schema()}")
 
                 inner_query_with_limit = _build_query(
                     schema,


### PR DESCRIPTION
## Problem

When debugging data warehouse import issues, there's no visibility into the source schema being used for SQL-based sources (Postgres, MySQL, MSSQL, Redshift). This makes it harder to diagnose schema-related sync failures.

## Changes

Adds `logger.debug()` calls to log the Arrow schema derived from the source table in all four SQL database sources. The logs are at DEBUG level so they won't appear unless explicitly enabled.

## How did you test this code?

Verified the debug log line is consistent across all four SQL sources and only fires at DEBUG level.

no

## 🤖 LLM context

Agent-authored PR.