### PR TITLE
feat(logs-alerts): add Prometheus metrics interceptor for logs alerting temporal worker

### DIFF
--- a/posthog/temporal/common/worker.py
+++ b/posthog/temporal/common/worker.py
@@ -36,6 +36,11 @@ from posthog.temporal.session_replay.delete_recordings.metrics import (
 )
 
 from products.batch_exports.backend.temporal.metrics import BatchExportsMetricsInterceptor
+from products.logs.backend.temporal.metrics import (
+    LOGS_ALERTING_LATENCY_HISTOGRAM_BUCKETS,
+    LOGS_ALERTING_LATENCY_HISTOGRAM_METRICS,
+    LogsAlertingMetricsInterceptor,
+)
 from products.tasks.backend.temporal.metrics import TASKS_LATENCY_HISTOGRAM_BUCKETS, TASKS_LATENCY_HISTOGRAM_METRICS
 
 logger = get_write_only_logger()
@@ -107,6 +112,7 @@ ALL_INTERCEPTOR_CLASSES = [
     SummarizationMetricsInterceptor,
     ClusteringMetricsInterceptor,
     SentimentMetricsInterceptor,
+    LogsAlertingMetricsInterceptor,
 ]
 
 
@@ -248,6 +254,12 @@ async def create_worker(
                     zip(
                         DELETE_RECORDINGS_LATENCY_HISTOGRAM_METRICS,
                         itertools.repeat(DELETE_RECORDINGS_LATENCY_HISTOGRAM_BUCKETS),
+                    )
+                )
+                | dict(
+                    zip(
+                        LOGS_ALERTING_LATENCY_HISTOGRAM_METRICS,
+                        itertools.repeat(LOGS_ALERTING_LATENCY_HISTOGRAM_BUCKETS),
                     )
                 )
                 | {"batch_exports_activity_attempt": [1.0, 5.0, 10.0, 100.0]},

--- a/products/logs/backend/temporal/activities.py
+++ b/products/logs/backend/temporal/activities.py
@@ -1,5 +1,6 @@
 """Temporal activities for logs alerting."""
 
+import time
 import asyncio
 import dataclasses
 from datetime import UTC, datetime, timedelta
@@ -23,6 +24,7 @@ from products.logs.backend.alert_state_machine import (
 )
 from products.logs.backend.alert_utils import advance_next_check_at
 from products.logs.backend.models import LogsAlertCheck, LogsAlertConfiguration
+from products.logs.backend.temporal.metrics import increment_checks_total, record_check_duration, record_scheduler_lag
 
 logger = structlog.get_logger(__name__)
 
@@ -96,6 +98,8 @@ def _evaluate_single_alert(
     stats: dict[str, int],
 ) -> None:
     """Run the ClickHouse query, apply state machine, persist, and emit events for a single alert."""
+    start_time = time.perf_counter()
+    original_next_check_at = alert.next_check_at
 
     date_to = now
     date_from = now - timedelta(minutes=alert.window_minutes)
