### PR TITLE
fix(insights): use multivariate match for simple editor experiment flag

### DIFF
--- a/frontend/src/queries/nodes/InsightViz/Breakdown.tsx
+++ b/frontend/src/queries/nodes/InsightViz/Breakdown.tsx
@@ -11,7 +11,7 @@ export function Breakdown({ insightProps }: EditorFilterProps): JSX.Element {
         insightVizDataLogic(insightProps)
     )
     const { updateBreakdownFilter, updateDisplay } = useActions(insightVizDataLogic(insightProps))
-    const editorPanelsEnabled = useFeatureFlag('PRODUCT_ANALYTICS_SIMPLE_EDITOR')
+    const editorPanelsEnabled = useFeatureFlag('PRODUCT_ANALYTICS_SIMPLE_EDITOR', 'test')
 
     return (
         <>

--- a/frontend/src/queries/nodes/InsightViz/EditorFilters.test.tsx
+++ b/frontend/src/queries/nodes/InsightViz/EditorFilters.test.tsx
@@ -112,8 +112,8 @@ describe('EditorFilters', () => {
     })
 
     describe.each([
-        { flagEnabled: false, label: 'flag off' },
-        { flagEnabled: true, label: 'flag on' },
+        { flagEnabled: 'control', label: 'flag off' },
+        { flagEnabled: 'test', label: 'flag on' },
     ])('PRODUCT_ANALYTICS_SIMPLE_EDITOR $label', ({ flagEnabled }) => {
         beforeEach(() => {
             featureFlagLogic.actions.setFeatureFlags([], {
@@ -172,7 +172,7 @@ describe('EditorFilters', () => {
     describe('classic layout (flag off)', () => {
         beforeEach(() => {
             featureFlagLogic.actions.setFeatureFlags([], {
-                [FEATURE_FLAGS.PRODUCT_ANALYTICS_SIMPLE_EDITOR]: false,
+                [FEATURE_FLAGS.PRODUCT_ANALYTICS_SIMPLE_EDITOR]: 'control',
             })
         })
 
@@ -209,7 +209,7 @@ describe('EditorFilters', () => {
     describe('panels layout (flag on)', () => {
         beforeEach(() => {
             featureFlagLogic.actions.setFeatureFlags([], {
-                [FEATURE_FLAGS.PRODUCT_ANALYTICS_SIMPLE_EDITOR]: true,
+                [FEATURE_FLAGS.PRODUCT_ANALYTICS_SIMPLE_EDITOR]: 'test',
             })
         })
 

--- a/frontend/src/queries/nodes/InsightViz/EditorFilters.tsx
+++ b/frontend/src/queries/nodes/InsightViz/EditorFilters.tsx
@@ -51,7 +51,7 @@ export interface EditorFiltersProps {
 
 export function EditorFilters({ query, showing, embedded }: EditorFiltersProps): JSX.Element | null {
     const { hasAvailableFeature } = useValues(userLogic)
-    const editorPanelsEnabled = useFeatureFlag('PRODUCT_ANALYTICS_SIMPLE_EDITOR')
+    const editorPanelsEnabled = useFeatureFlag('PRODUCT_ANALYTICS_SIMPLE_EDITOR', 'test')
 
     const { insightProps } = useValues(insightLogic)
     const {

--- a/frontend/src/queries/nodes/InsightViz/InsightViz.tsx
+++ b/frontend/src/queries/nodes/InsightViz/InsightViz.tsx
@@ -95,7 +95,7 @@ export function InsightViz({
 
     const isFunnels = isFunnelsQuery(query.source)
     const isHorizontalAlways = useFeatureFlag('PRODUCT_ANALYTICS_INSIGHT_HORIZONTAL_CONTROLS')
-    const editorPanelsEnabled = useFeatureFlag('PRODUCT_ANALYTICS_SIMPLE_EDITOR')
+    const editorPanelsEnabled = useFeatureFlag('PRODUCT_ANALYTICS_SIMPLE_EDITOR', 'test')
     const isRetention = isRetentionQuery(query.source)
 
     const showIfFull = !!query.full

--- a/frontend/src/queries/nodes/InsightViz/TrendsSeries.tsx
+++ b/frontend/src/queries/nodes/InsightViz/TrendsSeries.tsx
@@ -37,7 +37,7 @@ export function TrendsSeries(): JSX.Element | null {
     )
     const { updateQuerySource, toggleFormulaMode } = useActions(insightVizDataLogic(insightProps))
 
-    const editorPanelsEnabled = useFeatureFlag('PRODUCT_ANALYTICS_SIMPLE_EDITOR')
+    const editorPanelsEnabled = useFeatureFlag('PRODUCT_ANALYTICS_SIMPLE_EDITOR', 'test')
 
     const { groupsTaxonomicTypes } = useValues(groupsModel)
 

--- a/frontend/src/scenes/insights/EditorFilters/FunnelsQuerySteps.tsx
+++ b/frontend/src/scenes/insights/EditorFilters/FunnelsQuerySteps.tsx
@@ -31,7 +31,7 @@ export const FUNNEL_STEP_COUNT_LIMIT = 30
 export function FunnelsQuerySteps({ insightProps }: EditorFilterProps): JSX.Element | null {
     const { series, querySource } = useValues(insightVizDataLogic(insightProps))
     const { updateQuerySource } = useActions(insightVizDataLogic(insightProps))
-    const editorPanelsEnabled = useFeatureFlag('PRODUCT_ANALYTICS_SIMPLE_EDITOR')
+    const editorPanelsEnabled = useFeatureFlag('PRODUCT_ANALYTICS_SIMPLE_EDITOR', 'test')
 
     const { hasPageview, hasScreen } = getProjectEventExistence()
 

--- a/frontend/src/scenes/insights/InsightAsScene.tsx
+++ b/frontend/src/scenes/insights/InsightAsScene.tsx
@@ -57,7 +57,7 @@ export function InsightAsScene({ insightId, attachTo, tabId }: InsightAsScenePro
     useAttachedLogic(logic, attachTo) // insightLogic(insightProps)
     useAttachedLogic(insightDataLogic(insightProps), attachTo)
 
-    const editorPanelsEnabled = useFeatureFlag('PRODUCT_ANALYTICS_SIMPLE_EDITOR')
+    const editorPanelsEnabled = useFeatureFlag('PRODUCT_ANALYTICS_SIMPLE_EDITOR', 'test')
 
     const actuallyShowQueryEditor = insightMode === ItemMode.Edit && showQueryEditor
 

--- a/frontend/src/scenes/insights/InsightSceneHeader.tsx
+++ b/frontend/src/scenes/insights/InsightSceneHeader.tsx
@@ -21,7 +21,7 @@ export interface InsightSceneHeaderProps {
 export function InsightSceneHeader({ insightLogicProps }: InsightSceneHeaderProps): JSX.Element {
     const { insightMode, hasOverrides, freshQuery } = useValues(insightSceneLogic)
     const { showDebugPanel } = useValues(insightDataLogic(insightLogicProps))
-    const editorPanelsEnabled = useFeatureFlag('PRODUCT_ANALYTICS_SIMPLE_EDITOR')
+    const editorPanelsEnabled = useFeatureFlag('PRODUCT_ANALYTICS_SIMPLE_EDITOR', 'test')
     const insightId = insightLogicProps.dashboardItemId
 
     return (


### PR DESCRIPTION
## Problem

The `PRODUCT_ANALYTICS_SIMPLE_EDITOR` feature flag is multivariate (`control`/`test`) for the experiment, but the code was checking it as a boolean. Since both `'control'` and `'test'` are truthy strings, `!!featureFlags[flag]` returned `true` for everyone — meaning there was no actual control group and experiment data wasn't useful.

## Changes

- Pass `'test'` as the match parameter to `useFeatureFlag` across all 7 call sites
- Now `control` group → `false` (old UI), `test` group → `true` (new editor panels)

## How did you test this code?

I'm an agent — no manual testing was done. The change is mechanical (adding a second argument to existing hook calls). No new logic was introduced.

## Publish to changelog?