### PR TITLE
feat(mcp): mcp version feature flag

### DIFF
--- a/services/mcp/src/lib/analytics.ts
+++ b/services/mcp/src/lib/analytics.ts
@@ -33,3 +33,17 @@ export const getPostHogClient = (devMode?: boolean): PostHog => {
 
     return _client
 }
+
+export async function isFeatureFlagEnabled(
+    flagKey: string,
+    distinctId: string,
+    devMode?: boolean
+): Promise<boolean> {
+    try {
+        const client = getPostHogClient(devMode)
+        const result = await client.isFeatureEnabled(flagKey, distinctId)
+        return result === true
+    } catch {
+        return false
+    }
+}

--- a/services/mcp/src/mcp.ts
+++ b/services/mcp/src/mcp.ts
@@ -5,7 +5,7 @@ import { McpAgent } from 'agents/mcp'
 import type { z } from 'zod'
 
 import { ApiClient, type GroupType } from '@/api/client'
-import { AnalyticsEvent, generateId, getPostHogClient } from '@/lib/analytics'
+import { AnalyticsEvent, generateId, getPostHogClient, isFeatureFlagEnabled } from '@/lib/analytics'
 import { DurableObjectCache } from '@/lib/cache/DurableObjectCache'
 import {
     CUSTOM_API_BASE_URL,
@@ -413,10 +413,11 @@ export class MCP extends McpAgent<Env> {
     }
 
     async init(): Promise<void> {
-        const { features, version, organizationId, projectId, readOnly } = this.requestProperties
+        const { features, version: clientVersion, organizationId, projectId, readOnly } = this.requestProperties
 
-        // Pre-seed cache and fetch group types in parallel
+        // Pre-seed cache, fetch group types, and evaluate feature flag in parallel
         const groupTypesPromise = projectId ? this.getOrFetchGroupTypes(projectId) : Promise.resolve(undefined)
+        const flagPromise = this.resolveVersionFlag()
         if (organizationId) {
             await this.cache.set('orgId', organizationId)
         }
@@ -424,8 +425,10 @@ export class MCP extends McpAgent<Env> {
             await this.cache.set('projectId', projectId)
         }
 
-        // Resolve group types (started above in parallel with cache seeding)
+        // Resolve group types and feature flag (started above in parallel with cache seeding)
         const groupTypes = await groupTypesPromise
+        const flagVersion = await flagPromise
+        const version = flagVersion ?? clientVersion ?? 1
         const instructions = version === 2 ? buildInstructions(groupTypes) : INSTRUCTIONS_TEMPLATE_V1
 
         this.server = new McpServer({ name: 'PostHog', version: '1.0.0' }, { instructions })
@@ -465,6 +468,15 @@ export class MCP extends McpAgent<Env> {
         for (const tool of allTools) {
             const typedTool = tool as Tool<z.ZodObject>
             this.registerTool(typedTool, async (params) => typedTool.handler(context, params))
+        }
+    }
+
+    private async resolveVersionFlag(): Promise<number | undefined> {
+        try {
+            const distinctId = await this.getDistinctId()
+            return (await isFeatureFlagEnabled('mcp-version-2', distinctId, !!CUSTOM_API_BASE_URL)) ? 2 : undefined
+        } catch {
+            return undefined
         }
     }
 

--- a/services/mcp/tests/unit/feature-flag-version.test.ts
+++ b/services/mcp/tests/unit/feature-flag-version.test.ts
@@ -1,0 +1,47 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockIsFeatureEnabled = vi.fn()
+
+vi.mock('posthog-node', () => ({
+    PostHog: vi.fn().mockImplementation(() => ({
+        isFeatureEnabled: mockIsFeatureEnabled,
+    })),
+}))
+
+// Must import after vi.mock
+import { isFeatureFlagEnabled } from '@/lib/analytics'
+
+describe('isFeatureFlagEnabled', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+    })
+
+    it('should return true when the flag is enabled', async () => {
+        mockIsFeatureEnabled.mockResolvedValue(true)
+
+        const result = await isFeatureFlagEnabled('mcp-version-2', 'user-123')
+        expect(result).toBe(true)
+        expect(mockIsFeatureEnabled).toHaveBeenCalledWith('mcp-version-2', 'user-123')
+    })
+
+    it('should return false when the flag is disabled', async () => {
+        mockIsFeatureEnabled.mockResolvedValue(false)
+
+        const result = await isFeatureFlagEnabled('mcp-version-2', 'user-123')
+        expect(result).toBe(false)
+    })
+
+    it('should return false when the flag returns undefined', async () => {
+        mockIsFeatureEnabled.mockResolvedValue(undefined)
+
+        const result = await isFeatureFlagEnabled('mcp-version-2', 'user-123')
+        expect(result).toBe(false)
+    })
+
+    it('should return false when the client throws', async () => {
+        mockIsFeatureEnabled.mockRejectedValue(new Error('network error'))
+
+        const result = await isFeatureFlagEnabled('mcp-version-2', 'user-123')
+        expect(result).toBe(false)
+    })
+})


### PR DESCRIPTION
## Problem

The MCP service needs to support gradual rollout of version 2 through feature flags, allowing us to control which users get the new version without requiring client-side changes.

## Changes

- Added `isFeatureFlagEnabled()` function in `lib/analytics.ts` that wraps PostHog's feature flag evaluation with error handling
- Updated `MCP.init()` to evaluate the `mcp-version-2` feature flag and use it to determine the MCP version, with fallback to the client-provided version
- Added `resolveVersionFlag()` private method to safely evaluate the feature flag using the distinct ID
- Added comprehensive unit tests for the feature flag evaluation function covering success cases, disabled flags, undefined responses, and error handling

The implementation prioritizes the feature flag result when available, falling back to the client-provided version if the flag evaluation fails or returns undefined.

## How did you test this code?

Added unit tests in `services/mcp/tests/unit/feature-flag-version.test.ts` that cover:
- Feature flag enabled scenario
- Feature flag disabled scenario
- Undefined flag response handling
- Error handling when PostHog client throws

The tests mock the PostHog client and verify that `isFeatureFlagEnabled()` correctly handles all cases and returns false on errors.

## Publish to changelog?

No

https://claude.ai/code/session_01W7UQ4nzbs2NpWALVP9i3wy