### PR TITLE
feat: support email attachments

### DIFF
--- a/products/conversations/backend/api/email_events.py
+++ b/products/conversations/backend/api/email_events.py
@@ -86,7 +86,7 @@ def _extract_attachments(request: HttpRequest, team: Team) -> list[dict[str, Any
     attachments: list[dict[str, Any]] = []
     for _key in list(request.FILES.keys())[:MAX_ATTACHMENTS]:
         uploaded_file = cast(UploadedFile, request.FILES[_key])
-        if uploaded_file.size and uploaded_file.size > MAX_ATTACHMENT_SIZE:
+        if uploaded_file.size is not None and uploaded_file.size > MAX_ATTACHMENT_SIZE:
             logger.warning(
                 "email_inbound_attachment_too_large",
                 team_id=team.id,
@@ -221,13 +221,14 @@ def email_inbound_handler(request: HttpRequest) -> HttpResponse:
     content = (request.POST.get("stripped-text", "") or request.POST.get("body-plain", ""))[:MAX_EMAIL_BODY_LENGTH]
     subject = request.POST.get("subject", "")
 
-    # 7b. Extract and persist attachments (before transaction — storage writes aren't transactional)
-    attachments = _extract_attachments(request, team)
-    content, rich_content = _build_content_with_attachments(content, attachments)
-
-    # 8-10. Create ticket/comment/mapping in a transaction
+    # 8. Create ticket/comment/mapping in a transaction
+    # Attachments are extracted inside the transaction so UploadedMedia rows roll back
+    # on duplicate-race IntegrityError. Orphaned S3 blobs are acceptable.
     try:
         with transaction.atomic():
+            attachments = _extract_attachments(request, team)
+            content, rich_content = _build_content_with_attachments(content, attachments)
+
             ticket: Ticket | None = None
             if existing_ticket:
                 ticket = Ticket.objects.select_for_update().filter(id=existing_ticket.id, team=team).first()

--- a/products/conversations/backend/api/email_events.py
+++ b/products/conversations/backend/api/email_events.py
@@ -2,7 +2,9 @@
 
 import re
 from email.utils import parseaddr
+from typing import Any, cast
 
+from django.core.files.uploadedfile import UploadedFile
 from django.db import IntegrityError, transaction
 from django.db.models import F
 from django.http import HttpRequest, HttpResponse
@@ -11,16 +13,31 @@ from django.views.decorators.csrf import csrf_exempt
 import structlog
 
 from posthog.models.comment import Comment
+from posthog.models.team import Team
 
 from products.conversations.backend.mailgun import validate_webhook_signature
 from products.conversations.backend.models import Channel, EmailChannel, EmailMessageMapping, Status
 from products.conversations.backend.models.ticket import Ticket
+from products.conversations.backend.services.attachments import save_file_to_uploaded_media
 from products.conversations.backend.services.region_routing import is_primary_region, proxy_to_secondary_region
 
 logger = structlog.get_logger(__name__)
 
 INBOUND_TOKEN_PATTERN = re.compile(r"^team-([a-f0-9]+)@")
 MAX_EMAIL_BODY_LENGTH = 50_000
+MAX_ATTACHMENT_SIZE = 10 * 1024 * 1024  # 10 MB per file
+MAX_ATTACHMENTS = 20
+MAX_FILENAME_LENGTH = 255
+_FILENAME_STRIP_RE = re.compile(r"[^\w\s\-.,()]+")
+
+
+def _sanitize_filename(name: str) -> str:
+    """Strip potentially dangerous characters from an email attachment filename."""
+    name = name.strip().replace("/", "_").replace("\\", "_")
+    name = _FILENAME_STRIP_RE.sub("", name)
+    if len(name) > MAX_FILENAME_LENGTH:
+        name = name[:MAX_FILENAME_LENGTH]
+    return name or "attachment"
 
 
 def _extract_inbound_token(recipient: str) -> str | None:
@@ -62,6 +79,81 @@ def _find_thread_ticket(
                 return mapping_by_id[ref_id].ticket
 
     return None
+
+
+def _extract_attachments(request: HttpRequest, team: Team) -> list[dict[str, Any]]:
+    """Read file uploads from the Mailgun webhook and persist them."""
+    attachments: list[dict[str, Any]] = []
+    for _key in list(request.FILES.keys())[:MAX_ATTACHMENTS]:
+        uploaded_file = cast(UploadedFile, request.FILES[_key])
+        if uploaded_file.size and uploaded_file.size > MAX_ATTACHMENT_SIZE:
+            logger.warning(
+                "email_inbound_attachment_too_large",
+                team_id=team.id,
+                file_name=uploaded_file.name,
+                size=uploaded_file.size,
+            )
+            continue
+
+        file_bytes = uploaded_file.read()
+        safe_name = _sanitize_filename(uploaded_file.name or "attachment")
+        url = save_file_to_uploaded_media(team, safe_name, uploaded_file.content_type or "", file_bytes)
+        if url:
+            attachments.append(
+                {
+                    "url": url,
+                    "name": safe_name,
+                    "content_type": uploaded_file.content_type or "",
+                    "size": uploaded_file.size,
+                }
+            )
+    return attachments
+
+
+def _build_content_with_attachments(text: str, attachments: list[dict[str, Any]]) -> tuple[str, dict[str, Any] | None]:
+    """Merge plain text and attachments into content + rich_content."""
+    if not attachments:
+        return text, None
+
+    image_md_parts: list[str] = []
+    file_md_parts: list[str] = []
+    rich_nodes: list[dict[str, Any]] = []
+
+    if text:
+        rich_nodes.append({"type": "paragraph", "content": [{"type": "text", "text": text}]})
+
+    for att in attachments:
+        ct = att.get("content_type", "")
+        name = att.get("name", "attachment")
+        url = att["url"]
+
+        if ct.startswith("image/"):
+            image_md_parts.append(f"![{name}]({url})")
+            rich_nodes.append({"type": "image", "attrs": {"src": url, "alt": name}})
+        else:
+            file_md_parts.append(f"[{name}]({url})")
+            rich_nodes.append(
+                {
+                    "type": "paragraph",
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": name,
+                            "marks": [{"type": "link", "attrs": {"href": url}}],
+                        }
+                    ],
+                }
+            )
+
+    parts = [text] if text else []
+    if image_md_parts:
+        parts.append("\n".join(image_md_parts))
+    if file_md_parts:
+        parts.append("\n".join(file_md_parts))
+    content = "\n\n".join(parts)
+
+    rich_content: dict[str, Any] = {"type": "doc", "content": rich_nodes}
+    return content, rich_content
 
 
 @csrf_exempt
@@ -129,6 +221,10 @@ def email_inbound_handler(request: HttpRequest) -> HttpResponse:
     content = (request.POST.get("stripped-text", "") or request.POST.get("body-plain", ""))[:MAX_EMAIL_BODY_LENGTH]
     subject = request.POST.get("subject", "")
 
+    # 7b. Extract and persist attachments (before transaction — storage writes aren't transactional)
+    attachments = _extract_attachments(request, team)
+    content, rich_content = _build_content_with_attachments(content, attachments)
+
     # 8-10. Create ticket/comment/mapping in a transaction
     try:
         with transaction.atomic():
@@ -163,6 +259,7 @@ def email_inbound_handler(request: HttpRequest) -> HttpResponse:
                 "email_from": sender_email,
                 "email_from_name": sender_name,
                 "email_message_id": email_message_id,
+                "email_attachments": attachments if attachments else None,
             }
 
             comment = Comment.objects.create(
@@ -170,6 +267,7 @@ def email_inbound_handler(request: HttpRequest) -> HttpResponse:
                 scope="conversations_ticket",
                 item_id=str(ticket.id),
                 content=content,
+                rich_content=rich_content,
                 item_context=item_context,
             )
 

--- a/products/conversations/backend/api/tests/test_email_endpoints.py
+++ b/products/conversations/backend/api/tests/test_email_endpoints.py
@@ -1,15 +1,27 @@
+from io import BytesIO
+
 from posthog.test.base import BaseTest
 from unittest.mock import MagicMock, patch
 
+from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import Client
 
 from parameterized import parameterized
+from PIL import Image
 
+from posthog.models.comment import Comment
 from posthog.models.organization import OrganizationMembership
 from posthog.models.team import Team
 
 from products.conversations.backend.models import EmailChannel
 from products.conversations.backend.models.ticket import Ticket
+
+
+def _make_png_bytes() -> bytes:
+    """Generate a minimal valid 1x1 PNG."""
+    buf = BytesIO()
+    Image.new("RGB", (1, 1), color="red").save(buf, format="PNG")
+    return buf.getvalue()
 
 
 class TestEmailConnectDomainCaseInsensitivity(BaseTest):
@@ -628,3 +640,165 @@ class TestSendEmailReplyMultiConfig(BaseTest):
             rich_content=None,
             author_name="Agent",
         )
