### PR TITLE
feat(search): add alerts shortcut to quick search

### DIFF
--- a/frontend/src/lib/components/Search/searchLogic.tsx
+++ b/frontend/src/lib/components/Search/searchLogic.tsx
@@ -1,7 +1,7 @@
 import { actions, connect, kea, key, listeners, path, props, reducers, selectors } from 'kea'
 import { loaders } from 'kea-loaders'
 
-import { IconClock, IconDownload } from '@posthog/icons'
+import { IconBell, IconClock, IconDownload } from '@posthog/icons'
 
 import api from 'lib/api'
 import { commandLogic } from 'lib/components/Command/commandLogic'
@@ -578,6 +578,18 @@ export const searchLogic = kea<searchLogicType>([
                     itemType: null,
                     lastViewedAt: sceneLogViewsByRef['Exports'] ?? null,
                     record: { type: 'exports' },
+                },
+                {
+                    id: 'misc-alerts',
+                    name: 'Alerts',
+                    displayName: 'Alerts',
+                    category: 'misc',
+                    href: urls.alerts(),
+                    icon: <IconBell />,
+                    itemType: null,
+                    searchKeywords: ['alert', 'alerts', 'insight alerts'],
+                    lastViewedAt: sceneLogViewsByRef['SavedInsights'] ?? null,
+                    record: { type: 'alerts' },
                 },
             ],
         ],

--- a/frontend/src/lib/components/Search/searchLogic.tsx
+++ b/frontend/src/lib/components/Search/searchLogic.tsx
@@ -587,7 +587,6 @@ export const searchLogic = kea<searchLogicType>([
                     href: urls.alerts(),
                     icon: <IconBell />,
                     itemType: null,
-                    searchKeywords: ['alert', 'alerts', 'insight alerts'],
                     lastViewedAt: sceneLogViewsByRef['SavedInsights'] ?? null,
                     record: { type: 'alerts' },
                 },


### PR DESCRIPTION
## Problem

There was no quick way to open the saved insights Alerts tab from quick search (⌘K / search).

## Changes

<img width="1974" height="1854" alt="CleanShot 2026-04-02 at 10 06 59@2x" src="https://github.com/user-attachments/assets/321c598c-e9a4-40e2-b470-3cdb72f5d446" />


## How did you test this code?
Locally.


## Publish to changelog?

no

## Docs update

skip-inkeep-docs

## LLM context

This PR was drafted with AI assistance. It adds one `SearchItem` under `miscItems` in `frontend/src/lib/components/Search/searchLogic.tsx`; no API or schema changes.

Made with [Cursor](https://cursor.com)