### PR TITLE
feat: accept Stripe Shared Payment Tokens in agentic provisioning

### DIFF
--- a/ee/api/agentic_provisioning/__init__.py
+++ b/ee/api/agentic_provisioning/__init__.py
@@ -1,3 +1,4 @@
 AUTH_CODE_CACHE_PREFIX = "stripe_app_auth_code:"
 PENDING_AUTH_CACHE_PREFIX = "stripe_app_pending_auth:"
 RESOURCE_SERVICE_CACHE_PREFIX = "stripe_app_resource_service:"
+SHARED_PAYMENT_TOKEN_CACHE_PREFIX = "stripe_app_spt:"

--- a/ee/api/agentic_provisioning/__init__.py
+++ b/ee/api/agentic_provisioning/__init__.py
@@ -1,4 +1,3 @@
 AUTH_CODE_CACHE_PREFIX = "stripe_app_auth_code:"
 PENDING_AUTH_CACHE_PREFIX = "stripe_app_pending_auth:"
 RESOURCE_SERVICE_CACHE_PREFIX = "stripe_app_resource_service:"
-SHARED_PAYMENT_TOKEN_CACHE_PREFIX = "stripe_app_spt:"

--- a/ee/api/agentic_provisioning/test/test_spt.py
+++ b/ee/api/agentic_provisioning/test/test_spt.py
@@ -1,11 +1,18 @@
+from unittest.mock import MagicMock, patch
+
 from django.core.cache import cache
 
 from ee.api.agentic_provisioning.test.base import StripeProvisioningTestBase
-from ee.api.agentic_provisioning.views import get_shared_payment_token
 
 
 class TestSharedPaymentToken(StripeProvisioningTestBase):
-    def test_provisioning_stores_spt_when_provided(self):
+    @patch("ee.api.agentic_provisioning.views.requests.post")
+    @patch("ee.billing.billing_manager.build_billing_token", return_value="test_billing_token")
+    @patch("posthog.cloud_utils.get_cached_instance_license")
+    def test_provisioning_calls_billing_with_spt(self, mock_license, mock_build_token, mock_post):
+        mock_license.return_value = MagicMock()
+        mock_post.return_value = MagicMock(status_code=200)
+
         token = self._get_bearer_token()
         res = self._post_signed_with_bearer(
             "/api/agentic/provisioning/resources",
@@ -21,8 +28,11 @@ class TestSharedPaymentToken(StripeProvisioningTestBase):
         assert res.status_code == 200
         assert res.json()["status"] == "complete"
 
-        stored = get_shared_payment_token(str(self.organization.id))
-        assert stored == "spt_test_123"
+        mock_post.assert_called_once()
+        call_args, call_kwargs = mock_post.call_args
+        assert "/api/activate/authorize" in call_args[0]
+        assert call_kwargs["json"] == {"shared_payment_token": "spt_test_123"}
+        assert "Bearer test_billing_token" in call_kwargs["headers"]["Authorization"]
 
     def test_provisioning_works_without_spt(self):
         token = self._get_bearer_token()
@@ -34,10 +44,8 @@ class TestSharedPaymentToken(StripeProvisioningTestBase):
         assert res.status_code == 200
         assert res.json()["status"] == "complete"
 
-        stored = get_shared_payment_token(str(self.organization.id))
-        assert stored is None
-
-    def test_provisioning_ignores_invalid_payment_credentials_type(self):
+    @patch("ee.api.agentic_provisioning.views.requests.post")
+    def test_provisioning_ignores_invalid_payment_credentials_type(self, mock_post):
         token = self._get_bearer_token()
         res = self._post_signed_with_bearer(
             "/api/agentic/provisioning/resources",
@@ -51,40 +59,29 @@ class TestSharedPaymentToken(StripeProvisioningTestBase):
             token=token,
         )
         assert res.status_code == 200
+        mock_post.assert_not_called()
 
-        stored = get_shared_payment_token(str(self.organization.id))
-        assert stored is None
+    @patch("ee.api.agentic_provisioning.views.requests.post")
+    @patch("ee.billing.billing_manager.build_billing_token", return_value="test_billing_token")
+    @patch("posthog.cloud_utils.get_cached_instance_license")
+    def test_provisioning_succeeds_even_if_billing_activation_fails(self, mock_license, mock_build_token, mock_post):
+        mock_license.return_value = MagicMock()
+        mock_post.return_value = MagicMock(status_code=500)
 
-    def test_spt_overwrites_previous_value(self):
         token = self._get_bearer_token()
-
-        self._post_signed_with_bearer(
+        res = self._post_signed_with_bearer(
             "/api/agentic/provisioning/resources",
             data={
                 "service_id": "analytics",
                 "payment_credentials": {
                     "type": "stripe_payment_token",
-                    "stripe_payment_token": "spt_first",
+                    "stripe_payment_token": "spt_test_123",
                 },
             },
             token=token,
         )
-        assert get_shared_payment_token(str(self.organization.id)) == "spt_first"
-
-        # Provision again with a new SPT (e.g. plan upgrade)
-        token2 = self._get_bearer_token()
-        self._post_signed_with_bearer(
-            "/api/agentic/provisioning/resources",
-            data={
-                "service_id": "analytics",
-                "payment_credentials": {
-                    "type": "stripe_payment_token",
-                    "stripe_payment_token": "spt_second",
-                },
-            },
-            token=token2,
-        )
-        assert get_shared_payment_token(str(self.organization.id)) == "spt_second"
+        assert res.status_code == 200
+        assert res.json()["status"] == "complete"
 
     def test_token_exchange_returns_orchestrator(self):
         """Token exchange should return payment_credentials: orchestrator so Stripe collects payment."""

--- a/ee/api/agentic_provisioning/test/test_spt.py
+++ b/ee/api/agentic_provisioning/test/test_spt.py
@@ -64,7 +64,7 @@ class TestSharedPaymentToken(StripeProvisioningTestBase):
     @patch("ee.api.agentic_provisioning.views.requests.post")
     @patch("ee.billing.billing_manager.build_billing_token", return_value="test_billing_token")
     @patch("posthog.cloud_utils.get_cached_instance_license")
-    def test_provisioning_succeeds_even_if_billing_activation_fails(self, mock_license, mock_build_token, mock_post):
+    def test_provisioning_returns_error_if_billing_activation_fails(self, mock_license, mock_build_token, mock_post):
         mock_license.return_value = MagicMock()
         mock_post.return_value = MagicMock(status_code=500)
 
@@ -80,8 +80,10 @@ class TestSharedPaymentToken(StripeProvisioningTestBase):
             },
             token=token,
         )
