### PR TITLE
fix(batch-exports): Databricks: escape identifiers

### DIFF
--- a/products/batch_exports/backend/temporal/destinations/databricks_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/databricks_batch_export.py
@@ -85,6 +85,23 @@ NON_RETRYABLE_ERROR_TYPES: list[str] = [
 DatabricksField = tuple[str, str]
 
 
+def _escape_identifier(value: str) -> str:
+    """Escape a value for use in a backtick-quoted Databricks SQL identifier.
+
+    Doubles any backtick characters to prevent SQL injection.
+    See: https://docs.databricks.com/aws/en/sql/language-manual/sql-ref-identifiers
+    """
+    return value.replace("`", "``")
+
+
+def _escape_path_component(value: str) -> str:
+    """Escape a value for use in a single-quoted Databricks SQL path.
+
+    Escapes backslashes and single quotes.
+    """
+    return value.replace("\\", "\\\\").replace("'", "\\'")
+
+
 class DatabricksConnectionError(Exception):
     """Error for Databricks connection."""
 
@@ -356,7 +373,11 @@ class DatabricksClient:
             self._connection = None
 
     async def execute_query(
-        self, query: str, parameters: dict | None = None, query_kwargs: dict | None = None, fetch_results: bool = True
+        self,
+        query: str,
+        parameters: dict[str, t.Any] | None = None,
+        query_kwargs: dict[str, t.Any] | None = None,
+        fetch_results: bool = True,
     ) -> list[Row] | None:
         """Execute a query and wait for it to complete.
 
@@ -440,7 +461,7 @@ class DatabricksClient:
 
     async def use_catalog(self, catalog: str):
         try:
-            await self.execute_query(f"USE CATALOG `{catalog}`", fetch_results=False)
+            await self.execute_query(f"USE CATALOG `{_escape_identifier(catalog)}`", fetch_results=False)
         except ServerOperationError as err:
             if err.message and "[NO_SUCH_CATALOG_EXCEPTION]" in err.message:
                 raise DatabricksCatalogNotFoundError(catalog)
@@ -450,7 +471,7 @@ class DatabricksClient:
 
     async def use_schema(self, schema: str):
         try:
-            await self.execute_query(f"USE SCHEMA `{schema}`", fetch_results=False)
+            await self.execute_query(f"USE SCHEMA `{_escape_identifier(schema)}`", fetch_results=False)
         except ServerOperationError as err:
             if err.message and "[SCHEMA_NOT_FOUND]" in err.message:
                 raise DatabricksSchemaNotFoundError(schema)
@@ -488,10 +509,10 @@ class DatabricksClient:
 
     async def acreate_table(self, table_name: str, fields: list[DatabricksField]):
         """Asynchronously create the Databricks delta table if it doesn't exist."""
-        field_ddl = ", ".join(f"`{field[0]}` {field[1]}" for field in fields)
+        field_ddl = ", ".join(f"`{_escape_identifier(field[0])}` {field[1]}" for field in fields)
         try:
             query = f"""
-                CREATE TABLE IF NOT EXISTS `{table_name}` (
+                CREATE TABLE IF NOT EXISTS `{_escape_identifier(table_name)}` (
                     {field_ddl}
                 )
                 USING DELTA
@@ -506,7 +527,7 @@ class DatabricksClient:
     async def adelete_table(self, table_name: str):
         """Asynchronously delete the Databricks delta table if it exists."""
         try:
-            await self.execute_query(f"DROP TABLE IF EXISTS `{table_name}`", fetch_results=False)
+            await self.execute_query(f"DROP TABLE IF EXISTS `{_escape_identifier(table_name)}`", fetch_results=False)
         except ServerOperationError as err:
             if _is_insufficient_permissions_error(err):
                 raise DatabricksInsufficientPermissionsError("DROP TABLE", err.message)
@@ -514,8 +535,9 @@ class DatabricksClient:
 
     async def aput_file_stream_to_volume(self, file: io.BytesIO, volume_path: str, file_name: str):
         """Asynchronously put a local file stream to a Databricks volume."""
+        escaped_path = f"{_escape_path_component(volume_path)}/{_escape_path_component(file_name)}"
         await self.execute_query(
-            f"PUT '__input_stream__' INTO '{volume_path}/{file_name}' OVERWRITE",
+            f"PUT '__input_stream__' INTO '{escaped_path}' OVERWRITE",
             query_kwargs={"input_stream": file},
         )
 
@@ -558,22 +580,24 @@ class DatabricksClient:
         """
         select_fields = []
         for field in fields:
+            escaped_name = _escape_identifier(field[0])
             if field[1] == "VARIANT":
-                select_fields.append(f"PARSE_JSON(`{field[0]}`) as `{field[0]}`")
+                select_fields.append(f"PARSE_JSON(`{escaped_name}`) as `{escaped_name}`")
             elif field[1] == "BIGINT":
-                select_fields.append(f"CAST(`{field[0]}` as BIGINT) as `{field[0]}`")
+                select_fields.append(f"CAST(`{escaped_name}` as BIGINT) as `{escaped_name}`")
             elif field[1] == "INTEGER":
-                select_fields.append(f"CAST(`{field[0]}` as INTEGER) as `{field[0]}`")
+                select_fields.append(f"CAST(`{escaped_name}` as INTEGER) as `{escaped_name}`")
             else:
-                select_fields.append(f"`{field[0]}`")
+                select_fields.append(f"`{escaped_name}`")
         select_fields_str = ", ".join(select_fields)
 
-        merge_schema = f"true" if with_schema_evolution else "false"
+        merge_schema = "true" if with_schema_evolution else "false"
+        escaped_volume_path = _escape_path_component(volume_path)
 
         return f"""
-        COPY INTO `{table_name}`
+        COPY INTO `{_escape_identifier(table_name)}`
         FROM (
-            SELECT {select_fields_str} FROM '{volume_path}'
+            SELECT {select_fields_str} FROM '{escaped_volume_path}'
         )
         FILEFORMAT = PARQUET
         COPY_OPTIONS ('force' = 'true', 'mergeSchema' = '{merge_schema}')
@@ -601,7 +625,7 @@ class DatabricksClient:
         """Asynchronously create a Databricks volume."""
         try:
             await self.execute_query(
-                f"CREATE VOLUME IF NOT EXISTS `{volume}` COMMENT 'PostHog generated volume'",
+                f"CREATE VOLUME IF NOT EXISTS `{_escape_identifier(volume)}` COMMENT 'PostHog generated volume'",
                 fetch_results=False,
             )
         except ServerOperationError as err:
@@ -613,7 +637,7 @@ class DatabricksClient:
         """Asynchronously delete a Databricks volume."""
         try:
             await self.execute_query(
-                f"DROP VOLUME IF EXISTS `{volume}`",
+                f"DROP VOLUME IF EXISTS `{_escape_identifier(volume)}`",
                 fetch_results=False,
             )
         except ServerOperationError as err:
@@ -719,12 +743,16 @@ class DatabricksClient:
         merge_key: collections.abc.Iterable[str],
         update_key: collections.abc.Iterable[str],
     ) -> str:
-        merge_condition = " AND ".join([f"target.`{field}` = source.`{field}`" for field in merge_key])
-        update_condition = " OR ".join([f"target.`{field}` < source.`{field}`" for field in update_key])
+        merge_condition = " AND ".join(
+            [f"target.`{_escape_identifier(field)}` = source.`{_escape_identifier(field)}`" for field in merge_key]
+        )
+        update_condition = " OR ".join(
+            [f"target.`{_escape_identifier(field)}` < source.`{_escape_identifier(field)}`" for field in update_key]
+        )
 
         return f"""
-        MERGE WITH SCHEMA EVOLUTION INTO `{target_table}` AS target
-        USING `{source_table}` AS source
+        MERGE WITH SCHEMA EVOLUTION INTO `{_escape_identifier(target_table)}` AS target
+        USING `{_escape_identifier(source_table)}` AS source
         ON {merge_condition}
         WHEN MATCHED AND ({update_condition}) THEN
             UPDATE SET *
@@ -741,25 +769,37 @@ class DatabricksClient:
         source_table_fields: collections.abc.Iterable[DatabricksField],
         target_table_field_names: list[str],
     ) -> str:
