### PR TITLE
fix(vercel): handle 409 open invoices error during billing provider uninstall

### DIFF
--- a/ee/api/vercel/vercel_installation.py
+++ b/ee/api/vercel/vercel_installation.py
@@ -8,6 +8,7 @@ from rest_framework.response import Response
 
 from posthog.models.organization_integration import OrganizationIntegration
 
+from ee.billing.billing_manager import BillingServiceOpenInvoicesError
 from ee.api.authentication import VercelAuthentication
 from ee.api.vercel.utils import expect_vercel_user_claim
 from ee.api.vercel.vercel_error_mixin import VercelErrorResponseMixin
@@ -139,6 +140,11 @@ class VercelInstallationViewSet(VercelRegionProxyMixin, VercelErrorResponseMixin
         try:
             response_data = VercelIntegration.delete_installation(installation_id)
             self.invalidate_installation_cache(installation_id)
+        except BillingServiceOpenInvoicesError as e:
+            return Response(
+                {"error": e.message, "code": "open_invoices_error"},
+                status=409,
+            )
         except exceptions.NotFound:
             logger.info(
                 "Installation already deleted",

--- a/ee/api/vercel/vercel_installation.py
+++ b/ee/api/vercel/vercel_installation.py
@@ -8,12 +8,12 @@ from rest_framework.response import Response
 
 from posthog.models.organization_integration import OrganizationIntegration
 
-from ee.billing.billing_manager import BillingServiceOpenInvoicesError
 from ee.api.authentication import VercelAuthentication
 from ee.api.vercel.utils import expect_vercel_user_claim
 from ee.api.vercel.vercel_error_mixin import VercelErrorResponseMixin
 from ee.api.vercel.vercel_permission import VercelPermission
 from ee.api.vercel.vercel_region_proxy_mixin import VercelRegionProxyMixin
+from ee.billing.billing_manager import BillingServiceOpenInvoicesError
 from ee.vercel.integration import VercelIntegration
 
 logger = structlog.get_logger(__name__)

--- a/ee/api/vercel/vercel_installation.py
+++ b/ee/api/vercel/vercel_installation.py
@@ -142,7 +142,15 @@ class VercelInstallationViewSet(VercelRegionProxyMixin, VercelErrorResponseMixin
             self.invalidate_installation_cache(installation_id)
         except BillingServiceOpenInvoicesError as e:
             return Response(
-                {"error": e.message, "code": "open_invoices_error"},
+                {
+                    "error": {
+                        "code": "open_invoices_error",
+                        "message": e.message,
+                        "user": {
+                            "message": "This integration has unpaid invoices that must be resolved before uninstalling. Please contact support@posthog.com for help.",
+                        },
+                    }
+                },
                 status=409,
             )
         except exceptions.NotFound:

--- a/ee/api/vercel/vercel_installation.py
+++ b/ee/api/vercel/vercel_installation.py
@@ -13,7 +13,7 @@ from ee.api.vercel.utils import expect_vercel_user_claim
 from ee.api.vercel.vercel_error_mixin import VercelErrorResponseMixin
 from ee.api.vercel.vercel_permission import VercelPermission
 from ee.api.vercel.vercel_region_proxy_mixin import VercelRegionProxyMixin
-from ee.billing.billing_manager import BillingServiceOpenInvoicesError
+from ee.billing.billing_manager import BillingAPIErrorCodes, BillingServiceOpenInvoicesError
 from ee.vercel.integration import VercelIntegration
 
 logger = structlog.get_logger(__name__)
@@ -144,7 +144,7 @@ class VercelInstallationViewSet(VercelRegionProxyMixin, VercelErrorResponseMixin
             return Response(
                 {
                     "error": {
-                        "code": "open_invoices_error",
+                        "code": BillingAPIErrorCodes.OPEN_INVOICES_ERROR.value,
                         "message": e.message,
                         "user": {
                             "message": "This integration has unpaid invoices that must be resolved before uninstalling. Please contact support@posthog.com for help.",

--- a/ee/api/vercel/vercel_webhooks.py
+++ b/ee/api/vercel/vercel_webhooks.py
@@ -149,14 +149,13 @@ def vercel_webhook(request: Request) -> Response:
                 try:
                     VercelIntegration.delete_installation(config_id)
                 except BillingServiceOpenInvoicesError as e:
+                    # Vercel ignores non-200 from webhooks and shows "Integration Deleted" regardless.
+                    # The marketplace DELETE API endpoint handles the actual blocking with 409.
+                    # Log the warning but return 200 to avoid misleading error tracking noise.
                     logger.warning(
                         "vercel_webhook_deauthorize_blocked_by_open_invoices",
                         config_id=config_id,
                         reason=e.message,
-                    )
-                    return Response(
-                        {"error": e.message, "code": "open_invoices_error"},
-                        status=status.HTTP_409_CONFLICT,
                     )
                 except Exception as e:
                     logger.exception("vercel_webhook_deauthorize_delete_failed", config_id=config_id)

--- a/ee/api/vercel/vercel_webhooks.py
+++ b/ee/api/vercel/vercel_webhooks.py
@@ -14,7 +14,7 @@ from rest_framework.response import Response
 from posthog.exceptions_capture import capture_exception
 from posthog.models.organization_integration import OrganizationIntegration
 
-from ee.billing.billing_manager import BillingManager
+from ee.billing.billing_manager import BillingManager, BillingServiceOpenInvoicesError
 from ee.models import License
 from ee.vercel.integration import VercelIntegration
 
@@ -148,6 +148,16 @@ def vercel_webhook(request: Request) -> Response:
             else:
                 try:
                     VercelIntegration.delete_installation(config_id)
+                except BillingServiceOpenInvoicesError as e:
+                    logger.warning(
+                        "vercel_webhook_deauthorize_blocked_by_open_invoices",
+                        config_id=config_id,
+                        reason=e.message,
+                    )
+                    return Response(
+                        {"error": e.message, "code": "open_invoices_error"},
+                        status=status.HTTP_409_CONFLICT,
+                    )
                 except Exception as e:
                     logger.exception("vercel_webhook_deauthorize_delete_failed", config_id=config_id)
                     capture_exception(e, {"config_id": config_id})

--- a/ee/billing/billing_manager.py
+++ b/ee/billing/billing_manager.py
@@ -32,6 +32,12 @@ class BillingAPIErrorCodes(Enum):
     OPEN_INVOICES_ERROR = "open_invoices_error"
 
 
+class BillingServiceOpenInvoicesError(Exception):
+    def __init__(self, message: str):
+        self.message = message
+        super().__init__(message)
+
+
 def _get_user_organization_role(user: User, organization: Organization) -> Optional[str]:
     """
     Get a user role display string in a given organization, if membership doesn't exist return None.
@@ -588,6 +594,14 @@ class BillingManager:
             json={"billing_provider": billing_provider.value},
             timeout=30,
         )
+
+        if res.status_code == 409:
+            try:
+                data = res.json()
+            except JSONDecodeError:
+                data = {}
+            if data.get("code") == BillingAPIErrorCodes.OPEN_INVOICES_ERROR.value:
+                raise BillingServiceOpenInvoicesError(data.get("error_message", "Open invoices must be resolved first"))
 
         handle_billing_service_error(res, valid_codes=(200,))
 

--- a/ee/billing/test/test_billing_manager.py
+++ b/ee/billing/test/test_billing_manager.py
@@ -2,12 +2,11 @@ import json
 import datetime
 from typing import Any, cast
 
-import requests
-
 from posthog.test.base import BaseTest
 from unittest.mock import MagicMock, patch
 
 import jwt
+import requests
 from parameterized import parameterized
 from rest_framework.exceptions import NotAuthenticated
 

--- a/ee/billing/test/test_billing_manager.py
+++ b/ee/billing/test/test_billing_manager.py
@@ -2,6 +2,8 @@ import json
 import datetime
 from typing import Any, cast
 
+import requests
+
 from posthog.test.base import BaseTest
 from unittest.mock import MagicMock, patch
 
@@ -308,6 +310,104 @@ class TestBillingManager(BaseTest):
             BillingManager(license).deauthorize(self.organization, BillingProvider.VERCEL)
 
         assert "404" in str(context.exception)
+
+    @patch(
+        "ee.billing.billing_manager.requests.post",
+        return_value=MagicMock(
+            status_code=409,
+            json=MagicMock(
+                return_value={
+                    "success": False,
+                    "error_message": "Cannot uninstall billing provider: 1 unpaid invoice must be resolved first.",
+                    "code": "open_invoices_error",
+                }
+            ),
+            ok=False,
+        ),
+    )
+    def test_deauthorize_raises_open_invoices_error_on_409(self, billing_post_request_mock: MagicMock):
+        from ee.billing.billing_manager import BillingServiceOpenInvoicesError
+
+        license = super(LicenseManager, cast(LicenseManager, License.objects)).create(
+            key="key123::key123",
+            plan="enterprise",
+            valid_until=datetime.datetime(2038, 1, 19, 3, 14, 7),
+        )
+
+        with self.assertRaises(BillingServiceOpenInvoicesError) as context:
+            BillingManager(license).deauthorize(self.organization, BillingProvider.VERCEL)
+
+        assert "unpaid invoice" in str(context.exception)
+
+    @patch(
+        "ee.billing.billing_manager.requests.post",
+        return_value=MagicMock(
+            status_code=409,
+            json=MagicMock(side_effect=requests.JSONDecodeError("", "", 0)),
+            text="Not JSON",
+            ok=False,
+        ),
+    )
+    def test_deauthorize_409_no_json_falls_through_to_generic_error(self, billing_post_request_mock: MagicMock):
+        from ee.billing.billing_manager import BillingServiceOpenInvoicesError
+
+        license = super(LicenseManager, cast(LicenseManager, License.objects)).create(
+            key="key123::key123",
+            plan="enterprise",
+            valid_until=datetime.datetime(2038, 1, 19, 3, 14, 7),
+        )
+
+        with self.assertRaises(Exception) as context:
+            BillingManager(license).deauthorize(self.organization, BillingProvider.VERCEL)
+
+        assert not isinstance(context.exception, BillingServiceOpenInvoicesError)
+        assert "409" in str(context.exception)
+
+    @patch(
+        "ee.billing.billing_manager.requests.post",
+        return_value=MagicMock(
+            status_code=409,
+            json=MagicMock(return_value={"code": "some_other_error", "error_message": "Something else"}),
+            text='{"code": "some_other_error"}',
+            ok=False,
+        ),
+    )
+    def test_deauthorize_409_different_code_falls_through_to_generic_error(self, billing_post_request_mock: MagicMock):
+        from ee.billing.billing_manager import BillingServiceOpenInvoicesError
+
+        license = super(LicenseManager, cast(LicenseManager, License.objects)).create(
+            key="key123::key123",
+            plan="enterprise",
+            valid_until=datetime.datetime(2038, 1, 19, 3, 14, 7),
+        )
+
+        with self.assertRaises(Exception) as context:
+            BillingManager(license).deauthorize(self.organization, BillingProvider.VERCEL)
+
+        assert not isinstance(context.exception, BillingServiceOpenInvoicesError)
+        assert "409" in str(context.exception)
+
+    @patch(
+        "ee.billing.billing_manager.requests.post",
+        return_value=MagicMock(
+            status_code=409,
+            json=MagicMock(return_value={"code": "open_invoices_error"}),
+            ok=False,
+        ),
+    )
+    def test_deauthorize_409_open_invoices_missing_message_uses_default(self, billing_post_request_mock: MagicMock):
+        from ee.billing.billing_manager import BillingServiceOpenInvoicesError
+
+        license = super(LicenseManager, cast(LicenseManager, License.objects)).create(
+            key="key123::key123",
+            plan="enterprise",
+            valid_until=datetime.datetime(2038, 1, 19, 3, 14, 7),
+        )
+
+        with self.assertRaises(BillingServiceOpenInvoicesError) as context:
+            BillingManager(license).deauthorize(self.organization, BillingProvider.VERCEL)
+
+        assert "Open invoices must be resolved first" in str(context.exception)
 
 
 class TestBuildBillingToken(BaseTest):

--- a/ee/vercel/test/test_integration.py
+++ b/ee/vercel/test/test_integration.py
@@ -215,6 +215,23 @@ class TestVercelIntegration(TestCase):
 
         assert OrganizationIntegration.objects.filter(integration_id=self.installation_id).exists()
 
+    @patch("ee.vercel.integration.BillingManager")
+    @patch("ee.vercel.integration.get_cached_instance_license")
+    def test_delete_installation_blocked_by_open_invoices(self, mock_license, mock_billing_manager):
+        from ee.billing.billing_manager import BillingServiceOpenInvoicesError
+
+        mock_license.return_value = Mock()
+        mock_manager_instance = Mock()
+        mock_manager_instance.deauthorize.side_effect = BillingServiceOpenInvoicesError(
+            "Cannot uninstall billing provider: 1 unpaid invoice must be resolved first."
+        )
+        mock_billing_manager.return_value = mock_manager_instance
+
+        with self.assertRaises(BillingServiceOpenInvoicesError):
+            VercelIntegration.delete_installation(self.installation_id)
+
+        assert OrganizationIntegration.objects.filter(integration_id=self.installation_id).exists()
+
     def test_delete_installation_not_found(self):
         with self.assertRaises(NotFound):
             VercelIntegration.delete_installation(self.NONEXISTENT_INSTALLATION_ID)


### PR DESCRIPTION
## Problem

When a Vercel customer uninstalls the integration but has unpaid invoices, the billing service correctly returns a 409 with `open_invoices_error`. However, the PostHog app treats this as an unexpected error:

1. `handle_billing_service_error` raises a generic `Exception` (409 not in `valid_codes`)
2. The webhook handler catches it as `except Exception`, calls `capture_exception`, and returns 500
3. This creates noisy error tracking issues for expected behavior

Triggered by: https://posthog.slack.com/archives/C092FFT1H7V/p1775063661450859

## Changes

- Add `BillingServiceOpenInvoicesError` typed exception to `billing_manager.py`
- `deauthorize()` now parses 409 responses and raises the typed exception when the error code is `open_invoices_error`
- Marketplace API handler (`vercel_installation.py`) catches it in `destroy()` and returns 409 with Vercel's documented error schema (`error.code`, `error.message`, `error.user.message`) so Vercel can display a user-facing message
- Webhook handler (`vercel_webhooks.py`) catches it but returns 200 (see testing findings below)
- Unknown 409 codes or malformed responses still fall through to the generic error path

## How did you test this code?

### Local E2E testing against Vercel

Tested both uninstall paths end-to-end with real Vercel integrations via ngrok:

**Marketplace DELETE API (non-connectable install):**
- Created a fresh marketplace install (Vercel creates the account)
- Patched destroy handler to always return 409 with the documented error schema
- Triggered uninstall from Vercel dashboard
- **Result: Vercel blocks the deletion** and shows "Deletion Paused - We ran into a temporary issue while cleaning up your resources. Please try again to finish deleting the integration." with a "Try Again" button
- This is the correct behavior - the customer cannot uninstall while invoices are unpaid

**Webhook path (connectable install):**
- Connected an existing PostHog account via "Link Existing Account"
- Patched webhook handler to return 409
- Triggered uninstall from Vercel dashboard
- **Result: Vercel ignores the 409** and shows "Integration Deleted" with a green checkmark
- This is expected - webhooks are fire-and-forget. The webhook handler now returns 200 with a warning log instead of 409 to avoid misleading error noise. Connectable installs don't go through billing deauthorize anyway since PostHog owns the billing directly.

### Automated tests
- 7 billing manager unit tests (4 existing + 3 new edge cases)
- 6 Vercel integration unit tests (5 existing + 1 new for open invoices case)
- 242 Vercel API tests all passing

## Publish to changelog?

No

## LLM context

Claude Code session investigating a billing error alert. The 409 behavior was intentionally added in PostHog/billing#1767 per Pawel's review feedback, but the PostHog app side wasn't updated to handle it gracefully. The Vercel error schema fix and webhook behavior change were based on E2E testing that revealed Vercel ignores webhook errors but respects marketplace API 409s.