-        assert res.status_code == 200
-        assert res.json()["status"] == "complete"
+        assert res.status_code == 400
+        body = res.json()
+        assert body["status"] == "error"
+        assert body["error"]["code"] == "requires_payment_credentials"
 
     def test_token_exchange_returns_orchestrator(self):
         """Token exchange should return payment_credentials: orchestrator so Stripe collects payment."""

--- a/ee/api/agentic_provisioning/test/test_spt.py
+++ b/ee/api/agentic_provisioning/test/test_spt.py
@@ -1,8 +1,7 @@
 from django.core.cache import cache
 
-from ee.api.agentic_provisioning import SHARED_PAYMENT_TOKEN_CACHE_PREFIX
-from ee.api.agentic_provisioning.views import get_shared_payment_token
 from ee.api.agentic_provisioning.test.base import StripeProvisioningTestBase
+from ee.api.agentic_provisioning.views import get_shared_payment_token
 
 
 class TestSharedPaymentToken(StripeProvisioningTestBase):

--- a/ee/api/agentic_provisioning/test/test_spt.py
+++ b/ee/api/agentic_provisioning/test/test_spt.py
@@ -7,8 +7,8 @@ from ee.api.agentic_provisioning.test.base import StripeProvisioningTestBase
 
 class TestSharedPaymentToken(StripeProvisioningTestBase):
     @patch("ee.api.agentic_provisioning.views.requests.post")
-    @patch("ee.billing.billing_manager.build_billing_token", return_value="test_billing_token")
-    @patch("posthog.cloud_utils.get_cached_instance_license")
+    @patch("ee.api.agentic_provisioning.views.build_billing_token", return_value="test_billing_token")
+    @patch("ee.api.agentic_provisioning.views.get_cached_instance_license")
     def test_provisioning_calls_billing_with_spt(self, mock_license, mock_build_token, mock_post):
         mock_license.return_value = MagicMock()
         mock_post.return_value = MagicMock(status_code=200)
