### PR TITLE
feat(llma): enable sentiment analysis MCP tool

### DIFF
--- a/products/llm_analytics/mcp/tools.yaml
+++ b/products/llm_analytics/mcp/tools.yaml
@@ -79,7 +79,20 @@ tools:
         enabled: false
     llm-analytics-sentiment-create:
         operation: llm_analytics_sentiment_create
-        enabled: false
+        enabled: true
+        scopes:
+            - llm_analytics:write
+        annotations:
+            readOnly: false
+            destructive: false
+            idempotent: true
+        title: Analyze sentiment
+        description: >
+            Classify sentiment of LLM trace or generation user messages as positive,
+            neutral, or negative. Pass a list of trace or generation IDs and an
+            analysis_level ("trace" or "generation"). Returns per-ID sentiment labels
+            with confidence scores and per-message breakdowns. Results are cached —
+            use force_refresh to recompute. Rate-limited.
     llm-analytics-summarization-create:
         operation: llm_analytics_summarization_create
         enabled: false

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -1064,6 +1064,21 @@
             "readOnlyHint": false
         }
     },
+    "llm-analytics-sentiment-create": {
+        "description": "Classify sentiment of LLM trace or generation user messages as positive, neutral, or negative. Pass a list of trace or generation IDs and an analysis_level (\"trace\" or \"generation\"). Returns per-ID sentiment labels with confidence scores and per-message breakdowns. Results are cached — use force_refresh to recompute. Rate-limited.",
+        "category": "LLM analytics",
+        "feature": "llm_analytics",
+        "summary": "Analyze sentiment",
+        "title": "Analyze sentiment",
+        "required_scopes": ["llm_analytics:write"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        }
+    },
     "notebooks-list": {
         "description": "List all notebooks in the project. Supports filtering by search term, created_by, last_modified_by, date_from, date_to, and contains. Returns title, short_id, and creation/modification metadata.",
         "category": "Notebooks",

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -1794,6 +1794,21 @@
             "readOnlyHint": false
         }
     },
+    "llm-analytics-sentiment-create": {
+        "description": "Classify sentiment of LLM trace or generation user messages as positive, neutral, or negative. Pass a list of trace or generation IDs and an analysis_level (\"trace\" or \"generation\"). Returns per-ID sentiment labels with confidence scores and per-message breakdowns. Results are cached — use force_refresh to recompute. Rate-limited.",
+        "category": "LLM analytics",
+        "feature": "llm_analytics",
+        "summary": "Analyze sentiment",
+        "title": "Analyze sentiment",
+        "required_scopes": ["llm_analytics:write"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        }
+    },
     "notebooks-list": {
         "description": "List all notebooks in the project. Supports filtering by search term, created_by, last_modified_by, date_from, date_to, and contains. Returns title, short_id, and creation/modification metadata.",
         "category": "Notebooks",

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -7937,11 +7937,6 @@ export namespace Schemas {
       properties?: (EventPropertyFilter | PersonPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter)[] | null;
     }
 
-    export interface DashboardGeneratedMetadata {
-      name: string;
-      description: string;
-    }
-
     /**
      * * `team` - Only team
     * `global` - Global
@@ -9222,53 +9217,6 @@ export namespace Schemas {
       Empty: 'empty',
     } as const;
 
-    export type HrefMatching = typeof HrefMatching[keyof typeof HrefMatching];
-
-
-    export const HrefMatching = {
-      Contains: 'contains',
-      Exact: 'exact',
-      Regex: 'regex',
-    } as const;
-
-    export type TextMatching = typeof TextMatching[keyof typeof TextMatching];
-
-
-    export const TextMatching = {
-      Contains: 'contains',
-      Exact: 'exact',
-      Regex: 'regex',
-    } as const;
-
-    export type UrlMatching = typeof UrlMatching[keyof typeof UrlMatching];
-
-
-    export const UrlMatching = {
-      Contains: 'contains',
-      Exact: 'exact',
-      Regex: 'regex',
-    } as const;
-
-    export interface EventsQueryActionStep {
-      /** @nullable */
-      event?: string | null;
-      /** @nullable */
-      href?: string | null;
-      href_matching?: HrefMatching | null;
-      /** @nullable */
-      properties?: (EventPropertyFilter | PersonPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter)[] | null;
-      /** @nullable */
-      selector?: string | null;
-      /** @nullable */
-      tag_name?: string | null;
-      /** @nullable */
-      text?: string | null;
-      text_matching?: TextMatching | null;
-      /** @nullable */
-      url?: string | null;
-      url_matching?: UrlMatching | null;
-    }
-
     export type EventsQueryKind = typeof EventsQueryKind[keyof typeof EventsQueryKind];
 
 
