### PR TITLE
fix(ci): filter virtual properties from property definition verification test

### DIFF
--- a/ee/api/test/test_property_definition.py
+++ b/ee/api/test/test_property_definition.py
@@ -167,7 +167,7 @@ class TestPropertyDefinitionEnterpriseAPI(APIBaseTest):
         response = self.client.get(url)
 
         assert response.status_code == status.HTTP_200_OK
-        assert sorted([r["name"] for r in response.json()["results"]]) == expected_names
+        assert sorted([r["name"] for r in exclude_virtual_properties(response.json()["results"])]) == expected_names
 
     def test_update_property_definition(self):
         super(LicenseManager, cast(LicenseManager, License.objects)).create(


### PR DESCRIPTION
## Problem

The `test_filter_property_definitions_by_verified` test was comparing results without accounting for virtual properties that may be included in the API response. This causes the test to fail when virtual properties are present in the results.

## Changes

Updated the test assertion to filter out virtual properties from the response results before comparing names, ensuring the test only validates the expected non-virtual property definitions.

## How did you test this code?

The existing `test_filter_property_definitions_by_verified` test now properly handles virtual properties in the response by using the `exclude_virtual_properties` helper function. The test will pass when run with the updated assertion logic.

## Publish to changelog?

No

https://claude.ai/code/session_017Qmw7RdCp46xFkeUaGftEQ