### PR TITLE
feat(dashboards): open manage alerts from dashboard insight menu

### DIFF
--- a/frontend/src/lib/components/Alerts/insightAlertsLogic.test.ts
+++ b/frontend/src/lib/components/Alerts/insightAlertsLogic.test.ts
@@ -1,0 +1,236 @@
+import { expectLogic } from 'kea-test-utils'
+
+import api from 'lib/api'
+import { insightDataLogic } from 'scenes/insights/insightDataLogic'
+import { createEmptyInsight, insightLogic } from 'scenes/insights/insightLogic'
+import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
+
+import { NodeKind } from '~/queries/schema/schema-general'
+import { initKeaTests } from '~/test/init'
+import { InsightLogicProps, InsightShortId } from '~/types'
+
+import { areAlertsSupportedForInsight, insightAlertsLogic } from './insightAlertsLogic'
+import type { AlertType } from './types'
+
+const Insight42 = '42' as InsightShortId
+
+const API_QUERY = {
+    kind: NodeKind.InsightVizNode,
+    source: {
+        kind: NodeKind.TrendsQuery,
+        series: [{ kind: NodeKind.EventsNode, event: '$pageview', math: 'total' }],
+        trendsFilter: { display: 'ActionsLineGraph' },
+    },
+}
+
+const FUNNEL_QUERY = {
+    kind: NodeKind.InsightVizNode,
+    source: {
+        kind: NodeKind.FunnelsQuery,
+        series: [{ kind: NodeKind.EventsNode, event: '$pageview' }],
+    },
+}
+
+describe('insightAlertsLogic', () => {
+    let listSpy: jest.SpyInstance
+
+    beforeEach(() => {
+        initKeaTests()
+        listSpy = jest.spyOn(api.alerts, 'list').mockResolvedValue({ results: [], count: 0 })
+    })
+
+    afterEach(() => {
+        listSpy.mockRestore()
+    })
+
+    function mountInsightStack(insightLogicProps: InsightLogicProps): void {
+        insightLogic(insightLogicProps).mount()
+        insightDataLogic(insightLogicProps).mount()
+        insightVizDataLogic(insightLogicProps).mount()
+    }
+
+    it('does not hydrate from empty insight.alerts or fetch on mount when deferInitialAlertsLoad is true', async () => {
+        const insightLogicProps: InsightLogicProps = {
+            dashboardItemId: Insight42,
+            dashboardId: 1,
+            cachedInsight: {
+                ...createEmptyInsight(Insight42),
+                id: 42,
+                query: API_QUERY,
+                alerts: [],
+            },
+        }
+        mountInsightStack(insightLogicProps)
+
+        const alertsLogic = insightAlertsLogic({
+            insightId: 42,
+            insightLogicProps,
+            deferInitialAlertsLoad: true,
+        })
+        alertsLogic.mount()
+
+        await expectLogic(alertsLogic).toMatchValues({ alerts: [] })
+        await expectLogic(alertsLogic).toNotHaveDispatchedActions(['loadAlerts', 'loadAlertsSuccess'])
+        expect(listSpy).not.toHaveBeenCalled()
+    })
+
+    it('calls the alerts API when loadAlerts runs after a deferred mount', async () => {
+        const insightLogicProps: InsightLogicProps = {
+            dashboardItemId: Insight42,
+            dashboardId: 1,
+            cachedInsight: {
+                ...createEmptyInsight(Insight42),
+                id: 42,
+                query: API_QUERY,
+                alerts: [],
+            },
+        }
+        mountInsightStack(insightLogicProps)
+
+        const alertsLogic = insightAlertsLogic({
+            insightId: 42,
+            insightLogicProps,
+            deferInitialAlertsLoad: true,
+        })
+        alertsLogic.mount()
+
+        await expectLogic(alertsLogic, () => {
+            alertsLogic.actions.loadAlerts()
+        }).toFinishAllListeners()
+
+        expect(listSpy).toHaveBeenCalledWith(42)
+    })
+
+    it('dispatches loadAlerts on mount when not deferred and cached insight has no alerts field', async () => {
+        const insightLogicProps: InsightLogicProps = {
+            dashboardItemId: Insight42,
+            dashboardId: 1,
+            cachedInsight: {
+                ...createEmptyInsight(Insight42),
+                id: 42,
+                query: API_QUERY,
+            },
+        }
+        mountInsightStack(insightLogicProps)
+
+        const alertsLogic = insightAlertsLogic({
+            insightId: 42,
+            insightLogicProps,
+        })
+        alertsLogic.mount()
+
+        await expectLogic(alertsLogic).toFinishAllListeners()
+        expect(listSpy).toHaveBeenCalledWith(42)
+    })
+
+    it('uses loadAlertsSuccess from insight.alerts on mount when not deferred and does not call the API for an empty array', async () => {
+        const insightLogicProps: InsightLogicProps = {
+            dashboardItemId: Insight42,
+            dashboardId: 1,
+            cachedInsight: {
+                ...createEmptyInsight(Insight42),
+                id: 42,
+                query: API_QUERY,
+                alerts: [],
+            },
+        }
+        mountInsightStack(insightLogicProps)
+
+        const alertsLogic = insightAlertsLogic({
+            insightId: 42,
+            insightLogicProps,
+        })
+        alertsLogic.mount()
+
+        await expectLogic(alertsLogic).toDispatchActions(['loadAlertsSuccess'])
+        await expectLogic(alertsLogic).toMatchValues({ alerts: [] })
+        expect(listSpy).not.toHaveBeenCalled()
+    })
+
+    it('upsertAlert appends then replaces by id', async () => {
+        const insightLogicProps: InsightLogicProps = {
+            dashboardItemId: Insight42,
+            dashboardId: 1,
+            cachedInsight: {
+                ...createEmptyInsight(Insight42),
+                id: 42,
+                query: API_QUERY,
+                alerts: [],
+            },
+        }
+        mountInsightStack(insightLogicProps)
+
+        const alertsLogic = insightAlertsLogic({
+            insightId: 42,
+            insightLogicProps,
+            deferInitialAlertsLoad: true,
+        })
+        alertsLogic.mount()
+
+        const first = { id: 'alert-a', name: 'First' } as AlertType
+        const updated = { id: 'alert-a', name: 'Updated' } as AlertType
+
+        await expectLogic(alertsLogic, () => {
+            alertsLogic.actions.upsertAlert(first)
+            alertsLogic.actions.upsertAlert({ id: 'alert-b', name: 'Other' } as AlertType)
+            alertsLogic.actions.upsertAlert(updated)
+        }).toMatchValues({
+            alerts: [updated, expect.objectContaining({ id: 'alert-b', name: 'Other' })],
+        })
+    })
+
+    it('removeAlert drops the matching alert id', async () => {
+        const insightLogicProps: InsightLogicProps = {
+            dashboardItemId: Insight42,
+            dashboardId: 1,
+            cachedInsight: {
+                ...createEmptyInsight(Insight42),
+                id: 42,
+                query: API_QUERY,
+                alerts: [],
+            },
+        }
+        mountInsightStack(insightLogicProps)
+
+        const alertsLogic = insightAlertsLogic({
+            insightId: 42,
+            insightLogicProps,
+            deferInitialAlertsLoad: true,
+        })
+        alertsLogic.mount()
+
+        await expectLogic(alertsLogic, () => {
+            alertsLogic.actions.upsertAlert({ id: 'keep', name: 'K' } as AlertType)
+            alertsLogic.actions.upsertAlert({ id: 'drop', name: 'D' } as AlertType)
+            alertsLogic.actions.removeAlert('drop')
+        }).toMatchValues({
+            alerts: [expect.objectContaining({ id: 'keep' })],
+        })
+    })
+})
+
+describe('areAlertsSupportedForInsight', () => {
+    it('returns false when query is null or undefined', () => {
+        expect(areAlertsSupportedForInsight(null)).toBe(false)
+        expect(areAlertsSupportedForInsight(undefined)).toBe(false)
+    })
+
+    it('returns true for trends insight viz with trendsFilter', () => {
+        expect(areAlertsSupportedForInsight(API_QUERY)).toBe(true)
+    })
+
+    it('returns false for funnel insight viz', () => {
+        expect(areAlertsSupportedForInsight(FUNNEL_QUERY)).toBe(false)
+    })
+
+    it('returns false when trendsFilter is null', () => {
+        const query = {
+            ...API_QUERY,
+            source: {
+                ...API_QUERY.source,
+                trendsFilter: null,
+            },
+        }
+        expect(areAlertsSupportedForInsight(query)).toBe(false)
+    })
+})

