### PR TITLE
feat(deduplicator): address memory spike prior to S3 transfer

### DIFF
--- a/rust/kafka-deduplicator/src/checkpoint/config.rs
+++ b/rust/kafka-deduplicator/src/checkpoint/config.rs
@@ -115,8 +115,8 @@ impl Default for CheckpointConfig {
             s3_attempt_timeout: Duration::from_secs(20),
             s3_max_retries: 3,
             checkpoint_import_attempt_depth: 10,
-            max_concurrent_checkpoint_file_downloads: 1000,
-            max_concurrent_checkpoint_file_uploads: 1000,
+            max_concurrent_checkpoint_file_downloads: 40,
+            max_concurrent_checkpoint_file_uploads: 40,
             checkpoint_partition_import_timeout: Duration::from_secs(240),
             local_checkpoint_max_staleness: Duration::from_secs(
                 DEFAULT_LOCAL_CHECKPOINT_MAX_STALENESS_SECS,

--- a/rust/kafka-deduplicator/src/checkpoint/config.rs
+++ b/rust/kafka-deduplicator/src/checkpoint/config.rs
@@ -76,9 +76,14 @@ pub struct CheckpointConfig {
     pub max_concurrent_checkpoint_file_downloads: usize,
 
     /// Maximum concurrent S3 file uploads during checkpoint export.
-    /// Less critical than downloads since uploads are already bounded by max_concurrent_checkpoints,
-    /// but provides additional defense in depth.
+    /// Controls the LimitStore semaphore that bounds concurrent S3 HTTP requests.
     pub max_concurrent_checkpoint_file_uploads: usize,
+
+    /// Maximum number of upload futures actively polled (files open with read buffers
+    /// and BufWriters) per partition checkpoint. Controls the `buffer_unordered` window
+    /// to bound memory independently from the S3 HTTP concurrency limit above.
+    /// Each active buffer consumes ~18MB (8MB read buffer + ~10MB BufWriter).
+    pub max_upload_buffers_per_partition: usize,
 
     /// Maximum time allowed for a complete checkpoint import for a single partition.
     /// This includes listing checkpoints, downloading metadata, and downloading all files.
@@ -117,6 +122,7 @@ impl Default for CheckpointConfig {
             checkpoint_import_attempt_depth: 10,
             max_concurrent_checkpoint_file_downloads: 40,
             max_concurrent_checkpoint_file_uploads: 40,
+            max_upload_buffers_per_partition: 40,
             checkpoint_partition_import_timeout: Duration::from_secs(240),
             local_checkpoint_max_staleness: Duration::from_secs(
                 DEFAULT_LOCAL_CHECKPOINT_MAX_STALENESS_SECS,

--- a/rust/kafka-deduplicator/src/checkpoint/s3_downloader.rs
+++ b/rust/kafka-deduplicator/src/checkpoint/s3_downloader.rs
@@ -18,7 +18,7 @@ use crate::metrics_const::{
 use anyhow::{Context, Result};
 use async_trait::async_trait;
 use chrono::{Duration, Utc};
-use futures::stream::FuturesUnordered;
+use futures::stream;
 use futures::{StreamExt, TryStreamExt};
 use object_store::limit::LimitStore;
 use object_store::path::Path as ObjectPath;
@@ -100,6 +100,7 @@ pub struct S3Downloader {
     s3_bucket: String,
     s3_key_prefix: String,
     checkpoint_import_window_hours: u32,
+    max_concurrent_file_downloads: usize,
 }
 
 impl S3Downloader {
@@ -117,6 +118,7 @@ impl S3Downloader {
             s3_bucket: config.s3_bucket.clone(),
             s3_key_prefix: config.s3_key_prefix.clone(),
             checkpoint_import_window_hours: config.checkpoint_import_window_hours,
+            max_concurrent_file_downloads: config.max_concurrent_checkpoint_file_downloads,
         })
     }
 }
@@ -288,9 +290,15 @@ impl CheckpointDownloader for S3Downloader {
             }
         }
 
-        // Build download futures using FuturesUnordered for early exit with sibling cancellation.
-        // LimitStore's semaphore still limits concurrent S3 requests.
-        let mut futures: FuturesUnordered<_> = remote_keys
+        // buffer_unordered(N) only polls N futures concurrently, preventing
+        // eager resource allocation for all files at once. Futures outside the
+        // window aren't started, so no file handles or write buffers are created
+        // until a slot opens up.
+        //
+        // Pre-collect owned (remote_key, local_filepath) pairs to avoid lifetime
+        // issues with buffer_unordered's lazy stream requiring closures general
+        // over all lifetimes.
+        let download_tasks: Vec<_> = remote_keys
             .iter()
             .map(|remote_key| {
                 let remote_filename = remote_key
@@ -299,23 +307,22 @@ impl CheckpointDownloader for S3Downloader {
                     .unwrap_or(remote_key)
                     .to_string();
                 let local_filepath = local_base_path.join(&remote_filename);
-
-                async move {
-                    self.download_and_store_file_cancellable(
-                        remote_key,
-                        &local_filepath,
-                        cancel_token,
-                    )
-                    .await
-                    .with_context(|| format!("Failed to download: {remote_key}"))
-                }
+                (remote_key.clone(), local_filepath)
             })
             .collect();
+
+        let mut stream = stream::iter(download_tasks)
+            .map(|(remote_key, local_filepath)| async move {
+                self.download_and_store_file_cancellable(&remote_key, &local_filepath, cancel_token)
+                    .await
+                    .with_context(|| format!("Failed to download: {remote_key}"))
+            })
+            .buffer_unordered(self.max_concurrent_file_downloads);
 
         let mut first_error: Option<anyhow::Error> = None;
 
         // Process completions, cancel siblings on first error
-        while let Some(result) = futures.next().await {
+        while let Some(result) = stream.next().await {
             if let Err(e) = result {
                 first_error = Some(e);
                 // Cancel siblings via the attempt token - they'll exit on next chunk iteration
@@ -326,9 +333,11 @@ impl CheckpointDownloader for S3Downloader {
             }
         }
 
-        // Drain remaining futures - they'll exit quickly due to cancellation check in their loop
+        // Drain remaining active futures - they'll exit quickly due to cancellation.
+        // Futures not yet started (outside the buffer window) will see cancellation
+        // immediately when polled and exit without allocating resources.
         if first_error.is_some() {
-            while futures.next().await.is_some() {}
+            while stream.next().await.is_some() {}
         }
 
         if let Some(e) = first_error {

--- a/rust/kafka-deduplicator/src/checkpoint/s3_uploader.rs
+++ b/rust/kafka-deduplicator/src/checkpoint/s3_uploader.rs
@@ -236,7 +236,7 @@ impl CheckpointUploader for S3Uploader {
                     Ok::<String, anyhow::Error>(dest)
                 }
             })
-            .buffer_unordered(self.config.max_concurrent_checkpoint_file_uploads);
+            .buffer_unordered(self.config.max_upload_buffers_per_partition);
 
         let mut uploaded_keys = Vec::with_capacity(plan.files_to_upload.len());
         let mut first_error: Option<anyhow::Error> = None;

--- a/rust/kafka-deduplicator/src/checkpoint/s3_uploader.rs
+++ b/rust/kafka-deduplicator/src/checkpoint/s3_uploader.rs
@@ -1,6 +1,6 @@
 use anyhow::{Context, Result};
 use async_trait::async_trait;
-use futures::stream::FuturesUnordered;
+use futures::stream;
 use futures::StreamExt;
 use object_store::buffered::BufWriter;
 use object_store::path::Path as ObjectPath;
@@ -214,29 +214,35 @@ impl CheckpointUploader for S3Uploader {
             .map(|parent| parent.child_token())
             .unwrap_or_default();
 
-        // Build upload futures using FuturesUnordered for early exit with sibling cancellation.
-        // LimitStore's semaphore still limits concurrent S3 requests.
-        let mut futures: FuturesUnordered<_> = plan
+        // buffer_unordered(N) only polls N futures concurrently, so only N files
+        // are open with read buffers and BufWriters allocated at any time.
+        // Futures outside the window aren't started, bounding memory to
+        // N * ~18MB (8MB read buffer + ~10MB BufWriter) instead of all files at once.
+        //
+        // Pre-collect owned (src, dest) pairs to avoid lifetime issues with
+        // buffer_unordered's lazy stream requiring closures general over all lifetimes.
+        let upload_tasks: Vec<_> = plan
             .files_to_upload
             .iter()
-            .map(|local_file| {
-                let src = local_file.local_path.clone();
-                let dest = plan.info.get_file_key(&local_file.filename);
-                let token = upload_token.clone();
+            .map(|f| (f.local_path.clone(), plan.info.get_file_key(&f.filename)))
+            .collect();
 
+        let mut stream = stream::iter(upload_tasks)
+            .map(|(src, dest)| {
+                let token = upload_token.clone();
                 async move {
                     self.upload_file_cancellable(&src, &dest, Some(&token))
                         .await?;
                     Ok::<String, anyhow::Error>(dest)
                 }
             })
-            .collect();
+            .buffer_unordered(self.config.max_concurrent_checkpoint_file_uploads);
 
         let mut uploaded_keys = Vec::with_capacity(plan.files_to_upload.len());
         let mut first_error: Option<anyhow::Error> = None;
 
         // Process completions, cancel siblings on first error
-        while let Some(result) = futures.next().await {
+        while let Some(result) = stream.next().await {
             match result {
                 Ok(key) => uploaded_keys.push(key),
                 Err(e) => {
@@ -248,8 +254,10 @@ impl CheckpointUploader for S3Uploader {
             }
         }
 
-        // Drain remaining futures - they'll exit quickly due to cancellation
-        while futures.next().await.is_some() {}
+        // Drain remaining active futures - they'll exit quickly due to cancellation.
+        // Futures not yet started (outside the buffer window) will see cancellation
+        // immediately when polled and exit without allocating resources.
+        while stream.next().await.is_some() {}
 
         // Return early on error - DO NOT upload metadata
         if let Some(e) = first_error {

--- a/rust/kafka-deduplicator/src/config.rs
+++ b/rust/kafka-deduplicator/src/config.rs
@@ -288,12 +288,12 @@ pub struct Config {
     // Limits memory usage by bounding the number of in-flight HTTP connections
     // Critical during rebalance when many partitions are assigned simultaneously
     // Higher values speed up rebalance; streaming bounds memory per download to ~8KB
-    #[envconfig(default = "200")]
+    #[envconfig(default = "40")]
     pub max_concurrent_checkpoint_file_downloads: usize,
 
     // Maximum concurrent S3 file uploads during checkpoint export
     // Less critical than downloads since uploads are bounded by max_concurrent_checkpoints
-    #[envconfig(default = "200")]
+    #[envconfig(default = "40")]
     pub max_concurrent_checkpoint_file_uploads: usize,
 
     // Maximum time allowed for a complete checkpoint import for a single partition (seconds).

--- a/rust/kafka-deduplicator/src/config.rs
+++ b/rust/kafka-deduplicator/src/config.rs
@@ -292,9 +292,15 @@ pub struct Config {
     pub max_concurrent_checkpoint_file_downloads: usize,
 
     // Maximum concurrent S3 file uploads during checkpoint export
-    // Less critical than downloads since uploads are bounded by max_concurrent_checkpoints
+    // Controls the LimitStore semaphore that bounds concurrent S3 HTTP requests
     #[envconfig(default = "40")]
     pub max_concurrent_checkpoint_file_uploads: usize,
+
+    // Maximum upload futures actively polled per partition checkpoint (files open with
+    // read buffers + BufWriters). Bounds memory independently from S3 HTTP concurrency.
+    // Each active buffer consumes ~18MB (8MB read buffer + ~10MB BufWriter).
+    #[envconfig(default = "40")]
+    pub max_upload_buffers_per_partition: usize,
 
     // Maximum time allowed for a complete checkpoint import for a single partition (seconds).
     // This includes listing checkpoints, downloading metadata, and downloading all files.

--- a/rust/kafka-deduplicator/src/service.rs
+++ b/rust/kafka-deduplicator/src/service.rs
@@ -205,6 +205,7 @@ impl KafkaDeduplicatorService {
             max_concurrent_checkpoint_file_downloads: config
                 .max_concurrent_checkpoint_file_downloads,
             max_concurrent_checkpoint_file_uploads: config.max_concurrent_checkpoint_file_uploads,
+            max_upload_buffers_per_partition: config.max_upload_buffers_per_partition,
             checkpoint_partition_import_timeout: config.checkpoint_partition_import_timeout(),
             local_checkpoint_max_staleness: config.local_checkpoint_max_staleness(),
         };


### PR DESCRIPTION
## Problem
We need to eliminate the memory spikes caused by preallocations when loading files en route to S3 fully into memory before passing along to the bottlenecked `object_store` step. 
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
* Restrict files prepped for upload at same threshold as object_store
* Similar tweaks to download path
* Misc. config and test updates
* Lower max upload/download concurrency further (will tune more as needed)
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally and in CI. smoke test in PoC env on the way
<!-- Briefly describe the steps you took, and what steps reviewers must take to get to where changes are, and what is the expected behavior. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
N/A
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update
N/A
<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
