### PR TITLE
feat(insights): add tracking for insight query-building actions

### DIFF
--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -319,6 +319,11 @@ export const eventUsageLogic = kea<eventUsageLogicType>([
         }),
         reportInsightsTableCalcToggled: (mode: string) => ({ mode }),
         reportPropertyGroupFilterAdded: true,
+        reportPropertyGroupFilterRemoved: true,
+        reportPropertyGroupFilterDuplicated: true,
+        reportInsightDateRangeChanged: (queryKind: string | undefined) => ({ queryKind }),
+        reportInsightBreakdownChanged: (queryKind: string | undefined) => ({ queryKind }),
+        reportInsightCompareChanged: (queryKind: string | undefined) => ({ queryKind }),
         reportChangeOuterPropertyGroupFiltersType: (type: FilterLogicalOperator, groupsLength: number) => ({
             type,
             groupsLength,
@@ -1689,6 +1694,21 @@ export const eventUsageLogic = kea<eventUsageLogicType>([
         },
         reportPropertyGroupFilterAdded: () => {
             posthog.capture('property group filter added')
+        },
+        reportPropertyGroupFilterRemoved: () => {
+            posthog.capture('property group filter removed')
+        },
+        reportPropertyGroupFilterDuplicated: () => {
+            posthog.capture('property group filter duplicated')
+        },
+        reportInsightDateRangeChanged: ({ queryKind }) => {
+            posthog.capture('insight date range changed', { query_kind: queryKind })
+        },
+        reportInsightBreakdownChanged: ({ queryKind }) => {
+            posthog.capture('insight breakdown changed', { query_kind: queryKind })
+        },
+        reportInsightCompareChanged: ({ queryKind }) => {
+            posthog.capture('insight compare changed', { query_kind: queryKind })
         },
         reportChangeOuterPropertyGroupFiltersType: ({ type, groupsLength }) => {
             posthog.capture('outer match property groups type changed', { type, groupsLength })

--- a/frontend/src/queries/nodes/InsightViz/EditorFilterGroup.tsx
+++ b/frontend/src/queries/nodes/InsightViz/EditorFilterGroup.tsx
@@ -17,15 +17,27 @@ export interface EditorFilterGroupProps {
     insightProps: InsightLogicProps
     query: InsightQueryNode
     asTile?: boolean
+    queryKind?: string
 }
 
-export function EditorFilterGroup({ insightProps, editorFilterGroup, asTile }: EditorFilterGroupProps): JSX.Element {
+export function EditorFilterGroup({
+    insightProps,
+    editorFilterGroup,
+    asTile,
+    queryKind,
+}: EditorFilterGroupProps): JSX.Element {
     const { title, defaultExpanded, editorFilters, collapsedSummary } = editorFilterGroup
     const hasContent = !!collapsedSummary
     const [isRowExpanded, setIsRowExpanded, isExpandable] = useEditorGroupExpansion(defaultExpanded, hasContent)
 
     if (asTile) {
-        return <EditorFilterGroupTile insightProps={insightProps} editorFilterGroup={editorFilterGroup} />
+        return (
+            <EditorFilterGroupTile
+                insightProps={insightProps}
+                editorFilterGroup={editorFilterGroup}
+                queryKind={queryKind}
+            />
+        )
     }
 
     return (

--- a/frontend/src/queries/nodes/InsightViz/EditorFilterGroupTile.tsx
+++ b/frontend/src/queries/nodes/InsightViz/EditorFilterGroupTile.tsx
@@ -14,9 +14,14 @@ import { useEditorGroupExpansion } from './useEditorGroupExpansion'
 export interface EditorFilterGroupTileProps {
     editorFilterGroup: InsightEditorFilterGroup
     insightProps: InsightLogicProps
+    queryKind?: string
 }
 
-export function EditorFilterGroupTile({ insightProps, editorFilterGroup }: EditorFilterGroupTileProps): JSX.Element {
+export function EditorFilterGroupTile({
+    insightProps,
+    editorFilterGroup,
+    queryKind,
+}: EditorFilterGroupTileProps): JSX.Element {
     const { title, defaultExpanded, editorFilters, collapsedSummary } = editorFilterGroup
     const hasContent = !!collapsedSummary
     const [isRowExpanded, setIsRowExpanded, isExpandable] = useEditorGroupExpansion(defaultExpanded, hasContent)
@@ -32,6 +37,7 @@ export function EditorFilterGroupTile({ insightProps, editorFilterGroup }: Edito
                         posthog.capture('editor panel section toggled', {
                             section: title,
                             action: newState ? 'opened' : 'closed',
+                            query_kind: queryKind,
                         })
                     }}
                     sideIcon={isRowExpanded ? <IconCollapse /> : <IconExpand />}

--- a/frontend/src/queries/nodes/InsightViz/EditorFilters.tsx
+++ b/frontend/src/queries/nodes/InsightViz/EditorFilters.tsx
@@ -435,6 +435,7 @@ export function EditorFilters({ query, showing, embedded }: EditorFiltersProps):
                         insightProps={insightProps}
                         query={query}
                         asTile
+                        queryKind={querySource?.kind}
                     />
                 ))}
             </div>

--- a/frontend/src/queries/nodes/InsightViz/EditorFiltersShell.tsx
+++ b/frontend/src/queries/nodes/InsightViz/EditorFiltersShell.tsx
@@ -1,7 +1,6 @@
 import clsx from 'clsx'
 import { useActions, useValues } from 'kea'
-import posthog from 'posthog-js'
-import { useEffect, useMemo, useRef } from 'react'
+import { useMemo, useRef } from 'react'
 import { CSSTransition } from 'react-transition-group'
 
 import { Resizer } from 'lib/components/Resizer/Resizer'
@@ -64,13 +63,6 @@ export function EditorFiltersShell({
         []
     )
     const { desiredSize: panelWidth, isResizeInProgress: isResizing } = useValues(resizerLogic(resizerProps))
-
-    useEffect(() => {
-        if (asPanels && showing) {
-            posthog.capture('editor panel shown', { panel_width: panelWidth })
-        }
-    }, [asPanels, showing]) // oxlint-disable-line react-hooks/exhaustive-deps
-
     // MaxTool should not be active when insights are embedded (e.g., in notebooks)
     const maxToolActive = !embedded
 

--- a/frontend/src/queries/nodes/InsightViz/PropertyGroupFilters/propertyGroupFilterLogic.ts
+++ b/frontend/src/queries/nodes/InsightViz/PropertyGroupFilters/propertyGroupFilterLogic.ts
@@ -104,9 +104,15 @@ export const propertyGroupFilterLogic = kea<propertyGroupFilterLogicType>([
             eventUsageLogic.actions.reportChangeOuterPropertyGroupFiltersType(type, values.filters.values.length)
             actions.update()
         },
-        removeFilterGroup: () => actions.update(),
+        removeFilterGroup: () => {
+            eventUsageLogic.actions.reportPropertyGroupFilterRemoved()
+            actions.update()
+        },
         addFilterGroup: () => {
             eventUsageLogic.actions.reportPropertyGroupFilterAdded()
+        },
+        duplicateFilterGroup: () => {
+            eventUsageLogic.actions.reportPropertyGroupFilterDuplicated()
         },
         update: () => {
             // Don't persist empty PropertyGroupFilter structures — they cause ghost

--- a/frontend/src/scenes/insights/insightVizDataLogic.test.ts
+++ b/frontend/src/scenes/insights/insightVizDataLogic.test.ts
@@ -1,5 +1,4 @@
 import { expectLogic } from 'kea-test-utils'
-import posthog from 'posthog-js'
 
 import { FunnelLayout } from 'lib/constants'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
@@ -936,50 +935,6 @@ describe('insightVizDataLogic', () => {
                     },
                 } as Partial<TrendsQuery>)
             }).toMatchValues({ isBreakdownSeries: true })
-        })
-    })
-
-    describe('tracking', () => {
-        let captureSpy: jest.SpyInstance
-
-        beforeEach(() => {
-            captureSpy = jest.spyOn(posthog, 'capture').mockImplementation(() => undefined)
-        })
-
-        afterEach(() => {
-            captureSpy.mockRestore()
-        })
-
-        it('captures breakdown changed', async () => {
-            await expectLogic(builtInsightVizDataLogic, () => {
-                builtInsightVizDataLogic.actions.updateBreakdownFilter({
-                    breakdowns: [{ property: '$browser', type: 'event' }],
-                })
-            }).toFinishAllListeners()
-
-            expect(captureSpy).toHaveBeenCalledWith('insight breakdown changed', {
-                query_kind: 'TrendsQuery',
-            })
-        })
-
-        it('captures date range changed', async () => {
-            await expectLogic(builtInsightVizDataLogic, () => {
-                builtInsightVizDataLogic.actions.updateDateRange({ date_from: '-30d' })
-            }).toFinishAllListeners()
-
-            expect(captureSpy).toHaveBeenCalledWith('insight date range changed', {
-                query_kind: 'TrendsQuery',
-            })
-        })
-
-        it('captures compare changed', async () => {
-            await expectLogic(builtInsightVizDataLogic, () => {
-                builtInsightVizDataLogic.actions.updateCompareFilter({ compare: true })
-            }).toFinishAllListeners()
-
-            expect(captureSpy).toHaveBeenCalledWith('insight compare changed', {
-                query_kind: 'TrendsQuery',
-            })
         })
     })
 })

