### PR TITLE
fix(taxonomy): handle UUID-based survey response keys (#52309)

### DIFF
--- a/frontend/src/taxonomy/helpers.test.ts
+++ b/frontend/src/taxonomy/helpers.test.ts
@@ -1,0 +1,56 @@
+import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
+
+import { getCoreFilterDefinition } from './helpers'
+
+describe('getCoreFilterDefinition', () => {
+    const type = TaxonomicFilterGroupType.EventProperties
+
+    describe('$survey_response_ prefix', () => {
+        it.each([
+            [
+                '$survey_response_0',
+                'Survey response for 1th question',
+                'The response value for the 1th question in the survey.',
+            ],
+            [
+                '$survey_response_1',
+                'Survey response for 2nd question',
+                'The response value for the 2nd question in the survey.',
+            ],
+            [
+                '$survey_response_2',
+                'Survey response for 3rd question',
+                'The response value for the 3rd question in the survey.',
+            ],
+            [
+                '$survey_response_3',
+                'Survey response for 4th question',
+                'The response value for the 4th question in the survey.',
+            ],
+        ])('returns ordinal label for %s', (key, label, description) => {
+            expect(getCoreFilterDefinition(key, type)).toEqual({ label, description })
+        })
+
+        it.each([
+            [
+                '$survey_response_abc123-def4-5678',
+                'Survey response (abc123-def4-5678)',
+                'The response value for survey question with ID: "abc123-def4-5678".',
+            ],
+            ['$survey_response_q1', 'Survey response (q1)', 'The response value for survey question with ID: "q1".'],
+        ])('returns fallback label for non-numeric key %s', (key, label, description) => {
+            expect(getCoreFilterDefinition(key, type)).toEqual({ label, description })
+        })
+
+        it('returns core definition for bare $survey_response without suffix', () => {
+            const result = getCoreFilterDefinition('$survey_response', type)
+            expect(result).not.toBeNull()
+            expect(result!.label).toBe('Survey response')
+        })
+    })
+
+    it('returns null for null/undefined values', () => {
+        expect(getCoreFilterDefinition(null, type)).toBeNull()
+        expect(getCoreFilterDefinition(undefined, type)).toBeNull()
+    })
+})

--- a/frontend/src/taxonomy/helpers.ts
+++ b/frontend/src/taxonomy/helpers.ts
@@ -56,11 +56,18 @@ export function getCoreFilterDefinition(
     } else if (value.startsWith('$survey_response_')) {
         const surveyIndex = value.replace(/^\$survey_response_/, '')
         if (surveyIndex) {
-            const index = Number(surveyIndex) + 1
-            const suffix = index === 2 ? 'nd' : index === 3 ? 'rd' : 'th'
+            const index = Number(surveyIndex)
+            if (isNaN(index)) {
+                return {
+                    label: `Survey response (${surveyIndex})`,
+                    description: `The response value for survey question with ID: "${surveyIndex}".`,
+                }
+            }
+            const ordinal = index + 1
+            const suffix = ordinal === 2 ? 'nd' : ordinal === 3 ? 'rd' : 'th'
             return {
-                label: `Survey response for ${index}${suffix} question`,
-                description: `The response value for the ${index}${suffix} question in the survey.`,
+                label: `Survey response for ${ordinal}${suffix} question`,
+                description: `The response value for the ${ordinal}${suffix} question in the survey.`,
             }
         }
     } else if (value.startsWith('$feature/')) {


### PR DESCRIPTION
## Problem

Addresses the issue in https://github.com/PostHog/posthog/issues/52309

<!-- Who are we building for, what are their needs, why is this important? -->

When filtering by survey response in workflows trigger config, the filter displays all multi-question survey response properties as "Survey response for NaNth question".

### Root cause

UUID-based survey response keys (e.g. `$survey_response_abc123-def4`) produce NaN ordinal labels because Number() returns NaN on non-numeric suffixes. 

Added an `isNaN` guard to fall back to `Survey response (<id>)` for such keys. It's not ideal, but the key does not seem to have metadata.

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
Closes #52309

## Changes

| Before | After |
| ---- | --- |
|  <img width="1008" height="394" alt="before" src="https://github.com/user-attachments/assets/3565e36c-9f39-46db-9a7e-0b6aceb0c06b" /> | <img width="991" height="393" alt="after" src="https://github.com/user-attachments/assets/ad806174-307c-4ee3-90ad-ee00888aa811" /> |   


<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took, and what steps reviewers must take to get to where changes are, and what is the expected behavior. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

no

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
