### PR TITLE
feat(tasks): Task UI improvements

### DIFF
--- a/products/tasks/frontend/components/TaskDetailPage.tsx
+++ b/products/tasks/frontend/components/TaskDetailPage.tsx
@@ -3,9 +3,11 @@ import { useActions, useValues } from 'kea'
 import { IconArchive, IconExternal, IconGithub, IconPlay } from '@posthog/icons'
 import { LemonButton, Spinner } from '@posthog/lemon-ui'
 
+import { TZLabel } from 'lib/components/TZLabel'
 import { dayjs } from 'lib/dayjs'
 import { LemonMarkdown } from 'lib/lemon-ui/LemonMarkdown'
 import { ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
+import { humanFriendlyDuration } from 'lib/utils'
 import { urls } from 'scenes/urls'
 
 import { SceneContent } from '~/layout/scenes/components/SceneContent'
@@ -138,6 +140,27 @@ export function TaskDetailPage({ taskId }: TaskDetailPageProps): JSX.Element {
                     </div>
                 }
             />
+
+            {selectedRun && (
+                <div className="flex items-center gap-4 -mt-2 mb-2 px-2 text-xs text-muted">
+                    <span>
+                        Created: <TZLabel time={selectedRun.created_at} showSeconds />
+                    </span>
+                    {selectedRun.completed_at && (
+                        <span>
+                            Completed: <TZLabel time={selectedRun.completed_at} showSeconds />
+                        </span>
+                    )}
+                    {selectedRun.completed_at && (
+                        <span>
+                            Duration:{' '}
+                            {humanFriendlyDuration(
+                                dayjs(selectedRun.completed_at).diff(selectedRun.created_at, 'second')
+                            )}
+                        </span>
+                    )}
+                </div>
+            )}
 
             {task.description && (
                 <div className="relative -mt-2 mb-2 px-2">

--- a/products/tasks/frontend/components/TasksList.tsx
+++ b/products/tasks/frontend/components/TasksList.tsx
@@ -1,4 +1,5 @@
 import { useActions, useValues } from 'kea'
+import { router } from 'kea-router'
 
 import { IconPlus } from '@posthog/icons'
 import {
@@ -13,6 +14,8 @@ import {
 
 import { TZLabel } from 'lib/components/TZLabel'
 import { LemonTable, LemonTableColumn } from 'lib/lemon-ui/LemonTable'
+import { Link } from 'lib/lemon-ui/Link'
+import { urls } from 'scenes/urls'
 
 import { TASK_STATUS_CONFIG } from '../lib/task-status'
 import { tasksLogic } from '../logics/tasksLogic'
@@ -27,8 +30,6 @@ export function TasksList(): JSX.Element {
     const { tasksLoading, repositories } = useValues(tasksLogic)
     const { setSearchQuery, setRepository, setStatus, openCreateModal, closeCreateModal } =
         useActions(taskTrackerSceneLogic)
-    const { openTask } = useActions(tasksLogic)
-
     const columns: LemonTableColumn<Task, keyof Task | undefined>[] = [
         {
             title: 'Task',
@@ -37,12 +38,13 @@ export function TasksList(): JSX.Element {
             render: (_: any, task: Task) => (
                 <div className="flex flex-col gap-1 min-w-0">
                     <div className="flex items-center gap-2 min-w-0">
-                        <span
-                            className="font-semibold text-link cursor-pointer shrink-0"
-                            onClick={() => openTask(task.id)}
+                        <Link
+                            to={urls.taskDetail(task.id)}
+                            className="font-semibold text-link shrink-0"
+                            onClick={(e) => e.stopPropagation()}
                         >
                             {task.slug}
-                        </span>
+                        </Link>
                         <span className="text-default truncate">{task.title}</span>
                     </div>
                     {task.description && <div className="text-muted text-xs line-clamp-1">{task.description}</div>}
@@ -146,7 +148,14 @@ export function TasksList(): JSX.Element {
                     columns={columns}
                     rowKey="id"
                     onRow={(task) => ({
-                        onClick: () => openTask(task.id),
+                        onClick: (e) => {
+                            const url = urls.taskDetail(task.id)
+                            if (e.metaKey || e.ctrlKey || e.button === 1) {
+                                window.open(url, '_blank')
+                            } else {
+                                router.actions.push(url)
+                            }
+                        },
                         className: 'cursor-pointer hover:bg-bg-light',
                     })}
                     emptyState={

--- a/products/tasks/frontend/components/TasksList.tsx
+++ b/products/tasks/frontend/components/TasksList.tsx
@@ -35,12 +35,15 @@ export function TasksList(): JSX.Element {
             key: 'title',
             width: '40%',
             render: (_: any, task: Task) => (
-                <div className="flex flex-col gap-1">
-                    <div className="flex items-center gap-2">
-                        <span className="font-semibold text-link cursor-pointer" onClick={() => openTask(task.id)}>
+                <div className="flex flex-col gap-1 min-w-0">
+                    <div className="flex items-center gap-2 min-w-0">
+                        <span
+                            className="font-semibold text-link cursor-pointer shrink-0"
+                            onClick={() => openTask(task.id)}
+                        >
                             {task.slug}
                         </span>
-                        <span className="text-default">{task.title}</span>
+                        <span className="text-default truncate">{task.title}</span>
                     </div>
                     {task.description && <div className="text-muted text-xs line-clamp-1">{task.description}</div>}
                 </div>

--- a/products/tasks/frontend/components/TasksList.tsx
+++ b/products/tasks/frontend/components/TasksList.tsx
@@ -11,6 +11,7 @@ import {
     Spinner,
 } from '@posthog/lemon-ui'
 
+import { TZLabel } from 'lib/components/TZLabel'
 import { LemonTable, LemonTableColumn } from 'lib/lemon-ui/LemonTable'
 
 import { TASK_STATUS_CONFIG } from '../lib/task-status'
@@ -77,21 +78,7 @@ export function TasksList(): JSX.Element {
             title: 'Created',
             key: 'created_at',
             width: '10%',
-            render: (_: any, task: Task) => {
-                const date = new Date(task.created_at)
-                const now = new Date()
-                const diffInHours = (now.getTime() - date.getTime()) / (1000 * 60 * 60)
-
-                if (diffInHours < 1) {
-                    return <span className="text-sm">Just now</span>
-                }
-                if (diffInHours < 24) {
-                    const hours = Math.floor(diffInHours)
-                    return <span className="text-sm">{hours}h ago</span>
-                }
-                const days = Math.floor(diffInHours / 24)
-                return <span className="text-sm">{days}d ago</span>
-            },
+            render: (_: any, task: Task) => <TZLabel time={task.created_at} showSeconds className="text-sm" />,
         },
     ]
 


### PR DESCRIPTION
## Problem
- Can't open lots of tasks in new windows with mouswheel clicks or cmd+click
- Can't see the exact time when the tasks started/ended
- Can't see task duration
- Can't check task meta without horizontal scroll

<img width="1680" height="489" alt="CleanShot 2026-04-01 at 15 07 12" src="https://github.com/user-attachments/assets/fab9070c-a4ba-4515-9d4e-353a2e632bab" />


<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
- Now we can

<img width="1692" height="412" alt="CleanShot 2026-04-01 at 15 03 44-2" src="https://github.com/user-attachments/assets/9ea3ba8f-6d5c-4a1b-a169-51d15ae60439" />

<img width="1675" height="495" alt="CleanShot 2026-04-01 at 15 08 57-2" src="https://github.com/user-attachments/assets/c9fef952-e6ad-40a5-b92e-016f23b46f1b" />


<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took, and what steps reviewers must take to get to where changes are, and what is the expected behavior. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
