### PR TITLE
chore(personhog): metrics w/ client label

### DIFF
--- a/rust/personhog-common/src/grpc.rs
+++ b/rust/personhog-common/src/grpc.rs
@@ -159,7 +159,7 @@ pub struct ClientInFlightGuard {
 impl ClientInFlightGuard {
     pub fn new(backend: &'static str) -> Self {
         let client = current_client_name();
-        gauge!("personhog_router_client_requests_in_flight", "backend" => backend, "client" => client.to_string())
+        gauge!("personhog_router_client_requests_in_flight", "backend" => backend, "client" => client.clone())
             .increment(1.0);
         Self { backend, client }
     }
@@ -167,7 +167,7 @@ impl ClientInFlightGuard {
 
 impl Drop for ClientInFlightGuard {
     fn drop(&mut self) {
-        gauge!("personhog_router_client_requests_in_flight", "backend" => self.backend, "client" => self.client.to_string())
+        gauge!("personhog_router_client_requests_in_flight", "backend" => self.backend, "client" => self.client.clone())
             .decrement(1.0);
     }
 }
@@ -231,7 +231,7 @@ where
     fn call(&mut self, request: Request<ReqBody>) -> Self::Future {
         let method = extract_grpc_method(request.uri().path());
         let client = extract_client_name(&request);
-        gauge!("grpc_server_requests_in_flight", "method" => method.clone(), "client" => client.to_string())
+        gauge!("grpc_server_requests_in_flight", "method" => method.clone(), "client" => client.clone())
             .increment(1.0);
 
         let start = Instant::now();
@@ -275,11 +275,11 @@ where
                 let duration_ms = this.start.elapsed().as_secs_f64() * 1000.0;
                 counter!("grpc_server_requests_total",
                     "method" => this.method.clone(),
-                    "client" => this.client.to_string())
+                    "client" => this.client.clone())
                 .increment(1);
                 histogram!("grpc_server_request_duration_ms",
                     "method" => this.method.clone(),
-                    "client" => this.client.to_string())
+                    "client" => this.client.clone())
                 .record(duration_ms);
                 Poll::Ready(result)
             }
@@ -297,7 +297,7 @@ impl<F> PinnedDrop for GrpcMetricsFuture<F> {
         let this = self.project();
         gauge!("grpc_server_requests_in_flight",
             "method" => this.method.clone(),
-            "client" => this.client.to_string())
+            "client" => this.client.clone())
         .decrement(1.0);
     }
 }

--- a/rust/personhog-common/src/grpc.rs
+++ b/rust/personhog-common/src/grpc.rs
@@ -276,11 +276,11 @@ where
                 counter!("grpc_server_requests_total",
                     "method" => this.method.clone(),
                     "client" => this.client.to_string())
-                    .increment(1);
+                .increment(1);
                 histogram!("grpc_server_request_duration_ms",
                     "method" => this.method.clone(),
                     "client" => this.client.to_string())
-                    .record(duration_ms);
+                .record(duration_ms);
                 Poll::Ready(result)
             }
             Poll::Pending => Poll::Pending,
@@ -298,7 +298,7 @@ impl<F> PinnedDrop for GrpcMetricsFuture<F> {
         gauge!("grpc_server_requests_in_flight",
             "method" => this.method.clone(),
             "client" => this.client.to_string())
-            .decrement(1.0);
+        .decrement(1.0);
     }
 }
 

--- a/rust/personhog-common/src/grpc.rs
+++ b/rust/personhog-common/src/grpc.rs
@@ -14,6 +14,37 @@ use tonic::transport::server::Connected;
 use tower::{Layer, Service};
 
 // ============================================================
+// Client name extraction
+// ============================================================
+
+/// Header name for client identification in gRPC metadata.
+const CLIENT_NAME_HEADER: &str = "x-client-name";
+
+tokio::task_local! {
+    /// Per-request client name, set by `GrpcMetricsLayer` and readable
+    /// anywhere in the request's async call chain via `current_client_name()`.
+    pub static CLIENT_NAME: String;
+}
+
+/// Get the current client name from the task-local, or `"unknown"` if not set.
+pub fn current_client_name() -> String {
+    CLIENT_NAME
+        .try_with(|c| c.clone())
+        .unwrap_or_else(|_| "unknown".to_string())
+}
+
+/// Extract the client name from HTTP headers, defaulting to `"unknown"`.
+fn extract_client_name<B>(request: &Request<B>) -> String {
+    request
+        .headers()
+        .get(CLIENT_NAME_HEADER)
+        .and_then(|v| v.to_str().ok())
+        .filter(|s| !s.is_empty())
+        .unwrap_or("unknown")
+        .to_string()
+}
+
+// ============================================================
 // Connection tracking
 // ============================================================
 
