### PR TITLE
fix(notebooks): partial refresh mechanism

### DIFF
--- a/frontend/src/lib/components/RichContentEditor/types.ts
+++ b/frontend/src/lib/components/RichContentEditor/types.ts
@@ -9,6 +9,10 @@ import { Node as PMNode } from '@tiptap/pm/model'
 export interface RichContentNode extends PMNode {}
 export interface JSONContent extends TTJSONContent {}
 
+export type MergeContentOptions = {
+    skipNodeIds?: Record<string, true>
+}
+
 export type {
     ChainedCommands as EditorCommands,
     FocusPosition as EditorFocusPosition,
@@ -29,6 +33,7 @@ export interface RichContentEditorType {
     getAdjacentNodes: (pos: number) => { previous: RichContentNode | null; next: RichContentNode | null }
     setEditable: (editable: boolean) => void
     setContent: (content: JSONContent) => void
+    mergeContent: (content: JSONContent, options?: MergeContentOptions) => void
     setSelection: (position: number) => void
     setTextSelection: (position: number | EditorRange) => void
     focus: (position?: EditorFocusPosition) => void

--- a/frontend/src/lib/components/RichContentEditor/utils.test.ts
+++ b/frontend/src/lib/components/RichContentEditor/utils.test.ts
@@ -1,15 +1,22 @@
-import { Editor } from '@tiptap/core'
+import { Editor, Node } from '@tiptap/core'
 import Document from '@tiptap/extension-document'
-import Paragraph from '@tiptap/extension-paragraph'
-import Text from '@tiptap/extension-text'
+import StarterKit from '@tiptap/starter-kit'
 
 import { createEditor } from './utils'
 import { JSONContent } from './types'
 
-const ParagraphWithNotebookAttrs = Paragraph.extend({
+const NotebookParagraph = Node.create({
+    name: 'paragraph',
+    group: 'block',
+    content: 'inline*',
+    parseHTML() {
+        return [{ tag: 'p' }]
+    },
+    renderHTML({ HTMLAttributes }) {
+        return ['p', HTMLAttributes, 0]
+    },
     addAttributes() {
         return {
-            ...this.parent?.(),
             nodeId: { default: null },
             query: { default: null },
         }
@@ -36,9 +43,13 @@ const initialContent: JSONContent = {
 
 function createTestEditor(content: JSONContent = initialContent): Editor {
     return new Editor({
-        extensions: [Document, ParagraphWithNotebookAttrs, Text],
+        extensions: [Document, NotebookParagraph, StarterKit.configure({ document: false, paragraph: false })],
         content,
     })
+}
+
+function normalizeJson(content: JSONContent): JSONContent {
+    return JSON.parse(JSON.stringify(content)) as JSONContent
 }
 
 describe('createEditor.mergeContent', () => {
@@ -71,11 +82,12 @@ describe('createEditor.mergeContent', () => {
 
         expect(editor.state.doc.child(0)).toBe(firstNodeBefore)
         expect(editor.state.doc.child(2)).toBe(nodeTwoBefore)
-        expect(editor.getJSON()).toEqual({
+        expect(normalizeJson(editor.getJSON() as JSONContent)).toEqual({
             type: 'doc',
             content: [
                 {
                     type: 'paragraph',
+                    attrs: { nodeId: null, query: null },
                     content: [{ type: 'text', text: 'Heading' }],
                 },
                 {
@@ -116,11 +128,12 @@ describe('createEditor.mergeContent', () => {
 
         await Promise.resolve()
 
-        expect(editor.getJSON()).toEqual({
+        expect(normalizeJson(editor.getJSON() as JSONContent)).toEqual({
             type: 'doc',
             content: [
                 {
                     type: 'paragraph',
+                    attrs: { nodeId: null, query: null },
                     content: [{ type: 'text', text: 'Heading' }],
                 },
                 {
@@ -164,11 +177,12 @@ describe('createEditor.mergeContent', () => {
 
         await Promise.resolve()
 
-        expect(editor.getJSON()).toEqual({
+        expect(normalizeJson(editor.getJSON() as JSONContent)).toEqual({
             type: 'doc',
             content: [
                 {
                     type: 'paragraph',
+                    attrs: { nodeId: null, query: null },
                     content: [{ type: 'text', text: 'Heading' }],
                 },
                 {

--- a/frontend/src/lib/components/RichContentEditor/utils.test.ts
+++ b/frontend/src/lib/components/RichContentEditor/utils.test.ts
@@ -1,0 +1,187 @@
+import { Editor } from '@tiptap/core'
+import Document from '@tiptap/extension-document'
+import Paragraph from '@tiptap/extension-paragraph'
+import Text from '@tiptap/extension-text'
+
+import { createEditor } from './utils'
+import { JSONContent } from './types'
+
+const ParagraphWithNotebookAttrs = Paragraph.extend({
+    addAttributes() {
+        return {
+            ...this.parent?.(),
+            nodeId: { default: null },
+            query: { default: null },
+        }
+    },
+})
+
+const initialContent: JSONContent = {
+    type: 'doc',
+    content: [
+        {
+            type: 'paragraph',
+            content: [{ type: 'text', text: 'Heading' }],
+        },
+        {
+            type: 'paragraph',
+            attrs: { nodeId: 'node-1', query: { foo: 'bar' } },
+        },
+        {
+            type: 'paragraph',
+            attrs: { nodeId: 'node-2', query: { count: 1 } },
+        },
+    ],
+}
+
+function createTestEditor(content: JSONContent = initialContent): Editor {
+    return new Editor({
+        extensions: [Document, ParagraphWithNotebookAttrs, Text],
+        content,
+    })
+}
+
+describe('createEditor.mergeContent', () => {
+    it('updates matching nodes in place and keeps untouched nodes stable', async () => {
+        const editor = createTestEditor()
+        const richEditor = createEditor(editor)
+        const originalDoc = editor.state.doc
+        const firstNodeBefore = originalDoc.child(0)
+        const nodeTwoBefore = originalDoc.child(2)
+
+        richEditor.mergeContent({
+            type: 'doc',
+            content: [
+                {
+                    type: 'paragraph',
+                    content: [{ type: 'text', text: 'Heading' }],
+                },
+                {
+                    type: 'paragraph',
+                    attrs: { nodeId: 'node-1', query: { foo: 'baz' } },
+                },
+                {
+                    type: 'paragraph',
+                    attrs: { nodeId: 'node-2', query: { count: 1 } },
+                },
+            ],
+        })
+
+        await Promise.resolve()
+
+        expect(editor.state.doc.child(0)).toBe(firstNodeBefore)
+        expect(editor.state.doc.child(2)).toBe(nodeTwoBefore)
+        expect(editor.getJSON()).toEqual({
+            type: 'doc',
+            content: [
+                {
+                    type: 'paragraph',
+                    content: [{ type: 'text', text: 'Heading' }],
+                },
+                {
+                    type: 'paragraph',
+                    attrs: { nodeId: 'node-1', query: { foo: 'baz' } },
+                },
+                {
+                    type: 'paragraph',
+                    attrs: { nodeId: 'node-2', query: { count: 1 } },
+                },
+            ],
+        })
+
+        editor.destroy()
+    })
+
+    it('inserts and deletes top-level nodes by nodeId', async () => {
+        const editor = createTestEditor()
+        const richEditor = createEditor(editor)
+
+        richEditor.mergeContent({
+            type: 'doc',
+            content: [
+                {
+                    type: 'paragraph',
+                    content: [{ type: 'text', text: 'Heading' }],
+                },
+                {
+                    type: 'paragraph',
+                    attrs: { nodeId: 'node-3', query: { inserted: true } },
+                },
+                {
+                    type: 'paragraph',
+                    attrs: { nodeId: 'node-2', query: { count: 2 } },
+                },
+            ],
+        })
+
+        await Promise.resolve()
+
+        expect(editor.getJSON()).toEqual({
+            type: 'doc',
+            content: [
+                {
+                    type: 'paragraph',
+                    content: [{ type: 'text', text: 'Heading' }],
+                },
+                {
+                    type: 'paragraph',
+                    attrs: { nodeId: 'node-3', query: { inserted: true } },
+                },
+                {
+                    type: 'paragraph',
+                    attrs: { nodeId: 'node-2', query: { count: 2 } },
+                },
+            ],
+        })
+
+        editor.destroy()
+    })
+
+    it('skips updating actively edited nodes', async () => {
+        const editor = createTestEditor()
+        const richEditor = createEditor(editor)
+
+        richEditor.mergeContent(
+            {
+                type: 'doc',
+                content: [
+                    {
+                        type: 'paragraph',
+                        content: [{ type: 'text', text: 'Heading' }],
+                    },
+                    {
+                        type: 'paragraph',
+                        attrs: { nodeId: 'node-1', query: { foo: 'server-value' } },
+                    },
+                    {
+                        type: 'paragraph',
+                        attrs: { nodeId: 'node-2', query: { count: 2 } },
+                    },
+                ],
+            },
+            { skipNodeIds: { 'node-1': true } }
+        )
+
+        await Promise.resolve()
+
+        expect(editor.getJSON()).toEqual({
+            type: 'doc',
+            content: [
+                {
+                    type: 'paragraph',
+                    content: [{ type: 'text', text: 'Heading' }],
+                },
+                {
+                    type: 'paragraph',
+                    attrs: { nodeId: 'node-1', query: { foo: 'bar' } },
+                },
+                {
+                    type: 'paragraph',
+                    attrs: { nodeId: 'node-2', query: { count: 2 } },
+                },
+            ],
+        })
+
+        editor.destroy()
+    })
+})

--- a/frontend/src/lib/components/RichContentEditor/utils.ts
+++ b/frontend/src/lib/components/RichContentEditor/utils.ts
@@ -8,14 +8,14 @@ import {
     RichContentNodeType,
     TTEditor,
 } from './types'
-import equal from 'fast-deep-equal'
 import { Node as PMNode } from '@tiptap/pm/model'
 
 type MergeNode = {
-    json: JSONContent
     pmNode: PMNode
     nodeId: string | null
 }
+
+type EditorTransaction = TTEditor['state']['tr']
 
 export function createEditor(editor: TTEditor): RichContentEditorType {
     return {
@@ -174,7 +174,7 @@ function mergeContent(editor: TTEditor, content: JSONContent, options?: MergeCon
         }
 
         if (nodesMatch(currentNode, targetNode)) {
-            if (!shouldSkipNode(currentNode, options) && !equal(currentNode.json, targetNode.json)) {
+            if (!shouldSkipNode(currentNode, options) && !currentNode.pmNode.eq(targetNode.pmNode)) {
                 tr = syncMatchedNodeAtIndex(tr, workingNodes, currentIndex, targetNode)
             }
 
@@ -242,7 +242,6 @@ function getTopLevelNodes(doc: PMNode): MergeNode[] {
 
     doc.forEach((node) => {
         nodes.push({
-            json: node.toJSON() as JSONContent,
             pmNode: node,
             nodeId: getNodeId(node.attrs),
         })
@@ -291,27 +290,32 @@ function getPositionAtIndex(nodes: MergeNode[], index: number): number {
     return position
 }
 
-function insertNodeAtIndex(tr: typeof TTEditor.prototype.state.tr, nodes: MergeNode[], index: number, node: MergeNode) {
+function insertNodeAtIndex(tr: EditorTransaction, nodes: MergeNode[], index: number, node: MergeNode): EditorTransaction {
     tr.insert(getPositionAtIndex(nodes, index), node.pmNode)
     nodes.splice(index, 0, node)
     return tr
 }
 
-function deleteNodeAtIndex(tr: typeof TTEditor.prototype.state.tr, nodes: MergeNode[], index: number) {
+function deleteNodeAtIndex(tr: EditorTransaction, nodes: MergeNode[], index: number): EditorTransaction {
     const position = getPositionAtIndex(nodes, index)
     tr.delete(position, position + nodes[index].pmNode.nodeSize)
     nodes.splice(index, 1)
     return tr
 }
 
-function replaceNodeAtIndex(tr: typeof TTEditor.prototype.state.tr, nodes: MergeNode[], index: number, node: MergeNode) {
+function replaceNodeAtIndex(tr: EditorTransaction, nodes: MergeNode[], index: number, node: MergeNode): EditorTransaction {
     const position = getPositionAtIndex(nodes, index)
     tr.replaceWith(position, position + nodes[index].pmNode.nodeSize, node.pmNode)
     nodes[index] = node
     return tr
 }
 
-function syncMatchedNodeAtIndex(tr: typeof TTEditor.prototype.state.tr, nodes: MergeNode[], index: number, node: MergeNode) {
+function syncMatchedNodeAtIndex(
+    tr: EditorTransaction,
+    nodes: MergeNode[],
+    index: number,
+    node: MergeNode
+): EditorTransaction {
     const position = getPositionAtIndex(nodes, index)
     const currentNode = nodes[index]
 

--- a/frontend/src/lib/components/RichContentEditor/utils.ts
+++ b/frontend/src/lib/components/RichContentEditor/utils.ts
@@ -2,11 +2,20 @@ import {
     EditorFocusPosition,
     EditorRange,
     JSONContent,
+    MergeContentOptions,
     RichContentEditorType,
     RichContentNode,
     RichContentNodeType,
     TTEditor,
 } from './types'
+import equal from 'fast-deep-equal'
+import { Node as PMNode } from '@tiptap/pm/model'
+
+type MergeNode = {
+    json: JSONContent
+    pmNode: PMNode
+    nodeId: string | null
+}
 
 export function createEditor(editor: TTEditor): RichContentEditorType {
     return {
@@ -19,6 +28,8 @@ export function createEditor(editor: TTEditor): RichContentEditorType {
         setEditable: (editable: boolean) => queueMicrotask(() => editor.setEditable(editable, false)),
         setContent: (content: JSONContent) =>
             queueMicrotask(() => editor.commands.setContent(content, { emitUpdate: false })),
+        mergeContent: (content: JSONContent, options?: MergeContentOptions) =>
+            queueMicrotask(() => mergeContent(editor, content, options)),
         setSelection: (position: number) => editor.commands.setNodeSelection(position),
         setTextSelection: (position: number | EditorRange) =>
             queueMicrotask(() => editor.commands.setTextSelection(position)),
@@ -127,6 +138,190 @@ function getChildren(node: RichContentNode, direct: boolean = true): RichContent
         return !direct
     })
     return children
+}
+
+function mergeContent(editor: TTEditor, content: JSONContent, options?: MergeContentOptions): void {
+    const nextDoc = editor.schema.nodeFromJSON(normalizeDocumentContent(content))
+    const workingNodes = getTopLevelNodes(editor.state.doc)
+    const targetNodes = getTopLevelNodes(nextDoc)
+    let tr = editor.state.tr
+    let currentIndex = 0
+    let targetIndex = 0
+
+    while (targetIndex < targetNodes.length || currentIndex < workingNodes.length) {
+        const currentNode = workingNodes[currentIndex]
+        const targetNode = targetNodes[targetIndex]
+
+        if (!currentNode && targetNode) {
+            tr = insertNodeAtIndex(tr, workingNodes, currentIndex, targetNode)
+            currentIndex += 1
+            targetIndex += 1
+            continue
+        }
+
+        if (currentNode && !targetNode) {
+            if (shouldSkipNode(currentNode, options)) {
+                currentIndex += 1
+                continue
+            }
+
+            tr = deleteNodeAtIndex(tr, workingNodes, currentIndex)
+            continue
+        }
+
+        if (!currentNode || !targetNode) {
+            break
+        }
+
+        if (nodesMatch(currentNode, targetNode)) {
+            if (!shouldSkipNode(currentNode, options) && !equal(currentNode.json, targetNode.json)) {
+                tr = syncMatchedNodeAtIndex(tr, workingNodes, currentIndex, targetNode)
+            }
+
+            currentIndex += 1
+            targetIndex += 1
+            continue
+        }
+
+        const currentNodeAppearsLaterInTarget = findNodeIndexById(targetNodes, currentNode.nodeId, targetIndex + 1)
+        const targetNodeAppearsLaterInCurrent = findNodeIndexById(workingNodes, targetNode.nodeId, currentIndex + 1)
+
+        if (shouldSkipNode(currentNode, options)) {
+            if (currentNodeAppearsLaterInTarget !== -1) {
+                tr = insertNodeAtIndex(tr, workingNodes, currentIndex, targetNode)
+                currentIndex += 1
+                targetIndex += 1
+                continue
+            }
+
+            currentIndex += 1
+            continue
+        }
+
+        if (
+            currentNodeAppearsLaterInTarget !== -1 &&
+            (targetNodeAppearsLaterInCurrent === -1 || currentNodeAppearsLaterInTarget < targetNodeAppearsLaterInCurrent)
+        ) {
+            tr = insertNodeAtIndex(tr, workingNodes, currentIndex, targetNode)
+            currentIndex += 1
+            targetIndex += 1
+            continue
+        }
+
+        if (targetNodeAppearsLaterInCurrent !== -1) {
+            tr = deleteNodeAtIndex(tr, workingNodes, currentIndex)
+            continue
+        }
+
+        tr = replaceNodeAtIndex(tr, workingNodes, currentIndex, targetNode)
+        currentIndex += 1
+        targetIndex += 1
+    }
+
+    if (tr.docChanged) {
+        editor.view.dispatch(tr.setMeta('preventUpdate', true))
+    }
+}
+
+function normalizeDocumentContent(content: JSONContent): JSONContent {
+    const rawContent = content as JSONContent | JSONContent[]
+
+    if (Array.isArray(rawContent)) {
+        return { type: 'doc', content: rawContent }
+    }
+
+    if (rawContent.type === 'doc') {
+        return rawContent
+    }
+
+    return { type: 'doc', content: [rawContent] }
+}
+
+function getTopLevelNodes(doc: PMNode): MergeNode[] {
+    const nodes: MergeNode[] = []
+
+    doc.forEach((node) => {
+        nodes.push({
+            json: node.toJSON() as JSONContent,
+            pmNode: node,
+            nodeId: getNodeId(node.attrs),
+        })
+    })
+
+    return nodes
+}
+
+function getNodeId(attrs: Record<string, any> | undefined): string | null {
+    return typeof attrs?.nodeId === 'string' && attrs.nodeId.length > 0 ? attrs.nodeId : null
+}
+
+function shouldSkipNode(node: MergeNode, options?: MergeContentOptions): boolean {
+    return !!(node.nodeId && options?.skipNodeIds?.[node.nodeId])
+}
+
+function nodesMatch(currentNode: MergeNode, targetNode: MergeNode): boolean {
+    if (currentNode.nodeId || targetNode.nodeId) {
+        return currentNode.nodeId !== null && currentNode.nodeId === targetNode.nodeId
+    }
+
+    return currentNode.pmNode.type === targetNode.pmNode.type
+}
+
+function findNodeIndexById(nodes: MergeNode[], nodeId: string | null, startIndex: number): number {
+    if (!nodeId) {
+        return -1
+    }
+
+    for (let index = startIndex; index < nodes.length; index++) {
+        if (nodes[index].nodeId === nodeId) {
+            return index
+        }
+    }
+
+    return -1
+}
+
+function getPositionAtIndex(nodes: MergeNode[], index: number): number {
+    let position = 0
+
+    for (let nodeIndex = 0; nodeIndex < index; nodeIndex++) {
+        position += nodes[nodeIndex].pmNode.nodeSize
+    }
+
+    return position
+}
+
+function insertNodeAtIndex(tr: typeof TTEditor.prototype.state.tr, nodes: MergeNode[], index: number, node: MergeNode) {
+    tr.insert(getPositionAtIndex(nodes, index), node.pmNode)
+    nodes.splice(index, 0, node)
+    return tr
+}
+
+function deleteNodeAtIndex(tr: typeof TTEditor.prototype.state.tr, nodes: MergeNode[], index: number) {
+    const position = getPositionAtIndex(nodes, index)
+    tr.delete(position, position + nodes[index].pmNode.nodeSize)
+    nodes.splice(index, 1)
+    return tr
+}
+
+function replaceNodeAtIndex(tr: typeof TTEditor.prototype.state.tr, nodes: MergeNode[], index: number, node: MergeNode) {
+    const position = getPositionAtIndex(nodes, index)
+    tr.replaceWith(position, position + nodes[index].pmNode.nodeSize, node.pmNode)
+    nodes[index] = node
+    return tr
+}
+
+function syncMatchedNodeAtIndex(tr: typeof TTEditor.prototype.state.tr, nodes: MergeNode[], index: number, node: MergeNode) {
+    const position = getPositionAtIndex(nodes, index)
+    const currentNode = nodes[index]
+
+    if (currentNode.pmNode.type === node.pmNode.type && currentNode.pmNode.content.eq(node.pmNode.content)) {
+        tr.setNodeMarkup(position, node.pmNode.type, node.pmNode.attrs, node.pmNode.marks)
+        nodes[index] = node
+        return tr
+    }
+
+    return replaceNodeAtIndex(tr, nodes, index, node)
 }
 
 function getAdjacentNodes(

--- a/frontend/src/scenes/notebooks/Notebook/notebookLogic.ts
+++ b/frontend/src/scenes/notebooks/Notebook/notebookLogic.ts
@@ -339,8 +339,11 @@ export const notebookLogic = kea<notebookLogicType>([
                     const notebook = await migrate(response)
 
                     if (notebook.content && (!values.notebook || values.notebook.version !== notebook.version)) {
-                        // If this is the first load we need to override the content fully
-                        values.editor?.setContent(notebook.content)
+                        if (!values.notebook || values.editor?.isEmpty()) {
+                            values.editor?.setContent(notebook.content)
+                        } else {
+                            values.editor?.mergeContent(notebook.content, { skipNodeIds: values.editingNodeIds })
+                        }
                     }
 
                     return notebook
@@ -368,7 +371,7 @@ export const notebookLogic = kea<notebookLogicType>([
                             const currentEditorContent = values.editor.getJSON()
                             if (JSON.stringify(response.content) !== JSON.stringify(currentEditorContent)) {
                                 const currentPosition = values.editor.getCurrentPosition()
-                                values.editor.setContent(response.content)
+                                values.editor.mergeContent(response.content, { skipNodeIds: values.editingNodeIds })
                                 values.editor.setTextSelection(currentPosition)
                             }
                         }


### PR DESCRIPTION
## Problem

When a notebook is refreshed from the server (either on initial poll or periodic sync), the `setContent()` does a full document replacement. This destroys the entire ProseMirror document state, losing cursor position, undo history, any in-progress edits the user is making to individual nodes.       

## Changes

New `mergeContent()` method that diffs the current editor document against the server's version and applies the minimum set of ProseMirror transactions needed to reconcile them.

## How did you test this code?

<!-- Briefly describe the steps you took, and what steps reviewers must take to get to where changes are, and what is the expected behavior. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
