### PR TITLE
feat(signals): Add priority sorting to signal report list API

### DIFF
--- a/products/signals/backend/test/test_signal_report_api.py
+++ b/products/signals/backend/test/test_signal_report_api.py
@@ -235,6 +235,29 @@ class TestSignalReportListAPI(APIBaseTest):
         ids = [r["id"] for r in response.json()["results"]]
         assert ids.index(str(heavy.id)) < ids.index(str(light.id))
 
+    def test_ordering_by_priority_sorts_p0_first(self):
+        """priority ordering: P0 > P1 > P2 > P3 > P4 > null."""
+        r_p3 = self._create_report(title="P3 report", summary="s", signal_count=1, total_weight=1.0)
+        r_p1 = self._create_report(title="P1 report", summary="s", signal_count=1, total_weight=1.0)
+        r_p0 = self._create_report(title="P0 report", summary="s", signal_count=1, total_weight=1.0)
+        r_p2 = self._create_report(title="P2 report", summary="s", signal_count=1, total_weight=1.0)
+        r_none = self._create_report(title="No priority", summary="s", signal_count=1, total_weight=1.0)
+        r_p4 = self._create_report(title="P4 report", summary="s", signal_count=1, total_weight=1.0)
+        self._priority_artefact(r_p3, priority="P3")
+        self._priority_artefact(r_p1, priority="P1")
+        self._priority_artefact(r_p0, priority="P0")
+        self._priority_artefact(r_p2, priority="P2")
+        self._priority_artefact(r_p4, priority="P4")
+
+        response = self.client.get(self._list_url(status="ready", ordering="priority"))
+        assert response.status_code == status.HTTP_200_OK
+        ids = [r["id"] for r in response.json()["results"]]
+        assert ids.index(str(r_p0.id)) < ids.index(str(r_p1.id))
+        assert ids.index(str(r_p1.id)) < ids.index(str(r_p2.id))
+        assert ids.index(str(r_p2.id)) < ids.index(str(r_p3.id))
+        assert ids.index(str(r_p3.id)) < ids.index(str(r_p4.id))
+        assert ids.index(str(r_p4.id)) < ids.index(str(r_none.id))
+
     def test_ordering_by_total_weight_only_crosses_status_rank(self):
         """Without `status`, `ordering=-total_weight` is a global sort by weight."""
         low_ready = self._create_report(

--- a/products/signals/backend/views.py
+++ b/products/signals/backend/views.py
@@ -5,7 +5,23 @@ from typing import cast
 
 from django.conf import settings
 from django.db import IntegrityError
-from django.db.models import Case, Count, Exists, IntegerField, OuterRef, Prefetch, Q, Value, When
+from django.db.models import (
+    Case,
+    CharField,
+    Count,
+    Exists,
+    F,
+    Func,
+    IntegerField,
+    JSONField,
+    OuterRef,
+    Prefetch,
+    Q,
+    Subquery,
+    Value,
+    When,
+)
+from django.db.models.functions import Cast, Coalesce
 
 import structlog
 from asgiref.sync import async_to_sync
@@ -288,6 +304,7 @@ class SignalReportViewSet(
         "is_suggested_reviewer": "is_suggested_reviewer",
         "signal_count": "signal_count",
         "total_weight": "total_weight",
+        "priority": "priority_rank",
         "created_at": "created_at",
         "updated_at": "updated_at",
         "id": "id",
@@ -319,6 +336,30 @@ class SignalReportViewSet(
                 default=Value(50),
                 output_field=IntegerField(),
             )
+        )
+        # `ordering=priority` sorts by the priority value ("P0"–"P4") from the latest priority_judgment
+        # artefact. These sort lexicographically, so we extract via jsonb and coalesce NULL to "~"
+        # (sorts after "P4") for reports without a priority. The startswith guard skips non-object content.
+        latest_priority = Subquery(
+            SignalReportArtefact.objects.filter(
+                report_id=OuterRef("id"),
+                type=SignalReportArtefact.ArtefactType.PRIORITY_JUDGMENT,
+                content__startswith="{",
+            )
+            .order_by("-created_at")
+            .annotate(
+                _priority_val=Func(
+                    Cast(F("content"), output_field=JSONField()),
+                    Value("priority"),
+                    function="jsonb_extract_path_text",
+                    output_field=CharField(),
+                ),
+            )
+            .values("_priority_val")[:1],
+            output_field=CharField(),
+        )
+        qs = qs.annotate(
+            priority_rank=Coalesce(latest_priority, Value("~"), output_field=CharField()),
         )
         qs = qs.prefetch_related(
             Prefetch(


### PR DESCRIPTION
## Problem

Signal reports can be sorted by status, weight, etc. but not by priority (P0–P4), which we need to surface the most critical reports first.

## Changes

Adding `priority` as a valid ordering field for the signal report list endpoint.

## How did you test this code?

New test `test_ordering_by_priority_sorts_p0_first` in `test_signal_report_api.py`.

## Publish to changelog?

No
