### PR TITLE
fix(llma): allow OAuth-authenticated users to manage prompts

### DIFF
--- a/posthog/api/llm_prompt.py
+++ b/posthog/api/llm_prompt.py
@@ -136,10 +136,7 @@ class LLMPromptViewSet(
     def _ensure_web_authenticated(self, request: Request) -> Response | None:
         if not isinstance(
             request.successful_authenticator,
-            SessionAuthentication
-            | JwtAuthentication
-            | PersonalAPIKeyAuthentication
-            | OAuthAccessTokenAuthentication,
+            SessionAuthentication | JwtAuthentication | PersonalAPIKeyAuthentication | OAuthAccessTokenAuthentication,
         ):
             return Response(
                 {"detail": "This endpoint is only available to web-authenticated users."},

--- a/posthog/api/llm_prompt.py
+++ b/posthog/api/llm_prompt.py
@@ -41,7 +41,12 @@ from posthog.api.services.llm_prompt import (
     publish_prompt_version,
     resolve_versions_page,
 )
-from posthog.auth import JwtAuthentication, PersonalAPIKeyAuthentication, SessionAuthentication
+from posthog.auth import (
+    JwtAuthentication,
+    OAuthAccessTokenAuthentication,
+    PersonalAPIKeyAuthentication,
+    SessionAuthentication,
+)
 from posthog.event_usage import report_team_action, report_user_action
 from posthog.exceptions_capture import capture_exception
 from posthog.models import LLMPrompt, User
@@ -130,7 +135,11 @@ class LLMPromptViewSet(
 
     def _ensure_web_authenticated(self, request: Request) -> Response | None:
         if not isinstance(
-            request.successful_authenticator, SessionAuthentication | JwtAuthentication | PersonalAPIKeyAuthentication
+            request.successful_authenticator,
+            SessionAuthentication
+            | JwtAuthentication
+            | PersonalAPIKeyAuthentication
+            | OAuthAccessTokenAuthentication,
         ):
             return Response(
                 {"detail": "This endpoint is only available to web-authenticated users."},


### PR DESCRIPTION
## Problem

The `_ensure_web_authenticated` guard in `LLMPromptViewSet` only allowed `SessionAuthentication`, `JwtAuthentication`, and `PersonalAPIKeyAuthentication`. OAuth access tokens (used by the MCP server) were rejected with a 403 "This endpoint is only available to web-authenticated users" on four endpoints:

- `update_by_name` (PATCH) -- publish new prompt version
- `resolve_by_name` (GET) -- resolve prompt with version history
- `archive` (POST) -- archive a prompt
- `duplicate` (POST) -- duplicate a prompt

This broke MCP prompt management after switching from personal API keys to OAuth authentication.

## Changes

Added `OAuthAccessTokenAuthentication` to the allowed authenticator types in `_ensure_web_authenticated`. The OAuth scope checks (`llm_prompt:read`/`llm_prompt:write`) already exist via `dangerously_get_required_scopes` and the `required_scopes` action decorators, so access control is maintained.

## How did you test this code?

All 53 existing LLM prompt tests pass. The bug was discovered when attempting to update a prompt via MCP with OAuth auth and getting the 403 error.