### PR TITLE
fix(cli): eliminate content_hash_mismatch on incremental dSYM uploads

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # posthog-cli
 
+# 0.7.5
+
+- fix: stable content hash for dSYM uploads on incremental builds
+  - thin fat (universal) binaries per architecture before zipping, so rebuilding one arch slice does not change the hash of sibling slices
+  - extract source file paths from DWARF compilation-unit main files only, preventing cross-module source references (e.g. framework headers) from causing hash changes when a dependency is updated
+
 # 0.7.4
 
 - fix: create per-UUID ZIP for dSYM uploads

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -1833,7 +1833,7 @@ dependencies = [
 
 [[package]]
 name = "posthog-cli"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "anyhow",
  "chrono",

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -717,6 +717,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
 
 [[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1416,9 +1422,9 @@ checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
 name = "libc"
-version = "0.2.177"
+version = "0.2.184"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
+checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
 name = "libredox"
@@ -1438,9 +1444,9 @@ checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
@@ -1861,6 +1867,7 @@ dependencies = [
  "similar",
  "sourcemap",
  "symbolic",
+ "tempfile",
  "test-log",
  "thiserror 2.0.17",
  "tracing",
@@ -2287,14 +2294,14 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.1.2"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
  "bitflags 2.10.0",
  "errno",
  "libc",
- "linux-raw-sys 0.11.0",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
 ]
 
@@ -2851,12 +2858,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.4",
+ "once_cell",
+ "rustix 1.1.4",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "terminal_size"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b8cb979cb11c32ce1603f8137b22262a9d131aaa5c37b5678025f22b8becd0"
 dependencies = [
- "rustix 1.1.2",
+ "rustix 1.1.4",
  "windows-sys 0.60.2",
 ]
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "posthog-cli"
-version = "0.7.4"
+version = "0.7.5"
 authors = [
     "David <david@posthog.com>",
     "Olly <oliver@posthog.com>",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -58,6 +58,7 @@ open = "5"
 zip = { version = "2.2", default-features = false, features = ["deflate"] }
 symbolic = { version = "12.12", features = ["debuginfo"] }
 plist = "1"
+tempfile = "3.27.0"
 
 [dev-dependencies]
 test-log = "0.2.17"

--- a/cli/src/dsym/mod.rs
+++ b/cli/src/dsym/mod.rs
@@ -18,6 +18,8 @@ pub enum DsymSubcommand {
 struct DsymEntry {
     /// The UUID of this DWARF binary (used as chunk_id)
     uuid: String,
+    /// Architecture name as reported by dwarfdump (e.g. "arm64", "x86_64")
+    arch: String,
     /// ZIP containing only this DWARF binary (+ optional source files)
     data: Vec<u8>,
 }
@@ -32,9 +34,12 @@ pub struct DsymFile {
 
 impl DsymFile {
     /// Create a new DsymFile from a .dSYM bundle path.
-    /// Each DWARF binary in the bundle gets its own ZIP so that
-    /// stable UUIDs (e.g. app stubs) don't get a new content hash
-    /// when a sibling binary (e.g. debug dylib) changes.
+    ///
+    /// Each UUID gets its own ZIP containing only the architecture slice it
+    /// corresponds to (via `lipo -thin`). This ensures the content hash for a
+    /// stable slice (e.g. arm64) does not change when a sibling slice (e.g.
+    /// x86_64) is rebuilt with a new UUID, which would otherwise cause a
+    /// `content_hash_mismatch` error on incremental builds.
     pub fn new(path: &PathBuf, include_source: bool) -> Result<Self> {
         if !path.is_dir() {
             anyhow::bail!("Path {} is not a directory", path.display());
@@ -52,11 +57,12 @@ impl DsymFile {
         let uuid_entries = extract_dsym_uuids(path)?;
 
         let mut entries = Vec::new();
-        for (uuid, dwarf_filename) in &uuid_entries {
+        for (uuid, arch, dwarf_filename) in &uuid_entries {
             let dwarf_path = dwarf_dir.join(dwarf_filename);
-            let data = zip_dwarf_binary(&dwarf_path, include_source)?;
+            let data = zip_dwarf_binary(&dwarf_path, arch, include_source)?;
             entries.push(DsymEntry {
                 uuid: uuid.clone(),
+                arch: arch.clone(),
                 data,
             });
         }
@@ -69,6 +75,10 @@ impl DsymFile {
 
     pub fn uuids(&self) -> Vec<&str> {
         self.entries.iter().map(|e| e.uuid.as_str()).collect()
+    }
+
+    pub fn arches(&self) -> Vec<&str> {
+        self.entries.iter().map(|e| e.arch.as_str()).collect()
     }
 
     pub fn total_size(&self) -> usize {
@@ -88,9 +98,9 @@ impl DsymFile {
     }
 }
 
-/// Extract all UUIDs and their corresponding DWARF filenames from a dSYM bundle.
-/// Returns (uuid, dwarf_filename) pairs.
-fn extract_dsym_uuids(dsym_path: &PathBuf) -> Result<Vec<(String, String)>> {
+/// Extract all UUIDs, architectures, and DWARF filenames from a dSYM bundle.
+/// Returns `(uuid, arch, dwarf_filename)` triples.
+fn extract_dsym_uuids(dsym_path: &PathBuf) -> Result<Vec<(String, String, String)>> {
     use std::process::Command;
 
     let output = Command::new("dwarfdump")
@@ -107,7 +117,7 @@ fn extract_dsym_uuids(dsym_path: &PathBuf) -> Result<Vec<(String, String)>> {
     let stdout = String::from_utf8_lossy(&output.stdout);
 
     // Parse output like: "UUID: 12345678-1234-1234-1234-123456789ABC (arm64) /path/to/DWARF/PostHogExample"
-    let entries: Vec<(String, String)> = stdout
+    let entries: Vec<(String, String, String)> = stdout
         .lines()
         .filter_map(|line| {
             let uuid_start = line.find("UUID: ")? + 6;
@@ -115,13 +125,18 @@ fn extract_dsym_uuids(dsym_path: &PathBuf) -> Result<Vec<(String, String)>> {
             let uuid_end = uuid_part.find(' ')?;
             let uuid = uuid_part[..uuid_end].to_uppercase();
 
+            // Extract arch from "(arm64)" parentheses
+            let arch_start = line.find('(')? + 1;
+            let arch_end = line.find(')')?;
+            let arch = line.get(arch_start..arch_end)?.trim().to_string();
+
             // Extract the DWARF filename from the path at end of line
             // Format: "UUID: <uuid> (<arch>) <full_path>"
             let path_start = line.rfind(')')? + 2; // Skip ") "
             let dwarf_path = line.get(path_start..)?;
             let dwarf_filename = Path::new(dwarf_path).file_name()?.to_str()?.to_string();
 
-            Some((uuid, dwarf_filename))
+            Some((uuid, arch, dwarf_filename))
         })
         .collect();
 
@@ -137,13 +152,16 @@ fn extract_dsym_uuids(dsym_path: &PathBuf) -> Result<Vec<(String, String)>> {
 }
 
 /// Create a minimal ZIP containing a single DWARF binary and optional source files.
+///
+/// If the DWARF binary is a fat (universal) Mach-O, only the slice for `arch`
+/// is included. This ensures the content hash is stable for a given architecture
+/// even when a sibling architecture is rebuilt with new object files.
+///
 /// The ZIP layout is:
-///   dwarf                    — the raw DWARF Mach-O binary
+///   dwarf                    — the raw DWARF Mach-O binary (single-arch)
 ///   __source/manifest.json   — (optional) source file manifest
 ///   __source/...             — (optional) source files
-fn zip_dwarf_binary(dwarf_path: &Path, include_source: bool) -> Result<Vec<u8>> {
-    use std::fs::File;
-    use std::io::Read;
+fn zip_dwarf_binary(dwarf_path: &Path, arch: &str, include_source: bool) -> Result<Vec<u8>> {
     use std::io::{Cursor, Write};
     use tracing::info;
 
@@ -154,11 +172,11 @@ fn zip_dwarf_binary(dwarf_path: &Path, include_source: bool) -> Result<Vec<u8>> 
         let options = zip::write::SimpleFileOptions::default()
             .compression_method(zip::CompressionMethod::Deflated);
 
-        // Add the DWARF binary as "dwarf"
+        // Add the DWARF binary as "dwarf".
+        // If the file is a fat binary, thin it to only this arch first so that
+        // a rebuild of a sibling slice does not change this UUID's content hash.
         zip.start_file("dwarf", options)?;
-        let mut file = File::open(dwarf_path)?;
-        let mut contents = Vec::new();
-        file.read_to_end(&mut contents)?;
+        let contents = thin_if_fat(dwarf_path, arch)?;
         zip.write_all(&contents)?;
 
         // Optionally include source files referenced by this DWARF binary
@@ -198,6 +216,80 @@ fn zip_dwarf_binary(dwarf_path: &Path, include_source: bool) -> Result<Vec<u8>> 
     let zip_data = buffer.into_inner();
     let wrapped = write_symbol_data(AppleDsym { data: zip_data })?;
     Ok(wrapped)
+}
+
+/// Return the bytes for the given architecture slice of `path`.
+///
+/// If the file is a fat (universal) binary, runs `lipo -thin <arch>` to extract
+/// only the relevant slice. If it is already a thin binary (single-arch), the
+/// file is read as-is. Using only the relevant slice means the content hash for
+/// a stable architecture does not change when a sibling architecture is rebuilt.
+fn thin_if_fat(path: &Path, arch: &str) -> Result<Vec<u8>> {
+    use std::process::Command;
+
+    // Fat Mach-O magic numbers (big-endian and little-endian fat headers)
+    const FAT_MAGIC: u32 = 0xCAFE_BABE;
+    const FAT_MAGIC_64: u32 = 0xCAFE_BABF;
+    const FAT_CIGAM: u32 = 0xBEBA_FECA; // byte-swapped FAT_MAGIC
+
+    let raw = std::fs::read(path)
+        .map_err(|e| anyhow!("Failed to read DWARF binary {}: {e}", path.display()))?;
+
+    if raw.len() < 4 {
+        return Ok(raw);
+    }
+
+    let magic = u32::from_be_bytes([raw[0], raw[1], raw[2], raw[3]]);
+    let is_fat = magic == FAT_MAGIC || magic == FAT_MAGIC_64 || magic == FAT_CIGAM;
+
+    if !is_fat {
+        // Already a thin (single-arch) binary — use it directly.
+        tracing::info!("[lipo] {} is already a thin binary, using as-is", path.display());
+        return Ok(raw);
+    }
+
+    tracing::info!(
+        "[lipo] fat binary detected at {}, thinning to {} slice ({} bytes total)",
+        path.display(), arch, raw.len()
+    );
+
+    // Run `lipo -thin <arch>` to extract just this architecture.
+    let tmp_path = std::env::temp_dir().join(format!("posthog_lipo_{arch}_{pid}",
+        arch = arch,
+        pid = std::process::id()));
+
+    let status = Command::new("lipo")
+        .args([
+            path.to_str()
+                .ok_or_else(|| anyhow!("Non-UTF8 path: {}", path.display()))?,
+            "-thin",
+            arch,
+            "-output",
+            tmp_path
+                .to_str()
+                .ok_or_else(|| anyhow!("Non-UTF8 temp path"))?,
+        ])
+        .status()
+        .map_err(|e| anyhow!("Failed to run lipo: {e}. Is Xcode installed?"))?;
+
+    if !status.success() {
+        // lipo failed (e.g. arch not present) — fall back to full binary.
+        tracing::warn!(
+            "[lipo] lipo -thin {arch} failed for {}; falling back to full fat binary",
+            path.display()
+        );
+        return Ok(raw);
+    }
+
+    let thinned = std::fs::read(&tmp_path)
+        .map_err(|e| anyhow!("Failed to read lipo output: {e}"))?;
+    let _ = std::fs::remove_file(&tmp_path);
+    tracing::info!(
+        "[lipo] thinned {} ({} arch) to {} bytes (was {} bytes)",
+        path.file_name().unwrap_or_default().to_string_lossy(),
+        arch, thinned.len(), raw.len()
+    );
+    Ok(thinned)
 }
 
 /// Find all dSYM bundles in a directory

--- a/cli/src/dsym/mod.rs
+++ b/cli/src/dsym/mod.rs
@@ -18,8 +18,6 @@ pub enum DsymSubcommand {
 struct DsymEntry {
     /// The UUID of this DWARF binary (used as chunk_id)
     uuid: String,
-    /// Architecture name as reported by dwarfdump (e.g. "arm64", "x86_64")
-    arch: String,
     /// ZIP containing only this DWARF binary (+ optional source files)
     data: Vec<u8>,
 }
@@ -62,7 +60,6 @@ impl DsymFile {
             let data = zip_dwarf_binary(&dwarf_path, arch, include_source)?;
             entries.push(DsymEntry {
                 uuid: uuid.clone(),
-                arch: arch.clone(),
                 data,
             });
         }

--- a/cli/src/dsym/mod.rs
+++ b/cli/src/dsym/mod.rs
@@ -77,10 +77,6 @@ impl DsymFile {
         self.entries.iter().map(|e| e.uuid.as_str()).collect()
     }
 
-    pub fn arches(&self) -> Vec<&str> {
-        self.entries.iter().map(|e| e.arch.as_str()).collect()
-    }
-
     pub fn total_size(&self) -> usize {
         self.entries.iter().map(|e| e.data.len()).sum()
     }
@@ -259,11 +255,15 @@ fn thin_if_fat(path: &Path, arch: &str) -> Result<Vec<u8>> {
     );
 
     // Run `lipo -thin <arch>` to extract just this architecture.
-    let tmp_path = std::env::temp_dir().join(format!(
-        "posthog_lipo_{arch}_{pid}",
-        arch = arch,
-        pid = std::process::id()
-    ));
+    // `NamedTempFile` creates the file securely (random suffix, mode 0600) and
+    // automatically deletes it when dropped — covering both success and all
+    // early-return error paths without manual cleanup.
+    let tmp_file = tempfile::Builder::new()
+        .prefix(&format!("posthog_lipo_{arch}_"))
+        .suffix(".dwarf")
+        .tempfile()
+        .map_err(|e| anyhow!("Failed to create temp file for lipo output: {e}"))?;
+    let tmp_path = tmp_file.path().to_path_buf();
 
     let status = Command::new("lipo")
         .args([
@@ -281,6 +281,7 @@ fn thin_if_fat(path: &Path, arch: &str) -> Result<Vec<u8>> {
 
     if !status.success() {
         // lipo failed (e.g. arch not present) — fall back to full binary.
+        // tmp_file is dropped here, deleting the (possibly partial) output.
         tracing::warn!(
             "[lipo] lipo -thin {arch} failed for {}; falling back to full fat binary",
             path.display()
@@ -288,9 +289,9 @@ fn thin_if_fat(path: &Path, arch: &str) -> Result<Vec<u8>> {
         return Ok(raw);
     }
 
+    // Read the thinned slice. tmp_file is dropped at end of scope, cleaning up.
     let thinned =
         std::fs::read(&tmp_path).map_err(|e| anyhow!("Failed to read lipo output: {e}"))?;
-    let _ = std::fs::remove_file(&tmp_path);
     tracing::info!(
         "[lipo] thinned {} ({} arch) to {} bytes (was {} bytes)",
         path.file_name().unwrap_or_default().to_string_lossy(),

--- a/cli/src/dsym/mod.rs
+++ b/cli/src/dsym/mod.rs
@@ -244,19 +244,26 @@ fn thin_if_fat(path: &Path, arch: &str) -> Result<Vec<u8>> {
 
     if !is_fat {
         // Already a thin (single-arch) binary — use it directly.
-        tracing::info!("[lipo] {} is already a thin binary, using as-is", path.display());
+        tracing::info!(
+            "[lipo] {} is already a thin binary, using as-is",
+            path.display()
+        );
         return Ok(raw);
     }
 
     tracing::info!(
         "[lipo] fat binary detected at {}, thinning to {} slice ({} bytes total)",
-        path.display(), arch, raw.len()
+        path.display(),
+        arch,
+        raw.len()
     );
 
     // Run `lipo -thin <arch>` to extract just this architecture.
-    let tmp_path = std::env::temp_dir().join(format!("posthog_lipo_{arch}_{pid}",
+    let tmp_path = std::env::temp_dir().join(format!(
+        "posthog_lipo_{arch}_{pid}",
         arch = arch,
-        pid = std::process::id()));
+        pid = std::process::id()
+    ));
 
     let status = Command::new("lipo")
         .args([
@@ -281,13 +288,15 @@ fn thin_if_fat(path: &Path, arch: &str) -> Result<Vec<u8>> {
         return Ok(raw);
     }
 
-    let thinned = std::fs::read(&tmp_path)
-        .map_err(|e| anyhow!("Failed to read lipo output: {e}"))?;
+    let thinned =
+        std::fs::read(&tmp_path).map_err(|e| anyhow!("Failed to read lipo output: {e}"))?;
     let _ = std::fs::remove_file(&tmp_path);
     tracing::info!(
         "[lipo] thinned {} ({} arch) to {} bytes (was {} bytes)",
         path.file_name().unwrap_or_default().to_string_lossy(),
-        arch, thinned.len(), raw.len()
+        arch,
+        thinned.len(),
+        raw.len()
     );
     Ok(thinned)
 }

--- a/cli/src/dsym/source_bundle.rs
+++ b/cli/src/dsym/source_bundle.rs
@@ -5,7 +5,8 @@ use std::path::Path;
 
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
-use symbolic::debuginfo::Archive;
+use symbolic::debuginfo::dwarf::{gimli, Dwarf as DwarfObject};
+use symbolic::debuginfo::{Archive, Object};
 use tracing::{info, warn};
 
 /// Manifest format stored as `__source/manifest.json` inside the dSYM ZIP
@@ -23,7 +24,14 @@ pub struct SourceFiles {
     pub contents: BTreeMap<String, Vec<u8>>,
 }
 
-/// Extract all source file paths referenced in a DWARF binary file.
+/// Extract source file paths from a DWARF binary using only compilation-unit
+/// main files (`DW_AT_comp_dir` + `DW_AT_name` on each `DW_TAG_compile_unit`).
+///
+/// This intentionally excludes the full DWARF line-number file table, which also
+/// contains files from *other* modules referenced via `DW_AT_decl_file` on type
+/// declarations.  Including those would cause the source-bundle hash to change
+/// whenever a dependency's source changes — even when this binary's UUID is
+/// identical — triggering spurious `content_hash_mismatch` rejections.
 pub fn extract_source_paths_from_dwarf(dwarf_path: &Path) -> Result<Vec<String>> {
     let dwarf_data = fs::read(dwarf_path)?;
     let archive = Archive::parse(&dwarf_data)?;
@@ -32,13 +40,12 @@ pub fn extract_source_paths_from_dwarf(dwarf_path: &Path) -> Result<Vec<String>>
 
     for obj in archive.objects() {
         let obj = obj?;
-        let session = obj.debug_session()?;
-        for file in session.files() {
-            let file = file?;
-            let abs_path = file.abs_path_str();
-            if !abs_path.is_empty() {
-                paths.push(abs_path);
-            }
+        // collect_cu_source_paths requires the concrete Dwarf implementor; the
+        // Object enum itself does not implement the trait.
+        match &obj {
+            Object::MachO(m) => collect_cu_source_paths(m, &mut paths),
+            Object::Elf(e) => collect_cu_source_paths(e, &mut paths),
+            _ => {} // Other formats not relevant for iOS / Android
         }
     }
 
@@ -47,10 +54,127 @@ pub fn extract_source_paths_from_dwarf(dwarf_path: &Path) -> Result<Vec<String>>
     paths.dedup();
 
     for p in &paths {
-        tracing::debug!("DWARF source path: {}", p);
+        tracing::debug!("DWARF source path (CU main file): {}", p);
     }
 
     Ok(paths)
+}
+
+/// Walk `debug_info` with gimli and collect the main source file of each
+/// compilation unit (the `DW_AT_comp_dir + DW_AT_name` pair on the CU DIE).
+/// This does NOT read the line-number program's file table, so cross-module
+/// file references that appear there are never included.
+fn collect_cu_source_paths<'d>(obj: &impl DwarfObject<'d>, out: &mut Vec<String>) {
+    // Load the minimal DWARF sections we need: debug_info, debug_abbrev, debug_str,
+    // and debug_line_str (DWARF v5 string section).
+    let empty: &[u8] = &[];
+
+    let info_data = obj
+        .section("debug_info")
+        .map(|s| s.data.into_owned())
+        .unwrap_or_default();
+    let abbrev_data = obj
+        .section("debug_abbrev")
+        .map(|s| s.data.into_owned())
+        .unwrap_or_default();
+    let str_data = obj
+        .section("debug_str")
+        .map(|s| s.data.into_owned())
+        .unwrap_or_default();
+    let line_str_data = obj
+        .section("debug_line_str")
+        .map(|s| s.data.into_owned())
+        .unwrap_or_default();
+
+    let endian = if matches!(obj.endianity(), symbolic::debuginfo::dwarf::Endian::Big) {
+        gimli::RunTimeEndian::Big
+    } else {
+        gimli::RunTimeEndian::Little
+    };
+
+    let dwarf = gimli::Dwarf {
+        debug_info: gimli::DebugInfo::new(&info_data, endian),
+        debug_abbrev: gimli::DebugAbbrev::new(&abbrev_data, endian),
+        debug_str: gimli::DebugStr::new(&str_data, endian),
+        debug_line_str: gimli::DebugLineStr::new(&line_str_data, endian),
+        // Sections not needed for CU-name extraction:
+        debug_addr: gimli::DebugAddr::from(gimli::EndianSlice::new(empty, endian)),
+        debug_aranges: gimli::DebugAranges::new(empty, endian),
+        debug_line: gimli::DebugLine::new(empty, endian),
+        debug_str_offsets: gimli::DebugStrOffsets::from(gimli::EndianSlice::new(empty, endian)),
+        debug_types: Default::default(),
+        debug_macinfo: gimli::DebugMacinfo::new(empty, endian),
+        debug_macro: gimli::DebugMacro::new(empty, endian),
+        locations: Default::default(),
+        ranges: gimli::RangeLists::new(
+            gimli::DebugRanges::new(empty, endian),
+            gimli::DebugRngLists::new(empty, endian),
+        ),
+        file_type: gimli::DwarfFileType::Main,
+        abbreviations_cache: Default::default(),
+        sup: None,
+    };
+
+    let mut cu_count = 0u32;
+    let mut iter = dwarf.units();
+    loop {
+        let header = match iter.next() {
+            Ok(Some(h)) => h,
+            Ok(None) => break,
+            Err(e) => { tracing::debug!("units().next() error: {:?}", e); break; },
+        };
+        cu_count += 1;
+
+        // Obtain abbreviation table for this CU.
+        let abbrevs = match dwarf.abbreviations(&header) {
+            Ok(a) => a,
+            Err(e) => { tracing::debug!("CU {}: abbreviations() error: {:?}", cu_count, e); continue; }
+        };
+
+        // Parse the root DIE WITHOUT calling dwarf.unit() — that helper also
+        // tries to load the line program, which would fail because we omitted
+        // debug_line from our minimal Dwarf instance.
+        let mut cursor = header.entries(&abbrevs);
+        let (_, root) = match cursor.next_dfs() {
+            Ok(Some(e)) => e,
+            _ => continue,
+        };
+        if root.tag() != gimli::DW_TAG_compile_unit {
+            continue;
+        }
+
+        // Resolve an attribute value to a UTF-8 string from debug_str / inline data.
+        let resolve_str = |val: gimli::AttributeValue<gimli::EndianSlice<'_, gimli::RunTimeEndian>>| -> Option<String> {
+            match val {
+                gimli::AttributeValue::String(s) =>
+                    std::str::from_utf8(s.slice()).ok().map(|s| s.to_string()),
+                gimli::AttributeValue::DebugStrRef(offset) =>
+                    dwarf.debug_str.get_str(offset).ok()
+                        .and_then(|s| std::str::from_utf8(s.slice()).ok().map(|s| s.to_string())),
+                gimli::AttributeValue::DebugLineStrRef(offset) =>
+                    dwarf.debug_line_str.get_str(offset).ok()
+                        .and_then(|s| std::str::from_utf8(s.slice()).ok().map(|s| s.to_string())),
+                _ => None,
+            }
+        };
+
+        let comp_dir: Option<String> = root.attr_value(gimli::DW_AT_comp_dir).ok().flatten()
+            .and_then(&resolve_str);
+        let name: Option<String> = root.attr_value(gimli::DW_AT_name).ok().flatten()
+            .and_then(&resolve_str);
+
+        let path = match (comp_dir, name) {
+            (Some(dir), Some(name)) if !name.starts_with('/') =>
+                format!("{}/{}", dir.trim_end_matches('/'), name),
+            (_, Some(name)) if name.starts_with('/') => name,
+            (Some(dir), None) => dir,
+            _ => continue,
+        };
+
+        if !path.is_empty() {
+            out.push(path);
+        }
+    }
 }
 
 /// System/SDK path prefixes to exclude from source bundling
@@ -70,6 +194,30 @@ const EXCLUDED_SUBSTRINGS: &[&str] = &[
     "/DerivedData/",
 ];
 
+/// Short (root-level) names produced by Apple's Clang/Swift linker as synthetic
+/// DWARF compile-unit names for system frameworks. These are not real file paths
+/// and can never be read from disk.
+const EXCLUDED_SYNTHETIC_NAMES: &[&str] = &[
+    "/_AvailabilityInternal",
+    "/_Builtin_",
+    "/_DarwinFoundation",
+    "/CFNetwork",
+    "/CoreFoundation",
+    "/Darwin",
+    "/Dispatch",
+    "/Foundation",
+    "/MachO",
+    "/ObjectiveC",
+    "/Security",
+    "/XPC",
+    "/asl",
+    "/os_",
+    "/ptrcheck",
+    "/ptrauth",
+    "<stdin>",
+    "<swift-imported-modules>",
+];
+
 /// Filter out system framework and SDK paths, keeping only user source files.
 pub fn filter_source_paths(paths: &[String]) -> Vec<&str> {
     paths
@@ -86,6 +234,15 @@ pub fn filter_source_paths(paths: &[String]) -> Vec<&str> {
             // Exclude paths containing system substrings
             if EXCLUDED_SUBSTRINGS.iter().any(|sub| path.contains(sub)) {
                 tracing::debug!("Filtered out (substring): {}", path);
+                return false;
+            }
+            // Exclude synthetic short names that Apple's linker emits as
+            // placeholder compile-unit names for system frameworks.
+            if EXCLUDED_SYNTHETIC_NAMES
+                .iter()
+                .any(|s| path.starts_with(s))
+            {
+                tracing::debug!("Filtered out (synthetic): {}", path);
                 return false;
             }
             true

--- a/cli/src/dsym/source_bundle.rs
+++ b/cli/src/dsym/source_bundle.rs
@@ -121,14 +121,20 @@ fn collect_cu_source_paths<'d>(obj: &impl DwarfObject<'d>, out: &mut Vec<String>
         let header = match iter.next() {
             Ok(Some(h)) => h,
             Ok(None) => break,
-            Err(e) => { tracing::debug!("units().next() error: {:?}", e); break; },
+            Err(e) => {
+                tracing::debug!("units().next() error: {:?}", e);
+                break;
+            }
         };
         cu_count += 1;
 
         // Obtain abbreviation table for this CU.
         let abbrevs = match dwarf.abbreviations(&header) {
             Ok(a) => a,
-            Err(e) => { tracing::debug!("CU {}: abbreviations() error: {:?}", cu_count, e); continue; }
+            Err(e) => {
+                tracing::debug!("CU {}: abbreviations() error: {:?}", cu_count, e);
+                continue;
+            }
         };
 
         // Parse the root DIE WITHOUT calling dwarf.unit() — that helper also
@@ -144,28 +150,43 @@ fn collect_cu_source_paths<'d>(obj: &impl DwarfObject<'d>, out: &mut Vec<String>
         }
 
         // Resolve an attribute value to a UTF-8 string from debug_str / inline data.
-        let resolve_str = |val: gimli::AttributeValue<gimli::EndianSlice<'_, gimli::RunTimeEndian>>| -> Option<String> {
+        let resolve_str = |val: gimli::AttributeValue<
+            gimli::EndianSlice<'_, gimli::RunTimeEndian>,
+        >|
+         -> Option<String> {
             match val {
-                gimli::AttributeValue::String(s) =>
-                    std::str::from_utf8(s.slice()).ok().map(|s| s.to_string()),
-                gimli::AttributeValue::DebugStrRef(offset) =>
-                    dwarf.debug_str.get_str(offset).ok()
-                        .and_then(|s| std::str::from_utf8(s.slice()).ok().map(|s| s.to_string())),
-                gimli::AttributeValue::DebugLineStrRef(offset) =>
-                    dwarf.debug_line_str.get_str(offset).ok()
-                        .and_then(|s| std::str::from_utf8(s.slice()).ok().map(|s| s.to_string())),
+                gimli::AttributeValue::String(s) => {
+                    std::str::from_utf8(s.slice()).ok().map(|s| s.to_string())
+                }
+                gimli::AttributeValue::DebugStrRef(offset) => dwarf
+                    .debug_str
+                    .get_str(offset)
+                    .ok()
+                    .and_then(|s| std::str::from_utf8(s.slice()).ok().map(|s| s.to_string())),
+                gimli::AttributeValue::DebugLineStrRef(offset) => dwarf
+                    .debug_line_str
+                    .get_str(offset)
+                    .ok()
+                    .and_then(|s| std::str::from_utf8(s.slice()).ok().map(|s| s.to_string())),
                 _ => None,
             }
         };
 
-        let comp_dir: Option<String> = root.attr_value(gimli::DW_AT_comp_dir).ok().flatten()
+        let comp_dir: Option<String> = root
+            .attr_value(gimli::DW_AT_comp_dir)
+            .ok()
+            .flatten()
             .and_then(&resolve_str);
-        let name: Option<String> = root.attr_value(gimli::DW_AT_name).ok().flatten()
+        let name: Option<String> = root
+            .attr_value(gimli::DW_AT_name)
+            .ok()
+            .flatten()
             .and_then(&resolve_str);
 
         let path = match (comp_dir, name) {
-            (Some(dir), Some(name)) if !name.starts_with('/') =>
-                format!("{}/{}", dir.trim_end_matches('/'), name),
+            (Some(dir), Some(name)) if !name.starts_with('/') => {
+                format!("{}/{}", dir.trim_end_matches('/'), name)
+            }
             (_, Some(name)) if name.starts_with('/') => name,
             (Some(dir), None) => dir,
             _ => continue,
@@ -238,10 +259,7 @@ pub fn filter_source_paths(paths: &[String]) -> Vec<&str> {
             }
             // Exclude synthetic short names that Apple's linker emits as
             // placeholder compile-unit names for system frameworks.
-            if EXCLUDED_SYNTHETIC_NAMES
-                .iter()
-                .any(|s| path.starts_with(s))
-            {
+            if EXCLUDED_SYNTHETIC_NAMES.iter().any(|s| path.starts_with(s)) {
                 tracing::debug!("Filtered out (synthetic): {}", path);
                 return false;
             }


### PR DESCRIPTION
## What

Fixes spurious `content_hash_mismatch` errors that block dSYM re-uploads when the same UUID is encountered after a partial rebuild.

## Why

Two separate root causes were found:

1. **Fat binary hash instability** — the old code zipped the entire fat (universal) Mach-O for every UUID it contained. When only one architecture slice was rebuilt (getting a new UUID), the fat container changed, causing the *sibling* architecture's content hash to change even though its slice was byte-for-byte identical. A second upload of the same app would then fail with `content_hash_mismatch`.

2. **Cross-module source file contamination** — source-path extraction used `symbolic`'s `session.files()`, which iterates the DWARF line-number program file table. That table includes every file referenced via `DW_AT_decl_file` on type and variable declarations — including source files from *imported* frameworks. When a dependency (e.g. `PostHog.framework`) was updated, its source files changed on disk, causing the app's source bundle ZIP to differ even though the app's UUID was identical.

## How

**Fix 1 — thin fat binaries per architecture (`mod.rs`)**

- `extract_dsym_uuids()` now returns `(uuid, arch, filename)` triples (previously pairs).
- `zip_dwarf_binary()` accepts an `arch` parameter and calls the new `thin_if_fat()` helper before zipping.
- `thin_if_fat()` detects fat Mach-O magic bytes (`0xCAFEBABE` / `0xCAFEBABF` / `0xBEBAFECA`), runs `lipo -thin <arch>` to a temp file, reads the result, and cleans up. Falls back to the full binary if `lipo` fails.
- Each UUID's ZIP now contains only its own architecture slice, so the content hash for a stable slice is independent of sibling slice changes.

**Fix 2 — use CU main files only for source bundling (`source_bundle.rs`)**

- New `collect_cu_source_paths()` uses `gimli` directly to read only `DW_AT_comp_dir` + `DW_AT_name` from each `DW_TAG_compile_unit` DIE — the actual files compiled into this binary. Cross-module type-declaration references from the line-number file table are never included.
- The root DIE is parsed without calling `gimli::Dwarf::unit()` (which also tries to load the line program and would fail on our minimal `Dwarf` instance with an empty `debug_line` section).
- Adds `EXCLUDED_SYNTHETIC_NAMES` for short root-level paths emitted by Apple's linker as synthetic CU names (`/MachO`, `/asl`, `<swift-imported-modules>`, etc.) to suppress no-such-file warnings.

**Verified behaviour**

- First upload: all 4 UUIDs uploaded successfully.
- Second upload (same binaries, same sources): all 4 skipped as *already present* — no `content_hash_mismatch`.
- After rebuilding `PostHog.framework` (new UUIDs): 2 new framework UUIDs uploaded, 2 unchanged app UUIDs skipped — no error.