### PR TITLE
fix: Bump inkeep agent version for a fix

### DIFF
--- a/.github/workflows/inkeep-agent.yml
+++ b/.github/workflows/inkeep-agent.yml
@@ -27,7 +27,7 @@ jobs:
         timeout-minutes: 10
         steps:
             - name: Trigger Inkeep Agent
-              uses: inkeep/inkeep-agents-action@39c725a2bf4d24acb89ae70139e13bf50f637c20 # v0.6.0
+              uses: inkeep/inkeep-agents-action@267e6185c8b1b69dfba85d7ea1c31066891ee2a6 # Temp fix by inkeep team
               with:
                   trigger-url: ${{ secrets.INKEEP_TRIGGER_URL }}
                   pr-title-regex: '^(feat|fix|docs|chore)(\(.+\))?:'


### PR DESCRIPTION
## Problem

## Changes

We're seeing some [404 errors](https://github.com/PostHog/posthog/actions/runs/23899560613/job/69692431583) kicking off the inkeep agent

```
Performing OIDC token exchange for GitHub App authentication
Error: Token exchange failed (404): The deployment could not be found on Vercel.
```

## Changes

This new version is a temporary fix suggested by the inkeep team. [Context](https://posthog.slack.com/archives/C07GBG5U0TU/p1775136645766949)

## How did you test this code?

<!-- Briefly describe the steps you took, and what steps reviewers must take to get to where changes are, and what is the expected behavior. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
