### PR TITLE
fix: rounting emails attachment

### DIFF
--- a/products/conversations/backend/api/tests/test_email_endpoints.py
+++ b/products/conversations/backend/api/tests/test_email_endpoints.py
@@ -493,6 +493,68 @@ class TestEmailInboundRegionRouting(BaseTest):
         mock_proxy.assert_not_called()
 
 
+class TestBuildProxyKwargs(BaseTest):
+    """Unit tests for _build_proxy_kwargs multipart fallback."""
+
+    def test_raw_body_available(self):
+        from django.test import RequestFactory
+
+        from products.conversations.backend.services.region_routing import _build_proxy_kwargs
+
+        factory = RequestFactory()
+        request = factory.post(
+            "/api/conversations/v1/email/inbound",
+            data=b"key=val",
+            content_type="application/x-www-form-urlencoded",
+        )
+        result = _build_proxy_kwargs(request, {"Content-Type": "application/x-www-form-urlencoded"})
+        assert "data" in result
+        assert "files" not in result
+        assert result["data"] == b"key=val"
+
+    def test_multipart_fallback_after_stream_consumed(self):
+        from django.http.request import RawPostDataException
+        from django.test import RequestFactory
+
+        from products.conversations.backend.services.region_routing import _build_proxy_kwargs
+
+        factory = RequestFactory()
+        png_bytes = _make_png_bytes()
+        png = SimpleUploadedFile("photo.png", png_bytes, content_type="image/png")
+        request = factory.post(
+            "/api/conversations/v1/email/inbound",
+            data={"recipient": "team-abc@mg.posthog.com", "attachment-1": png},
+        )
+
+        # Force parsing so FILES is populated
+        _ = request.POST
+        _ = request.FILES
+
+        # Simulate ASGI: make body raise as if the stream was consumed
+        original_body = type(request).body
+
+        def raise_raw_post(*_args):
+            raise RawPostDataException()
+
+        type(request).body = property(raise_raw_post)
+        try:
+            headers = {"Content-Type": "multipart/form-data; boundary=xxx"}
+            result = _build_proxy_kwargs(request, headers)
+
+            assert "files" in result
+            assert len(result["files"]) == 1
+            key, (name, content_bytes, ct) = result["files"][0]
+            assert key == "attachment-1"
+            assert name == "photo.png"
+            assert ct == "image/png"
+            assert len(content_bytes) > 0
+
+            assert any(k == "recipient" and v == "team-abc@mg.posthog.com" for k, v in result["data"])
+            assert "content-type" not in {k.lower() for k in result["headers"]}
+        finally:
+            type(request).body = original_body
+
+
 class TestEmailInboundMultiConfig(BaseTest):
     def setUp(self):
         super().setUp()

--- a/products/conversations/backend/api/tests/test_email_endpoints.py
+++ b/products/conversations/backend/api/tests/test_email_endpoints.py
@@ -513,46 +513,37 @@ class TestBuildProxyKwargs(BaseTest):
         assert result["data"] == b"key=val"
 
     def test_multipart_fallback_after_stream_consumed(self):
+        from unittest.mock import PropertyMock, patch
+
         from django.http.request import RawPostDataException
         from django.test import RequestFactory
 
         from products.conversations.backend.services.region_routing import _build_proxy_kwargs
 
         factory = RequestFactory()
-        png_bytes = _make_png_bytes()
-        png = SimpleUploadedFile("photo.png", png_bytes, content_type="image/png")
+        png = SimpleUploadedFile("photo.png", _make_png_bytes(), content_type="image/png")
         request = factory.post(
             "/api/conversations/v1/email/inbound",
             data={"recipient": "team-abc@mg.posthog.com", "attachment-1": png},
         )
 
-        # Force parsing so FILES is populated
         _ = request.POST
         _ = request.FILES
 
-        # Simulate ASGI: make body raise as if the stream was consumed
-        original_body = type(request).body
-
-        def raise_raw_post(*_args):
-            raise RawPostDataException()
-
-        type(request).body = property(raise_raw_post)
-        try:
-            headers = {"Content-Type": "multipart/form-data; boundary=xxx"}
+        headers = {"Content-Type": "multipart/form-data; boundary=xxx"}
+        with patch.object(type(request), "body", new_callable=PropertyMock, side_effect=RawPostDataException()):
             result = _build_proxy_kwargs(request, headers)
 