@@ -62,8 +62,8 @@ class TestSharedPaymentToken(StripeProvisioningTestBase):
         mock_post.assert_not_called()
 
     @patch("ee.api.agentic_provisioning.views.requests.post")
-    @patch("ee.billing.billing_manager.build_billing_token", return_value="test_billing_token")
-    @patch("posthog.cloud_utils.get_cached_instance_license")
+    @patch("ee.api.agentic_provisioning.views.build_billing_token", return_value="test_billing_token")
+    @patch("ee.api.agentic_provisioning.views.get_cached_instance_license")
     def test_provisioning_succeeds_even_if_billing_activation_fails(self, mock_license, mock_build_token, mock_post):
         mock_license.return_value = MagicMock()
         mock_post.return_value = MagicMock(status_code=500)

--- a/ee/api/agentic_provisioning/test/test_spt.py
+++ b/ee/api/agentic_provisioning/test/test_spt.py
@@ -7,8 +7,8 @@ from ee.api.agentic_provisioning.test.base import StripeProvisioningTestBase
 
 class TestSharedPaymentToken(StripeProvisioningTestBase):
     @patch("ee.api.agentic_provisioning.views.requests.post")
-    @patch("ee.api.agentic_provisioning.views.build_billing_token", return_value="test_billing_token")
-    @patch("ee.api.agentic_provisioning.views.get_cached_instance_license")
+    @patch("ee.billing.billing_manager.build_billing_token", return_value="test_billing_token")
+    @patch("posthog.cloud_utils.get_cached_instance_license")
     def test_provisioning_calls_billing_with_spt(self, mock_license, mock_build_token, mock_post):
         mock_license.return_value = MagicMock()
         mock_post.return_value = MagicMock(status_code=200)
@@ -62,8 +62,8 @@ class TestSharedPaymentToken(StripeProvisioningTestBase):
         mock_post.assert_not_called()
 
     @patch("ee.api.agentic_provisioning.views.requests.post")
-    @patch("ee.api.agentic_provisioning.views.build_billing_token", return_value="test_billing_token")
-    @patch("ee.api.agentic_provisioning.views.get_cached_instance_license")
+    @patch("ee.billing.billing_manager.build_billing_token", return_value="test_billing_token")
+    @patch("posthog.cloud_utils.get_cached_instance_license")
     def test_provisioning_succeeds_even_if_billing_activation_fails(self, mock_license, mock_build_token, mock_post):
         mock_license.return_value = MagicMock()
         mock_post.return_value = MagicMock(status_code=500)

