### PR TITLE
chore(workflows): increase variable space limit to 5kb

### DIFF
--- a/nodejs/src/cdp/types.ts
+++ b/nodejs/src/cdp/types.ts
@@ -116,7 +116,7 @@ export type HogFunctionInvocationGlobals = {
  * These variables can be used to store loop state or pass data between actions
  *
  * Action's can read and write to these variables. Any value stored in the variables
- * map must be JSON serializable, and limited to 1KB in size.
+ * map must be JSON serializable, and limited to 5KB in size.
  *
  * After execution, every action will have a corresponding entry in the map with
  * the key `$action/{actionId}` containing the result of the action.

--- a/posthog/api/hog_flow.py
+++ b/posthog/api/hog_flow.py
@@ -174,12 +174,12 @@ class HogFlowVariableSerializer(serializers.ListSerializer):
         if len(keys) != len(set(keys)):
             raise serializers.ValidationError("Variable keys must be unique")
 
-        # Make sure entire variables definition is less than 1KB
+        # Make sure entire variables definition is less than 5KB
         # This is just a check for massive keys / default values, we also have a check for dynamically
         # set variables during execution
         total_size = sum(len(json.dumps(item)) for item in attrs)
-        if total_size > 1024:
-            raise serializers.ValidationError("Total size of variables definition must be less than 1KB")
+        if total_size > 5120:
+            raise serializers.ValidationError("Total size of variables definition must be less than 5KB")
 
         return super().validate(attrs)
 

--- a/posthog/api/test/test_hog_flow.py
+++ b/posthog/api/test/test_hog_flow.py
@@ -1410,37 +1410,37 @@ class TestHogFlowAPI(APIBaseTest):
             "variables": variables,
         }
 
-    def test_variables_with_unique_keys_accepted(self):
-        hog_flow = self._base_hog_flow_with_variables(
-            [
-                {"key": "name", "value": ""},
-                {"key": "email", "value": ""},
-            ]
-        )
+    @parameterized.expand(
+        [
+            (
+                "unique_keys_accepted",
+                [{"key": "name", "value": ""}, {"key": "email", "value": ""}],
+                201,
+                None,
+            ),
+            (
+                "duplicate_keys_rejected",
+                [{"key": "name", "value": ""}, {"key": "name", "value": "other"}],
+                400,
+                "Variable keys must be unique",
+            ),
+            (
+                "exceeding_5kb_rejected",
+                [{"key": f"var_{i}", "value": "x" * 1000} for i in range(6)],
+                400,
+                "Total size of variables definition must be less than 5KB",
+            ),
+            (
+                "just_under_5kb_accepted",
+                [{"key": f"v_{i:02d}", "value": "x" * 1200} for i in range(4)],
+                201,
+                None,
+            ),
+        ]
+    )
+    def test_variables_validation(self, _name, variables, expected_status, expected_error):
+        hog_flow = self._base_hog_flow_with_variables(variables)
         response = self.client.post(f"/api/projects/{self.team.id}/hog_flows", hog_flow)
-        assert response.status_code == 201, response.json()
-        assert len(response.json()["variables"]) == 2
-
-    def test_variables_with_duplicate_keys_rejected(self):
-        hog_flow = self._base_hog_flow_with_variables(
-            [
-                {"key": "name", "value": ""},
-                {"key": "name", "value": "other"},
-            ]
-        )
-        response = self.client.post(f"/api/projects/{self.team.id}/hog_flows", hog_flow)
-        assert response.status_code == 400, response.json()
-        assert response.json()["detail"] == "Variable keys must be unique"
-
-    def test_variables_exceeding_5kb_rejected(self):
-        hog_flow = self._base_hog_flow_with_variables([{"key": f"var_{i}", "value": "x" * 1000} for i in range(6)])
-        response = self.client.post(f"/api/projects/{self.team.id}/hog_flows", hog_flow)
-        assert response.status_code == 400, response.json()
-        assert response.json()["detail"] == "Total size of variables definition must be less than 5KB"
-
-    def test_variables_just_under_5kb_accepted(self):
-        # Each item: {"key": "v_XX", "value": "x..."} — about 30 bytes overhead per item
-        # 4 items with ~1200 char values ≈ 4920 bytes, under 5120
-        hog_flow = self._base_hog_flow_with_variables([{"key": f"v_{i:02d}", "value": "x" * 1200} for i in range(4)])
-        response = self.client.post(f"/api/projects/{self.team.id}/hog_flows", hog_flow)
-        assert response.status_code == 201, response.json()
+        assert response.status_code == expected_status, response.json()
+        if expected_error:
+            assert response.json()["detail"] == expected_error

--- a/posthog/api/test/test_hog_flow.py
+++ b/posthog/api/test/test_hog_flow.py
@@ -1391,3 +1391,56 @@ class TestHogFlowAPI(APIBaseTest):
         assert response.status_code == 200, response.json()
         assert response.json()["deleted"] == 0
         assert HogFlow.objects.filter(id=flow_id).exists()
+
+    def _base_hog_flow_with_variables(self, variables):
+        trigger_action = {
+            "id": "trigger_node",
+            "name": "trigger_1",
+            "type": "trigger",
+            "config": {
+                "type": "event",
+                "filters": {
+                    "events": [{"id": "$pageview", "name": "$pageview", "type": "events", "order": 0}],
+                },
+            },
+        }
+        return {
+            "name": "Test Flow",
+            "actions": [trigger_action],
+            "variables": variables,
+        }
+
+    def test_variables_with_unique_keys_accepted(self):
+        hog_flow = self._base_hog_flow_with_variables(
+            [
+                {"key": "name", "value": ""},
+                {"key": "email", "value": ""},
+            ]
+        )
+        response = self.client.post(f"/api/projects/{self.team.id}/hog_flows", hog_flow)
+        assert response.status_code == 201, response.json()
+        assert len(response.json()["variables"]) == 2
+
+    def test_variables_with_duplicate_keys_rejected(self):
+        hog_flow = self._base_hog_flow_with_variables(
+            [
+                {"key": "name", "value": ""},
+                {"key": "name", "value": "other"},
+            ]
+        )
+        response = self.client.post(f"/api/projects/{self.team.id}/hog_flows", hog_flow)
+        assert response.status_code == 400, response.json()
+        assert response.json()["detail"] == "Variable keys must be unique"
+
+    def test_variables_exceeding_5kb_rejected(self):
+        hog_flow = self._base_hog_flow_with_variables([{"key": f"var_{i}", "value": "x" * 1000} for i in range(6)])
+        response = self.client.post(f"/api/projects/{self.team.id}/hog_flows", hog_flow)
+        assert response.status_code == 400, response.json()
+        assert response.json()["detail"] == "Total size of variables definition must be less than 5KB"
+
+    def test_variables_just_under_5kb_accepted(self):
+        # Each item: {"key": "v_XX", "value": "x..."} — about 30 bytes overhead per item
+        # 4 items with ~1200 char values ≈ 4920 bytes, under 5120
+        hog_flow = self._base_hog_flow_with_variables([{"key": f"v_{i:02d}", "value": "x" * 1200} for i in range(4)])
+        response = self.client.post(f"/api/projects/{self.team.id}/hog_flows", hog_flow)
+        assert response.status_code == 201, response.json()


### PR DESCRIPTION
## Problem

We enforce 5kb on the hogflow-executor side, the hogflow api should enforce the same limit

## Changes

1kb->5kb limit 

## How did you test this code?

Add missing tests for this validation

## Publish to changelog?

No