### PR TITLE
fix(pinterest_ads): handle missing stats columns by returning zero values

### DIFF
--- a/products/marketing_analytics/backend/hogql_queries/adapters/pinterest_ads.py
+++ b/products/marketing_analytics/backend/hogql_queries/adapters/pinterest_ads.py
@@ -45,6 +45,13 @@ class PinterestAdsAdapter(MarketingSourceAdapter[PinterestAdsConfig]):
                     stats_table=self.config.stats_table.name,
                 )
 
+            for col in ("total_impression", "total_clickthrough", "spend_in_dollar"):
+                if not self._has_stats_column(col):
+                    self.logger.warning(
+                        f"Pinterest Ads stats table missing '{col}' column, metric will be reported as 0",
+                        stats_table=self.config.stats_table.name,
+                    )
+
             is_valid = len(errors) == 0
             self._log_validation_errors(errors)
 

--- a/products/marketing_analytics/backend/hogql_queries/adapters/pinterest_ads.py
+++ b/products/marketing_analytics/backend/hogql_queries/adapters/pinterest_ads.py
@@ -67,6 +67,9 @@ class PinterestAdsAdapter(MarketingSourceAdapter[PinterestAdsConfig]):
         return ast.Call(name="toString", args=[field_expr])
 
     def _get_impressions_field(self) -> ast.Expr:
+        if not self._has_stats_column("total_impression"):
+            return ast.Call(name="toFloat", args=[ast.Constant(value=0)])
+
         stats_table_name = self.config.stats_table.name
         field_as_float = ast.Call(
             name="ifNull",
@@ -79,6 +82,9 @@ class PinterestAdsAdapter(MarketingSourceAdapter[PinterestAdsConfig]):
         return ast.Call(name="toFloat", args=[sum])
 
     def _get_clicks_field(self) -> ast.Expr:
+        if not self._has_stats_column("total_clickthrough"):
+            return ast.Call(name="toFloat", args=[ast.Constant(value=0)])
+
         stats_table_name = self.config.stats_table.name
         field_as_float = ast.Call(
             name="ifNull",
@@ -91,6 +97,9 @@ class PinterestAdsAdapter(MarketingSourceAdapter[PinterestAdsConfig]):
         return ast.Call(name="toFloat", args=[sum])
 
     def _get_cost_field(self) -> ast.Expr:
+        if not self._has_stats_column("spend_in_dollar"):
+            return ast.Call(name="toFloat", args=[ast.Constant(value=0)])
+
         stats_table_name = self.config.stats_table.name
 
         # Pinterest spend_in_dollar is already in standard dollar units (no micro conversion needed)

--- a/products/marketing_analytics/backend/hogql_queries/test_adapters.py
+++ b/products/marketing_analytics/backend/hogql_queries/test_adapters.py
@@ -1140,6 +1140,33 @@ class TestMarketingAnalyticsAdapters(ClickhouseTestMixin, BaseTest):
         assert result.is_valid, "BingAdsAdapter validation should succeed"
         assert isinstance(result.errors, list), "BingAdsAdapter should return list of errors"
 
+    @parameterized.expand(
+        [
+            ("total_impression", "_get_impressions_field"),
+            ("total_clickthrough", "_get_clicks_field"),
+            ("spend_in_dollar", "_get_cost_field"),
+        ]
+    )
+    def test_pinterest_ads_returns_zero_when_stats_column_missing(self, missing_column, field_method):
+        campaign_table = self._create_mock_table("pinterestads_campaigns", "PinterestAds")
+        stats_table = self._create_mock_table("pinterestads_campaign_analytics", "PinterestAds")
+        all_columns = ("total_impression", "total_clickthrough", "spend_in_dollar")
+        stats_table.columns = {col: {"valid": True} for col in all_columns if col != missing_column}
+
+        config = PinterestAdsConfig(
+            campaign_table=campaign_table,
+            stats_table=stats_table,
+            source_type="PinterestAds",
+            source_id="test_missing_column",
+        )
+        adapter = PinterestAdsAdapter(config=config, context=self.context)
+        expr = getattr(adapter, field_method)()
+
+        assert isinstance(expr, ast.Call)
+        assert expr.name == "toFloat"
+        assert isinstance(expr.args[0], ast.Constant)
+        assert expr.args[0].value == 0
+
     def test_pinterest_ads_adapter_validation_consistency(self):
         campaign_table = self._create_mock_table("pinterestads_campaigns", "PinterestAds")
         stats_table = self._create_mock_table("pinterestads_campaign_analytics", "PinterestAds")

--- a/products/marketing_analytics/backend/hogql_queries/test_adapters.py
+++ b/products/marketing_analytics/backend/hogql_queries/test_adapters.py
@@ -1310,6 +1310,11 @@ class TestMarketingAnalyticsAdapters(ClickhouseTestMixin, BaseTest):
     def test_pinterest_ads_native_query_generation(self):
         campaign_table = self._create_mock_table("pinterest_campaigns", "PinterestAds")
         stats_table = self._create_mock_table("pinterest_campaign_analytics", "PinterestAds")
+        stats_table.columns = {
+            "total_impression": {"valid": True},
+            "total_clickthrough": {"valid": True},
+            "spend_in_dollar": {"valid": True},
+        }
 
         config = PinterestAdsConfig(
             campaign_table=campaign_table,


### PR DESCRIPTION
## Problem

Pinterest Ads adapter crashes with "Field not found: total_clickthrough" when querying the marketing analytics overview. This happens when the data warehouse table doesn't have certain columns in its metadata (e.g., the sync didn't include clickthrough data yet, or the column is marked as invalid).

The adapter already had defensive `_has_stats_column()` checks for optional fields (`total_conversions`, `total_checkout_value_in_micro_dollar`) but was missing them for core fields (`total_impression`, `total_clickthrough`, `spend_in_dollar`).

## Changes

- Add `_has_stats_column()` guards to `_get_impressions_field()`, `_get_clicks_field()`, and `_get_cost_field()` in the Pinterest Ads adapter, returning `toFloat(0)` when the column is missing — same pattern already used for conversion fields
- Update test mock to include column metadata so the snapshot test continues to verify the full query generation path

## How did you test this code?

- Existing `test_pinterest_ads_adapter_with_real_data` test validates the full query with real CSV data (columns present)
- Updated `test_pinterest_ads_native_query_generation` mock to include column metadata, ensuring snapshot stays valid
- Manually tested against a live Pinterest Ads account

## Publish to changelog?

No