--- a/ee/api/agentic_provisioning/test/test_spt.py
+++ b/ee/api/agentic_provisioning/test/test_spt.py
@@ -1,0 +1,125 @@
+from django.core.cache import cache
+
+from ee.api.agentic_provisioning import SHARED_PAYMENT_TOKEN_CACHE_PREFIX
+from ee.api.agentic_provisioning.views import get_shared_payment_token
+from ee.api.agentic_provisioning.test.base import StripeProvisioningTestBase
+
+
+class TestSharedPaymentToken(StripeProvisioningTestBase):
+    def test_provisioning_stores_spt_when_provided(self):
+        token = self._get_bearer_token()
+        res = self._post_signed_with_bearer(
+            "/api/agentic/provisioning/resources",
+            data={
+                "service_id": "analytics",
+                "payment_credentials": {
+                    "type": "stripe_payment_token",
+                    "stripe_payment_token": "spt_test_123",
+                },
+            },
+            token=token,
+        )
+        assert res.status_code == 200
+        assert res.json()["status"] == "complete"
+
+        stored = get_shared_payment_token(str(self.organization.id))
+        assert stored == "spt_test_123"
+
+    def test_provisioning_works_without_spt(self):
+        token = self._get_bearer_token()
+        res = self._post_signed_with_bearer(
+            "/api/agentic/provisioning/resources",
+            data={"service_id": "analytics"},
+            token=token,
+        )
+        assert res.status_code == 200
+        assert res.json()["status"] == "complete"
+
+        stored = get_shared_payment_token(str(self.organization.id))
+        assert stored is None
+
+    def test_provisioning_ignores_invalid_payment_credentials_type(self):
+        token = self._get_bearer_token()
+        res = self._post_signed_with_bearer(
+            "/api/agentic/provisioning/resources",
+            data={
+                "service_id": "analytics",
+                "payment_credentials": {
+                    "type": "unknown_type",
+                    "token": "abc",
+                },
+            },
+            token=token,
+        )
+        assert res.status_code == 200
+
+        stored = get_shared_payment_token(str(self.organization.id))
+        assert stored is None
+
+    def test_spt_overwrites_previous_value(self):
+        token = self._get_bearer_token()
+
+        self._post_signed_with_bearer(
+            "/api/agentic/provisioning/resources",
+            data={
+                "service_id": "analytics",
+                "payment_credentials": {
+                    "type": "stripe_payment_token",
+                    "stripe_payment_token": "spt_first",
+                },
+            },
+            token=token,
+        )
+        assert get_shared_payment_token(str(self.organization.id)) == "spt_first"
+
+        # Provision again with a new SPT (e.g. plan upgrade)
+        token2 = self._get_bearer_token()
+        self._post_signed_with_bearer(
+            "/api/agentic/provisioning/resources",
+            data={
+                "service_id": "analytics",
+                "payment_credentials": {
+                    "type": "stripe_payment_token",
+                    "stripe_payment_token": "spt_second",
+                },
+            },
+            token=token2,
+        )
+        assert get_shared_payment_token(str(self.organization.id)) == "spt_second"
+
+    def test_token_exchange_returns_orchestrator(self):
+        """Token exchange should return payment_credentials: orchestrator so Stripe collects payment."""
+        token_response = self._exchange_code_and_get_response()
+        assert token_response["account"]["payment_credentials"] == "orchestrator"
+
+    def _exchange_code_and_get_response(self) -> dict:
+        import time
+        from urllib.parse import urlencode
+
+        from ee.api.agentic_provisioning.signature import compute_signature
+        from ee.api.agentic_provisioning.test.base import HMAC_SECRET
+        from ee.api.agentic_provisioning.views import AUTH_CODE_CACHE_PREFIX
+
+        code = f"test_code_spt_{id(self)}"
+        cache.set(
+            f"{AUTH_CODE_CACHE_PREFIX}{code}",
+            {
+                "user_id": self.user.id,
+                "org_id": str(self.organization.id),
+                "team_id": self.team.id,
+                "stripe_account_id": "acct_123",
+                "scopes": ["query:read"],
+                "region": "US",
+            },
+            timeout=300,
+        )
+        body = urlencode({"grant_type": "authorization_code", "code": code}).encode()
+        ts = int(time.time())
+        sig = compute_signature(HMAC_SECRET, ts, body)
+        res = self.client.post(
+            "/api/agentic/oauth/token",
+            data=body,
+            content_type="application/x-www-form-urlencoded",
+            HTTP_STRIPE_SIGNATURE=f"t={ts},v1={sig}",
+        )
+        return res.json()

--- a/ee/api/agentic_provisioning/views.py
+++ b/ee/api/agentic_provisioning/views.py
@@ -26,6 +26,7 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from posthog.cloud_utils import get_cached_instance_license
 from posthog.exceptions_capture import capture_exception
 from posthog.models.integration import StripeIntegration
 from posthog.models.oauth import OAuthAccessToken, OAuthRefreshToken, find_oauth_refresh_token
@@ -40,6 +41,7 @@ from posthog.models.utils import (
 )
 from posthog.utils import get_instance_region
 
+from ee.billing.billing_manager import build_billing_token
 from ee.settings import BILLING_SERVICE_URL
 
 from . import AUTH_CODE_CACHE_PREFIX, PENDING_AUTH_CACHE_PREFIX, RESOURCE_SERVICE_CACHE_PREFIX
