### PR TITLE
fix(cdp): reduce memory pressure in cyclotron worker kafka job queue

### DIFF
--- a/nodejs/src/cdp/services/job-queue/job-queue-kafka.ts
+++ b/nodejs/src/cdp/services/job-queue/job-queue-kafka.ts
@@ -76,36 +76,51 @@ export class CyclotronJobQueueKafka {
 
         const producer = this.getKafkaProducer()
 
+        // Pre-serialize all messages eagerly so we can release references to the
+        // heavy invocation objects (globals, vmState, etc.) before awaiting produces
+        const messages = invocations.map((x) => {
+            const jsonString = JSON.stringify(serializeInvocation(x))
+            cdpJobSizeKb.labels('kafka').observe(jsonString.length / 1024)
+
+            return {
+                jsonString,
+                queue: x.queue,
+                id: x.id,
+                functionId: x.functionId,
+                teamId: x.teamId,
+            }
+        })
+
+        // Allow the original invocations (with full globals/vmState) to be GC'd
+        invocations.length = 0
+
         await Promise.all(
-            invocations.map(async (x) => {
-                const serialized = serializeInvocation(x)
-
-                const jsonString = JSON.stringify(serialized)
-                cdpJobSizeKb.labels('kafka').observe(jsonString.length / 1024)
-
-                const value = this.config.CDP_CYCLOTRON_COMPRESS_KAFKA_DATA ? await compress(jsonString) : jsonString
+            messages.map(async (msg) => {
+                const value = this.config.CDP_CYCLOTRON_COMPRESS_KAFKA_DATA
+                    ? await compress(msg.jsonString)
+                    : msg.jsonString
 
                 cdpJobSizeCompressedKb.labels('kafka').observe(value.length / 1024)
 
                 const headers: Record<string, string> = {
                     // NOTE: Later we should remove hogFunctionId as it is no longer used
-                    hogFunctionId: x.functionId,
-                    functionId: x.functionId,
-                    teamId: x.teamId.toString(),
+                    hogFunctionId: msg.functionId,
+                    functionId: msg.functionId,
+                    teamId: msg.teamId.toString(),
                 }
 
                 await producer
                     .produce({
                         value: Buffer.from(value),
-                        key: Buffer.from(x.id),
-                        topic: `cdp_cyclotron_${x.queue}`,
+                        key: Buffer.from(msg.id),
+                        topic: `cdp_cyclotron_${msg.queue}`,
                         headers,
                     })
                     .catch((e) => {
                         logger.error('🔄', 'Error producing kafka message', {
                             error: String(e),
-                            teamId: x.teamId,
-                            functionId: x.functionId,
+                            teamId: msg.teamId,
+                            functionId: msg.functionId,
                             payloadSizeKb: value.length / 1024,
                         })
 
@@ -117,13 +132,12 @@ export class CyclotronJobQueueKafka {
 
     public async queueInvocationResults(invocationResults: CyclotronJobInvocationResult[]) {
         // With kafka we are essentially re-queuing the work to the target topic if it isn't finished
-        const invocations = invocationResults.reduce((acc, res) => {
-            if (res.finished) {
-                return acc
+        const invocations: CyclotronJobInvocation[] = []
+        for (const res of invocationResults) {
+            if (!res.finished) {
+                invocations.push(res.invocation)
             }
-
-            return [...acc, res.invocation]
-        }, [] as CyclotronJobInvocation[])
+        }
 
         await this.queueInvocations(invocations)
     }

--- a/nodejs/src/cdp/services/job-queue/job-queue-kafka.ts
+++ b/nodejs/src/cdp/services/job-queue/job-queue-kafka.ts
@@ -76,8 +76,8 @@ export class CyclotronJobQueueKafka {
 
         const producer = this.getKafkaProducer()
 
-        // Pre-serialize all messages eagerly so we can release references to the
-        // heavy invocation objects (globals, vmState, etc.) before awaiting produces
+        // Pre-serialize all messages eagerly so the produce closures below only
+        // capture lightweight strings instead of full invocation objects (globals, vmState, etc.)
         const messages = invocations.map((x) => {
             const jsonString = JSON.stringify(serializeInvocation(x))
             cdpJobSizeKb.labels('kafka').observe(jsonString.length / 1024)
@@ -90,9 +90,6 @@ export class CyclotronJobQueueKafka {
                 teamId: x.teamId,
             }
         })
-
-        // Allow the original invocations (with full globals/vmState) to be GC'd
-        invocations.length = 0
 
         await Promise.all(
             messages.map(async (msg) => {


### PR DESCRIPTION
### Problem
                                                                                                                 
When the worker queues jobs to Kafka, it fires off all 1000 produces in parallel. Each produce waits for WarpStream to confirm it received the message. While waiting, the code holds onto the full job data (event payloads, person properties, VM state) because the function closures reference it. When WarpStream is slow, the next batch arrives before the previous one is done. Now you have two batches of heavy objects in memory. Then three. Then four. This keeps going until the pod runs out of memory.

### Fix                                                                                                            
  
1. We serialize the jobs into JSON strings first, then throw away the original heavy objects before starting the produces. The parallel produces still happen at the same speed, but the closures now only hold flat strings instead of deeply nested objects. Once the JSON strings are produced, they get cleaned up normally.            
                                                            
2. Also fixed a smaller issue where filtering jobs was copying the entire array on every iteration instead of just appending to it.
                                                      