@@ -9317,11 +9265,6 @@ export namespace Schemas {
        * @nullable
        */
       actionId?: number | null;
-      /**
-       * Show events matching action steps directly, used when no actionId is provided (e.g. previewing unsaved actions). Ignored if actionId is set.
-       * @nullable
-       */
-      actionSteps?: EventsQueryActionStep[] | null;
       /**
        * Only fetch events that happened after this timestamp
        * @nullable
@@ -29977,18 +29920,6 @@ export namespace Schemas {
       Txt: 'txt',
     } as const;
 
-    export type EnvironmentsDashboardsGenerateMetadataCreateParams = {
-    format?: EnvironmentsDashboardsGenerateMetadataCreateFormat;
-    };
-
-    export type EnvironmentsDashboardsGenerateMetadataCreateFormat = typeof EnvironmentsDashboardsGenerateMetadataCreateFormat[keyof typeof EnvironmentsDashboardsGenerateMetadataCreateFormat];
-
-
-    export const EnvironmentsDashboardsGenerateMetadataCreateFormat = {
-      Json: 'json',
-      Txt: 'txt',
-    } as const;
-
     export type EnvironmentsDashboardsMoveTilePartialUpdateParams = {
     format?: EnvironmentsDashboardsMoveTilePartialUpdateFormat;
     };
@@ -32621,18 +32552,6 @@ export namespace Schemas {
 
 
     export const DashboardsCopyTileCreateFormat = {
-      Json: 'json',
-      Txt: 'txt',
-    } as const;
-
-    export type DashboardsGenerateMetadataCreateParams = {
-    format?: DashboardsGenerateMetadataCreateFormat;
-    };
-
-    export type DashboardsGenerateMetadataCreateFormat = typeof DashboardsGenerateMetadataCreateFormat[keyof typeof DashboardsGenerateMetadataCreateFormat];
-
-
-    export const DashboardsGenerateMetadataCreateFormat = {
       Json: 'json',
       Txt: 'txt',
     } as const;

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -7937,6 +7937,11 @@ export namespace Schemas {
       properties?: (EventPropertyFilter | PersonPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter)[] | null;
     }
 
+    export interface DashboardGeneratedMetadata {
+      name: string;
+      description: string;
+    }
+
     /**
      * * `team` - Only team
     * `global` - Global
@@ -9217,6 +9222,53 @@ export namespace Schemas {
       Empty: 'empty',
     } as const;
 
+    export type HrefMatching = typeof HrefMatching[keyof typeof HrefMatching];
+
+
+    export const HrefMatching = {
+      Contains: 'contains',
+      Exact: 'exact',
+      Regex: 'regex',
+    } as const;
+
+    export type TextMatching = typeof TextMatching[keyof typeof TextMatching];
+
+
+    export const TextMatching = {
+      Contains: 'contains',
+      Exact: 'exact',
+      Regex: 'regex',
+    } as const;
+
+    export type UrlMatching = typeof UrlMatching[keyof typeof UrlMatching];
+
+
+    export const UrlMatching = {
+      Contains: 'contains',
+      Exact: 'exact',
+      Regex: 'regex',
+    } as const;
+
+    export interface EventsQueryActionStep {
+      /** @nullable */
+      event?: string | null;
+      /** @nullable */
+      href?: string | null;
+      href_matching?: HrefMatching | null;
+      /** @nullable */
+      properties?: (EventPropertyFilter | PersonPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter)[] | null;
+      /** @nullable */
+      selector?: string | null;
+      /** @nullable */
+      tag_name?: string | null;
+      /** @nullable */
+      text?: string | null;
+      text_matching?: TextMatching | null;
+      /** @nullable */
+      url?: string | null;
+      url_matching?: UrlMatching | null;
+    }
+
     export type EventsQueryKind = typeof EventsQueryKind[keyof typeof EventsQueryKind];
 
 
