### PR TITLE
feat(mcp): support for response attributes exclude/include

### DIFF
--- a/.agents/skills/implementing-mcp-tools/SKILL.md
+++ b/.agents/skills/implementing-mcp-tools/SKILL.md
@@ -139,6 +139,10 @@ tools:
     param_overrides:
       name:
         description: Custom description for the LLM
+    response: # filter response fields (applied per-item on list endpoints)
+      include: [id, key, name] # keep only these fields (dot-path wildcards supported)
+      exclude: [filters.groups.*.properties] # remove these fields
+      # include and exclude are mutually exclusive
 ```
 
 Unknown keys are rejected at build time (Zod `.strict()`).

--- a/docs/published/handbook/engineering/ai/implementing-mcp-tools.md
+++ b/docs/published/handbook/engineering/ai/implementing-mcp-tools.md
@@ -234,6 +234,10 @@ Product teams own their definitions and control which operations are exposed as 
        enrich_url: '{id}' # appended to url_prefix for result URLs
        exclude_params: [field] # hide params from tool input
        include_params: [field] # whitelist params (excludes all others)
+       response: # filter response fields (applied per-item on list endpoints)
+         include: [id, key, name] # keep only these fields (dot-path wildcards supported)
+         exclude: [filters.groups.*.properties] # remove these fields
+         # include and exclude are mutually exclusive
        input_schema: ActionCreateSchema # use a hand-crafted schema from tool-inputs (optional)
        param_overrides: # override Orval-generated param descriptions or schemas
          name:

--- a/products/feature_flags/mcp/tools.yaml
+++ b/products/feature_flags/mcp/tools.yaml
@@ -59,14 +59,6 @@ tools:
         title: Get feature flag definition
         description: |
             Get a feature flag by ID.
-        response:
-            include:
-                - id
-                - key
-                - name
-                - updated_at
-                - status
-                - tags
     create-feature-flag:
         operation: feature_flags_create
         enabled: true

--- a/products/feature_flags/mcp/tools.yaml
+++ b/products/feature_flags/mcp/tools.yaml
@@ -38,6 +38,14 @@ tools:
                 description:
                     Search by feature flag key or name (case-insensitive). Use this to find the flag ID for get/update/delete
                     tools.
+        response:
+            include:
+                - id
+                - key
+                - name
+                - updated_at
+                - status
+                - tags
     feature-flag-get-definition:
         operation: feature_flags_retrieve_2
         enabled: true
@@ -51,6 +59,14 @@ tools:
         title: Get feature flag definition
         description: |
             Get a feature flag by ID.
+        response:
+            include:
+                - id
+                - key
+                - name
+                - updated_at
+                - status
+                - tags
     create-feature-flag:
         operation: feature_flags_create
         enabled: true

--- a/services/mcp/definitions/README.md
+++ b/services/mcp/definitions/README.md
@@ -110,6 +110,10 @@ tools:
     enrich_url: '{id}' # appended to url_prefix for result URLs
     exclude_params: [field] # hide params from tool input
     include_params: [field] # whitelist params (excludes all others)
+    response: # filter response fields (applied per-item on list endpoints)
+      include: [id, key, name] # keep only these fields (dot-path wildcards supported)
+      exclude: [filters.groups.*.properties] # remove these fields
+      # include and exclude are mutually exclusive
     requires_ai_consent: true # gate behind org AI data processing consent
     param_overrides: # override individual param descriptions or schemas
       name:

--- a/services/mcp/scripts/generate-tools.ts
+++ b/services/mcp/scripts/generate-tools.ts
@@ -474,12 +474,12 @@ function buildResponseFilter(config: ToolConfig): {
         const paths = config.response?.include.map((f) => `'${f}'`).join(', ')
         if (config.list) {
             return {
-                code: `        const filtered = { ...result, results: result.results.map((item: any) => pickResponseFields(item, [${paths}])) }\n`,
+                code: `        const filtered = { ...result, results: result.results.map((item: any) => pickResponseFields(item, [${paths}])) } as typeof result\n`,
                 helperImport: 'pickResponseFields',
             }
         }
         return {
-            code: `        const filtered = pickResponseFields(result, [${paths}])\n`,
+            code: `        const filtered = pickResponseFields(result, [${paths}]) as typeof result\n`,
             helperImport: 'pickResponseFields',
         }
     }
@@ -487,12 +487,12 @@ function buildResponseFilter(config: ToolConfig): {
         const paths = config.response?.exclude.map((f) => `'${f}'`).join(', ')
         if (config.list) {
             return {
-                code: `        const filtered = { ...result, results: result.results.map((item: any) => omitResponseFields(item, [${paths}])) }\n`,
+                code: `        const filtered = { ...result, results: result.results.map((item: any) => omitResponseFields(item, [${paths}])) } as typeof result\n`,
                 helperImport: 'omitResponseFields',
             }
         }
         return {
-            code: `        const filtered = omitResponseFields(result, [${paths}])\n`,
+            code: `        const filtered = omitResponseFields(result, [${paths}]) as typeof result\n`,
             helperImport: 'omitResponseFields',
         }
     }

--- a/services/mcp/scripts/generate-tools.ts
+++ b/services/mcp/scripts/generate-tools.ts
@@ -463,34 +463,71 @@ function buildPathExpr(urlPath: string, pathParamNames: string[], paramAccessPre
 }
 
 // ------------------------------------------------------------------
+// Response filtering templates
+// ------------------------------------------------------------------
+
+function buildResponseFilter(config: ToolConfig): {
+    code: string
+    helperImport: 'pickResponseFields' | 'omitResponseFields' | null
+} {
+    if (config.response?.include?.length) {
+        const paths = config.response?.include.map((f) => `'${f}'`).join(', ')
+        if (config.list) {
+            return {
+                code: `        const filtered = { ...result, results: result.results.map((item: any) => pickResponseFields(item, [${paths}])) }\n`,
+                helperImport: 'pickResponseFields',
+            }
+        }
+        return {
+            code: `        const filtered = pickResponseFields(result, [${paths}])\n`,
+            helperImport: 'pickResponseFields',
+        }
+    }
+    if (config.response?.exclude?.length) {
+        const paths = config.response?.exclude.map((f) => `'${f}'`).join(', ')
+        if (config.list) {
+            return {
+                code: `        const filtered = { ...result, results: result.results.map((item: any) => omitResponseFields(item, [${paths}])) }\n`,
+                helperImport: 'omitResponseFields',
+            }
+        }
+        return {
+            code: `        const filtered = omitResponseFields(result, [${paths}])\n`,
+            helperImport: 'omitResponseFields',
+        }
+    }
+    return { code: '', helperImport: null }
+}
+
+// ------------------------------------------------------------------
 // Response enrichment templates
 // ------------------------------------------------------------------
 
-function buildEnrichment(config: ToolConfig, category: CategoryConfig): string {
+function buildEnrichment(config: ToolConfig, category: CategoryConfig, resultVar = 'result'): string {
     const baseUrl = category.url_prefix
 
     if (config.list && config.enrich_url) {
         const { prefix, field } = parseEnrichUrl(config.enrich_url)
         return [
             `        return await withPostHogUrl(context, {`,
-            `            ...result,`,
-            `            results: await Promise.all(result.results.map((item) => withPostHogUrl(context, item, \`${baseUrl}/${prefix}\${item.${field}}\`))),`,
+            `            ...${resultVar},`,
+            `            results: await Promise.all(${resultVar}.results.map((item) => withPostHogUrl(context, item, \`${baseUrl}/${prefix}\${item.${field}}\`))),`,
             `        }, '${baseUrl}')`,
             ``,
         ].join('\n')
     }
 
     if (config.list) {
-        return `        return await withPostHogUrl(context, result, '${baseUrl}')\n`
+        return `        return await withPostHogUrl(context, ${resultVar}, '${baseUrl}')\n`
     }
 
     if (config.enrich_url) {
         const { prefix, field } = parseEnrichUrl(config.enrich_url)
 
-        return `        return await withPostHogUrl(context, result, \`${baseUrl}/${prefix}\${result.${field}}\`)\n`
+        return `        return await withPostHogUrl(context, ${resultVar}, \`${baseUrl}/${prefix}\${${resultVar}.${field}}\`)\n`
     }
 
-    return `        return result\n`
+    return `        return ${resultVar}\n`
 }
 
 // ------------------------------------------------------------------
@@ -511,6 +548,7 @@ function generateToolCode(
     responseType: string | undefined
     needsWithPostHogUrl: boolean
     hasEnrichment: boolean
+    responseFilterImport: 'pickResponseFields' | 'omitResponseFields' | null
 } {
     const schemaName = `${toPascalCase(toolName)}Schema`
     const factoryName = toCamelCase(toolName)
@@ -585,8 +623,27 @@ function generateToolCode(
     }
     handlerBody += `        })\n`
 
+    // Response filtering — pick/omit fields before enrichment
+    const responseFilter = buildResponseFilter(config)
+    if (responseFilter.code) {
+        // Warn if filtering might break enrich_url
+        if (config.enrich_url) {
+            const { field } = parseEnrichUrl(config.enrich_url)
+            if (config.response?.exclude?.includes(field)) {
+                console.warn(`Warning: tool "${toolName}" excludes response field "${field}" used by enrich_url`)
+            }
+            if (config.response?.include?.length && !config.response?.include.includes(field)) {
+                console.warn(
+                    `Warning: tool "${toolName}" uses response_include without "${field}" needed by enrich_url`
+                )
+            }
+        }
+    }
+    handlerBody += responseFilter.code
+
     // Response enrichment — adds _posthogUrl for "View in PostHog" links
-    handlerBody += buildEnrichment(config, category)
+    const enrichmentVar = responseFilter.code ? 'filtered' : 'result'
+    handlerBody += buildEnrichment(config, category, enrichmentVar)
 
     // Compute the result type for the ToolBase generic parameter
     let resultType: string
@@ -632,6 +689,7 @@ const ${factoryName} = (): ToolBase<typeof ${schemaName}, ${resultType}> => ${fa
         responseType,
         needsWithPostHogUrl,
         hasEnrichment,
+        responseFilterImport: responseFilter.helperImport,
     }
 }
 
@@ -650,6 +708,7 @@ function generateCustomSchemaToolCode(
     responseType: string | undefined
     needsWithPostHogUrl: boolean
     hasEnrichment: boolean
+    responseFilterImport: 'pickResponseFields' | 'omitResponseFields' | null
 } {
     const pathParamNames = extractPathParams(resolved.path)
 
@@ -694,7 +753,12 @@ function generateCustomSchemaToolCode(
     }
     handlerBody += `        })\n`
 
-    handlerBody += buildEnrichment(config, category)
+    // Response filtering — pick/omit fields before enrichment
+    const responseFilter = buildResponseFilter(config)
+    handlerBody += responseFilter.code
+
+    const enrichmentVar = responseFilter.code ? 'filtered' : 'result'
+    handlerBody += buildEnrichment(config, category, enrichmentVar)
 
     const code = `
 const ${schemaName} = ${config.input_schema}
@@ -714,6 +778,7 @@ ${handlerBody}    },
         responseType,
         needsWithPostHogUrl: false,
         hasEnrichment: false,
+        responseFilterImport: responseFilter.helperImport,
     }
 }
 
@@ -760,6 +825,8 @@ function generateCategoryFile(
 
     let hasEnrichment = false
 
+    const responseFilterImports = new Set<string>()
+
     for (const [name, config, resolved] of enabledTools) {
         const result = generateToolCode(name, config, resolved, category, spec, knownTypes)
         toolCodes.push(result.code)
@@ -777,6 +844,9 @@ function generateCategoryFile(
         }
         if (result.hasEnrichment) {
             hasEnrichment = true
+        }
+        if (result.responseFilterImport) {
+            responseFilterImports.add(result.responseFilterImport)
         }
     }
 
@@ -805,6 +875,9 @@ function generateCategoryFile(
     }
     if (hasEnrichment) {
         toolUtilsValueImports.push('withPostHogUrl')
+    }
+    for (const imp of responseFilterImports) {
+        toolUtilsValueImports.push(imp)
     }
     let toolUtilsImportLine = ''
     if (toolUtilsValueImports.length > 0 && toolUtilsTypeImports.length > 0) {
@@ -1148,6 +1221,7 @@ ${spreads}
 
 // Export for testing
 export {
+    buildResponseFilter,
     composeToolSchema,
     extractPathParams,
     generateCategoryFile,

--- a/services/mcp/scripts/yaml-config-schema.ts
+++ b/services/mcp/scripts/yaml-config-schema.ts
@@ -62,6 +62,22 @@ export const ToolConfigSchema = z
          * the request body still sends the original field name.
          */
         rename_params: z.record(z.string(), z.string()).optional(),
+        /**
+         * Response field filtering. Supports dot-path patterns with wildcards (e.g. 'filters.groups.*.key').
+         * For list endpoints, applied to each item in `results`. `include` and `exclude` are mutually exclusive.
+         */
+        response: z
+            .object({
+                /** Dot-path patterns of response fields to keep. Only matched fields are preserved. */
+                include: z.array(z.string()).optional(),
+                /** Dot-path patterns of response fields to remove. */
+                exclude: z.array(z.string()).optional(),
+            })
+            .strict()
+            .refine((data) => !(data.include?.length && data.exclude?.length), {
+                message: 'response.include and response.exclude are mutually exclusive',
+            })
+            .optional(),
     })
     .strict()
     .refine(

--- a/services/mcp/src/tools/generated/feature_flags.ts
+++ b/services/mcp/src/tools/generated/feature_flags.ts
@@ -57,7 +57,7 @@ const featureFlagGetAll = (): ToolBase<
             results: result.results.map((item: any) =>
                 pickResponseFields(item, ['id', 'key', 'name', 'updated_at', 'status', 'tags'])
             ),
-        }
+        } as typeof result
         return await withPostHogUrl(
             context,
             {
@@ -85,7 +85,14 @@ const featureFlagGetDefinition = (): ToolBase<
             method: 'GET',
             path: `/api/projects/${projectId}/feature_flags/${params.id}/`,
         })
-        const filtered = pickResponseFields(result, ['id', 'key', 'name', 'updated_at', 'status', 'tags'])
+        const filtered = pickResponseFields(result, [
+            'id',
+            'key',
+            'name',
+            'updated_at',
+            'status',
+            'tags',
+        ]) as typeof result
         return await withPostHogUrl(context, filtered, `/feature_flags/${filtered.id}`)
     },
 })

--- a/services/mcp/src/tools/generated/feature_flags.ts
+++ b/services/mcp/src/tools/generated/feature_flags.ts
@@ -23,7 +23,7 @@ import {
     ScheduledChangesPartialUpdateParams,
     ScheduledChangesRetrieveParams,
 } from '@/generated/feature_flags/api'
-import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
+import { withPostHogUrl, pickResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
 import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const FeatureFlagGetAllSchema = FeatureFlagsListQueryParams
@@ -52,12 +52,18 @@ const featureFlagGetAll = (): ToolBase<
                 type: params.type,
             },
         })
+        const filtered = {
+            ...result,
+            results: result.results.map((item: any) =>
+                pickResponseFields(item, ['id', 'key', 'name', 'updated_at', 'status', 'tags'])
+            ),
+        }
         return await withPostHogUrl(
             context,
             {
-                ...result,
+                ...filtered,
                 results: await Promise.all(
-                    result.results.map((item) => withPostHogUrl(context, item, `/feature_flags/${item.id}`))
+                    filtered.results.map((item) => withPostHogUrl(context, item, `/feature_flags/${item.id}`))
                 ),
             },
             '/feature_flags'
@@ -79,7 +85,8 @@ const featureFlagGetDefinition = (): ToolBase<
             method: 'GET',
             path: `/api/projects/${projectId}/feature_flags/${params.id}/`,
         })
-        return await withPostHogUrl(context, result, `/feature_flags/${result.id}`)
+        const filtered = pickResponseFields(result, ['id', 'key', 'name', 'updated_at', 'status', 'tags'])
+        return await withPostHogUrl(context, filtered, `/feature_flags/${filtered.id}`)
     },
 })
 

--- a/services/mcp/src/tools/generated/feature_flags.ts
+++ b/services/mcp/src/tools/generated/feature_flags.ts
@@ -85,15 +85,7 @@ const featureFlagGetDefinition = (): ToolBase<
             method: 'GET',
             path: `/api/projects/${projectId}/feature_flags/${params.id}/`,
         })
-        const filtered = pickResponseFields(result, [
-            'id',
-            'key',
-            'name',
-            'updated_at',
-            'status',
-            'tags',
-        ]) as typeof result
-        return await withPostHogUrl(context, filtered, `/feature_flags/${filtered.id}`)
+        return await withPostHogUrl(context, result, `/feature_flags/${result.id}`)
     },
 })
 

--- a/services/mcp/src/tools/tool-utils.ts
+++ b/services/mcp/src/tools/tool-utils.ts
@@ -72,7 +72,7 @@ function copyAtPath(source: unknown, target: Record<string, unknown>, segments: 
             return
         }
         if (target[head] === undefined) {
-            target[head] = Array.isArray(src) ? new Array(src.length).fill(undefined).map(() => ({})) : {}
+            target[head] = Array.isArray(src) ? [] : {}
         }
         copyAtPath(src, target[head] as Record<string, unknown>, rest)
     }

--- a/services/mcp/src/tools/tool-utils.ts
+++ b/services/mcp/src/tools/tool-utils.ts
@@ -12,3 +12,107 @@ export async function withPostHogUrl<T>(context: Context, result: T, path: strin
 
     return { ...result, _posthogUrl: fullUrl } as WithPostHogUrl<T>
 }
+
+/**
+ * Pick only fields matching the given dot-path patterns.
+ * Supports wildcards: `'groups.*.key'` iterates all array items / object keys.
+ */
+export function pickResponseFields<T>(obj: T, paths: string[]): Partial<T> {
+    const result: Record<string, unknown> = {}
+    for (const p of paths) {
+        copyAtPath(obj, result, p.split('.'))
+    }
+    return result as Partial<T>
+}
+
+function copyAtPath(source: unknown, target: Record<string, unknown>, segments: string[]): void {
+    if (source === null || source === undefined || typeof source !== 'object') {
+        return
+    }
+    const [head, ...rest] = segments
+    if (!head) {
+        return
+    }
+    if (head === '*') {
+        const src = source as Record<string, unknown>
+        if (Array.isArray(source)) {
+            const arr = target as unknown as unknown[]
+            for (let i = 0; i < source.length; i++) {
+                if (arr[i] === undefined) {
+                    arr[i] = {}
+                }
+                if (rest.length === 0) {
+                    arr[i] = structuredClone(source[i])
+                } else {
+                    copyAtPath(source[i], arr[i] as Record<string, unknown>, rest)
+                }
+            }
+        } else {
+            for (const key of Object.keys(src)) {
+                if (target[key] === undefined) {
+                    target[key] = {}
+                }
+                if (rest.length === 0) {
+                    target[key] = structuredClone(src[key])
+                } else {
+                    copyAtPath(src[key], target[key] as Record<string, unknown>, rest)
+                }
+            }
+        }
+        return
+    }
+    const src = (source as Record<string, unknown>)[head]
+    if (src === undefined) {
+        return
+    }
+    if (rest.length === 0) {
+        target[head] = structuredClone(src)
+    } else {
+        if (src === null || typeof src !== 'object') {
+            return
+        }
+        if (target[head] === undefined) {
+            target[head] = Array.isArray(src) ? new Array(src.length).fill(undefined).map(() => ({})) : {}
+        }
+        copyAtPath(src, target[head] as Record<string, unknown>, rest)
+    }
+}
+
+/**
+ * Remove fields matching the given dot-path patterns.
+ * Supports wildcards: `'groups.*.properties'` iterates all array items / object keys.
+ */
+export function omitResponseFields<T>(obj: T, paths: string[]): Partial<T> {
+    const result = structuredClone(obj)
+    for (const p of paths) {
+        removeAtPath(result, p.split('.'))
+    }
+    return result as Partial<T>
+}
+
+function removeAtPath(obj: unknown, segments: string[]): void {
+    if (obj === null || obj === undefined || typeof obj !== 'object') {
+        return
+    }
+    const [head, ...rest] = segments
+    if (!head) {
+        return
+    }
+    if (head === '*') {
+        const items = Array.isArray(obj) ? obj : Object.values(obj)
+        for (const item of items) {
+            if (rest.length === 0) {
+                // Wildcard at leaf makes no sense for omit — skip
+            } else {
+                removeAtPath(item, rest)
+            }
+        }
+        return
+    }
+    const record = obj as Record<string, unknown>
+    if (rest.length === 0) {
+        delete record[head]
+    } else {
+        removeAtPath(record[head], rest)
+    }
+}

--- a/services/mcp/tests/unit/generate-tools.test.ts
+++ b/services/mcp/tests/unit/generate-tools.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import {
+    buildResponseFilter,
     composeToolSchema,
     extractPathParams,
     generateQueryWrapperFile,
@@ -556,5 +557,180 @@ describe('ToolConfigSchema validation', () => {
     it('allows input_schema without include_params, exclude_params, or param_overrides', () => {
         const result = ToolConfigSchema.safeParse(validBase)
         expect(result.success).toBe(true)
+    })
+
+    it('rejects response.include with response.exclude', () => {
+        const result = ToolConfigSchema.safeParse({
+            operation: 'things_list',
+            enabled: true,
+            response: { include: ['id'], exclude: ['name'] },
+        })
+        expect(result.success).toBe(false)
+    })
+
+    it('accepts response.include alone', () => {
+        const result = ToolConfigSchema.safeParse({
+            operation: 'things_list',
+            enabled: true,
+            response: { include: ['id', 'name'] },
+        })
+        expect(result.success).toBe(true)
+    })
+
+    it('accepts response.exclude alone', () => {
+        const result = ToolConfigSchema.safeParse({
+            operation: 'things_list',
+            enabled: true,
+            response: { exclude: ['filters', 'created_by'] },
+        })
+        expect(result.success).toBe(true)
+    })
+})
+
+// ------------------------------------------------------------------
+// buildResponseFilter
+// ------------------------------------------------------------------
+
+describe('buildResponseFilter', () => {
+    it('returns empty code when no response filtering configured', () => {
+        const config: ToolConfig = { operation: 'things_list', enabled: true }
+        const result = buildResponseFilter(config)
+        expect(result.code).toBe('')
+        expect(result.helperImport).toBeNull()
+    })
+
+    it('generates pickResponseFields for detail endpoint with response.include', () => {
+        const config: ToolConfig = {
+            operation: 'things_retrieve',
+            enabled: true,
+            response: { include: ['id', 'name', 'status'] },
+        }
+        const result = buildResponseFilter(config)
+        expect(result.code).toContain('pickResponseFields(result, ')
+        expect(result.code).toContain("'id', 'name', 'status'")
+        expect(result.helperImport).toBe('pickResponseFields')
+    })
+
+    it('generates omitResponseFields for detail endpoint with response.exclude', () => {
+        const config: ToolConfig = {
+            operation: 'things_retrieve',
+            enabled: true,
+            response: { exclude: ['filters', 'created_by'] },
+        }
+        const result = buildResponseFilter(config)
+        expect(result.code).toContain('omitResponseFields(result, ')
+        expect(result.code).toContain("'filters', 'created_by'")
+        expect(result.helperImport).toBe('omitResponseFields')
+    })
+
+    it('maps pickResponseFields over results for list endpoint with response.include', () => {
+        const config: ToolConfig = {
+            operation: 'things_list',
+            enabled: true,
+            list: true,
+            response: { include: ['id', 'key'] },
+        }
+        const result = buildResponseFilter(config)
+        expect(result.code).toContain('result.results.map')
+        expect(result.code).toContain('pickResponseFields(item, ')
+        expect(result.helperImport).toBe('pickResponseFields')
+    })
+
+    it('maps omitResponseFields over results for list endpoint with response.exclude', () => {
+        const config: ToolConfig = {
+            operation: 'things_list',
+            enabled: true,
+            list: true,
+            response: { exclude: ['large_blob'] },
+        }
+        const result = buildResponseFilter(config)
+        expect(result.code).toContain('result.results.map')
+        expect(result.code).toContain('omitResponseFields(item, ')
+        expect(result.helperImport).toBe('omitResponseFields')
+    })
+
+    it('preserves wildcard dot-path patterns in generated code', () => {
+        const config: ToolConfig = {
+            operation: 'things_retrieve',
+            enabled: true,
+            response: { exclude: ['filters.groups.*.properties', 'created_by'] },
+        }
+        const result = buildResponseFilter(config)
+        expect(result.code).toContain("'filters.groups.*.properties'")
+        expect(result.code).toContain("'created_by'")
+    })
+})
+
+// ------------------------------------------------------------------
+// generateToolCode — response filtering
+// ------------------------------------------------------------------
+
+describe('generateToolCode with response filtering', () => {
+    it('generates pickResponseFields and uses filtered var for enrichment', () => {
+        const config: ToolConfig = {
+            operation: 'things_retrieve',
+            enabled: true,
+            response: { include: ['id', 'name'] },
+            enrich_url: '{id}',
+        }
+        const resolved = makeResolved({
+            method: 'GET',
+            path: '/api/projects/{project_id}/things/{id}/',
+        })
+
+        const result = generateToolCode('things-get', config, resolved, defaultCategory, makeSpec(), new Set<string>())
+
+        expect(result.code).toContain('pickResponseFields(result, ')
+        expect(result.code).toContain('const filtered = ')
+        expect(result.code).toContain('withPostHogUrl(context, filtered,')
+        expect(result.responseFilterImport).toBe('pickResponseFields')
+    })
+
+    it('generates omitResponseFields for detail endpoint', () => {
+        const config: ToolConfig = {
+            operation: 'things_retrieve',
+            enabled: true,
+            response: { exclude: ['filters'] },
+        }
+        const resolved = makeResolved({
+            method: 'GET',
+            path: '/api/projects/{project_id}/things/{id}/',
+        })
+
+        const result = generateToolCode('things-get', config, resolved, defaultCategory, makeSpec(), new Set<string>())
+
+        expect(result.code).toContain('omitResponseFields(result, ')
+        expect(result.code).toContain('return filtered')
+        expect(result.responseFilterImport).toBe('omitResponseFields')
+    })
+
+    it('returns null responseFilterImport when no filtering', () => {
+        const config: ToolConfig = {
+            operation: 'things_list',
+            enabled: true,
+        }
+        const resolved = makeResolved()
+
+        const result = generateToolCode('things-list', config, resolved, defaultCategory, makeSpec(), new Set<string>())
+
+        expect(result.responseFilterImport).toBeNull()
+    })
+
+    it('generates response filtering for list endpoint with enrichment', () => {
+        const config: ToolConfig = {
+            operation: 'things_list',
+            enabled: true,
+            list: true,
+            enrich_url: '{id}',
+            response: { exclude: ['large_field'] },
+        }
+        const resolved = makeResolved()
+
+        const result = generateToolCode('things-list', config, resolved, defaultCategory, makeSpec(), new Set<string>())
+
+        expect(result.code).toContain('result.results.map((item: any) => omitResponseFields(item, ')
+        expect(result.code).toContain('...filtered,')
+        expect(result.code).toContain('filtered.results.map')
+        expect(result.responseFilterImport).toBe('omitResponseFields')
     })
 })

--- a/services/mcp/tests/unit/utils.test.ts
+++ b/services/mcp/tests/unit/utils.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import { sanitizeHeaderValue } from '@/lib/utils'
+import { omitResponseFields, pickResponseFields } from '@/tools/tool-utils'
 
 describe('utils', () => {
     describe('sanitizeHeaderValue', () => {
@@ -15,6 +16,153 @@ describe('utils', () => {
             ['undefined is undefined', undefined, undefined],
         ])('%s', (_name, input, expected) => {
             expect(sanitizeHeaderValue(input)).toBe(expected)
+        })
+    })
+
+    describe('pickResponseFields', () => {
+        it('keeps only specified top-level fields', () => {
+            const obj = { id: 1, name: 'test', filters: { a: 1 }, created_by: 'user' }
+            expect(pickResponseFields(obj, ['id', 'name'])).toEqual({ id: 1, name: 'test' })
+        })
+
+        it('handles missing fields gracefully', () => {
+            const obj = { id: 1, name: 'test' }
+            expect(pickResponseFields(obj, ['id', 'nonexistent'])).toEqual({ id: 1 })
+        })
+
+        it('supports nested dot-paths without wildcards', () => {
+            const obj = { filters: { groups: [1, 2] }, name: 'flag' }
+            expect(pickResponseFields(obj, ['filters.groups'])).toEqual({ filters: { groups: [1, 2] } })
+        })
+
+        it('supports wildcard dot-path patterns on arrays', () => {
+            const obj = {
+                groups: [
+                    { key: 'a', properties: [1, 2], extra: 'x' },
+                    { key: 'b', properties: [3], extra: 'y' },
+                ],
+            }
+            expect(pickResponseFields(obj, ['groups.*.key'])).toEqual({
+                groups: [{ key: 'a' }, { key: 'b' }],
+            })
+        })
+
+        it('combines multiple paths including wildcards', () => {
+            const obj = {
+                id: 1,
+                name: 'flag',
+                groups: [
+                    { key: 'a', props: [1], extra: 'x' },
+                    { key: 'b', props: [2], extra: 'y' },
+                ],
+            }
+            expect(pickResponseFields(obj, ['id', 'groups.*.key'])).toEqual({
+                id: 1,
+                groups: [{ key: 'a' }, { key: 'b' }],
+            })
+        })
+
+        it('handles deeply nested wildcards', () => {
+            const obj = {
+                a: [
+                    {
+                        b: [
+                            { c: 1, d: 2 },
+                            { c: 3, d: 4 },
+                        ],
+                    },
+                    { b: [{ c: 5, d: 6 }] },
+                ],
+            }
+            expect(pickResponseFields(obj, ['a.*.b.*.c'])).toEqual({
+                a: [{ b: [{ c: 1 }, { c: 3 }] }, { b: [{ c: 5 }] }],
+            })
+        })
+
+        it('handles null values in the tree', () => {
+            const obj = { id: 1, nested: null, name: 'test' }
+            expect(pickResponseFields(obj, ['id', 'nested.foo'])).toEqual({ id: 1 })
+        })
+
+        it('handles empty arrays', () => {
+            const obj = { groups: [] }
+            expect(pickResponseFields(obj, ['groups.*.key'])).toEqual({ groups: [] })
+        })
+
+        it('does not mutate the original object', () => {
+            const obj = { id: 1, name: 'test', extra: 'data' }
+            pickResponseFields(obj, ['id'])
+            expect(obj).toEqual({ id: 1, name: 'test', extra: 'data' })
+        })
+    })
+
+    describe('omitResponseFields', () => {
+        it('removes specified top-level fields', () => {
+            const obj = { id: 1, name: 'test', filters: { a: 1 }, created_by: 'user' }
+            expect(omitResponseFields(obj, ['filters', 'created_by'])).toEqual({ id: 1, name: 'test' })
+        })
+
+        it('handles missing fields gracefully', () => {
+            const obj = { id: 1, name: 'test' }
+            expect(omitResponseFields(obj, ['nonexistent'])).toEqual({ id: 1, name: 'test' })
+        })
+
+        it('supports nested dot-paths without wildcards', () => {
+            const obj = { filters: { groups: [1], extra: true }, name: 'flag' }
+            expect(omitResponseFields(obj, ['filters.groups'])).toEqual({ filters: { extra: true }, name: 'flag' })
+        })
+
+        it('supports wildcard dot-path patterns on arrays', () => {
+            const obj = {
+                groups: [
+                    { key: 'a', properties: [1, 2], extra: 'x' },
+                    { key: 'b', properties: [3], extra: 'y' },
+                ],
+            }
+            expect(omitResponseFields(obj, ['groups.*.properties'])).toEqual({
+                groups: [
+                    { key: 'a', extra: 'x' },
+                    { key: 'b', extra: 'y' },
+                ],
+            })
+        })
+
+        it('removes multiple paths at once', () => {
+            const obj = { id: 1, name: 'test', filters: { a: 1 }, tags: ['x'] }
+            expect(omitResponseFields(obj, ['filters', 'tags'])).toEqual({ id: 1, name: 'test' })
+        })
+
+        it('handles deeply nested wildcards', () => {
+            const obj = {
+                a: [
+                    {
+                        b: [
+                            { c: 1, d: 2 },
+                            { c: 3, d: 4 },
+                        ],
+                    },
+                    { b: [{ c: 5, d: 6 }] },
+                ],
+            }
+            expect(omitResponseFields(obj, ['a.*.b.*.d'])).toEqual({
+                a: [{ b: [{ c: 1 }, { c: 3 }] }, { b: [{ c: 5 }] }],
+            })
+        })
+
+        it('handles null values in the tree', () => {
+            const obj = { id: 1, nested: null }
+            expect(omitResponseFields(obj, ['nested.foo'])).toEqual({ id: 1, nested: null })
+        })
+
+        it('handles empty arrays', () => {
+            const obj = { groups: [] }
+            expect(omitResponseFields(obj, ['groups.*.key'])).toEqual({ groups: [] })
+        })
+
+        it('does not mutate the original object', () => {
+            const obj = { id: 1, name: 'test', extra: { nested: true } }
+            omitResponseFields(obj, ['extra'])
+            expect(obj).toEqual({ id: 1, name: 'test', extra: { nested: true } })
         })
     })
 })


### PR DESCRIPTION
## Problem

  MCP tool responses return full API payloads, which are large and consume significant tokens. For  example, a feature flag response includes 30+ fields (`experiment_set`, `surveys`, `analytics_dashboards`, etc.) when an agent typically only needs `id`, `key`, `name`, and `status`.  There was no way to control which response fields are returned to the MCP client.

  ## Changes

  Add a `response` config object to the MCP YAML tool definitions that supports `include` and `exclude`
  field lists with wildcard dot-path patterns.

  **YAML schema** (`yaml-config-schema.ts`):
  - New optional `response` object with mutually exclusive `include`/`exclude` arrays
  - Validated with Zod `.strict()` and a refinement for mutual exclusivity

  **Codegen** (`generate-tools.ts`):
  - New `buildResponseFilter()` generates filtering code between the API call and `_posthogUrl` enrichment
  - `buildEnrichment()` now accepts a `resultVar` parameter to operate on `filtered` when filtering is
  active
  - Both `generateToolCode()` and `generateCustomSchemaToolCode()` support the new config
  - Codegen-time warnings when filtering conflicts with `enrich_url`

  **Runtime helpers** (`tool-utils.ts`):
  - `pickResponseFields(obj, paths)` — builds a new object with only matched fields
  - `omitResponseFields(obj, paths)` — deep clones then removes matched fields
  - Both support wildcard dot-path patterns (e.g., `filters.groups.*.properties`)
  - Zero external dependencies — custom recursive implementations (~40 lines each)

  **Feature flags** (`tools.yaml`):
  - `feature-flag-get-all` and `feature-flag-get-definition` now return only `id`, `key`, `name`,
  `updated_at`, `status`, `tags`

  **Documentation**:
  - Updated YAML schema reference in `definitions/README.md`, implementing-mcp-tools skill, and handbook
  doc

  ### Usage

  ```yaml
  tools:
    my-tool:
      operation: things_list
      enabled: true
      response:
        include:             
          - id
          - key
          - name
          - filters.groups.*.key   
        ... OR ...
        exclude:             
          - experiment_set
          - filters.groups.*.properties
```

##  How did you test this code?

  - tests and unitests passing
  - tested manually as well

 ## Publish to changelog?

  No

 ## Docs update

  Internal docs updated in this PR (skill + handbook + definitions README).