### PR TITLE
feat(llma): use PostHog SDK integration for stamphog LLM analytics

### DIFF
--- a/tools/pr-approval-agent/review_pr.py
+++ b/tools/pr-approval-agent/review_pr.py
@@ -4,6 +4,7 @@
 # dependencies = [
 #     "claude-agent-sdk",
 #     "anthropic",
+#     "posthoganalytics",
 # ]
 # ///
 # ruff: noqa: T201

--- a/tools/pr-approval-agent/reviewer.py
+++ b/tools/pr-approval-agent/reviewer.py
@@ -18,8 +18,12 @@ from github import PRData
 
 try:
     from posthoganalytics.ai.claude_agent_sdk import query
+
+    _POSTHOG_AI_AVAILABLE = True
 except ImportError:
-    from claude_agent_sdk import query
+    from claude_agent_sdk import query  # type: ignore[no-redef]
+
+    _POSTHOG_AI_AVAILABLE = False
 
 MODEL = "claude-sonnet-4-6"
 
@@ -217,21 +221,21 @@ class Reviewer:
             extra_args={"no-session-persistence": None},
         )
 
-        posthog_props = {
-            "stamphog_pr_number": pr.number,
-            "stamphog_repo": pr.repo,
-            "stamphog_author": pr.author,
-            "stamphog_tier": classification.get("tier", ""),
-            "stamphog_verdict": gate_context.get("gate_verdict", ""),
-        }
+        posthog_kwargs: dict = {}
+        if _POSTHOG_AI_AVAILABLE:
+            posthog_kwargs = {
+                "posthog_distinct_id": "stamphog",
+                "posthog_properties": {
+                    "stamphog_pr_number": pr.number,
+                    "stamphog_repo": pr.repo,
+                    "stamphog_author": pr.author,
+                    "stamphog_tier": classification.get("tier", ""),
+                    "stamphog_verdict": gate_context.get("gate_verdict", ""),
+                },
+            }
 
         structured_output = None
-        async for message in query(
-            prompt=prompt,
-            options=options,
-            posthog_distinct_id="stamphog",
-            posthog_properties=posthog_props,
-        ):
+        async for message in query(prompt=prompt, options=options, **posthog_kwargs):
             if self.verbose:
                 print(f"\033[2m    [{type(message).__name__}]\033[0m", flush=True)
             if isinstance(message, ResultMessage):

--- a/tools/pr-approval-agent/reviewer.py
+++ b/tools/pr-approval-agent/reviewer.py
@@ -12,9 +12,14 @@ import textwrap
 import subprocess
 from pathlib import Path
 
-from claude_agent_sdk import ClaudeAgentOptions, ResultMessage, query
+from claude_agent_sdk import ClaudeAgentOptions, ResultMessage
 from claude_agent_sdk.types import AssistantMessage, ToolUseBlock
 from github import PRData
+
+try:
+    from posthoganalytics.ai.claude_agent_sdk import query
+except ImportError:
+    from claude_agent_sdk import query
 
 MODEL = "claude-sonnet-4-6"
 
@@ -212,8 +217,21 @@ class Reviewer:
             extra_args={"no-session-persistence": None},
         )
 
+        posthog_props = {
+            "stamphog_pr_number": pr.number,
+            "stamphog_repo": pr.repo,
+            "stamphog_author": pr.author,
+            "stamphog_tier": classification.get("tier", ""),
+            "stamphog_verdict": gate_context.get("gate_verdict", ""),
+        }
+
         structured_output = None
-        async for message in query(prompt=prompt, options=options):
+        async for message in query(
+            prompt=prompt,
+            options=options,
+            posthog_distinct_id="stamphog",
+            posthog_properties=posthog_props,
+        ):
             if self.verbose:
                 print(f"\033[2m    [{type(message).__name__}]\033[0m", flush=True)
             if isinstance(message, ResultMessage):


### PR DESCRIPTION
## Problem

The stamphog PR approval agent has no observability into LLM performance, costs, and behavior. PR #52984 added a hand-rolled 202-line analytics module, but PostHog's Python SDK now has a proper Claude Agent SDK integration (`posthog.ai.claude_agent_sdk`) that handles this automatically.

## Changes

Minimal change (21 lines added) to wire stamphog into the SDK integration:

- **`reviewer.py`**: Import `query` from `posthoganalytics.ai.claude_agent_sdk` instead of `claude_agent_sdk`. Falls back to the original if posthoganalytics is not installed. Passes PR metadata (number, repo, author, tier, gate verdict) as custom properties.
- **`review_pr.py`**: Add `posthoganalytics` to PEP 723 script dependencies.

The SDK integration automatically emits `$ai_generation` (per LLM turn), `$ai_span` (per tool use), and `$ai_trace` (per query) events with token counts, costs, latency, input/output, and cache metrics.

Depends on PostHog/posthog-python#477.

## How did you test this code?

This is an agent-authored change. The PostHog SDK integration was tested separately:
- 16 unit tests passing in posthog-python
- Live tested against EU PostHog project with multi-turn tool-calling queries
- Verified generation, span, and trace events appear correctly in LLM Analytics dashboard

No changes to stamphog's review behavior — the `query()` wrapper is a transparent pass-through.

## Publish to changelog?

No