@@ -627,10 +629,6 @@ def _activate_billing_with_spt(team: Team, user: User, spt_token: str) -> bool:
     Returns True if activation succeeded, False otherwise.
     """
     try:
-        from posthog.cloud_utils import get_cached_instance_license
-
-        from ee.billing.billing_manager import build_billing_token
-
         license = get_cached_instance_license()
         if not license:
             capture_exception(Exception("No license found for SPT billing activation"))
@@ -720,16 +718,23 @@ def provisioning_resources_create(request: Request) -> Response:
     resolved_service_id = service_id or ANALYTICS_SERVICE_ID
     cache.set(f"{RESOURCE_SERVICE_CACHE_PREFIX}{team_id}", resolved_service_id, timeout=None)
 
+    billing_activated = False
     payment_credentials = request.data.get("payment_credentials")
     if isinstance(payment_credentials, dict) and payment_credentials.get("type") == "stripe_payment_token":
         spt_token = payment_credentials.get("stripe_payment_token")
         if spt_token:
-            _activate_billing_with_spt(team, user, spt_token)
+            billing_activated = _activate_billing_with_spt(team, user, spt_token)
 
     region = get_instance_region() or "US"
     host = _region_to_host(region)
 
-    _capture_provisioning_event("resource_created", "success", service_id=resolved_service_id, team_id=team_id)
+    _capture_provisioning_event(
+        "resource_created",
+        "success",
+        service_id=resolved_service_id,
+        team_id=team_id,
+        billing_activated=billing_activated,
+    )
 
     access_configuration: dict[str, str] = {
         "api_key": team.api_token,

--- a/ee/api/agentic_provisioning/views.py
+++ b/ee/api/agentic_provisioning/views.py
@@ -42,7 +42,7 @@ from posthog.utils import get_instance_region
 
 from ee.settings import BILLING_SERVICE_URL
 
-from . import AUTH_CODE_CACHE_PREFIX, PENDING_AUTH_CACHE_PREFIX, RESOURCE_SERVICE_CACHE_PREFIX
+from . import AUTH_CODE_CACHE_PREFIX, PENDING_AUTH_CACHE_PREFIX, RESOURCE_SERVICE_CACHE_PREFIX, SHARED_PAYMENT_TOKEN_CACHE_PREFIX
 from .region_proxy import stripe_region_proxy
 from .signature import SUPPORTED_VERSIONS, verify_api_version, verify_stripe_signature
 
@@ -560,7 +560,7 @@ def _exchange_authorization_code(request: Request) -> Response:
             "expires_in": ACCESS_TOKEN_EXPIRY_SECONDS,
             "account": {
                 "id": account_id,
-                "payment_credentials": "provider",
+                "payment_credentials": "orchestrator",
             },
         }
     )
@@ -619,6 +619,30 @@ def _exchange_refresh_token(request: Request) -> Response:
             "expires_in": ACCESS_TOKEN_EXPIRY_SECONDS,
         }
     )
+
+
+def _store_shared_payment_token(team: Team, spt_token: str) -> None:
+    """Store a Stripe Shared Payment Token for the team's organization.
+
+    The SPT is used as the payment instrument when creating Stripe subscriptions
+    for orgs provisioned via Stripe Projects (instead of collecting a card directly).
+    """
+    cache_key = f"{SHARED_PAYMENT_TOKEN_CACHE_PREFIX}{team.organization_id}"
+    cache.set(
+        cache_key,
+        {"spt_token": spt_token, "team_id": team.id, "org_id": str(team.organization_id)},
+        timeout=None,
+    )
+    logger.info("stripe_app.spt_stored", team_id=team.id, org_id=str(team.organization_id))
+
+
+def get_shared_payment_token(org_id: str) -> str | None:
+    """Retrieve the stored SPT for an organization. Returns None if not set."""
+    cache_key = f"{SHARED_PAYMENT_TOKEN_CACHE_PREFIX}{org_id}"
+    data = cache.get(cache_key)
+    if data and isinstance(data, dict):
+        return data.get("spt_token")
+    return None
 
 
 def _create_provisioned_pat(user: User, team: Team) -> str | None:
@@ -680,6 +704,13 @@ def provisioning_resources_create(request: Request) -> Response:
 
     resolved_service_id = service_id or ANALYTICS_SERVICE_ID
     cache.set(f"{RESOURCE_SERVICE_CACHE_PREFIX}{team_id}", resolved_service_id, timeout=None)
+
+    # Store Stripe Shared Payment Token if provided (pay_as_you_go plan)
+    payment_credentials = request.data.get("payment_credentials")
+    if payment_credentials and payment_credentials.get("type") == "stripe_payment_token":
+        spt_token = payment_credentials.get("stripe_payment_token")
+        if spt_token:
+            _store_shared_payment_token(team, spt_token)
 
     region = get_instance_region() or "US"
     host = _region_to_host(region)

--- a/ee/api/agentic_provisioning/views.py
+++ b/ee/api/agentic_provisioning/views.py
@@ -660,6 +660,19 @@ def _activate_billing_with_spt(team: Team, user: User, spt_token: str) -> bool:
         return False
 
 
+def _try_activate_billing_with_spt(request: Request, team: Team, user: User) -> bool | None:
+    """Try to activate billing with an SPT from payment_credentials.
+
+    Returns True if succeeded, False if failed, None if no SPT was present.
+    """
+    payment_credentials = request.data.get("payment_credentials")
+    if isinstance(payment_credentials, dict) and payment_credentials.get("type") == "stripe_payment_token":
+        spt_token = payment_credentials.get("stripe_payment_token")
+        if spt_token:
+            return _activate_billing_with_spt(team, user, spt_token)
+    return None
+
+
 def _create_provisioned_pat(user: User, team: Team) -> str | None:
     """Create a Personal API Key for a Stripe-provisioned user and return the raw key value."""
     try:
@@ -720,23 +733,24 @@ def provisioning_resources_create(request: Request) -> Response:
     resolved_service_id = service_id or ANALYTICS_SERVICE_ID
     cache.set(f"{RESOURCE_SERVICE_CACHE_PREFIX}{team_id}", resolved_service_id, timeout=None)
 
-    billing_activated = False
-    payment_credentials = request.data.get("payment_credentials")
-    if isinstance(payment_credentials, dict) and payment_credentials.get("type") == "stripe_payment_token":
-        spt_token = payment_credentials.get("stripe_payment_token")
-        if spt_token:
-            billing_activated = _activate_billing_with_spt(team, user, spt_token)
+    billing_result = _try_activate_billing_with_spt(request, team, user)
+    if billing_result is False:
+        return Response(
+            {
+                "status": "error",
+                "id": str(team_id),
+                "error": {
+                    "code": "requires_payment_credentials",
+                    "message": "Billing activation failed",
+                },
+            },
+            status=400,
+        )
 
     region = get_instance_region() or "US"
     host = _region_to_host(region)
 
-    _capture_provisioning_event(
-        "resource_created",
-        "success",
-        service_id=resolved_service_id,
-        team_id=team_id,
-        billing_activated=billing_activated,
-    )
+    _capture_provisioning_event("resource_created", "success", service_id=resolved_service_id, team_id=team_id)
 
     access_configuration: dict[str, str] = {
         "api_key": team.api_token,

--- a/ee/api/agentic_provisioning/views.py
+++ b/ee/api/agentic_provisioning/views.py
@@ -707,7 +707,7 @@ def provisioning_resources_create(request: Request) -> Response:
 
     # Store Stripe Shared Payment Token if provided (pay_as_you_go plan)
     payment_credentials = request.data.get("payment_credentials")
-    if payment_credentials and payment_credentials.get("type") == "stripe_payment_token":
+    if isinstance(payment_credentials, dict) and payment_credentials.get("type") == "stripe_payment_token":
         spt_token = payment_credentials.get("stripe_payment_token")
         if spt_token:
             _store_shared_payment_token(team, spt_token)

--- a/ee/api/agentic_provisioning/views.py
+++ b/ee/api/agentic_provisioning/views.py
@@ -26,7 +26,6 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from posthog.cloud_utils import get_cached_instance_license
 from posthog.exceptions_capture import capture_exception
 from posthog.models.integration import StripeIntegration
 from posthog.models.oauth import OAuthAccessToken, OAuthRefreshToken, find_oauth_refresh_token
@@ -41,7 +40,6 @@ from posthog.models.utils import (
 )
 from posthog.utils import get_instance_region
 
-from ee.billing.billing_manager import build_billing_token
 from ee.settings import BILLING_SERVICE_URL
 
 from . import AUTH_CODE_CACHE_PREFIX, PENDING_AUTH_CACHE_PREFIX, RESOURCE_SERVICE_CACHE_PREFIX
@@ -629,6 +627,10 @@ def _activate_billing_with_spt(team: Team, user: User, spt_token: str) -> bool:
     Returns True if activation succeeded, False otherwise.
     """
     try:
