### PR TITLE
feat(logs): move saved views button to the filter bar of the logs viewer

### DIFF
--- a/products/logs/frontend/LogsScene.tsx
+++ b/products/logs/frontend/LogsScene.tsx
@@ -15,7 +15,6 @@ import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
 import { ProductKey } from '~/queries/schema/schema-general'
 
 import { LogsViewer } from 'products/logs/frontend/components/LogsViewer'
-import { SavedViewsButton } from 'products/logs/frontend/components/LogsViews/SavedViewsButton'
 import { logsIngestionLogic } from 'products/logs/frontend/components/SetupPrompt/logsIngestionLogic'
 import { LogsSetupPrompt } from 'products/logs/frontend/components/SetupPrompt/SetupPrompt'
 
@@ -56,7 +55,6 @@ const LogsSceneContent = (): JSX.Element => {
                 actions={
                     <>
                         {hasLogs && <LogsSceneFeedbackButton />}
-                        <SavedViewsButton id={tabId} />
                         <LemonButton size="small" type="secondary" icon={<IconGear />} onClick={openLogsSettings}>
                             Settings
                         </LemonButton>
@@ -78,7 +76,7 @@ const LogsSceneContent = (): JSX.Element => {
             )}
             <LogsSetupPrompt>
                 <div className="flex flex-col gap-2 py-2 flex-1 min-h-0">
-                    <LogsViewer id={tabId} />
+                    <LogsViewer id={tabId} showSavedViewsButton />
                 </div>
             </LogsSetupPrompt>
         </>
@@ -97,12 +95,7 @@ const LogsSceneTabbedContent = (): JSX.Element => {
                 resourceType={{
                     type: sceneConfigurations[Scene.Logs].iconType || 'default_icon_type',
                 }}
-                actions={
-                    <>
-                        {hasLogs && <LogsSceneFeedbackButton />}
-                        <SavedViewsButton id={tabId} />
-                    </>
-                }
+                actions={<>{hasLogs && <LogsSceneFeedbackButton />}</>}
             />
             {teamHasLogsCheckFailed && (
                 <LemonBanner
@@ -129,7 +122,7 @@ const LogsSceneTabbedContent = (): JSX.Element => {
             {activeTab === 'viewer' && (
                 <LogsSetupPrompt>
                     <div className="flex flex-col gap-2 py-2 flex-1 min-h-0">
-                        <LogsViewer id={tabId} />
+                        <LogsViewer id={tabId} showSavedViewsButton />
                     </div>
                 </LogsSetupPrompt>
             )}

--- a/products/logs/frontend/components/LogsViewer/Filters/LogsFilterBar/LogsFilterBar.tsx
+++ b/products/logs/frontend/components/LogsViewer/Filters/LogsFilterBar/LogsFilterBar.tsx
@@ -31,6 +31,7 @@ import {
 
 import { logsViewerDataLogic } from 'products/logs/frontend/components/LogsViewer/data/logsViewerDataLogic'
 import { logsViewerFiltersLogic } from 'products/logs/frontend/components/LogsViewer/Filters/logsViewerFiltersLogic'
+import { SavedViewsButton } from 'products/logs/frontend/components/LogsViews/SavedViewsButton'
 
 import { DateRangeFilter } from '../DateRangeFilter'
 import { FilterHistoryDropdown } from '../FilterHistoryDropdown'
@@ -45,12 +46,12 @@ const taxonomicGroupTypes = [
     TaxonomicFilterGroupType.LogAttributes,
 ]
 
-export const LogsFilterBar = (): JSX.Element => {
+export const LogsFilterBar = ({ showSavedViewsButton = false }: { showSavedViewsButton?: boolean }): JSX.Element => {
     const newLogsDateRangePicker = useFeatureFlag('NEW_LOGS_DATE_RANGE_PICKER')
     const { logsLoading, liveTailRunning, liveTailDisabledReason } = useValues(logsViewerDataLogic)
     const { runQuery, setLiveTailRunning } = useActions(logsViewerDataLogic)
     const { zoomDateRange, setSeverityLevels, setServiceNames } = useActions(logsViewerFiltersLogic)
-    const { filters, utcDateRange } = useValues(logsViewerFiltersLogic)
+    const { filters, utcDateRange, id } = useValues(logsViewerFiltersLogic)
     const { setDateRange } = useActions(logsViewerFiltersLogic)
     const { dateRange, severityLevels, serviceNames } = filters
 
@@ -65,6 +66,7 @@ export const LogsFilterBar = (): JSX.Element => {
                             <LogsFilterSearch />
                         </div>
                         <FilterHistoryDropdown />
+                        {showSavedViewsButton && <SavedViewsButton id={id} iconOnly />}
                     </div>
                     <div className="flex shrink-0 gap-1.5">
                         <div className="LogsDateButtonGroup">

--- a/products/logs/frontend/components/LogsViewer/LogsViewer.tsx
+++ b/products/logs/frontend/components/LogsViewer/LogsViewer.tsx
@@ -29,10 +29,16 @@ const SCROLL_AMOUNT_PX = 8
 export interface LogsViewerProps {
     id: string
     showFullScreenButton?: boolean
+    showSavedViewsButton?: boolean
     initialFilters?: Partial<LogsViewerFilters>
 }
 
-export function LogsViewer({ id, showFullScreenButton = true, initialFilters }: LogsViewerProps): JSX.Element {
+export function LogsViewer({
+    id,
+    showFullScreenButton = true,
+    showSavedViewsButton = false,
+    initialFilters,
+}: LogsViewerProps): JSX.Element {
     return (
         <BindLogic logic={logsViewerFiltersLogic} props={{ id, initialFilters }}>
             <BindLogic logic={logsViewerConfigLogic} props={{ id }}>
@@ -41,7 +47,10 @@ export function LogsViewer({ id, showFullScreenButton = true, initialFilters }: 
                         <BindLogic logic={logsViewerLogic} props={{ id }}>
                             <BindLogic logic={logsExportLogic} props={{ id }}>
                                 <BindLogic logic={logsFilterHistoryLogic} props={{ id }}>
-                                    <LogsViewerContent showFullScreenButton={showFullScreenButton} />
+                                    <LogsViewerContent
+                                        showFullScreenButton={showFullScreenButton}
+                                        showSavedViewsButton={showSavedViewsButton}
+                                    />
                                 </BindLogic>
                             </BindLogic>
                         </BindLogic>
@@ -52,7 +61,13 @@ export function LogsViewer({ id, showFullScreenButton = true, initialFilters }: 
     )
 }
 
-function LogsViewerContent({ showFullScreenButton }: { showFullScreenButton: boolean }): JSX.Element {
+function LogsViewerContent({
+    showFullScreenButton,
+    showSavedViewsButton,
+}: {
+    showFullScreenButton: boolean
+    showSavedViewsButton: boolean
+}): JSX.Element {
     const {
         id,
         wrapBody,
@@ -263,7 +278,7 @@ function LogsViewerContent({ showFullScreenButton }: { showFullScreenButton: boo
                 onToggleCollapse={toggleSparklineCollapsed}
             />
             <SceneDivider />
-            <LogsFilterBar />
+            <LogsFilterBar showSavedViewsButton={showSavedViewsButton} />
             <LogsViewerToolbar
                 totalLogsCount={sparklineLoading ? undefined : totalLogsMatchingFilters}
                 orderBy={orderBy}

--- a/products/logs/frontend/components/LogsViews/SavedViewsButton.tsx
+++ b/products/logs/frontend/components/LogsViews/SavedViewsButton.tsx
@@ -9,25 +9,35 @@ import { logsViewsListLogic } from './logsViewsListLogic'
 import { LogsViewsLogicProps } from './logsViewsLogic'
 import { SavedViewsModal } from './SavedViewsModal'
 
-function SavedViewsButtonInner({ id }: LogsViewsLogicProps): JSX.Element {
+interface SavedViewsButtonProps extends LogsViewsLogicProps {
+    iconOnly?: boolean
+}
+
+function SavedViewsButtonInner({ id, iconOnly }: SavedViewsButtonProps): JSX.Element {
     const { openModal } = useActions(logsViewsListLogic({ id }))
 
     return (
         <>
-            <LemonButton size="small" type="secondary" icon={<IconBookmark />} onClick={openModal}>
-                Saved views
+            <LemonButton
+                size="small"
+                type="secondary"
+                icon={<IconBookmark />}
+                onClick={openModal}
+                tooltip={iconOnly ? 'Saved views' : undefined}
+            >
+                {iconOnly ? undefined : 'Saved views'}
             </LemonButton>
             <SavedViewsModal id={id} />
         </>
     )
 }
 
-export function SavedViewsButton({ id }: LogsViewsLogicProps): JSX.Element | null {
+export function SavedViewsButton({ id, iconOnly }: SavedViewsButtonProps): JSX.Element | null {
     const enabled = useFeatureFlag('LOGS_SAVED_VIEWS')
 
     if (!enabled) {
         return null
     }
 
-    return <SavedViewsButtonInner id={id} />
+    return <SavedViewsButtonInner id={id} iconOnly={iconOnly} />
 }


### PR DESCRIPTION
## Problem

The SavedViewsButton was positioned in the LogsScene header, but this placement made the button less discoverable when users are actively filtering logs.

## Changes

- Moved SavedViewsButton from LogsScene header to LogsFilterBar component
- Added `showSavedViewsButton` prop to LogsViewer and LogsFilterBar components to control button visibility
- Added `iconOnly` prop to SavedViewsButton to display as icon-only with tooltip in the filter bar
- Removed SavedViewsButton import and usage from LogsScene components

The button now appears inline with other filter controls, providing better context and discoverability when users are working with log filters and views.

## How did you test this code?

local dev

<!-- I am an agent and have not manually tested this code. The changes involve moving a UI component and adding props to control its display behavior. Manual testing should verify:
- SavedViewsButton appears in the filter bar when showSavedViewsButton=true
- Button displays as icon-only with tooltip in the filter bar
- Button functionality (opening saved views modal) works correctly
- No visual regressions in LogsScene header after button removal -->

## Publish to changelog?

No