### PR TITLE
fix(ci): temporal client thread cleanup on command exit

### DIFF
--- a/posthog/management/commands/register_temporal_search_attributes.py
+++ b/posthog/management/commands/register_temporal_search_attributes.py
@@ -1,4 +1,4 @@
-import os
+import gc
 import asyncio
 import logging
 
@@ -49,48 +49,50 @@ class Command(BaseCommand):
     def handle(self, **options):
         logger.setLevel(logging.INFO)
         asyncio.run(self._run(options))
-        # The Temporal client's Rust/gRPC bridge spawns background threads that
-        # can outlive the event loop.  During CPython finalization those threads
-        # trip over a destroyed GIL → "PyGILState_Release: thread state … must
-        # be current" + SIGABRT.  Since the command is done at this point, skip
-        # interpreter teardown entirely.
-        os._exit(0)
 
     async def _run(self, options):
         namespace = options["namespace"]
         dry_run = options["dry_run"]
         temporal = await async_connect()
 
-        # List existing attributes
-        resp = await temporal.operator_service.list_search_attributes(
-            ops.ListSearchAttributesRequest(namespace=namespace)
-        )
-        existing = set(resp.custom_attributes.keys())
-
-        # Find which ones need registering
-        to_register = {}
-        for key in POSTHOG_SEARCH_ATTRIBUTES:
-            if key.name in existing:
-                logger.info("Already registered", attribute=key.name)
-            else:
-                to_register[key.name] = _resolve_type(key)
-
-        if not to_register:
-            logger.info("All search attributes already registered")
-            return
-
-        if dry_run:
-            for name, typ in to_register.items():
-                logger.info("Would register", attribute=name, type=enums.IndexedValueType.Name(typ))
-            return
-
-        logger.info(f"Registering {len(to_register)} search attribute(s)", attributes=list(to_register.keys()))
-
-        await temporal.operator_service.add_search_attributes(
-            ops.AddSearchAttributesRequest(
-                namespace=namespace,
-                search_attributes=to_register,
+        try:
+            # List existing attributes
+            resp = await temporal.operator_service.list_search_attributes(
+                ops.ListSearchAttributesRequest(namespace=namespace)
             )
-        )
+            existing = set(resp.custom_attributes.keys())
 
-        logger.info("Done")
+            # Find which ones need registering
+            to_register = {}
+            for key in POSTHOG_SEARCH_ATTRIBUTES:
+                if key.name in existing:
+                    logger.info("Already registered", attribute=key.name)
+                else:
+                    to_register[key.name] = _resolve_type(key)
+
+            if not to_register:
+                logger.info("All search attributes already registered")
+                return
+
+            if dry_run:
+                for name, typ in to_register.items():
+                    logger.info("Would register", attribute=name, type=enums.IndexedValueType.Name(typ))
+                return
+
+            logger.info(f"Registering {len(to_register)} search attribute(s)", attributes=list(to_register.keys()))
+
+            await temporal.operator_service.add_search_attributes(
+                ops.AddSearchAttributesRequest(
+                    namespace=namespace,
+                    search_attributes=to_register,
+                )
+            )
+
+            logger.info("Done")
+        finally:
+            # Drop the Temporal client reference and force GC before the event
+            # loop tears down.  The Rust/gRPC bridge spawns background threads
+            # that crash during CPython finalization ("PyGILState_Release: thread
+            # state … must be current") if the bridge destructor hasn't run yet.
+            del temporal
+            gc.collect()

--- a/posthog/management/commands/register_temporal_search_attributes.py
+++ b/posthog/management/commands/register_temporal_search_attributes.py
@@ -1,3 +1,4 @@
+import os
 import asyncio
 import logging
 
@@ -48,6 +49,12 @@ class Command(BaseCommand):
     def handle(self, **options):
         logger.setLevel(logging.INFO)
         asyncio.run(self._run(options))
+        # The Temporal client's Rust/gRPC bridge spawns background threads that
+        # can outlive the event loop.  During CPython finalization those threads
+        # trip over a destroyed GIL → "PyGILState_Release: thread state … must
+        # be current" + SIGABRT.  Since the command is done at this point, skip
+        # interpreter teardown entirely.
+        os._exit(0)
 
     async def _run(self, options):
         namespace = options["namespace"]


### PR DESCRIPTION
## Problem

Jovan: CI sporadically fails with:
```
    ] Registering 3 search attribute(s) [posthog.management.commands.register_temporal_search_attributes] attributes=['PostHogTeamId', 'PostHogOrgId', 'PostHogDagId'] pid=9751 tid=140608323758976
    ] Done                           [posthog.management.commands.register_temporal_search_attributes] pid=9751 tid=140608323758976
Fatal Python error: PyGILState_Release: thread state 0x7fe19c00f8f0 must be current when releasing
Python runtime state: finalizing (tstate=0x00007fe1ed28ba30)

Thread 0x00007fe1ed30ab80 (most recent call first):
  <no Python frame>
```
Claude:
The Temporal client's Rust/gRPC bridge spawns background threads that can outlive the event loop. During CPython finalization, these threads can cause a crash with "PyGILState_Release: thread state … must be current" followed by SIGABRT when the GIL is destroyed while threads are still active.

## Changes

Added `os._exit(0)` call at the end of the `handle()` method in the `register_temporal_search_attributes` management command to skip interpreter teardown entirely once the command completes. This prevents the Python interpreter from attempting to clean up Temporal's background threads during finalization.

Also added the necessary `import os` statement.

## How did you test this code?

This is a targeted fix for a known issue with Temporal client cleanup. The change is minimal and only affects the exit behavior of this specific management command after it has completed its work. Existing tests should continue to pass, and the command will now exit cleanly without triggering GIL-related crashes during finalization.

## Docs update

No documentation update needed.

https://claude.ai/code/session_01XyNKiKLd78prdWRk5Ns8F3