-        merge_condition = " AND ".join([f"target.`{field}` = source.`{field}`" for field in merge_key])
-        update_condition = " OR ".join([f"target.`{field}` < source.`{field}`" for field in update_key])
+        merge_condition = " AND ".join(
+            [f"target.`{_escape_identifier(field)}` = source.`{_escape_identifier(field)}`" for field in merge_key]
+        )
+        update_condition = " OR ".join(
+            [f"target.`{_escape_identifier(field)}` < source.`{_escape_identifier(field)}`" for field in update_key]
+        )
         update_clause = ", ".join(
             [
-                f"target.`{field[0]}` = source.`{field[0]}`"
+                f"target.`{_escape_identifier(field[0])}` = source.`{_escape_identifier(field[0])}`"
                 for field in source_table_fields
                 if field[0] in target_table_field_names
             ]
         )
         field_names = ", ".join(
-            [f"`{field[0]}`" for field in source_table_fields if field[0] in target_table_field_names]
+            [
+                f"`{_escape_identifier(field[0])}`"
+                for field in source_table_fields
+                if field[0] in target_table_field_names
+            ]
         )
         values = ", ".join(
-            [f"source.`{field[0]}`" for field in source_table_fields if field[0] in target_table_field_names]
+            [
+                f"source.`{_escape_identifier(field[0])}`"
+                for field in source_table_fields
+                if field[0] in target_table_field_names
+            ]
         )
 
         return f"""
-        MERGE INTO `{target_table}` AS target
-        USING `{source_table}` AS source
+        MERGE INTO `{_escape_identifier(target_table)}` AS target
+        USING `{_escape_identifier(source_table)}` AS source
         ON {merge_condition}
         WHEN MATCHED AND ({update_condition}) THEN
             UPDATE SET

--- a/products/batch_exports/backend/tests/temporal/destinations/databricks/test_client.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/databricks/test_client.py
@@ -1,9 +1,21 @@
+import os
+import uuid
+
 import pytest
 
+from databricks.sql.exc import ServerOperationError
+
 from products.batch_exports.backend.temporal.destinations.databricks_batch_export import (
+    DatabricksCatalogNotFoundError,
     DatabricksClient,
     DatabricksConnectionError,
+    DatabricksSchemaNotFoundError,
 )
+
+pytestmark = [
+    pytest.mark.asyncio,
+    pytest.mark.django_db,
+]
 
 
 async def test_get_merge_query_with_schema_evolution():
@@ -191,3 +203,240 @@ async def test_connect_when_invalid_host():
     ):
         async with client.connect():
             pass
+
+
+# --- SQL injection integration tests ---
+# These tests run against a real Databricks instance to verify that SQL injection
+# via backtick/quote characters in identifiers is not possible.
+
+REQUIRED_ENV_VARS = (
+    "DATABRICKS_BE_SERVER_HOSTNAME",
+    "DATABRICKS_BE_HTTP_PATH",
+    "DATABRICKS_BE_CLIENT_ID",
+    "DATABRICKS_BE_CLIENT_SECRET",
+)
+
+SKIP_IF_MISSING_DATABRICKS_CREDENTIALS = pytest.mark.skipif(
+    not all(env_var in os.environ for env_var in REQUIRED_ENV_VARS),
+    reason=f"Databricks required env vars are not set: {', '.join(REQUIRED_ENV_VARS)}",
+)
+
+TEST_CATALOG = os.getenv("DATABRICKS_CATALOG", "batch_export_tests")
+
+
+@pytest.fixture(scope="class")
+async def sqli_schema_name():
+    """Generate a unique schema name for this test session to avoid collisions."""
+    return f"sqli_tests_{uuid.uuid4().hex[:8]}"
+
+
+@pytest.fixture(scope="class")
+async def sqli_other_schema_name(sqli_schema_name: str):
+    """Generate the companion 'other' schema name used by cross-schema tests."""
+    return f"{sqli_schema_name}_other"
+
+
+@pytest.fixture(scope="class")
+async def databricks_client(sqli_schema_name: str):
+    """Create a connected DatabricksClient for SQL injection tests."""
+    client = DatabricksClient(
+        server_hostname=os.getenv("DATABRICKS_BE_SERVER_HOSTNAME", ""),
+        http_path=os.getenv("DATABRICKS_BE_HTTP_PATH", ""),
+        client_id=os.getenv("DATABRICKS_BE_CLIENT_ID", ""),
+        client_secret=os.getenv("DATABRICKS_BE_CLIENT_SECRET", ""),
+        catalog=TEST_CATALOG,
+        schema=sqli_schema_name,
+    )
+    async with client.connect(set_context=False) as connected_client:
+        yield connected_client
+
+
+@pytest.fixture(scope="class")
+async def setup_sqli_schema(databricks_client: DatabricksClient, sqli_schema_name: str):
+    """Create and tear down the test schema used by SQL injection tests."""
+    await databricks_client.use_catalog(TEST_CATALOG)
+    await databricks_client.execute_query(f"CREATE SCHEMA IF NOT EXISTS `{sqli_schema_name}`", fetch_results=False)
+    await databricks_client.use_schema(sqli_schema_name)
+
+    yield
+
+    await databricks_client.use_catalog(TEST_CATALOG)
+    await databricks_client.execute_query(f"DROP SCHEMA IF EXISTS `{sqli_schema_name}` CASCADE", fetch_results=False)
+
+
+@pytest.fixture
+async def canary_table(databricks_client: DatabricksClient, setup_sqli_schema: None):
+    """Create a canary table that injection attacks will attempt to drop.
+
+    If any injection succeeds, this table will be missing when we check for it.
+    """
+    table_name = f"canary_{uuid.uuid4().hex[:8]}"
+    await databricks_client.acreate_table(
+        table_name=table_name,
+        fields=[("id", "INTEGER")],
+    )
+    yield table_name
+    # clean up (may already be gone if injection succeeded)
+    try:
+        await databricks_client.adelete_table(table_name)
+    except Exception:
+        pass
+
+
+async def _assert_table_exists(client: DatabricksClient, table_name: str, schema_name: str):
+    """Re-establish catalog/schema context and assert that a table exists."""
+    await client.use_catalog(TEST_CATALOG)
+    await client.use_schema(schema_name)
+    results = await client.execute_query(f"SELECT 1 FROM `{table_name}` LIMIT 0")
+    assert results is not None
+
+
+@pytest.fixture(scope="class")
+async def other_schema_with_table(
+    databricks_client: DatabricksClient, setup_sqli_schema: None, sqli_other_schema_name: str
+):
+    """Create a table in a separate schema that cross-schema injection attacks will try to target."""
+    await databricks_client.execute_query(
+        f"CREATE SCHEMA IF NOT EXISTS `{sqli_other_schema_name}`", fetch_results=False
+    )
+    table_name = f"target_{uuid.uuid4().hex[:8]}"
+    await databricks_client.execute_query(
+        f"CREATE TABLE IF NOT EXISTS `{sqli_other_schema_name}`.`{table_name}` (id INTEGER)", fetch_results=False
+    )
+
+    yield table_name
+
+    # Clean up
+    try:
+        await databricks_client.execute_query(
+            f"DROP SCHEMA IF EXISTS `{sqli_other_schema_name}` CASCADE", fetch_results=False
+        )
+    except Exception:
+        pass
+
+
+async def _assert_table_exists_in_schema(client: DatabricksClient, schema: str, table_name: str):
+    """Assert that a table exists in a specific schema."""
+    try:
+        results = await client.execute_query(f"SELECT 1 FROM `{schema}`.`{table_name}` LIMIT 0")
+    except ServerOperationError as e:
+        if "TABLE_OR_VIEW_NOT_FOUND" in str(e):
+            raise AssertionError(f"Table `{schema}`.`{table_name}` not found")
+        raise
+    assert results is not None
+
+
+@SKIP_IF_MISSING_DATABRICKS_CREDENTIALS
+class TestSQLInjection:
+    """Test that SQL injection via backtick/quote characters in identifiers is not possible.
+
+    Two categories of attack are tested:
+
+    1. Multi-statement injection: Databricks doesn't support multi-statement execution,
+       so payloads like "`; DROP TABLE t; --" will be rejected with a syntax error.
+       These tests verify that even if the backtick quoting is broken, no damage occurs.
+
+    2. Cross-schema targeting: breaking out of backtick quoting to form a
+       fully-qualified reference that targets a different schema's objects.
+       E.g. table_name = 'other_schema`.`target_table' produces:
+         DROP TABLE IF EXISTS `other_schema`.`target_table`  (cross-schema drop)
+    """
+
+    # --- Multi-statement injection ---
+
+    async def test_use_schema_multi_statement_injection(
+        self, databricks_client: DatabricksClient, canary_table: str, sqli_schema_name: str
+    ):
+        malicious_schema = f"{sqli_schema_name}`; DROP TABLE {canary_table}; --"
+        with pytest.raises(DatabricksSchemaNotFoundError):
+            await databricks_client.use_schema(malicious_schema)
+
+        await _assert_table_exists(databricks_client, canary_table, sqli_schema_name)
+
+    async def test_use_catalog_multi_statement_injection(
+        self, databricks_client: DatabricksClient, canary_table: str, sqli_schema_name: str
+    ):
+        malicious_catalog = f"{TEST_CATALOG}`; DROP TABLE {canary_table}; --"
+        with pytest.raises(DatabricksCatalogNotFoundError):
+            await databricks_client.use_catalog(malicious_catalog)
+
+        await _assert_table_exists(databricks_client, canary_table, sqli_schema_name)
+
+    async def test_create_table_name_multi_statement_injection(
+        self, databricks_client: DatabricksClient, canary_table: str, sqli_schema_name: str
+    ):
+        malicious_table = f"{canary_table}` (id INTEGER); DROP TABLE {canary_table}; --"
+        with pytest.raises(ServerOperationError, match="INVALID_PARAMETER_VALUE"):
+            await databricks_client.acreate_table(
+                table_name=malicious_table,
+                fields=[("id", "INTEGER")],
+            )
+
+        await _assert_table_exists(databricks_client, canary_table, sqli_schema_name)
+
+    async def test_create_table_field_name_multi_statement_injection(
+        self, databricks_client: DatabricksClient, canary_table: str, sqli_schema_name: str
+    ):
+        malicious_field = f"id` INTEGER); DROP TABLE {canary_table}; CREATE TABLE x (y"
+        with pytest.raises(ServerOperationError, match="DELTA_INVALID_CHARACTERS_IN_COLUMN_NAMES"):
+            await databricks_client.acreate_table(
+                table_name=f"safe_{uuid.uuid4().hex[:8]}",
+                fields=[(malicious_field, "INTEGER")],
+            )
+
+        await _assert_table_exists(databricks_client, canary_table, sqli_schema_name)
+
+    async def test_delete_table_multi_statement_injection(
+        self, databricks_client: DatabricksClient, canary_table: str, sqli_schema_name: str
+    ):
+        # adelete_table uses IF EXISTS, therefore isn't expected to raise an
+        # error if an invalid table name is provided - the important thing is the canary survives
+        await databricks_client.adelete_table(f"{canary_table}`; DROP TABLE {canary_table}; --")
+        await _assert_table_exists(databricks_client, canary_table, sqli_schema_name)
+
+    async def test_create_volume_multi_statement_injection(
+        self, databricks_client: DatabricksClient, canary_table: str, sqli_schema_name: str
+    ):
+        malicious_volume = f"x` COMMENT 'ok'; DROP TABLE {canary_table}; --"
+        with pytest.raises(ServerOperationError, match="INVALID_ATTRIBUTE_NAME_SYNTAX"):
+            await databricks_client.acreate_volume(malicious_volume)
+
+        await _assert_table_exists(databricks_client, canary_table, sqli_schema_name)
+
+    async def test_delete_volume_multi_statement_injection(
+        self, databricks_client: DatabricksClient, canary_table: str, sqli_schema_name: str
+    ):
+        malicious_volume = f"x`; DROP TABLE {canary_table}; --"
+        with pytest.raises(ServerOperationError, match="INVALID_ATTRIBUTE_NAME_SYNTAX"):
+            await databricks_client.adelete_volume(malicious_volume)
+
+        await _assert_table_exists(databricks_client, canary_table, sqli_schema_name)
+
+    # --- Cross-schema targeting (single-statement attacks) ---
+
+    async def test_cross_schema_use_schema(
+        self,
+        databricks_client: DatabricksClient,
+        other_schema_with_table: str,
+        sqli_schema_name: str,
+        sqli_other_schema_name: str,
+    ):
+        await databricks_client.use_catalog(TEST_CATALOG)
+        await databricks_client.use_schema(sqli_schema_name)
+
+        malicious_schema = f"{TEST_CATALOG}`.`{sqli_other_schema_name}"
+        with pytest.raises(DatabricksSchemaNotFoundError):
+            await databricks_client.use_schema(malicious_schema)
+
+    async def test_cross_schema_delete_table(
+        self,
+        databricks_client: DatabricksClient,
+        other_schema_with_table: str,
+        sqli_other_schema_name: str,
+    ):
+        # We use DROP TABLE IF EXISTS so in this test it will just attempt to
+        # drop a nonexistent table, so no error is raised — the important thing
+        # is the target table survives
+        malicious_table = f"{sqli_other_schema_name}`.`{other_schema_with_table}"
+        await databricks_client.adelete_table(malicious_table)
+        await _assert_table_exists_in_schema(databricks_client, sqli_other_schema_name, other_schema_with_table)


### PR DESCRIPTION
## Problem

In Databricks some identifiers need characters escaping.

## Changes

Escape certain characters from identifiers and paths.

## How did you test this code?

Added tests and ran existing ones against test Databricks instance.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## 🤖 LLM context

Co-authored using Claude Opus 4.6