@@ -118,18 +149,21 @@ pub fn tracked_tcp_incoming(
 /// ensuring cancellation-safety for outbound request tracking.
 pub struct ClientInFlightGuard {
     pub backend: &'static str,
+    client: String,
 }
 
 impl ClientInFlightGuard {
     pub fn new(backend: &'static str) -> Self {
-        gauge!("personhog_router_client_requests_in_flight", "backend" => backend).increment(1.0);
-        Self { backend }
+        let client = current_client_name();
+        gauge!("personhog_router_client_requests_in_flight", "backend" => backend, "client" => client.clone())
+            .increment(1.0);
+        Self { backend, client }
     }
 }
 
 impl Drop for ClientInFlightGuard {
     fn drop(&mut self) {
-        gauge!("personhog_router_client_requests_in_flight", "backend" => self.backend)
+        gauge!("personhog_router_client_requests_in_flight", "backend" => self.backend, "client" => self.client.clone())
             .decrement(1.0);
     }
 }
@@ -152,9 +186,12 @@ fn is_fatal_accept_error(e: &io::Error) -> bool {
 /// Tower layer that instruments gRPC requests with timing and concurrency metrics.
 ///
 /// Records:
-/// - `grpc_server_requests_total` - counter with method label
-/// - `grpc_server_request_duration_ms` - histogram with method label
-/// - `grpc_server_requests_in_flight` - gauge with method label
+/// - `grpc_server_requests_total` - counter with method and client labels
+/// - `grpc_server_request_duration_ms` - histogram with method and client labels
+/// - `grpc_server_requests_in_flight` - gauge with method and client labels
+///
+/// Also sets the `CLIENT_NAME` task-local so downstream code can read
+/// the client name via `current_client_name()`.
 #[derive(Clone, Default)]
 pub struct GrpcMetricsLayer;
 
@@ -175,11 +212,13 @@ impl<S, ReqBody, ResBody> Service<Request<ReqBody>> for GrpcMetricsService<S>
 where
     S: Service<Request<ReqBody>, Response = Response<ResBody>> + Clone + Send + 'static,
     S::Future: Send,
+    S::Error: Send,
     ReqBody: Send + 'static,
+    ResBody: Send + 'static,
 {
     type Response = S::Response;
     type Error = S::Error;
-    type Future = GrpcMetricsFuture<S::Future>;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
 
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         self.inner.poll_ready(cx)
@@ -187,14 +226,29 @@ where
 
     fn call(&mut self, request: Request<ReqBody>) -> Self::Future {
         let method = extract_grpc_method(request.uri().path());
-        gauge!("grpc_server_requests_in_flight", "method" => method.clone()).increment(1.0);
+        let client = extract_client_name(&request);
+        gauge!("grpc_server_requests_in_flight", "method" => method.clone(), "client" => client.clone())
+            .increment(1.0);
 
-        GrpcMetricsFuture {
-            inner: self.inner.call(request),
-            start: Instant::now(),
+        let start = Instant::now();
+        let inner = self.inner.call(request);
+        let in_flight_guard = InFlightGuard {
             method: method.clone(),
-            _in_flight_guard: InFlightGuard { method },
-        }
+            client: client.clone(),
+        };
+
+        Box::pin(CLIENT_NAME.scope(client.clone(), async move {
+            let _guard = in_flight_guard;
+            let result = inner.await;
+            let duration_ms = start.elapsed().as_secs_f64() * 1000.0;
+
+            counter!("grpc_server_requests_total", "method" => method.clone(), "client" => client.clone())
+                .increment(1);
+            histogram!("grpc_server_request_duration_ms", "method" => method, "client" => client)
+                .record(duration_ms);
+
+            result
+        }))
     }
 }
 
@@ -202,42 +256,13 @@ where
 /// or is cancelled.
 struct InFlightGuard {
     method: String,
+    client: String,
 }
 
 impl Drop for InFlightGuard {
     fn drop(&mut self) {
-        gauge!("grpc_server_requests_in_flight", "method" => self.method.clone()).decrement(1.0);
-    }
-}
-
-#[pin_project]
-pub struct GrpcMetricsFuture<F> {
-    #[pin]
-    inner: F,
-    start: Instant,
-    method: String,
-    _in_flight_guard: InFlightGuard,
-}
-
-impl<F, ResBody, E> Future for GrpcMetricsFuture<F>
-where
-    F: Future<Output = Result<Response<ResBody>, E>>,
-{
-    type Output = F::Output;
-
-    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        let this = self.project();
-        let result = this.inner.poll(cx);
-
-        if result.is_ready() {
-            let duration_ms = this.start.elapsed().as_secs_f64() * 1000.0;
-
-            counter!("grpc_server_requests_total", "method" => this.method.clone()).increment(1);
-            histogram!("grpc_server_request_duration_ms", "method" => this.method.clone())
-                .record(duration_ms);
-        }
-
-        result
+        gauge!("grpc_server_requests_in_flight", "method" => self.method.clone(), "client" => self.client.clone())
+            .decrement(1.0);
     }
 }
 

--- a/rust/personhog-common/src/grpc.rs
+++ b/rust/personhog-common/src/grpc.rs
@@ -1,6 +1,7 @@
 use std::future::Future;
 use std::io;
 use std::pin::Pin;
+use std::sync::Arc;
 use std::task::{Context, Poll};
 use std::time::Instant;
 
@@ -23,25 +24,27 @@ const CLIENT_NAME_HEADER: &str = "x-client-name";
 tokio::task_local! {
     /// Per-request client name, set by `GrpcMetricsLayer` and readable
     /// anywhere in the request's async call chain via `current_client_name()`.
-    pub static CLIENT_NAME: String;
+    pub static CLIENT_NAME: Arc<str>;
 }
 
 /// Get the current client name from the task-local, or `"unknown"` if not set.
-pub fn current_client_name() -> String {
+/// Returns `Arc<str>` so cloning is a cheap refcount bump rather than a
+/// heap allocation + memcpy on every call.
+pub fn current_client_name() -> Arc<str> {
     CLIENT_NAME
         .try_with(|c| c.clone())
-        .unwrap_or_else(|_| "unknown".to_string())
+        .unwrap_or_else(|_| Arc::from("unknown"))
 }
 
 /// Extract the client name from HTTP headers, defaulting to `"unknown"`.
-fn extract_client_name<B>(request: &Request<B>) -> String {
+fn extract_client_name<B>(request: &Request<B>) -> Arc<str> {
     request
         .headers()
         .get(CLIENT_NAME_HEADER)
         .and_then(|v| v.to_str().ok())
         .filter(|s| !s.is_empty())
         .unwrap_or("unknown")
-        .to_string()
+        .into()
 }
 
 // ============================================================
@@ -149,13 +152,13 @@ pub fn tracked_tcp_incoming(
 /// ensuring cancellation-safety for outbound request tracking.
 pub struct ClientInFlightGuard {
     pub backend: &'static str,
-    client: String,
+    client: Arc<str>,
 }
 
 impl ClientInFlightGuard {
     pub fn new(backend: &'static str) -> Self {
         let client = current_client_name();
-        gauge!("personhog_router_client_requests_in_flight", "backend" => backend, "client" => client.clone())
+        gauge!("personhog_router_client_requests_in_flight", "backend" => backend, "client" => client.to_string())
             .increment(1.0);
         Self { backend, client }
     }
@@ -163,7 +166,7 @@ impl ClientInFlightGuard {
 
 impl Drop for ClientInFlightGuard {
     fn drop(&mut self) {
-        gauge!("personhog_router_client_requests_in_flight", "backend" => self.backend, "client" => self.client.clone())
+        gauge!("personhog_router_client_requests_in_flight", "backend" => self.backend, "client" => self.client.to_string())
             .decrement(1.0);
     }
 }
@@ -227,7 +230,7 @@ where
     fn call(&mut self, request: Request<ReqBody>) -> Self::Future {
         let method = extract_grpc_method(request.uri().path());
         let client = extract_client_name(&request);
-        gauge!("grpc_server_requests_in_flight", "method" => method.clone(), "client" => client.clone())
+        gauge!("grpc_server_requests_in_flight", "method" => method.clone(), "client" => client.to_string())
             .increment(1.0);
 
         let start = Instant::now();
@@ -243,9 +246,9 @@ where
             let result = inner.await;
             let duration_ms = start.elapsed().as_secs_f64() * 1000.0;
 
-            counter!("grpc_server_requests_total", "method" => method.clone(), "client" => client.clone())
+            counter!("grpc_server_requests_total", "method" => method.clone(), "client" => client.to_string())
                 .increment(1);
-            histogram!("grpc_server_request_duration_ms", "method" => method, "client" => client)
+            histogram!("grpc_server_request_duration_ms", "method" => method, "client" => client.to_string())
                 .record(duration_ms);
 
             result
@@ -257,12 +260,12 @@ where
 /// or is cancelled.
 struct InFlightGuard {
     method: String,
-    client: String,
+    client: Arc<str>,
 }
 
 impl Drop for InFlightGuard {
     fn drop(&mut self) {
-        gauge!("grpc_server_requests_in_flight", "method" => self.method.clone(), "client" => self.client.clone())
+        gauge!("grpc_server_requests_in_flight", "method" => self.method.clone(), "client" => self.client.to_string())
             .decrement(1.0);
     }
 }

--- a/rust/personhog-common/src/grpc.rs
+++ b/rust/personhog-common/src/grpc.rs
@@ -231,7 +231,8 @@ where
             .increment(1.0);
 
         let start = Instant::now();
-        let inner = self.inner.call(request);
+        // Call inner inside the scope so any synchronous work in call() sees CLIENT_NAME.
+        let inner = CLIENT_NAME.sync_scope(client.clone(), || self.inner.call(request));
         let in_flight_guard = InFlightGuard {
             method: method.clone(),
             client: client.clone(),

--- a/rust/personhog-common/src/grpc.rs
+++ b/rust/personhog-common/src/grpc.rs
@@ -8,9 +8,10 @@ use std::time::Instant;
 use futures::stream::unfold;
 use http::{Request, Response};
 use metrics::{counter, gauge, histogram};
-use pin_project::pin_project;
+use pin_project::{pin_project, pinned_drop};
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 use tokio::net::{TcpListener, TcpStream};
+use tokio::task::futures::TaskLocalFuture;
 use tonic::transport::server::Connected;
 use tower::{Layer, Service};
 
@@ -221,7 +222,7 @@ where
 {
     type Response = S::Response;
     type Error = S::Error;
-    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+    type Future = GrpcMetricsFuture<S::Future>;
 
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         self.inner.poll_ready(cx)
@@ -236,36 +237,67 @@ where
         let start = Instant::now();
         // Call inner inside the scope so any synchronous work in call() sees CLIENT_NAME.
         let inner = CLIENT_NAME.sync_scope(client.clone(), || self.inner.call(request));
-        let in_flight_guard = InFlightGuard {
-            method: method.clone(),
-            client: client.clone(),
-        };
 
-        Box::pin(CLIENT_NAME.scope(client.clone(), async move {
-            let _guard = in_flight_guard;
-            let result = inner.await;
-            let duration_ms = start.elapsed().as_secs_f64() * 1000.0;
-
-            counter!("grpc_server_requests_total", "method" => method.clone(), "client" => client.to_string())
-                .increment(1);
-            histogram!("grpc_server_request_duration_ms", "method" => method, "client" => client.to_string())
-                .record(duration_ms);
-
-            result
-        }))
+        GrpcMetricsFuture {
+            inner: CLIENT_NAME.scope(client.clone(), inner),
+            method,
+            client,
+            start,
+        }
     }
 }
 
-/// Drop guard that decrements the in-flight gauge when a request completes
-/// or is cancelled.
-struct InFlightGuard {
+/// Future returned by [`GrpcMetricsService`].
+///
+/// Wraps the inner service future with task-local client name propagation
+/// and records request metrics (counter, histogram, in-flight gauge) on
+/// completion or cancellation. Lives inline in the caller's async state
+/// machine — no heap allocation or dynamic dispatch.
+#[pin_project(PinnedDrop)]
+pub struct GrpcMetricsFuture<F> {
+    #[pin]
+    inner: TaskLocalFuture<Arc<str>, F>,
     method: String,
     client: Arc<str>,
+    start: Instant,
 }
 
-impl Drop for InFlightGuard {
-    fn drop(&mut self) {
-        gauge!("grpc_server_requests_in_flight", "method" => self.method.clone(), "client" => self.client.to_string())
+impl<F, ResBody, E> Future for GrpcMetricsFuture<F>
+where
+    F: Future<Output = Result<Response<ResBody>, E>>,
+{
+    type Output = F::Output;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.project();
+        match this.inner.poll(cx) {
+            Poll::Ready(result) => {
+                let duration_ms = this.start.elapsed().as_secs_f64() * 1000.0;
+                counter!("grpc_server_requests_total",
+                    "method" => this.method.clone(),
+                    "client" => this.client.to_string())
+                    .increment(1);
+                histogram!("grpc_server_request_duration_ms",
+                    "method" => this.method.clone(),
+                    "client" => this.client.to_string())
+                    .record(duration_ms);
+                Poll::Ready(result)
+            }
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+/// Decrement the in-flight gauge when the future is dropped (on both
+/// normal completion and cancellation), matching the original
+/// `InFlightGuard` behavior.
+#[pinned_drop]
+impl<F> PinnedDrop for GrpcMetricsFuture<F> {
+    fn drop(self: Pin<&mut Self>) {
+        let this = self.project();
+        gauge!("grpc_server_requests_in_flight",
+            "method" => this.method.clone(),
+            "client" => this.client.to_string())
             .decrement(1.0);
     }
 }

--- a/rust/personhog-replica/src/service/error.rs
+++ b/rust/personhog-replica/src/service/error.rs
@@ -1,3 +1,4 @@
+use personhog_common::grpc::current_client_name;
 use tonic::Status;
 use tracing::error;
 
@@ -6,6 +7,7 @@ use crate::storage;
 const STORAGE_ERRORS_TOTAL: &str = "personhog_replica_storage_errors_total";
 
 pub fn log_and_convert_error(err: storage::StorageError, operation: &str) -> Status {
+    let client = current_client_name();
     match &err {
         storage::StorageError::Connection(msg) => {
             error!(operation, error = %msg, "Database connection error");
@@ -14,6 +16,7 @@ pub fn log_and_convert_error(err: storage::StorageError, operation: &str) -> Sta
                 &[
                     ("error_type".to_string(), "connection".to_string()),
                     ("operation".to_string(), operation.to_string()),
+                    ("client".to_string(), client),
                 ],
                 1,
             );
@@ -26,6 +29,7 @@ pub fn log_and_convert_error(err: storage::StorageError, operation: &str) -> Sta
                 &[
                     ("error_type".to_string(), "pool_exhausted".to_string()),
                     ("operation".to_string(), operation.to_string()),
+                    ("client".to_string(), client),
                 ],
                 1,
             );
@@ -38,6 +42,7 @@ pub fn log_and_convert_error(err: storage::StorageError, operation: &str) -> Sta
                 &[
                     ("error_type".to_string(), "query".to_string()),
                     ("operation".to_string(), operation.to_string()),
+                    ("client".to_string(), client),
                 ],
                 1,
             );

--- a/rust/personhog-replica/src/service/error.rs
+++ b/rust/personhog-replica/src/service/error.rs
@@ -16,7 +16,7 @@ pub fn log_and_convert_error(err: storage::StorageError, operation: &str) -> Sta
                 &[
                     ("error_type".to_string(), "connection".to_string()),
                     ("operation".to_string(), operation.to_string()),
-                    ("client".to_string(), client),
+                    ("client".to_string(), client.to_string()),
                 ],
                 1,
             );
@@ -29,7 +29,7 @@ pub fn log_and_convert_error(err: storage::StorageError, operation: &str) -> Sta
                 &[
                     ("error_type".to_string(), "pool_exhausted".to_string()),
                     ("operation".to_string(), operation.to_string()),
-                    ("client".to_string(), client),
+                    ("client".to_string(), client.to_string()),
                 ],
                 1,
             );
@@ -42,7 +42,7 @@ pub fn log_and_convert_error(err: storage::StorageError, operation: &str) -> Sta
                 &[
                     ("error_type".to_string(), "query".to_string()),
                     ("operation".to_string(), operation.to_string()),
-                    ("client".to_string(), client),
+                    ("client".to_string(), client.to_string()),
                 ],
                 1,
             );

--- a/rust/personhog-replica/src/storage/postgres/cohort.rs
+++ b/rust/personhog-replica/src/storage/postgres/cohort.rs
@@ -29,7 +29,7 @@ impl CohortStorage for PostgresStorage {
                 "check_cohort_membership".to_string(),
             ),
             ("pool".to_string(), pool_label.to_string()),
-            ("client".to_string(), client),
+            ("client".to_string(), client.to_string()),
         ];
         let _timer = common_metrics::timing_guard(DB_QUERY_DURATION, &labels);
 

--- a/rust/personhog-replica/src/storage/postgres/cohort.rs
+++ b/rust/personhog-replica/src/storage/postgres/cohort.rs
@@ -2,6 +2,8 @@ use std::collections::HashSet;
 
 use async_trait::async_trait;
 
+use personhog_common::grpc::current_client_name;
+
 use super::{ConsistencyLevel, PostgresStorage, DB_QUERY_DURATION};
 use crate::storage::error::StorageResult;
 use crate::storage::traits::CohortStorage;
@@ -19,6 +21,7 @@ impl CohortStorage for PostgresStorage {
             return Ok(Vec::new());
         }
 
+        let client = current_client_name();
         let pool_label = PostgresStorage::pool_label(consistency);
         let labels = [
             (
@@ -26,6 +29,7 @@ impl CohortStorage for PostgresStorage {
                 "check_cohort_membership".to_string(),
             ),
             ("pool".to_string(), pool_label.to_string()),
+            ("client".to_string(), client),
         ];
         let _timer = common_metrics::timing_guard(DB_QUERY_DURATION, &labels);
 

--- a/rust/personhog-replica/src/storage/postgres/distinct_id.rs
+++ b/rust/personhog-replica/src/storage/postgres/distinct_id.rs
@@ -24,7 +24,7 @@ impl DistinctIdLookup for PostgresStorage {
                 "get_distinct_ids_for_person".to_string(),
             ),
             ("pool".to_string(), pool_label.to_string()),
-            ("client".to_string(), client.clone()),
+            ("client".to_string(), client.to_string()),
         ];
         let _timer = common_metrics::timing_guard(DB_QUERY_DURATION, &labels);
 
@@ -71,7 +71,7 @@ impl DistinctIdLookup for PostgresStorage {
                     "operation".to_string(),
                     "get_distinct_ids_for_person".to_string(),
                 ),
-                ("client".to_string(), client),
+                ("client".to_string(), client.to_string()),
             ],
             rows.len() as f64,
         );
@@ -98,7 +98,7 @@ impl DistinctIdLookup for PostgresStorage {
                 "get_distinct_ids_for_persons".to_string(),
             ),
             ("pool".to_string(), pool_label.to_string()),
-            ("client".to_string(), client.clone()),
+            ("client".to_string(), client.to_string()),
         ];
         let _timer = common_metrics::timing_guard(DB_QUERY_DURATION, &labels);
 
@@ -149,7 +149,7 @@ impl DistinctIdLookup for PostgresStorage {
                     "operation".to_string(),
                     "get_distinct_ids_for_persons".to_string(),
                 ),
-                ("client".to_string(), client),
+                ("client".to_string(), client.to_string()),
             ],
             rows.len() as f64,
         );

--- a/rust/personhog-replica/src/storage/postgres/distinct_id.rs
+++ b/rust/personhog-replica/src/storage/postgres/distinct_id.rs
@@ -1,5 +1,7 @@
 use async_trait::async_trait;
 
+use personhog_common::grpc::current_client_name;
+
 use super::{ConsistencyLevel, PostgresStorage, DB_QUERY_DURATION, DB_ROWS_RETURNED};
 use crate::storage::error::StorageResult;
 use crate::storage::traits::DistinctIdLookup;
@@ -14,6 +16,7 @@ impl DistinctIdLookup for PostgresStorage {
         consistency: ConsistencyLevel,
         limit: Option<i64>,
     ) -> StorageResult<Vec<DistinctIdWithVersion>> {
+        let client = current_client_name();
         let pool_label = PostgresStorage::pool_label(consistency);
         let labels = [
             (
@@ -21,6 +24,7 @@ impl DistinctIdLookup for PostgresStorage {
                 "get_distinct_ids_for_person".to_string(),
             ),
             ("pool".to_string(), pool_label.to_string()),
+            ("client".to_string(), client.clone()),
         ];
         let _timer = common_metrics::timing_guard(DB_QUERY_DURATION, &labels);
 
@@ -62,10 +66,13 @@ impl DistinctIdLookup for PostgresStorage {
 
         common_metrics::histogram(
             DB_ROWS_RETURNED,
-            &[(
-                "operation".to_string(),
-                "get_distinct_ids_for_person".to_string(),
-            )],
+            &[
+                (
+                    "operation".to_string(),
+                    "get_distinct_ids_for_person".to_string(),
+                ),
+                ("client".to_string(), client),
+            ],
             rows.len() as f64,
         );
 
@@ -83,6 +90,7 @@ impl DistinctIdLookup for PostgresStorage {
             return Ok(Vec::new());
         }
 
+        let client = current_client_name();
         let pool_label = PostgresStorage::pool_label(consistency);
         let labels = [
             (
@@ -90,6 +98,7 @@ impl DistinctIdLookup for PostgresStorage {
                 "get_distinct_ids_for_persons".to_string(),
             ),
             ("pool".to_string(), pool_label.to_string()),
+            ("client".to_string(), client.clone()),
         ];
         let _timer = common_metrics::timing_guard(DB_QUERY_DURATION, &labels);
 
@@ -135,10 +144,13 @@ impl DistinctIdLookup for PostgresStorage {
 
         common_metrics::histogram(
             DB_ROWS_RETURNED,
-            &[(
-                "operation".to_string(),
-                "get_distinct_ids_for_persons".to_string(),
-            )],
+            &[
+                (
+                    "operation".to_string(),
+                    "get_distinct_ids_for_persons".to_string(),
+                ),
+                ("client".to_string(), client),
+            ],
             rows.len() as f64,
         );
 

--- a/rust/personhog-replica/src/storage/postgres/feature_flag.rs
+++ b/rust/personhog-replica/src/storage/postgres/feature_flag.rs
@@ -42,7 +42,7 @@ impl FeatureFlagStorage for PostgresStorage {
                 "get_hash_key_override_context".to_string(),
             ),
             ("pool".to_string(), pool_label.to_string()),
-            ("client".to_string(), client.clone()),
+            ("client".to_string(), client.to_string()),
         ];
         let _timer = common_metrics::timing_guard(DB_QUERY_DURATION, &labels);
 
@@ -103,7 +103,7 @@ impl FeatureFlagStorage for PostgresStorage {
                     "operation".to_string(),
                     "get_hash_key_override_context".to_string(),
                 ),
-                ("client".to_string(), client),
+                ("client".to_string(), client.to_string()),
             ],
             rows.len() as f64,
         );
@@ -157,7 +157,7 @@ impl FeatureFlagStorage for PostgresStorage {
                 "upsert_hash_key_overrides".to_string(),
             ),
             ("pool".to_string(), "primary".to_string()),
-            ("client".to_string(), client),
+            ("client".to_string(), client.to_string()),
         ];
         let _timer = common_metrics::timing_guard(DB_QUERY_DURATION, &labels);
 
@@ -196,7 +196,7 @@ impl FeatureFlagStorage for PostgresStorage {
                 "delete_hash_key_overrides_by_teams".to_string(),
             ),
             ("pool".to_string(), "primary".to_string()),
-            ("client".to_string(), client),
+            ("client".to_string(), client.to_string()),
         ];
         let _timer = common_metrics::timing_guard(DB_QUERY_DURATION, &labels);
 

--- a/rust/personhog-replica/src/storage/postgres/feature_flag.rs
+++ b/rust/personhog-replica/src/storage/postgres/feature_flag.rs
@@ -3,6 +3,8 @@ use std::collections::HashMap;
 use async_trait::async_trait;
 use sqlx::FromRow;
 
+use personhog_common::grpc::current_client_name;
+
 use super::{ConsistencyLevel, PostgresStorage, DB_QUERY_DURATION, DB_ROWS_RETURNED};
 use crate::storage::error::StorageResult;
 use crate::storage::traits::FeatureFlagStorage;
@@ -32,6 +34,7 @@ impl FeatureFlagStorage for PostgresStorage {
             return Ok(Vec::new());
         }
 
+        let client = current_client_name();
         let pool_label = PostgresStorage::pool_label(consistency);
         let labels = [
             (
@@ -39,6 +42,7 @@ impl FeatureFlagStorage for PostgresStorage {
                 "get_hash_key_override_context".to_string(),
             ),
             ("pool".to_string(), pool_label.to_string()),
+            ("client".to_string(), client.clone()),
         ];
         let _timer = common_metrics::timing_guard(DB_QUERY_DURATION, &labels);
 
@@ -94,10 +98,13 @@ impl FeatureFlagStorage for PostgresStorage {
 
         common_metrics::histogram(
             DB_ROWS_RETURNED,
-            &[(
-                "operation".to_string(),
-                "get_hash_key_override_context".to_string(),
-            )],
+            &[
+                (
+                    "operation".to_string(),
+                    "get_hash_key_override_context".to_string(),
+                ),
+                ("client".to_string(), client),
+            ],
             rows.len() as f64,
         );
 
@@ -143,12 +150,14 @@ impl FeatureFlagStorage for PostgresStorage {
             return Ok(0);
         }
 
+        let client = current_client_name();
         let labels = [
             (
                 "operation".to_string(),
                 "upsert_hash_key_overrides".to_string(),
             ),
             ("pool".to_string(), "primary".to_string()),
+            ("client".to_string(), client),
         ];
         let _timer = common_metrics::timing_guard(DB_QUERY_DURATION, &labels);
 
@@ -180,12 +189,14 @@ impl FeatureFlagStorage for PostgresStorage {
             return Ok(0);
         }
 
+        let client = current_client_name();
         let labels = [
             (
                 "operation".to_string(),
                 "delete_hash_key_overrides_by_teams".to_string(),
             ),
             ("pool".to_string(), "primary".to_string()),
+            ("client".to_string(), client),
         ];
         let _timer = common_metrics::timing_guard(DB_QUERY_DURATION, &labels);
 

--- a/rust/personhog-replica/src/storage/postgres/group.rs
+++ b/rust/personhog-replica/src/storage/postgres/group.rs
@@ -21,7 +21,7 @@ impl GroupStorage for PostgresStorage {
         let labels = [
             ("operation".to_string(), "get_group".to_string()),
             ("pool".to_string(), pool_label.to_string()),
-            ("client".to_string(), client),
+            ("client".to_string(), client.to_string()),
         ];
         let _timer = common_metrics::timing_guard(DB_QUERY_DURATION, &labels);
 
@@ -65,7 +65,7 @@ impl GroupStorage for PostgresStorage {
         let labels = [
             ("operation".to_string(), "get_groups".to_string()),
             ("pool".to_string(), pool_label.to_string()),
-            ("client".to_string(), client.clone()),
+            ("client".to_string(), client.to_string()),
         ];
         let _timer = common_metrics::timing_guard(DB_QUERY_DURATION, &labels);
 
@@ -100,7 +100,7 @@ impl GroupStorage for PostgresStorage {
             DB_ROWS_RETURNED,
             &[
                 ("operation".to_string(), "get_groups".to_string()),
-                ("client".to_string(), client),
+                ("client".to_string(), client.to_string()),
             ],
             rows.len() as f64,
         );
@@ -122,7 +122,7 @@ impl GroupStorage for PostgresStorage {
         let labels = [
             ("operation".to_string(), "get_groups_batch".to_string()),
             ("pool".to_string(), pool_label.to_string()),
-            ("client".to_string(), client.clone()),
+            ("client".to_string(), client.to_string()),
         ];
         let _timer = common_metrics::timing_guard(DB_QUERY_DURATION, &labels);
 
@@ -157,7 +157,7 @@ impl GroupStorage for PostgresStorage {
             DB_ROWS_RETURNED,
             &[
                 ("operation".to_string(), "get_groups_batch".to_string()),
-                ("client".to_string(), client),
+                ("client".to_string(), client.to_string()),
             ],
             groups.len() as f64,
         );
@@ -188,7 +188,7 @@ impl GroupStorage for PostgresStorage {
                 "get_group_type_mappings_by_team_id".to_string(),
             ),
             ("pool".to_string(), pool_label.to_string()),
-            ("client".to_string(), client.clone()),
+            ("client".to_string(), client.to_string()),
         ];
         let _timer = common_metrics::timing_guard(DB_QUERY_DURATION, &labels);
 
@@ -218,7 +218,7 @@ impl GroupStorage for PostgresStorage {
                     "operation".to_string(),
                     "get_group_type_mappings_by_team_id".to_string(),
                 ),
-                ("client".to_string(), client),
+                ("client".to_string(), client.to_string()),
             ],
             rows.len() as f64,
         );
@@ -243,7 +243,7 @@ impl GroupStorage for PostgresStorage {
                 "get_group_type_mappings_by_team_ids".to_string(),
             ),
             ("pool".to_string(), pool_label.to_string()),
-            ("client".to_string(), client.clone()),
+            ("client".to_string(), client.to_string()),
         ];
         let _timer = common_metrics::timing_guard(DB_QUERY_DURATION, &labels);
 
@@ -275,7 +275,7 @@ impl GroupStorage for PostgresStorage {
                     "operation".to_string(),
                     "get_group_type_mappings_by_team_ids".to_string(),
                 ),
-                ("client".to_string(), client),
+                ("client".to_string(), client.to_string()),
             ],
             rows.len() as f64,
         );
@@ -296,7 +296,7 @@ impl GroupStorage for PostgresStorage {
                 "get_group_type_mappings_by_project_id".to_string(),
             ),
             ("pool".to_string(), pool_label.to_string()),
-            ("client".to_string(), client.clone()),
+            ("client".to_string(), client.to_string()),
         ];
         let _timer = common_metrics::timing_guard(DB_QUERY_DURATION, &labels);
 
@@ -326,7 +326,7 @@ impl GroupStorage for PostgresStorage {
                     "operation".to_string(),
                     "get_group_type_mappings_by_project_id".to_string(),
                 ),
-                ("client".to_string(), client),
+                ("client".to_string(), client.to_string()),
             ],
             rows.len() as f64,
         );