@@ -209,6 +213,27 @@ def _evaluate_single_alert(
 
     if outcome.error_message:
         stats["errored"] += 1
+
+    # Per-alert metrics — must never break alerting
+    try:
+        elapsed_ms = int((time.perf_counter() - start_time) * 1000)
+        record_check_duration(elapsed_ms)
+        if original_next_check_at is not None:
+            lag_ms = int((now - original_next_check_at).total_seconds() * 1000)
+            if lag_ms > 0:
+                record_scheduler_lag(lag_ms)
+        if outcome.error_message:
+            increment_checks_total("errored")
+        elif notification_failed:
+            increment_checks_total("errored")
+        elif outcome.notification == NotificationAction.FIRE:
+            increment_checks_total("fired")
+        elif outcome.notification == NotificationAction.RESOLVE:
+            increment_checks_total("resolved")
+        else:
+            increment_checks_total("ok")
+    except Exception:
+        logger.exception("Failed to record alert check metrics", alert_id=str(alert.id))
 
 
 def _emit_alert_event(

--- a/products/logs/backend/temporal/metrics.py
+++ b/products/logs/backend/temporal/metrics.py
@@ -1,0 +1,166 @@
+"""Prometheus metrics and Temporal interceptor for logs alerting."""
+
+import time
+import typing
+import datetime as dt
+
+from django.conf import settings
+
+from temporalio import activity, workflow
+from temporalio.common import MetricMeter
+from temporalio.worker import ActivityInboundInterceptor, ExecuteActivityInput, Interceptor
+
+from posthog.temporal.common.logger import get_write_only_logger
+
+logger = get_write_only_logger(__name__)
+
+ALERTING_ACTIVITY_TYPES = frozenset(
+    {
+        "check_alerts_activity",
+    }
+)
+
+Attributes = dict[str, str | int | float | bool]
+
+LOGS_ALERTING_LATENCY_HISTOGRAM_METRICS = (
+    "logs_alerting_check_duration_ms",
+    "logs_alerting_cycle_duration_ms",
+    "logs_alerting_scheduler_lag_ms",
+    "logs_alerting_schedule_to_start_ms",
+)
+
+LOGS_ALERTING_LATENCY_HISTOGRAM_BUCKETS = [
+    100.0,
+    500.0,
+    1_000.0,
+    5_000.0,
+    10_000.0,
+    30_000.0,
+    60_000.0,
+    120_000.0,
+    300_000.0,
+]
+
+
+def get_metric_meter(additional_attributes: Attributes | None = None) -> MetricMeter:
+    """Return a meter depending on whether we are in an activity or workflow context."""
+    if activity.in_activity():
+        meter = activity.metric_meter()
+    elif workflow.in_workflow():
+        meter = workflow.metric_meter()
+    else:
+        raise RuntimeError("Not within workflow or activity context")
+
+    if additional_attributes:
+        meter = meter.with_additional_attributes(additional_attributes)
+
+    return meter
+
+
+def _record_histogram(name: str, description: str, duration_ms: int, attributes: Attributes | None = None) -> None:
+    meter = get_metric_meter(attributes)
+    hist = meter.create_histogram_timedelta(name=name, description=description, unit="ms")
+    hist.record(dt.timedelta(milliseconds=duration_ms))
+
+
+AlertOutcome = typing.Literal["ok", "fired", "resolved", "errored"]
+
+
+def increment_checks_total(outcome: AlertOutcome) -> None:
+    """Increment per-alert check counter."""
+    meter = get_metric_meter({"outcome": outcome})
+    counter = meter.create_counter("logs_alerting_checks_total", "Number of individual alert checks by outcome")
+    counter.add(1)
+
+
+def record_check_duration(duration_ms: int) -> None:
+    _record_histogram("logs_alerting_check_duration_ms", "Per-alert evaluation duration", duration_ms)
+
+
+def record_scheduler_lag(lag_ms: int) -> None:
+    _record_histogram("logs_alerting_scheduler_lag_ms", "Delay between alert due time and actual check time", lag_ms)
+
+
+def record_schedule_to_start_latency(activity_type: str, latency_ms: int) -> None:
+    _record_histogram(
+        "logs_alerting_schedule_to_start_ms",
+        "Time between activity scheduling and start",
+        latency_ms,
+        {"activity_type": activity_type},
+    )
+
+
+# TODO: Extract ExecutionTimeRecorder to posthog/temporal/common/ — copied from
+# posthog/temporal/llm_analytics/metrics.py to avoid cross-product import.
+class ExecutionTimeRecorder:
+    """Context manager to record execution time to a histogram metric."""
+
+    def __init__(
+        self,
+        histogram_name: str,
+        /,
+        description: str | None = None,
+        histogram_attributes: Attributes | None = None,
+    ) -> None:
+        self.histogram_name = histogram_name
+        self.description = description
+        self.histogram_attributes = histogram_attributes or {}
+        self._start_counter: float | None = None
+
+    def __enter__(self) -> typing.Self:
+        self._start_counter = time.perf_counter()
+        return self
+
+    def __exit__(
+        self, exc_type: type[BaseException] | None, exc_value: BaseException | None, traceback: object
+    ) -> None:
+        if self._start_counter is None:
+            raise RuntimeError("Start counter not initialized, did you call `__enter__`?")
+
+        end_counter = time.perf_counter()
+        delta_ms = int((end_counter - self._start_counter) * 1000)
+        delta = dt.timedelta(milliseconds=delta_ms)
+
+        attributes = dict(self.histogram_attributes)
+        if exc_value is not None:
+            attributes["status"] = "FAILED"
+        else:
+            attributes["status"] = "COMPLETED"
+
+        meter = get_metric_meter(attributes)
+        hist = meter.create_histogram_timedelta(name=self.histogram_name, description=self.description, unit="ms")
+        try:
+            hist.record(value=delta)
+        except Exception:
+            logger.exception("Failed to record execution time to histogram '%s'", self.histogram_name)
+
+
+class LogsAlertingMetricsInterceptor(Interceptor):
+    """Interceptor to emit Prometheus metrics for logs alerting workflows."""
+
+    task_queue = settings.LOGS_ALERTING_TASK_QUEUE
+
+    def intercept_activity(self, next: ActivityInboundInterceptor) -> ActivityInboundInterceptor:
+        return _LogsAlertingActivityInterceptor(super().intercept_activity(next))
+
+
+class _LogsAlertingActivityInterceptor(ActivityInboundInterceptor):
+    async def execute_activity(self, input: ExecuteActivityInput) -> typing.Any:
+        activity_info = activity.info()
+        activity_type = activity_info.activity_type
+
+        if activity_type not in ALERTING_ACTIVITY_TYPES:
+            return await super().execute_activity(input)
+
+        scheduled_time = activity_info.scheduled_time
+        started_time = activity_info.started_time
+        if scheduled_time and started_time:
+            schedule_to_start_ms = int((started_time - scheduled_time).total_seconds() * 1000)
+            record_schedule_to_start_latency(activity_type, schedule_to_start_ms)
+
+        with ExecutionTimeRecorder(
+            "logs_alerting_cycle_duration_ms",
+            description="Full alert check cycle duration",
+            histogram_attributes={"activity_type": activity_type},
+        ):
+            return await super().execute_activity(input)

--- a/products/logs/backend/test/test_logs_alerting_metrics.py
+++ b/products/logs/backend/test/test_logs_alerting_metrics.py
@@ -1,0 +1,126 @@
+import datetime as dt
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+from django.conf import settings
+
+from products.logs.backend.temporal.metrics import (
+    ALERTING_ACTIVITY_TYPES,
+    AlertOutcome,
+    ExecutionTimeRecorder,
+    LogsAlertingMetricsInterceptor,
+    increment_checks_total,
+    record_check_duration,
+    record_schedule_to_start_latency,
+    record_scheduler_lag,
+)
+
+
+class TestLogsAlertingMetricsInterceptor:
+    def test_task_queue_matches_settings(self):
+        assert LogsAlertingMetricsInterceptor.task_queue == settings.LOGS_ALERTING_TASK_QUEUE
+
+    def test_creates_activity_interceptor(self):
+        interceptor = LogsAlertingMetricsInterceptor()
+        mock_next = MagicMock()
+        result = interceptor.intercept_activity(mock_next)
+        assert result is not None
+
+
+class TestActivityTypes:
+    def test_alerting_activity_types(self):
+        assert ALERTING_ACTIVITY_TYPES == frozenset({"check_alerts_activity"})
+
+
+class TestIncrementChecksTotal:
+    @pytest.mark.parametrize("outcome", ["ok", "fired", "resolved", "errored"])
+    @patch("products.logs.backend.temporal.metrics.get_metric_meter")
+    def test_increments_counter_with_outcome(self, mock_get_meter: MagicMock, outcome: AlertOutcome):
+        mock_meter = MagicMock()
+        mock_counter = MagicMock()
+        mock_meter.create_counter.return_value = mock_counter
+        mock_get_meter.return_value = mock_meter
+
+        increment_checks_total(outcome)
+
+        mock_get_meter.assert_called_once_with({"outcome": outcome})
+        mock_counter.add.assert_called_once_with(1)
+
+
+class TestRecordCheckDuration:
+    @patch("products.logs.backend.temporal.metrics._record_histogram")
+    def test_records_histogram_with_duration(self, mock_record: MagicMock):
+        record_check_duration(150)
+        mock_record.assert_called_once_with("logs_alerting_check_duration_ms", "Per-alert evaluation duration", 150)
+
+
+class TestRecordScheduleToStartLatency:
+    @patch("products.logs.backend.temporal.metrics._record_histogram")
+    def test_records_latency_with_activity_type(self, mock_record: MagicMock):
+        record_schedule_to_start_latency("check_alerts_activity", 250)
+        mock_record.assert_called_once_with(
+            "logs_alerting_schedule_to_start_ms",
+            "Time between activity scheduling and start",
+            250,
+            {"activity_type": "check_alerts_activity"},
+        )
+
+
+class TestRecordSchedulerLag:
+    @patch("products.logs.backend.temporal.metrics._record_histogram")
+    def test_records_lag_as_histogram(self, mock_record: MagicMock):
+        record_scheduler_lag(5000)
+        mock_record.assert_called_once_with(
+            "logs_alerting_scheduler_lag_ms", "Delay between alert due time and actual check time", 5000
+        )
+
+
+class TestRecordHistogram:
+    @patch("products.logs.backend.temporal.metrics.get_metric_meter")
+    def test_creates_histogram_and_records(self, mock_get_meter: MagicMock):
+        from products.logs.backend.temporal.metrics import _record_histogram
+
+        mock_meter = MagicMock()
+        mock_hist = MagicMock()
+        mock_meter.create_histogram_timedelta.return_value = mock_hist
+        mock_get_meter.return_value = mock_meter
+
+        _record_histogram("test_metric", "test description", 150, {"label": "value"})
+
+        mock_get_meter.assert_called_once_with({"label": "value"})
+        mock_meter.create_histogram_timedelta.assert_called_once_with(
+            name="test_metric", description="test description", unit="ms"
+        )
+        mock_hist.record.assert_called_once_with(dt.timedelta(milliseconds=150))
+
+
+class TestExecutionTimeRecorder:
+    @patch("products.logs.backend.temporal.metrics.get_metric_meter")
+    def test_records_completed_on_success(self, mock_get_meter: MagicMock):
+        mock_meter = MagicMock()
+        mock_hist = MagicMock()
+        mock_meter.create_histogram_timedelta.return_value = mock_hist
+        mock_get_meter.return_value = mock_meter
+
+        with ExecutionTimeRecorder("test_histogram"):
+            pass
+
+        call_args = mock_get_meter.call_args[0][0]
+        assert call_args["status"] == "COMPLETED"
+
+    @patch("products.logs.backend.temporal.metrics.get_metric_meter")
+    def test_records_failed_on_exception(self, mock_get_meter: MagicMock):
+        mock_meter = MagicMock()
+        mock_hist = MagicMock()
+        mock_meter.create_histogram_timedelta.return_value = mock_hist
+        mock_get_meter.return_value = mock_meter
+
+        try:
+            with ExecutionTimeRecorder("test_histogram"):
+                raise ValueError("boom")
+        except ValueError:
+            pass
+
+        call_args = mock_get_meter.call_args[0][0]
+        assert call_args["status"] == "FAILED"


### PR DESCRIPTION
## Problem

The logs alerting temporal worker has no observability

## Changes

- New `products/logs/backend/temporal/metrics.py` with `LogsAlertingMetricsInterceptor` following the `EvalsMetricsInterceptor` pattern
- Five metrics: `logs_alerting_checks_total` (by outcome), `logs_alerting_check_duration_ms`, `logs_alerting_cycle_duration_ms`,
`logs_alerting_scheduler_lag_ms`, `logs_alerting_schedule_to_start_ms`
- Per-alert inline metrics in `_evaluate_single_alert()` wrapped in try/except so metrics never break alerting
- Interceptor registered in `posthog/temporal/common/worker.py` with histogram bucket overrides

## How did you test this code?

10 unit tests in `products/logs/backend/test/test_logs_alerting_metrics.py` covering interceptor registration, metric helpers, histogram recording, and `ExecutionTimeRecorder` behavior.

## Publish to changelog?

No

## Docs update

N/A