### PR TITLE
fix(storybook): disable visual regression for SidePanelDocs

### DIFF
--- a/frontend/src/layout/navigation-3000/sidepanel/SidePanel.stories.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/SidePanel.stories.tsx
@@ -77,7 +77,7 @@ export const SidePanelDocs: Story = {
         testOptions: {
             // Skip iframe wait since the external docs iframe fails to load in CI
             skipIframeWait: true,
-            browsers: [], // disable visual regression — external iframe is non-deterministic
+            snapshotBrowsers: [], // disable visual regression — external iframe is non-deterministic
         },
     },
 }

--- a/frontend/src/layout/navigation-3000/sidepanel/SidePanel.stories.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/SidePanel.stories.tsx
@@ -77,6 +77,7 @@ export const SidePanelDocs: Story = {
         testOptions: {
             // Skip iframe wait since the external docs iframe fails to load in CI
             skipIframeWait: true,
+            browsers: [], // disable visual regression — external iframe is non-deterministic
         },
     },
 }


### PR DESCRIPTION
## Problem

`SidePanelDocs` visual regression test is flaky — the external docs iframe produces non-deterministic screenshots, causing consistent failures in chromium shard 14/16 (~3.5% pixel diff).

## Changes

Set `browsers: []` on the story's `testOptions` to skip visual snapshot comparison. The smoke test still runs, just no screenshot diffing.

## How did you test this code?

No automated tests needed — this disables a flaky visual check. The story itself still renders and the smoke test passes.

## Publish to changelog?

no

## 🤖 LLM context

Agent-authored. Diagnosed from CI logs of run 23842483564.