### PR TITLE
fix(dashboards): preserve null dashboard variable overrides

### DIFF
--- a/frontend/src/scenes/dashboard/dashboardLogic.test.ts
+++ b/frontend/src/scenes/dashboard/dashboardLogic.test.ts
@@ -15,8 +15,9 @@ import { useMocks } from '~/mocks/jest'
 import { dashboardsModel } from '~/models/dashboardsModel'
 import { insightsModel } from '~/models/insightsModel'
 import { examples } from '~/queries/examples'
+import { variableDataLogic } from '~/queries/nodes/DataVisualization/Components/Variables/variableDataLogic'
 import { getQueryBasedDashboard } from '~/queries/nodes/InsightViz/utils'
-import { DashboardFilter, InsightVizNode, TrendsQuery } from '~/queries/schema/schema-general'
+import { DashboardFilter, InsightVizNode, NodeKind, TrendsQuery } from '~/queries/schema/schema-general'
 import { initKeaTests } from '~/test/init'
 import { DashboardTile, DashboardType, InsightColor, InsightShortId, QueryBasedInsightModel } from '~/types'
 
@@ -892,6 +893,91 @@ describe('dashboardLogic', () => {
                     .toDispatchActions(['setPageVisibility'])
                     .toNotHaveDispatchedActions(['resetInterval'])
             })
+        })
+    })
+
+    describe('dashboard variables', () => {
+        it('respects persisted null overrides in the dashboard header selector', async () => {
+            const variableId = '019d4e3a-3ae0-0000-0698-96f9eecd74ef'
+            const insightWithVariable = {
+                ...insightOnDashboard(175, [12]),
+                query: {
+                    kind: NodeKind.DataVisualizationNode,
+                    source: {
+                        kind: NodeKind.HogQLQuery,
+                        query: 'select {variables.organization}',
+                        variables: {
+                            [variableId]: {
+                                code_name: 'organization',
+                                variableId,
+                            },
+                        },
+                    },
+                    chartSettings: {},
+                    tableSettings: {},
+                } as any,
+            }
+            const dashboardWithVariableOverride = {
+                ...dashboardResult(12, [tileFromInsight(insightWithVariable)]),
+                persisted_variables: {
+                    [variableId]: {
+                        value: null,
+                        isNull: true,
+                        code_name: 'organization',
+                        variableId,
+                    },
+                },
+            }
+
+            variableDataLogic.mount()
+            logic = dashboardLogic({ id: 12, dashboard: dashboardWithVariableOverride })
+            logic.mount()
+
+            await expectLogic(logic).toFinishAllListeners()
+
+            await expectLogic(variableDataLogic, () => {
+                variableDataLogic.actions.loadVariablesSuccess([
+                    {
+                        id: variableId,
+                        name: 'Organization',
+                        code_name: 'organization',
+                        type: 'String',
+                        default_value: 'Default org',
+                    },
+                ] as any)
+            }).toMatchValues({
+                variables: [
+                    expect.objectContaining({
+                        id: variableId,
+                        code_name: 'organization',
+                    }),
+                ],
+            })
+
+            expect(logic.values.variables).toEqual([
+                expect.objectContaining({
+                    id: variableId,
+                    code_name: 'organization',
+                }),
+            ])
+            expect(logic.values.dashboard?.tiles[0].insight?.query).toEqual(
+                expect.objectContaining({
+                    kind: NodeKind.DataVisualizationNode,
+                })
+            )
+
+            expect(logic.values.effectiveVariablesAndAssociatedInsights).toEqual([
+                {
+                    variable: expect.objectContaining({
+                        id: variableId,
+                        name: 'Organization',
+                        code_name: 'organization',
+                        value: null,
+                        isNull: true,
+                    }),
+                    insightNames: ['donut'],
+                },
+            ])
         })
     })
 

--- a/frontend/src/scenes/dashboard/dashboardLogic.test.ts
+++ b/frontend/src/scenes/dashboard/dashboardLogic.test.ts
@@ -1,6 +1,7 @@
 // let tiles assert an insight is present in tests i.e. `tile!.insight` when it must be present for tests to pass
 import { MOCK_TEAM_ID } from 'lib/api.mock'
 
