### PR TITLE
fix(ci): fix agent skills release race condition

### DIFF
--- a/.github/workflows/ci-agent-skills.yml
+++ b/.github/workflows/ci-agent-skills.yml
@@ -11,7 +11,7 @@ on:
             - '.github/workflows/ci-agent-skills.yml'
 
 concurrency:
-    group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+    group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
     cancel-in-progress: true
 
 jobs:
@@ -208,6 +208,7 @@ jobs:
             - name: Determine next version
               id: version
               run: |
+                  git fetch --tags --force
                   LATEST_TAG=$(git tag -l 'agent-skills-v*' | grep -E '^agent-skills-v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -n 1)
                   if [ -z "$LATEST_TAG" ]; then LATEST_TAG="agent-skills-v0.0.0"; fi
                   MINOR=$(echo "${LATEST_TAG#agent-skills-v}" | cut -d. -f2)


### PR DESCRIPTION
## Problem

Two concurrent pushes to `master` can race in the agent skills release workflow.
The concurrency group used `github.head_ref || github.run_id` — but `head_ref` is empty on push events, so each run got a unique group via `run_id`, allowing parallel execution.

Both runs computed the same next version tag and the second one failed with "a release with the same tag name already exists."

Seen in: https://github.com/PostHog/posthog/actions/runs/23901114078/job/69698997931

## Changes

- Fix concurrency group to use `github.ref` instead of `github.run_id` as fallback — all master pushes now share one group, so the older run gets cancelled
- Add `git fetch --tags --force` before version computation as a defense-in-depth measure

## How did you test this code?

Verified the root cause by comparing the existing `v0.36.0` release (created at 12:42 from `ee9eb21`) against the failed run (started at 12:47 from `c558d4c`).

## Publish to changelog?

no

## 🤖 LLM context

Diagnosed the CI failure by inspecting the failed job logs and correlating release timestamps with workflow run times to identify the race condition.