### PR TITLE
feat(replay): fix extra toasts on v2 success

### DIFF
--- a/frontend/src/lib/components/IngestionControls/triggers/triggerGroups/TriggerGroupsEditor.tsx
+++ b/frontend/src/lib/components/IngestionControls/triggers/triggerGroups/TriggerGroupsEditor.tsx
@@ -19,14 +19,8 @@ import { TriggerGroupCard } from './TriggerGroupCard'
 import { triggerGroupFormLogic } from './triggerGroupFormLogic'
 
 export function TriggerGroupsEditor(): JSX.Element {
-    const {
-        triggerGroups,
-        isAddingGroup,
-        editingGroupId,
-        showLegacyModal,
-        previewLegacyGroups,
-        confirmCreateFromLegacyStateLoading,
-    } = useValues(replayTriggersV2Logic)
+    const { triggerGroups, isAddingGroup, editingGroupId, showLegacyModal, previewLegacyGroups, _savingStateLoading } =
+        useValues(replayTriggersV2Logic)
     const {
         addTriggerGroup,
         updateTriggerGroup,
@@ -117,7 +111,7 @@ export function TriggerGroupsEditor(): JSX.Element {
                 onClose={hideCreateFromLegacyModal}
                 onConfirm={confirmCreateFromLegacy}
                 previewGroups={previewLegacyGroups}
-                isCreating={confirmCreateFromLegacyStateLoading}
+                isCreating={_savingStateLoading}
             />
         </div>
     )

--- a/frontend/src/lib/components/IngestionControls/triggers/triggerGroups/replayTriggersV2Logic.ts
+++ b/frontend/src/lib/components/IngestionControls/triggers/triggerGroups/replayTriggersV2Logic.ts
@@ -1,8 +1,6 @@
 import { actions, afterMount, connect, kea, listeners, path, reducers, selectors } from 'kea'
 import { loaders } from 'kea-loaders'
 
-import { lemonToast } from '@posthog/lemon-ui'
-
 import { uuid } from 'lib/utils'
 import { teamLogic } from 'scenes/teamLogic'
 
@@ -32,7 +30,7 @@ export const replayTriggersV2Logic = kea<replayTriggersV2LogicType>([
         confirmCreateFromLegacy: true,
     }),
     loaders(({ values, actions }) => ({
-        saveConfigState: [
+        _savingState: [
             null as boolean | null,
             {
                 saveConfig: async () => {
@@ -42,11 +40,6 @@ export const replayTriggersV2Logic = kea<replayTriggersV2LogicType>([
                     })
                     return true
                 },
-            },
-        ],
-        confirmCreateFromLegacyState: [
-            null as boolean | null,
-            {
                 confirmCreateFromLegacy: async () => {
                     const groups = values.previewLegacyGroups
                     if (groups.length === 0) {
@@ -246,20 +239,6 @@ export const replayTriggersV2Logic = kea<replayTriggersV2LogicType>([
         updateTriggerGroup: async () => {
             // Auto-save after updating
             await asyncActions.saveConfig()
-        },
-        saveConfigSuccess: () => {
-            lemonToast.success('Trigger group saved')
-        },
-        saveConfigFailure: ({ error }) => {
-            lemonToast.error('Failed to save trigger group. Please try again.')
-            console.error('Error saving trigger group:', error)
-        },
-        confirmCreateFromLegacySuccess: () => {
-            lemonToast.success('Created trigger groups from legacy settings')
-        },
-        confirmCreateFromLegacyFailure: ({ error }) => {
-            lemonToast.error('Failed to create trigger groups from legacy settings')
-            console.error('Error creating trigger groups from legacy:', error)
         },
     })),
     // Load config from currentTeam on mount


### PR DESCRIPTION
## Problem

success toasts getting out of control, condense to a single generic success toast following posthog convention (already handled in Team logic)

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

## Changes

combine success callbacks into a single one

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

![Screenshot 2026-04-01 at 9.20.29 PM.png](https://app.graphite.com/user-attachments/assets/33e638db-2d1f-482c-b624-3aff5e1f00bf.png)

<!-- Briefly describe the steps you took, and what steps reviewers must take to get to where changes are, and what is the expected behavior. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->