### PR TITLE
feat(insights): capture save_type property on insight saved event

### DIFF
--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -274,8 +274,9 @@ export const eventUsageLogic = kea<eventUsageLogicType>([
         reportInsightSaved: (
             insight: Partial<QueryBasedInsightModel> | null,
             query: Node | null,
-            isNewInsight: boolean
-        ) => ({ insight, query, isNewInsight }),
+            isNewInsight: boolean,
+            saveType: 'save' | 'save_as'
+        ) => ({ insight, query, isNewInsight, saveType }),
         reportInsightViewed: (
             insightModel: Partial<QueryBasedInsightModel>,
             query: Node | null,
@@ -1093,12 +1094,13 @@ export const eventUsageLogic = kea<eventUsageLogicType>([
         reportDashboardMetadataAiGenerationFailed: async ({ dashboardId }) => {
             posthog.capture('dashboard metadata ai generation failed', { dashboard_id: dashboardId })
         },
-        reportInsightSaved: async ({ insight, query, isNewInsight }) => {
+        reportInsightSaved: async ({ insight, query, isNewInsight, saveType }) => {
             // "insight saved" is a proxy for the new insight's results being valuable to the user
             posthog.capture('insight saved', {
                 ...sanitizeQuery(query),
                 insight: sanitizeInsight(insight),
                 is_new_insight: isNewInsight,
+                save_type: saveType,
             })
         },
         reportInsightViewed: ({ insightModel, query, isFirstLoad, delay }) => {

--- a/frontend/src/scenes/insights/insightLogic.tsx
+++ b/frontend/src/scenes/insights/insightLogic.tsx
@@ -579,7 +579,12 @@ export const insightLogic: LogicWrapper<insightLogicType> = kea<insightLogicType
             // and so we shouldn't copy the result from `values.insight` as it might be stale
             const result = savedInsight.result || (values.query ? values.insight.result : null)
             actions.setInsight({ ...savedInsight, result: result }, { fromPersistentApi: true, overrideQuery: true })
-            eventUsageLogic.actions.reportInsightSaved(savedInsight, values.query, insightNumericId === undefined)
+            eventUsageLogic.actions.reportInsightSaved(
+                savedInsight,
+                values.query,
+                insightNumericId === undefined,
+                'save'
+            )
             lemonToast.success(`Insight saved${dashboards?.length === 1 ? ' & added to dashboard' : ''}`, {
                 button: {
                     label: 'View Insights list',
@@ -676,6 +681,7 @@ export const insightLogic: LogicWrapper<insightLogicType> = kea<insightLogicType
             }
 
             persist && actions.setInsight(insight, { fromPersistentApi: true, overrideQuery: true })
+            eventUsageLogic.actions.reportInsightSaved(insight, values.query, true, 'save_as')
             actions.reloadSavedInsights() // Load insights afresh
 
             if (redirectToViewMode) {

--- a/frontend/src/scenes/insights/insightLogic.tsx
+++ b/frontend/src/scenes/insights/insightLogic.tsx
@@ -680,9 +680,11 @@ export const insightLogic: LogicWrapper<insightLogicType> = kea<insightLogicType
                 )
             }
 
-            persist && actions.setInsight(insight, { fromPersistentApi: true, overrideQuery: true })
-            eventUsageLogic.actions.reportInsightSaved(insight, values.query, true, 'save_as')
-            actions.reloadSavedInsights() // Load insights afresh
+            if (persist) {
+                actions.setInsight(insight, { fromPersistentApi: true, overrideQuery: true })
+                eventUsageLogic.actions.reportInsightSaved(insight, values.query, true, 'save_as')
+                actions.reloadSavedInsights() // Load insights afresh
+            }
 
             if (redirectToViewMode) {
                 router.actions.push(urls.insightView(insight.short_id))

--- a/frontend/src/scenes/insights/insightLogic.tsx
+++ b/frontend/src/scenes/insights/insightLogic.tsx
@@ -683,8 +683,8 @@ export const insightLogic: LogicWrapper<insightLogicType> = kea<insightLogicType
             if (persist) {
                 actions.setInsight(insight, { fromPersistentApi: true, overrideQuery: true })
                 eventUsageLogic.actions.reportInsightSaved(insight, values.query, true, 'save_as')
-                actions.reloadSavedInsights() // Load insights afresh
             }
+            actions.reloadSavedInsights() // Load insights afresh
 
             if (redirectToViewMode) {
                 router.actions.push(urls.insightView(insight.short_id))


### PR DESCRIPTION
## Summary

- Adds a `save_type` property (`'save'` or `'save_as'`) to the `'insight saved'` analytics event
- Fires the `'insight saved'` event from `saveAsConfirmation`, which previously never reported the save at all

## Test plan

- [ ] Save an existing insight — verify `'insight saved'` fires with `save_type: 'save'`
- [ ] Save a new (unsaved) insight — verify `'insight saved'` fires with `save_type: 'save'` and `is_new_insight: true`
- [ ] Use "Save as new insight" — verify `'insight saved'` fires with `save_type: 'save_as'` and `is_new_insight: true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)