### PR TITLE
feat(workflows): Add timezone picker into recurring schedules

### DIFF
--- a/products/workflows/frontend/Workflows/hogflows/steps/components/RecurringSchedulePicker.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/steps/components/RecurringSchedulePicker.tsx
@@ -2,9 +2,18 @@ import { useActions, useValues } from 'kea'
 import { useMemo } from 'react'
 
 import { IconCalendar } from '@posthog/icons'
-import { LemonButton, LemonCalendarSelectInput, LemonInput, LemonSelect, LemonSwitch } from '@posthog/lemon-ui'
+import {
+    LemonButton,
+    LemonCalendarSelectInput,
+    LemonInput,
+    LemonSearchableSelect,
+    LemonSelect,
+    LemonSwitch,
+} from '@posthog/lemon-ui'
 
 import { dayjs } from 'lib/dayjs'
+import { timeZoneLabel } from 'lib/utils'
+import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
 
 import { workflowLogic } from '../../../workflowLogic'
 import { OccurrencesList } from './OccurrencesList'
@@ -225,9 +234,37 @@ function SchedulePreview({ state, summary, previewOccurrences, timezone }: Sched
     )
 }
 
+function TimezoneMenuPicker({ value, onChange }: { value: string; onChange: (timezone: string) => void }): JSX.Element {
+    const { preflight } = useValues(preflightLogic)
+    const options = useMemo(
+        () =>
+            Object.entries(preflight?.available_timezones || {}).map(([tz, offset]) => ({
+                value: tz,
+                label: timeZoneLabel(tz, offset),
+            })),
+        [preflight?.available_timezones]
+    )
+
+    return (
+        <LemonSearchableSelect
+            value={value}
+            options={options}
+            onChange={(val) => val && onChange(val)}
+            searchPlaceholder="Search timezones..."
+            fullWidth
+        />
+    )
+}
+
 export function RecurringSchedulePicker(): JSX.Element {
     const { scheduleState, scheduleStartsAt, scheduleTimezone, isScheduleRepeating } = useValues(workflowLogic)
-    const { setScheduleState, setScheduleStartsAt, setScheduleRepeating } = useActions(workflowLogic)
+    const {
+        setScheduleState,
+        setScheduleStartsAt,
+        setScheduleStartsAtFromPicker,
+        setScheduleTimezone,
+        setScheduleRepeating,
+    } = useActions(workflowLogic)
 
     const previewOccurrences = useMemo(() => {
         if (!isScheduleRepeating || !scheduleStartsAt) {
@@ -266,38 +303,58 @@ export function RecurringSchedulePicker(): JSX.Element {
                         buttonProps={{ fullWidth: true }}
                         format="MMMM D, YYYY h:mm A"
                         clearable
-                        value={scheduleStartsAt ? dayjs(scheduleStartsAt) : null}
+                        value={
+                            scheduleStartsAt
+                                ? dayjs(scheduleStartsAt).tz(scheduleTimezone).tz(dayjs.tz.guess(), true)
+                                : null
+                        }
                         onChange={(date) => {
-                            setScheduleStartsAt(date ? date.startOf('minute').toISOString() : null)
+                            setScheduleStartsAtFromPicker(date ? date.toISOString() : null)
                         }}
                         granularity="minute"
-                        selectionPeriod="upcoming"
+                        // Recurring schedules use the start date as an anchor for rrule computation,
+                        // so past dates are valid. One-time schedules must be in the future.
+                        selectionPeriod={isScheduleRepeating ? undefined : 'upcoming'}
                         showTimeToggle={false}
                     />
                 </div>
-                {scheduleStartsAt && (
-                    <div className="w-22 shrink-0">
-                        <LemonSwitch
-                            label="Repeat"
-                            checked={isScheduleRepeating}
-                            onChange={(checked) => setScheduleRepeating(checked)}
-                        />
-                    </div>
-                )}
+                <div className="w-22 shrink-0">
+                    <LemonSwitch
+                        label="Repeat"
+                        checked={isScheduleRepeating}
+                        onChange={(checked) => {
+                            if (!scheduleStartsAt) {
+                                // If no start date yet, set one so the toggle is meaningful
+                                setScheduleStartsAt(new Date().toISOString())
+                            }
+                            setScheduleRepeating(checked)
+                        }}
+                    />
+                </div>
             </div>
             {scheduleStartsAt && (
-                <div className="text-xs text-muted -mt-1">
-                    Schedule timezone: {scheduleTimezone} (
-                    {dayjs(scheduleStartsAt).tz(scheduleTimezone).format('h:mm A')})
+                <div className="flex flex-col gap-1 -mt-1">
+                    <div className="flex items-center gap-2">
+                        <div className="flex-1 min-w-0">
+                            <TimezoneMenuPicker
+                                value={scheduleTimezone}
+                                onChange={(newTimezone) => {
+                                    setScheduleTimezone(newTimezone, scheduleTimezone)
+                                }}
+                            />
+                        </div>
+                        <div className="w-22 shrink-0" />
+                    </div>
                     {scheduleTimezone !== dayjs.tz.guess() && (
-                        <>
-                            {' '}
+                        <span className="text-xs text-muted">
+                            Schedule: {dayjs(scheduleStartsAt).tz(scheduleTimezone).format('h:mm A')} {scheduleTimezone}{' '}
                             · Your time: {dayjs(scheduleStartsAt).format('h:mm A')} {dayjs.tz.guess()}
-                        </>
+                        </span>
                     )}
                 </div>
             )}
-            {scheduleStartsAt && isScheduleRepeating && (
+
+            {isScheduleRepeating && (
                 <>
                     <div className="flex items-center gap-2 flex-wrap">
                         <FrequencyPicker state={scheduleState} onStateChange={setScheduleState} />

--- a/products/workflows/frontend/Workflows/workflowLogic.schedule.test.ts
+++ b/products/workflows/frontend/Workflows/workflowLogic.schedule.test.ts
@@ -271,12 +271,16 @@ describe('workflowLogic schedule reducers', () => {
     })
 
     describe('timezone reinterpretation', () => {
-        it('setScheduleStartsAtFromPicker reinterprets browser time as schedule timezone', () => {
-            logic.actions.setScheduleTimezone('Europe/Helsinki')
-            // Picker returns 9:00 AM in browser local time
+        it.each([
+            ['Europe/Helsinki', '2026-04-10T06:00:00.000Z'], // UTC+3
+            ['US/Eastern', '2026-04-10T13:00:00.000Z'], // EDT UTC-4
+            ['Asia/Kolkata', '2026-04-10T03:30:00.000Z'], // UTC+5:30
+            ['Pacific/Auckland', '2026-04-09T21:00:00.000Z'], // NZST UTC+12
+            ['UTC', '2026-04-10T09:00:00.000Z'], // No shift
+        ])('setScheduleStartsAtFromPicker reinterprets 9:00 AM as %s', (timezone, expected) => {
+            logic.actions.setScheduleTimezone(timezone)
             logic.actions.setScheduleStartsAtFromPicker('2026-04-10T09:00:00.000Z')
-            // Should be stored as 9:00 AM Helsinki = 06:00 UTC (Helsinki is UTC+3 in April)
-            expect(logic.values.scheduleStartsAt).toBe('2026-04-10T06:00:00.000Z')
+            expect(logic.values.scheduleStartsAt).toBe(expected)
         })
 
         it('setScheduleStartsAtFromPicker with null clears starts_at', () => {
@@ -285,14 +289,14 @@ describe('workflowLogic schedule reducers', () => {
             expect(logic.values.scheduleStartsAt).toBeNull()
         })
 
-        it('changing timezone preserves wall-clock time', () => {
-            logic.actions.setSchedules([makeSchedule()])
-            expect(logic.values.scheduleStartsAt).toBe('2026-04-10T09:00:00.000Z')
-
-            // Change to US/Eastern - wall clock stays 9:00 AM, UTC shifts
-            logic.actions.setScheduleTimezone('US/Eastern', 'UTC')
-            // 9:00 AM Eastern in April (EDT, UTC-4) = 13:00 UTC
-            expect(logic.values.scheduleStartsAt).toBe('2026-04-10T13:00:00.000Z')
+        it.each([
+            ['US/Eastern', '2026-04-10T13:00:00.000Z'], // EDT UTC-4
+            ['Asia/Kolkata', '2026-04-10T03:30:00.000Z'], // UTC+5:30
+            ['Pacific/Auckland', '2026-04-09T21:00:00.000Z'], // NZST UTC+12
+        ])('changing timezone to %s preserves wall-clock time', (newTimezone, expected) => {
+            logic.actions.setSchedules([makeSchedule()]) // 09:00 UTC
+            logic.actions.setScheduleTimezone(newTimezone, 'UTC')
+            expect(logic.values.scheduleStartsAt).toBe(expected)
         })
     })
 

--- a/products/workflows/frontend/Workflows/workflowLogic.schedule.test.ts
+++ b/products/workflows/frontend/Workflows/workflowLogic.schedule.test.ts
@@ -100,11 +100,12 @@ describe('workflowLogic schedule reducers', () => {
             logic.actions.setSchedules([makeSchedule()])
 
             await expectLogic(logic, () => {
-                logic.actions.setScheduleTimezone('US/Eastern')
+                logic.actions.setScheduleTimezone('US/Eastern', 'UTC')
             }).toMatchValues({
                 pendingSchedule: {
                     rrule: expect.any(String),
-                    starts_at: STARTS_AT,
+                    // Wall clock stays 9:00 AM, UTC shifts from 09:00 to 13:00 (9:00 AM EDT = UTC-4)
+                    starts_at: '2026-04-10T13:00:00.000Z',
                     timezone: 'US/Eastern',
                 },
             })
@@ -210,15 +211,15 @@ describe('workflowLogic schedule reducers', () => {
 
             // Change frequency to daily
             logic.actions.setScheduleState({ ...DEFAULT_STATE, frequency: 'daily', interval: 1 })
-            // Change timezone
-            logic.actions.setScheduleTimezone('US/Eastern')
+            // Change timezone - wall clock stays 9:00 AM, UTC shifts
+            logic.actions.setScheduleTimezone('US/Eastern', 'UTC')
 
             const pending = logic.values.pendingSchedule
             expect(pending).not.toBe(false)
             expect((pending as any).rrule).toContain('FREQ=DAILY')
             expect((pending as any).rrule).not.toContain('BYDAY')
             expect((pending as any).timezone).toBe('US/Eastern')
-            expect((pending as any).starts_at).toBe(STARTS_AT)
+            expect((pending as any).starts_at).toBe('2026-04-10T13:00:00.000Z')
         })
 
         it('scenario 3: clear changes reverts end type and count', async () => {
@@ -233,11 +234,13 @@ describe('workflowLogic schedule reducers', () => {
             expect(logic.values.hasUnsavedChanges).toBe(true)
 
             // Clear changes
-            logic.actions.resetWorkflow(logic.values.workflow)
-
+            await expectLogic(logic, () => {
+                logic.actions.resetWorkflow(logic.values.workflow)
+            }).toMatchValues({
+                hasUnsavedChanges: false,
+                pendingSchedule: false,
+            })
             expect(logic.values.scheduleState.endType).toBe('never')
-            expect(logic.values.hasUnsavedChanges).toBe(false)
-            expect(logic.values.pendingSchedule).toBe(false)
         })
 
         it('scenario 4: toggle repeat off produces one-time rrule', async () => {
@@ -267,10 +270,36 @@ describe('workflowLogic schedule reducers', () => {
         })
     })
 
+    describe('timezone reinterpretation', () => {
+        it('setScheduleStartsAtFromPicker reinterprets browser time as schedule timezone', () => {
+            logic.actions.setScheduleTimezone('Europe/Helsinki')
+            // Picker returns 9:00 AM in browser local time
+            logic.actions.setScheduleStartsAtFromPicker('2026-04-10T09:00:00.000Z')
+            // Should be stored as 9:00 AM Helsinki = 06:00 UTC (Helsinki is UTC+3 in April)
+            expect(logic.values.scheduleStartsAt).toBe('2026-04-10T06:00:00.000Z')
+        })
+
+        it('setScheduleStartsAtFromPicker with null clears starts_at', () => {
+            logic.actions.setScheduleStartsAt(STARTS_AT)
+            logic.actions.setScheduleStartsAtFromPicker(null)
+            expect(logic.values.scheduleStartsAt).toBeNull()
+        })
+
+        it('changing timezone preserves wall-clock time', () => {
+            logic.actions.setSchedules([makeSchedule()])
+            expect(logic.values.scheduleStartsAt).toBe('2026-04-10T09:00:00.000Z')
+
+            // Change to US/Eastern - wall clock stays 9:00 AM, UTC shifts
+            logic.actions.setScheduleTimezone('US/Eastern', 'UTC')
+            // 9:00 AM Eastern in April (EDT, UTC-4) = 13:00 UTC
+            expect(logic.values.scheduleStartsAt).toBe('2026-04-10T13:00:00.000Z')
+        })
+    })
+
     describe('resetWorkflow', () => {
         it('restores schedule state from saved repeating schedule', async () => {
             logic.actions.setSchedules([makeSchedule()])
-            logic.actions.setScheduleTimezone('US/Eastern')
+            logic.actions.setScheduleTimezone('US/Eastern', 'UTC')
             logic.actions.setScheduleRepeating(false)
 
             await expectLogic(logic, () => {

--- a/products/workflows/frontend/Workflows/workflowLogic.ts
+++ b/products/workflows/frontend/Workflows/workflowLogic.ts
@@ -151,7 +151,8 @@ export const workflowLogic = kea<workflowLogicType>([
         setWorkflowInfo: (workflow: Partial<HogFlow>) => ({ workflow }),
         setScheduleState: (scheduleState: ScheduleState) => ({ scheduleState }),
         setScheduleStartsAt: (startsAt: string | null) => ({ startsAt }),
-        setScheduleTimezone: (timezone: string) => ({ timezone }),
+        setScheduleStartsAtFromPicker: (pickerDate: string | null) => ({ pickerDate }),
+        setScheduleTimezone: (timezone: string, previousTimezone?: string) => ({ timezone, previousTimezone }),
         setScheduleRepeating: (repeating: boolean) => ({ repeating }),
         setSchedules: (schedules: HogFlowSchedule[]) => ({ schedules }),
         saveWorkflowPartial: (workflow: Partial<HogFlow>) => ({ workflow }),
@@ -529,8 +530,28 @@ export const workflowLogic = kea<workflowLogicType>([
         ],
     }),
     listeners(({ actions, values, props }) => ({
+        setScheduleStartsAtFromPicker: ({ pickerDate }) => {
+            if (!pickerDate) {
+                actions.setScheduleStartsAt(null)
+                return
+            }
+            // The picker returns browser-local time. Reinterpret as the schedule timezone.
+            const wallClock = dayjs(pickerDate).startOf('minute').format('YYYY-MM-DDTHH:mm:ss')
+            actions.setScheduleStartsAt(dayjs.tz(wallClock, values.scheduleTimezone).toISOString())
+        },
+        setScheduleTimezone: ({ timezone, previousTimezone }) => {
+            // When timezone changes, keep the wall-clock time the same by reinterpreting
+            // the current starts_at in the new timezone.
+            const oldTz = previousTimezone ?? dayjs.tz.guess()
+            if (values.scheduleStartsAt) {
+                const wallClock = dayjs(values.scheduleStartsAt).tz(oldTz).format('YYYY-MM-DDTHH:mm:ss')
+                actions.setScheduleStartsAt(dayjs.tz(wallClock, timezone).toISOString())
+            }
+        },
         resetWorkflow: () => {
-            // Re-initialize all schedule reducers atomically from the saved schedule.
+            // Re-initialize schedule reducers from the saved schedule.
+            // Using setSchedules resets all reducers atomically without triggering
+            // the setScheduleTimezone listener's wall-clock reinterpretation.
             actions.setSchedules(values.schedules)
         },
         saveWorkflowPartial: async ({ workflow }) => {


### PR DESCRIPTION
## Problem

The recurring schedule picker uses the browser's timezone by default, but users can't change it. If someone wants to schedule a campaign for a different timezone (e.g. Tokyo time from Prague), there's no way to do that.

## Changes

- **Timezone picker**: Added a searchable timezone dropdown (using `LemonSearchableSelect` with `preflightLogic` timezone list) below the date picker. Users can select any timezone. When the selected timezone differs from the browser's, both schedule time and local time are shown.
- **Timezone-aware date picker**: The date picker now shows and picks times in the schedule timezone, not the browser timezone. If you pick "9:00 AM" with timezone set to US/Eastern, it stores 9:00 AM Eastern regardless of your browser's timezone. Changing the timezone preserves the wall-clock time.
- **Timezone reinterpretation in workflowLogic**: Added `setScheduleStartsAtFromPicker` action that reinterprets browser-local time as the schedule timezone, and a `setScheduleTimezone` listener that adjusts `scheduleStartsAt` to preserve the wall-clock time when the timezone changes. Reset uses `setSchedules` to avoid triggering the reinterpretation listener.

<img width="712" height="821" alt="Screenshot 2026-04-03 at 15 35 53" src="https://github.com/user-attachments/assets/0ea84a7c-f469-4986-8f49-b083dba395fe" />

## How did you test this code?

Unit tests covering timezone reinterpretation (picker-to-UTC conversion, wall-clock preservation on timezone change) and updated end-to-end scenarios. Verified locally: timezone picker, date preservation, clear changes reset, save/load roundtrip.

## Publish to changelog?

No (behind feature flag)