### PR TITLE
feat(llma): expose evaluation test_hog endpoint as MCP tool

### DIFF
--- a/products/llm_analytics/backend/api/evaluations.py
+++ b/products/llm_analytics/backend/api/evaluations.py
@@ -348,7 +348,7 @@ class EvaluationViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, Forbi
     def partial_update(self, request, *args, **kwargs):
         return super().partial_update(request, *args, **kwargs)
 
-    @action(detail=False, methods=["post"], url_path="test_hog")
+    @action(detail=False, methods=["post"], url_path="test_hog", required_scopes=["evaluation:read"])
     def test_hog(self, request: Request, **kwargs) -> Response:
         """Test Hog evaluation code against sample events without saving."""
         serializer = TestHogRequestSerializer(data=request.data)

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -356,6 +356,21 @@
             "readOnlyHint": false
         }
     },
+    "evaluation-test-hog": {
+        "description": "Test Hog evaluation code against recent $ai_generation events without persisting results. Compiles the provided Hog source code and runs it against a sample of recent events (up to 10 from the last 7 days). Returns per-event results with input/output previews, pass/fail verdicts, and any errors. Use this to validate Hog evaluation logic before enabling it.",
+        "category": "LLM analytics",
+        "feature": "llm_analytics",
+        "summary": "Dry-run Hog evaluation code against sample events.",
+        "title": "Test Hog evaluation",
+        "required_scopes": ["evaluation:read"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        }
+    },
     "get-llm-total-costs-for-project": {
         "description": "Fetches the total LLM daily costs for each model for a project over a given number of days. If no number of days is provided, it defaults to 7. The results are sorted by model name. The total cost is rounded to 4 decimal places. The query is executed against the project's data warehouse. Show the results as a Markdown formatted table with the following information for each model: Model name, Total cost in USD, Each day's date, Each day's cost in USD. Write in bold the model name with the highest total cost. Properly render the markdown table in the response.",
         "category": "LLM analytics",

--- a/services/mcp/schema/tool-definitions.json
+++ b/services/mcp/schema/tool-definitions.json
@@ -356,6 +356,21 @@
             "readOnlyHint": false
         }
     },