+import { router } from 'kea-router'
 import { expectLogic, truth } from 'kea-test-utils'
 
 import api from 'lib/api'
@@ -17,7 +18,7 @@ import { insightsModel } from '~/models/insightsModel'
 import { examples } from '~/queries/examples'
 import { variableDataLogic } from '~/queries/nodes/DataVisualization/Components/Variables/variableDataLogic'
 import { getQueryBasedDashboard } from '~/queries/nodes/InsightViz/utils'
-import { DashboardFilter, InsightVizNode, NodeKind, TrendsQuery } from '~/queries/schema/schema-general'
+import { DashboardFilter, HogQLVariable, InsightVizNode, NodeKind, TrendsQuery } from '~/queries/schema/schema-general'
 import { initKeaTests } from '~/test/init'
 import { DashboardTile, DashboardType, InsightColor, InsightShortId, QueryBasedInsightModel } from '~/types'
 
@@ -897,8 +898,32 @@ describe('dashboardLogic', () => {
     })
 
     describe('dashboard variables', () => {
-        it('respects persisted null overrides in the dashboard header selector', async () => {
-            const variableId = '019d4e3a-3ae0-0000-0698-96f9eecd74ef'
+        const variableId = '019d4e3a-3ae0-0000-0698-96f9eecd74ef'
+        const baseVariable = {
+            code_name: 'organization',
+            variableId,
+        }
+
+        const mountDashboardWithVariable = async ({
+            urlValue,
+            dashboardOverride,
+            insightOverride,
+        }: {
+            urlValue?: string | null
+            dashboardOverride?: Partial<HogQLVariable>
+            insightOverride?: Partial<HogQLVariable>
+        }): Promise<void> => {
+            router.actions.push(
+                '/',
+                urlValue === undefined
+                    ? {}
+                    : {
+                          [dashboardUtils.SEARCH_PARAM_QUERY_VARIABLES_KEY]: JSON.stringify({
+                              organization: urlValue,
+                          }),
+                      }
+            )
+
             const insightWithVariable = {
                 ...insightOnDashboard(175, [12]),
                 query: {
@@ -908,8 +933,8 @@ describe('dashboardLogic', () => {
                         query: 'select {variables.organization}',
                         variables: {
                             [variableId]: {
-                                code_name: 'organization',
-                                variableId,
+                                ...baseVariable,
+                                ...insightOverride,
                             },
                         },
                     },
@@ -917,16 +942,17 @@ describe('dashboardLogic', () => {
                     tableSettings: {},
                 } as any,
             }
+
             const dashboardWithVariableOverride = {
                 ...dashboardResult(12, [tileFromInsight(insightWithVariable)]),
-                persisted_variables: {
-                    [variableId]: {
-                        value: null,
-                        isNull: true,
-                        code_name: 'organization',
-                        variableId,
-                    },
-                },
+                persisted_variables: dashboardOverride
+                    ? {
+                          [variableId]: {
+                              ...baseVariable,
+                              ...dashboardOverride,
+                          },
+                      }
+                    : undefined,
             }
 
             variableDataLogic.mount()
@@ -953,32 +979,40 @@ describe('dashboardLogic', () => {
                     }),
                 ],
             })
+        }
 
-            expect(logic.values.variables).toEqual([
-                expect.objectContaining({
-                    id: variableId,
-                    code_name: 'organization',
-                }),
-            ])
-            expect(logic.values.dashboard?.tiles[0].insight?.query).toEqual(
-                expect.objectContaining({
-                    kind: NodeKind.DataVisualizationNode,
-                })
-            )
+        it.each([
+            ['url override (non-null)', 'url-val', undefined, undefined, 'url-val', false],
+            ['url override (null)', null, undefined, undefined, null, true],
+            ['persisted null override', undefined, { value: null, isNull: true }, undefined, null, true],
+            ['insight value fallback', undefined, undefined, { value: 'insight' }, 'insight', undefined],
+            ['default value fallback', undefined, undefined, undefined, 'Default org', undefined],
+        ])(
+            'resolves variable value: %s',
+            async (
+                _name: string,
+                urlValue: string | null | undefined,
+                dashboardOverride: Partial<HogQLVariable> | undefined,
+                insightOverride: Partial<HogQLVariable> | undefined,
+                expectedValue: string | null,
+                expectedIsNull: boolean | undefined
+            ) => {
+                await mountDashboardWithVariable({ urlValue, dashboardOverride, insightOverride })
 
-            expect(logic.values.effectiveVariablesAndAssociatedInsights).toEqual([
-                {
-                    variable: expect.objectContaining({
-                        id: variableId,
-                        name: 'Organization',
-                        code_name: 'organization',
-                        value: null,
-                        isNull: true,
-                    }),
-                    insightNames: ['donut'],
-                },
-            ])
-        })
+                expect(logic.values.effectiveVariablesAndAssociatedInsights).toEqual([
+                    {
+                        variable: expect.objectContaining({
+                            id: variableId,
+                            name: 'Organization',
+                            code_name: 'organization',
+                            value: expectedValue,
+                            isNull: expectedIsNull,
+                        }),
+                        insightNames: ['donut'],
+                    },
+                ])
+            }
+        )
     })
 
     describe('external updates', () => {

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -1273,29 +1273,20 @@ export const dashboardLogic = kea<dashboardLogicType>([
                             return null
                         }
 
-                        const urlValueOverride = urlVariable?.value
-                        const dashboardValueOverride = dashboard.persisted_variables?.[v.variableId]?.value
-                        const insightValueOverride = v.value
-                        const defaultVariableValue = variable.default_value
-
-                        const urlIsNullOverride = urlVariable?.isNull
-                        const dashboardIsNullOverride = dashboard.persisted_variables?.[v.variableId]?.isNull
-                        const insightIsNullOverride = v.isNull
-                        const defaultVariableIsNull = variable.isNull
+                        const dashboardVariable = dashboard.persisted_variables?.[v.variableId]
+                        const variableSources = [urlVariable, dashboardVariable, v]
+                        const valueSource = variableSources.find((source) =>
+                            source ? Object.prototype.hasOwnProperty.call(source, 'value') : false
+                        )
+                        const isNullSource = variableSources.find((source) =>
+                            source ? Object.prototype.hasOwnProperty.call(source, 'isNull') : false
+                        )
 
                         // determine effective variable state
                         const resultVar: Variable = {
                             ...variable,
-                            value:
-                                urlValueOverride ||
-                                dashboardValueOverride ||
-                                insightValueOverride ||
-                                defaultVariableValue,
-                            isNull:
-                                urlIsNullOverride ||
-                                dashboardIsNullOverride ||
-                                insightIsNullOverride ||
-                                defaultVariableIsNull,
+                            value: valueSource ? valueSource.value : variable.default_value,
+                            isNull: isNullSource ? isNullSource.isNull : variable.isNull,
                         }
 
                         // get insights using variable


### PR DESCRIPTION
## Problem

https://posthoghelp.zendesk.com/agent/tickets/54413 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/56004)

Dashboard variable overrides stored on the dashboard were resolved with truthy fallback logic in the dashboard header.
That caused explicit overrides like `value: null` / `isNull: true` to be ignored, so the header field no longer reflected the persisted override state.

## Changes

Updated dashboard variable resolution to use field presence rather than truthiness when choosing between URL overrides, persisted dashboard overrides, and insight/default values.
Added a regression test covering persisted `null` overrides in the dashboard header selector.

## How did you test this code?

Ran:

`pnpm --filter=@posthog/frontend jest frontend/src/scenes/dashboard/dashboardLogic.test.ts`

Added a focused regression test for the persisted `null` override case and verified the full `dashboardLogic` test file passes.

## 🤖 LLM context

Agent-authored PR.
Implemented the fix in the dashboard variable selector and added a regression test in the dashboard logic test suite.
Verified with the frontend Jest test file for `dashboardLogic`.

I (Thomas) also verified it on a repro dashboard.