### PR TITLE
chore(endpoints): another team_id backfill migraiton

### DIFF
--- a/products/endpoints/backend/migrations/0023_backfill_team_id_on_endpointversion_fix.py
+++ b/products/endpoints/backend/migrations/0023_backfill_team_id_on_endpointversion_fix.py
@@ -1,0 +1,24 @@
+from django.db import migrations, models
+
+
+def backfill_team(apps, schema_editor):
+    Endpoint = apps.get_model("endpoints", "Endpoint")
+    EndpointVersion = apps.get_model("endpoints", "EndpointVersion")
+
+    all_ids = list(EndpointVersion.objects.filter(team_id__isnull=True).order_by("id").values_list("id", flat=True))
+
+    for i in range(0, len(all_ids), 500):
+        batch = all_ids[i : i + 500]
+        EndpointVersion.objects.filter(id__in=batch).update(
+            team_id=models.Subquery(Endpoint.objects.filter(pk=models.OuterRef("endpoint_id")).values("team_id")[:1])
+        )
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("endpoints", "0022_backfill_team_id_on_endpointversion"),
+    ]
+
+    operations = [
+        migrations.RunPython(backfill_team, migrations.RunPython.noop),
+    ]

--- a/products/endpoints/backend/migrations/max_migration.txt
+++ b/products/endpoints/backend/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0022_backfill_team_id_on_endpointversion
+0023_backfill_team_id_on_endpointversion_fix


### PR DESCRIPTION
## Problem

prev migration was updating them in place with the paginator

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

## Changes

- add new one that collects IDs and then update sthem

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

ran it

<!-- Briefly describe the steps you took, and what steps reviewers must take to get to where changes are, and what is the expected behavior. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Publish to changelog?

no

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->