### PR TITLE
fix(workflows): Use CDP_PRODUCER for hogflow scheduler Kafka producer

### DIFF
--- a/nodejs/src/cdp/services/hogflow-schedule/hogflow-schedule.service.ts
+++ b/nodejs/src/cdp/services/hogflow-schedule/hogflow-schedule.service.ts
@@ -82,7 +82,7 @@ export class HogFlowScheduleService {
         }
 
         logger.info('HogFlowScheduleService: starting...')
-        this.kafkaProducer = await KafkaProducerWrapper.create(this.config.KAFKA_CLIENT_RACK)
+        this.kafkaProducer = await KafkaProducerWrapper.create(this.config.KAFKA_CLIENT_RACK, 'CDP_PRODUCER')
         logger.info('HogFlowScheduleService: Kafka producer connected')
 
         this.running = true


### PR DESCRIPTION
## Problem

The hogflow scheduler was using the default Kafka producer which reads from `KAFKA_PRODUCER_METADATA_BROKER_LIST` (pointing at MSK events). The `cdp_batch_hogflow_requests` topic only exists on WarpStream Cyclotron, so all dispatch attempts failed with `unknown topic or partition`.

## Changes

Switch from `KafkaProducerWrapper.create(rack)` to `KafkaProducerWrapper.create(rack, 'CDP_PRODUCER')` so the scheduler reads from `KAFKA_CDP_PRODUCER_METADATA_BROKER_LIST` which already points at WarpStream Cyclotron via the shared CDP config. This matches how the Cyclotron job queue and cohort membership consumer create their producers.

## How did you test this code?

Verified in dev that the scheduler was failing with `unknown topic or partition` on `cdp_batch_hogflow_requests`. Confirmed the topic exists on WarpStream Cyclotron via Kafbat UI. The `CDP_PRODUCER` env vars are already configured in `shared/cdp/common.dev.yaml`.

## Publish to changelog?

no

## Docs update

No docs update needed.