### PR TITLE
chore(nodejs): set client header for personhog requests

### DIFF
--- a/nodejs/src/ingestion/config.ts
+++ b/nodejs/src/ingestion/config.ts
@@ -61,6 +61,7 @@ export type PersonHogConfig = Pick<
     | 'PERSONHOG_PING_INTERVAL_MS'
     | 'PERSONHOG_PING_TIMEOUT_MS'
     | 'PERSONHOG_PING_IDLE_CONNECTION'
+    | 'PLUGIN_SERVER_MODE'
 >
 
 /** Kafka consumer loop tuning config */

--- a/nodejs/src/ingestion/personhog/client.ts
+++ b/nodejs/src/ingestion/personhog/client.ts
@@ -60,8 +60,9 @@ export class PersonHogClient {
         const scheme = config.useTls ? 'https' : 'http'
         const interceptors: Interceptor[] = []
         if (config.clientName) {
+            const clientName = config.clientName
             interceptors.push((next) => async (req) => {
-                req.header.set('x-client-name', config.clientName!)
+                req.header.set('x-client-name', clientName)
                 return await next(req)
             })
         }

--- a/nodejs/src/ingestion/personhog/client.ts
+++ b/nodejs/src/ingestion/personhog/client.ts
@@ -1,5 +1,5 @@
 import { create } from '@bufbuild/protobuf'
-import { Transport, createClient } from '@connectrpc/connect'
+import { Interceptor, Transport, createClient } from '@connectrpc/connect'
 import { createGrpcTransport } from '@connectrpc/connect-node'
 import { DateTime } from 'luxon'
 
@@ -32,6 +32,7 @@ export function eventualReadOptions() {
 
 export interface PersonHogClientConfig {
     addr: string
+    clientName?: string
     useTls?: boolean
     timeoutMs?: number
     readMaxBytes?: number
@@ -57,6 +58,13 @@ export class PersonHogClient {
 
     static fromConfig(config: PersonHogClientConfig): PersonHogClient {
         const scheme = config.useTls ? 'https' : 'http'
+        const interceptors: Interceptor[] = []
+        if (config.clientName) {
+            interceptors.push((next) => async (req) => {
+                req.header.set('x-client-name', config.clientName!)
+                return await next(req)
+            })
+        }
         const transport = createGrpcTransport({
             baseUrl: `${scheme}://${config.addr}`,
             defaultTimeoutMs: config.timeoutMs ?? 5_000,
@@ -65,6 +73,7 @@ export class PersonHogClient {
             pingIntervalMs: config.pingIntervalMs ?? 30_000,
             pingTimeoutMs: config.pingTimeoutMs ?? 5_000,
             pingIdleConnection: config.pingIdleConnection ?? true,
+            interceptors,
         })
         return new PersonHogClient(transport)
     }

--- a/nodejs/src/ingestion/personhog/index.ts
+++ b/nodejs/src/ingestion/personhog/index.ts
@@ -20,6 +20,7 @@ export function createPersonHogClient(config: PersonHogConfig): PersonHogClient 
 
     return PersonHogClient.fromConfig({
         addr: config.PERSONHOG_ADDR,
+        clientName: config.PLUGIN_SERVER_MODE ?? 'unknown',
         useTls: config.PERSONHOG_TLS,
         timeoutMs: config.PERSONHOG_TIMEOUT_MS,
         readMaxBytes: config.PERSONHOG_READ_MAX_BYTES,


### PR DESCRIPTION
## Problem

The Node.js personhog gRPC client doesn't set the `x-client-name` header on requests, unlike the Django client which sends it via `ClientNameInterceptor`. This means the personhog service can't identify which Node.js process is making requests, making it harder to debug and attribute traffic server-side.

## Changes

- Added a Connect RPC interceptor in `PersonHogClient.fromConfig` that sets the `x-client-name` header on every gRPC request
- The header value is `PLUGIN_SERVER_MODE` (e.g. `ingestion`, `error-tracking`), the same value already used as the `client` label on client-side metrics (`personhog_requests_total`, `personhog_latency_seconds`)
- Added `PLUGIN_SERVER_MODE` to the `PersonHogConfig` type so it's available in `createPersonHogClient`

## How did you test this code?

- Confirmed the `clientName` value matches the existing `clientLabel` used in metrics, ensuring consistency between what we report in Prometheus and what the server sees in request headers
- Current tests passing ensures same beahviour
