### PR TITLE
fix(workflows): Create HogFlowBatchJob for scheduler-triggered runs

### DIFF
--- a/nodejs/src/cdp/services/hogflow-schedule/hogflow-schedule.service.test.ts
+++ b/nodejs/src/cdp/services/hogflow-schedule/hogflow-schedule.service.test.ts
@@ -111,9 +111,10 @@ describe('HogFlowScheduleService', () => {
     describe('lifecycle', () => {
         it('does not allow double start', () => {
             mockDjangoResponse({ processed: [], initialized: [], failed: [] })
-            const startCount = (service as any).running
+            const pollPromiseBefore = (service as any).pollPromise
             service.start()
-            expect(startCount).toBe(true)
+            // Poll promise should be the same instance, not a new one
+            expect((service as any).pollPromise).toBe(pollPromiseBefore)
         })
     })
 

--- a/nodejs/src/cdp/services/hogflow-schedule/hogflow-schedule.service.test.ts
+++ b/nodejs/src/cdp/services/hogflow-schedule/hogflow-schedule.service.test.ts
@@ -1,22 +1,6 @@
-import { KafkaProducerWrapper } from '~/kafka/producer'
-import { parseJSON } from '~/utils/json-parse'
-
 import { HogFlowScheduleService } from './hogflow-schedule.service'
 
-const mockProduce = jest.fn()
-const mockDisconnect = jest.fn()
 const mockFetch = jest.fn()
-
-jest.mock('~/kafka/producer', () => ({
-    KafkaProducerWrapper: {
-        create: jest.fn().mockImplementation(() =>
-            Promise.resolve({
-                produce: mockProduce,
-                disconnect: mockDisconnect,
-            })
-        ),
-    },
-}))
 
 jest.mock('~/common/services/internal-fetch', () => ({
     InternalFetchService: jest.fn().mockImplementation(() => ({
@@ -27,7 +11,6 @@ jest.mock('~/common/services/internal-fetch', () => ({
 const config = {
     INTERNAL_API_BASE_URL: 'http://localhost:8000',
     INTERNAL_API_SECRET: 'test-secret',
-    KAFKA_CLIENT_RACK: undefined,
     HOGFLOW_SCHEDULER_POLL_INTERVAL_MS: 60_000,
     HOGFLOW_SCHEDULER_MAX_POLL_INTERVAL_MS: 300_000,
     HOGFLOW_SCHEDULER_HEALTH_TIMEOUT_MS: 600_000,
@@ -46,12 +29,11 @@ function mockDjangoResponse(body: Record<string, unknown>): void {
 describe('HogFlowScheduleService', () => {
     let service: HogFlowScheduleService
 
-    beforeEach(async () => {
+    beforeEach(() => {
         jest.clearAllMocks()
         service = new HogFlowScheduleService(config)
-        // Initialize with empty response so start() completes its first poll
         mockDjangoResponse({ processed: [], initialized: [], failed: [] })
-        await service.start()
+        service.start()
         jest.clearAllMocks()
     })
 
@@ -60,51 +42,23 @@ describe('HogFlowScheduleService', () => {
     })
 
     describe('pollAndDispatch', () => {
-        it('produces correct Kafka message for processed schedules', async () => {
+        it('returns true on successful poll with processed schedules', async () => {
             mockDjangoResponse({
-                processed: [
-                    {
-                        schedule_id: 'schedule-1',
-                        team_id: 1,
-                        hog_flow_id: 'flow-1',
-                        filters: { properties: [{ key: 'email', value: '@posthog.com' }] },
-                        variables: { greeting: 'Hello' },
-                    },
-                ],
+                processed: ['schedule-1', 'schedule-2'],
                 initialized: [],
                 failed: [],
             })
 
-            await service.pollAndDispatch()
-
-            expect(mockProduce).toHaveBeenCalledWith({
-                topic: expect.stringContaining('cdp_batch_hogflow_requests'),
-                value: expect.any(Buffer),
-                key: '1_flow-1',
-            })
-
-            const producedValue = parseJSON(mockProduce.mock.calls[0][0].value.toString())
-            expect(producedValue).toEqual({
-                teamId: 1,
-                hogFlowId: 'flow-1',
-                parentRunId: null,
-                filters: {
-                    properties: [{ key: 'email', value: '@posthog.com' }],
-                    filter_test_accounts: false,
-                },
-                variables: { greeting: 'Hello' },
-            })
+            expect(await service.pollAndDispatch()).toBe(true)
         })
 
-        it('does not produce to Kafka when no schedules are due', async () => {
+        it('returns true on successful poll with no due schedules', async () => {
             mockDjangoResponse({ processed: [], initialized: [], failed: [] })
 
-            await service.pollAndDispatch()
-
-            expect(mockProduce).not.toHaveBeenCalled()
+            expect(await service.pollAndDispatch()).toBe(true)
         })
 
-        it('does not produce to Kafka when endpoint returns error', async () => {
+        it('returns false when endpoint returns error', async () => {
             mockFetch.mockResolvedValue({
                 fetchResponse: {
                     status: 500,
@@ -113,37 +67,16 @@ describe('HogFlowScheduleService', () => {
                 fetchError: null,
             })
 
-            await service.pollAndDispatch()
-
-            expect(mockProduce).not.toHaveBeenCalled()
+            expect(await service.pollAndDispatch()).toBe(false)
         })
 
-        it('does not produce to Kafka when fetch fails', async () => {
+        it('returns false when fetch fails', async () => {
             mockFetch.mockResolvedValue({
                 fetchResponse: null,
                 fetchError: new Error('Connection refused'),
             })
 
-            await service.pollAndDispatch()
-
-            expect(mockProduce).not.toHaveBeenCalled()
-        })
-
-        it('dispatches all schedules even when one fails', async () => {
-            mockDjangoResponse({
-                processed: [
-                    { schedule_id: 's1', team_id: 1, hog_flow_id: 'f1', filters: {}, variables: {} },
-                    { schedule_id: 's2', team_id: 2, hog_flow_id: 'f2', filters: {}, variables: {} },
-                ],
-                initialized: [],
-                failed: [],
-            })
-
-            mockProduce.mockRejectedValueOnce(new Error('Kafka error')).mockResolvedValueOnce(undefined)
-
-            await service.pollAndDispatch()
-
-            expect(mockProduce).toHaveBeenCalledTimes(2)
+            expect(await service.pollAndDispatch()).toBe(false)
         })
     })
 
@@ -159,30 +92,28 @@ describe('HogFlowScheduleService', () => {
         it('backs off exponentially capped at 5 minutes', () => {
             const s = service as any
             s.consecutiveFailures = 0
-            expect(s.nextSleepMs()).toBe(60_000) // base interval
+            expect(s.nextSleepMs()).toBe(60_000)
 
             s.consecutiveFailures = 1
-            expect(s.nextSleepMs()).toBe(120_000) // 60s * 2^1
+            expect(s.nextSleepMs()).toBe(120_000)
 
             s.consecutiveFailures = 2
-            expect(s.nextSleepMs()).toBe(240_000) // 60s * 2^2
+            expect(s.nextSleepMs()).toBe(240_000)
 
             s.consecutiveFailures = 3
-            expect(s.nextSleepMs()).toBe(300_000) // capped at 5 min
+            expect(s.nextSleepMs()).toBe(300_000)
 
             s.consecutiveFailures = 10
-            expect(s.nextSleepMs()).toBe(300_000) // still capped
+            expect(s.nextSleepMs()).toBe(300_000)
         })
     })
 
     describe('lifecycle', () => {
-        it('does not allow double start', async () => {
+        it('does not allow double start', () => {
             mockDjangoResponse({ processed: [], initialized: [], failed: [] })
-
-            await service.start()
-
-            // KafkaProducerWrapper.create was called once in beforeEach, not again
-            expect(KafkaProducerWrapper.create).not.toHaveBeenCalled()
+            const startCount = (service as any).running
+            service.start()
+            expect(startCount).toBe(true)
         })
     })
 

--- a/nodejs/src/cdp/services/hogflow-schedule/hogflow-schedule.service.ts
+++ b/nodejs/src/cdp/services/hogflow-schedule/hogflow-schedule.service.ts
@@ -2,8 +2,6 @@ import { Counter, Gauge } from 'prom-client'
 import { z } from 'zod'
 
 import { InternalFetchService } from '~/common/services/internal-fetch'
-import { KAFKA_CDP_BATCH_HOGFLOW_REQUESTS } from '~/config/kafka-topics'
-import { KafkaProducerWrapper } from '~/kafka/producer'
 import {
     HealthCheckResult,
     HealthCheckResultError,
@@ -20,9 +18,9 @@ const schedulerPollCounter = new Counter({
     labelNames: ['status'],
 })
 
-const schedulerDispatchedCounter = new Counter({
-    name: 'cdp_hogflow_scheduler_dispatched',
-    help: 'Number of batch triggers dispatched to Kafka',
+const schedulerProcessedCounter = new Counter({
+    name: 'cdp_hogflow_scheduler_processed',
+    help: 'Number of due schedules processed (batch jobs created by Django)',
 })
 
 const schedulerInitializedCounter = new Counter({
@@ -41,24 +39,13 @@ const schedulerPollDurationGauge = new Gauge({
     help: 'Duration of the last poll cycle in milliseconds',
 })
 
-const ProcessedScheduleSchema = z.object({
-    schedule_id: z.string(),
-    team_id: z.number(),
-    hog_flow_id: z.string(),
-    filters: z.record(z.unknown()),
-    variables: z.record(z.unknown()),
-})
-
 const ProcessDueSchedulesResponseSchema = z.object({
-    processed: z.array(ProcessedScheduleSchema),
+    processed: z.array(z.string()),
     initialized: z.array(z.string()),
     failed: z.array(z.string()),
 })
 
-type ProcessedSchedule = z.infer<typeof ProcessedScheduleSchema>
-
 export class HogFlowScheduleService {
-    private kafkaProducer: KafkaProducerWrapper | null = null
     private running = false
     private pollPromise: Promise<void> | null = null
     private sleepResolve: (() => void) | null = null
@@ -76,14 +63,12 @@ export class HogFlowScheduleService {
         this.internalFetchService = new InternalFetchService(config.INTERNAL_API_BASE_URL, config.INTERNAL_API_SECRET)
     }
 
-    async start(): Promise<void> {
+    start(): void {
         if (this.running) {
             return
         }
 
         logger.info('HogFlowScheduleService: starting...')
-        this.kafkaProducer = await KafkaProducerWrapper.create(this.config.KAFKA_CLIENT_RACK, 'CDP_PRODUCER')
-        logger.info('HogFlowScheduleService: Kafka producer connected')
 
         this.running = true
         this.pollPromise = this.pollLoop()
@@ -165,34 +150,11 @@ export class HogFlowScheduleService {
                 })
             }
 
-            const results = await Promise.allSettled(
-                data.processed.map((schedule) => this.dispatchBatchTrigger(schedule))
-            )
-
-            const failures = results.filter((r): r is PromiseRejectedResult => r.status === 'rejected')
-            const dispatched = data.processed.length - failures.length
-
-            if (failures.length > 0) {
-                const failedIds = data.processed
-                    .filter((_, i) => results[i].status === 'rejected')
-                    .map((s) => s.schedule_id)
-                schedulerFailedCounter.inc({ stage: 'dispatch' }, failures.length)
-                logger.error('HogFlowScheduleService: failed to dispatch some schedules', {
-                    failedCount: failures.length,
-                    totalCount: data.processed.length,
-                    scheduleIds: failedIds,
-                })
-            }
-
             if (data.processed.length > 0) {
-                const dispatchedIds = data.processed
-                    .filter((_, i) => results[i].status === 'fulfilled')
-                    .map((s) => s.schedule_id)
-                schedulerDispatchedCounter.inc(dispatched)
+                schedulerProcessedCounter.inc(data.processed.length)
                 logger.info('HogFlowScheduleService: processed due schedules', {
                     count: data.processed.length,
-                    dispatched: dispatchedIds.length,
-                    scheduleIds: dispatchedIds,
+                    scheduleIds: data.processed,
                 })
             }
 
@@ -208,40 +170,10 @@ export class HogFlowScheduleService {
         }
     }
 
-    private async dispatchBatchTrigger(schedule: ProcessedSchedule): Promise<void> {
-        if (!this.kafkaProducer) {
-            throw new Error('Kafka producer not available')
-        }
-
-        const batchHogFlowRequest = {
-            teamId: schedule.team_id,
-            hogFlowId: schedule.hog_flow_id,
-            parentRunId: null,
-            filters: {
-                properties: (schedule.filters?.properties as unknown[]) || [],
-                filter_test_accounts: (schedule.filters?.filter_test_accounts as boolean) ?? false,
-            },
-            variables: schedule.variables,
-        }
-
-        await this.kafkaProducer.produce({
-            topic: KAFKA_CDP_BATCH_HOGFLOW_REQUESTS,
-            value: Buffer.from(JSON.stringify(batchHogFlowRequest)),
-            key: `${schedule.team_id}_${schedule.hog_flow_id}`,
-        })
-
-        logger.info('HogFlowScheduleService: dispatched batch trigger', {
-            scheduleId: schedule.schedule_id,
-            hogFlowId: schedule.hog_flow_id,
-            teamId: schedule.team_id,
-        })
-    }
-
     async stop(): Promise<void> {
         this.running = false
         this.sleepResolve?.()
         await this.pollPromise
-        await this.kafkaProducer?.disconnect()
     }
 
     isHealthy(): HealthCheckResult {

--- a/nodejs/src/server.ts
+++ b/nodejs/src/server.ts
@@ -223,10 +223,10 @@ export class PluginServer implements NodeServer {
         }
 
         if (capabilities.cdpHogflowScheduler) {
-            serviceLoaders.push(async () => {
+            serviceLoaders.push(() => {
                 const scheduler = new HogFlowScheduleService(this.config)
-                await scheduler.start()
-                return scheduler.service
+                scheduler.start()
+                return Promise.resolve(scheduler.service)
             })
         }
 

--- a/posthog/api/hog_flow.py
+++ b/posthog/api/hog_flow.py
@@ -733,6 +733,7 @@ class InternalHogFlowViewSet(TeamAndOrgViewSetMixin, LogEntryMixin, AppMetricsMi
 
             for schedule_id in due_schedule_ids:
                 try:
+                    batch_job_params = None
                     with transaction.atomic():
                         # Per-schedule transaction: lock only one row at a time to minimize
                         # lock duration and allow concurrent replicas via skip_locked.
@@ -760,22 +761,21 @@ class InternalHogFlowViewSet(TeamAndOrgViewSetMixin, LogEntryMixin, AppMetricsMi
 
                         advance_next_run(schedule, after=schedule.next_run_at)
 
-                        variables = resolve_variables(hog_flow, schedule)
-                        filters = (hog_flow.trigger or {}).get("filters", {})
+                        batch_job_params = {
+                            "team_id": schedule.team_id,
+                            "hog_flow": hog_flow,
+                            "variables": resolve_variables(hog_flow, schedule),
+                            "filters": (hog_flow.trigger or {}).get("filters", {}),
+                        }
 
-                        # Create a HogFlowBatchJob so the run appears in
-                        # the workflow's Invocations/Metrics tabs. The
-                        # post_save signal dispatches to the CDP API which
-                        # handles the actual batch execution.
+                    # Create the batch job outside the transaction so the
+                    # post_save signal's HTTP call doesn't hold the row lock.
+                    if batch_job_params:
                         HogFlowBatchJob.objects.create(
-                            team_id=schedule.team_id,
-                            hog_flow=hog_flow,
-                            variables=variables,
-                            filters=filters,
+                            **batch_job_params,
                             status=HogFlowBatchJob.State.QUEUED,
                         )
-
-                        processed.append(str(schedule.id))
+                        processed.append(str(schedule_id))
                 except Exception:
                     logger.exception("Error processing schedule", schedule_id=str(schedule_id))
                     failed.append(str(schedule_id))

--- a/posthog/api/hog_flow.py
+++ b/posthog/api/hog_flow.py
@@ -688,6 +688,7 @@ class InternalHogFlowViewSet(TeamAndOrgViewSetMixin, LogEntryMixin, AppMetricsMi
         """
         from django.db import transaction
 
+        from products.workflows.backend.models.hog_flow_batch_job import HogFlowBatchJob
         from products.workflows.backend.models.hog_flow_schedule import HogFlowSchedule
         from products.workflows.backend.utils.rrule_utils import compute_next_occurrences
 
@@ -759,15 +760,22 @@ class InternalHogFlowViewSet(TeamAndOrgViewSetMixin, LogEntryMixin, AppMetricsMi
 
                         advance_next_run(schedule, after=schedule.next_run_at)
 
-                        processed.append(
-                            {
-                                "schedule_id": str(schedule.id),
-                                "team_id": schedule.team_id,
-                                "hog_flow_id": str(schedule.hog_flow_id),
-                                "filters": (hog_flow.trigger or {}).get("filters", {}),
-                                "variables": resolve_variables(hog_flow, schedule),
-                            }
+                        variables = resolve_variables(hog_flow, schedule)
+                        filters = (hog_flow.trigger or {}).get("filters", {})
+
+                        # Create a HogFlowBatchJob so the run appears in
+                        # the workflow's Invocations/Metrics tabs. The
+                        # post_save signal dispatches to the CDP API which
+                        # handles the actual batch execution.
+                        HogFlowBatchJob.objects.create(
+                            team_id=schedule.team_id,
+                            hog_flow=hog_flow,
+                            variables=variables,
+                            filters=filters,
+                            status=HogFlowBatchJob.State.QUEUED,
                         )
+
+                        processed.append(str(schedule.id))
                 except Exception:
                     logger.exception("Error processing schedule", schedule_id=str(schedule_id))
                     failed.append(str(schedule_id))

--- a/products/workflows/backend/test/test_hog_flow_schedule.py
+++ b/products/workflows/backend/test/test_hog_flow_schedule.py
@@ -186,6 +186,9 @@ class TestHogFlowScheduleAPI(APIBaseTest):
 
 
 @override_settings(INTERNAL_API_SECRET="test-secret")
+@unittest.mock.patch(
+    "products.workflows.backend.models.hog_flow_batch_job.hog_flow_batch_job.create_batch_hog_flow_job_invocation"
+)
 class TestProcessDueSchedules(APIBaseTest):
     INTERNAL_URL = "/api/internal/hog_flows/process_due_schedules"
 
@@ -216,7 +219,7 @@ class TestProcessDueSchedules(APIBaseTest):
             HTTP_X_INTERNAL_API_SECRET="test-secret",
         )
 
-    def test_due_schedule_is_processed_and_next_run_at_advanced(self):
+    def test_due_schedule_is_processed_and_next_run_at_advanced(self, mock_dispatch):
         hog_flow, schedule = self._create_workflow_with_schedule(
             next_run_at=datetime(2020, 1, 1, tzinfo=UTC),
         )
@@ -231,9 +234,6 @@ class TestProcessDueSchedules(APIBaseTest):
         assert schedule.next_run_at is not None
         assert schedule.next_run_at > datetime(2020, 1, 1, tzinfo=UTC)
 
-    @unittest.mock.patch(
-        "products.workflows.backend.models.hog_flow_batch_job.hog_flow_batch_job.create_batch_hog_flow_job_invocation"
-    )
     def test_due_schedule_creates_batch_job(self, mock_dispatch):
         hog_flow, schedule = self._create_workflow_with_schedule(
             next_run_at=datetime(2020, 1, 1, tzinfo=UTC),
@@ -248,7 +248,7 @@ class TestProcessDueSchedules(APIBaseTest):
         assert batch_job.variables == {"greeting": "Hello"}
         mock_dispatch.assert_called_once()
 
-    def test_inactive_workflow_clears_next_run_at(self):
+    def test_inactive_workflow_clears_next_run_at(self, mock_dispatch):
         hog_flow, schedule = self._create_workflow_with_schedule(
             next_run_at=datetime(2020, 1, 1, tzinfo=UTC),
         )
@@ -262,7 +262,7 @@ class TestProcessDueSchedules(APIBaseTest):
         schedule.refresh_from_db()
         assert schedule.next_run_at is None
 
-    def test_uninitialized_schedule_gets_next_run_at(self):
+    def test_uninitialized_schedule_gets_next_run_at(self, mock_dispatch):
         _, schedule = self._create_workflow_with_schedule(next_run_at=None)
         response = self._post()
         assert response.status_code == 200
@@ -271,7 +271,7 @@ class TestProcessDueSchedules(APIBaseTest):
         schedule.refresh_from_db()
         assert schedule.next_run_at is not None
 
-    def test_exhausted_rrule_marks_schedule_completed(self):
+    def test_exhausted_rrule_marks_schedule_completed(self, mock_dispatch):
         _, schedule = self._create_workflow_with_schedule(
             next_run_at=datetime(2020, 1, 1, tzinfo=UTC),
             starts_at=datetime(2019, 12, 31, tzinfo=UTC),
@@ -284,7 +284,7 @@ class TestProcessDueSchedules(APIBaseTest):
         assert schedule.status == "completed"
         assert schedule.next_run_at is None
 
-    def test_bad_rrule_appears_in_failed(self):
+    def test_bad_rrule_appears_in_failed(self, mock_dispatch):
         _, schedule = self._create_workflow_with_schedule(
             next_run_at=datetime(2020, 1, 1, tzinfo=UTC),
             rrule="INVALID_RRULE",
@@ -294,7 +294,7 @@ class TestProcessDueSchedules(APIBaseTest):
         assert str(schedule.id) in response.json()["failed"]
         assert len(response.json()["processed"]) == 0
 
-    def test_no_due_schedules_returns_empty(self):
+    def test_no_due_schedules_returns_empty(self, mock_dispatch):
         self._create_workflow_with_schedule(
             next_run_at=datetime(2099, 1, 1, tzinfo=UTC),
         )
@@ -304,9 +304,6 @@ class TestProcessDueSchedules(APIBaseTest):
         assert len(response.json()["initialized"]) == 0
         assert len(response.json()["failed"]) == 0
 
-    @unittest.mock.patch(
-        "products.workflows.backend.models.hog_flow_batch_job.hog_flow_batch_job.create_batch_hog_flow_job_invocation"
-    )
     def test_schedule_with_variable_overrides_resolves_correctly(self, mock_dispatch):
         hog_flow, schedule = self._create_workflow_with_schedule(
             next_run_at=datetime(2020, 1, 1, tzinfo=UTC),
@@ -323,7 +320,7 @@ class TestProcessDueSchedules(APIBaseTest):
         assert batch_job.variables["greeting"] == "Overridden"
         assert batch_job.variables["extra"] == "value"
 
-    def test_multiple_due_schedules_processed_independently(self):
+    def test_multiple_due_schedules_processed_independently(self, mock_dispatch):
         self._create_workflow_with_schedule(next_run_at=datetime(2020, 1, 1, tzinfo=UTC))
         self._create_workflow_with_schedule(next_run_at=datetime(2020, 1, 1, tzinfo=UTC))
         self._create_workflow_with_schedule(
@@ -336,7 +333,7 @@ class TestProcessDueSchedules(APIBaseTest):
         assert len(response.json()["processed"]) == 2
         assert len(response.json()["failed"]) == 1
 
-    def test_non_batch_trigger_not_reinitialized(self):
+    def test_non_batch_trigger_not_reinitialized(self, mock_dispatch):
         hog_flow, schedule = self._create_workflow_with_schedule(
             next_run_at=datetime(2020, 1, 1, tzinfo=UTC),
         )

--- a/products/workflows/backend/test/test_hog_flow_schedule.py
+++ b/products/workflows/backend/test/test_hog_flow_schedule.py
@@ -1,5 +1,6 @@
 from datetime import UTC, datetime, timedelta
 
+import unittest.mock
 from posthog.test.base import APIBaseTest
 
 from django.test import override_settings
@@ -10,6 +11,7 @@ from rest_framework import status
 
 from posthog.models.hog_flow.hog_flow import HogFlow
 
+from products.workflows.backend.models.hog_flow_batch_job import HogFlowBatchJob
 from products.workflows.backend.models.hog_flow_schedule import HogFlowSchedule
 
 BATCH_TRIGGER = {
@@ -223,12 +225,28 @@ class TestProcessDueSchedules(APIBaseTest):
 
         data = response.json()
         assert len(data["processed"]) == 1
-        assert data["processed"][0]["hog_flow_id"] == str(hog_flow.id)
-        assert data["processed"][0]["variables"]["greeting"] == "Hello"
+        assert str(schedule.id) in data["processed"]
 
         schedule.refresh_from_db()
         assert schedule.next_run_at is not None
         assert schedule.next_run_at > datetime(2020, 1, 1, tzinfo=UTC)
+
+    @unittest.mock.patch(
+        "products.workflows.backend.models.hog_flow_batch_job.hog_flow_batch_job.create_batch_hog_flow_job_invocation"
+    )
+    def test_due_schedule_creates_batch_job(self, mock_dispatch):
+        hog_flow, schedule = self._create_workflow_with_schedule(
+            next_run_at=datetime(2020, 1, 1, tzinfo=UTC),
+        )
+        response = self._post()
+        assert response.status_code == 200
+        assert len(response.json()["processed"]) == 1
+
+        batch_job = HogFlowBatchJob.objects.filter(hog_flow=hog_flow).first()
+        assert batch_job is not None
+        assert batch_job.status == "queued"
+        assert batch_job.variables == {"greeting": "Hello"}
+        mock_dispatch.assert_called_once()
 
     def test_inactive_workflow_clears_next_run_at(self):
         hog_flow, schedule = self._create_workflow_with_schedule(
@@ -286,7 +304,10 @@ class TestProcessDueSchedules(APIBaseTest):
         assert len(response.json()["initialized"]) == 0
         assert len(response.json()["failed"]) == 0
 
-    def test_schedule_with_variable_overrides_resolves_correctly(self):
+    @unittest.mock.patch(
+        "products.workflows.backend.models.hog_flow_batch_job.hog_flow_batch_job.create_batch_hog_flow_job_invocation"
+    )
+    def test_schedule_with_variable_overrides_resolves_correctly(self, mock_dispatch):
         hog_flow, schedule = self._create_workflow_with_schedule(
             next_run_at=datetime(2020, 1, 1, tzinfo=UTC),
         )
@@ -295,10 +316,12 @@ class TestProcessDueSchedules(APIBaseTest):
 
         response = self._post()
         assert response.status_code == 200
+        assert len(response.json()["processed"]) == 1
 
-        variables = response.json()["processed"][0]["variables"]
-        assert variables["greeting"] == "Overridden"
-        assert variables["extra"] == "value"
+        batch_job = HogFlowBatchJob.objects.filter(hog_flow=hog_flow).first()
+        assert batch_job is not None
+        assert batch_job.variables["greeting"] == "Overridden"
+        assert batch_job.variables["extra"] == "value"
 
     def test_multiple_due_schedules_processed_independently(self):
         self._create_workflow_with_schedule(next_run_at=datetime(2020, 1, 1, tzinfo=UTC))

--- a/products/workflows/frontend/Workflows/WorkflowLogs.tsx
+++ b/products/workflows/frontend/Workflows/WorkflowLogs.tsx
@@ -48,19 +48,15 @@ function BatchRunHeader({ job }: { job: HogFlowBatchJob }): JSX.Element {
                 <TZLabel title="Created at" time={job.created_at} />
                 <LemonDivider vertical className="h-full" />
 
-                <Tooltip
-                    title={`${job.scheduled_at ? 'Scheduled' : 'Triggered'} by ${job.created_by?.email || 'unknown user'}`}
-                >
-                    <div>
-                        <ProfilePicture
-                            user={{
-                                email: job.created_by?.email || '',
-                            }}
-                            showName
-                            size="sm"
-                        />
-                    </div>
-                </Tooltip>
+                {job.created_by ? (
+                    <Tooltip title={`Triggered by ${job.created_by.email}`}>
+                        <div>
+                            <ProfilePicture user={{ email: job.created_by.email }} showName size="sm" />
+                        </div>
+                    </Tooltip>
+                ) : (
+                    <span className="text-muted text-sm">Scheduled run</span>
+                )}
             </div>
         </div>
     )

--- a/products/workflows/frontend/Workflows/WorkflowMetrics.tsx
+++ b/products/workflows/frontend/Workflows/WorkflowMetrics.tsx
@@ -163,7 +163,11 @@ function BatchJobMetricsHeader({ job }: { job: HogFlowBatchJob }): JSX.Element {
                     </Tooltip>
                 )}
                 <TZLabel title="Created at" time={job.created_at} />
-                {job.created_by && <ProfilePicture user={{ email: job.created_by.email || '' }} showName size="sm" />}
+                {job.created_by ? (
+                    <ProfilePicture user={{ email: job.created_by.email || '' }} showName size="sm" />
+                ) : (
+                    <span className="text-muted text-sm">Scheduled run</span>
+                )}
             </div>
         </div>
     )


### PR DESCRIPTION
## Problem

I realized we can simplify the whole scheduler and batch job creation. The scheduler was dispatching directly to Kafka, bypassing the `HogFlowBatchJob` record that the UI queries. The email did send and the flow worked, but it didn't show in the metrics.

## Changes

- **Django endpoint**: `process_due_schedules` now creates a `HogFlowBatchJob` for each due schedule. The existing `post_save` signal dispatches to the CDP API, which handles person matching and workflow execution.
- **Scheduler service**: Removed Kafka producer and dispatch logic. The scheduler is now a pure poll-trigger that calls Django. Django handles everything via the batch job signal. This eliminates duplicate dispatch paths and simplifies the service.
- **UI**: Invocations and Metrics tabs show "Scheduled run" instead of "an unknown user" when `created_by` is null (scheduler-created batch jobs). We can add an explicit source into the `HogFlowBatchJob` model later when there's a need for it.

<img width="1825" height="315" alt="Screenshot 2026-04-02 at 15 32 11" src="https://github.com/user-attachments/assets/7801c675-df03-4872-9ced-86dd8a17cfd7" />

## How did you test this code?

- Created a recurring schedule on localhost, verified the batch job appears in Invocations tab with "Scheduled run" label and "Workflow completed" in logs.
- Existing scheduler tests updated to reflect the simplified service (no Kafka mocks needed).
- Existing Django endpoint tests still pass.

## Publish to changelog?

No