### PR TITLE
chore(modeling): fix possible race for failed row counts

### DIFF
--- a/posthog/temporal/data_modeling/run_workflow.py
+++ b/posthog/temporal/data_modeling/run_workflow.py
@@ -575,6 +575,8 @@ async def materialize_model(
 
     except ObjectDoesNotExist:
         raise
+    except DataModelingCancelledException:
+        raise
     except Exception as e:
         error_message = str(e)
         await logger.aerror(f"Error materializing model {model_label}: {error_message}")

--- a/posthog/temporal/data_modeling/run_workflow.py
+++ b/posthog/temporal/data_modeling/run_workflow.py
@@ -554,11 +554,15 @@ async def materialize_model(
             write_duration = (dt.datetime.now() - write_start).total_seconds()
 
             row_count = row_count + batch.num_rows
-            job.rows_materialized = row_count
-
             save_start = dt.datetime.now()
-            await database_sync_to_async(job.save)()
+            updated = await database_sync_to_async(
+                DataModelingJob.objects.filter(id=job.id, status=DataModelingJob.Status.RUNNING).update
+            )(rows_materialized=row_count)
             save_duration = (dt.datetime.now() - save_start).total_seconds()
+
+            if updated == 0:
+                await logger.awarning("Job %s is no longer running, stopping materialization", job.id)
+                raise DataModelingCancelledException("Job was cancelled or preempted during materialization")
 
             await logger.adebug(
                 f"Batch {index} timings: write={write_duration:.2f}s, save={save_duration:.2f}s, total={write_duration + save_duration:.2f}s"

--- a/posthog/temporal/tests/data_modeling/test_run_workflow.py
+++ b/posthog/temporal/tests/data_modeling/test_run_workflow.py
@@ -753,12 +753,6 @@ async def test_run_workflow_with_minio_bucket(
     expected_events_a = [event for event in all_expected_events if event["distinct_id"] == "a"]
     expected_events_b = [event for event in all_expected_events if event["distinct_id"] == "b"]
 
-    workflow_id = str(uuid.uuid4())
-    inputs = RunWorkflowInputs(
-        team_id=ateam.pk,
-        select=[Selector(label=saved_query.id.hex, ancestors=0, descendants=0) for saved_query in saved_queries],
-    )
-
     with (
         override_settings(
             BUCKET_URL=f"s3://{bucket_name}",
@@ -786,14 +780,21 @@ async def test_run_workflow_with_minio_bucket(
         ):
             # Ensure the team exists in the DB context before running workflow
             await database_sync_to_async(Team.objects.get)(pk=ateam.pk)
-            await temporal_client.execute_workflow(
-                RunWorkflow.run,
-                inputs,
-                id=workflow_id,
-                task_queue=settings.DATA_MODELING_TASK_QUEUE,
-                retry_policy=temporalio.common.RetryPolicy(maximum_attempts=1),
-                execution_timeout=dt.timedelta(seconds=30),
-            )
+
+            for saved_query in saved_queries:
+                workflow_id = str(uuid.uuid4())
+                inputs = RunWorkflowInputs(
+                    team_id=ateam.pk,
+                    select=[Selector(label=saved_query.id.hex, ancestors=0, descendants=0)],
+                )
+                await temporal_client.execute_workflow(
+                    RunWorkflow.run,
+                    inputs,
+                    id=workflow_id,
+                    task_queue=settings.DATA_MODELING_TASK_QUEUE,
+                    retry_policy=temporalio.common.RetryPolicy(maximum_attempts=1),
+                    execution_timeout=dt.timedelta(seconds=30),
+                )
 
             tables_and_queries = {}
 


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

we still have some (very few) failed jobs that slip through with a non-zero materialized row count

## Changes

i think this is a race between preempting / cancelling a job and the row count update in the batch. if the job is retrieved (RUNNING) and then preempted / cancelled, and then the row count is updated by the batch, then we end up with a failed job with a row count until the next batch iteration catches that the job is no longer RUNNING.

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took, and what steps reviewers must take to get to where changes are, and what is the expected behavior. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

i didn't bc this is prob an async issue and kinda hard to repro. this fix is mostly a hunch

## Publish to changelog?

no

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->