### PR TITLE
fix(sandbox): couldn't sed with non utf-8

### DIFF
--- a/bin/posthog-worktree
+++ b/bin/posthog-worktree
@@ -303,7 +303,7 @@ setup_worktree_environment() {
             local sed_inplace=(-i)
             [[ "$(uname -s)" == "Darwin" ]] && sed_inplace=(-i '')
             for activate_script in "${venv_bin}"/activate*; do
-                [[ -f "$activate_script" ]] && sed "${sed_inplace[@]}" "s|${old_venv}|${new_venv}|g" "$activate_script"
+                [[ -f "$activate_script" ]] && LC_ALL=C sed "${sed_inplace[@]}" "s|${old_venv}|${new_venv}|g" "$activate_script"
             done
             print_color blue "Patched venv activate scripts for worktree path"
         else


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

robot say

```
Why this happens: macOS BSD sed validates byte sequences against the current locale (typically en_US.UTF-8). If any activate script contains bytes that aren't valid UTF-8 (common in activate.fish or activate.csh which sometimes have locale-dependent
  strings), sed refuses to process the file. This is a macOS-specific behavior — GNU sed on Linux handles it fine
```

## Changes

make it happen

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

runs after the change

<!-- Briefly describe the steps you took, and what steps reviewers must take to get to where changes are, and what is the expected behavior. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Publish to changelog?

no

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->