### PR TITLE
chore: Make transient error logs warning level

### DIFF
--- a/products/batch_exports/backend/temporal/destinations/bigquery_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/bigquery_batch_export.py
@@ -981,7 +981,7 @@ class BigQueryClient:
                 self.logger.exception(
                     "LoadJob transient error encountered", attempt=attempt, backoff=backoff, error_code=err.code
                 )
-                self.external_logger.error(  # noqa: TRY400
+                self.external_logger.warning(
                     "Encountered a service-side issue that will be retried in %d seconds, this is attempt number %d."
                     " These type of errors indicate BigQuery may be under too much load from all sources. You may have"
                     " to check with BigQuery if it keeps happening consistently."
@@ -1003,7 +1003,7 @@ class BigQueryClient:
 
                 backoff = min(max_retry, initial_retry * (backoff_factor**attempt))
                 self.logger.exception("LoadJob quota exceeded", attempt=attempt, backoff=backoff, error_code=err.code)
-                self.external_logger.error(  # noqa: TRY400
+                self.external_logger.warning(
                     "BigQuery load job quota exceeded. This error will be retried in %d seconds, this is attempt number %d."
                     " It may take several minutes or longer until the quota is restored, as it is restored over the course"
                     " of 24 hours. If this happens frequently, consider contacting Google Cloud support to increase your quota.",

--- a/products/batch_exports/backend/temporal/destinations/bigquery_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/bigquery_batch_export.py
@@ -978,8 +978,12 @@ class BigQueryClient:
                 BigQueryQuotaExceededError,
             ) as err:
                 backoff = min(max_retry, initial_retry * (backoff_factor**attempt))
-                self.logger.exception(
-                    "LoadJob transient error encountered", attempt=attempt, backoff=backoff, error_code=err.code
+                self.logger.warning(
+                    "LoadJob transient error encountered",
+                    attempt=attempt,
+                    backoff=backoff,
+                    error_code=err.code,
+                    exc_info=True,
                 )
                 self.external_logger.warning(
                     "Encountered a service-side issue that will be retried in %d seconds, this is attempt number %d."
@@ -1002,7 +1006,9 @@ class BigQueryClient:
                     raise
 
                 backoff = min(max_retry, initial_retry * (backoff_factor**attempt))
-                self.logger.exception("LoadJob quota exceeded", attempt=attempt, backoff=backoff, error_code=err.code)
+                self.logger.warning(
+                    "LoadJob quota exceeded", attempt=attempt, backoff=backoff, error_code=err.code, exc_info=True
+                )
                 self.external_logger.warning(
                     "BigQuery load job quota exceeded. This error will be retried in %d seconds, this is attempt number %d."
                     " It may take several minutes or longer until the quota is restored, as it is restored over the course"


### PR DESCRIPTION
## Problem

We are currently logging for users at error level transient errors that are retried. These should be warnings for users, as we are trying to fix things by retrying, so there is no need to raise an alarm on their side. 

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Update log level to warning for transient errors. 

Not done: I didn't update our internal log level, at least for now. 

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took, and what steps reviewers must take to get to where changes are, and what is the expected behavior. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