--- a/frontend/src/scenes/insights/insightVizDataLogic.test.ts
+++ b/frontend/src/scenes/insights/insightVizDataLogic.test.ts
@@ -1,4 +1,5 @@
 import { expectLogic } from 'kea-test-utils'
+import posthog from 'posthog-js'
 
 import { FunnelLayout } from 'lib/constants'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
@@ -935,6 +936,50 @@ describe('insightVizDataLogic', () => {
                     },
                 } as Partial<TrendsQuery>)
             }).toMatchValues({ isBreakdownSeries: true })
+        })
+    })
+
+    describe('tracking', () => {
+        let captureSpy: jest.SpyInstance
+
+        beforeEach(() => {
+            captureSpy = jest.spyOn(posthog, 'capture').mockImplementation(() => undefined)
+        })
+
+        afterEach(() => {
+            captureSpy.mockRestore()
+        })
+
+        it('captures breakdown changed', async () => {
+            await expectLogic(builtInsightVizDataLogic, () => {
+                builtInsightVizDataLogic.actions.updateBreakdownFilter({
+                    breakdowns: [{ property: '$browser', type: 'event' }],
+                })
+            }).toFinishAllListeners()
+
+            expect(captureSpy).toHaveBeenCalledWith('insight breakdown changed', {
+                query_kind: 'TrendsQuery',
+            })
+        })
+
+        it('captures date range changed', async () => {
+            await expectLogic(builtInsightVizDataLogic, () => {
+                builtInsightVizDataLogic.actions.updateDateRange({ date_from: '-30d' })
+            }).toFinishAllListeners()
+
+            expect(captureSpy).toHaveBeenCalledWith('insight date range changed', {
+                query_kind: 'TrendsQuery',
+            })
+        })
+
+        it('captures compare changed', async () => {
+            await expectLogic(builtInsightVizDataLogic, () => {
+                builtInsightVizDataLogic.actions.updateCompareFilter({ compare: true })
+            }).toFinishAllListeners()
+
+            expect(captureSpy).toHaveBeenCalledWith('insight compare changed', {
+                query_kind: 'TrendsQuery',
+            })
         })
     })
 })

