### PR TITLE
fix(livestream): add heartbeat to StreamEventsHandler and standardize interval

### DIFF
--- a/livestream/handlers/handlers.go
+++ b/livestream/handlers/handlers.go
@@ -157,7 +157,7 @@ func StreamEventsHandler(log echo.Logger, subChan chan events.Subscription, unSu
 		w.Header().Set("Cache-Control", "no-cache")
 		w.Header().Set("Connection", "keep-alive")
 
-		heartbeat := time.NewTicker(60 * time.Second)
+		heartbeat := time.NewTicker(30 * time.Second)
 		defer heartbeat.Stop()
 		timeout := time.After(30 * time.Minute)
 		for {
@@ -228,7 +228,7 @@ func NotificationsHandler(redisClient rueidis.Client) func(c echo.Context) error
 		w.Header().Set("Cache-Control", "no-cache")
 		w.Header().Set("Connection", "keep-alive")
 
-		heartbeat := time.NewTicker(60 * time.Second)
+		heartbeat := time.NewTicker(30 * time.Second)
 		defer heartbeat.Stop()
 		timeout := time.After(30 * time.Minute)
 

--- a/livestream/handlers/handlers.go
+++ b/livestream/handlers/handlers.go
@@ -89,6 +89,8 @@ func StatsHandler(stats *events.Stats, sessionStats *events.SessionStats, redisS
 	}
 }
 
+const sseHeartbeatInterval = 30 * time.Second
+
 var subID uint64 = 1
 
 func StreamEventsHandler(log echo.Logger, subChan chan events.Subscription, unSubChan chan events.Subscription) func(c echo.Context) error {
@@ -157,7 +159,7 @@ func StreamEventsHandler(log echo.Logger, subChan chan events.Subscription, unSu
 		w.Header().Set("Cache-Control", "no-cache")
 		w.Header().Set("Connection", "keep-alive")
 
-		heartbeat := time.NewTicker(30 * time.Second)
+		heartbeat := time.NewTicker(sseHeartbeatInterval)
 		defer heartbeat.Stop()
 		timeout := time.After(30 * time.Minute)
 		for {
@@ -228,7 +230,7 @@ func NotificationsHandler(redisClient rueidis.Client) func(c echo.Context) error
 		w.Header().Set("Cache-Control", "no-cache")
 		w.Header().Set("Connection", "keep-alive")
 
-		heartbeat := time.NewTicker(30 * time.Second)
+		heartbeat := time.NewTicker(sseHeartbeatInterval)
 		defer heartbeat.Stop()
 		timeout := time.After(30 * time.Minute)
 

--- a/livestream/handlers/handlers.go
+++ b/livestream/handlers/handlers.go
@@ -156,6 +156,9 @@ func StreamEventsHandler(log echo.Logger, subChan chan events.Subscription, unSu
 		w.Header().Set("Content-Type", "text/event-stream")
 		w.Header().Set("Cache-Control", "no-cache")
 		w.Header().Set("Connection", "keep-alive")
+
+		heartbeat := time.NewTicker(60 * time.Second)
+		defer heartbeat.Stop()
 		timeout := time.After(30 * time.Minute)
 		for {
 			select {
@@ -176,6 +179,12 @@ func StreamEventsHandler(log echo.Logger, subChan chan events.Subscription, unSu
 				event := Event{
 					Data: jsonData,
 				}
+				if err := event.WriteTo(w); err != nil {
+					return err
+				}
+				w.Flush()
+			case <-heartbeat.C:
+				event := Event{Comment: []byte("heartbeat")}
 				if err := event.WriteTo(w); err != nil {
 					return err
 				}
@@ -219,7 +228,7 @@ func NotificationsHandler(redisClient rueidis.Client) func(c echo.Context) error
 		w.Header().Set("Cache-Control", "no-cache")
 		w.Header().Set("Connection", "keep-alive")
 
-		heartbeat := time.NewTicker(15 * time.Second)
+		heartbeat := time.NewTicker(60 * time.Second)
 		defer heartbeat.Stop()
 		timeout := time.After(30 * time.Minute)
 

--- a/livestream/handlers/handlers.go
+++ b/livestream/handlers/handlers.go
@@ -91,6 +91,8 @@ func StatsHandler(stats *events.Stats, sessionStats *events.SessionStats, redisS
 
 const sseHeartbeatInterval = 30 * time.Second
 
+var sseHeartbeatEvent = Event{Comment: []byte("heartbeat")}
+
 var subID uint64 = 1
 
 func StreamEventsHandler(log echo.Logger, subChan chan events.Subscription, unSubChan chan events.Subscription) func(c echo.Context) error {
@@ -186,7 +188,7 @@ func StreamEventsHandler(log echo.Logger, subChan chan events.Subscription, unSu
 				}
 				w.Flush()
 			case <-heartbeat.C:
-				event := Event{Comment: []byte("heartbeat")}
+				event := sseHeartbeatEvent
 				if err := event.WriteTo(w); err != nil {
 					return err
 				}
@@ -256,7 +258,7 @@ func NotificationsHandler(redisClient rueidis.Client) func(c echo.Context) error
 				}
 				w.Flush()
 			case <-heartbeat.C:
-				event := Event{Comment: []byte("heartbeat")}
+				event := sseHeartbeatEvent
 				if err := event.WriteTo(w); err != nil {
 					return err
 				}


### PR DESCRIPTION
## Problem

`StreamEventsHandler` had no SSE heartbeat, making idle connections vulnerable to silent drops by proxies and load balancers (typically 60-120s idle timeout).

## Changes

- Add 30s heartbeat to `StreamEventsHandler` SSE endpoint
- Standardize `NotificationsHandler` heartbeat from 15s to 30s

## How did you test this code?

- Verified Go build compiles cleanly

## Publish to changelog?

no