-            assert "files" in result
-            assert len(result["files"]) == 1
-            key, (name, content_bytes, ct) = result["files"][0]
-            assert key == "attachment-1"
-            assert name == "photo.png"
-            assert ct == "image/png"
-            assert len(content_bytes) > 0
+        assert "files" in result
+        assert len(result["files"]) == 1
+        key, (name, content_bytes, ct) = result["files"][0]
+        assert key == "attachment-1"
+        assert name == "photo.png"
+        assert ct == "image/png"
+        assert len(content_bytes) > 0
 
-            assert any(k == "recipient" and v == "team-abc@mg.posthog.com" for k, v in result["data"])
-            assert "content-type" not in {k.lower() for k in result["headers"]}
-        finally:
-            type(request).body = original_body
+        assert any(k == "recipient" and v == "team-abc@mg.posthog.com" for k, v in result["data"])
+        assert "content-type" not in {k.lower() for k in result["headers"]}
 
 
 class TestEmailInboundMultiConfig(BaseTest):

--- a/products/conversations/backend/services/region_routing.py
+++ b/products/conversations/backend/services/region_routing.py
@@ -50,6 +50,9 @@ def _build_proxy_kwargs(request: HttpRequest, headers: dict[str, str]) -> dict:
             for f in request.FILES.getlist(key):
                 f.seek(0)
                 files.append((key, (f.name, f.read(), f.content_type)))
+        # When files is empty, `requests` will use form-encoding instead of
+        # multipart. That's fine — the receiving handler reads via
+        # request.POST.get() which Django populates for both encodings.
         return {"data": data, "files": files, "headers": cleaned_headers}
 
 

--- a/products/conversations/backend/services/region_routing.py
+++ b/products/conversations/backend/services/region_routing.py
@@ -9,6 +9,7 @@ from urllib.parse import urlparse, urlunparse
 
 from django.conf import settings
 from django.http import HttpRequest
+from django.http.request import RawPostDataException
 
 import requests
 import structlog
@@ -28,6 +29,30 @@ def is_primary_region(request: HttpRequest) -> bool:
     return request.get_host() == PRIMARY_REGION_DOMAIN
 
 
+def _build_proxy_kwargs(request: HttpRequest, headers: dict[str, str]) -> dict:
+    """Build data/files kwargs for the proxy request.
+
+    Prefers the raw body for an exact byte-for-byte forward.  Under ASGI,
+    if request.POST/FILES have already been accessed the raw stream is
+    consumed and request.body raises RawPostDataException.  In that case
+    we reconstruct from the parsed multipart data.
+    """
+    try:
+        body = request.body
+        return {"data": body or None, "headers": headers}
+    except RawPostDataException:
+        # Drop Content-Type so `requests` generates a fresh multipart
+        # boundary matching the reconstructed payload.
+        cleaned_headers = {k: v for k, v in headers.items() if k.lower() != "content-type"}
+        data = [(key, value) for key, values in request.POST.lists() for value in values]
+        files = []
+        for key in request.FILES:
+            for f in request.FILES.getlist(key):
+                f.seek(0)
+                files.append((key, (f.name, f.read(), f.content_type)))
+        return {"data": data, "files": files, "headers": cleaned_headers}
+
+
 def proxy_to_secondary_region(request: HttpRequest, *, log_prefix: str, timeout: int = 3) -> bool:
     """Forward an incoming webhook to the secondary region.
 
@@ -38,13 +63,13 @@ def proxy_to_secondary_region(request: HttpRequest, *, log_prefix: str, timeout:
     headers = {key: value for key, value in request.headers.items() if key.lower() != "host"}
 
     try:
+        proxy_kwargs = _build_proxy_kwargs(request, headers)
         response = requests.request(
             method=request.method or "POST",
             url=target_url,
-            headers=headers,
             params=dict(request.GET.lists()) if request.GET else None,
-            data=request.body or None,
             timeout=timeout,
+            **proxy_kwargs,
         )
         if response.ok:
             logger.info(


### PR DESCRIPTION
## Problem

Emails with attachments dropped as it uses multipart form data. [Error](https://us.posthog.com/project/2/error_tracking/019d439a-c352-7643-adb8-0a52c65e637f?timestamp=2026-04-01T07%3A44%3A39.553000-07%3A00&searchQuery=conversations&dateRange=%7B%22date_from%22%3A%22-1h%22%2C%22date_to%22%3Anull%7D).

## Changes

Reconstruct the POST from the already-parsed request.POST and request.FILES instead of trying to re-read the raw body