+
+
+class TestEmailInboundAttachments(BaseTest):
+    def setUp(self):
+        super().setUp()
+        self.client = Client()
+        self.team.conversations_settings = {"email_enabled": True}
+        self.team.save()
+        self.config = EmailChannel.objects.create(
+            team=self.team,
+            inbound_token="aabbcc111222",
+            from_email="support@example.com",
+            from_name="Support",
+            domain="example.com",
+            domain_verified=True,
+        )
+
+    def _base_post_data(self, msg_id: str = "<att@test.com>") -> dict:
+        return {
+            "recipient": "team-aabbcc111222@mg.posthog.com",
+            "from": "sender@test.com",
+            "Message-Id": msg_id,
+            "subject": "With attachment",
+            "stripped-text": "See attached",
+        }
+
+    @patch("products.conversations.backend.services.attachments.save_content_to_object_storage")
+    @patch("products.conversations.backend.api.email_events.validate_webhook_signature", return_value=True)
+    def test_inbound_with_image_attachment(self, _mock_sig: MagicMock, mock_storage: MagicMock):
+        attachment = SimpleUploadedFile("photo.png", _make_png_bytes(), content_type="image/png")
+
+        data = self._base_post_data("<img@test.com>")
+        with self.settings(OBJECT_STORAGE_ENABLED=True):
+            response = self.client.post("/api/conversations/v1/email/inbound", {**data, "attachment-1": attachment})
+
+        assert response.status_code == 200
+        mock_storage.assert_called_once()
+
+        comment = Comment.objects.filter(team=self.team, scope="conversations_ticket").first()
+        assert comment is not None
+        assert "![photo.png]" in comment.content
+        assert comment.rich_content is not None
+        image_nodes = [n for n in comment.rich_content["content"] if n["type"] == "image"]
+        assert len(image_nodes) == 1
+        assert image_nodes[0]["attrs"]["alt"] == "photo.png"
+        assert comment.item_context["email_attachments"] is not None
+        assert len(comment.item_context["email_attachments"]) == 1
+        assert comment.item_context["email_attachments"][0]["content_type"] == "image/png"
+
+    @patch("products.conversations.backend.services.attachments.save_content_to_object_storage")
+    @patch("products.conversations.backend.api.email_events.validate_webhook_signature", return_value=True)
+    def test_inbound_with_non_image_attachment(self, _mock_sig: MagicMock, mock_storage: MagicMock):
+        pdf = SimpleUploadedFile("invoice.pdf", b"%PDF-1.4 fake content", content_type="application/pdf")
+
+        data = self._base_post_data("<pdf@test.com>")
+        with self.settings(OBJECT_STORAGE_ENABLED=True):
+            response = self.client.post("/api/conversations/v1/email/inbound", {**data, "attachment-1": pdf})
+
+        assert response.status_code == 200
+
+        comment = Comment.objects.filter(team=self.team, scope="conversations_ticket").first()
+        assert comment is not None
+        assert "[invoice.pdf]" in comment.content
+        assert comment.rich_content is not None
+        link_nodes = [
+            n
+            for n in comment.rich_content["content"]
+            if n["type"] == "paragraph"
+            and any(m.get("type") == "link" for child in n.get("content", []) for m in child.get("marks", []))
+        ]
+        assert len(link_nodes) == 1
+
+    @patch("products.conversations.backend.services.attachments.save_content_to_object_storage")
+    @patch("products.conversations.backend.api.email_events.validate_webhook_signature", return_value=True)
+    def test_inbound_with_multiple_attachments(self, _mock_sig: MagicMock, mock_storage: MagicMock):
+        png = SimpleUploadedFile("photo.png", _make_png_bytes(), content_type="image/png")
+        pdf = SimpleUploadedFile("doc.pdf", b"%PDF-1.4 content", content_type="application/pdf")
+
+        data = self._base_post_data("<multi@test.com>")
+        with self.settings(OBJECT_STORAGE_ENABLED=True):
+            response = self.client.post(
+                "/api/conversations/v1/email/inbound", {**data, "attachment-1": png, "attachment-2": pdf}
+            )
+
+        assert response.status_code == 200
+        assert mock_storage.call_count == 2
+
+        comment = Comment.objects.filter(team=self.team, scope="conversations_ticket").first()
+        assert comment is not None
+        assert comment.rich_content is not None
+        assert len(comment.rich_content["content"]) == 3  # text paragraph + image + file link
+        assert comment.item_context["email_attachments"] is not None
+        assert len(comment.item_context["email_attachments"]) == 2
+
+    @patch("products.conversations.backend.services.attachments.save_content_to_object_storage")
+    @patch("products.conversations.backend.api.email_events.MAX_ATTACHMENT_SIZE", 100)
+    @patch("products.conversations.backend.api.email_events.validate_webhook_signature", return_value=True)
+    def test_inbound_attachment_too_large_is_skipped(self, _mock_sig: MagicMock, mock_storage: MagicMock):
+        oversized = SimpleUploadedFile("big.bin", b"x" * 101, content_type="application/octet-stream")
+
+        data = self._base_post_data("<huge@test.com>")
+        with self.settings(OBJECT_STORAGE_ENABLED=True):
+            response = self.client.post("/api/conversations/v1/email/inbound", {**data, "attachment-1": oversized})
+
+        assert response.status_code == 200
+        mock_storage.assert_not_called()
+
+        comment = Comment.objects.filter(team=self.team, scope="conversations_ticket").first()
+        assert comment is not None
+        assert comment.content == "See attached"
+        assert comment.rich_content is None
+        assert comment.item_context.get("email_attachments") is None
+
+    @patch("products.conversations.backend.services.attachments.save_content_to_object_storage")
+    @patch("products.conversations.backend.api.email_events.validate_webhook_signature", return_value=True)
+    def test_inbound_without_object_storage_skips_attachments(self, _mock_sig: MagicMock, mock_storage: MagicMock):
+        png = SimpleUploadedFile("photo.png", _make_png_bytes(), content_type="image/png")
+
+        data = self._base_post_data("<nostorage@test.com>")
+        with self.settings(OBJECT_STORAGE_ENABLED=False):
+            response = self.client.post("/api/conversations/v1/email/inbound", {**data, "attachment-1": png})
+
+        assert response.status_code == 200
+        mock_storage.assert_not_called()
+
+        comment = Comment.objects.filter(team=self.team, scope="conversations_ticket").first()
+        assert comment is not None
+        assert comment.content == "See attached"
+        assert comment.rich_content is None
+
+    @patch("products.conversations.backend.services.attachments.save_content_to_object_storage")
+    @patch("products.conversations.backend.api.email_events.validate_webhook_signature", return_value=True)
+    def test_inbound_invalid_image_is_rejected(self, _mock_sig: MagicMock, mock_storage: MagicMock):
+        fake_image = SimpleUploadedFile("evil.png", b"<html>not an image</html>", content_type="image/png")
+
+        data = self._base_post_data("<evil@test.com>")
+        with self.settings(OBJECT_STORAGE_ENABLED=True):
+            response = self.client.post("/api/conversations/v1/email/inbound", {**data, "attachment-1": fake_image})
+
+        assert response.status_code == 200
+        mock_storage.assert_not_called()
+
+        comment = Comment.objects.filter(team=self.team, scope="conversations_ticket").first()
+        assert comment is not None
+        assert comment.content == "See attached"
+        assert comment.rich_content is None
+
+    @patch("products.conversations.backend.services.attachments.save_content_to_object_storage")
+    @patch("products.conversations.backend.api.email_events.validate_webhook_signature", return_value=True)
+    def test_inbound_no_attachments_unchanged(self, _mock_sig: MagicMock, mock_storage: MagicMock):
+        data = self._base_post_data("<plain@test.com>")
+        with self.settings(OBJECT_STORAGE_ENABLED=True):
+            response = self.client.post("/api/conversations/v1/email/inbound", data)
+
+        assert response.status_code == 200
+        mock_storage.assert_not_called()
+
+        comment = Comment.objects.filter(team=self.team, scope="conversations_ticket").first()
+        assert comment is not None
+        assert comment.content == "See attached"
+        assert comment.rich_content is None
+        assert comment.item_context.get("email_attachments") is None

