### PR TITLE
fix: prevent race condition in SelectExistingFeatureFlagModal test

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentForm/SelectExistingFeatureFlagModal.test.tsx
+++ b/frontend/src/scenes/experiments/ExperimentForm/SelectExistingFeatureFlagModal.test.tsx
@@ -5,6 +5,8 @@ import '@testing-library/jest-dom'
 import { cleanup, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 
+import { teamLogic } from 'scenes/teamLogic'
+
 import { useMocks } from '~/mocks/jest'
 import { initKeaTests } from '~/test/init'
 import {
@@ -94,6 +96,12 @@ describe('SelectExistingFeatureFlagModal', () => {
         initKeaTests()
         logic = selectExistingFeatureFlagModalLogic()
         logic.mount()
+
+        // Wait for teamLogic to have currentProjectId ready before opening modal
+        await waitFor(() => {
+            expect(teamLogic.values.currentProjectId).toBe(MOCK_TEAM_ID)
+        })
+
         logic.actions.openSelectExistingFeatureFlagModal()
 
         await waitFor(() => {


### PR DESCRIPTION
## Problem
The test was calling `openSelectExistingFeatureFlagModal()` immediately after mounting the logic, but `teamLogic.currentProjectId` hadn't loaded yet, causing the API URL to use "@current" instead of the actual team ID (997).

The `currentProjectId` selector in `teamLogic` falls back to "@current" when `currentTeam` hasn't been loaded yet, creating a race condition between:
1. `teamLogic` loading the currentTeam from the app context
2. `selectExistingFeatureFlagModalLogic` building the API URL

## Changes

Fixes race condition in SelectExistingFeatureFlagModal test where API URL becomes undefined/invalid due to timing issues.

- Added `waitFor` to ensure `teamLogic.values.currentProjectId` equals `MOCK_TEAM_ID` before opening the modal
- Added import for `teamLogic` to access currentProjectId directly
- This prevents the race condition and ensures proper test setup ordering