### PR TITLE
fix(experiments): preserve shared metric state across tab switches

### DIFF
--- a/frontend/src/scenes/experiments/SharedMetrics/sharedMetricLogic.tsx
+++ b/frontend/src/scenes/experiments/SharedMetrics/sharedMetricLogic.tsx
@@ -203,7 +203,7 @@ export const sharedMetricLogic = kea<sharedMetricLogicType>([
 
             if (id && didPathChange) {
                 const parsedId = id === 'new' ? 'new' : parseInt(id)
-                if (parsedId === 'new') {
+                if (parsedId === 'new' && !values.sharedMetric?.query) {
                     actions.setSharedMetric({ ...values.newSharedMetric, query: getDefaultFunnelMetric() })
                 }
 


### PR DESCRIPTION
## Problem

Creating a new shared metric, switching to another PostHog tab, and returning resets all configured state to defaults.

## Changes

Guard the `urlToAction` default-setting with `!values.sharedMetric?.query` so it only initializes on fresh mounts, not on every navigation back.

## How did you test this code?
Manually