+        from posthog.cloud_utils import get_cached_instance_license
+
+        from ee.billing.billing_manager import build_billing_token
+
         license = get_cached_instance_license()
         if not license:
             capture_exception(Exception("No license found for SPT billing activation"))

--- a/ee/api/agentic_provisioning/views.py
+++ b/ee/api/agentic_provisioning/views.py
@@ -42,12 +42,7 @@ from posthog.utils import get_instance_region
 
 from ee.settings import BILLING_SERVICE_URL
 
-from . import (
-    AUTH_CODE_CACHE_PREFIX,
-    PENDING_AUTH_CACHE_PREFIX,
-    RESOURCE_SERVICE_CACHE_PREFIX,
-    SHARED_PAYMENT_TOKEN_CACHE_PREFIX,
-)
+from . import AUTH_CODE_CACHE_PREFIX, PENDING_AUTH_CACHE_PREFIX, RESOURCE_SERVICE_CACHE_PREFIX
 from .region_proxy import stripe_region_proxy
 from .signature import SUPPORTED_VERSIONS, verify_api_version, verify_stripe_signature
 
@@ -626,28 +621,43 @@ def _exchange_refresh_token(request: Request) -> Response:
     )
 
 
-def _store_shared_payment_token(team: Team, spt_token: str) -> None:
-    """Store a Stripe Shared Payment Token for the team's organization.
+def _activate_billing_with_spt(team: Team, user: User, spt_token: str) -> bool:
+    """Call the billing service to activate a subscription with a Stripe Shared Payment Token.
 
