### PR TITLE
chore: add .claude/scheduled_tasks.lock to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -145,6 +145,7 @@ posthog/management/commands/clear_demo_data.py
 # Ignore Claude Code settings
 .claude/settings.local.json
 .claude/worktrees/
+.claude/scheduled_tasks.lock
 
 # Ignore local mprocs configs
 bin/mprocs*.local.yaml


### PR DESCRIPTION
This is kept locally if you use `/loop` or some of the other scheduler commands