### PR TITLE
feat(cloud-agent): user-authored PRs

### DIFF
--- a/products/tasks/backend/api.py
+++ b/products/tasks/backend/api.py
@@ -63,7 +63,7 @@ from .serializers import (
 from .services.connection_token import create_sandbox_connection_token
 from .stream.redis_stream import TaskRunRedisStream, TaskRunStreamError, get_task_run_stream_key
 from .temporal.client import execute_posthog_code_agent_relay_workflow, execute_task_processing_workflow
-from .temporal.process_task.utils import PR_AUTHORSHIP_MODE_USER, cache_github_user_token
+from .temporal.process_task.utils import PrAuthorshipMode, cache_github_user_token, parse_run_state
 
 logger = logging.getLogger(__name__)
 
@@ -264,27 +264,23 @@ class TaskViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
                 return Response({"detail": "Invalid resume_from_run_id"}, status=400)
 
             # Derive snapshot_external_id from the validated previous run
-            snapshot_ext_id = (previous_run.state or {}).get("snapshot_external_id")
+            prev_state = parse_run_state(previous_run.state)
             extra_state = extra_state or {}
             extra_state["resume_from_run_id"] = str(resume_from_run_id)
-            if snapshot_ext_id:
-                extra_state["snapshot_external_id"] = snapshot_ext_id
+            if prev_state.snapshot_external_id:
+                extra_state["snapshot_external_id"] = prev_state.snapshot_external_id
 
-            prev_sandbox_env_id = (previous_run.state or {}).get("sandbox_environment_id")
-            if prev_sandbox_env_id and sandbox_environment_id is None:
-                sandbox_environment_id = prev_sandbox_env_id
+            if prev_state.sandbox_environment_id and sandbox_environment_id is None:
+                sandbox_environment_id = prev_state.sandbox_environment_id
 
-            previous_state = previous_run.state or {}
             if pr_authorship_mode is None:
-                pr_authorship_mode = previous_state.get("pr_authorship_mode")
+                pr_authorship_mode = prev_state.pr_authorship_mode
             if run_source is None:
-                run_source = previous_state.get("run_source")
+                run_source = prev_state.run_source
             if signal_report_id is None:
-                signal_report_id = previous_state.get("signal_report_id")
-            if branch is None:
-                previous_base_branch = previous_state.get("pr_base_branch")
-                if isinstance(previous_base_branch, str):
-                    branch = previous_base_branch
+                signal_report_id = prev_state.signal_report_id
+            if branch is None and prev_state.pr_base_branch is not None:
+                branch = prev_state.pr_base_branch
 
         for key, value in {
             "pr_base_branch": branch,
@@ -297,7 +293,7 @@ class TaskViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
                 extra_state[key] = value
 
         # Only require a user token when the task has a repo (no-repo cloud runs skip GitHub operations)
-        if pr_authorship_mode == PR_AUTHORSHIP_MODE_USER and task.repository and not github_user_token:
+        if pr_authorship_mode == PrAuthorshipMode.USER and task.repository and not github_user_token:
             return Response({"detail": "github_user_token is required for user-authored cloud runs"}, status=400)
 
         if sandbox_environment_id is not None:
@@ -322,7 +318,7 @@ class TaskViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
 
         task_run = task.create_run(mode=mode, branch=branch, extra_state=extra_state)
 
-        if github_user_token and pr_authorship_mode == PR_AUTHORSHIP_MODE_USER:
+        if github_user_token and pr_authorship_mode == PrAuthorshipMode.USER:
             cache_github_user_token(str(task_run.id), github_user_token)
 
         logger.info(f"Triggering workflow for task {task.id}, run {task_run.id}")
@@ -862,16 +858,15 @@ class TaskRunViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
     )
     def command(self, request, pk=None, **kwargs):
         task_run = cast(TaskRun, self.get_object())
-        state = task_run.state or {}
+        run_state = parse_run_state(task_run.state)
 
-        sandbox_url = state.get("sandbox_url")
-        if not sandbox_url:
+        if not run_state.sandbox_url:
             return Response(
                 ErrorResponseSerializer({"error": "No active sandbox for this task run"}).data,
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
-        if not self._is_valid_sandbox_url(sandbox_url):
+        if not self._is_valid_sandbox_url(run_state.sandbox_url):
             logger.warning(f"Blocked request to disallowed sandbox URL for task run {task_run.id}")
             return Response(
                 ErrorResponseSerializer({"error": "Invalid sandbox URL"}).data,
@@ -884,8 +879,6 @@ class TaskRunViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
             distinct_id=request.user.distinct_id,
         )
 
-        sandbox_connect_token = state.get("sandbox_connect_token")
-
         command_payload: dict = {
             "jsonrpc": request.validated_data["jsonrpc"],
             "method": request.validated_data["method"],
@@ -897,9 +890,9 @@ class TaskRunViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
 
         try:
             agent_response = self._proxy_command_to_agent_server(
-                sandbox_url=sandbox_url,
+                sandbox_url=run_state.sandbox_url,
                 connection_token=connection_token,
-                sandbox_connect_token=sandbox_connect_token,
+                sandbox_connect_token=run_state.sandbox_connect_token,
                 payload=command_payload,
             )
 

--- a/products/tasks/backend/api.py
+++ b/products/tasks/backend/api.py
@@ -63,6 +63,7 @@ from .serializers import (
 from .services.connection_token import create_sandbox_connection_token
 from .stream.redis_stream import TaskRunRedisStream, TaskRunStreamError, get_task_run_stream_key
 from .temporal.client import execute_posthog_code_agent_relay_workflow, execute_task_processing_workflow
+from .temporal.process_task.utils import PR_AUTHORSHIP_MODE_USER, cache_github_user_token
 
 logger = logging.getLogger(__name__)
 
@@ -247,6 +248,10 @@ class TaskViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         resume_from_run_id = request.validated_data.get("resume_from_run_id")
         pending_user_message = request.validated_data.get("pending_user_message")
         sandbox_environment_id = request.validated_data.get("sandbox_environment_id")
+        pr_authorship_mode = request.validated_data.get("pr_authorship_mode")
+        run_source = request.validated_data.get("run_source")
+        signal_report_id = request.validated_data.get("signal_report_id")
+        github_user_token = request.validated_data.get("github_user_token")
 
         extra_state = None
         if pending_user_message is not None:
@@ -269,6 +274,32 @@ class TaskViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
             if prev_sandbox_env_id and sandbox_environment_id is None:
                 sandbox_environment_id = prev_sandbox_env_id
 
+            previous_state = previous_run.state or {}
+            if pr_authorship_mode is None:
+                pr_authorship_mode = previous_state.get("pr_authorship_mode")
+            if run_source is None:
+                run_source = previous_state.get("run_source")
+            if signal_report_id is None:
+                signal_report_id = previous_state.get("signal_report_id")
+            if branch is None:
+                previous_base_branch = previous_state.get("pr_base_branch")
+                if isinstance(previous_base_branch, str):
+                    branch = previous_base_branch
+
+        for key, value in {
+            "pr_base_branch": branch,
+            "pr_authorship_mode": pr_authorship_mode,
+            "run_source": run_source,
+            "signal_report_id": signal_report_id,
+        }.items():
+            if value is not None:
+                extra_state = extra_state or {}
+                extra_state[key] = value
+
+        # Only require a user token when the task has a repo (no-repo cloud runs skip GitHub operations)
+        if pr_authorship_mode == PR_AUTHORSHIP_MODE_USER and task.repository and not github_user_token:
+            return Response({"detail": "github_user_token is required for user-authored cloud runs"}, status=400)
+
         if sandbox_environment_id is not None:
             sandbox_environment = SandboxEnvironment.objects.filter(id=sandbox_environment_id, team=task.team).first()
             if not sandbox_environment:
@@ -290,6 +321,9 @@ class TaskViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         logger.info(f"Creating task run for task {task.id} with mode={mode}, branch={branch}")
 
         task_run = task.create_run(mode=mode, branch=branch, extra_state=extra_state)
+
+        if github_user_token and pr_authorship_mode == PR_AUTHORSHIP_MODE_USER:
+            cache_github_user_token(str(task_run.id), github_user_token)
 
         logger.info(f"Triggering workflow for task {task.id}, run {task_run.id}")
 
@@ -379,34 +413,50 @@ class TaskRunViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
     )
     def partial_update(self, request, *args, **kwargs):
         task_run = cast(TaskRun, self.get_object())
-        old_status = task_run.status
+        has_output_merge = "output" in request.validated_data and isinstance(request.validated_data["output"], dict)
 
-        # Update fields from validated data
-        for key, value in request.validated_data.items():
-            setattr(task_run, key, value)
+        with transaction.atomic():
+            # Re-fetch with row lock when merging output to prevent concurrent
+            # PATCHes (e.g. branch sync + PR URL) from clobbering each other.
+            if has_output_merge:
+                task_run = TaskRun.objects.select_for_update().get(pk=task_run.pk)
 
-        new_status = request.validated_data.get("status")
-        terminal_statuses = [
-            TaskRun.Status.COMPLETED,
-            TaskRun.Status.FAILED,
-            TaskRun.Status.CANCELLED,
-        ]
+            old_status = task_run.status
+            old_pr_url = (task_run.output or {}).get("pr_url") if isinstance(task_run.output, dict) else None
 
-        # Auto-set completed_at if status is completed or failed
-        if new_status in terminal_statuses:
-            if not task_run.completed_at:
-                task_run.completed_at = timezone.now()
+            # Update fields from validated data
+            for key, value in request.validated_data.items():
+                if key == "output" and isinstance(value, dict):
+                    existing_output = task_run.output if isinstance(task_run.output, dict) else {}
+                    setattr(task_run, key, {**existing_output, **value})
+                    continue
+                setattr(task_run, key, value)
 
-            # Signal Temporal workflow if status changed to terminal state
-            if old_status != new_status:
-                self._signal_workflow_completion(
-                    task_run,
-                    new_status,
-                    request.validated_data.get("error_message"),
-                )
+            new_status = request.validated_data.get("status")
+            terminal_statuses = [
+                TaskRun.Status.COMPLETED,
+                TaskRun.Status.FAILED,
+                TaskRun.Status.CANCELLED,
+            ]
 
-        task_run.save()
-        self._post_slack_update_for_pr(task_run)
+            # Auto-set completed_at if status is completed or failed
+            if new_status in terminal_statuses:
+                if not task_run.completed_at:
+                    task_run.completed_at = timezone.now()
+
+            task_run.save()
+
+        # Signal Temporal and post Slack updates after commit to avoid
+        # holding the row lock during external calls.
+        if new_status in terminal_statuses and old_status != new_status:
+            self._signal_workflow_completion(
+                task_run,
+                new_status,
+                request.validated_data.get("error_message"),
+            )
+        new_pr_url = (task_run.output or {}).get("pr_url") if isinstance(task_run.output, dict) else None
+        if new_pr_url and new_pr_url != old_pr_url:
+            self._post_slack_update_for_pr(task_run)
 
         return Response(TaskRunDetailSerializer(task_run, context=self.get_serializer_context()).data)
 

--- a/products/tasks/backend/sandbox/images/Dockerfile.sandbox-base
+++ b/products/tasks/backend/sandbox/images/Dockerfile.sandbox-base
@@ -101,9 +101,11 @@ RUN chmod +x /tmp/install-skills.sh && \
     /tmp/install-skills.sh /tmp/skills && \
     rm -rf /tmp/install-skills.sh /tmp/skills
 
-# Configure git for commits - TODO: Use user's email and name
-RUN git config --global user.email "array@posthog.com" && \
-    git config --global user.name "Array"
+# Default git identity for bot-authored commits.
+# Runs configured for user-authored pull requests receive
+# GIT_AUTHOR_*/GIT_COMMITTER_* env vars that override these defaults.
+RUN git config --global user.email "code@posthog.com" && \
+    git config --global user.name "PostHog Code"
 
 # This is required for the Claude Code SDK to allow --dangerously-skip-permissions as the root user
 ENV IS_SANDBOX=1

--- a/products/tasks/backend/sandbox/images/Dockerfile.sandbox-notebook
+++ b/products/tasks/backend/sandbox/images/Dockerfile.sandbox-notebook
@@ -82,9 +82,11 @@ RUN cd /scripts && \
     -o runAgent.mjs && \
     chmod +x runAgent.mjs
 
-# Configure git for commits - TODO: Use user's email and name
-RUN git config --global user.email "array@posthog.com" && \
-    git config --global user.name "Array"
+# Default git identity for bot-authored commits.
+# Runs configured for user-authored pull requests receive
+# GIT_AUTHOR_*/GIT_COMMITTER_* env vars that override these defaults.
+RUN git config --global user.email "code@posthog.com" && \
+    git config --global user.name "PostHog Code"
 
 # This is required for the Claude Code SDK to allow --dangerously-skip-permissions as the root user
 ENV IS_SANDBOX=1

--- a/products/tasks/backend/serializers.py
+++ b/products/tasks/backend/serializers.py
@@ -10,6 +10,12 @@ from posthog.storage import object_storage
 
 from .models import SandboxEnvironment, Task, TaskRun
 from .services.title_generator import generate_task_title
+from .temporal.process_task.utils import (
+    PR_AUTHORSHIP_MODE_BOT,
+    PR_AUTHORSHIP_MODE_USER,
+    RUN_SOURCE_MANUAL,
+    RUN_SOURCE_SIGNAL_REPORT,
+)
 
 PRESIGNED_URL_CACHE_TTL = 55 * 60  # 55 minutes (less than 1 hour URL expiry)
 
@@ -357,6 +363,9 @@ class ConnectionTokenResponseSerializer(serializers.Serializer):
 class TaskRunCreateRequestSerializer(serializers.Serializer):
     """Request body for creating a new task run"""
 
+    PR_AUTHORSHIP_MODE_CHOICES = [PR_AUTHORSHIP_MODE_USER, PR_AUTHORSHIP_MODE_BOT]
+    RUN_SOURCE_CHOICES = [RUN_SOURCE_MANUAL, RUN_SOURCE_SIGNAL_REPORT]
+
     mode = serializers.ChoiceField(
         choices=["interactive", "background"],
         required=False,
@@ -385,6 +394,31 @@ class TaskRunCreateRequestSerializer(serializers.Serializer):
         required=False,
         default=None,
         help_text="Optional sandbox environment to apply for this cloud run.",
+    )
+    pr_authorship_mode = serializers.ChoiceField(
+        choices=PR_AUTHORSHIP_MODE_CHOICES,
+        required=False,
+        default=None,
+        help_text="Whether pull requests for this run should be authored by the user or the bot.",
+    )
+    run_source = serializers.ChoiceField(
+        choices=RUN_SOURCE_CHOICES,
+        required=False,
+        default=None,
+        help_text="High-level source that triggered this run, used to distinguish manual and signal-based cloud runs.",
+    )
+    signal_report_id = serializers.CharField(
+        required=False,
+        default=None,
+        allow_blank=False,
+        help_text="Optional signal report identifier when this run was started from Inbox.",
+    )
+    github_user_token = serializers.CharField(
+        required=False,
+        default=None,
+        allow_blank=False,
+        write_only=True,
+        help_text="Ephemeral GitHub user token from PostHog Code for user-authored cloud pull requests.",
     )
 
 

--- a/products/tasks/backend/serializers.py
+++ b/products/tasks/backend/serializers.py
@@ -10,12 +10,7 @@ from posthog.storage import object_storage
 
 from .models import SandboxEnvironment, Task, TaskRun
 from .services.title_generator import generate_task_title
-from .temporal.process_task.utils import (
-    PR_AUTHORSHIP_MODE_BOT,
-    PR_AUTHORSHIP_MODE_USER,
-    RUN_SOURCE_MANUAL,
-    RUN_SOURCE_SIGNAL_REPORT,
-)
+from .temporal.process_task.utils import PrAuthorshipMode, RunSource
 
 PRESIGNED_URL_CACHE_TTL = 55 * 60  # 55 minutes (less than 1 hour URL expiry)
 
@@ -363,8 +358,8 @@ class ConnectionTokenResponseSerializer(serializers.Serializer):
 class TaskRunCreateRequestSerializer(serializers.Serializer):
     """Request body for creating a new task run"""
 
-    PR_AUTHORSHIP_MODE_CHOICES = [PR_AUTHORSHIP_MODE_USER, PR_AUTHORSHIP_MODE_BOT]
-    RUN_SOURCE_CHOICES = [RUN_SOURCE_MANUAL, RUN_SOURCE_SIGNAL_REPORT]
+    PR_AUTHORSHIP_MODE_CHOICES = [mode.value for mode in PrAuthorshipMode]
+    RUN_SOURCE_CHOICES = [source.value for source in RunSource]
 
     mode = serializers.ChoiceField(
         choices=["interactive", "background"],

--- a/products/tasks/backend/services/modal_sandbox.py
+++ b/products/tasks/backend/services/modal_sandbox.py
@@ -162,12 +162,12 @@ def _copy_directory_contents(source: Path, destination: Path) -> None:
 
 def _populate_local_skills_directory(destination: Path) -> None:
     built_skills_dir = Path(settings.BASE_DIR) / LOCAL_BUILT_SKILLS_PATH
-    if built_skills_dir.exists():
+    if built_skills_dir.exists() and any(built_skills_dir.iterdir()):
         logger.info(f"Using pre-built skills from {built_skills_dir} for local Modal sandbox builds")
         _copy_directory_contents(built_skills_dir, destination)
         return
 
-    logger.info("Built skills directory missing; falling back to local skill sources for Modal sandbox builds")
+    logger.info("Built skills directory empty or missing; falling back to local skill sources for Modal sandbox builds")
     for relative_path in LOCAL_SOURCE_SKILLS_PATHS:
         _copy_directory_contents(Path(settings.BASE_DIR) / relative_path, destination)
 

--- a/products/tasks/backend/temporal/process_task/activities/create_sandbox_from_snapshot.py
+++ b/products/tasks/backend/temporal/process_task/activities/create_sandbox_from_snapshot.py
@@ -17,7 +17,8 @@ from products.tasks.backend.temporal.oauth import create_oauth_access_token
 from products.tasks.backend.temporal.observability import emit_agent_log, log_activity_execution
 from products.tasks.backend.temporal.process_task.utils import (
     build_sandbox_environment_variables,
-    get_github_token,
+    get_git_identity_env_vars,
+    get_sandbox_github_token,
     get_sandbox_name_for_task,
 )
 
@@ -70,7 +71,14 @@ def create_sandbox_from_snapshot(input: CreateSandboxFromSnapshotInput) -> Creat
         github_token = ""
         if ctx.github_integration_id is not None:
             try:
-                github_token = get_github_token(ctx.github_integration_id) or ""
+                github_token = (
+                    get_sandbox_github_token(
+                        ctx.github_integration_id,
+                        run_id=ctx.run_id,
+                        state=ctx.state,
+                    )
+                    or ""
+                )
             except Exception as e:
                 raise GitHubAuthenticationError(
                     f"Failed to get GitHub token for integration {ctx.github_integration_id}",
@@ -99,6 +107,7 @@ def create_sandbox_from_snapshot(input: CreateSandboxFromSnapshotInput) -> Creat
             team_id=ctx.team_id,
             sandbox_environment=sandbox_env,
         )
+        environment_variables.update(get_git_identity_env_vars(task, ctx.state))
 
         config = SandboxConfig(
             name=get_sandbox_name_for_task(ctx.task_id),

--- a/products/tasks/backend/temporal/process_task/activities/get_sandbox_for_repository.py
+++ b/products/tasks/backend/temporal/process_task/activities/get_sandbox_for_repository.py
@@ -20,6 +20,7 @@ from products.tasks.backend.temporal.process_task.utils import (
     get_sandbox_api_url,
     get_sandbox_github_token,
     get_sandbox_name_for_task,
+    parse_run_state,
 )
 
 from .get_task_processing_context import TaskProcessingContext
@@ -158,14 +159,15 @@ def get_sandbox_for_repository(input: GetSandboxForRepositoryInput) -> GetSandbo
 
         environment_variables.update(get_git_identity_env_vars(task, ctx.state))
 
+        run_state = parse_run_state(ctx.state)
+
         # Set resume run ID independently of snapshot so conversation history
         # can be rebuilt from logs even when the filesystem snapshot has expired.
-        resume_from_run_id = (ctx.state or {}).get("resume_from_run_id", "")
-        if resume_from_run_id:
-            environment_variables["POSTHOG_RESUME_RUN_ID"] = resume_from_run_id
+        if run_state.resume_from_run_id:
+            environment_variables["POSTHOG_RESUME_RUN_ID"] = run_state.resume_from_run_id
 
         # Check for resume snapshot (takes priority over integration-level snapshots)
-        resume_snapshot_ext_id = (ctx.state or {}).get("snapshot_external_id")
+        resume_snapshot_ext_id = run_state.snapshot_external_id
         if resume_snapshot_ext_id:
             used_snapshot = True
 

--- a/products/tasks/backend/temporal/process_task/activities/get_sandbox_for_repository.py
+++ b/products/tasks/backend/temporal/process_task/activities/get_sandbox_for_repository.py
@@ -16,8 +16,9 @@ from products.tasks.backend.temporal.metrics import StepTimer, increment_snapsho
 from products.tasks.backend.temporal.oauth import create_oauth_access_token
 from products.tasks.backend.temporal.observability import emit_agent_log, log_activity_execution
 from products.tasks.backend.temporal.process_task.utils import (
-    get_github_token,
+    get_git_identity_env_vars,
     get_sandbox_api_url,
+    get_sandbox_github_token,
     get_sandbox_name_for_task,
 )
 
@@ -31,6 +32,7 @@ RESERVED_SANDBOX_ENVIRONMENT_VARIABLE_KEYS = {
     "POSTHOG_PROJECT_ID",
     "JWT_PUBLIC_KEY",
     "GITHUB_TOKEN",
+    "GH_TOKEN",
     "LLM_GATEWAY_URL",
     "POSTHOG_RESUME_RUN_ID",
 }
@@ -89,7 +91,14 @@ def get_sandbox_for_repository(input: GetSandboxForRepositoryInput) -> GetSandbo
         if has_repo:
             assert github_integration_id is not None
             try:
-                github_token = get_github_token(github_integration_id) or ""
+                github_token = (
+                    get_sandbox_github_token(
+                        github_integration_id,
+                        run_id=ctx.run_id,
+                        state=ctx.state,
+                    )
+                    or ""
+                )
             except Exception as e:
                 raise GitHubAuthenticationError(
                     f"Failed to get GitHub token for integration {github_integration_id}",
@@ -142,9 +151,12 @@ def get_sandbox_for_repository(input: GetSandboxForRepositoryInput) -> GetSandbo
 
         if github_token:
             environment_variables["GITHUB_TOKEN"] = github_token
+            environment_variables["GH_TOKEN"] = github_token
 
         if settings.SANDBOX_LLM_GATEWAY_URL:
             environment_variables["LLM_GATEWAY_URL"] = settings.SANDBOX_LLM_GATEWAY_URL
+
+        environment_variables.update(get_git_identity_env_vars(task, ctx.state))
 
         # Set resume run ID independently of snapshot so conversation history
         # can be rebuilt from logs even when the filesystem snapshot has expired.

--- a/products/tasks/backend/temporal/process_task/tests/test_utils.py
+++ b/products/tasks/backend/temporal/process_task/tests/test_utils.py
@@ -1,10 +1,16 @@
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from django.test import TestCase
 
 from parameterized import parameterized
 
-from products.tasks.backend.temporal.process_task.utils import McpServerConfig, get_sandbox_mcp_configs
+from products.tasks.backend.models import Task
+from products.tasks.backend.temporal.process_task.utils import (
+    McpServerConfig,
+    get_git_identity_env_vars,
+    get_sandbox_github_token,
+    get_sandbox_mcp_configs,
+)
 
 
 class TestGetSandboxMcpConfigs(TestCase):
@@ -140,3 +146,132 @@ class TestMcpServerConfigToDict(TestCase):
             "url": "https://mcp.example.com/mcp",
             "headers": [{"name": "Authorization", "value": "Bearer token"}],
         }
+
+
+class TestGetGitIdentityEnvVars(TestCase):
+    @staticmethod
+    def _make_task(origin_product: str, user: object | None = None) -> MagicMock:
+        task = MagicMock(spec=Task)
+        task.origin_product = origin_product
+        task.created_by = user
+        return task
+
+    @staticmethod
+    def _make_user(*, first_name: str = "Jane", last_name: str = "Doe", email: str = "jane@example.com") -> MagicMock:
+        user = MagicMock()
+        user.first_name = first_name
+        user.last_name = last_name
+        user.email = email
+        user.get_full_name.return_value = f"{first_name} {last_name}".strip()
+        return user
+
+    def test_user_created_task_returns_user_identity(self) -> None:
+        user = self._make_user(first_name="Jane", last_name="Doe", email="jane@example.com")
+        task = self._make_task(Task.OriginProduct.USER_CREATED, user=user)
+        result = get_git_identity_env_vars(task)
+        assert result == {
+            "GIT_AUTHOR_NAME": "Jane Doe",
+            "GIT_AUTHOR_EMAIL": "jane@example.com",
+            "GIT_COMMITTER_NAME": "Jane Doe",
+            "GIT_COMMITTER_EMAIL": "jane@example.com",
+        }
+
+    def test_user_created_with_explicit_bot_mode_returns_empty(self) -> None:
+        user = self._make_user()
+        task = self._make_task(Task.OriginProduct.USER_CREATED, user=user)
+        assert get_git_identity_env_vars(task, {"pr_authorship_mode": "bot"}) == {}
+
+    def test_non_user_created_with_explicit_user_mode_returns_user_identity(self) -> None:
+        user = self._make_user(first_name="June", last_name="Bug", email="june@example.com")
+        task = self._make_task(Task.OriginProduct.ERROR_TRACKING, user=user)
+        result = get_git_identity_env_vars(task, {"pr_authorship_mode": "user"})
+        assert result == {
+            "GIT_AUTHOR_NAME": "June Bug",
+            "GIT_AUTHOR_EMAIL": "june@example.com",
+            "GIT_COMMITTER_NAME": "June Bug",
+            "GIT_COMMITTER_EMAIL": "june@example.com",
+        }
+
+    @parameterized.expand(
+        [
+            (Task.OriginProduct.SLACK,),
+            (Task.OriginProduct.ERROR_TRACKING,),
+            (Task.OriginProduct.SUPPORT_QUEUE,),
+            (Task.OriginProduct.EVAL_CLUSTERS,),
+            (Task.OriginProduct.SESSION_SUMMARIES,),
+        ]
+    )
+    def test_non_user_created_returns_empty(self, origin_product: str) -> None:
+        user = self._make_user()
+        task = self._make_task(origin_product, user=user)
+        assert get_git_identity_env_vars(task) == {}
+
+    def test_user_created_without_user_returns_empty(self) -> None:
+        task = self._make_task(Task.OriginProduct.USER_CREATED, user=None)
+        assert get_git_identity_env_vars(task) == {}
+
+    def test_first_name_only_fallback(self) -> None:
+        user = self._make_user(first_name="Jane", last_name="", email="jane@example.com")
+        task = self._make_task(Task.OriginProduct.USER_CREATED, user=user)
+        result = get_git_identity_env_vars(task)
+        assert result["GIT_AUTHOR_NAME"] == "Jane"
+
+    def test_empty_name_falls_back_to_posthog_user(self) -> None:
+        user = self._make_user(first_name="", last_name="", email="anon@example.com")
+        user.get_full_name.return_value = ""
+        task = self._make_task(Task.OriginProduct.USER_CREATED, user=user)
+        result = get_git_identity_env_vars(task)
+        assert result["GIT_AUTHOR_NAME"] == "PostHog User"
+        assert result["GIT_AUTHOR_EMAIL"] == "anon@example.com"
+
+
+class TestGetSandboxGitHubToken(TestCase):
+    @patch("products.tasks.backend.temporal.process_task.utils.get_github_token")
+    @patch("products.tasks.backend.temporal.process_task.utils.get_cached_github_user_token")
+    def test_user_authorship_uses_cached_user_token(self, mock_cached_token, mock_get_github_token) -> None:
+        mock_cached_token.return_value = "ghu_user"
+
+        result = get_sandbox_github_token(123, run_id="run-1", state={"pr_authorship_mode": "user"})
+
+        assert result == "ghu_user"
+        mock_cached_token.assert_called_once_with("run-1")
+        mock_get_github_token.assert_not_called()
+
+    @patch("products.tasks.backend.temporal.process_task.utils.get_cached_github_user_token")
+    def test_user_authorship_requires_cached_user_token(self, mock_cached_token) -> None:
+        mock_cached_token.return_value = None
+
+        with self.assertRaises(ValueError):
+            get_sandbox_github_token(123, run_id="run-1", state={"pr_authorship_mode": "user"})
+
+    @patch("products.tasks.backend.temporal.process_task.utils.get_github_token")
+    def test_bot_authorship_uses_installation_token(self, mock_get_github_token) -> None:
+        mock_get_github_token.return_value = "ghs_bot"
+
+        result = get_sandbox_github_token(123, run_id="run-1", state={"pr_authorship_mode": "bot"})
+
+        assert result == "ghs_bot"
+        mock_get_github_token.assert_called_once_with(123)
+
+    @patch("products.tasks.backend.temporal.process_task.utils.get_github_token")
+    def test_no_state_falls_through_to_installation_token(self, mock_get_github_token) -> None:
+        mock_get_github_token.return_value = "ghs_default"
+
+        result = get_sandbox_github_token(123, run_id="run-1", state=None)
+
+        assert result == "ghs_default"
+        mock_get_github_token.assert_called_once_with(123)
+
+    @patch("products.tasks.backend.temporal.process_task.utils.get_github_token")
+    def test_empty_state_falls_through_to_installation_token(self, mock_get_github_token) -> None:
+        mock_get_github_token.return_value = "ghs_default"
+
+        result = get_sandbox_github_token(123, run_id="run-1", state={})
+
+        assert result == "ghs_default"
+        mock_get_github_token.assert_called_once_with(123)
+
+    def test_no_integration_id_returns_none(self) -> None:
+        result = get_sandbox_github_token(None, run_id="run-1", state={"pr_authorship_mode": "bot"})
+
+        assert result is None

--- a/products/tasks/backend/temporal/process_task/utils.py
+++ b/products/tasks/backend/temporal/process_task/utils.py
@@ -1,11 +1,24 @@
+from __future__ import annotations
+
 from dataclasses import dataclass, field
-from typing import Any, Optional
+from typing import TYPE_CHECKING, Any, Optional
 from urllib.parse import urlparse
 
 from django.conf import settings
+from django.core.cache import cache
 
 from posthog.models.integration import GitHubIntegration, Integration
 from posthog.temporal.oauth import PosthogMcpScopes, has_write_scopes
+
+if TYPE_CHECKING:
+    from products.tasks.backend.models import Task
+
+
+PR_AUTHORSHIP_MODE_USER = "user"
+PR_AUTHORSHIP_MODE_BOT = "bot"
+RUN_SOURCE_MANUAL = "manual"
+RUN_SOURCE_SIGNAL_REPORT = "signal_report"
+GITHUB_USER_TOKEN_CACHE_TTL_SECONDS = 6 * 60 * 60
 
 
 @dataclass(frozen=True)
@@ -90,6 +103,38 @@ def get_github_token(github_integration_id: int) -> Optional[str]:
     return github_integration.integration.access_token or None
 
 
+def _github_user_token_cache_key(run_id: str) -> str:
+    return f"task-run-github-user-token:{run_id}"
+
+
+def cache_github_user_token(run_id: str, github_user_token: str) -> None:
+    cache.set(_github_user_token_cache_key(run_id), github_user_token, timeout=GITHUB_USER_TOKEN_CACHE_TTL_SECONDS)
+
+
+def get_cached_github_user_token(run_id: str) -> str | None:
+    token = cache.get(_github_user_token_cache_key(run_id))
+    return token if isinstance(token, str) and token else None
+
+
+def get_sandbox_github_token(
+    github_integration_id: int | None, *, run_id: str, state: dict[str, Any] | None = None
+) -> str | None:
+    authorship_mode = (state or {}).get("pr_authorship_mode")
+    if authorship_mode == PR_AUTHORSHIP_MODE_USER:
+        github_user_token = get_cached_github_user_token(run_id)
+        if not github_user_token:
+            raise ValueError(
+                f"Missing GitHub user token for user-authored run {run_id} "
+                f"(token may have expired after {GITHUB_USER_TOKEN_CACHE_TTL_SECONDS // 3600}h TTL)"
+            )
+        return github_user_token
+
+    if github_integration_id is None:
+        return None
+
+    return get_github_token(github_integration_id)
+
+
 def format_allowed_domains_for_log(domains: list[str], limit: int = 5) -> str:
     preview = ", ".join(domains[:limit])
     remaining = len(domains) - limit
@@ -117,12 +162,12 @@ def build_sandbox_environment_variables(
 
     env_vars: dict[str, str] = {}
 
-    # Apply user-provided vars first so system vars always take precedence
     if sandbox_environment and sandbox_environment.environment_variables:
         env_vars.update(sandbox_environment.environment_variables)
 
     if github_token:
         env_vars["GITHUB_TOKEN"] = github_token
+        env_vars["GH_TOKEN"] = github_token
 
     env_vars.update(
         {
@@ -137,3 +182,47 @@ def build_sandbox_environment_variables(
         env_vars["LLM_GATEWAY_URL"] = settings.SANDBOX_LLM_GATEWAY_URL
 
     return env_vars
+
+
+def get_pr_authorship_mode(task: Task, state: dict[str, Any] | None = None) -> str:
+    """Return the effective PR authorship mode for a run.
+
+    Newer cloud runs store the mode in ``TaskRun.state``. Older user-created
+    runs fall back to user authorship so they still get a human git identity.
+    """
+    from products.tasks.backend.models import Task as TaskModel
+
+    mode = (state or {}).get("pr_authorship_mode")
+    if mode in {PR_AUTHORSHIP_MODE_USER, PR_AUTHORSHIP_MODE_BOT}:
+        return mode
+
+    return (
+        PR_AUTHORSHIP_MODE_USER
+        if task.origin_product == TaskModel.OriginProduct.USER_CREATED
+        else PR_AUTHORSHIP_MODE_BOT
+    )
+
+
+def get_git_identity_env_vars(task: Task, state: dict[str, Any] | None = None) -> dict[str, str]:
+    """Return git author/committer env vars for the sandbox.
+
+    Runs with user authorship are attributed to the user who created the task.
+    Bot-authored runs fall back to the Dockerfile defaults ("PostHog Code" /
+    code@posthog.com).
+    """
+    if get_pr_authorship_mode(task, state) != PR_AUTHORSHIP_MODE_USER:
+        return {}
+
+    user = task.created_by
+    if user is None:
+        return {}
+
+    name = user.get_full_name() or user.first_name or "PostHog User"
+    email = user.email
+
+    return {
+        "GIT_AUTHOR_NAME": name,
+        "GIT_AUTHOR_EMAIL": email,
+        "GIT_COMMITTER_NAME": name,
+        "GIT_COMMITTER_EMAIL": email,
+    }

--- a/products/tasks/backend/temporal/process_task/utils.py
+++ b/products/tasks/backend/temporal/process_task/utils.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from enum import StrEnum
 from typing import TYPE_CHECKING, Any, Optional
 from urllib.parse import urlparse
 
 from django.conf import settings
 from django.core.cache import cache
+
+from pydantic import BaseModel
 
 from posthog.models.integration import GitHubIntegration, Integration
 from posthog.temporal.oauth import PosthogMcpScopes, has_write_scopes
@@ -14,10 +17,38 @@ if TYPE_CHECKING:
     from products.tasks.backend.models import Task
 
 
-PR_AUTHORSHIP_MODE_USER = "user"
-PR_AUTHORSHIP_MODE_BOT = "bot"
-RUN_SOURCE_MANUAL = "manual"
-RUN_SOURCE_SIGNAL_REPORT = "signal_report"
+class PrAuthorshipMode(StrEnum):
+    USER = "user"
+    BOT = "bot"
+
+
+class RunSource(StrEnum):
+    MANUAL = "manual"
+    SIGNAL_REPORT = "signal_report"
+
+
+class RunState(BaseModel, extra="allow"):
+    pr_authorship_mode: PrAuthorshipMode | None = None
+    pr_base_branch: str | None = None
+    run_source: RunSource | None = None
+    signal_report_id: str | None = None
+    resume_from_run_id: str | None = None
+    snapshot_external_id: str | None = None
+    sandbox_id: str | None = None
+    sandbox_url: str | None = None
+    sandbox_connect_token: str | None = None
+    sandbox_environment_id: str | None = None
+    pending_user_message: str | None = None
+    pending_user_message_ts: str | None = None
+    slack_thread_url: str | None = None
+    interaction_origin: str | None = None
+    slack_sent_relay_ids: list[str] | None = None
+
+
+def parse_run_state(state: dict[str, Any] | None) -> RunState:
+    return RunState.model_validate(state or {})
+
+
 GITHUB_USER_TOKEN_CACHE_TTL_SECONDS = 6 * 60 * 60
 
 
@@ -119,8 +150,8 @@ def get_cached_github_user_token(run_id: str) -> str | None:
 def get_sandbox_github_token(
     github_integration_id: int | None, *, run_id: str, state: dict[str, Any] | None = None
 ) -> str | None:
-    authorship_mode = (state or {}).get("pr_authorship_mode")
-    if authorship_mode == PR_AUTHORSHIP_MODE_USER:
+    run_state = parse_run_state(state)
+    if run_state.pr_authorship_mode == PrAuthorshipMode.USER:
         github_user_token = get_cached_github_user_token(run_id)
         if not github_user_token:
             raise ValueError(
@@ -184,7 +215,7 @@ def build_sandbox_environment_variables(
     return env_vars
 
 
-def get_pr_authorship_mode(task: Task, state: dict[str, Any] | None = None) -> str:
+def get_pr_authorship_mode(task: Task, state: dict[str, Any] | None = None) -> PrAuthorshipMode:
     """Return the effective PR authorship mode for a run.
 
     Newer cloud runs store the mode in ``TaskRun.state``. Older user-created
@@ -192,14 +223,12 @@ def get_pr_authorship_mode(task: Task, state: dict[str, Any] | None = None) -> s
     """
     from products.tasks.backend.models import Task as TaskModel
 
-    mode = (state or {}).get("pr_authorship_mode")
-    if mode in {PR_AUTHORSHIP_MODE_USER, PR_AUTHORSHIP_MODE_BOT}:
-        return mode
+    run_state = parse_run_state(state)
+    if run_state.pr_authorship_mode is not None:
+        return run_state.pr_authorship_mode
 
     return (
-        PR_AUTHORSHIP_MODE_USER
-        if task.origin_product == TaskModel.OriginProduct.USER_CREATED
-        else PR_AUTHORSHIP_MODE_BOT
+        PrAuthorshipMode.USER if task.origin_product == TaskModel.OriginProduct.USER_CREATED else PrAuthorshipMode.BOT
     )
 
 
@@ -210,7 +239,7 @@ def get_git_identity_env_vars(task: Task, state: dict[str, Any] | None = None) -
     Bot-authored runs fall back to the Dockerfile defaults ("PostHog Code" /
     code@posthog.com).
     """
-    if get_pr_authorship_mode(task, state) != PR_AUTHORSHIP_MODE_USER:
+    if get_pr_authorship_mode(task, state) != PrAuthorshipMode.USER:
         return {}
 
     user = task.created_by

--- a/products/tasks/backend/tests/test_api.py
+++ b/products/tasks/backend/tests/test_api.py
@@ -19,6 +19,7 @@ from posthog.storage import object_storage
 
 from products.tasks.backend.models import CodeInvite, CodeInviteRedemption, SandboxEnvironment, Task, TaskRun
 from products.tasks.backend.services.connection_token import get_sandbox_jwt_public_key
+from products.tasks.backend.temporal.process_task.utils import get_cached_github_user_token
 
 # Test RSA private key for JWT tests (RS256)
 TEST_RSA_PRIVATE_KEY = """-----BEGIN PRIVATE KEY-----
@@ -338,6 +339,106 @@ class TestTaskAPI(BaseTaskAPITest):
             "Read the attached file first",
         )
         mock_workflow.assert_called_once()
+
+    @patch("products.tasks.backend.api.execute_task_processing_workflow")
+    def test_run_endpoint_persists_pr_authorship_metadata(self, mock_workflow):
+        task = self.create_task()
+        github_user_token = "ghu_test_token"
+
+        response = self.client.post(
+            f"/api/projects/@current/tasks/{task.id}/run/",
+            {
+                "mode": "interactive",
+                "branch": "main",
+                "pr_authorship_mode": "user",
+                "run_source": "manual",
+                "github_user_token": github_user_token,
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        task_run = TaskRun.objects.get(id=response.json()["latest_run"]["id"])
+        assert task_run.state["pr_authorship_mode"] == "user"
+        assert task_run.state["run_source"] == "manual"
+        assert task_run.state["pr_base_branch"] == "main"
+        assert get_cached_github_user_token(str(task_run.id)) == github_user_token
+        mock_workflow.assert_called_once()
+
+    @patch("products.tasks.backend.api.execute_task_processing_workflow")
+    def test_run_endpoint_rejects_user_authorship_without_github_user_token(self, mock_workflow):
+        task = self.create_task()
+        task.repository = "posthog/posthog"
+        task.save(update_fields=["repository"])
+
+        response = self.client.post(
+            f"/api/projects/@current/tasks/{task.id}/run/",
+            {
+                "mode": "interactive",
+                "pr_authorship_mode": "user",
+                "run_source": "manual",
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.json()["detail"] == "github_user_token is required for user-authored cloud runs"
+        mock_workflow.assert_not_called()
+
+    @patch("products.tasks.backend.api.execute_task_processing_workflow")
+    def test_run_endpoint_allows_user_authorship_without_token_when_no_repo(self, mock_workflow):
+        task = self.create_task()
+
+        response = self.client.post(
+            f"/api/projects/@current/tasks/{task.id}/run/",
+            {
+                "mode": "interactive",
+                "pr_authorship_mode": "user",
+                "run_source": "manual",
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        mock_workflow.assert_called_once()
+
+    @patch("products.tasks.backend.api.execute_task_processing_workflow")
+    def test_run_endpoint_resume_carries_forward_pr_authorship_metadata(self, mock_workflow):
+        task = self.create_task()
+        github_user_token = "ghu_resume_token"
+        previous_run = TaskRun.objects.create(
+            task=task,
+            team=self.team,
+            status=TaskRun.Status.COMPLETED,
+            state={
+                "pr_authorship_mode": "bot",
+                "run_source": "signal_report",
+                "signal_report_id": "report-123",
+                "pr_base_branch": "main",
+                "snapshot_external_id": "snap-1",
+            },
+        )
+
+        response = self.client.post(
+            f"/api/projects/@current/tasks/{task.id}/run/",
+            {
+                "mode": "interactive",
+                "resume_from_run_id": str(previous_run.id),
+                "pending_user_message": "Please continue",
+                "github_user_token": github_user_token,
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        task_run = TaskRun.objects.get(id=response.json()["latest_run"]["id"])
+        assert task_run.state["pr_authorship_mode"] == "bot"
+        assert task_run.state["run_source"] == "signal_report"
+        assert task_run.state["signal_report_id"] == "report-123"
+        assert task_run.state["snapshot_external_id"] == "snap-1"
+        assert task_run.state["pr_base_branch"] == "main"
+        # Token not cached for bot-authored runs even if the client sends one
+        assert get_cached_github_user_token(str(task_run.id)) is None
 
     def test_run_endpoint_rejects_invalid_sandbox_environment_id(self):
         task = self.create_task()
@@ -799,6 +900,31 @@ class TestTaskRunAPI(BaseTaskAPITest):
         input_arg = mock_post_slack_update.call_args[0][0]
         self.assertEqual(input_arg.run_id, str(run.id))
         self.assertEqual(input_arg.slack_thread_context["integration_id"], integration.pk)
+
+    def test_partial_update_merges_output_dict(self):
+        task = self.create_task()
+        run = TaskRun.objects.create(
+            task=task,
+            team=self.team,
+            status=TaskRun.Status.IN_PROGRESS,
+            output={"head_branch": "posthog-code/update-readme"},
+        )
+
+        response = self.client.patch(
+            f"/api/projects/@current/tasks/{task.id}/runs/{run.id}/",
+            {"output": {"pr_url": "https://github.com/org/repo/pull/2"}},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        run.refresh_from_db()
+        self.assertEqual(
+            run.output,
+            {
+                "head_branch": "posthog-code/update-readme",
+                "pr_url": "https://github.com/org/repo/pull/2",
+            },
+        )
 
     @patch("products.tasks.backend.api.execute_posthog_code_agent_relay_workflow")
     def test_relay_message_enqueues_slack_relay_workflow(self, mock_execute_relay):

--- a/products/tasks/frontend/generated/api.schemas.ts
+++ b/products/tasks/frontend/generated/api.schemas.ts
@@ -233,6 +233,28 @@ export const TaskRunCreateRequestModeEnumApi = {
 } as const
 
 /**
+ * * `user` - user
+ * `bot` - bot
+ */
+export type PrAuthorshipModeEnumApi = (typeof PrAuthorshipModeEnumApi)[keyof typeof PrAuthorshipModeEnumApi]
+
+export const PrAuthorshipModeEnumApi = {
+    User: 'user',
+    Bot: 'bot',
+} as const
+
+/**
+ * * `manual` - manual
+ * `signal_report` - signal_report
+ */
+export type RunSourceEnumApi = (typeof RunSourceEnumApi)[keyof typeof RunSourceEnumApi]
+
+export const RunSourceEnumApi = {
+    Manual: 'manual',
+    SignalReport: 'signal_report',
+} as const
+
+/**
  * Request body for creating a new task run
  */
 export interface TaskRunCreateRequestApi {
@@ -253,6 +275,20 @@ export interface TaskRunCreateRequestApi {
     pending_user_message?: string
     /** Optional sandbox environment to apply for this cloud run. */
     sandbox_environment_id?: string
+    /** Whether pull requests for this run should be authored by the user or the bot.
+
+* `user` - user
+* `bot` - bot */
+    pr_authorship_mode?: PrAuthorshipModeEnumApi
+    /** High-level source that triggered this run, used to distinguish manual and signal-based cloud runs.
+
+* `manual` - manual
+* `signal_report` - signal_report */
+    run_source?: RunSourceEnumApi
+    /** Optional signal report identifier when this run was started from Inbox. */
+    signal_report_id?: string
+    /** Ephemeral GitHub user token from PostHog Code for user-authored cloud pull requests. */
+    github_user_token?: string
 }
 
 /**

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -26551,6 +26551,18 @@ export namespace Schemas {
     }
 
     /**
+     * * `user` - user
+    * `bot` - bot
+     */
+    export type PrAuthorshipModeEnum = typeof PrAuthorshipModeEnum[keyof typeof PrAuthorshipModeEnum];
+
+
+    export const PrAuthorshipModeEnum = {
+      User: 'user',
+      Bot: 'bot',
+    } as const;
+
+    /**
      * Serializer for creating and updating ProductTour.
      */
     export interface ProductTourSerializerCreateUpdateOnly {
@@ -29810,6 +29822,18 @@ export namespace Schemas {
       stale: number;
     }
 
+    /**
+     * * `manual` - manual
+    * `signal_report` - signal_report
+     */
+    export type RunSourceEnum = typeof RunSourceEnum[keyof typeof RunSourceEnum];
+
+
+    export const RunSourceEnum = {
+      Manual: 'manual',
+      SignalReport: 'signal_report',
+    } as const;
+
     export interface SandboxEnvironment {
       readonly id: string;
       /** @maxLength 255 */
@@ -30692,6 +30716,20 @@ export namespace Schemas {
       pending_user_message?: string;
       /** Optional sandbox environment to apply for this cloud run. */
       sandbox_environment_id?: string;
+      /** Whether pull requests for this run should be authored by the user or the bot.
+
+    * `user` - user
+    * `bot` - bot */
+      pr_authorship_mode?: PrAuthorshipModeEnum;
+      /** High-level source that triggered this run, used to distinguish manual and signal-based cloud runs.
+
+    * `manual` - manual
+    * `signal_report` - signal_report */
+      run_source?: RunSourceEnum;
+      /** Optional signal report identifier when this run was started from Inbox. */
+      signal_report_id?: string;
+      /** Ephemeral GitHub user token from PostHog Code for user-authored cloud pull requests. */
+      github_user_token?: string;
     }
 
     export interface TaskRunRelayMessageRequest {


### PR DESCRIPTION
## Problem

<img width="917" height="450" alt="CleanShot 2026-04-02 at 3  10 19" src="https://github.com/user-attachments/assets/71af3504-8d32-4e9a-ae42-70791e94c451" />

Cloud runs commits and PRs are always authored as the a bot, regardless of who initiated the task. Users who manually start cloud runs from PostHog Code expect their PRs to appear under their own GH identity.

## Changes

- user starts a cloud task from `code`,  their `gh auth token` is cached ephemerally in Redis and injected into the sandbox
- signal-based runs continue using the GH app installation token
- new `pr_authorship_mode`, `run_source`, `signal_report_id` fields on the run request, persisted in `TaskRun.state` and carried forward on resume task process

Companion PR: PostHog/code#1453

## Publish to changelog?

No.