--- a/products/conversations/backend/api/tests/test_slack_image_sync.py
+++ b/products/conversations/backend/api/tests/test_slack_image_sync.py
@@ -18,7 +18,7 @@ class TestSlackImageIngest(SimpleTestCase):
         assert image_bytes is None
         mock_build_opener.assert_not_called()
 
-    @patch("products.conversations.backend.slack._save_image_to_uploaded_media")
+    @patch("products.conversations.backend.slack.save_file_to_uploaded_media")
     @patch("products.conversations.backend.slack._download_slack_image_bytes")
     def test_extract_slack_files_copies_to_uploaded_media(self, mock_download: MagicMock, mock_save: MagicMock) -> None:
         mock_download.return_value = VALID_PNG_BYTES
@@ -44,7 +44,7 @@ class TestSlackImageIngest(SimpleTestCase):
         mock_download.assert_called_once()
         mock_save.assert_called_once()
 
-    @patch("products.conversations.backend.slack._save_image_to_uploaded_media")
+    @patch("products.conversations.backend.slack.save_file_to_uploaded_media")
     @patch("products.conversations.backend.slack._download_slack_image_bytes")
     def test_extract_slack_files_skips_failed_downloads(self, mock_download: MagicMock, mock_save: MagicMock) -> None:
         mock_download.return_value = None
