### PR TITLE
fix(insights): fix tooltip positioning on bold number previous period link

### DIFF
--- a/frontend/src/scenes/insights/views/BoldNumber/BoldNumber.tsx
+++ b/frontend/src/scenes/insights/views/BoldNumber/BoldNumber.tsx
@@ -7,7 +7,7 @@ import { useEffect } from 'react'
 import React from 'react'
 
 import { IconTrending } from '@posthog/icons'
-import { LemonRow, Link, Tooltip } from '@posthog/lemon-ui'
+import { LemonRow, Link } from '@posthog/lemon-ui'
 
 import { IconFlare, IconTrendingDown, IconTrendingFlat } from 'lib/lemon-ui/icons'
 import { percentage } from 'lib/utils'
@@ -57,10 +57,12 @@ const BOLD_NUMBER_TOOLTIP_OFFSET_PX = 8
 function useBoldNumberTooltip({
     showPersonsModal,
     isTooltipShown,
+    seriesIndex = 0,
     groupTypeLabel,
 }: {
     showPersonsModal: boolean
     isTooltipShown: boolean
+    seriesIndex?: number
     groupTypeLabel?: string
 }): React.RefObject<HTMLDivElement> {
     const { insightProps } = useValues(insightLogic)
@@ -77,7 +79,7 @@ function useBoldNumberTooltip({
     useLayoutEffect(() => {
         tooltipEl.style.opacity = isTooltipShown ? '1' : '0'
 
-        const seriesResult = insightData?.result?.[0]
+        const seriesResult = insightData?.result?.[seriesIndex]
 
         tooltipRoot.render(
             <InsightTooltip
@@ -179,8 +181,14 @@ function BoldNumberComparison({
     context,
 }: Pick<ChartParams, 'showPersonsModal' | 'context'>): JSX.Element | null {
     const { insightProps } = useValues(insightLogic)
-    const { insightData, trendsFilter, querySource } = useValues(insightVizDataLogic(insightProps))
-    const { baseCurrency } = useValues(teamLogic)
+    const { insightData, querySource } = useValues(insightVizDataLogic(insightProps))
+
+    const [isTooltipShown, setIsTooltipShown] = useState(false)
+    const comparisonRef = useBoldNumberTooltip({
+        showPersonsModal,
+        isTooltipShown,
+        seriesIndex: 1,
+    })
 
     if (!insightData?.result) {
         return null
@@ -196,9 +204,6 @@ function BoldNumberComparison({
         hasComparableDiff,
         displayText: percentageDiffDisplay,
     } = computeComparisonDisplay(currentValue, previousValue)
-
-    const formattedPreviousValue =
-        previousValue !== null ? formatAggregationAxisValue(trendsFilter, previousValue, baseCurrency) : null
 
     return (
         <LemonRow
@@ -225,7 +230,11 @@ function BoldNumberComparison({
                 ) : previousValue === null || !showPersonsModal || !hasComparableDiff ? (
                     'previous period'
                 ) : (
-                    <Tooltip title={`Previous period value: ${formattedPreviousValue}`}>
+                    <span
+                        ref={comparisonRef}
+                        onMouseEnter={() => setIsTooltipShown(true)}
+                        onMouseLeave={() => setIsTooltipShown(false)}
+                    >
                         <Link
                             onClick={() => {
                                 if (context?.onDataPointClick) {
@@ -250,7 +259,7 @@ function BoldNumberComparison({
                         >
                             previous period
                         </Link>
-                    </Tooltip>
+                    </span>
                 )}
             </span>
         </LemonRow>

--- a/frontend/src/scenes/insights/views/BoldNumber/BoldNumber.tsx
+++ b/frontend/src/scenes/insights/views/BoldNumber/BoldNumber.tsx
@@ -7,7 +7,7 @@ import { useEffect } from 'react'
 import React from 'react'
 
 import { IconTrending } from '@posthog/icons'
-import { LemonRow, Link } from '@posthog/lemon-ui'
+import { LemonRow, Link, Tooltip } from '@posthog/lemon-ui'
 
 import { IconFlare, IconTrendingDown, IconTrendingFlat } from 'lib/lemon-ui/icons'
 import { percentage } from 'lib/utils'
@@ -147,6 +147,7 @@ export function BoldNumber({ showPersonsModal = true, context }: ChartParams): J
                                     query: {
                                         kind: NodeKind.InsightActorsQuery,
                                         source: querySource!,
+                                        compare: showComparison ? 'current' : undefined,
                                         includeRecordings: true,
                                     },
                                     additionalSelect: {
@@ -178,7 +179,8 @@ function BoldNumberComparison({
     context,
 }: Pick<ChartParams, 'showPersonsModal' | 'context'>): JSX.Element | null {
     const { insightProps } = useValues(insightLogic)
-    const { insightData, querySource } = useValues(insightVizDataLogic(insightProps))
+    const { insightData, trendsFilter, querySource } = useValues(insightVizDataLogic(insightProps))
+    const { baseCurrency } = useValues(teamLogic)
 
     if (!insightData?.result) {
         return null
@@ -194,6 +196,9 @@ function BoldNumberComparison({
         hasComparableDiff,
         displayText: percentageDiffDisplay,
     } = computeComparisonDisplay(currentValue, previousValue)
+
+    const formattedPreviousValue =
+        previousValue !== null ? formatAggregationAxisValue(trendsFilter, previousValue, baseCurrency) : null
 
     return (
         <LemonRow
@@ -220,29 +225,38 @@ function BoldNumberComparison({
                 ) : previousValue === null || !showPersonsModal || !hasComparableDiff ? (
                     'previous period'
                 ) : (
-                    <Link
-                        onClick={() => {
-                            if (context?.onDataPointClick) {
-                                context.onDataPointClick({ compare: 'previous' }, currentPeriodSeries)
-                            } else {
-                                openPersonsModal({
-                                    title: previousPeriodSeries.label,
-                                    query: {
-                                        kind: NodeKind.InsightActorsQuery,
-                                        source: querySource!,
-                                        includeRecordings: true,
-                                    },
-                                    additionalSelect: {
-                                        value_at_data_point: 'event_count',
-                                        matched_recordings: 'matched_recordings',
-                                    },
-                                    orderBy: ['event_count DESC, actor_id DESC'],
-                                })
-                            }
-                        }}
+                    <Tooltip
+                        title={
+                            formattedPreviousValue !== null
+                                ? `Previous period value: ${formattedPreviousValue}`
+                                : undefined
+                        }
                     >
-                        previous period
-                    </Link>
+                        <Link
+                            onClick={() => {
+                                if (context?.onDataPointClick) {
+                                    context.onDataPointClick({ compare: 'previous' }, currentPeriodSeries)
+                                } else {
+                                    openPersonsModal({
+                                        title: previousPeriodSeries.label,
+                                        query: {
+                                            kind: NodeKind.InsightActorsQuery,
+                                            source: querySource!,
+                                            compare: 'previous',
+                                            includeRecordings: true,
+                                        },
+                                        additionalSelect: {
+                                            value_at_data_point: 'event_count',
+                                            matched_recordings: 'matched_recordings',
+                                        },
+                                        orderBy: ['event_count DESC, actor_id DESC'],
+                                    })
+                                }
+                            }}
+                        >
+                            previous period
+                        </Link>
+                    </Tooltip>
                 )}
             </span>
         </LemonRow>

--- a/frontend/src/scenes/insights/views/BoldNumber/BoldNumber.tsx
+++ b/frontend/src/scenes/insights/views/BoldNumber/BoldNumber.tsx
@@ -225,13 +225,7 @@ function BoldNumberComparison({
                 ) : previousValue === null || !showPersonsModal || !hasComparableDiff ? (
                     'previous period'
                 ) : (
-                    <Tooltip
-                        title={
-                            formattedPreviousValue !== null
-                                ? `Previous period value: ${formattedPreviousValue}`
-                                : undefined
-                        }
-                    >
+                    <Tooltip title={`Previous period value: ${formattedPreviousValue}`}>
                         <Link
                             onClick={() => {
                                 if (context?.onDataPointClick) {

--- a/frontend/src/scenes/insights/views/BoldNumber/BoldNumber.tsx
+++ b/frontend/src/scenes/insights/views/BoldNumber/BoldNumber.tsx
@@ -64,15 +64,15 @@ function useBoldNumberTooltip({
     isTooltipShown: boolean
     seriesIndex?: number
     groupTypeLabel?: string
-}): React.RefObject<HTMLDivElement> {
+}): React.RefObject<HTMLElement | null> {
     const { insightProps } = useValues(insightLogic)
     const { series, insightData, trendsFilter, breakdownFilter } = useValues(insightVizDataLogic(insightProps))
     const { aggregationLabel } = useValues(groupsModel)
     const { baseCurrency } = useValues(teamLogic)
 
-    const divRef = useRef<HTMLDivElement>(null)
+    const elementRef = useRef<HTMLElement | null>(null)
 
-    const divRect = divRef.current?.getBoundingClientRect()
+    const elementRect = elementRef.current?.getBoundingClientRect()
     const { getTooltip } = useInsightTooltip()
     const [tooltipRoot, tooltipEl] = getTooltip()
 
@@ -106,15 +106,15 @@ function useBoldNumberTooltip({
 
     useEffect(() => {
         const tooltipRect = tooltipEl.getBoundingClientRect()
-        if (divRect) {
+        if (elementRect) {
             tooltipEl.style.top = `${
-                window.scrollY + divRect.top - tooltipRect.height - BOLD_NUMBER_TOOLTIP_OFFSET_PX
+                window.scrollY + elementRect.top - tooltipRect.height - BOLD_NUMBER_TOOLTIP_OFFSET_PX
             }px`
-            tooltipEl.style.left = `${divRect.left + divRect.width / 2 - tooltipRect.width / 2}px`
+            tooltipEl.style.left = `${elementRect.left + elementRect.width / 2 - tooltipRect.width / 2}px`
         }
     })
 
-    return divRef
+    return elementRef
 }
 
 export function BoldNumber({ showPersonsModal = true, context }: ChartParams): JSX.Element {
@@ -230,38 +230,33 @@ function BoldNumberComparison({
                 ) : previousValue === null || !showPersonsModal || !hasComparableDiff ? (
                     'previous period'
                 ) : (
-                    <span
+                    <Link
                         ref={comparisonRef}
                         onMouseEnter={() => setIsTooltipShown(true)}
                         onMouseLeave={() => setIsTooltipShown(false)}
-                        // eslint-disable-next-line react/forbid-dom-props
-                        style={{ display: 'contents' }}
+                        onClick={() => {
+                            if (context?.onDataPointClick) {
+                                context.onDataPointClick({ compare: 'previous' }, currentPeriodSeries)
+                            } else {
+                                openPersonsModal({
+                                    title: previousPeriodSeries.label,
+                                    query: {
+                                        kind: NodeKind.InsightActorsQuery,
+                                        source: querySource!,
+                                        compare: 'previous',
+                                        includeRecordings: true,
+                                    },
+                                    additionalSelect: {
+                                        value_at_data_point: 'event_count',
+                                        matched_recordings: 'matched_recordings',
+                                    },
+                                    orderBy: ['event_count DESC, actor_id DESC'],
+                                })
+                            }
+                        }}
                     >
-                        <Link
-                            onClick={() => {
-                                if (context?.onDataPointClick) {
-                                    context.onDataPointClick({ compare: 'previous' }, currentPeriodSeries)
-                                } else {
-                                    openPersonsModal({
-                                        title: previousPeriodSeries.label,
-                                        query: {
-                                            kind: NodeKind.InsightActorsQuery,
-                                            source: querySource!,
-                                            compare: 'previous',
-                                            includeRecordings: true,
-                                        },
-                                        additionalSelect: {
-                                            value_at_data_point: 'event_count',
-                                            matched_recordings: 'matched_recordings',
-                                        },
-                                        orderBy: ['event_count DESC, actor_id DESC'],
-                                    })
-                                }
-                            }}
-                        >
-                            previous period
-                        </Link>
-                    </span>
+                        previous period
+                    </Link>
                 )}
             </span>
         </LemonRow>

--- a/frontend/src/scenes/insights/views/BoldNumber/BoldNumber.tsx
+++ b/frontend/src/scenes/insights/views/BoldNumber/BoldNumber.tsx
@@ -234,6 +234,8 @@ function BoldNumberComparison({
                         ref={comparisonRef}
                         onMouseEnter={() => setIsTooltipShown(true)}
                         onMouseLeave={() => setIsTooltipShown(false)}
+                        // eslint-disable-next-line react/forbid-dom-props
+                        style={{ display: 'contents' }}
                     >
                         <Link
                             onClick={() => {

--- a/frontend/src/scenes/insights/views/BoldNumber/BoldNumber.tsx
+++ b/frontend/src/scenes/insights/views/BoldNumber/BoldNumber.tsx
@@ -177,7 +177,7 @@ export function BoldNumber({ showPersonsModal = true, context }: ChartParams): J
 }
 
 function BoldNumberComparison({
-    showPersonsModal,
+    showPersonsModal = true,
     context,
 }: Pick<ChartParams, 'showPersonsModal' | 'context'>): JSX.Element | null {
     const { insightProps } = useValues(insightLogic)


### PR DESCRIPTION
## Problem

The tooltip on the "previous period" link in BoldNumber insights wasn't showing. The wrapper `<span style={{ display: 'contents' }}>` had no bounding box, causing `getBoundingClientRect()` to return zeros and tooltip positioning to fail.

## Changes

- Changed the ref type from `React.RefObject<HTMLDivElement>` to `React.RefObject<HTMLElement | null>` so it can be used on both `div` and `Link` elements
- Removed the wrapper `<span>` with `display: contents` and applied the ref directly to the `<Link>` component
- This gives the ref a proper bounding box for tooltip positioning

## How did you test this code?

Manually verified that hovering the "previous period" link now shows the InsightTooltip with the previous period value.

Slack thread: https://posthog.slack.com/archives/C0ACRAMJUAG/p1775050764968779?thread_ts=1774977653.814709&cid=C0ACRAMJUAG

## LLM context

Follow-up fix to #53033. The `display: contents` CSS property makes an element have no box model, which broke the tooltip positioning that relies on `getBoundingClientRect()`.

https://claude.ai/code/session_015LBYzb8bfxVCZkG2XwkEmL