+    "evaluation-test-hog": {
+        "description": "Test Hog evaluation code against recent $ai_generation events without persisting results. Compiles the provided Hog source code and runs it against a sample of recent events (up to 10 from the last 7 days). Returns per-event results with input/output previews, pass/fail verdicts, and any errors. Use this to validate Hog evaluation logic before enabling it.",
+        "category": "LLM analytics",
+        "feature": "llm_analytics",
+        "summary": "Dry-run Hog evaluation code against sample events.",
+        "title": "Test Hog evaluation",
+        "required_scopes": ["evaluation:read"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        }
+    },
     "get-llm-total-costs-for-project": {
         "description": "Fetches the total LLM daily costs for each model for a project over a given number of days. If no number of days is provided, it defaults to 7. The results are sorted by model name. The total cost is rounded to 4 decimal places. The query is executed against the project's data warehouse. Show the results as a Markdown formatted table with the following information for each model: Model name, Total cost in USD, Each day's date, Each day's cost in USD. Write in bold the model name with the highest total cost. Properly render the markdown table in the response.",
         "category": "LLM analytics",

--- a/services/mcp/src/tools/index.ts
+++ b/services/mcp/src/tools/index.ts
@@ -30,6 +30,7 @@ import evaluationDelete from './llmAnalytics/evaluations/delete'
 import evaluationGet from './llmAnalytics/evaluations/get'
 import evaluationsGet from './llmAnalytics/evaluations/getAll'
 import evaluationRun from './llmAnalytics/evaluations/run'
+import evaluationTestHog from './llmAnalytics/evaluations/testHog'
 import evaluationUpdate from './llmAnalytics/evaluations/update'
 import getLLMCosts from './llmAnalytics/getLLMCosts'
 import logsListAttributes from './logs/listAttributes'
@@ -116,6 +117,7 @@ export const TOOL_MAP: Record<string, () => ToolBase<ZodObjectAny>> = {
     'evaluation-update': evaluationUpdate,
     'evaluation-delete': evaluationDelete,
     'evaluation-run': evaluationRun,
+    'evaluation-test-hog': evaluationTestHog,
 
     // Search
     'entity-search': entitySearch,

--- a/services/mcp/src/tools/llmAnalytics/evaluations/testHog.ts
+++ b/services/mcp/src/tools/llmAnalytics/evaluations/testHog.ts
@@ -1,0 +1,50 @@
+import { z } from 'zod'
+
+import type { Context, ToolBase } from '@/tools/types'
+
+const schema = z.object({
+    source: z
+        .string()
+        .min(1)
+        .describe('Hog source code to test. Must return a boolean (true = pass, false = fail).'),
+    sample_count: z
+        .number()
+        .int()
+        .min(1)
+        .max(10)
+        .optional()
+        .default(5)
+        .describe('Number of recent $ai_generation events to test against (1-10, default 5).'),
+    allows_na: z
+        .boolean()
+        .optional()
+        .default(false)
+        .describe('Whether the evaluation can return N/A for non-applicable generations.'),
+    conditions: z
+        .array(z.record(z.string(), z.unknown()))
+        .optional()
+        .default([])
+        .describe('Optional trigger conditions to filter which events are sampled.'),
+})
+
+type Params = z.infer<typeof schema>
+
+export const handler: ToolBase<typeof schema>['handler'] = async (context: Context, params: Params) => {
+    const projectId = await context.stateManager.getProjectId()
+
+    const result = await context.api.request({
+        method: 'POST',
+        path: `/api/environments/${projectId}/evaluations/test_hog/`,
+        body: params as unknown as Record<string, unknown>,
+    })
+
+    return result
+}
+
+const tool = (): ToolBase<typeof schema> => ({
+    name: 'evaluation-test-hog',
+    schema,
+    handler,
+})
+
+export default tool

--- a/services/mcp/src/tools/llmAnalytics/evaluations/testHog.ts
+++ b/services/mcp/src/tools/llmAnalytics/evaluations/testHog.ts
@@ -35,7 +35,7 @@ export const handler: ToolBase<typeof schema>['handler'] = async (context: Conte
     const result = await context.api.request({
         method: 'POST',
         path: `/api/environments/${projectId}/evaluations/test_hog/`,
-        body: params as unknown as Record<string, unknown>,
+        body: { ...params },
     })
 
     return result

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/evaluation-test-hog.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/evaluation-test-hog.json
@@ -1,0 +1,36 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "allows_na": {
+            "default": false,
+            "description": "Whether the evaluation can return N/A for non-applicable generations.",
+            "type": "boolean"
+        },
+        "conditions": {
+            "default": [],
+            "description": "Optional trigger conditions to filter which events are sampled.",
+            "items": {
+                "additionalProperties": {},
+                "propertyNames": {
+                    "type": "string"
+                },
+                "type": "object"
+            },
+            "type": "array"
+        },
+        "sample_count": {
+            "default": 5,
+            "description": "Number of recent $ai_generation events to test against (1-10, default 5).",
+            "maximum": 10,
+            "minimum": 1,
+            "type": "integer"
+        },
+        "source": {
+            "description": "Hog source code to test. Must return a boolean (true = pass, false = fail).",
+            "minLength": 1,
+            "type": "string"
+        }
+    },
+    "required": ["source"],
+    "type": "object"
+}


### PR DESCRIPTION
## Problem

The `test_hog` endpoint on `EvaluationViewSet` lets users dry-run Hog evaluation code against recent events, but it was not exposed as an MCP tool. This meant agents could not validate Hog evaluation logic before creating or enabling evaluations -- they had to create the evaluation blind and run it against real events to check correctness.

## Changes

- Added `evaluation-test-hog` MCP tool (`services/mcp/src/tools/llmAnalytics/evaluations/testHog.ts`) that calls `POST /api/environments/{projectId}/evaluations/test_hog/`
- Registered the tool in the MCP tool map (`index.ts`)
- Added tool definition to `tool-definitions.json` and `tool-definitions-all.json` with `evaluation:read` scope and read-only annotations
- Tool accepts `source` (Hog code), `sample_count` (1-10), `allows_na`, and optional `conditions`

## How did you test this code?

- TypeScript type check passes (`pnpm tsc --noEmit`)
- All 423 MCP unit tests pass, including the snapshot test which auto-generated the new tool's schema snapshot

## Publish to changelog?

No

## Docs update

No docs changes needed -- the tool is auto-discoverable via MCP.