@@ -351,7 +351,7 @@ impl GroupStorage for PostgresStorage {
                 "get_group_type_mappings_by_project_ids".to_string(),
             ),
             ("pool".to_string(), pool_label.to_string()),
-            ("client".to_string(), client.clone()),
+            ("client".to_string(), client.to_string()),
         ];
         let _timer = common_metrics::timing_guard(DB_QUERY_DURATION, &labels);
 
@@ -381,7 +381,7 @@ impl GroupStorage for PostgresStorage {
                     "operation".to_string(),
                     "get_group_type_mappings_by_project_ids".to_string(),
                 ),
-                ("client".to_string(), client),
+                ("client".to_string(), client.to_string()),
             ],
             rows.len() as f64,
         );

--- a/rust/personhog-replica/src/storage/postgres/group.rs
+++ b/rust/personhog-replica/src/storage/postgres/group.rs
@@ -1,5 +1,7 @@
 use async_trait::async_trait;
 
+use personhog_common::grpc::current_client_name;
+
 use super::{ConsistencyLevel, PostgresStorage, DB_QUERY_DURATION, DB_ROWS_RETURNED};
 use crate::storage::error::StorageResult;
 use crate::storage::traits::GroupStorage;
@@ -14,10 +16,12 @@ impl GroupStorage for PostgresStorage {
         group_key: &str,
         consistency: ConsistencyLevel,
     ) -> StorageResult<Option<Group>> {
+        let client = current_client_name();
         let pool_label = PostgresStorage::pool_label(consistency);
         let labels = [
             ("operation".to_string(), "get_group".to_string()),
             ("pool".to_string(), pool_label.to_string()),
+            ("client".to_string(), client),
         ];
         let _timer = common_metrics::timing_guard(DB_QUERY_DURATION, &labels);
 
@@ -56,10 +60,12 @@ impl GroupStorage for PostgresStorage {
             return Ok(Vec::new());
         }
 
+        let client = current_client_name();
         let pool_label = PostgresStorage::pool_label(consistency);
         let labels = [
             ("operation".to_string(), "get_groups".to_string()),
             ("pool".to_string(), pool_label.to_string()),
+            ("client".to_string(), client.clone()),
         ];
         let _timer = common_metrics::timing_guard(DB_QUERY_DURATION, &labels);
 
@@ -92,7 +98,10 @@ impl GroupStorage for PostgresStorage {
 
         common_metrics::histogram(
             DB_ROWS_RETURNED,
-            &[("operation".to_string(), "get_groups".to_string())],
+            &[
+                ("operation".to_string(), "get_groups".to_string()),
+                ("client".to_string(), client),
+            ],
             rows.len() as f64,
         );
 
@@ -108,10 +117,12 @@ impl GroupStorage for PostgresStorage {
             return Ok(Vec::new());
         }
 
+        let client = current_client_name();
         let pool_label = PostgresStorage::pool_label(consistency);
         let labels = [
             ("operation".to_string(), "get_groups_batch".to_string()),
             ("pool".to_string(), pool_label.to_string()),
+            ("client".to_string(), client.clone()),
         ];
         let _timer = common_metrics::timing_guard(DB_QUERY_DURATION, &labels);
 
@@ -144,7 +155,10 @@ impl GroupStorage for PostgresStorage {
 
         common_metrics::histogram(
             DB_ROWS_RETURNED,
-            &[("operation".to_string(), "get_groups_batch".to_string())],
+            &[
+                ("operation".to_string(), "get_groups_batch".to_string()),
+                ("client".to_string(), client),
+            ],
             groups.len() as f64,
         );
 
@@ -166,6 +180,7 @@ impl GroupStorage for PostgresStorage {
         team_id: i64,
         consistency: ConsistencyLevel,
     ) -> StorageResult<Vec<GroupTypeMapping>> {
+        let client = current_client_name();
         let pool_label = PostgresStorage::pool_label(consistency);
         let labels = [
             (
@@ -173,6 +188,7 @@ impl GroupStorage for PostgresStorage {
                 "get_group_type_mappings_by_team_id".to_string(),
             ),
             ("pool".to_string(), pool_label.to_string()),
+            ("client".to_string(), client.clone()),
         ];
         let _timer = common_metrics::timing_guard(DB_QUERY_DURATION, &labels);
 
@@ -197,10 +213,13 @@ impl GroupStorage for PostgresStorage {
 
         common_metrics::histogram(
             DB_ROWS_RETURNED,
-            &[(
-                "operation".to_string(),
-                "get_group_type_mappings_by_team_id".to_string(),
-            )],
+            &[
+                (
+                    "operation".to_string(),
+                    "get_group_type_mappings_by_team_id".to_string(),
+                ),
+                ("client".to_string(), client),
+            ],
             rows.len() as f64,
         );
 
@@ -216,6 +235,7 @@ impl GroupStorage for PostgresStorage {
             return Ok(Vec::new());
         }
 
+        let client = current_client_name();
         let pool_label = PostgresStorage::pool_label(consistency);
         let labels = [
             (
@@ -223,6 +243,7 @@ impl GroupStorage for PostgresStorage {
                 "get_group_type_mappings_by_team_ids".to_string(),
             ),
             ("pool".to_string(), pool_label.to_string()),
+            ("client".to_string(), client.clone()),
         ];
         let _timer = common_metrics::timing_guard(DB_QUERY_DURATION, &labels);
 
@@ -249,10 +270,13 @@ impl GroupStorage for PostgresStorage {
 
         common_metrics::histogram(
             DB_ROWS_RETURNED,
-            &[(
-                "operation".to_string(),
-                "get_group_type_mappings_by_team_ids".to_string(),
-            )],
+            &[
+                (
+                    "operation".to_string(),
+                    "get_group_type_mappings_by_team_ids".to_string(),
+                ),
+                ("client".to_string(), client),
+            ],
             rows.len() as f64,
         );
 
@@ -264,6 +288,7 @@ impl GroupStorage for PostgresStorage {
         project_id: i64,
         consistency: ConsistencyLevel,
     ) -> StorageResult<Vec<GroupTypeMapping>> {
+        let client = current_client_name();
         let pool_label = PostgresStorage::pool_label(consistency);
         let labels = [
             (
@@ -271,6 +296,7 @@ impl GroupStorage for PostgresStorage {
                 "get_group_type_mappings_by_project_id".to_string(),
             ),
             ("pool".to_string(), pool_label.to_string()),
+            ("client".to_string(), client.clone()),
         ];
         let _timer = common_metrics::timing_guard(DB_QUERY_DURATION, &labels);
 
@@ -295,10 +321,13 @@ impl GroupStorage for PostgresStorage {
 
         common_metrics::histogram(
             DB_ROWS_RETURNED,
-            &[(
-                "operation".to_string(),
-                "get_group_type_mappings_by_project_id".to_string(),
-            )],
+            &[
+                (
+                    "operation".to_string(),
+                    "get_group_type_mappings_by_project_id".to_string(),
+                ),
+                ("client".to_string(), client),
+            ],
             rows.len() as f64,
         );
 
@@ -314,6 +343,7 @@ impl GroupStorage for PostgresStorage {
             return Ok(Vec::new());
         }
 
+        let client = current_client_name();
         let pool_label = PostgresStorage::pool_label(consistency);
         let labels = [
             (
@@ -321,6 +351,7 @@ impl GroupStorage for PostgresStorage {
                 "get_group_type_mappings_by_project_ids".to_string(),
             ),
             ("pool".to_string(), pool_label.to_string()),
+            ("client".to_string(), client.clone()),
         ];
         let _timer = common_metrics::timing_guard(DB_QUERY_DURATION, &labels);
 
@@ -345,10 +376,13 @@ impl GroupStorage for PostgresStorage {
 
         common_metrics::histogram(
             DB_ROWS_RETURNED,
-            &[(
-                "operation".to_string(),
-                "get_group_type_mappings_by_project_ids".to_string(),
-            )],
+            &[
+                (
+                    "operation".to_string(),
+                    "get_group_type_mappings_by_project_ids".to_string(),
+                ),
+                ("client".to_string(), client),
+            ],
             rows.len() as f64,
         );
 

--- a/rust/personhog-replica/src/storage/postgres/mod.rs
+++ b/rust/personhog-replica/src/storage/postgres/mod.rs
@@ -86,7 +86,7 @@ impl PostgresStorage {
                 ("pool".to_string(), pool_label.to_string()),
                 (
                     "client".to_string(),
-                    personhog_common::grpc::current_client_name(),
+                    personhog_common::grpc::current_client_name().to_string(),
                 ),
             ],
             elapsed_ms,

--- a/rust/personhog-replica/src/storage/postgres/mod.rs
+++ b/rust/personhog-replica/src/storage/postgres/mod.rs
@@ -72,7 +72,7 @@ impl PostgresStorage {
     }
 
     /// Acquire a connection from the given pool, recording the acquisition time
-    /// as `personhog_replica_db_pool_acquire_duration_ms` with a `pool` label.
+    /// as `personhog_replica_db_pool_acquire_duration_ms` with `pool` and `client` labels.
     pub(crate) async fn acquire_timed(
         pool: &PgPool,
         pool_label: &str,
@@ -82,7 +82,13 @@ impl PostgresStorage {
         let elapsed_ms = start.elapsed().as_secs_f64() * 1000.0;
         common_metrics::histogram(
             DB_POOL_ACQUIRE_DURATION,
-            &[("pool".to_string(), pool_label.to_string())],
+            &[
+                ("pool".to_string(), pool_label.to_string()),
+                (
+                    "client".to_string(),
+                    personhog_common::grpc::current_client_name(),
+                ),
+            ],
             elapsed_ms,
         );
         Ok(conn)

--- a/rust/personhog-replica/src/storage/postgres/person.rs
+++ b/rust/personhog-replica/src/storage/postgres/person.rs
@@ -3,6 +3,8 @@ use std::collections::HashMap;
 use async_trait::async_trait;
 use uuid::Uuid;
 
+use personhog_common::grpc::current_client_name;
+
 use super::{PostgresStorage, DB_QUERY_DURATION, DB_ROWS_RETURNED};
 use crate::storage::error::StorageResult;
 use crate::storage::traits::PersonLookup;
@@ -17,9 +19,11 @@ impl PersonLookup for PostgresStorage {
         team_id: i64,
         person_id: i64,
     ) -> StorageResult<Option<Person>> {
+        let client = current_client_name();
         let labels = [
             ("operation".to_string(), "get_person_by_id".to_string()),
             ("pool".to_string(), POOL_LABEL.to_string()),
+            ("client".to_string(), client),
         ];
         let _timer = common_metrics::timing_guard(DB_QUERY_DURATION, &labels);
 
@@ -46,9 +50,11 @@ impl PersonLookup for PostgresStorage {
     }
 
     async fn get_person_by_uuid(&self, team_id: i64, uuid: Uuid) -> StorageResult<Option<Person>> {
+        let client = current_client_name();
         let labels = [
             ("operation".to_string(), "get_person_by_uuid".to_string()),
             ("pool".to_string(), POOL_LABEL.to_string()),
+            ("client".to_string(), client),
         ];
         let _timer = common_metrics::timing_guard(DB_QUERY_DURATION, &labels);
 
@@ -83,9 +89,11 @@ impl PersonLookup for PostgresStorage {
             return Ok(Vec::new());
         }
 
+        let client = current_client_name();
         let labels = [
             ("operation".to_string(), "get_persons_by_ids".to_string()),
             ("pool".to_string(), POOL_LABEL.to_string()),
+            ("client".to_string(), client.clone()),
         ];
         let _timer = common_metrics::timing_guard(DB_QUERY_DURATION, &labels);
 
@@ -110,7 +118,10 @@ impl PersonLookup for PostgresStorage {
 
         common_metrics::histogram(
             DB_ROWS_RETURNED,
-            &[("operation".to_string(), "get_persons_by_ids".to_string())],
+            &[
+                ("operation".to_string(), "get_persons_by_ids".to_string()),
+                ("client".to_string(), client),
+            ],
             rows.len() as f64,
         );
 
@@ -126,9 +137,11 @@ impl PersonLookup for PostgresStorage {
             return Ok(Vec::new());
         }
 
+        let client = current_client_name();
         let labels = [
             ("operation".to_string(), "get_persons_by_uuids".to_string()),
             ("pool".to_string(), POOL_LABEL.to_string()),
+            ("client".to_string(), client.clone()),
         ];
         let _timer = common_metrics::timing_guard(DB_QUERY_DURATION, &labels);
 
@@ -153,7 +166,10 @@ impl PersonLookup for PostgresStorage {
 
         common_metrics::histogram(
             DB_ROWS_RETURNED,
-            &[("operation".to_string(), "get_persons_by_uuids".to_string())],
+            &[
+                ("operation".to_string(), "get_persons_by_uuids".to_string()),
+                ("client".to_string(), client),
+            ],
             rows.len() as f64,
         );
 
@@ -165,12 +181,14 @@ impl PersonLookup for PostgresStorage {
         team_id: i64,
         distinct_id: &str,
     ) -> StorageResult<Option<Person>> {
+        let client = current_client_name();
         let labels = [
             (
                 "operation".to_string(),
                 "get_person_by_distinct_id".to_string(),
             ),
             ("pool".to_string(), POOL_LABEL.to_string()),
+            ("client".to_string(), client),
         ];
         let _timer = common_metrics::timing_guard(DB_QUERY_DURATION, &labels);
 
@@ -207,12 +225,14 @@ impl PersonLookup for PostgresStorage {
             return Ok(Vec::new());
         }
 
+        let client = current_client_name();
         let labels = [
             (
                 "operation".to_string(),
                 "get_persons_by_distinct_ids_in_team".to_string(),
             ),
             ("pool".to_string(), POOL_LABEL.to_string()),
+            ("client".to_string(), client.clone()),
         ];
         let _timer = common_metrics::timing_guard(DB_QUERY_DURATION, &labels);
 
@@ -240,10 +260,13 @@ impl PersonLookup for PostgresStorage {
 
         common_metrics::histogram(
             DB_ROWS_RETURNED,
-            &[(
-                "operation".to_string(),
-                "get_persons_by_distinct_ids_in_team".to_string(),
-            )],
+            &[
+                (
+                    "operation".to_string(),
+                    "get_persons_by_distinct_ids_in_team".to_string(),
+                ),
+                ("client".to_string(), client),
+            ],
             rows.len() as f64,
         );
 
@@ -281,12 +304,14 @@ impl PersonLookup for PostgresStorage {
             return Ok(Vec::new());
         }
 
+        let client = current_client_name();
         let labels = [
             (
                 "operation".to_string(),
                 "get_persons_by_distinct_ids_cross_team".to_string(),
             ),
             ("pool".to_string(), POOL_LABEL.to_string()),
+            ("client".to_string(), client.clone()),
         ];
         let _timer = common_metrics::timing_guard(DB_QUERY_DURATION, &labels);
 
@@ -318,10 +343,13 @@ impl PersonLookup for PostgresStorage {
 
         common_metrics::histogram(
             DB_ROWS_RETURNED,
-            &[(
-                "operation".to_string(),
-                "get_persons_by_distinct_ids_cross_team".to_string(),
-            )],
+            &[
+                (
+                    "operation".to_string(),
+                    "get_persons_by_distinct_ids_cross_team".to_string(),
+                ),
+                ("client".to_string(), client),
+            ],
             rows.len() as f64,
         );
 

--- a/rust/personhog-replica/src/storage/postgres/person.rs
+++ b/rust/personhog-replica/src/storage/postgres/person.rs
@@ -23,7 +23,7 @@ impl PersonLookup for PostgresStorage {
         let labels = [
             ("operation".to_string(), "get_person_by_id".to_string()),
             ("pool".to_string(), POOL_LABEL.to_string()),
-            ("client".to_string(), client),
+            ("client".to_string(), client.to_string()),
         ];
         let _timer = common_metrics::timing_guard(DB_QUERY_DURATION, &labels);
 
@@ -54,7 +54,7 @@ impl PersonLookup for PostgresStorage {
         let labels = [
             ("operation".to_string(), "get_person_by_uuid".to_string()),
             ("pool".to_string(), POOL_LABEL.to_string()),
-            ("client".to_string(), client),
+            ("client".to_string(), client.to_string()),
         ];
         let _timer = common_metrics::timing_guard(DB_QUERY_DURATION, &labels);
 
@@ -93,7 +93,7 @@ impl PersonLookup for PostgresStorage {
         let labels = [
             ("operation".to_string(), "get_persons_by_ids".to_string()),
             ("pool".to_string(), POOL_LABEL.to_string()),
-            ("client".to_string(), client.clone()),
+            ("client".to_string(), client.to_string()),
         ];
         let _timer = common_metrics::timing_guard(DB_QUERY_DURATION, &labels);
 
@@ -120,7 +120,7 @@ impl PersonLookup for PostgresStorage {
             DB_ROWS_RETURNED,
             &[
                 ("operation".to_string(), "get_persons_by_ids".to_string()),
-                ("client".to_string(), client),
+                ("client".to_string(), client.to_string()),
             ],
             rows.len() as f64,
         );
@@ -141,7 +141,7 @@ impl PersonLookup for PostgresStorage {
         let labels = [
             ("operation".to_string(), "get_persons_by_uuids".to_string()),
             ("pool".to_string(), POOL_LABEL.to_string()),
-            ("client".to_string(), client.clone()),
+            ("client".to_string(), client.to_string()),
         ];
         let _timer = common_metrics::timing_guard(DB_QUERY_DURATION, &labels);
 
@@ -168,7 +168,7 @@ impl PersonLookup for PostgresStorage {
             DB_ROWS_RETURNED,
             &[
                 ("operation".to_string(), "get_persons_by_uuids".to_string()),
-                ("client".to_string(), client),
+                ("client".to_string(), client.to_string()),
             ],
             rows.len() as f64,
         );
@@ -188,7 +188,7 @@ impl PersonLookup for PostgresStorage {
                 "get_person_by_distinct_id".to_string(),
             ),
             ("pool".to_string(), POOL_LABEL.to_string()),
-            ("client".to_string(), client),
+            ("client".to_string(), client.to_string()),
         ];
         let _timer = common_metrics::timing_guard(DB_QUERY_DURATION, &labels);
 
@@ -232,7 +232,7 @@ impl PersonLookup for PostgresStorage {
                 "get_persons_by_distinct_ids_in_team".to_string(),
             ),
             ("pool".to_string(), POOL_LABEL.to_string()),
-            ("client".to_string(), client.clone()),
+            ("client".to_string(), client.to_string()),
         ];
         let _timer = common_metrics::timing_guard(DB_QUERY_DURATION, &labels);
 
@@ -265,7 +265,7 @@ impl PersonLookup for PostgresStorage {
                     "operation".to_string(),
                     "get_persons_by_distinct_ids_in_team".to_string(),
                 ),
-                ("client".to_string(), client),
+                ("client".to_string(), client.to_string()),
             ],
             rows.len() as f64,
         );
@@ -311,7 +311,7 @@ impl PersonLookup for PostgresStorage {
                 "get_persons_by_distinct_ids_cross_team".to_string(),
             ),
             ("pool".to_string(), POOL_LABEL.to_string()),
-            ("client".to_string(), client.clone()),
+            ("client".to_string(), client.to_string()),
         ];
         let _timer = common_metrics::timing_guard(DB_QUERY_DURATION, &labels);
 
@@ -348,7 +348,7 @@ impl PersonLookup for PostgresStorage {
                     "operation".to_string(),
                     "get_persons_by_distinct_ids_cross_team".to_string(),
                 ),
-                ("client".to_string(), client),
+                ("client".to_string(), client.to_string()),
             ],
             rows.len() as f64,
         );

--- a/rust/personhog-router/src/backend/leader.rs
+++ b/rust/personhog-router/src/backend/leader.rs
@@ -14,6 +14,8 @@ use tokio::sync::RwLock;
 use tonic::transport::Channel;
 use tonic::{Request, Status};
 
+use personhog_common::grpc::current_client_name;
+
 use super::retry::with_retry;
 use super::LeaderOps;
 use crate::config::RetryConfig;
@@ -189,10 +191,15 @@ impl LeaderOps for LeaderBackend {
         with_retry(&self.retry_config, "get_person", || {
             let client_fut = self.resolve_leader(partition);
             let req = leader_req;
+            let client_name = current_client_name();
             async move {
                 let mut client = client_fut.await?;
+                let mut request = Request::new(req);
+                if let Ok(val) = client_name.parse() {
+                    request.metadata_mut().insert("x-client-name", val);
+                }
                 client
-                    .get_person(Request::new(req))
+                    .get_person(request)
                     .await
                     .map(|r| r.into_inner())
             }
@@ -210,10 +217,15 @@ impl LeaderOps for LeaderBackend {
         with_retry(&self.retry_config, "update_person_properties", || {
             let client_fut = self.resolve_leader(partition);
             let req = req_with_partition.clone();
+            let client_name = current_client_name();
             async move {
                 let mut client = client_fut.await?;
+                let mut request = Request::new(req);
+                if let Ok(val) = client_name.parse() {
+                    request.metadata_mut().insert("x-client-name", val);
+                }
                 client
-                    .update_person_properties(Request::new(req))
+                    .update_person_properties(request)
                     .await
                     .map(|r| r.into_inner())
             }

--- a/rust/personhog-router/src/backend/leader.rs
+++ b/rust/personhog-router/src/backend/leader.rs
@@ -198,10 +198,7 @@ impl LeaderOps for LeaderBackend {
                 if let Ok(val) = client_name.parse() {
                     request.metadata_mut().insert("x-client-name", val);
                 }
-                client
-                    .get_person(request)
-                    .await
-                    .map(|r| r.into_inner())
+                client.get_person(request).await.map(|r| r.into_inner())
             }
         })
         .await

--- a/rust/personhog-router/src/backend/replica.rs
+++ b/rust/personhog-router/src/backend/replica.rs
@@ -19,6 +19,8 @@ use std::time::Duration;
 use tonic::transport::Channel;
 use tonic::{Request, Status};
 
+use personhog_common::grpc::current_client_name;
+
 use super::retry::with_retry;
 use super::PersonHogBackend;
 use crate::config::RetryConfig;
@@ -61,14 +63,21 @@ impl ReplicaBackend {
 }
 
 /// Wraps a gRPC call with retry logic. Clones the request for each attempt.
+/// Forwards the `x-client-name` header so the downstream service can
+/// attribute metrics to the originating client.
 macro_rules! retry_call {
     ($self:expr, $method:ident, $request:expr) => {
         with_retry(&$self.retry_config, stringify!($method), || {
             let mut client = $self.client.clone();
             let req = $request.clone();
+            let client_name = current_client_name();
             async move {
+                let mut request = Request::new(req);
+                if let Ok(val) = client_name.parse() {
+                    request.metadata_mut().insert("x-client-name", val);
+                }
                 client
-                    .$method(Request::new(req))
+                    .$method(request)
                     .await
                     .map(|r| r.into_inner())
             }

--- a/rust/personhog-router/src/backend/replica.rs
+++ b/rust/personhog-router/src/backend/replica.rs
@@ -76,10 +76,7 @@ macro_rules! retry_call {
                 if let Ok(val) = client_name.parse() {
                     request.metadata_mut().insert("x-client-name", val);
                 }
-                client
-                    .$method(request)
-                    .await
-                    .map(|r| r.into_inner())
+                client.$method(request).await.map(|r| r.into_inner())
             }
         })
         .await

--- a/rust/personhog-router/src/backend/retry.rs
+++ b/rust/personhog-router/src/backend/retry.rs
@@ -61,7 +61,7 @@ where
                     "personhog_router_backend_retries_total",
                     "method" => method,
                     "status_code" => code_str,
-                    "client" => client.to_string()
+                    "client" => client.clone()
                 )
                 .increment(1);
 

--- a/rust/personhog-router/src/backend/retry.rs
+++ b/rust/personhog-router/src/backend/retry.rs
@@ -2,6 +2,7 @@ use std::future::Future;
 use std::time::Duration;
 
 use metrics::counter;
+use personhog_common::grpc::current_client_name;
 use rand::Rng;
 use tonic::{Code, Status};
 use tracing::warn;
@@ -54,11 +55,13 @@ where
             Ok(value) => return Ok(value),
             Err(status) if attempt < config.max_retries && is_retryable(status.code()) => {
                 let code_str = code_as_str(status.code());
+                let client = current_client_name();
 
                 counter!(
                     "personhog_router_backend_retries_total",
                     "method" => method,
-                    "status_code" => code_str
+                    "status_code" => code_str,
+                    "client" => client
                 )
                 .increment(1);
 

--- a/rust/personhog-router/src/backend/retry.rs
+++ b/rust/personhog-router/src/backend/retry.rs
@@ -61,7 +61,7 @@ where
                     "personhog_router_backend_retries_total",
                     "method" => method,
                     "status_code" => code_str,
-                    "client" => client
+                    "client" => client.to_string()
                 )
                 .increment(1);
 

--- a/rust/personhog-router/src/router/mod.rs
+++ b/rust/personhog-router/src/router/mod.rs
@@ -36,7 +36,7 @@ macro_rules! call_backend {
             "personhog_router_backend_requests_total",
             "method" => $method_name,
             "backend" => "replica",
-            "client" => client.clone()
+            "client" => client.to_string()
         )
         .increment(1);
 
@@ -50,7 +50,7 @@ macro_rules! call_backend {
             "personhog_router_backend_duration_ms",
             "method" => $method_name,
             "backend" => "replica",
-            "client" => client.clone()
+            "client" => client.to_string()
         )
         .record(duration_ms);
 
@@ -59,7 +59,7 @@ macro_rules! call_backend {
                 "personhog_router_backend_errors_total",
                 "method" => $method_name,
                 "backend" => "replica",
-                "client" => client
+                "client" => client.to_string()
             )
             .increment(1);
         }
@@ -80,7 +80,7 @@ macro_rules! call_leader {
             "personhog_router_backend_requests_total",
             "method" => $method_name,
             "backend" => "leader",
-            "client" => client.clone()
+            "client" => client.to_string()
         )
         .increment(1);
 
@@ -92,7 +92,7 @@ macro_rules! call_leader {
             "personhog_router_backend_duration_ms",
             "method" => $method_name,
             "backend" => "leader",
-            "client" => client.clone()
+            "client" => client.to_string()
         )
         .record(duration_ms);
 
@@ -101,7 +101,7 @@ macro_rules! call_leader {
                 "personhog_router_backend_errors_total",
                 "method" => $method_name,
                 "backend" => "leader",
-                "client" => client
+                "client" => client.to_string()
             )
             .increment(1);
         }

--- a/rust/personhog-router/src/router/mod.rs
+++ b/rust/personhog-router/src/router/mod.rs
@@ -36,7 +36,7 @@ macro_rules! call_backend {
             "personhog_router_backend_requests_total",
             "method" => $method_name,
             "backend" => "replica",
-            "client" => client.to_string()
+            "client" => client.clone()
         )
         .increment(1);
 
@@ -50,7 +50,7 @@ macro_rules! call_backend {
             "personhog_router_backend_duration_ms",
             "method" => $method_name,
             "backend" => "replica",
-            "client" => client.to_string()
+            "client" => client.clone()
         )
         .record(duration_ms);
 
@@ -59,7 +59,7 @@ macro_rules! call_backend {
                 "personhog_router_backend_errors_total",
                 "method" => $method_name,
                 "backend" => "replica",
-                "client" => client.to_string()
+                "client" => client.clone()
             )
             .increment(1);
         }
@@ -80,7 +80,7 @@ macro_rules! call_leader {
             "personhog_router_backend_requests_total",
             "method" => $method_name,
             "backend" => "leader",
-            "client" => client.to_string()
+            "client" => client.clone()
         )
         .increment(1);
 
@@ -92,7 +92,7 @@ macro_rules! call_leader {
             "personhog_router_backend_duration_ms",
             "method" => $method_name,
             "backend" => "leader",
-            "client" => client.to_string()
+            "client" => client.clone()
         )
         .record(duration_ms);
 
@@ -101,7 +101,7 @@ macro_rules! call_leader {
                 "personhog_router_backend_errors_total",
                 "method" => $method_name,
                 "backend" => "leader",
-                "client" => client.to_string()
+                "client" => client.clone()
             )
             .increment(1);
         }

--- a/rust/personhog-router/src/router/mod.rs
+++ b/rust/personhog-router/src/router/mod.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use metrics::{counter, histogram};
-use personhog_common::grpc::ClientInFlightGuard;
+use personhog_common::grpc::{current_client_name, ClientInFlightGuard};
 use personhog_proto::personhog::types::v1::{
     CheckCohortMembershipRequest, CohortMembershipResponse, DeleteHashKeyOverridesByTeamsRequest,
     DeleteHashKeyOverridesByTeamsResponse, GetDistinctIdsForPersonRequest,
@@ -31,10 +31,12 @@ use routing::{get_consistency, route_request};
 /// Calls a replica backend method with timing instrumentation.
 macro_rules! call_backend {
     ($self:expr, $method_name:expr, $method:ident, $request:expr) => {{
+        let client = current_client_name();
         counter!(
             "personhog_router_backend_requests_total",
             "method" => $method_name,
-            "backend" => "replica"
+            "backend" => "replica",
+            "client" => client.clone()
         )
         .increment(1);
 
@@ -47,7 +49,8 @@ macro_rules! call_backend {
         histogram!(
             "personhog_router_backend_duration_ms",
             "method" => $method_name,
-            "backend" => "replica"
+            "backend" => "replica",
+            "client" => client.clone()
         )
         .record(duration_ms);
 
@@ -55,7 +58,8 @@ macro_rules! call_backend {
             counter!(
                 "personhog_router_backend_errors_total",
                 "method" => $method_name,
-                "backend" => "replica"
+                "backend" => "replica",
+                "client" => client
             )
             .increment(1);
         }
@@ -71,10 +75,12 @@ macro_rules! call_leader {
             Status::unimplemented("leader backend not configured for this router")
         })?;
 
+        let client = current_client_name();
         counter!(
             "personhog_router_backend_requests_total",
             "method" => $method_name,
-            "backend" => "leader"
+            "backend" => "leader",
+            "client" => client.clone()
         )
         .increment(1);
 
@@ -85,7 +91,8 @@ macro_rules! call_leader {
         histogram!(
             "personhog_router_backend_duration_ms",
             "method" => $method_name,
-            "backend" => "leader"
+            "backend" => "leader",
+            "client" => client.clone()
         )
         .record(duration_ms);
 
@@ -93,7 +100,8 @@ macro_rules! call_leader {
             counter!(
                 "personhog_router_backend_errors_total",
                 "method" => $method_name,
-                "backend" => "leader"
+                "backend" => "leader",
+                "client" => client
             )
             .increment(1);
         }


### PR DESCRIPTION
## Problem

We send an `x-client-name` gRPC metadata header from every personhog client (Django web, Django worker, property-defs-rs, etc.), but personhog-router and personhog-replica never read it. All server-side metrics are only broken down by `method` — there's no way to tell which client is responsible for latency spikes, error surges, or pool exhaustion on the server side.

## Changes

Extract the `x-client-name` header in the shared `GrpcMetricsLayer` (Tower middleware) and add a `client` label to **every** metric emitted by both personhog-router and personhog-replica.

**personhog-common** (`grpc.rs`):
- Added a `tokio::task_local! CLIENT_NAME` and `current_client_name()` helper so any code in the request's async call chain can read the client name without parameter threading
- `GrpcMetricsLayer` now extracts `x-client-name` from HTTP/2 headers, sets the task-local via `.scope()`, and adds `client` to `grpc_server_requests_total`, `grpc_server_request_duration_ms`, and `grpc_server_requests_in_flight`
- `ClientInFlightGuard` now includes `client` on `personhog_router_client_requests_in_flight`

**personhog-router**:
- `call_backend!` / `call_leader!` macros add `client` to `personhog_router_backend_requests_total`, `personhog_router_backend_duration_ms`, `personhog_router_backend_errors_total`
- Retry counter (`personhog_router_backend_retries_total`) gains `client`
- `retry_call!` in `replica.rs` and retry closures in `leader.rs` now **forward** the `x-client-name` header to downstream services so the replica/leader also see the originating client

**personhog-replica**:
- `acquire_timed` adds `client` to `personhog_replica_db_pool_acquire_duration_ms`
- All storage methods in `person.rs`, `distinct_id.rs`, `group.rs`, `feature_flag.rs`, `cohort.rs` add `client` to `personhog_replica_db_query_duration_ms` and `personhog_replica_db_rows_returned`
- `log_and_convert_error` adds `client` to `personhog_replica_storage_errors_total`

Defaults to `"unknown"` when the header is absent (backwards-compatible — existing callers without the header just get the unknown bucket).


## How did you test this code?

- `cargo check -p personhog-common -p personhog-router -p personhog-replica` — compiles cleanly
- `cargo test -p personhog-common -p personhog-router -p personhog-replica` — all existing tests pass (task-local defaults to `"unknown"` in tests)
- `cargo clippy -p personhog-common -p personhog-router -p personhog-replica -- -D warnings` — zero warnings