### PR TITLE
feat(sql-editor): close objects

### DIFF
--- a/frontend/src/scenes/data-warehouse/editor/SQLEditor.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/SQLEditor.tsx
@@ -402,9 +402,8 @@ function SQLEditorSceneTitle(): JSX.Element | null {
                                 <LemonButton
                                     onClick={() => closeEditingObject()}
                                     icon={<IconX />}
-                                    type="secondary"
+                                    type="tertiary"
                                     size="small"
-                                    //   noPadding
                                     aria-label="close"
                                     tooltip={closeObjectTooltip}
                                 />

--- a/frontend/src/scenes/data-warehouse/editor/SQLEditor.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/SQLEditor.tsx
@@ -3,7 +3,7 @@ import { BindLogic, useActions, useValues } from 'kea'
 import type { editor as importedEditor } from 'monaco-editor'
 import { useEffect, useMemo, useRef, useState } from 'react'
 
-import { IconBook, IconChevronDown, IconDownload } from '@posthog/icons'
+import { IconBook, IconChevronDown, IconDownload, IconX } from '@posthog/icons'
 import { Spinner } from '@posthog/lemon-ui'
 
 import { useOnMountEffect } from 'lib/hooks/useOnMountEffect'
@@ -401,12 +401,13 @@ function SQLEditorSceneTitle(): JSX.Element | null {
                                 </LemonButton>
                                 <LemonButton
                                     onClick={() => closeEditingObject()}
+                                    icon={<IconX />}
                                     type="secondary"
                                     size="small"
+                                    //   noPadding
+                                    aria-label="close"
                                     tooltip={closeObjectTooltip}
-                                >
-                                    Close
-                                </LemonButton>
+                                />
                             </>
                         ) : editingInsight ? (
                             <>
@@ -454,12 +455,13 @@ function SQLEditorSceneTitle(): JSX.Element | null {
                                 </LemonButton>
                                 <LemonButton
                                     onClick={() => closeEditingObject()}
+                                    icon={<IconX />}
                                     type="secondary"
                                     size="small"
+                                    noPadding
+                                    aria-label="close"
                                     tooltip={closeObjectTooltip}
-                                >
-                                    Close
-                                </LemonButton>
+                                />
                             </>
                         ) : (
                             <LemonButton

--- a/frontend/src/scenes/data-warehouse/editor/SQLEditor.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/SQLEditor.tsx
@@ -224,6 +224,7 @@ function SQLEditorSceneTitle(): JSX.Element | null {
     const {
         updateView,
         updateInsight,
+        closeEditingObject,
         saveAsInsight,
         saveAsView,
         saveAsEndpoint,
@@ -305,6 +306,11 @@ function SQLEditorSceneTitle(): JSX.Element | null {
     }
 
     const isMaterializedView = editingView?.is_materialized === true
+    const closeObjectTooltip = editingInsight
+        ? 'Close this insight and reset the SQL editor to an unsaved query without clearing your SQL or visualization settings.'
+        : editingView
+          ? 'Close this view and reset the SQL editor to an unsaved query without clearing your SQL or visualization settings.'
+          : 'Reset the SQL editor to an unsaved query without clearing your SQL or visualization settings.'
 
     return (
         <>
@@ -393,50 +399,68 @@ function SQLEditorSceneTitle(): JSX.Element | null {
                                 >
                                     {isMaterializedView ? 'Update and re-materialize view' : 'Update view'}
                                 </LemonButton>
+                                <LemonButton
+                                    onClick={() => closeEditingObject()}
+                                    type="secondary"
+                                    size="small"
+                                    tooltip={closeObjectTooltip}
+                                >
+                                    Close
+                                </LemonButton>
                             </>
                         ) : editingInsight ? (
-                            <LemonButton
-                                disabledReason={
-                                    !isSourceQueryLastRun
-                                        ? 'Run latest query changes before saving'
-                                        : !updateInsightButtonEnabled
-                                          ? 'No updates to save'
-                                          : undefined
-                                }
-                                loading={insightLoading}
-                                type="primary"
-                                size="small"
-                                onClick={() => updateInsight()}
-                                sideAction={{
-                                    icon: <IconChevronDown />,
-                                    dropdown: {
-                                        placement: 'bottom-end',
-                                        overlay: (
-                                            <LemonMenuOverlay
-                                                items={[
-                                                    {
-                                                        label: 'Save as new insight...',
-                                                        disabledReason: saveAsDisabledReason,
-                                                        onClick: () => saveAsInsight(),
-                                                    },
-                                                    {
-                                                        label: 'Save as new view...',
-                                                        disabledReason: saveAsDisabledReason,
-                                                        onClick: () => saveAsView(),
-                                                    },
-                                                    {
-                                                        label: 'Save as endpoint...',
-                                                        disabledReason: saveAsDisabledReason,
-                                                        onClick: () => saveAsEndpoint(),
-                                                    },
-                                                ]}
-                                            />
-                                        ),
-                                    },
-                                }}
-                            >
-                                Update insight
-                            </LemonButton>
+                            <>
+                                <LemonButton
+                                    disabledReason={
+                                        !isSourceQueryLastRun
+                                            ? 'Run latest query changes before saving'
+                                            : !updateInsightButtonEnabled
+                                              ? 'No updates to save'
+                                              : undefined
+                                    }
+                                    loading={insightLoading}
+                                    type="primary"
+                                    size="small"
+                                    onClick={() => updateInsight()}
+                                    sideAction={{
+                                        icon: <IconChevronDown />,
+                                        dropdown: {
+                                            placement: 'bottom-end',
+                                            overlay: (
+                                                <LemonMenuOverlay
+                                                    items={[
+                                                        {
+                                                            label: 'Save as new insight...',
+                                                            disabledReason: saveAsDisabledReason,
+                                                            onClick: () => saveAsInsight(),
+                                                        },
+                                                        {
+                                                            label: 'Save as new view...',
+                                                            disabledReason: saveAsDisabledReason,
+                                                            onClick: () => saveAsView(),
+                                                        },
+                                                        {
+                                                            label: 'Save as endpoint...',
+                                                            disabledReason: saveAsDisabledReason,
+                                                            onClick: () => saveAsEndpoint(),
+                                                        },
+                                                    ]}
+                                                />
+                                            ),
+                                        },
+                                    }}
+                                >
+                                    Update insight
+                                </LemonButton>
+                                <LemonButton
+                                    onClick={() => closeEditingObject()}
+                                    type="secondary"
+                                    size="small"
+                                    tooltip={closeObjectTooltip}
+                                >
+                                    Close
+                                </LemonButton>
+                            </>
                         ) : (
                             <LemonButton
                                 type="primary"

--- a/frontend/src/scenes/data-warehouse/editor/sqlEditorLogic.test.ts
+++ b/frontend/src/scenes/data-warehouse/editor/sqlEditorLogic.test.ts
@@ -194,6 +194,92 @@ describe('sqlEditorLogic', () => {
 
             expect(logic.values.titleSectionProps.name).toEqual('Loading insight...')
         })
+
+        it('closes an insight into an unsaved query without clearing SQL or visualization settings', async () => {
+            logic = sqlEditorLogic({
+                tabId: TAB_ID,
+                monaco: createMockMonaco(),
+                editor: createMockEditor(),
+            })
+            logic.mount()
+
+            window.history.replaceState(
+                {},
+                '',
+                `${urls.sqlEditor()}?open_insight=${MOCK_INSIGHT.short_id}#${JSON.stringify({ insight: MOCK_INSIGHT.short_id })}`
+            )
+            logic.actions.createTab(MOCK_INSIGHT_QUERY.source.query, undefined, MOCK_INSIGHT)
+            await expectLogic(logic).toDispatchActions(['createTab', 'updateTab'])
+
+            logic.actions.setSourceQuery({
+                ...MOCK_INSIGHT_QUERY,
+                display: ChartDisplayType.BoldNumber,
+            })
+            logic.actions.setInsightLoading(true)
+            logic.actions.closeEditingObject()
+
+            await expectLogic(logic)
+                .toDispatchActions(['closeEditingObject', 'setInsightLoading', 'setViewLoading', 'updateTab'])
+                .toMatchValues({
+                    editingInsight: null,
+                    insightLoading: false,
+                    queryInput: MOCK_INSIGHT_QUERY.source.query,
+                    titleSectionProps: partial({
+                        name: 'New SQL query',
+                    }),
+                    sourceQuery: partial({
+                        display: ChartDisplayType.BoldNumber,
+                    }),
+                })
+
+            expect(window.location.hash).not.toContain('insight')
+            expect(window.location.search).not.toContain('open_insight')
+        })
+
+        it('closes a view into an unsaved query without clearing SQL or visualization settings', async () => {
+            logic = sqlEditorLogic({
+                tabId: TAB_ID,
+                monaco: createMockMonaco(),
+                editor: createMockEditor(),
+            })
+            logic.mount()
+
+            window.history.replaceState(
+                {},
+                '',
+                `${urls.sqlEditor()}?open_view=${MOCK_VIEW.id}#${JSON.stringify({ view: MOCK_VIEW.id })}`
+            )
+            logic.actions.createTab(MOCK_VIEW.query.query, MOCK_VIEW)
+            await expectLogic(logic).toDispatchActions(['createTab', 'updateTab'])
+
+            logic.actions.setSourceQuery({
+                kind: NodeKind.DataVisualizationNode,
+                source: {
+                    kind: NodeKind.HogQLQuery,
+                    query: MOCK_VIEW.query.query,
+                },
+                display: ChartDisplayType.ActionsBar,
+            })
+            logic.actions.setViewLoading(true)
+            logic.actions.closeEditingObject()
+
+            await expectLogic(logic)
+                .toDispatchActions(['closeEditingObject', 'setInsightLoading', 'setViewLoading', 'updateTab'])
+                .toMatchValues({
+                    editingView: undefined,
+                    viewLoading: false,
+                    queryInput: MOCK_VIEW.query.query,
+                    titleSectionProps: partial({
+                        name: 'New SQL query',
+                    }),
+                    sourceQuery: partial({
+                        display: ChartDisplayType.ActionsBar,
+                    }),
+                })
+
+            expect(window.location.hash).not.toContain('view')
+            expect(window.location.search).not.toContain('open_view')
+        })
     })
 
     describe('getDisplayTypeToSaveInsight', () => {

--- a/frontend/src/scenes/data-warehouse/editor/sqlEditorLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/sqlEditorLogic.tsx
@@ -304,6 +304,7 @@ export const sqlEditorLogic = kea<sqlEditorLogicType>([
         saveAsEndpoint: true,
         saveAsEndpointSubmit: (name: string, description?: string) => ({ name, description }),
         updateInsight: true,
+        closeEditingObject: true,
         setFinishedLoading: (loading: boolean) => ({ loading }),
         setError: (error: string | null) => ({ error }),
         setDataError: (error: string | null) => ({ error }),
@@ -1140,6 +1141,38 @@ export const sqlEditorLogic = kea<sqlEditorLogicType>([
                 router.actions.push(urls.insightView(savedInsight.short_id))
             }
         },
+        closeEditingObject: () => {
+            actions.setInsightLoading(false)
+            actions.setViewLoading(false)
+
+            if (!values.activeTab) {
+                actions.createTab(values.queryInput ?? '')
+                return
+            }
+
+            const nextActiveTab = {
+                ...values.activeTab,
+                name: NEW_QUERY,
+                view: undefined,
+                insight: undefined,
+                draft: undefined,
+            }
+
+            actions.updateTab(nextActiveTab)
+
+            if (!values.isEmbeddedMode) {
+                const nextHash = encodeURIComponent(JSON.stringify(getTabHash({ ...values, activeTab: nextActiveTab })))
+                const currentUrl = new URL(window.location.href)
+                currentUrl.searchParams.delete('open_insight')
+                currentUrl.searchParams.delete('open_view')
+                currentUrl.searchParams.delete('open_draft')
+                window.history.replaceState(
+                    {},
+                    '',
+                    `${urls.sqlEditor()}${currentUrl.searchParams.toString() ? `?${currentUrl.searchParams.toString()}` : ''}#${nextHash}`
+                )
+            }
+        },
         loadDataWarehouseSavedQueriesSuccess: ({ dataWarehouseSavedQueries }) => {
             if (values.activeTab?.view) {
                 const updatedView = dataWarehouseSavedQueries.find((v) => v.id === values.activeTab?.view?.id)
@@ -1446,8 +1479,16 @@ export const sqlEditorLogic = kea<sqlEditorLogicType>([
             },
         ],
         titleSectionProps: [
-            (s) => [s.editingInsight, s.insightLoading, s.editingView, s.viewLoading, s.editorSource, s.dashboardId],
-            (editingInsight, insightLoading, editingView, viewLoading, editorSource, dashboardId) => {
+            (s) => [
+                s.editingInsight,
+                s.insightLoading,
+                s.editingView,
+                s.viewLoading,
+                s.editorSource,
+                s.dashboardId,
+                s.activeTab,
+            ],
+            (editingInsight, insightLoading, editingView, viewLoading, editorSource, dashboardId, activeTab) => {
                 if (editingInsight) {
                     const forceBackTo: Breadcrumb = dashboardId
                         ? {
@@ -1491,19 +1532,21 @@ export const sqlEditorLogic = kea<sqlEditorLogicType>([
                     }
                 }
 
-                const searchParams = new URLSearchParams(window.location.search)
-                const hashParams = new URLSearchParams(window.location.hash.slice(1))
-                if (searchParams.get('open_view') || hashParams.get('view')) {
-                    return {
-                        name: 'Loading view...',
-                        resourceType: { type: 'view' },
+                if (!activeTab) {
+                    const searchParams = new URLSearchParams(window.location.search)
+                    const hashParams = new URLSearchParams(window.location.hash.slice(1))
+                    if (searchParams.get('open_view') || hashParams.get('view')) {
+                        return {
+                            name: 'Loading view...',
+                            resourceType: { type: 'view' },
+                        }
                     }
-                }
 
-                if (searchParams.get('open_insight') || hashParams.get('insight')) {
-                    return {
-                        name: 'Loading insight...',
-                        resourceType: { type: 'insight/hog' },
+                    if (searchParams.get('open_insight') || hashParams.get('insight')) {
+                        return {
+                            name: 'Loading insight...',
+                            resourceType: { type: 'insight/hog' },
+                        }
                     }
                 }
 


### PR DESCRIPTION
## Problem

Once you start editing a view or an insight, there's no way back to a normal SQL editor

## Changes

Add a close button when you're editing a view or insight:

![2026-04-02 16 33 52](https://github.com/user-attachments/assets/24fec572-16e1-423c-a756-2545e5771173)


## How did you test this code?

👀 
## Publish to changelog?
no
## Docs update
no