### PR TITLE
feat(bi): e2e test for direct queries

### DIFF
--- a/frontend/src/scenes/data-warehouse/editor/ConnectionSelector.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/ConnectionSelector.tsx
@@ -53,7 +53,7 @@ export function ConnectionSelector(): JSX.Element | null {
                 }
 
                 if (nextValue === ADD_POSTGRES_DIRECT_CONNECTION) {
-                    router.actions.push(urls.dataWarehouseSourceNew('Postgres'))
+                    router.actions.push(urls.dataWarehouseSourceNew('Postgres', undefined, undefined, 'direct'))
                     return
                 }
 

--- a/frontend/src/scenes/data-warehouse/new/NewSourceWizard.tsx
+++ b/frontend/src/scenes/data-warehouse/new/NewSourceWizard.tsx
@@ -260,7 +260,7 @@ function FirstStep({ allowedSources }: NewSourcesWizardProps): JSX.Element {
 }
 
 function SecondStep(): JSX.Element {
-    const { selectedConnector } = useValues(sourceWizardLogic)
+    const { selectedConnector, source } = useValues(sourceWizardLogic)
 
     return selectedConnector ? (
         <div className="space-y-4">
@@ -291,7 +291,7 @@ function SecondStep(): JSX.Element {
 
             <LemonDivider />
 
-            <SourceForm sourceConfig={selectedConnector} />
+            <SourceForm sourceConfig={selectedConnector} initialAccessMethod={source.access_method} />
         </div>
     ) : (
         <BindLogic logic={dataWarehouseTableLogic} props={{ id: 'new' }}>

--- a/frontend/src/scenes/data-warehouse/new/sourceWizardLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/new/sourceWizardLogic.tsx
@@ -1096,6 +1096,7 @@ export const sourceWizardLogic = kea<sourceWizardLogicType>([
             const kind = searchParams.kind?.toLowerCase()
             const returnUrl = searchParams.returnUrl
             const returnLabel = searchParams.returnLabel
+            const accessMethod = searchParams.access_method === 'direct' ? 'direct' : 'warehouse'
 
             if (returnUrl && returnLabel) {
                 actions.setReturnConfig(returnUrl, returnLabel)
@@ -1114,6 +1115,8 @@ export const sourceWizardLogic = kea<sourceWizardLogicType>([
 
             if (source) {
                 actions.selectConnector(source)
+                actions.updateSource({ access_method: accessMethod })
+                actions.setSourceConnectionDetailsValue('access_method', accessMethod)
                 actions.handleRedirect(source.name)
                 actions.setStep(2)
                 // Restore form values saved before an OAuth redirect

--- a/frontend/src/scenes/urls.ts
+++ b/frontend/src/scenes/urls.ts
@@ -244,7 +244,12 @@ export const urls = {
     dataPipelinesNew: (kind?: DataPipelinesNewSceneKind): string => `/pipeline/new/${kind ?? ''}`,
     dataWarehouseSource: (id: string, tab?: DataWarehouseSourceSceneTab): string =>
         `/data-management/sources/${id}/${tab ?? 'schemas'}`,
-    dataWarehouseSourceNew: (kind?: string, returnUrl?: string, returnLabel?: string): string => {
+    dataWarehouseSourceNew: (
+        kind?: string,
+        returnUrl?: string,
+        returnLabel?: string,
+        accessMethod?: 'warehouse' | 'direct'
+    ): string => {
         const params = new URLSearchParams()
         if (kind) {
             params.set('kind', kind)
@@ -254,6 +259,9 @@ export const urls = {
         }
         if (returnLabel) {
             params.set('returnLabel', returnLabel)
+        }
+        if (accessMethod) {
+            params.set('access_method', accessMethod)
         }
         const queryString = params.toString()
         return `/data-warehouse/new-source${queryString ? `?${queryString}` : ''}`

--- a/playwright/e2e/sql-editor-direct-postgres.spec.ts
+++ b/playwright/e2e/sql-editor-direct-postgres.spec.ts
@@ -1,0 +1,156 @@
+import { execFileSync } from 'node:child_process'
+
+import { mockFeatureFlags } from '../utils/mockApi'
+import { expect, LOGIN_PASSWORD, LOGIN_USERNAME, test } from '../utils/playwright-test-core'
+
+test.describe('SQL Editor direct Postgres queries', () => {
+    test('creates a Postgres direct source and queries it successfully', async ({ page }) => {
+        test.setTimeout(180000)
+        const sourceName = `Playwright direct ${Date.now()}`
+        const tableName = `playwright_direct_query_${Date.now()}`
+        let sourceId: string | null = null
+
+        execFileSync('psql', [
+            'postgresql://posthog:posthog@127.0.0.1:5432/posthog',
+            '-c',
+            `
+                DROP TABLE IF EXISTS ${tableName};
+                CREATE TABLE ${tableName} (
+                    id integer primary key,
+                    label text not null
+                );
+                INSERT INTO ${tableName} (id, label) VALUES (1, 'alpha'), (2, 'beta');
+            `,
+        ])
+
+        try {
+            await mockFeatureFlags(page, {
+                'dwh-postgres-direct-query': true,
+            })
+
+            await page.goto('/login')
+            await page.evaluate(
+                async ({ email, password }) => {
+                    await fetch('/api/login/', {
+                        method: 'POST',
+                        headers: {
+                            'Content-Type': 'application/json',
+                        },
+                        body: JSON.stringify({ email, password }),
+                    })
+                },
+                { email: LOGIN_USERNAME, password: LOGIN_PASSWORD }
+            )
+            await page.goto('/')
+            await expect(page).toHaveURL(/\/project\/\d+/)
+            await page.goToMenuItem('sql-editor')
+            await expect(page.locator('[data-attr=editor-scene]')).toBeVisible({ timeout: 60000 })
+
+            await test.step('Open the direct Postgres source flow with direct query preselected', async () => {
+                await expect(page.locator('[data-attr=sql-editor-output-pane-empty-state]')).toBeVisible()
+
+                const connectionSelector = page.getByRole('button', { name: /PostHog \(ClickHouse\)/ })
+                await connectionSelector.click()
+                await page.getByRole('menuitem', { name: '+ Add postgres direct connection' }).click()
+
+                await expect(page).toHaveURL(/.*\/data-warehouse\/new-source/)
+                await expect(page).toHaveURL(/kind=Postgres/)
+                await expect(page).toHaveURL(/access_method=direct/)
+                await expect(page.getByText('How should PostHog query this source?')).toBeVisible({ timeout: 60000 })
+                await expect(page.getByText('Shown as:')).toBeVisible({ timeout: 60000 })
+            })
+
+            await test.step('Create the Postgres direct source for the selected table', async () => {
+                sourceId = await page.evaluate(
+                    async ({ name, table }) => {
+                        const response = await fetch('/api/projects/@current/external_data_sources/', {
+                            method: 'POST',
+                            headers: {
+                                'Content-Type': 'application/json',
+                            },
+                            body: JSON.stringify({
+                                source_type: 'Postgres',
+                                access_method: 'direct',
+                                prefix: name,
+                                payload: {
+                                    source_type: 'Postgres',
+                                    host: '127.0.0.1',
+                                    port: '5432',
+                                    database: 'posthog',
+                                    user: 'posthog',
+                                    password: 'posthog',
+                                    schema: 'public',
+                                    schemas: [
+                                        {
+                                            name: table,
+                                            should_sync: true,
+                                            sync_type: null,
+                                            incremental_field: null,
+                                            incremental_field_type: null,
+                                            sync_time_of_day: null,
+                                        },
+                                    ],
+                                },
+                            }),
+                        })
+
+                        if (!response.ok) {
+                            throw new Error(await response.text())
+                        }
+
+                        const data = await response.json()
+                        return data.id as string
+                    },
+                    { name: sourceName, table: tableName }
+                )
+            })
+
+            await test.step('Run a successful raw query against the new connection', async () => {
+                await page.goto('/')
+                await page.goToMenuItem('sql-editor')
+                await expect(page.locator('[data-attr=editor-scene]')).toBeVisible({ timeout: 60000 })
+
+                const connectionSelector = page.getByRole('button', { name: /PostHog \(ClickHouse\)/ })
+                await connectionSelector.click()
+                await page.getByRole('menuitem', { name: `${sourceName} (Postgres)` }).click()
+
+                await page.getByTestId('sql-editor-settings-toggle').click()
+                await page.getByTestId('sql-editor-send-raw-query-toggle').click()
+
+                await page.locator('[data-attr=hogql-query-editor]').click()
+                await page
+                    .locator('[data-attr=hogql-query-editor]')
+                    .press(`${process.platform === 'darwin' ? 'Meta' : 'Control'}+A`)
+                await page.locator('[data-attr=hogql-query-editor]').press('Delete')
+                await page
+                    .locator('[data-attr=hogql-query-editor]')
+                    .pressSequentially(`SELECT id, label FROM ${tableName} ORDER BY id`)
+                await page.locator('[data-attr=sql-editor-run-button]').click()
+
+                await expect(page.locator('[data-attr=sql-editor-output-pane-empty-state]')).not.toBeVisible()
+                await expect(page.getByText('alpha')).toBeVisible()
+                await expect(page.getByText('beta')).toBeVisible()
+            })
+        } finally {
+            if (sourceId) {
+                try {
+                    await page.evaluate(
+                        async ({ id }) => {
+                            await fetch(`/api/projects/@current/external_data_sources/${id}/`, {
+                                method: 'DELETE',
+                            })
+                        },
+                        { id: sourceId }
+                    )
+                } catch {
+                    // Best-effort cleanup for the source created during the test.
+                }
+            }
+            execFileSync('psql', [
+                'postgresql://posthog:posthog@127.0.0.1:5432/posthog',
+                '-c',
+                `DROP TABLE IF EXISTS ${tableName};`,
+            ])
+        }
+    })
+})

--- a/playwright/e2e/sql-editor-direct-postgres.spec.ts
+++ b/playwright/e2e/sql-editor-direct-postgres.spec.ts
@@ -90,7 +90,7 @@ test.describe('SQL Editor direct Postgres queries', () => {
                                     prefix: name,
                                     payload: {
                                         source_type: 'Postgres',
-                                        host: '127.0.0.1',
+                                        host: 'localhost',
                                         port: '5432',
                                         database: 'posthog',
                                         user: 'posthog',

--- a/playwright/e2e/sql-editor-direct-postgres.spec.ts
+++ b/playwright/e2e/sql-editor-direct-postgres.spec.ts
@@ -76,45 +76,52 @@ test.describe('SQL Editor direct Postgres queries', () => {
                             throw new Error('CSRF cookie missing in browser context')
                         }
 
-                        const response = await fetch('/api/projects/@current/external_data_sources/', {
-                            method: 'POST',
-                            credentials: 'include',
-                            headers: {
-                                'Content-Type': 'application/json',
-                                'X-CSRFToken': decodeURIComponent(csrfToken),
-                            },
-                            body: JSON.stringify({
-                                source_type: 'Postgres',
-                                access_method: 'direct',
-                                prefix: name,
-                                payload: {
-                                    source_type: 'Postgres',
-                                    host: '127.0.0.1',
-                                    port: '5432',
-                                    database: 'posthog',
-                                    user: 'posthog',
-                                    password: 'posthog',
-                                    schema: 'public',
-                                    schemas: [
-                                        {
-                                            name: table,
-                                            should_sync: true,
-                                            sync_type: null,
-                                            incremental_field: null,
-                                            incremental_field_type: null,
-                                            sync_time_of_day: null,
-                                        },
-                                    ],
+                        for (let attempt = 1; attempt <= 3; attempt++) {
+                            const response = await fetch('/api/projects/@current/external_data_sources/', {
+                                method: 'POST',
+                                credentials: 'include',
+                                headers: {
+                                    'Content-Type': 'application/json',
+                                    'X-CSRFToken': decodeURIComponent(csrfToken),
                                 },
-                            }),
-                        })
+                                body: JSON.stringify({
+                                    source_type: 'Postgres',
+                                    access_method: 'direct',
+                                    prefix: name,
+                                    payload: {
+                                        source_type: 'Postgres',
+                                        host: '127.0.0.1',
+                                        port: '5432',
+                                        database: 'posthog',
+                                        user: 'posthog',
+                                        password: 'posthog',
+                                        schema: 'public',
+                                        schemas: [
+                                            {
+                                                name: table,
+                                                should_sync: true,
+                                                sync_type: null,
+                                                incremental_field: null,
+                                                incremental_field_type: null,
+                                                sync_time_of_day: null,
+                                            },
+                                        ],
+                                    },
+                                }),
+                            })
 
-                        if (!response.ok) {
-                            throw new Error(`${response.status} ${await response.text()}`)
+                            if (response.ok) {
+                                const data = await response.json()
+                                return data.id as string
+                            }
+
+                            if (![502, 503, 504].includes(response.status) || attempt === 3) {
+                                throw new Error(`${response.status} ${await response.text()}`)
+                            }
+
+                            await new Promise((resolve) => window.setTimeout(resolve, attempt * 1000))
                         }
-
-                        const data = await response.json()
-                        return data.id as string
+                        throw new Error('Failed to create Postgres direct source after retries')
                     },
                     { name: sourceName, table: tableName }
                 )
@@ -141,14 +148,16 @@ test.describe('SQL Editor direct Postgres queries', () => {
                     .locator('[data-attr=hogql-query-editor]')
                     .pressSequentially(`SELECT id, label FROM ${tableName} ORDER BY id`)
                 await page.locator('[data-attr=sql-editor-run-button]').click()
+                await expect(page.locator('[data-attr=sql-editor-run-button]')).toContainText('Cancel')
+                await expect(page.locator('[data-attr=sql-editor-run-button]')).toContainText('Run', { timeout: 60000 })
 
                 await expect(page.locator('[data-attr=sql-editor-output-pane-empty-state]')).not.toBeVisible()
                 await expect
-                    .poll(async () => await page.locator('body').innerText(), { timeout: 15000 })
-                    .toContain('Showing 2 rows')
-                await expect
-                    .poll(async () => await page.locator('body').innerText(), { timeout: 15000 })
+                    .poll(async () => await page.locator('body').innerText(), { timeout: 60000 })
                     .toContain('alpha')
+                await expect
+                    .poll(async () => await page.locator('body').innerText(), { timeout: 60000 })
+                    .toContain('beta')
             })
         } finally {
             if (sourceId) {

--- a/playwright/e2e/sql-editor-direct-postgres.spec.ts
+++ b/playwright/e2e/sql-editor-direct-postgres.spec.ts
@@ -10,20 +10,20 @@ test.describe('SQL Editor direct Postgres queries', () => {
         const tableName = `playwright_direct_query_${Date.now()}`
         let sourceId: string | null = null
 
-        execFileSync('psql', [
-            'postgresql://posthog:posthog@127.0.0.1:5432/posthog',
-            '-c',
-            `
-                DROP TABLE IF EXISTS ${tableName};
-                CREATE TABLE ${tableName} (
-                    id integer primary key,
-                    label text not null
-                );
-                INSERT INTO ${tableName} (id, label) VALUES (1, 'alpha'), (2, 'beta');
-            `,
-        ])
-
         try {
+            execFileSync('psql', [
+                'postgresql://posthog:posthog@127.0.0.1:5432/posthog',
+                '-c',
+                `
+                    DROP TABLE IF EXISTS ${tableName};
+                    CREATE TABLE ${tableName} (
+                        id integer primary key,
+                        label text not null
+                    );
+                    INSERT INTO ${tableName} (id, label) VALUES (1, 'alpha'), (2, 'beta');
+                `,
+            ])
+
             await mockFeatureFlags(page, {
                 'dwh-postgres-direct-query': true,
             })
@@ -191,11 +191,15 @@ test.describe('SQL Editor direct Postgres queries', () => {
                     // Best-effort cleanup for the source created during the test.
                 }
             }
-            execFileSync('psql', [
-                'postgresql://posthog:posthog@127.0.0.1:5432/posthog',
-                '-c',
-                `DROP TABLE IF EXISTS ${tableName};`,
-            ])
+            try {
+                execFileSync('psql', [
+                    'postgresql://posthog:posthog@127.0.0.1:5432/posthog',
+                    '-c',
+                    `DROP TABLE IF EXISTS ${tableName};`,
+                ])
+            } catch {
+                // Best-effort cleanup for the table created during the test.
+            }
         }
     })
 })

--- a/playwright/e2e/sql-editor-direct-postgres.spec.ts
+++ b/playwright/e2e/sql-editor-direct-postgres.spec.ts
@@ -63,10 +63,25 @@ test.describe('SQL Editor direct Postgres queries', () => {
             await test.step('Create the Postgres direct source for the selected table', async () => {
                 sourceId = await page.evaluate(
                     async ({ name, table }) => {
+                        const csrfToken =
+                            document.cookie
+                                .split(';')
+                                .map((cookie) => cookie.trim())
+                                .find((cookie) => cookie.startsWith('posthog_csrftoken='))
+                                ?.split('=')
+                                .slice(1)
+                                .join('=') || ''
+
+                        if (!csrfToken) {
+                            throw new Error('CSRF cookie missing in browser context')
+                        }
+
                         const response = await fetch('/api/projects/@current/external_data_sources/', {
                             method: 'POST',
+                            credentials: 'include',
                             headers: {
                                 'Content-Type': 'application/json',
+                                'X-CSRFToken': decodeURIComponent(csrfToken),
                             },
                             body: JSON.stringify({
                                 source_type: 'Postgres',
@@ -95,7 +110,7 @@ test.describe('SQL Editor direct Postgres queries', () => {
                         })
 
                         if (!response.ok) {
-                            throw new Error(await response.text())
+                            throw new Error(`${response.status} ${await response.text()}`)
                         }
 
                         const data = await response.json()
@@ -128,16 +143,37 @@ test.describe('SQL Editor direct Postgres queries', () => {
                 await page.locator('[data-attr=sql-editor-run-button]').click()
 
                 await expect(page.locator('[data-attr=sql-editor-output-pane-empty-state]')).not.toBeVisible()
-                await expect(page.getByText('alpha')).toBeVisible()
-                await expect(page.getByText('beta')).toBeVisible()
+                await expect
+                    .poll(async () => await page.locator('body').innerText(), { timeout: 15000 })
+                    .toContain('Showing 2 rows')
+                await expect
+                    .poll(async () => await page.locator('body').innerText(), { timeout: 15000 })
+                    .toContain('alpha')
             })
         } finally {
             if (sourceId) {
                 try {
                     await page.evaluate(
                         async ({ id }) => {
+                            const csrfToken =
+                                document.cookie
+                                    .split(';')
+                                    .map((cookie) => cookie.trim())
+                                    .find((cookie) => cookie.startsWith('posthog_csrftoken='))
+                                    ?.split('=')
+                                    .slice(1)
+                                    .join('=') || ''
+
+                            if (!csrfToken) {
+                                throw new Error('CSRF cookie missing in browser context')
+                            }
+
                             await fetch(`/api/projects/@current/external_data_sources/${id}/`, {
                                 method: 'DELETE',
+                                credentials: 'include',
+                                headers: {
+                                    'X-CSRFToken': decodeURIComponent(csrfToken),
+                                },
                             })
                         },
                         { id: sourceId }

--- a/playwright/e2e/sql-editor.spec.ts
+++ b/playwright/e2e/sql-editor.spec.ts
@@ -1,71 +1,73 @@
 import { expect, test } from '../utils/playwright-test-base'
 
 test.describe('SQL Editor', () => {
-    test.beforeEach(async ({ page }) => {
-        await page.goToMenuItem('sql-editor')
-    })
+    test.describe('Basic flow', () => {
+        test.beforeEach(async ({ page }) => {
+            await page.goToMenuItem('sql-editor')
+        })
 
-    test('See SQL Editor', async ({ page }) => {
-        await expect(page.locator('[data-attr=editor-scene]')).toBeVisible()
-        await expect(page.locator('[data-attr=sql-editor-source-empty-state]')).toBeVisible()
-        await expect(page.locator('.scene-name h1 span').getByText('New SQL query', { exact: true })).toBeVisible()
-    })
+        test('See SQL Editor', async ({ page }) => {
+            await expect(page.locator('[data-attr=editor-scene]')).toBeVisible()
+            await expect(page.locator('[data-attr=sql-editor-source-empty-state]')).toBeVisible()
+            await expect(page.locator('.scene-name h1 span').getByText('New SQL query', { exact: true })).toBeVisible()
+        })
 
-    test('Add source link', async ({ page }) => {
-        await page.locator('[data-attr=sql-editor-add-source]').click()
-        await expect(page).toHaveURL(/.*\/data-warehouse\/new-source/)
-    })
+        test('Add source link', async ({ page }) => {
+            await page.locator('[data-attr=sql-editor-add-source]').click()
+            await expect(page).toHaveURL(/.*\/data-warehouse\/new-source/)
+        })
 
-    test('Run query', async ({ page }) => {
-        await expect(page.locator('[data-attr=sql-editor-output-pane-empty-state]')).toBeVisible()
-        await page.locator('[data-attr=hogql-query-editor]').click()
-        await page.locator('[data-attr=hogql-query-editor]').pressSequentially('SELECT 1')
-        await page.locator('[data-attr=sql-editor-run-button]').click()
+        test('Run query', async ({ page }) => {
+            await expect(page.locator('[data-attr=sql-editor-output-pane-empty-state]')).toBeVisible()
+            await page.locator('[data-attr=hogql-query-editor]').click()
+            await page.locator('[data-attr=hogql-query-editor]').pressSequentially('SELECT 1')
+            await page.locator('[data-attr=sql-editor-run-button]').click()
 
-        // query run
-        await expect(page.locator('[data-attr=sql-editor-output-pane-empty-state]')).not.toBeVisible()
-    })
+            // query run
+            await expect(page.locator('[data-attr=sql-editor-output-pane-empty-state]')).not.toBeVisible()
+        })
 
-    test('Save view', async ({ page }) => {
-        // Wait for the query editor to be visible and ready
-        await expect(page.locator('[data-attr=hogql-query-editor]')).toBeVisible()
-        await page.locator('[data-attr=hogql-query-editor]').click()
-        await page.locator('[data-attr=hogql-query-editor]').pressSequentially('SELECT 1')
-        await page.locator('[data-attr=sql-editor-run-button]').click()
-        await expect(page.locator('[data-attr=sql-editor-output-pane-empty-state]')).not.toBeVisible()
+        test('Save view', async ({ page }) => {
+            // Wait for the query editor to be visible and ready
+            await expect(page.locator('[data-attr=hogql-query-editor]')).toBeVisible()
+            await page.locator('[data-attr=hogql-query-editor]').click()
+            await page.locator('[data-attr=hogql-query-editor]').pressSequentially('SELECT 1')
+            await page.locator('[data-attr=sql-editor-run-button]').click()
+            await expect(page.locator('[data-attr=sql-editor-output-pane-empty-state]')).not.toBeVisible()
 
-        // Open save options, then click save as view
-        await expect(page.locator('[data-attr=sql-editor-save-options-button]')).toBeEnabled()
-        await page.locator('[data-attr=sql-editor-save-options-button]').click()
-        await page.getByText('Save as view', { exact: true }).click()
+            // Open save options, then click save as view
+            await expect(page.locator('[data-attr=sql-editor-save-options-button]')).toBeEnabled()
+            await page.locator('[data-attr=sql-editor-save-options-button]').click()
+            await page.getByText('Save as view', { exact: true }).click()
 
-        // Wait for the modal/dialog to appear and be ready
-        const nameInput = page.locator('[data-attr=sql-editor-input-save-view-name]')
-        await expect(nameInput).toBeVisible()
+            // Wait for the modal/dialog to appear and be ready
+            const nameInput = page.locator('[data-attr=sql-editor-input-save-view-name]')
+            await expect(nameInput).toBeVisible()
 
-        // Use a unique name to avoid conflicts with retries
-        const uniqueViewName = `test_view_${Date.now()}`
-        await nameInput.fill(uniqueViewName)
+            // Use a unique name to avoid conflicts with retries
+            const uniqueViewName = `test_view_${Date.now()}`
+            await nameInput.fill(uniqueViewName)
 
-        // Wait for the Submit button to be enabled (form validation may need time)
-        const submitButton = page.getByRole('button', { name: 'Submit' })
-        await expect(submitButton).toBeEnabled()
+            // Wait for the Submit button to be enabled (form validation may need time)
+            const submitButton = page.getByRole('button', { name: 'Submit' })
+            await expect(submitButton).toBeEnabled()
 
-        // Click submit
-        await submitButton.click()
+            // Click submit
+            await submitButton.click()
 
-        // Wait for the success message which confirms the API call completed
-        await expect(page.getByText(`${uniqueViewName} successfully created`)).toBeVisible()
-        await expect(page.locator('.scene-name h1 span').getByText(uniqueViewName, { exact: true })).toBeVisible()
-    })
+            // Wait for the success message which confirms the API call completed
+            await expect(page.getByText(`${uniqueViewName} successfully created`)).toBeVisible()
+            await expect(page.locator('.scene-name h1 span').getByText(uniqueViewName, { exact: true })).toBeVisible()
+        })
 
-    test('Materialize view pane', async ({ page }) => {
-        await page.getByText('Materialization').click()
-        await expect(page.locator('[data-attr=sql-editor-sidebar-query-info-pane]')).toBeVisible()
-    })
+        test('Materialize view pane', async ({ page }) => {
+            await page.getByText('Materialization').click()
+            await expect(page.locator('[data-attr=sql-editor-sidebar-query-info-pane]')).toBeVisible()
+        })
 
-    test('Query variables pane', async ({ page }) => {
-        await page.getByText('Variables').click()
-        await expect(page.locator('[data-attr=sql-editor-variables-button]')).toBeVisible()
+        test('Query variables pane', async ({ page }) => {
+            await page.getByText('Variables').click()
+            await expect(page.locator('[data-attr=sql-editor-variables-button]')).toBeVisible()
+        })
     })
 })

--- a/posthog/hogql/test/test_direct_postgres_query.py
+++ b/posthog/hogql/test/test_direct_postgres_query.py
@@ -1109,6 +1109,59 @@ class TestDirectPostgresQuery(APIBaseTest):
 
         self.assertEqual(mock_connect.call_args.kwargs["sslmode"], "require")
 
+    @override_settings(DEBUG=False, TEST=False, E2E_TESTING=True)
+    @patch("posthog.hogql.query.psycopg.connect")
+    def test_execute_direct_postgres_query_uses_prefer_sslmode_in_e2e_for_new_sources(self, mock_connect):
+        source = ExternalDataSource.objects.create(
+            team=self.team,
+            source_id="source_id",
+            connection_id="connection_id",
+            status=ExternalDataSource.Status.COMPLETED,
+            source_type="Postgres",
+            access_method=ExternalDataSource.AccessMethod.DIRECT,
+            prefix="ph3",
+            job_inputs={
+                "host": "localhost",
+                "port": 5432,
+                "database": "postgres",
+                "user": "postgres",
+                "password": "postgres",
+                "schema": "ph3",
+            },
+        )
+        source.created_at = SSL_REQUIRED_AFTER_DATE + timedelta(days=1)
+        source.save(update_fields=["created_at"])
+
+        DataWarehouseTable.objects.create(
+            name="posthog_dashboard",
+            format="Parquet",
+            team=self.team,
+            external_data_source=source,
+            url_pattern="direct://postgres",
+            columns={
+                "id": {"hogql": "IntegerDatabaseField", "clickhouse": "Int64", "valid": True},
+            },
+        )
+
+        mocked_cursor = MagicMock()
+        mocked_cursor.fetchall.return_value = [(1,)]
+        column = MagicMock(type_code=23)
+        column.name = "id"
+        mocked_cursor.description = [column]
+        mocked_connection = MagicMock()
+        mocked_connection.cursor.return_value.__enter__.return_value = mocked_cursor
+        mock_connect.return_value.__enter__.return_value = mocked_connection
+
+        executor = HogQLQueryExecutor(
+            query="SELECT id FROM posthog_dashboard LIMIT 1",
+            team=self.team,
+            connection_id=str(source.id),
+        )
+
+        executor.execute()
+
+        self.assertEqual(mock_connect.call_args.kwargs["sslmode"], "prefer")
+
     @override_settings(DEBUG=False, TEST=False)
     @patch("posthog.hogql.query.psycopg.connect")
     def test_execute_direct_postgres_query_adds_ssl_cert_paths_for_postwh_hosts(self, mock_connect):

--- a/posthog/temporal/data_imports/sources/common/mixins.py
+++ b/posthog/temporal/data_imports/sources/common/mixins.py
@@ -28,6 +28,9 @@ def _is_host_safe(host: str, team_id: int) -> tuple[bool, str | None]:
         return True, None
 
     region = get_instance_region()
+    if region == "E2E":
+        return True, None
+
     if (region == "US" and team_id == 2) or (region == "EU" and team_id == 1):
         return True, None
 

--- a/posthog/temporal/data_imports/sources/common/test_mixins.py
+++ b/posthog/temporal/data_imports/sources/common/test_mixins.py
@@ -58,6 +58,19 @@ class TestIsHostSafe(SimpleTestCase):
 
     @parameterized.expand(
         [
+            ("localhost", "localhost"),
+            ("loopback", "127.0.0.1"),
+            ("private_ip", "10.0.0.1"),
+        ]
+    )
+    @override_settings(CLOUD_DEPLOYMENT="E2E", E2E_TESTING=True)
+    def test_allows_internal_hosts_in_e2e(self, _name: str, host: str):
+        valid, error = _is_host_safe(host, team_id=999)
+        assert valid
+        assert error is None
+
+    @parameterized.expand(
+        [
             ("postwh_us", "entirely-chief-wildcat.us.postwh.com"),
             ("postwh_eu", "my-db.eu.postwh.com"),
             ("postwh_bare", "something.postwh.com"),

--- a/posthog/temporal/data_imports/sources/postgres/postgres.py
+++ b/posthog/temporal/data_imports/sources/postgres/postgres.py
@@ -55,7 +55,7 @@ def _get_sslmode(require_ssl: bool) -> str:
             tries SSL but falls back to unencrypted if not available.
     """
 
-    if settings.TEST or settings.DEBUG:
+    if settings.TEST or settings.DEBUG or settings.E2E_TESTING:
         return "prefer"
 
     return "require" if require_ssl else "prefer"

--- a/posthog/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/posthog/temporal/data_imports/sources/postgres/test_postgres.py
@@ -108,18 +108,28 @@ class TestGetSslmode:
         with patch("posthog.temporal.data_imports.sources.postgres.postgres.settings") as mock_settings:
             mock_settings.TEST = False
             mock_settings.DEBUG = False
+            mock_settings.E2E_TESTING = False
             assert _get_sslmode(True) == "require"
 
     def test_returns_prefer_when_ssl_not_required_outside_test(self):
         with patch("posthog.temporal.data_imports.sources.postgres.postgres.settings") as mock_settings:
             mock_settings.TEST = False
             mock_settings.DEBUG = False
+            mock_settings.E2E_TESTING = False
             assert _get_sslmode(False) == "prefer"
 
     def test_returns_prefer_in_debug_mode(self):
         with patch("posthog.temporal.data_imports.sources.postgres.postgres.settings") as mock_settings:
             mock_settings.TEST = False
             mock_settings.DEBUG = True
+            mock_settings.E2E_TESTING = False
+            assert _get_sslmode(True) == "prefer"
+
+    def test_returns_prefer_in_e2e_mode(self):
+        with patch("posthog.temporal.data_imports.sources.postgres.postgres.settings") as mock_settings:
+            mock_settings.TEST = False
+            mock_settings.DEBUG = False
+            mock_settings.E2E_TESTING = True
             assert _get_sslmode(True) == "prefer"
 
 


### PR DESCRIPTION
## Problem

Direct queries need more coverage

## Changes

- Add E2E test that sets up a database connection and makes a direct query
- Also preselects "Direct query" when clicking the "+" button in the sql editor

## How did you test this code?

Tests, CI, 👀 

## Publish to changelog?

no

## Docs update

no