### PR TITLE
feat(actions): improve add match group button layout

### DIFF
--- a/products/actions/frontend/pages/ActionEdit.tsx
+++ b/products/actions/frontend/pages/ActionEdit.tsx
@@ -260,7 +260,7 @@ export function ActionEdit({ action: loadedAction, id, actionLoading }: ActionEd
                     ) : (
                         <LemonField name="steps">
                             {({ value: stepsValue, onChange }) => (
-                                <div className="grid @4xl:grid-cols-2 gap-3">
+                                <div className="grid @4xl:grid-cols-2 gap-3 items-start">
                                     {stepsValue.map((step: ActionStepType, index: number) => {
                                         const identifier = String(JSON.stringify(step))
                                         return (
@@ -286,7 +286,7 @@ export function ActionEdit({ action: loadedAction, id, actionLoading }: ActionEd
                                         )
                                     })}
 
-                                    <div>
+                                    <div className="h-fit flex items-center justify-center self-center">
                                         <LemonButton
                                             icon={<IconPlus />}
                                             type="secondary"
@@ -294,7 +294,6 @@ export function ActionEdit({ action: loadedAction, id, actionLoading }: ActionEd
                                                 onChange([...(action.steps || []), DEFAULT_ACTION_STEP])
                                             }}
                                             center
-                                            className="w-full h-full"
                                             disabledReason={cannotEditReason ?? undefined}
                                         >
                                             Add match group


### PR DESCRIPTION
## Problem

When editing an action with multiple match groups in a two-column layout, the "Add match group" control stretched to full row height and looked misaligned with the match group cards.

## Changes

- Align the steps grid with `items-start` so columns top-align.
- Wrap the add button in a centered, height-fit container (`self-center`) instead of stretching the button (`w-full h-full` on `LemonButton`).

<!-- If there are frontend changes, please include screenshots. -->

## How did you test this code?

Locally.

## Publish to changelog?

no

## Docs update

no

## 🤖 LLM context

Agent drafted the PR body from the branch diff (`ActionEdit.tsx` layout classes); branch pushed and PR opened via `gh pr create` against `master`.

Made with [Cursor](https://cursor.com)