@@ -66,7 +66,7 @@ class TestSlackImageIngest(SimpleTestCase):
         assert images == []
         mock_save.assert_not_called()
 
-    @patch("products.conversations.backend.slack._save_image_to_uploaded_media")
+    @patch("products.conversations.backend.slack.save_file_to_uploaded_media")
     @patch("products.conversations.backend.slack._download_slack_image_bytes")
     def test_extract_slack_files_skips_invalid_image_payload(
         self, mock_download: MagicMock, mock_save: MagicMock

--- a/products/conversations/backend/services/attachments.py
+++ b/products/conversations/backend/services/attachments.py
@@ -1,0 +1,79 @@
+"""Shared attachment helpers for conversations channels (email, Slack, etc.)."""
+
+from io import BytesIO
+
+from django.conf import settings
+
+import structlog
+from PIL import Image
+
+from posthog.models.team import Team
+from posthog.models.uploaded_media import UploadedMedia, save_content_to_object_storage
+
+logger = structlog.get_logger(__name__)
+
+
+def is_valid_image(content: bytes) -> bool:
+    """Verify bytes are a real image (prevents serving disguised malicious content).
+
+    Uses the same PIL open + transpose check as the frontend upload API.
+    """
+    try:
+        image = Image.open(BytesIO(content))
+        image.transpose(Image.Transpose.FLIP_LEFT_RIGHT)
+        image.close()
+        return True
+    except Exception:
+        return False
+
+
+def save_file_to_uploaded_media(
+    team: Team,
+    file_name: str,
+    content_type: str,
+    content: bytes,
+    *,
+    validate_images: bool = True,
+) -> str | None:
+    """Persist a file to object storage via UploadedMedia.
+
+    Returns the absolute URL on success, None on failure.
+    For image content types, validates the bytes are a real image unless
+    validate_images is False.
+    """
+    if not settings.OBJECT_STORAGE_ENABLED:
+        logger.warning("conversations_attachment_no_object_storage", team_id=team.id)
+        return None
+
+    if validate_images and content_type.startswith("image/") and not is_valid_image(content):
+        logger.warning("conversations_attachment_invalid_image", team_id=team.id, file_name=file_name)
+        return None
+
+    uploaded_media = UploadedMedia.objects.create(
+        team=team,
+        file_name=file_name,
+        content_type=content_type,
+        created_by=None,
+    )
+    try:
+        save_content_to_object_storage(uploaded_media, content)
+    except Exception as e:
+        logger.warning(
+            "conversations_attachment_storage_failed",
+            team_id=team.id,
+            uploaded_media_id=str(uploaded_media.id),
+            file_name=file_name,
+            error=str(e),
+        )
+        uploaded_media.delete()
+        return None
+
+    logger.info(
+        "conversations_attachment_saved",
+        team_id=team.id,
+        uploaded_media_id=str(uploaded_media.id),
+        file_name=file_name,
+        content_type=content_type,
+        bytes_size=len(content),
+    )
+    return uploaded_media.get_absolute_url()

--- a/products/conversations/backend/slack.py
+++ b/products/conversations/backend/slack.py
@@ -9,7 +9,6 @@ Handles three triggers that create or update tickets from Slack:
 All three converge to create_or_update_slack_ticket().
 """
 
-from io import BytesIO
 from types import MappingProxyType
 from typing import Any
 from urllib.parse import urljoin, urlparse
@@ -19,19 +18,18 @@ from django.conf import settings
 from django.db.models import F
 
 import structlog
-from PIL import Image
 from slack_sdk import WebClient
 
 from posthog.models.comment import Comment
 from posthog.models.organization import OrganizationMembership
 from posthog.models.team.team import Team
-from posthog.models.uploaded_media import UploadedMedia, save_content_to_object_storage
 from posthog.models.user import User
 
 from .cache import get_cached_slack_user, set_cached_slack_user
 from .formatting import extract_slack_user_ids, slack_to_content_and_rich_content
 from .models import Ticket
 from .models.constants import Channel, ChannelDetail, Status
+from .services.attachments import is_valid_image, save_file_to_uploaded_media
 from .support_slack import (
     SUPPORT_SLACK_ALLOWED_HOST_SUFFIXES,
     SUPPORT_SLACK_MAX_IMAGE_BYTES,
@@ -162,16 +160,6 @@ def _is_allowed_slack_file_url(url: str) -> bool:
     return any(hostname == suffix or hostname.endswith(f".{suffix}") for suffix in SUPPORT_SLACK_ALLOWED_HOST_SUFFIXES)
 
 
-def _is_valid_image_bytes(content: bytes) -> bool:
-    try:
-        image = Image.open(BytesIO(content))
-        image.transpose(Image.Transpose.FLIP_LEFT_RIGHT)
-        image.close()
-        return True
-    except Exception:
-        return False
-
-
 def _download_slack_image_bytes(url: str, bot_token: str) -> bytes | None:
     if not _is_allowed_slack_file_url(url):
         logger.warning("🖼️ slack_file_download_invalid_host", url=url)
@@ -233,35 +221,6 @@ def _download_slack_image_bytes(url: str, bot_token: str) -> bytes | None:
     return None
 
 
-def _save_image_to_uploaded_media(team: Team, file_name: str, mimetype: str, content: bytes) -> str | None:
-    team_id = _get_team_id(team)
-    if not settings.OBJECT_STORAGE_ENABLED:
-        logger.warning("🖼️ slack_file_copy_no_object_storage", team_id=team_id)
-        return None
-
-    uploaded_media = UploadedMedia.objects.create(
-        team=team,
-        file_name=file_name,
-        content_type=mimetype,
-        created_by=None,
-    )
-    try:
-        save_content_to_object_storage(uploaded_media, content)
-    except Exception as e:
-        logger.warning("🖼️ slack_file_copy_storage_failed", uploaded_media_id=str(uploaded_media.id), error=str(e))
-        uploaded_media.delete()
-        return None
-    logger.info(
-        "🖼️ slack_file_copy_saved",
-        team_id=team_id,
-        uploaded_media_id=str(uploaded_media.id),
-        file_name=file_name,
-        content_type=mimetype,
-        bytes_size=len(content),
-    )
-    return uploaded_media.get_absolute_url()
-
-
 def extract_slack_files(files: list[dict] | None, team: Team, client: WebClient | None = None) -> list[dict]:
     """
     Extract image attachments from Slack and re-host them in UploadedMedia.
@@ -300,11 +259,13 @@ def extract_slack_files(files: list[dict] | None, team: Team, client: WebClient 
             logger.warning("🖼️ slack_file_download_rejected", file_id=file_id, source_url=source_url)
             continue
 
-        if not _is_valid_image_bytes(image_bytes):
+        if not is_valid_image(image_bytes):
             logger.warning("🖼️ slack_file_invalid_image_content", file_id=file_id)
             continue
 
-        stored_url = _save_image_to_uploaded_media(team, f.get("name", "image"), mimetype, image_bytes)
+        stored_url = save_file_to_uploaded_media(
+            team, f.get("name", "image"), mimetype, image_bytes, validate_images=False
+        )
         if stored_url:
             images.append(
                 {


### PR DESCRIPTION
## Problem

emails with attachments were skipped

## Changes

let's use the same approach as in slack upload (moving that part to a separate service to not duplicate)