--- a/frontend/src/scenes/insights/insightVizDataLogic.ts
+++ b/frontend/src/scenes/insights/insightVizDataLogic.ts
@@ -623,10 +623,10 @@ export const insightVizDataLogic = kea<insightVizDataLogicType>([
 
         // query source properties
         updateDateRange: async ({ dateRange, ignoreDebounce }, breakpoint) => {
-            eventUsageLogic.actions.reportInsightDateRangeChanged(values.querySource?.kind)
             if (!ignoreDebounce) {
                 await breakpoint(300)
             }
+            eventUsageLogic.actions.reportInsightDateRangeChanged(values.querySource?.kind)
             const updates = {
                 dateRange: {
                     ...values.dateRange,
@@ -655,14 +655,14 @@ export const insightVizDataLogic = kea<insightVizDataLogicType>([
             })
         },
         updateBreakdownFilter: async ({ breakdownFilter }, breakpoint) => {
-            eventUsageLogic.actions.reportInsightBreakdownChanged(values.querySource?.kind)
             await breakpoint(500) // extra debounce time because of number input
+            eventUsageLogic.actions.reportInsightBreakdownChanged(values.querySource?.kind)
             const update: Partial<TrendsQuery> = { breakdownFilter: { ...values.breakdownFilter, ...breakdownFilter } }
             actions.updateQuerySource(update)
         },
         updateCompareFilter: async ({ compareFilter }, breakpoint) => {
-            eventUsageLogic.actions.reportInsightCompareChanged(values.querySource?.kind)
             await breakpoint(500) // extra debounce time because of number input
+            eventUsageLogic.actions.reportInsightCompareChanged(values.querySource?.kind)
             const update: Partial<TrendsQuery> = { compareFilter: { ...values.compareFilter, ...compareFilter } }
             actions.updateQuerySource(update)
         },

--- a/frontend/src/scenes/insights/insightVizDataLogic.ts
+++ b/frontend/src/scenes/insights/insightVizDataLogic.ts
@@ -12,6 +12,7 @@ import { parseProperties } from 'lib/components/PropertyFilters/utils'
 import { NON_TIME_SERIES_DISPLAY_TYPES, NON_VALUES_ON_SERIES_DISPLAY_TYPES } from 'lib/constants'
 import { dayjs } from 'lib/dayjs'
 import { dateMapping, is12HoursOrLess, isLessThan2Days } from 'lib/utils'
+import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { databaseTableListLogic } from 'scenes/data-management/database/databaseTableListLogic'
 import { dataThemeLogic } from 'scenes/dataThemeLogic'
 import { getClampedFunnelStepRange } from 'scenes/funnels/funnelUtils'
@@ -622,6 +623,7 @@ export const insightVizDataLogic = kea<insightVizDataLogicType>([
 
         // query source properties
         updateDateRange: async ({ dateRange, ignoreDebounce }, breakpoint) => {
+            eventUsageLogic.actions.reportInsightDateRangeChanged(values.querySource?.kind)
             if (!ignoreDebounce) {
                 await breakpoint(300)
             }
@@ -653,11 +655,13 @@ export const insightVizDataLogic = kea<insightVizDataLogicType>([
             })
         },
         updateBreakdownFilter: async ({ breakdownFilter }, breakpoint) => {
+            eventUsageLogic.actions.reportInsightBreakdownChanged(values.querySource?.kind)
             await breakpoint(500) // extra debounce time because of number input
             const update: Partial<TrendsQuery> = { breakdownFilter: { ...values.breakdownFilter, ...breakdownFilter } }
             actions.updateQuerySource(update)
         },
         updateCompareFilter: async ({ compareFilter }, breakpoint) => {
+            eventUsageLogic.actions.reportInsightCompareChanged(values.querySource?.kind)
             await breakpoint(500) // extra debounce time because of number input
             const update: Partial<TrendsQuery> = { compareFilter: { ...values.compareFilter, ...compareFilter } }
             actions.updateQuerySource(update)


### PR DESCRIPTION
## Problem

We want to understand how often users modify specific insight query settings (date range, breakdowns, compare, filter groups) to inform product decisions around the editor experience.

## Changes

- Add `reportInsightDateRangeChanged`, `reportInsightBreakdownChanged`, `reportInsightCompareChanged` to `eventUsageLogic`
- Add `reportPropertyGroupFilterRemoved` and `reportPropertyGroupFilterDuplicated` to `eventUsageLogic`
- Wire up tracking in `insightVizDataLogic` and `propertyGroupFilterLogic` listeners
- Remove unused `editor panel shown` event from `EditorFiltersShell`
- Add integration tests verifying events fire through the real kea logic

## How did you test this code?

I'm an agent. I ran the `insightVizDataLogic.test.ts` integration tests which mount the real kea logic, trigger actions, and verify the correct `posthog.capture` calls fire. All 35 tests pass. I did not manually test in the browser.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?