### PR TITLE
feat(common): expose consumer configs WarpStream tuning requires

### DIFF
--- a/rust/common/kafka/src/config.rs
+++ b/rust/common/kafka/src/config.rs
@@ -48,6 +48,14 @@ pub struct ConsumerConfig {
     // Kafka offset commit attempts
     #[envconfig(default = "5000")]
     pub kafka_consumer_auto_commit_interval_ms: i32,
+
+    // Fetch tuning — None means "use librdkafka default" (i.e. don't override).
+    // WarpStream reads from object storage and benefits from larger, less frequent fetches.
+    pub kafka_consumer_fetch_wait_max_ms: Option<u32>,
+
+    pub kafka_consumer_fetch_min_bytes: Option<u32>,
+
+    pub kafka_consumer_fetch_max_bytes: Option<u32>,
 }
 
 impl ConsumerConfig {

--- a/rust/common/kafka/src/kafka_consumer.rs
+++ b/rust/common/kafka/src/kafka_consumer.rs
@@ -84,6 +84,16 @@ impl SingleTopicConsumer {
             );
         }
 
+        if let Some(v) = consumer_config.kafka_consumer_fetch_wait_max_ms {
+            client_config.set("fetch.wait.max.ms", v.to_string());
+        }
+        if let Some(v) = consumer_config.kafka_consumer_fetch_min_bytes {
+            client_config.set("fetch.min.bytes", v.to_string());
+        }
+        if let Some(v) = consumer_config.kafka_consumer_fetch_max_bytes {
+            client_config.set("fetch.max.bytes", v.to_string());
+        }
+
         let consumer: StreamConsumer = client_config.create()?;
         consumer.subscribe(&[consumer_config.kafka_consumer_topic.as_str()])?;
 


### PR DESCRIPTION
## Problem
Expose Kafka consumer tuning vars on `common` client pkg that `property-defs-rs` (and possibly other Rust projects in the workspace) need to fix fetch frequency and size configs to clear WarpStream Console warnings.

**This PR will need to land first before the deploy-config changes to enable them**
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
* Expose 3 new Kafka consumer env vars and set if present in the client config
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally and in CI; will smoke test in prod before rolling out
<!-- Briefly describe the steps you took, and what steps reviewers must take to get to where changes are, and what is the expected behavior. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
N/A
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update
N/A
<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