@@ -9265,6 +9317,11 @@ export namespace Schemas {
        * @nullable
        */
       actionId?: number | null;
+      /**
+       * Show events matching action steps directly, used when no actionId is provided (e.g. previewing unsaved actions). Ignored if actionId is set.
+       * @nullable
+       */
+      actionSteps?: EventsQueryActionStep[] | null;
       /**
        * Only fetch events that happened after this timestamp
        * @nullable
@@ -29920,6 +29977,18 @@ export namespace Schemas {
       Txt: 'txt',
     } as const;
 
+    export type EnvironmentsDashboardsGenerateMetadataCreateParams = {
+    format?: EnvironmentsDashboardsGenerateMetadataCreateFormat;
+    };
+
+    export type EnvironmentsDashboardsGenerateMetadataCreateFormat = typeof EnvironmentsDashboardsGenerateMetadataCreateFormat[keyof typeof EnvironmentsDashboardsGenerateMetadataCreateFormat];
+
+
+    export const EnvironmentsDashboardsGenerateMetadataCreateFormat = {
+      Json: 'json',
+      Txt: 'txt',
+    } as const;
+
     export type EnvironmentsDashboardsMoveTilePartialUpdateParams = {
     format?: EnvironmentsDashboardsMoveTilePartialUpdateFormat;
     };
@@ -32552,6 +32621,18 @@ export namespace Schemas {
 
 
     export const DashboardsCopyTileCreateFormat = {
+      Json: 'json',
+      Txt: 'txt',
+    } as const;
+
+    export type DashboardsGenerateMetadataCreateParams = {
+    format?: DashboardsGenerateMetadataCreateFormat;
+    };
+
+    export type DashboardsGenerateMetadataCreateFormat = typeof DashboardsGenerateMetadataCreateFormat[keyof typeof DashboardsGenerateMetadataCreateFormat];
+
+
+    export const DashboardsGenerateMetadataCreateFormat = {
       Json: 'json',
       Txt: 'txt',
     } as const;

--- a/services/mcp/src/generated/llm_analytics/api.ts
+++ b/services/mcp/src/generated/llm_analytics/api.ts
@@ -1,0 +1,33 @@
+/**
+ * Auto-generated from the Django backend OpenAPI schema.
+ * MCP service uses these Zod schemas for generated tool handlers.
+ * To regenerate: hogli build:openapi
+ *
+ * PostHog API - MCP 1 enabled ops
+ * OpenAPI spec version: 1.0.0
+ */
+import * as zod from 'zod'
+
+export const LlmAnalyticsSentimentCreateParams = /* @__PURE__ */ zod.object({
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+})
+
+export const llmAnalyticsSentimentCreateBodyIdsMax = 5
+
+export const llmAnalyticsSentimentCreateBodyAnalysisLevelDefault = `trace`
+export const llmAnalyticsSentimentCreateBodyForceRefreshDefault = false
+
+export const LlmAnalyticsSentimentCreateBody = /* @__PURE__ */ zod.object({
+    ids: zod.array(zod.string()).min(1).max(llmAnalyticsSentimentCreateBodyIdsMax),
+    analysis_level: zod
+        .enum(['trace', 'generation'])
+        .describe('* `trace` - trace\n* `generation` - generation')
+        .default(llmAnalyticsSentimentCreateBodyAnalysisLevelDefault),
+    force_refresh: zod.boolean().default(llmAnalyticsSentimentCreateBodyForceRefreshDefault),
+    date_from: zod.string().nullish(),
+    date_to: zod.string().nullish(),
+})

--- a/services/mcp/src/lib/constants.ts
+++ b/services/mcp/src/lib/constants.ts
@@ -98,6 +98,8 @@ export const OAUTH_SCOPES_SUPPORTED = [
     'hog_function:write',
     'insight:read',
     'insight:write',
+    'llm_analytics:read',
+    'llm_analytics:write',
     'llm_prompt:read',
     'llm_prompt:write',
     'logs:read',

--- a/services/mcp/src/tools/generated/index.ts
+++ b/services/mcp/src/tools/generated/index.ts
@@ -13,6 +13,7 @@ import { GENERATED_TOOLS as data_warehouse } from './data_warehouse'
 import { GENERATED_TOOLS as early_access_features } from './early_access_features'
 import { GENERATED_TOOLS as error_tracking } from './error_tracking'
 import { GENERATED_TOOLS as feature_flags } from './feature_flags'
+import { GENERATED_TOOLS as llm_analytics } from './llm_analytics'
 import { GENERATED_TOOLS as notebooks } from './notebooks'
 import { GENERATED_TOOLS as persons } from './persons'
 import { GENERATED_TOOLS as prompts } from './prompts'
@@ -34,6 +35,7 @@ export const GENERATED_TOOL_MAP: Record<string, () => ToolBase<ZodObjectAny>> = 
     ...early_access_features,
     ...error_tracking,
     ...feature_flags,
+    ...llm_analytics,
     ...notebooks,
     ...persons,
     ...prompts,

--- a/services/mcp/src/tools/generated/llm_analytics.ts
+++ b/services/mcp/src/tools/generated/llm_analytics.ts
@@ -1,0 +1,45 @@
+// AUTO-GENERATED from products/llm_analytics/mcp/tools.yaml + OpenAPI — do not edit
+import { z } from 'zod'
+
+import type { Schemas } from '@/api/generated'
+import { LlmAnalyticsSentimentCreateBody } from '@/generated/llm_analytics/api'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
+
+const LlmAnalyticsSentimentCreateSchema = LlmAnalyticsSentimentCreateBody
+
+const llmAnalyticsSentimentCreate = (): ToolBase<
+    typeof LlmAnalyticsSentimentCreateSchema,
+    Schemas.SentimentBatchResponse
+> => ({
+    name: 'llm-analytics-sentiment-create',
+    schema: LlmAnalyticsSentimentCreateSchema,
+    handler: async (context: Context, params: z.infer<typeof LlmAnalyticsSentimentCreateSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const body: Record<string, unknown> = {}
+        if (params.ids !== undefined) {
+            body['ids'] = params.ids
+        }
+        if (params.analysis_level !== undefined) {
+            body['analysis_level'] = params.analysis_level
+        }
+        if (params.force_refresh !== undefined) {
+            body['force_refresh'] = params.force_refresh
+        }
+        if (params.date_from !== undefined) {
+            body['date_from'] = params.date_from
+        }
+        if (params.date_to !== undefined) {
+            body['date_to'] = params.date_to
+        }
+        const result = await context.api.request<Schemas.SentimentBatchResponse>({
+            method: 'POST',
+            path: `/api/environments/${projectId}/llm_analytics/sentiment/`,
+            body,
+        })
+        return result
+    },
+})
+
+export const GENERATED_TOOLS: Record<string, () => ToolBase<ZodObjectAny>> = {
+    'llm-analytics-sentiment-create': llmAnalyticsSentimentCreate,
+}

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/llm-analytics-sentiment-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/llm-analytics-sentiment-create.json
@@ -1,0 +1,45 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "analysis_level": {
+            "default": "trace",
+            "description": "* `trace` - trace\n* `generation` - generation",
+            "enum": ["trace", "generation"],
+            "type": "string"
+        },
+        "date_from": {
+            "anyOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "null"
+                }
+            ]
+        },
+        "date_to": {
+            "anyOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "null"
+                }
+            ]
+        },
+        "force_refresh": {
+            "default": false,
+            "type": "boolean"
+        },
+        "ids": {
+            "items": {
+                "type": "string"
+            },
+            "maxItems": 5,
+            "minItems": 1,
+            "type": "array"
+        }
+    },
+    "required": ["ids"],
+    "type": "object"
+}


### PR DESCRIPTION
## Problem

MCP users exploring LLM traces and clusters have no way to analyze user message sentiment. The sentiment API exists and is production-ready (rate-limited, cached, access-controlled), but the MCP tool is disabled.

## Changes

Enable `llm-analytics-sentiment-create` in `products/llm_analytics/mcp/tools.yaml` with proper scopes and annotations.

The tool accepts a list of trace or generation IDs and returns sentiment classification (positive/neutral/negative) with confidence scores and per-message breakdowns. Results are cached server-side.

No backend changes — just YAML config.

## How did you test this code?

Agent-authored PR. YAML-only change, no logic to test. Verified lint/format hooks pass.

## Publish to changelog?

No

## 🤖 LLM context

Agent-authored. This is a companion to #53107 (clustering read tools). The sentiment tool completes a natural MCP workflow: explore clusters → find interesting traces → analyze sentiment.