### PR TITLE
chore(docs): add public open source repo guidance to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,6 +68,25 @@ Keep descriptions high-level, focusing on rationale and architecture for the hum
 - Description should be lowercase and not end with a period
 - Keep the first line under 72 characters
 
+### Public open source repo guidance
+
+This repository is public and all commit messages, pull request titles, and pull request descriptions must be safe for public readers.
+
+- Never mention internal-only systems, private incidents, customer data, private Slack threads, unreleased roadmap details, or security-sensitive implementation details.
+- Use product-facing and code-facing context that a public OSS contributor could understand from this repository alone.
+- If context is sensitive, summarize it at a high level without naming internal tools, accounts, or people.
+- Avoid citing private operational scale or incident metrics (for example, exact affected team counts, internal row-volume anecdotes, or customer-specific performance numbers) unless that data is already public and linkable.
+
+Examples:
+
+- ✅ Good: `fix(insights): handle missing series color in trend export`
+- ✅ Good: `chore(ci): reduce flaky backend test retries`
+- ❌ Avoid: `fix: patch issue found in acme-co prod workspace after sales escalation`
+- ❌ Avoid: `chore: workaround for internal k8s outage in us-east-2`
+- ❌ Avoid: `feat: add migration for private enterprise customer contract requirement`
+- ❌ Avoid: `fix: will run fine on our 12 million rows there now`
+- ❌ Avoid: `fix: we were failing there for 300 teams`
+
 ## CI / GitHub Actions
 
 - Every job in `.github/workflows/` must declare `timeout-minutes` — prevents stuck runners from burning credits indefinitely


### PR DESCRIPTION
### Motivation

- Clarify public repository guidance for commit messages and PR content to avoid leaking internal or sensitive information.

### Description

- Add a new "Public open source repo guidance" section to `AGENTS.md` that lists do/don't rules, examples of good/bad commit messages, and notes about using product- and code-facing context while avoiding internal details and sensitive metrics.

### Testing

- No automated tests were run for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd73cda1f4832e87128fcc2cff4e1e)