-    The SPT is used as the payment instrument when creating Stripe subscriptions
-    for orgs provisioned via Stripe Projects (instead of collecting a card directly).
+    Returns True if activation succeeded, False otherwise.
     """
-    cache_key = f"{SHARED_PAYMENT_TOKEN_CACHE_PREFIX}{team.organization_id}"
-    cache.set(
-        cache_key,
-        {"spt_token": spt_token, "team_id": team.id, "org_id": str(team.organization_id)},
-        timeout=None,
-    )
-    logger.info("stripe_app.spt_stored", team_id=team.id, org_id=str(team.organization_id))
+    try:
+        from posthog.cloud_utils import get_cached_instance_license
 
+        from ee.billing.billing_manager import build_billing_token
 
-def get_shared_payment_token(org_id: str) -> str | None:
-    """Retrieve the stored SPT for an organization. Returns None if not set."""
-    cache_key = f"{SHARED_PAYMENT_TOKEN_CACHE_PREFIX}{org_id}"
-    data = cache.get(cache_key)
-    if data and isinstance(data, dict):
-        return data.get("spt_token")
-    return None
+        license = get_cached_instance_license()
+        if not license:
+            capture_exception(Exception("No license found for SPT billing activation"))
+            return False
+
+        organization = team.organization
+        billing_token = build_billing_token(license, organization, user)
+
+        res = requests.post(
+            f"{BILLING_SERVICE_URL}/api/activate/authorize",
+            headers={"Authorization": f"Bearer {billing_token}"},
+            json={"shared_payment_token": spt_token},
+            timeout=30,
+        )
+
+        if res.status_code not in (200, 201):
+            capture_exception(
+                Exception(f"Billing SPT activation failed: {res.status_code}"),
+                {"team_id": team.id, "org_id": str(organization.id), "status": res.status_code},
+            )
+            return False
+
+        logger.info("stripe_app.spt_billing_activated", team_id=team.id, org_id=str(organization.id))
+        return True
+    except Exception:
+        capture_exception(additional_properties={"team_id": team.id, "org_id": str(team.organization_id)})
+        return False
 
 
 def _create_provisioned_pat(user: User, team: Team) -> str | None:
@@ -710,12 +720,11 @@ def provisioning_resources_create(request: Request) -> Response:
     resolved_service_id = service_id or ANALYTICS_SERVICE_ID
     cache.set(f"{RESOURCE_SERVICE_CACHE_PREFIX}{team_id}", resolved_service_id, timeout=None)
 
-    # Store Stripe Shared Payment Token if provided (pay_as_you_go plan)
     payment_credentials = request.data.get("payment_credentials")
     if isinstance(payment_credentials, dict) and payment_credentials.get("type") == "stripe_payment_token":
         spt_token = payment_credentials.get("stripe_payment_token")
         if spt_token:
-            _store_shared_payment_token(team, spt_token)
+            _activate_billing_with_spt(team, user, spt_token)
 
     region = get_instance_region() or "US"
     host = _region_to_host(region)

--- a/ee/api/agentic_provisioning/views.py
+++ b/ee/api/agentic_provisioning/views.py
@@ -42,7 +42,12 @@ from posthog.utils import get_instance_region
 
 from ee.settings import BILLING_SERVICE_URL
 
-from . import AUTH_CODE_CACHE_PREFIX, PENDING_AUTH_CACHE_PREFIX, RESOURCE_SERVICE_CACHE_PREFIX, SHARED_PAYMENT_TOKEN_CACHE_PREFIX
+from . import (
+    AUTH_CODE_CACHE_PREFIX,
+    PENDING_AUTH_CACHE_PREFIX,
+    RESOURCE_SERVICE_CACHE_PREFIX,
+    SHARED_PAYMENT_TOKEN_CACHE_PREFIX,
+)
 from .region_proxy import stripe_region_proxy
 from .signature import SUPPORTED_VERSIONS, verify_api_version, verify_stripe_signature
 


### PR DESCRIPTION
## Problem

Orgs provisioned via `stripe projects add posthog/analytics` with the `pay_as_you_go` plan need to be billed through Stripe's Shared Payment Token (SPT). Currently the token exchange returns `payment_credentials: "provider"` (self-managed billing) and the resource provisioning endpoint ignores SPT data from Stripe.

## Changes

- **`ee/api/agentic_provisioning/views.py`**:
  - Token exchange returns `payment_credentials: "orchestrator"` instead of `"provider"` so Stripe collects payment for paid plans
  - `provisioning_resources_create()` extracts SPT from `payment_credentials` in request body and passes it directly to the billing service via `_activate_billing_with_spt()`
  - `_activate_billing_with_spt()` calls `POST {BILLING_SERVICE_URL}/api/activate/authorize` with the SPT, authenticating via billing JWT. Returns status: "error" with code "requires_payment_credentials" if billing activation fails, so Stripe can retry or inform the user.
- **`ee/api/agentic_provisioning/test/test_spt.py`**: 5 tests covering SPT pass-through to billing, missing/invalid credentials, billing failure resilience, and orchestrator response

## Dependencies

**Must deploy after** PostHog/billing#1832 (the billing service endpoint that accepts SPTs and creates subscriptions).

## Deployment order

1. **PostHog/billing#1832** - billing service accepts SPTs, creates subscriptions with `default_shared_payment_token`
2. **This PR** - posthog provisioning passes SPT through to billing during resource creation
3. **Follow-up PR** (not yet created) - add `pay_as_you_go` plan to service catalog, `update_service` endpoint for free-to-paid upgrades, manifest capability

## How did you test this code?

- 5 unit tests pass:
  - `test_provisioning_calls_billing_with_spt` - verifies billing service called with correct URL, auth header, and SPT payload
  - `test_provisioning_works_without_spt` - no billing call when no payment_credentials
  - `test_provisioning_ignores_invalid_payment_credentials_type` - no billing call for unknown credential types
  - `test_provisioning_returns_error_if_billing_activation_fails` - returns 400 with requires_payment_credentials when billing returns 500
  - `test_token_exchange_returns_orchestrator` - token exchange response includes `payment_credentials: "orchestrator"`
- All existing agentic provisioning tests pass
- **Full E2E tested locally** (PostHog on :8000, billing on :8100): sent a signed provisioning request with `payment_credentials.stripe_payment_token`, PostHog returned `status: "complete"` with API key/PAT, billing service received the SPT via JWT-authenticated call, created a customer, stored the SPT encrypted at rest (Fernet), and attempted Stripe subscription creation with `default_shared_payment_token`
- CI green (Django tests, Python code quality, Playwright, Semgrep)

## Publish to changelog?

No

## 🤖 LLM context

Co-authored with Claude Code.