--- a/frontend/src/lib/components/Alerts/insightAlertsLogic.test.ts
+++ b/frontend/src/lib/components/Alerts/insightAlertsLogic.test.ts
@@ -36,7 +36,7 @@ describe('insightAlertsLogic', () => {
 
     beforeEach(() => {
         initKeaTests()
-        listSpy = jest.spyOn(api.alerts, 'list').mockResolvedValue({ results: [], count: 0 })
+        listSpy = jest.spyOn(api.alerts, 'list').mockResolvedValue({ results: [] })
     })
 
     afterEach(() => {

--- a/frontend/src/lib/components/Alerts/insightAlertsLogic.ts
+++ b/frontend/src/lib/components/Alerts/insightAlertsLogic.ts
@@ -15,6 +15,12 @@ import { AlertType, AnomalyPoint } from './types'
 export interface InsightAlertsLogicProps {
     insightId: number
     insightLogicProps: InsightLogicProps
+    /**
+     * When true, skip the afterMount alerts fetch. Used for dashboard tiles where `insight.alerts` is often an
+     * unprefetched `[]` and we must not N+1 on mount. Call `loadAlerts()` when surfacing the UI that needs the list
+     * (e.g. before `ManageAlertsModal` opens).
+     */
+    deferInitialAlertsLoad?: boolean
 }
 
 export const areAlertsSupportedForInsight = (query?: Record<string, any> | null): boolean => {
@@ -213,7 +219,10 @@ export const insightAlertsLogic = kea<insightAlertsLogicType>([
         },
     })),
 
-    afterMount(({ actions, values }) => {
+    afterMount(({ actions, values, props }) => {
+        if (props.deferInitialAlertsLoad) {
+            return
+        }
         // If the insight has an alerts property (even if empty), use it - this means the backend sent us the alerts data
         if (values.insight?.alerts && Array.isArray(values.insight.alerts)) {
             actions.loadAlertsSuccess(values.insight.alerts)

--- a/frontend/src/lib/components/Alerts/views/ManageAlertsModal.tsx
+++ b/frontend/src/lib/components/Alerts/views/ManageAlertsModal.tsx
@@ -7,6 +7,7 @@ import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { LemonModal } from 'lib/lemon-ui/LemonModal'
 import { LemonTag } from 'lib/lemon-ui/LemonTag'
 import { ProfileBubbles } from 'lib/lemon-ui/ProfilePicture'
+import { Spinner } from 'lib/lemon-ui/Spinner'
 import { pluralize } from 'lib/utils'
 import { urls } from 'scenes/urls'
 
@@ -100,7 +101,9 @@ export function ManageAlertsModal(props: ManageAlertsModalProps): JSX.Element {
     const { push } = useActions(router)
     const logic = insightAlertsLogic(props)
 
-    const { alerts } = useValues(logic)
+    const { alerts, alertsLoading } = useValues(logic)
+
+    const showDeferredListSpinner = props.deferInitialAlertsLoad && props.isOpen && alertsLoading
 
     return (
         <LemonModal onClose={props.onClose} isOpen={props.isOpen} width={600} simple title="">
@@ -117,7 +120,11 @@ export function ManageAlertsModal(props: ManageAlertsModalProps): JSX.Element {
                     </Link>
                 </div>
 
-                {alerts.length ? (
+                {showDeferredListSpinner ? (
+                    <div className="flex justify-center p-8">
+                        <Spinner />
+                    </div>
+                ) : alerts.length ? (
                     <div className="deprecated-space-y-2">
                         <div>
                             <strong>{alerts?.length}</strong> {pluralize(alerts.length || 0, 'alert', 'alerts', false)}

--- a/frontend/src/lib/components/Cards/InsightCard/InsightMeta.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/InsightMeta.tsx
@@ -5,6 +5,8 @@ import React, { useCallback, useEffect, useRef, useState } from 'react'
 import { IconInfo, IconThumbsDown, IconThumbsUp } from '@posthog/icons'
 import { lemonToast } from '@posthog/lemon-ui'
 
+import { areAlertsSupportedForInsight, insightAlertsLogic } from 'lib/components/Alerts/insightAlertsLogic'
+import { ManageAlertsModal } from 'lib/components/Alerts/views/ManageAlertsModal'
 import { CardMeta } from 'lib/components/Cards/CardMeta'
 import { TopHeading } from 'lib/components/Cards/InsightCard/TopHeading'
 import { EditableField } from 'lib/components/EditableField/EditableField'
@@ -50,6 +52,7 @@ import {
     ExporterFormat,
     InsightColor,
     InsightLogicProps,
+    InsightShortId,
     QueryBasedInsightModel,
 } from '~/types'
 
@@ -134,7 +137,15 @@ export function InsightMeta({
         insightLogic(insightLogicProps)
     )
     const { setInsightFeedback } = useActions(insightLogic(insightLogicProps))
-    const { exportContext, insightData } = useValues(insightDataLogic(insightLogicProps))
+    const { exportContext, insightData, query } = useValues(insightDataLogic(insightLogicProps))
+    const [isManageAlertsModalOpen, setIsManageAlertsModalOpen] = useState(false)
+    const { loadAlerts: loadDeferredInsightAlerts } = useActions(
+        insightAlertsLogic({
+            insightId: insight.id ?? 0,
+            insightLogicProps,
+            deferInitialAlertsLoad: true,
+        })
+    )
     const { samplingFactor } = useValues(insightVizDataLogic(insightLogicProps))
     const { nameSortedDashboards } = useValues(dashboardsModel)
     const { copyToDestinations } = useValues(
@@ -149,15 +160,16 @@ export function InsightMeta({
     const { reportDashboardInsightMetaUpdated } = useActions(eventUsageLogic)
     const { featureFlags } = useValues(featureFlagLogic)
 
-    const showCompactTile =
-        placement === DashboardPlacement.Dashboard ||
-        placement === DashboardPlacement.ProjectHomepage ||
-        placement === DashboardPlacement.Public
-    const isDashboardCardPlacement =
-        placement === DashboardPlacement.Dashboard ||
-        placement === DashboardPlacement.Public ||
-        placement === DashboardPlacement.Builtin
-
+    const showCompactTile = [
+        DashboardPlacement.Dashboard,
+        DashboardPlacement.ProjectHomepage,
+        DashboardPlacement.Public,
+    ].includes(placement)
+    const isUsedAsDashboardTile = [
+        DashboardPlacement.Dashboard,
+        DashboardPlacement.Public,
+        DashboardPlacement.Builtin,
+    ].includes(placement)
     const isSqlInsight = isDataVisualizationNode(insight.query)
     const showCompactHeading = !showCompactTile || (!filtersOverride?.date_from && !isSqlInsight)
 
@@ -181,8 +193,12 @@ export function InsightMeta({
                   AccessControlLevel.Editor
               )
             : true
-    const canToggleDisplayLabels = isDashboardCardPlacement && canEditInsight && canToggleDisplayLabelsForInsight
-    const canToggleLegend = isDashboardCardPlacement && canEditInsight && canToggleLegendForInsight
+
+    const showDashboardAlertsMenuItem = isUsedAsDashboardTile && !!dashboardId && !!insight.id && canViewInsight
+    const canCreateAlertForInsight = areAlertsSupportedForInsight(query)
+
+    const canToggleDisplayLabels = isUsedAsDashboardTile && canEditInsight && canToggleDisplayLabelsForInsight
+    const canToggleLegend = isUsedAsDashboardTile && canEditInsight && canToggleLegendForInsight
 
     const hasTileStyleActions = !!(showCompactTile && toggleShowDescription && insight.description) || !!updateColor
     const canShowCopyToDashboardTile = showCompactTile && !!copyToDashboard && canViewInsight
@@ -295,287 +311,316 @@ export function InsightMeta({
         : undefined
 
     return (
-        <CardMeta
-            compact={showCompactTile}
-            ribbonColor={ribbonColor}
-            showEditingControls={showEditingControls}
-            showDetailsControls={showDetailsControls}
-            setAreDetailsShown={setAreDetailsShown}
-            areDetailsShown={areDetailsShown}
-            detailsTooltip="Show insight details, such as creator, last edit, and applied filters."
-            onMouseDown={onDragHandleMouseDown}
-            topHeading={topHeadingEl}
-            popoverTopHeading={popoverTopHeadingEl}
-            content={
-                <InsightMetaContent
-                    link={urls.insightView(
-                        short_id,
-                        dashboardId,
-                        variablesOverride,
-                        filtersOverride,
-                        tile?.filters_overrides
-                    )}
-                    title={name}
-                    fallbackTitle={summary}
-                    description={insight.description}
-                    loading={loading}
-                    loadingQueued={loadingQueued}
-                    tags={insight.tags}
-                    compact={showCompactTile}
-                    showDescription={tile?.show_description !== false}
-                    infoPopover={
-                        showCompactTile ? (
-                            <CompactInfoPopover
-                                popoverTopHeading={popoverTopHeadingEl ?? topHeadingEl}
-                                metaTitle={name}
-                                metaDescription={metaDescriptionEl}
-                                metaDescriptionText={insight.description || ''}
-                                onMetaSave={onMetaSave}
-                                metaDetails={metaDetailsEl}
-                            />
-                        ) : null
-                    }
-                />
-            }
-            metaTitle={name}
-            metaDescription={metaDescriptionEl}
-            metaDescriptionText={insight.description || ''}
-            onMetaSave={onMetaSave}
-            metaDetails={metaDetailsEl}
-            samplingFactor={samplingFactor}
-            moreButtons={
-                <>
-                    {/* Insight related */}
-                    {canViewInsight && (
-                        <LemonButton
-                            to={urls.insightView(
-                                short_id,
-                                dashboardId,
-                                variablesOverride,
-                                filtersOverride,
-                                tile?.filters_overrides
-                            )}
-                            fullWidth
-                        >
-                            View
-                        </LemonButton>
-                    )}
-                    {canEditInsight && (
-                        <>
-                            <LemonButton
-                                to={
-                                    isDataVisualizationNode(insight.query)
-                                        ? urls.sqlEditor({
-                                              insightShortId: short_id,
-                                              dashboard: dashboardId ?? undefined,
-                                          })
-                                        : urls.insightEdit(short_id, dashboardId)
-                                }
-                                fullWidth
-                                {...getOverrideWarningPropsForButton(filtersOverride, variablesOverride)}
-                            >
-                                Edit
-                            </LemonButton>
-                            <LemonButton onClick={rename} fullWidth>
-                                Rename
-                            </LemonButton>
-                            {tile && (
-                                <LemonButton onClick={setOverride} fullWidth>
-                                    Set override
-                                </LemonButton>
-                            )}
-                        </>
-                    )}
-                    <LemonButton
-                        onClick={duplicate}
-                        fullWidth
-                        data-attr={
-                            dashboardId ? 'duplicate-insight-from-dashboard' : 'duplicate-insight-from-card-list-view'
+        <>
+            <CardMeta
+                compact={showCompactTile}
+                ribbonColor={ribbonColor}
+                showEditingControls={showEditingControls}
+                showDetailsControls={showDetailsControls}
+                setAreDetailsShown={setAreDetailsShown}
+                areDetailsShown={areDetailsShown}
+                detailsTooltip="Show insight details, such as creator, last edit, and applied filters."
+                onMouseDown={onDragHandleMouseDown}
+                topHeading={topHeadingEl}
+                popoverTopHeading={popoverTopHeadingEl}
+                content={
+                    <InsightMetaContent
+                        link={urls.insightView(
+                            short_id,
+                            dashboardId,
+                            variablesOverride,
+                            filtersOverride,
+                            tile?.filters_overrides
+                        )}
+                        title={name}
+                        fallbackTitle={summary}
+                        description={insight.description}
+                        loading={loading}
+                        loadingQueued={loadingQueued}
+                        tags={insight.tags}
+                        compact={showCompactTile}
+                        showDescription={tile?.show_description !== false}
+                        infoPopover={
+                            showCompactTile ? (
+                                <CompactInfoPopover
+                                    popoverTopHeading={popoverTopHeadingEl ?? topHeadingEl}
+                                    metaTitle={name}
+                                    metaDescription={metaDescriptionEl}
+                                    metaDescriptionText={insight.description || ''}
+                                    onMetaSave={onMetaSave}
+                                    metaDetails={metaDetailsEl}
+                                />
+                            ) : null
                         }
-                    >
-                        Duplicate
-                    </LemonButton>
-                    <DashboardInsightActions
-                        insight={insight}
-                        insightLogicProps={insightLogicProps}
-                        dashboardId={dashboardId}
-                        canToggleDisplayLabels={canToggleDisplayLabels}
-                        canToggleLegend={canToggleLegend}
                     />
-
-                    {canShowCopyToDashboardTile && !canEditDashboard && (
-                        <>
-                            {!canToggleDisplayLabels && <LemonDivider />}
-                            <h5 className="mx-2 my-1">Dashboard</h5>
-                            <DashboardWidgetPlacementMenus
-                                placementDestinations={copyToDestinations}
-                                onCopyToDashboard={copyToDashboard}
-                            />
-                        </>
-                    )}
-
-                    {/* Dashboard related */}
-                    {canEditDashboard && (
-                        <>
-                            {!canToggleDisplayLabels && !canToggleLegend && <LemonDivider />}
-                            {showCompactTile && toggleShowDescription && !!insight.description && (
-                                <LemonButton onClick={toggleShowDescription} fullWidth>
-                                    {tile?.show_description === false ? 'Show description' : 'Hide description'}
-                                </LemonButton>
-                            )}
-                            {updateColor && (
-                                <LemonMenu
-                                    items={Object.values(InsightColor).map((availableColor) => ({
-                                        label: (
-                                            <span className="flex items-center gap-2">
-                                                {availableColor !== InsightColor.White ? (
-                                                    <Splotch color={availableColor as string as SplotchColor} />
-                                                ) : null}
-                                                <span>
-                                                    {availableColor !== InsightColor.White
-                                                        ? capitalizeFirstLetter(availableColor)
-                                                        : 'No color'}
-                                                </span>
-                                            </span>
-                                        ),
-                                        key: availableColor,
-                                        active: availableColor === (ribbonColor || InsightColor.White),
-                                        onClick: () => {
-                                            updateColor?.(availableColor)
-                                        },
-                                    }))}
-                                    placement="right-start"
-                                    fallbackPlacements={['left-start']}
-                                    closeParentPopoverOnClickInside
-                                >
-                                    <LemonButton fullWidth>Set color</LemonButton>
-                                </LemonMenu>
-                            )}
-                            {hasDashboardPlacementActions && (
-                                <>
-                                    {hasTileStyleActions && <LemonDivider />}
-                                    <h5 className="mx-2 my-1">Dashboard</h5>
-                                    <DashboardWidgetPlacementMenus
-                                        placementDestinations={copyToDestinations}
-                                        onMoveToDashboard={moveToDashboard}
-                                        onCopyToDashboard={canShowCopyToDashboardTile ? copyToDashboard : undefined}
-                                    />
-                                    {removeFromDashboard && (
-                                        <LemonButton
-                                            status="danger"
-                                            onClick={() =>
-                                                LemonDialog.open({
-                                                    title: 'Remove from dashboard',
-                                                    description:
-                                                        'Are you sure you want to remove this insight from the dashboard?',
-                                                    primaryButton: {
-                                                        children: 'Remove from dashboard',
-                                                        status: 'danger',
-                                                        onClick: removeFromDashboard,
-                                                    },
-                                                    secondaryButton: {
-                                                        children: 'Cancel',
-                                                    },
-                                                })
-                                            }
-                                            fullWidth
-                                        >
-                                            Remove from dashboard
-                                        </LemonButton>
-                                    )}
-                                </>
-                            )}
-                        </>
-                    )}
-
-                    {/* Insight deletion - separate from dashboard actions */}
-                    {canEditInsight && !removeFromDashboard && deleteWithUndo && (
-                        <>
-                            <LemonDivider />
-                            <LemonButton
-                                status="danger"
-                                onClick={() => {
-                                    void (async () => {
-                                        try {
-                                            await deleteWithUndo?.()
-                                        } catch (error: any) {
-                                            lemonToast.error(`Failed to delete insight meta: ${error.detail}`)
-                                        }
-                                    })()
-                                }}
-                                fullWidth
-                            >
-                                Delete insight
-                            </LemonButton>
-                        </>
-                    )}
-
-                    {/* Data related */}
-                    {exportContext ? (
-                        <>
-                            <LemonDivider />
-                            <ExportButton
-                                fullWidth
-                                items={[
-                                    {
-                                        export_format: ExporterFormat.PNG,
-                                        insight: insight.id,
-                                        dashboard: insightLogicProps.dashboardId,
-                                    },
-                                    {
-                                        export_format: ExporterFormat.CSV,
-                                        export_context: exportContext,
-                                    },
-                                    {
-                                        export_format: ExporterFormat.XLSX,
-                                        export_context: exportContext,
-                                    },
-                                ]}
-                            />
-                        </>
-                    ) : null}
+                }
+                metaTitle={name}
+                metaDescription={metaDescriptionEl}
+                metaDescriptionText={insight.description || ''}
+                onMetaSave={onMetaSave}
+                metaDetails={metaDetailsEl}
+                samplingFactor={samplingFactor}
+                moreButtons={
                     <>
-                        {refresh && (
+                        {/* Insight related */}
+                        {canViewInsight && (
                             <LemonButton
-                                onClick={() => {
-                                    refresh()
-                                }}
-                                disabledReason={refreshDisabledReason}
+                                to={urls.insightView(
+                                    short_id,
+                                    dashboardId,
+                                    variablesOverride,
+                                    filtersOverride,
+                                    tile?.filters_overrides
+                                )}
                                 fullWidth
                             >
-                                {insight.last_refresh ? (
-                                    <div className="block my-1">
-                                        Refresh data
-                                        <p className="text-xs text-muted mt-0.5">
-                                            Last computed{' '}
-                                            <TZLabel
-                                                time={insight.last_refresh}
-                                                noStyles
-                                                className="whitespace-nowrap border-dotted border-b"
-                                            />
-                                        </p>
-                                    </div>
-                                ) : (
-                                    <>Refresh data</>
-                                )}
+                                View
                             </LemonButton>
                         )}
-                    </>
+                        {canEditInsight && (
+                            <>
+                                <LemonButton
+                                    to={
+                                        isDataVisualizationNode(insight.query)
+                                            ? urls.sqlEditor({
+                                                  insightShortId: short_id,
+                                                  dashboard: dashboardId ?? undefined,
+                                              })
+                                            : urls.insightEdit(short_id, dashboardId)
+                                    }
+                                    fullWidth
+                                    {...getOverrideWarningPropsForButton(filtersOverride, variablesOverride)}
+                                >
+                                    Edit
+                                </LemonButton>
+                                <LemonButton onClick={rename} fullWidth>
+                                    Rename
+                                </LemonButton>
+                                {tile && (
+                                    <LemonButton onClick={setOverride} fullWidth>
+                                        Set override
+                                    </LemonButton>
+                                )}
+                            </>
+                        )}
+                        <LemonButton
+                            onClick={duplicate}
+                            fullWidth
+                            data-attr={
+                                dashboardId
+                                    ? 'duplicate-insight-from-dashboard'
+                                    : 'duplicate-insight-from-card-list-view'
+                            }
+                        >
+                            Duplicate
+                        </LemonButton>
+                        {showDashboardAlertsMenuItem && insight.id ? (
+                            <LemonButton
+                                onClick={() => {
+                                    void loadDeferredInsightAlerts()
+                                    setIsManageAlertsModalOpen(true)
+                                }}
+                                fullWidth
+                                data-attr="dashboard-insight-manage-alerts"
+                            >
+                                Alerts
+                            </LemonButton>
+                        ) : null}
+                        <DashboardInsightActions
+                            insight={insight}
+                            insightLogicProps={insightLogicProps}
+                            dashboardId={dashboardId}
+                            canToggleDisplayLabels={canToggleDisplayLabels}
+                            canToggleLegend={canToggleLegend}
+                        />
 
-                    {/* More */}
-                    {moreButtons && (
+                        {canShowCopyToDashboardTile && !canEditDashboard && (
+                            <>
+                                {!canToggleDisplayLabels && <LemonDivider />}
+                                <h5 className="mx-2 my-1">Dashboard</h5>
+                                <DashboardWidgetPlacementMenus
+                                    placementDestinations={copyToDestinations}
+                                    onCopyToDashboard={copyToDashboard}
+                                />
+                            </>
+                        )}
+
+                        {/* Dashboard related */}
+                        {canEditDashboard && (
+                            <>
+                                {!canToggleDisplayLabels && !canToggleLegend && <LemonDivider />}
+                                {showCompactTile && toggleShowDescription && !!insight.description && (
+                                    <LemonButton onClick={toggleShowDescription} fullWidth>
+                                        {tile?.show_description === false ? 'Show description' : 'Hide description'}
+                                    </LemonButton>
+                                )}
+                                {updateColor && (
+                                    <LemonMenu
+                                        items={Object.values(InsightColor).map((availableColor) => ({
+                                            label: (
+                                                <span className="flex items-center gap-2">
+                                                    {availableColor !== InsightColor.White ? (
+                                                        <Splotch color={availableColor as string as SplotchColor} />
+                                                    ) : null}
+                                                    <span>
+                                                        {availableColor !== InsightColor.White
+                                                            ? capitalizeFirstLetter(availableColor)
+                                                            : 'No color'}
+                                                    </span>
+                                                </span>
+                                            ),
+                                            key: availableColor,
+                                            active: availableColor === (ribbonColor || InsightColor.White),
+                                            onClick: () => {
+                                                updateColor?.(availableColor)
+                                            },
+                                        }))}
+                                        placement="right-start"
+                                        fallbackPlacements={['left-start']}
+                                        closeParentPopoverOnClickInside
+                                    >
+                                        <LemonButton fullWidth>Set color</LemonButton>
+                                    </LemonMenu>
+                                )}
+                                {hasDashboardPlacementActions && (
+                                    <>
+                                        {hasTileStyleActions && <LemonDivider />}
+                                        <h5 className="mx-2 my-1">Dashboard</h5>
+                                        <DashboardWidgetPlacementMenus
+                                            placementDestinations={copyToDestinations}
+                                            onMoveToDashboard={moveToDashboard}
+                                            onCopyToDashboard={canShowCopyToDashboardTile ? copyToDashboard : undefined}
+                                        />
+                                        {removeFromDashboard && (
+                                            <LemonButton
+                                                status="danger"
+                                                onClick={() =>
+                                                    LemonDialog.open({
+                                                        title: 'Remove from dashboard',
+                                                        description:
+                                                            'Are you sure you want to remove this insight from the dashboard?',
+                                                        primaryButton: {
+                                                            children: 'Remove from dashboard',
+                                                            status: 'danger',
+                                                            onClick: removeFromDashboard,
+                                                        },
+                                                        secondaryButton: {
+                                                            children: 'Cancel',
+                                                        },
+                                                    })
+                                                }
+                                                fullWidth
+                                            >
+                                                Remove from dashboard
+                                            </LemonButton>
+                                        )}
+                                    </>
+                                )}
+                            </>
+                        )}
+
+                        {/* Insight deletion - separate from dashboard actions */}
+                        {canEditInsight && !removeFromDashboard && deleteWithUndo && (
+                            <>
+                                <LemonDivider />
+                                <LemonButton
+                                    status="danger"
+                                    onClick={() => {
+                                        void (async () => {
+                                            try {
+                                                await deleteWithUndo?.()
+                                            } catch (error: any) {
+                                                lemonToast.error(`Failed to delete insight meta: ${error.detail}`)
+                                            }
+                                        })()
+                                    }}
+                                    fullWidth
+                                >
+                                    Delete insight
+                                </LemonButton>
+                            </>
+                        )}
+
+                        {/* Data related */}
+                        {exportContext ? (
+                            <>
+                                <LemonDivider />
+                                <ExportButton
+                                    fullWidth
+                                    items={[
+                                        {
+                                            export_format: ExporterFormat.PNG,
+                                            insight: insight.id,
+                                            dashboard: insightLogicProps.dashboardId,
+                                        },
+                                        {
+                                            export_format: ExporterFormat.CSV,
+                                            export_context: exportContext,
+                                        },
+                                        {
+                                            export_format: ExporterFormat.XLSX,
+                                            export_context: exportContext,
+                                        },
+                                    ]}
+                                />
+                            </>
+                        ) : null}
                         <>
-                            <LemonDivider />
-                            {moreButtons}
+                            {refresh && (
+                                <LemonButton
+                                    onClick={() => {
+                                        refresh()
+                                    }}
+                                    disabledReason={refreshDisabledReason}
+                                    fullWidth
+                                >
+                                    {insight.last_refresh ? (
+                                        <div className="block my-1">
+                                            Refresh data
+                                            <p className="text-xs text-muted mt-0.5">
+                                                Last computed{' '}
+                                                <TZLabel
+                                                    time={insight.last_refresh}
+                                                    noStyles
+                                                    className="whitespace-nowrap border-dotted border-b"
+                                                />
+                                            </p>
+                                        </div>
+                                    ) : (
+                                        <>Refresh data</>
+                                    )}
+                                </LemonButton>
+                            )}
                         </>
-                    )}
-                </>
-            }
-            moreTooltip={
-                canEditInsight ? 'Rename, duplicate, export, refresh and more…' : 'Duplicate, export, refresh and more…'
-            }
-            extraControls={surveyOpportunityButton ?? feedbackButtons}
-        />
+
+                        {/* More */}
+                        {moreButtons && (
+                            <>
+                                <LemonDivider />
+                                {moreButtons}
+                            </>
+                        )}
+                    </>
+                }
+                moreTooltip={
+                    canEditInsight
+                        ? 'Rename, duplicate, export, refresh and more…'
+                        : 'Duplicate, export, refresh and more…'
+                }
+                extraControls={surveyOpportunityButton ?? feedbackButtons}
+            />
+            {showDashboardAlertsMenuItem && insight.id ? (
+                <ManageAlertsModal
+                    isOpen={isManageAlertsModalOpen}
+                    onClose={() => setIsManageAlertsModalOpen(false)}
+                    insightLogicProps={insightLogicProps}
+                    insightId={insight.id}
+                    insightShortId={short_id as InsightShortId}
+                    canCreateAlertForInsight={canCreateAlertForInsight}
+                    deferInitialAlertsLoad
+                />
+            ) : null}
+        </>
     )
 }
 

--- a/frontend/src/lib/components/Cards/InsightCard/InsightMeta.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/InsightMeta.tsx
@@ -160,16 +160,14 @@ export function InsightMeta({
     const { reportDashboardInsightMetaUpdated } = useActions(eventUsageLogic)
     const { featureFlags } = useValues(featureFlagLogic)
 
-    const showCompactTile = [
-        DashboardPlacement.Dashboard,
-        DashboardPlacement.ProjectHomepage,
-        DashboardPlacement.Public,
-    ].includes(placement)
-    const isUsedAsDashboardTile = [
-        DashboardPlacement.Dashboard,
-        DashboardPlacement.Public,
-        DashboardPlacement.Builtin,
-    ].includes(placement)
+    const showCompactTile =
+        placement === DashboardPlacement.Dashboard ||
+        placement === DashboardPlacement.ProjectHomepage ||
+        placement === DashboardPlacement.Public
+    const isUsedAsDashboardTile =
+        placement === DashboardPlacement.Dashboard ||
+        placement === DashboardPlacement.Public ||
+        placement === DashboardPlacement.Builtin
     const isSqlInsight = isDataVisualizationNode(insight.query)
     const showCompactHeading = !showCompactTile || (!filtersOverride?.date_from && !isSqlInsight)
 


### PR DESCRIPTION
## Problem

From the dashboard, if i wanted to open the alerts for an insight, i would have to navigate to the insight, open the side drawer, and then click the alerts modal. This is quite distracting if you have many insights you want to see alerts for.

## Changes

Allows opening the alerts modal directly from dashboard insights. It defers loading the alerts for an insight on dashboard, until the modal is opened.


https://github.com/user-attachments/assets/037ff3e5-0b42-4706-8245-b3100cc48ecd


## How did you test this code?

Locally.

Added new tests.

## Publish to changelog?

Yes.