### PR TITLE
chore(clickhouse): add desired-state YAML for all 210 production tables

### DIFF
--- a/posthog/clickhouse/schema/adhoc_events_deletion.yaml
+++ b/posthog/clickhouse/schema/adhoc_events_deletion.yaml
@@ -1,0 +1,30 @@
+# Desired-state schema for the adhoc_events_deletion table.
+
+ecosystem: adhoc_events_deletion
+cluster: main
+
+tables:
+    adhoc_events_deletion:
+        engine: ReplicatedReplacingMergeTree
+        sharded: false
+        on_nodes:
+            - DATA
+            - COORDINATOR
+        order_by:
+            - team_id
+            - uuid
+        columns:
+            - name: team_id
+              type: Int64
+            - name: uuid
+              type: UUID
+            - name: created_at
+              type: "DateTime64(6, 'UTC')"
+              default_expression: 'now64()'
+              default_kind: DEFAULT
+            - name: deleted_at
+              type: DateTime
+            - name: is_deleted
+              type: UInt8
+              default_expression: '0'
+              default_kind: DEFAULT

--- a/posthog/clickhouse/schema/adhoc_events_deletion.yaml
+++ b/posthog/clickhouse/schema/adhoc_events_deletion.yaml
@@ -9,7 +9,7 @@ tables:
         sharded: false
         on_nodes:
             - DATA
-            - COORDINATOR
+            - DATA
         order_by:
             - team_id
             - uuid

--- a/posthog/clickhouse/schema/adhoc_events_deletion.yaml
+++ b/posthog/clickhouse/schema/adhoc_events_deletion.yaml
@@ -9,7 +9,7 @@ tables:
         sharded: false
         on_nodes:
             - DATA
-            - DATA
+            - COORDINATOR
         order_by:
             - team_id
             - uuid

--- a/posthog/clickhouse/schema/ai_events.yaml
+++ b/posthog/clickhouse/schema/ai_events.yaml
@@ -1,0 +1,190 @@
+# Desired-state schema for the ai_events ecosystem.
+
+ecosystem: ai_events
+cluster: main
+
+tables:
+    sharded_ai_events:
+        engine: ReplicatedMergeTree
+        sharded: true
+        on_nodes: DATA
+        order_by:
+            - team_id
+            - trace_id
+            - timestamp
+        partition_by: 'toYYYYMM(drop_date)'
+        settings:
+            ttl_only_drop_parts: '1'
+        columns:
+            - name: uuid
+              type: UUID
+            - name: event
+              type: LowCardinality(String)
+            - name: timestamp
+              type: "DateTime64(6, 'UTC')"
+            - name: team_id
+              type: Int64
+            - name: distinct_id
+              type: String
+            - name: person_id
+              type: UUID
+            - name: properties
+              type: String
+            - name: retention_days
+              type: Int16
+              default_expression: '30'
+              default_kind: DEFAULT
+            - name: drop_date
+              type: Date
+            - name: trace_id
+              type: String
+            - name: session_id
+              type: Nullable(String)
+            - name: parent_id
+              type: Nullable(String)
+            - name: span_id
+              type: Nullable(String)
+            - name: span_type
+              type: LowCardinality(Nullable(String))
+            - name: generation_id
+              type: Nullable(String)
+            - name: experiment_id
+              type: Nullable(String)
+            - name: span_name
+              type: Nullable(String)
+            - name: trace_name
+              type: Nullable(String)
+            - name: prompt_name
+              type: Nullable(String)
+            - name: model
+              type: LowCardinality(Nullable(String))
+            - name: provider
+              type: LowCardinality(Nullable(String))
+            - name: framework
+              type: LowCardinality(Nullable(String))
+            - name: total_tokens
+              type: Nullable(Int64)
+            - name: input_tokens
+              type: Nullable(Int64)
+            - name: output_tokens
+              type: Nullable(Int64)
+            - name: text_input_tokens
+              type: Nullable(Int64)
+            - name: text_output_tokens
+              type: Nullable(Int64)
+            - name: image_input_tokens
+              type: Nullable(Int64)
+            - name: image_output_tokens
+              type: Nullable(Int64)
+            - name: audio_input_tokens
+              type: Nullable(Int64)
+            - name: audio_output_tokens
+              type: Nullable(Int64)
+            - name: video_input_tokens
+              type: Nullable(Int64)
+            - name: video_output_tokens
+              type: Nullable(Int64)
+            - name: reasoning_tokens
+              type: Nullable(Int64)
+            - name: cache_read_input_tokens
+              type: Nullable(Int64)
+            - name: cache_creation_input_tokens
+              type: Nullable(Int64)
+            - name: web_search_count
+              type: Nullable(Int64)
+            - name: input_cost_usd
+              type: Nullable(Float64)
+            - name: output_cost_usd
+              type: Nullable(Float64)
+            - name: total_cost_usd
+              type: Nullable(Float64)
+            - name: request_cost_usd
+              type: Nullable(Float64)
+            - name: web_search_cost_usd
+              type: Nullable(Float64)
+            - name: audio_cost_usd
+              type: Nullable(Float64)
+            - name: image_cost_usd
+              type: Nullable(Float64)
+            - name: video_cost_usd
+              type: Nullable(Float64)
+            - name: latency
+              type: Nullable(Float64)
+            - name: time_to_first_token
+              type: Nullable(Float64)
+            - name: is_error
+              type: UInt8
+            - name: error
+              type: Nullable(String)
+            - name: error_type
+              type: LowCardinality(Nullable(String))
+            - name: error_normalized
+              type: Nullable(String)
+            - name: input
+              type: Nullable(String)
+            - name: output
+              type: Nullable(String)
+            - name: output_choices
+              type: Nullable(String)
+            - name: input_state
+              type: Nullable(String)
+            - name: output_state
+              type: Nullable(String)
+            - name: tools
+              type: Nullable(String)
+
+    writable_ai_events:
+        engine: Distributed
+        source: sharded_ai_events
+        sharding_key: "cityHash64(concat(toString(team_id), '-', trace_id, '-', toString(toDate(timestamp))))"
+        on_nodes: COORDINATOR
+        columns: inherit sharded_ai_events
+
+    ai_events:
+        engine: Distributed
+        source: sharded_ai_events
+        sharding_key: "cityHash64(concat(toString(team_id), '-', trace_id, '-', toString(toDate(timestamp))))"
+        on_nodes: ALL
+        columns: inherit sharded_ai_events
+
+    kafka_ai_events_json:
+        engine: Kafka
+        on_nodes: INGESTION_EVENTS
+        settings:
+            kafka_broker_list: __from_settings__
+            kafka_topic_list: clickhouse_ai_events_json
+            kafka_group_name: ai_events
+            kafka_format: JSONEachRow
+        columns:
+            - name: uuid
+              type: UUID
+            - name: event
+              type: String
+            - name: properties
+              type: String
+            - name: timestamp
+              type: "DateTime64(6, 'UTC')"
+            - name: team_id
+              type: Int64
+            - name: distinct_id
+              type: String
+            - name: elements_chain
+              type: String
+            - name: created_at
+              type: "DateTime64(6, 'UTC')"
+            - name: person_id
+              type: UUID
+            - name: person_properties
+              type: String
+            - name: person_created_at
+              type: DateTime64(3)
+            - name: person_mode
+              type: "Enum8('full' = 0, 'propertyless' = 1, 'force_upgrade' = 2)"
+
+    ai_events_json_mv:
+        engine: MaterializedView
+        source: kafka_ai_events_json
+        target: writable_ai_events
+        select: "SELECT ... FROM {{ database }}.kafka_ai_events_json"
+        on_nodes: INGESTION_EVENTS
+        columns: []

--- a/posthog/clickhouse/schema/ai_events.yaml
+++ b/posthog/clickhouse/schema/ai_events.yaml
@@ -185,6 +185,6 @@ tables:
         engine: MaterializedView
         source: kafka_ai_events_json
         target: writable_ai_events
-        select: "SELECT ... FROM {{ database }}.kafka_ai_events_json"
+        select: 'SELECT ... FROM {{ database }}.kafka_ai_events_json'
         on_nodes: INGESTION_EVENTS
         columns: []

--- a/posthog/clickhouse/schema/ai_events.yaml
+++ b/posthog/clickhouse/schema/ai_events.yaml
@@ -137,7 +137,7 @@ tables:
         engine: Distributed
         source: sharded_ai_events
         sharding_key: "cityHash64(concat(toString(team_id), '-', trace_id, '-', toString(toDate(timestamp))))"
-        on_nodes: DATA
+        on_nodes: COORDINATOR
         columns: inherit sharded_ai_events
 
     ai_events:

--- a/posthog/clickhouse/schema/ai_events.yaml
+++ b/posthog/clickhouse/schema/ai_events.yaml
@@ -137,7 +137,7 @@ tables:
         engine: Distributed
         source: sharded_ai_events
         sharding_key: "cityHash64(concat(toString(team_id), '-', trace_id, '-', toString(toDate(timestamp))))"
-        on_nodes: COORDINATOR
+        on_nodes: DATA
         columns: inherit sharded_ai_events
 
     ai_events:

--- a/posthog/clickhouse/schema/app_metrics.yaml
+++ b/posthog/clickhouse/schema/app_metrics.yaml
@@ -1,0 +1,96 @@
+# Desired-state schema for the app_metrics ecosystem.
+
+ecosystem: app_metrics
+cluster: main
+
+tables:
+    sharded_app_metrics:
+        engine: ReplicatedAggregatingMergeTree
+        sharded: true
+        on_nodes: DATA
+        order_by:
+            - team_id
+            - plugin_config_id
+            - job_id
+            - category
+            - 'toStartOfHour(timestamp)'
+            - error_type
+            - error_uuid
+        partition_by: 'toYYYYMM(timestamp)'
+        columns:
+            - name: team_id
+              type: Int64
+            - name: timestamp
+              type: "DateTime64(6, 'UTC')"
+            - name: plugin_config_id
+              type: Int64
+            - name: category
+              type: LowCardinality(String)
+            - name: job_id
+              type: String
+            - name: successes
+              type: "SimpleAggregateFunction(sum, Int64)"
+            - name: successes_on_retry
+              type: "SimpleAggregateFunction(sum, Int64)"
+            - name: failures
+              type: "SimpleAggregateFunction(sum, Int64)"
+            - name: error_uuid
+              type: UUID
+            - name: error_type
+              type: String
+            - name: error_details
+              type: String
+
+    writable_app_metrics:
+        engine: Distributed
+        source: sharded_app_metrics
+        sharding_key: 'rand()'
+        on_nodes: COORDINATOR
+        columns: inherit sharded_app_metrics
+
+    app_metrics:
+        engine: Distributed
+        source: sharded_app_metrics
+        sharding_key: 'rand()'
+        on_nodes: ALL
+        columns: inherit sharded_app_metrics
+
+    kafka_app_metrics:
+        engine: Kafka
+        on_nodes: INGESTION_EVENTS
+        settings:
+            kafka_broker_list: __from_settings__
+            kafka_topic_list: clickhouse_app_metrics
+            kafka_group_name: clickhouse_app_metrics
+            kafka_format: JSONEachRow
+        columns:
+            - name: team_id
+              type: Int64
+            - name: timestamp
+              type: "DateTime64(6, 'UTC')"
+            - name: plugin_config_id
+              type: Int64
+            - name: category
+              type: LowCardinality(String)
+            - name: job_id
+              type: String
+            - name: successes
+              type: Int64
+            - name: successes_on_retry
+              type: Int64
+            - name: failures
+              type: Int64
+            - name: error_uuid
+              type: UUID
+            - name: error_type
+              type: String
+            - name: error_details
+              type: String
+
+    app_metrics_mv:
+        engine: MaterializedView
+        source: kafka_app_metrics
+        target: writable_app_metrics
+        select: "SELECT team_id, timestamp, plugin_config_id, category, job_id, successes, successes_on_retry, failures, error_uuid, error_type, error_details, _timestamp, _offset, _partition FROM {{ database }}.kafka_app_metrics"
+        on_nodes: INGESTION_EVENTS
+        columns: []

--- a/posthog/clickhouse/schema/app_metrics.yaml
+++ b/posthog/clickhouse/schema/app_metrics.yaml
@@ -45,7 +45,7 @@ tables:
         engine: Distributed
         source: sharded_app_metrics
         sharding_key: 'rand()'
-        on_nodes: COORDINATOR
+        on_nodes: DATA
         columns: inherit sharded_app_metrics
 
     app_metrics:

--- a/posthog/clickhouse/schema/app_metrics.yaml
+++ b/posthog/clickhouse/schema/app_metrics.yaml
@@ -40,6 +40,13 @@ tables:
               type: String
             - name: error_details
               type: String
+            # Kafka virtual columns
+            - name: _timestamp
+              type: DateTime
+            - name: _offset
+              type: UInt64
+            - name: _partition
+              type: UInt64
 
     writable_app_metrics:
         engine: Distributed

--- a/posthog/clickhouse/schema/app_metrics.yaml
+++ b/posthog/clickhouse/schema/app_metrics.yaml
@@ -29,11 +29,11 @@ tables:
             - name: job_id
               type: String
             - name: successes
-              type: "SimpleAggregateFunction(sum, Int64)"
+              type: 'SimpleAggregateFunction(sum, Int64)'
             - name: successes_on_retry
-              type: "SimpleAggregateFunction(sum, Int64)"
+              type: 'SimpleAggregateFunction(sum, Int64)'
             - name: failures
-              type: "SimpleAggregateFunction(sum, Int64)"
+              type: 'SimpleAggregateFunction(sum, Int64)'
             - name: error_uuid
               type: UUID
             - name: error_type
@@ -98,6 +98,6 @@ tables:
         engine: MaterializedView
         source: kafka_app_metrics
         target: writable_app_metrics
-        select: "SELECT team_id, timestamp, plugin_config_id, category, job_id, successes, successes_on_retry, failures, error_uuid, error_type, error_details, _timestamp, _offset, _partition FROM {{ database }}.kafka_app_metrics"
+        select: 'SELECT team_id, timestamp, plugin_config_id, category, job_id, successes, successes_on_retry, failures, error_uuid, error_type, error_details, _timestamp, _offset, _partition FROM {{ database }}.kafka_app_metrics'
         on_nodes: INGESTION_EVENTS
         columns: []

--- a/posthog/clickhouse/schema/app_metrics.yaml
+++ b/posthog/clickhouse/schema/app_metrics.yaml
@@ -45,7 +45,7 @@ tables:
         engine: Distributed
         source: sharded_app_metrics
         sharding_key: 'rand()'
-        on_nodes: DATA
+        on_nodes: COORDINATOR
         columns: inherit sharded_app_metrics
 
     app_metrics:

--- a/posthog/clickhouse/schema/app_metrics2.yaml
+++ b/posthog/clickhouse/schema/app_metrics2.yaml
@@ -1,0 +1,84 @@
+# Desired-state schema for the app_metrics2 ecosystem.
+
+ecosystem: app_metrics2
+cluster: main
+
+tables:
+    sharded_app_metrics2:
+        engine: ReplicatedAggregatingMergeTree
+        sharded: true
+        on_nodes: DATA
+        order_by:
+            - team_id
+            - app_source
+            - app_source_id
+            - instance_id
+            - 'toStartOfHour(timestamp)'
+            - metric_kind
+            - metric_name
+        partition_by: 'toYYYYMM(timestamp)'
+        columns:
+            - name: team_id
+              type: Int64
+            - name: timestamp
+              type: "DateTime64(6, 'UTC')"
+            - name: app_source
+              type: LowCardinality(String)
+            - name: app_source_id
+              type: String
+            - name: instance_id
+              type: String
+            - name: metric_kind
+              type: LowCardinality(String)
+            - name: metric_name
+              type: LowCardinality(String)
+            - name: count
+              type: "SimpleAggregateFunction(sum, Int64)"
+
+    writable_app_metrics2:
+        engine: Distributed
+        source: sharded_app_metrics2
+        sharding_key: 'rand()'
+        on_nodes: COORDINATOR
+        columns: inherit sharded_app_metrics2
+
+    app_metrics2:
+        engine: Distributed
+        source: sharded_app_metrics2
+        sharding_key: 'rand()'
+        on_nodes: ALL
+        columns: inherit sharded_app_metrics2
+
+    kafka_app_metrics2:
+        engine: Kafka
+        on_nodes: INGESTION_EVENTS
+        settings:
+            kafka_broker_list: __from_settings__
+            kafka_topic_list: clickhouse_app_metrics2
+            kafka_group_name: clickhouse_app_metrics2
+            kafka_format: JSONEachRow
+        columns:
+            - name: team_id
+              type: Int64
+            - name: timestamp
+              type: "DateTime64(6, 'UTC')"
+            - name: app_source
+              type: LowCardinality(String)
+            - name: app_source_id
+              type: String
+            - name: instance_id
+              type: String
+            - name: metric_kind
+              type: String
+            - name: metric_name
+              type: String
+            - name: count
+              type: Int64
+
+    app_metrics2_mv:
+        engine: MaterializedView
+        source: kafka_app_metrics2
+        target: writable_app_metrics2
+        select: "SELECT team_id, timestamp, app_source, app_source_id, instance_id, metric_kind, metric_name, count, _timestamp, _offset, _partition FROM {{ database }}.kafka_app_metrics2"
+        on_nodes: INGESTION_EVENTS
+        columns: []

--- a/posthog/clickhouse/schema/app_metrics2.yaml
+++ b/posthog/clickhouse/schema/app_metrics2.yaml
@@ -34,6 +34,13 @@ tables:
               type: LowCardinality(String)
             - name: count
               type: "SimpleAggregateFunction(sum, Int64)"
+            # Kafka virtual columns
+            - name: _timestamp
+              type: DateTime
+            - name: _offset
+              type: UInt64
+            - name: _partition
+              type: UInt64
 
     writable_app_metrics2:
         engine: Distributed

--- a/posthog/clickhouse/schema/app_metrics2.yaml
+++ b/posthog/clickhouse/schema/app_metrics2.yaml
@@ -39,7 +39,7 @@ tables:
         engine: Distributed
         source: sharded_app_metrics2
         sharding_key: 'rand()'
-        on_nodes: COORDINATOR
+        on_nodes: DATA
         columns: inherit sharded_app_metrics2
 
     app_metrics2:

--- a/posthog/clickhouse/schema/app_metrics2.yaml
+++ b/posthog/clickhouse/schema/app_metrics2.yaml
@@ -39,7 +39,7 @@ tables:
         engine: Distributed
         source: sharded_app_metrics2
         sharding_key: 'rand()'
-        on_nodes: DATA
+        on_nodes: COORDINATOR
         columns: inherit sharded_app_metrics2
 
     app_metrics2:

--- a/posthog/clickhouse/schema/app_metrics2.yaml
+++ b/posthog/clickhouse/schema/app_metrics2.yaml
@@ -33,7 +33,7 @@ tables:
             - name: metric_name
               type: LowCardinality(String)
             - name: count
-              type: "SimpleAggregateFunction(sum, Int64)"
+              type: 'SimpleAggregateFunction(sum, Int64)'
             # Kafka virtual columns
             - name: _timestamp
               type: DateTime
@@ -86,6 +86,6 @@ tables:
         engine: MaterializedView
         source: kafka_app_metrics2
         target: writable_app_metrics2
-        select: "SELECT team_id, timestamp, app_source, app_source_id, instance_id, metric_kind, metric_name, count, _timestamp, _offset, _partition FROM {{ database }}.kafka_app_metrics2"
+        select: 'SELECT team_id, timestamp, app_source, app_source_id, instance_id, metric_kind, metric_name, count, _timestamp, _offset, _partition FROM {{ database }}.kafka_app_metrics2'
         on_nodes: INGESTION_EVENTS
         columns: []

--- a/posthog/clickhouse/schema/channel_definition.yaml
+++ b/posthog/clickhouse/schema/channel_definition.yaml
@@ -1,0 +1,39 @@
+# Desired-state schema for the channel_definition ecosystem.
+
+ecosystem: channel_definition
+cluster: main
+
+tables:
+    channel_definition:
+        engine: ReplicatedMergeTree
+        sharded: false
+        on_nodes: ALL
+        order_by:
+            - domain
+            - kind
+        columns:
+            - name: domain
+              type: String
+            - name: kind
+              type: String
+            - name: domain_type
+              type: Nullable(String)
+            - name: type_if_paid
+              type: Nullable(String)
+            - name: type_if_organic
+              type: Nullable(String)
+
+    channel_definition_dict:
+        engine: Dictionary
+        on_nodes: ALL
+        columns:
+            - name: domain
+              type: String
+            - name: kind
+              type: String
+            - name: domain_type
+              type: Nullable(String)
+            - name: type_if_paid
+              type: Nullable(String)
+            - name: type_if_organic
+              type: Nullable(String)

--- a/posthog/clickhouse/schema/channel_definition.yaml
+++ b/posthog/clickhouse/schema/channel_definition.yaml
@@ -26,6 +26,16 @@ tables:
     channel_definition_dict:
         engine: Dictionary
         on_nodes: ALL
+        primary_key: domain, kind
+        source:
+            type: CLICKHOUSE
+            table: channel_definition
+            password: __from_settings__
+        layout:
+            type: COMPLEX_KEY_HASHED
+        lifetime:
+            min: 3000
+            max: 3600
         columns:
             - name: domain
               type: String

--- a/posthog/clickhouse/schema/cohort_membership.yaml
+++ b/posthog/clickhouse/schema/cohort_membership.yaml
@@ -1,0 +1,62 @@
+# Desired-state schema for the cohort_membership ecosystem.
+
+ecosystem: cohort_membership
+cluster: main
+
+tables:
+    cohort_membership:
+        engine: ReplicatedReplacingMergeTree
+        sharded: false
+        on_nodes: DATA
+        order_by:
+            - team_id
+            - cohort_id
+            - person_id
+        columns:
+            - name: team_id
+              type: Int64
+            - name: cohort_id
+              type: Int64
+            - name: person_id
+              type: UUID
+            - name: status
+              type: "Enum8('entered' = 1, 'left' = 2)"
+            - name: last_updated
+              type: DateTime64(6)
+              default_expression: 'now64()'
+              default_kind: DEFAULT
+
+    writable_cohort_membership:
+        engine: Distributed
+        source: cohort_membership
+        sharding_key: 'rand()'
+        on_nodes: COORDINATOR
+        columns: inherit cohort_membership
+
+    kafka_cohort_membership:
+        engine: Kafka
+        on_nodes: INGESTION_EVENTS
+        settings:
+            kafka_broker_list: __from_settings__
+            kafka_topic_list: cohort_membership_changed
+            kafka_group_name: clickhouse_cohort_membership_changed
+            kafka_format: JSONEachRow
+        columns:
+            - name: team_id
+              type: Int64
+            - name: cohort_id
+              type: Int64
+            - name: person_id
+              type: UUID
+            - name: status
+              type: "Enum8('entered' = 1, 'left' = 2, 'member' = 3, 'not_member' = 4)"
+            - name: last_updated
+              type: DateTime64(6)
+
+    cohort_membership_mv:
+        engine: MaterializedView
+        source: kafka_cohort_membership
+        target: writable_cohort_membership
+        select: "SELECT team_id, cohort_id, person_id, multiIf(status = 'member', 'entered', status = 'not_member', 'left', status) AS status, last_updated FROM {{ database }}.kafka_cohort_membership"
+        on_nodes: INGESTION_EVENTS
+        columns: []

--- a/posthog/clickhouse/schema/cohort_membership.yaml
+++ b/posthog/clickhouse/schema/cohort_membership.yaml
@@ -30,7 +30,7 @@ tables:
         engine: Distributed
         source: cohort_membership
         sharding_key: 'rand()'
-        on_nodes: COORDINATOR
+        on_nodes: DATA
         columns: inherit cohort_membership
 
     kafka_cohort_membership:

--- a/posthog/clickhouse/schema/cohort_membership.yaml
+++ b/posthog/clickhouse/schema/cohort_membership.yaml
@@ -30,7 +30,7 @@ tables:
         engine: Distributed
         source: cohort_membership
         sharding_key: 'rand()'
-        on_nodes: DATA
+        on_nodes: COORDINATOR
         columns: inherit cohort_membership
 
     kafka_cohort_membership:

--- a/posthog/clickhouse/schema/cohortpeople.yaml
+++ b/posthog/clickhouse/schema/cohortpeople.yaml
@@ -1,0 +1,26 @@
+# Desired-state schema for the cohortpeople ecosystem.
+
+ecosystem: cohortpeople
+cluster: main
+
+tables:
+    cohortpeople:
+        engine: ReplicatedCollapsingMergeTree
+        sharded: false
+        on_nodes: DATA
+        order_by:
+            - team_id
+            - cohort_id
+            - person_id
+            - version
+        columns:
+            - name: person_id
+              type: UUID
+            - name: cohort_id
+              type: Int64
+            - name: team_id
+              type: Int64
+            - name: sign
+              type: Int8
+            - name: version
+              type: UInt64

--- a/posthog/clickhouse/schema/custom_metrics.yaml
+++ b/posthog/clickhouse/schema/custom_metrics.yaml
@@ -20,6 +20,6 @@ tables:
               default_expression: 'now()'
               default_kind: DEFAULT
             - name: labels
-              type: "Map(String, String)"
+              type: 'Map(String, String)'
             - name: increment
               type: Float64

--- a/posthog/clickhouse/schema/custom_metrics.yaml
+++ b/posthog/clickhouse/schema/custom_metrics.yaml
@@ -1,0 +1,25 @@
+# Desired-state schema for the custom_metrics_counter_events table.
+
+ecosystem: custom_metrics
+cluster: main
+
+tables:
+    custom_metrics_counter_events:
+        engine: ReplicatedMergeTree
+        sharded: false
+        on_nodes: ALL
+        order_by:
+            - name
+            - timestamp
+        partition_by: 'toYYYYMM(timestamp)'
+        columns:
+            - name: name
+              type: String
+            - name: timestamp
+              type: "DateTime64(3, 'UTC')"
+              default_expression: 'now()'
+              default_kind: DEFAULT
+            - name: labels
+              type: "Map(String, String)"
+            - name: increment
+              type: Float64

--- a/posthog/clickhouse/schema/dead_letter_queue.yaml
+++ b/posthog/clickhouse/schema/dead_letter_queue.yaml
@@ -107,6 +107,6 @@ tables:
         engine: MaterializedView
         source: kafka_events_dead_letter_queue
         target: writable_events_dead_letter_queue
-        select: "SELECT id, event_uuid, event, properties, distinct_id, team_id, elements_chain, created_at, ip, site_url, now, raw_payload, error_timestamp, error_location, error, tags, _timestamp, _offset FROM {{ database }}.kafka_events_dead_letter_queue"
+        select: 'SELECT id, event_uuid, event, properties, distinct_id, team_id, elements_chain, created_at, ip, site_url, now, raw_payload, error_timestamp, error_location, error, tags, _timestamp, _offset FROM {{ database }}.kafka_events_dead_letter_queue'
         on_nodes: ALL
         columns: []

--- a/posthog/clickhouse/schema/dead_letter_queue.yaml
+++ b/posthog/clickhouse/schema/dead_letter_queue.yaml
@@ -1,0 +1,112 @@
+# Desired-state schema for the events_dead_letter_queue ecosystem.
+
+ecosystem: dead_letter_queue
+cluster: main
+
+tables:
+    events_dead_letter_queue:
+        engine: ReplicatedReplacingMergeTree
+        sharded: false
+        on_nodes: ALL
+        order_by:
+            - id
+            - event_uuid
+            - distinct_id
+            - team_id
+        settings:
+            index_granularity: '512'
+        columns:
+            - name: id
+              type: UUID
+            - name: event_uuid
+              type: UUID
+            - name: event
+              type: String
+            - name: properties
+              type: String
+            - name: distinct_id
+              type: String
+            - name: team_id
+              type: Int64
+            - name: elements_chain
+              type: String
+            - name: created_at
+              type: "DateTime64(6, 'UTC')"
+            - name: ip
+              type: String
+            - name: site_url
+              type: String
+            - name: now
+              type: "DateTime64(6, 'UTC')"
+            - name: raw_payload
+              type: String
+            - name: error_timestamp
+              type: "DateTime64(6, 'UTC')"
+            - name: error_location
+              type: String
+            - name: error
+              type: String
+            - name: tags
+              type: Array(String)
+            - name: _timestamp
+              type: DateTime
+            - name: _offset
+              type: UInt64
+
+    writable_events_dead_letter_queue:
+        engine: Distributed
+        source: events_dead_letter_queue
+        sharding_key: 'rand()'
+        on_nodes: ALL
+        columns: inherit events_dead_letter_queue
+
+    kafka_events_dead_letter_queue:
+        engine: Kafka
+        on_nodes: ALL
+        settings:
+            kafka_broker_list: __from_settings__
+            kafka_topic_list: events_dead_letter_queue
+            kafka_group_name: events_dead_letter_queue
+            kafka_format: JSONEachRow
+            kafka_skip_broken_messages: '1000'
+        columns:
+            - name: id
+              type: UUID
+            - name: event_uuid
+              type: UUID
+            - name: event
+              type: String
+            - name: properties
+              type: String
+            - name: distinct_id
+              type: String
+            - name: team_id
+              type: Int64
+            - name: elements_chain
+              type: String
+            - name: created_at
+              type: "DateTime64(6, 'UTC')"
+            - name: ip
+              type: String
+            - name: site_url
+              type: String
+            - name: now
+              type: "DateTime64(6, 'UTC')"
+            - name: raw_payload
+              type: String
+            - name: error_timestamp
+              type: "DateTime64(6, 'UTC')"
+            - name: error_location
+              type: String
+            - name: error
+              type: String
+            - name: tags
+              type: Array(String)
+
+    events_dead_letter_queue_mv:
+        engine: MaterializedView
+        source: kafka_events_dead_letter_queue
+        target: writable_events_dead_letter_queue
+        select: "SELECT id, event_uuid, event, properties, distinct_id, team_id, elements_chain, created_at, ip, site_url, now, raw_payload, error_timestamp, error_location, error, tags, _timestamp, _offset FROM {{ database }}.kafka_events_dead_letter_queue"
+        on_nodes: ALL
+        columns: []

--- a/posthog/clickhouse/schema/distinct_id_usage.yaml
+++ b/posthog/clickhouse/schema/distinct_id_usage.yaml
@@ -60,6 +60,6 @@ tables:
         engine: MaterializedView
         source: kafka_distinct_id_usage
         target: writable_distinct_id_usage
-        select: "SELECT team_id, distinct_id, toStartOfMinute(timestamp) AS minute, 1 AS event_count FROM {{ database }}.kafka_distinct_id_usage"
+        select: 'SELECT team_id, distinct_id, toStartOfMinute(timestamp) AS minute, 1 AS event_count FROM {{ database }}.kafka_distinct_id_usage'
         on_nodes: INGESTION_EVENTS
         columns: []

--- a/posthog/clickhouse/schema/distinct_id_usage.yaml
+++ b/posthog/clickhouse/schema/distinct_id_usage.yaml
@@ -1,0 +1,65 @@
+# Desired-state schema for the distinct_id_usage ecosystem.
+
+ecosystem: distinct_id_usage
+cluster: main
+
+tables:
+    sharded_distinct_id_usage:
+        engine: ReplicatedSummingMergeTree
+        sharded: true
+        on_nodes: DATA
+        order_by:
+            - team_id
+            - minute
+            - distinct_id
+        partition_by: 'toYYYYMMDD(minute)'
+        settings:
+            ttl_only_drop_parts: '1'
+        columns:
+            - name: team_id
+              type: Int64
+            - name: distinct_id
+              type: String
+            - name: minute
+              type: DateTime
+            - name: event_count
+              type: UInt64
+
+    writable_distinct_id_usage:
+        engine: Distributed
+        source: sharded_distinct_id_usage
+        sharding_key: 'sipHash64(distinct_id)'
+        on_nodes: COORDINATOR
+        columns: inherit sharded_distinct_id_usage
+
+    distinct_id_usage:
+        engine: Distributed
+        source: sharded_distinct_id_usage
+        sharding_key: 'sipHash64(distinct_id)'
+        on_nodes: ALL
+        columns: inherit sharded_distinct_id_usage
+
+    kafka_distinct_id_usage:
+        engine: Kafka
+        on_nodes: INGESTION_EVENTS
+        settings:
+            kafka_broker_list: __from_settings__
+            kafka_topic_list: distinct_id_usage_events_json
+            kafka_group_name: distinct_id_usage
+            kafka_format: JSONEachRow
+            kafka_skip_broken_messages: '100'
+        columns:
+            - name: team_id
+              type: Int64
+            - name: distinct_id
+              type: String
+            - name: timestamp
+              type: "DateTime64(6, 'UTC')"
+
+    distinct_id_usage_mv:
+        engine: MaterializedView
+        source: kafka_distinct_id_usage
+        target: writable_distinct_id_usage
+        select: "SELECT team_id, distinct_id, toStartOfMinute(timestamp) AS minute, 1 AS event_count FROM {{ database }}.kafka_distinct_id_usage"
+        on_nodes: INGESTION_EVENTS
+        columns: []

--- a/posthog/clickhouse/schema/distinct_id_usage.yaml
+++ b/posthog/clickhouse/schema/distinct_id_usage.yaml
@@ -29,7 +29,7 @@ tables:
         engine: Distributed
         source: sharded_distinct_id_usage
         sharding_key: 'sipHash64(distinct_id)'
-        on_nodes: COORDINATOR
+        on_nodes: DATA
         columns: inherit sharded_distinct_id_usage
 
     distinct_id_usage:

--- a/posthog/clickhouse/schema/distinct_id_usage.yaml
+++ b/posthog/clickhouse/schema/distinct_id_usage.yaml
@@ -29,7 +29,7 @@ tables:
         engine: Distributed
         source: sharded_distinct_id_usage
         sharding_key: 'sipHash64(distinct_id)'
-        on_nodes: DATA
+        on_nodes: COORDINATOR
         columns: inherit sharded_distinct_id_usage
 
     distinct_id_usage:

--- a/posthog/clickhouse/schema/distributed_system_processes.yaml
+++ b/posthog/clickhouse/schema/distributed_system_processes.yaml
@@ -1,0 +1,16 @@
+# Desired-state schema for the distributed_system_processes table.
+# Wraps system.processes across all cluster nodes.
+
+ecosystem: distributed_system_processes
+cluster: main
+
+tables:
+    distributed_system_processes:
+        engine: Distributed
+        source: system.processes
+        on_nodes:
+            - DATA
+            - COORDINATOR
+        settings:
+            skip_unavailable_shards: '1'
+        columns: []

--- a/posthog/clickhouse/schema/distributed_system_processes.yaml
+++ b/posthog/clickhouse/schema/distributed_system_processes.yaml
@@ -10,7 +10,7 @@ tables:
         source: system.processes
         on_nodes:
             - DATA
-            - COORDINATOR
+            - DATA
         settings:
             skip_unavailable_shards: '1'
         columns: []

--- a/posthog/clickhouse/schema/distributed_system_processes.yaml
+++ b/posthog/clickhouse/schema/distributed_system_processes.yaml
@@ -10,7 +10,7 @@ tables:
         source: system.processes
         on_nodes:
             - DATA
-            - DATA
+            - COORDINATOR
         settings:
             skip_unavailable_shards: '1'
         columns: []

--- a/posthog/clickhouse/schema/document_embeddings.yaml
+++ b/posthog/clickhouse/schema/document_embeddings.yaml
@@ -1,0 +1,354 @@
+# Desired-state schema for the document_embeddings ecosystem.
+# Pipeline: Kafka → Buffer (1-day TTL) → Model-Specific Tables (3-month TTL).
+
+ecosystem: document_embeddings
+cluster: main
+
+tables:
+    # --- Main partitioned sharded table (legacy, pre-model-specific) ---
+    partitioned_sharded_posthog_document_embeddings:
+        engine: ReplicatedReplacingMergeTree
+        sharded: true
+        on_nodes: DATA
+        order_by:
+            - team_id
+            - 'toDate(timestamp)'
+            - product
+            - document_type
+            - model_name
+            - rendering
+            - 'cityHash64(document_id)'
+        partition_by: 'toMonday(timestamp)'
+        settings:
+            index_granularity: '512'
+            ttl_only_drop_parts: '1'
+        columns:
+            - name: team_id
+              type: Int64
+            - name: product
+              type: LowCardinality(String)
+            - name: document_type
+              type: LowCardinality(String)
+            - name: model_name
+              type: LowCardinality(String)
+            - name: rendering
+              type: LowCardinality(String)
+            - name: document_id
+              type: String
+            - name: timestamp
+              type: "DateTime64(3, 'UTC')"
+            - name: inserted_at
+              type: "DateTime64(3, 'UTC')"
+            - name: content
+              type: String
+              default_expression: "''"
+              default_kind: DEFAULT
+            - name: metadata
+              type: String
+              default_expression: "'{}'"
+              default_kind: DEFAULT
+            - name: embedding
+              type: Array(Float64)
+            - name: _timestamp
+              type: DateTime
+            - name: _offset
+              type: UInt64
+            - name: _partition
+              type: UInt64
+
+    distributed_posthog_document_embeddings:
+        engine: Distributed
+        source: partitioned_sharded_posthog_document_embeddings
+        sharding_key: 'cityHash64(document_id)'
+        on_nodes:
+            - DATA
+            - COORDINATOR
+        columns: inherit partitioned_sharded_posthog_document_embeddings
+
+    writable_posthog_document_embeddings:
+        engine: Distributed
+        source: partitioned_sharded_posthog_document_embeddings
+        sharding_key: 'cityHash64(document_id)'
+        on_nodes: INGESTION_SMALL
+        columns: inherit partitioned_sharded_posthog_document_embeddings
+
+    kafka_posthog_document_embeddings:
+        engine: Kafka
+        on_nodes: INGESTION_SMALL
+        settings:
+            kafka_broker_list: __from_settings__
+            kafka_topic_list: clickhouse_document_embeddings
+            kafka_group_name: posthog-clickhouse-embeddings-document-embeddings
+            kafka_format: JSONEachRow
+        columns:
+            - name: team_id
+              type: Int64
+            - name: product
+              type: LowCardinality(String)
+            - name: document_type
+              type: LowCardinality(String)
+            - name: model_name
+              type: LowCardinality(String)
+            - name: rendering
+              type: LowCardinality(String)
+            - name: document_id
+              type: String
+            - name: timestamp
+              type: "DateTime64(3, 'UTC')"
+            - name: content
+              type: String
+            - name: metadata
+              type: String
+            - name: embedding
+              type: Array(Float64)
+
+    posthog_document_embeddings_mv:
+        engine: MaterializedView
+        source: kafka_posthog_document_embeddings
+        target: writable_posthog_document_embeddings
+        select: "SELECT team_id, product, document_type, model_name, rendering, document_id, timestamp, _timestamp as inserted_at, coalesce(content, '') as content, coalesce(metadata, '{}') as metadata, embedding, _timestamp, _offset, _partition FROM {{ database }}.kafka_posthog_document_embeddings"
+        on_nodes: INGESTION_SMALL
+        columns: []
+
+    # --- Buffer tables (short-lived, receives all embeddings before routing to model-specific tables) ---
+    sharded_posthog_document_embeddings_buffer:
+        engine: ReplicatedReplacingMergeTree
+        sharded: true
+        on_nodes: DATA
+        order_by:
+            - inserted_at
+            - model_name
+            - 'cityHash64(document_id)'
+        partition_by: 'toDate(inserted_at)'
+        settings:
+            index_granularity: '8192'
+            ttl_only_drop_parts: '1'
+        columns:
+            - name: team_id
+              type: Int64
+            - name: product
+              type: LowCardinality(String)
+            - name: document_type
+              type: LowCardinality(String)
+            - name: model_name
+              type: LowCardinality(String)
+            - name: rendering
+              type: LowCardinality(String)
+            - name: document_id
+              type: String
+            - name: timestamp
+              type: "DateTime64(3, 'UTC')"
+            - name: inserted_at
+              type: "DateTime64(3, 'UTC')"
+            - name: content
+              type: String
+              default_expression: "''"
+              default_kind: DEFAULT
+            - name: metadata
+              type: String
+              default_expression: "'{}'"
+              default_kind: DEFAULT
+            - name: embedding
+              type: Array(Float64)
+            - name: _timestamp
+              type: DateTime
+            - name: _offset
+              type: UInt64
+            - name: _partition
+              type: UInt64
+
+    writable_posthog_document_embeddings_buffer:
+        engine: Distributed
+        source: sharded_posthog_document_embeddings_buffer
+        sharding_key: 'cityHash64(document_id)'
+        on_nodes: INGESTION_SMALL
+        columns: inherit sharded_posthog_document_embeddings_buffer
+
+    posthog_document_embeddings_kafka_to_buffer_mv:
+        engine: MaterializedView
+        source: kafka_posthog_document_embeddings
+        target: writable_posthog_document_embeddings_buffer
+        select: "SELECT team_id, product, document_type, model_name, rendering, document_id, timestamp, _timestamp as inserted_at, coalesce(content, '') as content, coalesce(metadata, '{}') as metadata, embedding, _timestamp, _offset, _partition FROM {{ database }}.kafka_posthog_document_embeddings"
+        on_nodes: INGESTION_SMALL
+        columns: []
+
+    # --- Model-specific tables: text-embedding-3-small-1536 ---
+    sharded_posthog_document_embeddings_text_embedding_3_small_1536:
+        engine: ReplicatedReplacingMergeTree
+        sharded: true
+        on_nodes: DATA
+        order_by:
+            - team_id
+            - 'toDate(timestamp)'
+            - product
+            - document_type
+            - rendering
+            - 'cityHash64(document_id)'
+        partition_by: 'toMonday(timestamp)'
+        settings:
+            index_granularity: '512'
+            ttl_only_drop_parts: '1'
+        columns:
+            - name: team_id
+              type: Int64
+            - name: product
+              type: LowCardinality(String)
+            - name: document_type
+              type: LowCardinality(String)
+            - name: rendering
+              type: LowCardinality(String)
+            - name: document_id
+              type: String
+            - name: timestamp
+              type: "DateTime64(3, 'UTC')"
+            - name: inserted_at
+              type: "DateTime64(3, 'UTC')"
+            - name: content
+              type: String
+              default_expression: "''"
+              default_kind: DEFAULT
+            - name: metadata
+              type: String
+              default_expression: "'{}'"
+              default_kind: DEFAULT
+            - name: embedding
+              type: Array(Float64)
+            - name: _timestamp
+              type: DateTime
+            - name: _offset
+              type: UInt64
+            - name: _partition
+              type: UInt64
+
+    distributed_posthog_document_embeddings_text_embedding_3_small_1536:
+        engine: Distributed
+        source: sharded_posthog_document_embeddings_text_embedding_3_small_1536
+        sharding_key: 'cityHash64(document_id)'
+        on_nodes:
+            - DATA
+            - COORDINATOR
+        columns: inherit sharded_posthog_document_embeddings_text_embedding_3_small_1536
+
+    writable_posthog_document_embeddings_text_embedding_3_small_1536:
+        engine: Distributed
+        source: sharded_posthog_document_embeddings_text_embedding_3_small_1536
+        sharding_key: 'cityHash64(document_id)'
+        on_nodes: DATA
+        columns: inherit sharded_posthog_document_embeddings_text_embedding_3_small_1536
+
+    posthog_document_embeddings_text_embedding_3_small_1536_mv:
+        engine: MaterializedView
+        source: sharded_posthog_document_embeddings_buffer
+        target: writable_posthog_document_embeddings_text_embedding_3_small_1536
+        select: "SELECT team_id, product, document_type, rendering, document_id, timestamp, inserted_at, content, metadata, embedding, _timestamp, _offset, _partition FROM {{ database }}.sharded_posthog_document_embeddings_buffer WHERE model_name = 'text-embedding-3-small-1536'"
+        on_nodes: DATA
+        columns: []
+
+    # --- Model-specific tables: text-embedding-3-large-3072 ---
+    sharded_posthog_document_embeddings_text_embedding_3_large_3072:
+        engine: ReplicatedReplacingMergeTree
+        sharded: true
+        on_nodes: DATA
+        order_by:
+            - team_id
+            - 'toDate(timestamp)'
+            - product
+            - document_type
+            - rendering
+            - 'cityHash64(document_id)'
+        partition_by: 'toMonday(timestamp)'
+        settings:
+            index_granularity: '512'
+            ttl_only_drop_parts: '1'
+        columns:
+            - name: team_id
+              type: Int64
+            - name: product
+              type: LowCardinality(String)
+            - name: document_type
+              type: LowCardinality(String)
+            - name: rendering
+              type: LowCardinality(String)
+            - name: document_id
+              type: String
+            - name: timestamp
+              type: "DateTime64(3, 'UTC')"
+            - name: inserted_at
+              type: "DateTime64(3, 'UTC')"
+            - name: content
+              type: String
+              default_expression: "''"
+              default_kind: DEFAULT
+            - name: metadata
+              type: String
+              default_expression: "'{}'"
+              default_kind: DEFAULT
+            - name: embedding
+              type: Array(Float64)
+            - name: _timestamp
+              type: DateTime
+            - name: _offset
+              type: UInt64
+            - name: _partition
+              type: UInt64
+
+    distributed_posthog_document_embeddings_text_embedding_3_large_3072:
+        engine: Distributed
+        source: sharded_posthog_document_embeddings_text_embedding_3_large_3072
+        sharding_key: 'cityHash64(document_id)'
+        on_nodes:
+            - DATA
+            - COORDINATOR
+        columns: inherit sharded_posthog_document_embeddings_text_embedding_3_large_3072
+
+    writable_posthog_document_embeddings_text_embedding_3_large_3072:
+        engine: Distributed
+        source: sharded_posthog_document_embeddings_text_embedding_3_large_3072
+        sharding_key: 'cityHash64(document_id)'
+        on_nodes: DATA
+        columns: inherit sharded_posthog_document_embeddings_text_embedding_3_large_3072
+
+    posthog_document_embeddings_text_embedding_3_large_3072_mv:
+        engine: MaterializedView
+        source: sharded_posthog_document_embeddings_buffer
+        target: writable_posthog_document_embeddings_text_embedding_3_large_3072
+        select: "SELECT team_id, product, document_type, rendering, document_id, timestamp, inserted_at, content, metadata, embedding, _timestamp, _offset, _partition FROM {{ database }}.sharded_posthog_document_embeddings_buffer WHERE model_name = 'text-embedding-3-large-3072'"
+        on_nodes: DATA
+        columns: []
+
+    # --- Legacy unsharded table (kept for historical data per migration 0183) ---
+    posthog_document_embeddings:
+        engine: ReplicatedReplacingMergeTree
+        sharded: false
+        on_nodes: DATA
+        order_by:
+            - team_id
+            - 'toDate(timestamp)'
+            - product
+            - document_type
+            - model_name
+            - rendering
+            - 'cityHash64(document_id)'
+        partition_by: 'toMonday(timestamp)'
+        settings:
+            index_granularity: '512'
+            ttl_only_drop_parts: '1'
+        columns: inherit partitioned_sharded_posthog_document_embeddings
+
+    sharded_posthog_document_embeddings:
+        engine: ReplicatedReplacingMergeTree
+        sharded: true
+        on_nodes: DATA
+        order_by:
+            - team_id
+            - 'toDate(timestamp)'
+            - product
+            - document_type
+            - model_name
+            - rendering
+            - 'cityHash64(document_id)'
+        partition_by: 'toMonday(timestamp)'
+        settings:
+            index_granularity: '512'
+            ttl_only_drop_parts: '1'
+        columns: inherit partitioned_sharded_posthog_document_embeddings

--- a/posthog/clickhouse/schema/document_embeddings.yaml
+++ b/posthog/clickhouse/schema/document_embeddings.yaml
@@ -62,7 +62,7 @@ tables:
         sharding_key: 'cityHash64(document_id)'
         on_nodes:
             - DATA
-            - DATA
+            - COORDINATOR
         columns: inherit partitioned_sharded_posthog_document_embeddings
 
     writable_posthog_document_embeddings:
@@ -226,7 +226,7 @@ tables:
         sharding_key: 'cityHash64(document_id)'
         on_nodes:
             - DATA
-            - DATA
+            - COORDINATOR
         columns: inherit sharded_posthog_document_embeddings_text_embedding_3_small_1536
 
     writable_posthog_document_embeddings_text_embedding_3_small_1536:
@@ -298,7 +298,7 @@ tables:
         sharding_key: 'cityHash64(document_id)'
         on_nodes:
             - DATA
-            - DATA
+            - COORDINATOR
         columns: inherit sharded_posthog_document_embeddings_text_embedding_3_large_3072
 
     writable_posthog_document_embeddings_text_embedding_3_large_3072:

--- a/posthog/clickhouse/schema/document_embeddings.yaml
+++ b/posthog/clickhouse/schema/document_embeddings.yaml
@@ -62,7 +62,7 @@ tables:
         sharding_key: 'cityHash64(document_id)'
         on_nodes:
             - DATA
-            - COORDINATOR
+            - DATA
         columns: inherit partitioned_sharded_posthog_document_embeddings
 
     writable_posthog_document_embeddings:
@@ -226,7 +226,7 @@ tables:
         sharding_key: 'cityHash64(document_id)'
         on_nodes:
             - DATA
-            - COORDINATOR
+            - DATA
         columns: inherit sharded_posthog_document_embeddings_text_embedding_3_small_1536
 
     writable_posthog_document_embeddings_text_embedding_3_small_1536:
@@ -298,7 +298,7 @@ tables:
         sharding_key: 'cityHash64(document_id)'
         on_nodes:
             - DATA
-            - COORDINATOR
+            - DATA
         columns: inherit sharded_posthog_document_embeddings_text_embedding_3_large_3072
 
     writable_posthog_document_embeddings_text_embedding_3_large_3072:

--- a/posthog/clickhouse/schema/document_embeddings.yaml
+++ b/posthog/clickhouse/schema/document_embeddings.yaml
@@ -95,6 +95,8 @@ tables:
               type: String
             - name: timestamp
               type: "DateTime64(3, 'UTC')"
+            - name: inserted_at
+              type: "DateTime64(3, 'UTC')"
             - name: content
               type: String
             - name: metadata

--- a/posthog/clickhouse/schema/duplicate_events.yaml
+++ b/posthog/clickhouse/schema/duplicate_events.yaml
@@ -1,0 +1,108 @@
+# Desired-state schema for the duplicate_events ecosystem.
+
+ecosystem: duplicate_events
+cluster: main
+
+tables:
+    duplicate_events:
+        engine: ReplicatedMergeTree
+        sharded: false
+        on_nodes: DATA
+        order_by:
+            - team_id
+            - distinct_id
+            - event
+            - inserted_at
+        partition_by: 'toYYYYMMDD(inserted_at)'
+        settings:
+            index_granularity: '512'
+        columns:
+            - name: team_id
+              type: Int64
+            - name: distinct_id
+              type: String
+            - name: event
+              type: String
+            - name: source_uuid
+              type: UUID
+            - name: duplicate_uuid
+              type: UUID
+            - name: similarity_score
+              type: Float64
+            - name: dedup_type
+              type: LowCardinality(String)
+            - name: is_confirmed
+              type: UInt8
+            - name: reason
+              type: Nullable(String)
+            - name: version
+              type: String
+            - name: different_property_count
+              type: UInt32
+            - name: properties_similarity
+              type: Float64
+            - name: source_message
+              type: String
+            - name: duplicate_message
+              type: String
+            - name: distinct_fields
+              type: "Array(Tuple(field_name String, original_value String, new_value String))"
+            - name: inserted_at
+              type: "DateTime64(3, 'UTC')"
+
+    writable_duplicate_events:
+        engine: Distributed
+        source: duplicate_events
+        sharding_key: 'rand()'
+        on_nodes: COORDINATOR
+        columns: inherit duplicate_events
+
+    kafka_duplicate_events:
+        engine: Kafka
+        on_nodes: INGESTION_EVENTS
+        settings:
+            kafka_broker_list: __from_settings__
+            kafka_topic_list: clickhouse_ingestion_events_duplicates
+            kafka_group_name: clickhouse_duplicate_events
+            kafka_format: JSONEachRow
+        columns:
+            - name: team_id
+              type: Int64
+            - name: distinct_id
+              type: String
+            - name: event
+              type: String
+            - name: source_uuid
+              type: UUID
+            - name: duplicate_uuid
+              type: UUID
+            - name: similarity_score
+              type: Float64
+            - name: dedup_type
+              type: LowCardinality(String)
+            - name: is_confirmed
+              type: UInt8
+            - name: reason
+              type: Nullable(String)
+            - name: version
+              type: String
+            - name: different_property_count
+              type: UInt32
+            - name: properties_similarity
+              type: Float64
+            - name: source_message
+              type: String
+            - name: duplicate_message
+              type: String
+            - name: distinct_fields
+              type: String
+            - name: inserted_at
+              type: "DateTime64(3, 'UTC')"
+
+    duplicate_events_mv:
+        engine: MaterializedView
+        source: kafka_duplicate_events
+        target: writable_duplicate_events
+        select: "SELECT team_id, distinct_id, event, source_uuid, duplicate_uuid, similarity_score, dedup_type, is_confirmed, reason, version, different_property_count, properties_similarity, source_message, duplicate_message, JSONExtract(distinct_fields, 'Array(Tuple(field_name String, original_value String, new_value String))') as distinct_fields, inserted_at, _timestamp, _offset, _partition FROM {{ database }}.kafka_duplicate_events"
+        on_nodes: INGESTION_EVENTS
+        columns: []

--- a/posthog/clickhouse/schema/duplicate_events.yaml
+++ b/posthog/clickhouse/schema/duplicate_events.yaml
@@ -49,6 +49,13 @@ tables:
               type: "Array(Tuple(field_name String, original_value String, new_value String))"
             - name: inserted_at
               type: "DateTime64(3, 'UTC')"
+            # Kafka virtual columns
+            - name: _timestamp
+              type: DateTime
+            - name: _offset
+              type: UInt64
+            - name: _partition
+              type: UInt64
 
     writable_duplicate_events:
         engine: Distributed

--- a/posthog/clickhouse/schema/duplicate_events.yaml
+++ b/posthog/clickhouse/schema/duplicate_events.yaml
@@ -46,7 +46,7 @@ tables:
             - name: duplicate_message
               type: String
             - name: distinct_fields
-              type: "Array(Tuple(field_name String, original_value String, new_value String))"
+              type: 'Array(Tuple(field_name String, original_value String, new_value String))'
             - name: inserted_at
               type: "DateTime64(3, 'UTC')"
             # Kafka virtual columns

--- a/posthog/clickhouse/schema/duplicate_events.yaml
+++ b/posthog/clickhouse/schema/duplicate_events.yaml
@@ -54,7 +54,7 @@ tables:
         engine: Distributed
         source: duplicate_events
         sharding_key: 'rand()'
-        on_nodes: DATA
+        on_nodes: COORDINATOR
         columns: inherit duplicate_events
 
     kafka_duplicate_events:

--- a/posthog/clickhouse/schema/duplicate_events.yaml
+++ b/posthog/clickhouse/schema/duplicate_events.yaml
@@ -54,7 +54,7 @@ tables:
         engine: Distributed
         source: duplicate_events
         sharding_key: 'rand()'
-        on_nodes: COORDINATOR
+        on_nodes: DATA
         columns: inherit duplicate_events
 
     kafka_duplicate_events:

--- a/posthog/clickhouse/schema/error_tracking.yaml
+++ b/posthog/clickhouse/schema/error_tracking.yaml
@@ -1,0 +1,51 @@
+# Desired-state schema for the error_tracking ecosystem.
+
+ecosystem: error_tracking
+cluster: main
+
+tables:
+    error_tracking_issue_fingerprint_overrides:
+        engine: ReplicatedReplacingMergeTree
+        sharded: false
+        on_nodes: DATA
+        order_by:
+            - team_id
+            - fingerprint
+        settings:
+            index_granularity: '512'
+        columns:
+            - name: team_id
+              type: Int64
+            - name: fingerprint
+              type: String
+            - name: issue_id
+              type: UUID
+            - name: is_deleted
+              type: Int8
+            - name: version
+              type: Int64
+
+    writable_error_tracking_issue_fingerprint_overrides:
+        engine: Distributed
+        source: error_tracking_issue_fingerprint_overrides
+        sharding_key: 'rand()'
+        on_nodes: COORDINATOR
+        columns: inherit error_tracking_issue_fingerprint_overrides
+
+    kafka_error_tracking_issue_fingerprint_overrides:
+        engine: Kafka
+        on_nodes: INGESTION_EVENTS
+        settings:
+            kafka_broker_list: __from_settings__
+            kafka_topic_list: error_tracking_issue_fingerprint
+            kafka_group_name: clickhouse-error-tracking-issue-fingerprint-overrides
+            kafka_format: JSONEachRow
+        columns: inherit error_tracking_issue_fingerprint_overrides
+
+    error_tracking_issue_fingerprint_overrides_mv:
+        engine: MaterializedView
+        source: kafka_error_tracking_issue_fingerprint_overrides
+        target: writable_error_tracking_issue_fingerprint_overrides
+        select: "SELECT team_id, fingerprint, issue_id, is_deleted, version, _timestamp, _offset, _partition FROM {{ database }}.kafka_error_tracking_issue_fingerprint_overrides WHERE version > 0"
+        on_nodes: INGESTION_EVENTS
+        columns: []

--- a/posthog/clickhouse/schema/error_tracking.yaml
+++ b/posthog/clickhouse/schema/error_tracking.yaml
@@ -29,7 +29,7 @@ tables:
         engine: Distributed
         source: error_tracking_issue_fingerprint_overrides
         sharding_key: 'rand()'
-        on_nodes: COORDINATOR
+        on_nodes: DATA
         columns: inherit error_tracking_issue_fingerprint_overrides
 
     kafka_error_tracking_issue_fingerprint_overrides:

--- a/posthog/clickhouse/schema/error_tracking.yaml
+++ b/posthog/clickhouse/schema/error_tracking.yaml
@@ -63,6 +63,6 @@ tables:
         engine: MaterializedView
         source: kafka_error_tracking_issue_fingerprint_overrides
         target: writable_error_tracking_issue_fingerprint_overrides
-        select: "SELECT team_id, fingerprint, issue_id, is_deleted, version, _timestamp, _offset, _partition FROM {{ database }}.kafka_error_tracking_issue_fingerprint_overrides WHERE version > 0"
+        select: 'SELECT team_id, fingerprint, issue_id, is_deleted, version, _timestamp, _offset, _partition FROM {{ database }}.kafka_error_tracking_issue_fingerprint_overrides WHERE version > 0'
         on_nodes: INGESTION_EVENTS
         columns: []

--- a/posthog/clickhouse/schema/error_tracking.yaml
+++ b/posthog/clickhouse/schema/error_tracking.yaml
@@ -29,7 +29,7 @@ tables:
         engine: Distributed
         source: error_tracking_issue_fingerprint_overrides
         sharding_key: 'rand()'
-        on_nodes: DATA
+        on_nodes: COORDINATOR
         columns: inherit error_tracking_issue_fingerprint_overrides
 
     kafka_error_tracking_issue_fingerprint_overrides:

--- a/posthog/clickhouse/schema/error_tracking.yaml
+++ b/posthog/clickhouse/schema/error_tracking.yaml
@@ -24,6 +24,13 @@ tables:
               type: Int8
             - name: version
               type: Int64
+            # Kafka virtual columns
+            - name: _timestamp
+              type: DateTime
+            - name: _offset
+              type: UInt64
+            - name: _partition
+              type: UInt64
 
     writable_error_tracking_issue_fingerprint_overrides:
         engine: Distributed
@@ -40,7 +47,17 @@ tables:
             kafka_topic_list: error_tracking_issue_fingerprint
             kafka_group_name: clickhouse-error-tracking-issue-fingerprint-overrides
             kafka_format: JSONEachRow
-        columns: inherit error_tracking_issue_fingerprint_overrides
+        columns:
+            - name: team_id
+              type: Int64
+            - name: fingerprint
+              type: String
+            - name: issue_id
+              type: UUID
+            - name: is_deleted
+              type: Int8
+            - name: version
+              type: Int64
 
     error_tracking_issue_fingerprint_overrides_mv:
         engine: MaterializedView

--- a/posthog/clickhouse/schema/error_tracking_fingerprint_issue_state.yaml
+++ b/posthog/clickhouse/schema/error_tracking_fingerprint_issue_state.yaml
@@ -100,6 +100,6 @@ tables:
         engine: MaterializedView
         source: kafka_error_tracking_fingerprint_issue_state
         target: writable_error_tracking_fingerprint_issue_state
-        select: "SELECT team_id, fingerprint, issue_id, issue_name, issue_description, issue_status, assigned_user_id, assigned_role_id, first_seen, is_deleted, version, _timestamp, _offset, _partition FROM {{ database }}.kafka_error_tracking_fingerprint_issue_state"
+        select: 'SELECT team_id, fingerprint, issue_id, issue_name, issue_description, issue_status, assigned_user_id, assigned_role_id, first_seen, is_deleted, version, _timestamp, _offset, _partition FROM {{ database }}.kafka_error_tracking_fingerprint_issue_state'
         on_nodes: AUX
         columns: []

--- a/posthog/clickhouse/schema/error_tracking_fingerprint_issue_state.yaml
+++ b/posthog/clickhouse/schema/error_tracking_fingerprint_issue_state.yaml
@@ -1,0 +1,105 @@
+# Desired-state schema for the error_tracking_fingerprint_issue_state ecosystem.
+#
+# Created by legacy migration 0226. Lives on the AUX cluster (separate from the
+# main error_tracking ecosystem on `cluster: main`). Provides issue metadata
+# alongside fingerprint mappings, eliminating a Postgres JOIN in the list query.
+
+ecosystem: error_tracking_fingerprint_issue_state
+cluster: aux
+
+tables:
+    raw_error_tracking_fingerprint_issue_state:
+        engine: ReplicatedReplacingMergeTree
+        sharded: false
+        on_nodes: AUX
+        order_by:
+            - team_id
+            - fingerprint
+        settings:
+            index_granularity: '512'
+        columns:
+            - name: team_id
+              type: Int64
+            - name: fingerprint
+              type: String
+            - name: issue_id
+              type: UUID
+            - name: issue_name
+              type: Nullable(String)
+            - name: issue_description
+              type: Nullable(String)
+            - name: issue_status
+              type: String
+            - name: assigned_user_id
+              type: Nullable(Int64)
+            - name: assigned_role_id
+              type: Nullable(UUID)
+            - name: first_seen
+              type: "DateTime64(3, 'UTC')"
+            - name: is_deleted
+              type: Int8
+            - name: version
+              type: Int64
+            # Kafka virtual columns
+            - name: _timestamp
+              type: DateTime
+            - name: _offset
+              type: UInt64
+            - name: _partition
+              type: UInt64
+
+    writable_error_tracking_fingerprint_issue_state:
+        engine: Distributed
+        source: raw_error_tracking_fingerprint_issue_state
+        sharding_key: 'rand()'
+        on_nodes: AUX
+        columns: inherit raw_error_tracking_fingerprint_issue_state
+
+    error_tracking_fingerprint_issue_state:
+        engine: Distributed
+        source: raw_error_tracking_fingerprint_issue_state
+        sharding_key: 'rand()'
+        on_nodes:
+            - AUX
+            - DATA
+        columns: inherit raw_error_tracking_fingerprint_issue_state
+
+    kafka_error_tracking_fingerprint_issue_state:
+        engine: Kafka
+        on_nodes: AUX
+        settings:
+            kafka_broker_list: __from_settings__
+            kafka_topic_list: clickhouse_error_tracking_fingerprint_issue_state
+            kafka_group_name: clickhouse-error-tracking-fingerprint-issue-state
+            kafka_format: JSONEachRow
+        columns:
+            - name: team_id
+              type: Int64
+            - name: fingerprint
+              type: String
+            - name: issue_id
+              type: UUID
+            - name: issue_name
+              type: Nullable(String)
+            - name: issue_description
+              type: Nullable(String)
+            - name: issue_status
+              type: String
+            - name: assigned_user_id
+              type: Nullable(Int64)
+            - name: assigned_role_id
+              type: Nullable(UUID)
+            - name: first_seen
+              type: "DateTime64(3, 'UTC')"
+            - name: is_deleted
+              type: Int8
+            - name: version
+              type: Int64
+
+    error_tracking_fingerprint_issue_state_mv:
+        engine: MaterializedView
+        source: kafka_error_tracking_fingerprint_issue_state
+        target: writable_error_tracking_fingerprint_issue_state
+        select: "SELECT team_id, fingerprint, issue_id, issue_name, issue_description, issue_status, assigned_user_id, assigned_role_id, first_seen, is_deleted, version, _timestamp, _offset, _partition FROM {{ database }}.kafka_error_tracking_fingerprint_issue_state"
+        on_nodes: AUX
+        columns: []

--- a/posthog/clickhouse/schema/events.yaml
+++ b/posthog/clickhouse/schema/events.yaml
@@ -1,0 +1,116 @@
+# Desired-state schema for the events ecosystem.
+# Edit this file to declare the desired schema, then run:
+#   python manage.py ch_migrate plan
+#   python manage.py ch_migrate apply
+
+ecosystem: events
+cluster: main
+
+tables:
+    sharded_events:
+        engine: ReplicatedReplacingMergeTree
+        sharded: true
+        on_nodes: DATA
+        order_by:
+            - team_id
+            - 'toDate(timestamp)'
+            - event
+            - 'cityHash64(distinct_id)'
+            - 'cityHash64(uuid)'
+        partition_by: 'toYYYYMM(timestamp)'
+        columns:
+            - name: uuid
+              type: UUID
+            - name: event
+              type: String
+            - name: properties
+              type: String
+            - name: timestamp
+              type: DateTime64(6, 'UTC')
+            - name: team_id
+              type: Int64
+            - name: distinct_id
+              type: String
+            - name: elements_chain
+              type: String
+            - name: created_at
+              type: DateTime64(6, 'UTC')
+            - name: person_id
+              type: UUID
+            - name: person_created_at
+              type: DateTime64(3)
+            - name: person_properties
+              type: String
+            - name: group0_properties
+              type: String
+            - name: group1_properties
+              type: String
+            - name: group2_properties
+              type: String
+            - name: group3_properties
+              type: String
+            - name: group4_properties
+              type: String
+            - name: group0_created_at
+              type: DateTime64(3)
+            - name: group1_created_at
+              type: DateTime64(3)
+            - name: group2_created_at
+              type: DateTime64(3)
+            - name: group3_created_at
+              type: DateTime64(3)
+            - name: group4_created_at
+              type: DateTime64(3)
+
+    writable_events:
+        engine: Distributed
+        source: sharded_events
+        sharding_key: 'cityHash64(distinct_id)'
+        on_nodes: COORDINATOR
+        columns: inherit sharded_events
+
+    events:
+        engine: Distributed
+        source: sharded_events
+        sharding_key: 'cityHash64(distinct_id)'
+        on_nodes: ALL
+        columns: inherit sharded_events
+
+    kafka_events_json:
+        engine: Kafka
+        on_nodes: INGESTION_EVENTS
+        settings:
+            kafka_broker_list: __from_settings__
+            kafka_topic_list: events_json
+            kafka_group_name: events_json_consumer
+            kafka_format: JSONEachRow
+            kafka_skip_broken_messages: '100'
+        columns: inherit sharded_events
+
+    events_json_mv:
+        engine: MaterializedView
+        source: kafka_events_json
+        target: writable_events
+        select: 'SELECT * FROM {{ database }}.kafka_events_json'
+        on_nodes: INGESTION_EVENTS
+        columns: []
+
+    # Production-only: daily aggregation of event counts
+    events_by_day:
+        engine: ReplicatedSummingMergeTree
+        sharded: false
+        on_nodes: DATA
+        order_by:
+            - team_id
+            - 'toDate(timestamp)'
+            - event
+        partition_by: 'toYYYYMM(timestamp)'
+        columns:
+            - name: team_id
+              type: Int64
+            - name: timestamp
+              type: Date
+            - name: event
+              type: String
+            - name: count
+              type: UInt64

--- a/posthog/clickhouse/schema/events.yaml
+++ b/posthog/clickhouse/schema/events.yaml
@@ -66,7 +66,7 @@ tables:
         engine: Distributed
         source: sharded_events
         sharding_key: 'cityHash64(distinct_id)'
-        on_nodes: DATA
+        on_nodes: COORDINATOR
         columns: inherit sharded_events
 
     events:

--- a/posthog/clickhouse/schema/events.yaml
+++ b/posthog/clickhouse/schema/events.yaml
@@ -61,6 +61,180 @@ tables:
               type: DateTime64(3)
             - name: group4_created_at
               type: DateTime64(3)
+            # Base columns from EVENTS_TABLE_BASE_SQL
+            - name: person_mode
+              type: "Enum8('full' = 0, 'propertyless' = 1, 'force_upgrade' = 2)"
+            - name: historical_migration
+              type: Bool
+            # Dynamically materialized columns (dmat slots)
+            - name: dmat_string_0
+              type: Nullable(String)
+            - name: dmat_string_1
+              type: Nullable(String)
+            - name: dmat_string_2
+              type: Nullable(String)
+            - name: dmat_string_3
+              type: Nullable(String)
+            - name: dmat_string_4
+              type: Nullable(String)
+            - name: dmat_string_5
+              type: Nullable(String)
+            - name: dmat_string_6
+              type: Nullable(String)
+            - name: dmat_string_7
+              type: Nullable(String)
+            - name: dmat_string_8
+              type: Nullable(String)
+            - name: dmat_string_9
+              type: Nullable(String)
+            - name: dmat_numeric_0
+              type: Nullable(Float64)
+            - name: dmat_numeric_1
+              type: Nullable(Float64)
+            - name: dmat_numeric_2
+              type: Nullable(Float64)
+            - name: dmat_numeric_3
+              type: Nullable(Float64)
+            - name: dmat_numeric_4
+              type: Nullable(Float64)
+            - name: dmat_numeric_5
+              type: Nullable(Float64)
+            - name: dmat_numeric_6
+              type: Nullable(Float64)
+            - name: dmat_numeric_7
+              type: Nullable(Float64)
+            - name: dmat_numeric_8
+              type: Nullable(Float64)
+            - name: dmat_numeric_9
+              type: Nullable(Float64)
+            - name: dmat_bool_0
+              type: Nullable(UInt8)
+            - name: dmat_bool_1
+              type: Nullable(UInt8)
+            - name: dmat_bool_2
+              type: Nullable(UInt8)
+            - name: dmat_bool_3
+              type: Nullable(UInt8)
+            - name: dmat_bool_4
+              type: Nullable(UInt8)
+            - name: dmat_bool_5
+              type: Nullable(UInt8)
+            - name: dmat_bool_6
+              type: Nullable(UInt8)
+            - name: dmat_bool_7
+              type: Nullable(UInt8)
+            - name: dmat_bool_8
+              type: Nullable(UInt8)
+            - name: dmat_bool_9
+              type: Nullable(UInt8)
+            - name: dmat_datetime_0
+              type: Nullable(DateTime64(6, 'UTC'))
+            - name: dmat_datetime_1
+              type: Nullable(DateTime64(6, 'UTC'))
+            - name: dmat_datetime_2
+              type: Nullable(DateTime64(6, 'UTC'))
+            - name: dmat_datetime_3
+              type: Nullable(DateTime64(6, 'UTC'))
+            - name: dmat_datetime_4
+              type: Nullable(DateTime64(6, 'UTC'))
+            - name: dmat_datetime_5
+              type: Nullable(DateTime64(6, 'UTC'))
+            - name: dmat_datetime_6
+              type: Nullable(DateTime64(6, 'UTC'))
+            - name: dmat_datetime_7
+              type: Nullable(DateTime64(6, 'UTC'))
+            - name: dmat_datetime_8
+              type: Nullable(DateTime64(6, 'UTC'))
+            - name: dmat_datetime_9
+              type: Nullable(DateTime64(6, 'UTC'))
+            # Materialized columns from properties
+            - name: $group_0
+              type: String
+              default_kind: MATERIALIZED
+              default_expression: "replaceRegexpAll(JSONExtractRaw(properties, '$group_0'), '^\"|\"$', '')"
+            - name: $group_1
+              type: String
+              default_kind: MATERIALIZED
+              default_expression: "replaceRegexpAll(JSONExtractRaw(properties, '$group_1'), '^\"|\"$', '')"
+            - name: $group_2
+              type: String
+              default_kind: MATERIALIZED
+              default_expression: "replaceRegexpAll(JSONExtractRaw(properties, '$group_2'), '^\"|\"$', '')"
+            - name: $group_3
+              type: String
+              default_kind: MATERIALIZED
+              default_expression: "replaceRegexpAll(JSONExtractRaw(properties, '$group_3'), '^\"|\"$', '')"
+            - name: $group_4
+              type: String
+              default_kind: MATERIALIZED
+              default_expression: "replaceRegexpAll(JSONExtractRaw(properties, '$group_4'), '^\"|\"$', '')"
+            - name: $window_id
+              type: String
+              default_kind: MATERIALIZED
+              default_expression: "replaceRegexpAll(JSONExtractRaw(properties, '$window_id'), '^\"|\"$', '')"
+            - name: $session_id
+              type: String
+              default_kind: MATERIALIZED
+              default_expression: "replaceRegexpAll(JSONExtractRaw(properties, '$session_id'), '^\"|\"$', '')"
+            - name: $session_id_uuid
+              type: Nullable(UInt128)
+              default_kind: MATERIALIZED
+              default_expression: "toUInt128(JSONExtract(properties, '$session_id', 'Nullable(UUID)'))"
+            # Materialized columns from elements_chain
+            - name: elements_chain_href
+              type: String
+              default_kind: MATERIALIZED
+              default_expression: "extract(elements_chain, '(?::|\\\")href=\"(.*?)\"')"
+            - name: elements_chain_texts
+              type: Array(String)
+              default_kind: MATERIALIZED
+              default_expression: "arrayDistinct(extractAll(elements_chain, '(?::|\\\")text=\"(.*?)\"'))"
+            - name: elements_chain_ids
+              type: Array(String)
+              default_kind: MATERIALIZED
+              default_expression: "arrayDistinct(extractAll(elements_chain, '(?::|\\\")attr_id=\"(.*?)\"'))"
+            - name: elements_chain_elements
+              type: "Array(Enum('a', 'button', 'form', 'input', 'select', 'textarea', 'label'))"
+              default_kind: MATERIALIZED
+              default_expression: "arrayDistinct(extractAll(elements_chain, '(?:^|;)(a|button|form|input|select|textarea|label)(?:\\\\.|$|:)'))"
+            # Property group map columns
+            - name: properties_group_custom
+              type: Map(String, String)
+              default_kind: MATERIALIZED
+              default_expression: "mapSort(mapFilter((key, _) -> key NOT LIKE '$%' AND key NOT IN ('token', 'distinct_id', 'utm_source', 'utm_medium', 'utm_campaign', 'utm_content', 'utm_term', 'gclid', 'gad_source', 'gclsrc', 'dclid', 'gbraid', 'wbraid', 'fbclid', 'msclkid', 'twclid', 'li_fat_id', 'mc_cid', 'igshid', 'ttclid', 'rdt_cid', 'epik', 'qclid', 'sccid', 'irclid', '_kx'), CAST(JSONExtractKeysAndValues(properties, 'String'), 'Map(String, String)')))"
+              codec: ZSTD(1)
+            - name: properties_group_ai
+              type: Map(String, String)
+              default_kind: MATERIALIZED
+              default_expression: "mapSort(mapFilter((key, _) -> key LIKE '$ai_%' AND key NOT IN ('$ai_input', '$ai_input_state', '$ai_output', '$ai_output_choices', '$ai_output_state', '$ai_tools'), CAST(JSONExtractKeysAndValues(properties, 'String'), 'Map(String, String)')))"
+              codec: ZSTD(1)
+            - name: properties_group_ai_large
+              type: Map(String, String)
+              default_kind: MATERIALIZED
+              default_expression: "mapSort(mapFilter((key, _) -> key IN ('$ai_input', '$ai_input_state', '$ai_output', '$ai_output_choices', '$ai_output_state', '$ai_tools'), CAST(JSONExtractKeysAndValues(properties, 'String'), 'Map(String, String)')))"
+              codec: ZSTD(1)
+            - name: properties_group_feature_flags
+              type: Map(String, String)
+              default_kind: MATERIALIZED
+              default_expression: "mapSort(mapFilter((key, _) -> key like '$feature/%', CAST(JSONExtractKeysAndValues(properties, 'String'), 'Map(String, String)')))"
+              codec: ZSTD(1)
+            - name: person_properties_map_custom
+              type: Map(String, String)
+              default_kind: MATERIALIZED
+              default_expression: "mapSort(mapFilter((key, _) -> key NOT LIKE '$%', CAST(JSONExtractKeysAndValues(person_properties, 'String'), 'Map(String, String)')))"
+              codec: ZSTD(1)
+            # Kafka virtual columns
+            - name: _timestamp
+              type: DateTime
+            - name: _offset
+              type: UInt64
+            # Extra columns
+            - name: inserted_at
+              type: Nullable(DateTime64(6, 'UTC'))
+              default_kind: DEFAULT
+              default_expression: "NOW64()"
+            - name: consumer_breadcrumbs
+              type: Array(String)
 
     writable_events:
         engine: Distributed

--- a/posthog/clickhouse/schema/events.yaml
+++ b/posthog/clickhouse/schema/events.yaml
@@ -235,6 +235,39 @@ tables:
               default_expression: "NOW64()"
             - name: consumer_breadcrumbs
               type: Array(String)
+            # Soft delete
+            - name: is_deleted
+              type: Boolean
+            # Ephemeral property maps (used by ingestion for fast property access)
+            - name: properties_map_ephemeral
+              type: Map(String, String)
+              default_kind: EPHEMERAL
+              default_expression: "CAST(JSONExtractKeysAndValues(properties, 'String'), 'Map(String, String)')"
+            - name: person_properties_map_ephemeral
+              type: Map(String, String)
+              default_kind: EPHEMERAL
+              default_expression: "CAST(JSONExtractKeysAndValues(person_properties, 'String'), 'Map(String, String)')"
+            # Materialized AI columns
+            - name: mat_$ai_trace_id
+              type: Nullable(String)
+              default_kind: MATERIALIZED
+              default_expression: "JSONExtract(properties, '$ai_trace_id', 'Nullable(String)')"
+            - name: mat_$ai_session_id
+              type: Nullable(String)
+              default_kind: MATERIALIZED
+              default_expression: "JSONExtract(properties, '$ai_session_id', 'Nullable(String)')"
+            - name: mat_$ai_is_error
+              type: Nullable(String)
+              default_kind: MATERIALIZED
+              default_expression: "JSONExtract(properties, '$ai_is_error', 'Nullable(String)')"
+            - name: mat_$ai_prompt_name
+              type: Nullable(String)
+              default_kind: MATERIALIZED
+              default_expression: "JSONExtract(properties, '$ai_prompt_name', 'Nullable(String)')"
+            - name: mat_$ai_experiment_id
+              type: Nullable(String)
+              default_kind: DEFAULT
+              default_expression: "JSONExtract(properties, '$ai_experiment_id', 'Nullable(String)')"
 
     writable_events:
         engine: Distributed

--- a/posthog/clickhouse/schema/events.yaml
+++ b/posthog/clickhouse/schema/events.yaml
@@ -66,7 +66,7 @@ tables:
         engine: Distributed
         source: sharded_events
         sharding_key: 'cityHash64(distinct_id)'
-        on_nodes: COORDINATOR
+        on_nodes: DATA
         columns: inherit sharded_events
 
     events:

--- a/posthog/clickhouse/schema/events.yaml
+++ b/posthog/clickhouse/schema/events.yaml
@@ -292,13 +292,164 @@ tables:
             kafka_group_name: events_json_consumer
             kafka_format: JSONEachRow
             kafka_skip_broken_messages: '100'
-        columns: inherit sharded_events
+        columns:
+            - name: uuid
+              type: UUID
+            - name: event
+              type: String
+            - name: properties
+              type: String
+            - name: timestamp
+              type: DateTime64(6, 'UTC')
+            - name: team_id
+              type: Int64
+            - name: distinct_id
+              type: String
+            - name: elements_chain
+              type: String
+            - name: created_at
+              type: DateTime64(6, 'UTC')
+            - name: person_id
+              type: UUID
+            - name: person_created_at
+              type: DateTime64(3)
+            - name: person_properties
+              type: String
+            - name: group0_properties
+              type: String
+            - name: group1_properties
+              type: String
+            - name: group2_properties
+              type: String
+            - name: group3_properties
+              type: String
+            - name: group4_properties
+              type: String
+            - name: group0_created_at
+              type: DateTime64(3)
+            - name: group1_created_at
+              type: DateTime64(3)
+            - name: group2_created_at
+              type: DateTime64(3)
+            - name: group3_created_at
+              type: DateTime64(3)
+            - name: group4_created_at
+              type: DateTime64(3)
+            - name: person_mode
+              type: "Enum8('full' = 0, 'propertyless' = 1, 'force_upgrade' = 2)"
+            - name: historical_migration
+              type: Bool
+            # Dynamically materialized columns (dmat slots)
+            - name: dmat_string_0
+              type: Nullable(String)
+            - name: dmat_string_1
+              type: Nullable(String)
+            - name: dmat_string_2
+              type: Nullable(String)
+            - name: dmat_string_3
+              type: Nullable(String)
+            - name: dmat_string_4
+              type: Nullable(String)
+            - name: dmat_string_5
+              type: Nullable(String)
+            - name: dmat_string_6
+              type: Nullable(String)
+            - name: dmat_string_7
+              type: Nullable(String)
+            - name: dmat_string_8
+              type: Nullable(String)
+            - name: dmat_string_9
+              type: Nullable(String)
+            - name: dmat_numeric_0
+              type: Nullable(Float64)
+            - name: dmat_numeric_1
+              type: Nullable(Float64)
+            - name: dmat_numeric_2
+              type: Nullable(Float64)
+            - name: dmat_numeric_3
+              type: Nullable(Float64)
+            - name: dmat_numeric_4
+              type: Nullable(Float64)
+            - name: dmat_numeric_5
+              type: Nullable(Float64)
+            - name: dmat_numeric_6
+              type: Nullable(Float64)
+            - name: dmat_numeric_7
+              type: Nullable(Float64)
+            - name: dmat_numeric_8
+              type: Nullable(Float64)
+            - name: dmat_numeric_9
+              type: Nullable(Float64)
+            - name: dmat_bool_0
+              type: Nullable(UInt8)
+            - name: dmat_bool_1
+              type: Nullable(UInt8)
+            - name: dmat_bool_2
+              type: Nullable(UInt8)
+            - name: dmat_bool_3
+              type: Nullable(UInt8)
+            - name: dmat_bool_4
+              type: Nullable(UInt8)
+            - name: dmat_bool_5
+              type: Nullable(UInt8)
+            - name: dmat_bool_6
+              type: Nullable(UInt8)
+            - name: dmat_bool_7
+              type: Nullable(UInt8)
+            - name: dmat_bool_8
+              type: Nullable(UInt8)
+            - name: dmat_bool_9
+              type: Nullable(UInt8)
+            - name: dmat_datetime_0
+              type: Nullable(DateTime64(6, 'UTC'))
+            - name: dmat_datetime_1
+              type: Nullable(DateTime64(6, 'UTC'))
+            - name: dmat_datetime_2
+              type: Nullable(DateTime64(6, 'UTC'))
+            - name: dmat_datetime_3
+              type: Nullable(DateTime64(6, 'UTC'))
+            - name: dmat_datetime_4
+              type: Nullable(DateTime64(6, 'UTC'))
+            - name: dmat_datetime_5
+              type: Nullable(DateTime64(6, 'UTC'))
+            - name: dmat_datetime_6
+              type: Nullable(DateTime64(6, 'UTC'))
+            - name: dmat_datetime_7
+              type: Nullable(DateTime64(6, 'UTC'))
+            - name: dmat_datetime_8
+              type: Nullable(DateTime64(6, 'UTC'))
+            - name: dmat_datetime_9
+              type: Nullable(DateTime64(6, 'UTC'))
 
     events_json_mv:
         engine: MaterializedView
         source: kafka_events_json
         target: writable_events
-        select: 'SELECT * FROM {{ database }}.kafka_events_json'
+        select: >-
+            SELECT
+            uuid, event, properties, timestamp, team_id, distinct_id,
+            elements_chain, created_at, person_id, person_created_at,
+            person_properties,
+            group0_properties, group1_properties, group2_properties,
+            group3_properties, group4_properties,
+            group0_created_at, group1_created_at, group2_created_at,
+            group3_created_at, group4_created_at,
+            person_mode, historical_migration,
+            dmat_string_0, dmat_string_1, dmat_string_2, dmat_string_3,
+            dmat_string_4, dmat_string_5, dmat_string_6, dmat_string_7,
+            dmat_string_8, dmat_string_9,
+            dmat_numeric_0, dmat_numeric_1, dmat_numeric_2, dmat_numeric_3,
+            dmat_numeric_4, dmat_numeric_5, dmat_numeric_6, dmat_numeric_7,
+            dmat_numeric_8, dmat_numeric_9,
+            dmat_bool_0, dmat_bool_1, dmat_bool_2, dmat_bool_3,
+            dmat_bool_4, dmat_bool_5, dmat_bool_6, dmat_bool_7,
+            dmat_bool_8, dmat_bool_9,
+            dmat_datetime_0, dmat_datetime_1, dmat_datetime_2, dmat_datetime_3,
+            dmat_datetime_4, dmat_datetime_5, dmat_datetime_6, dmat_datetime_7,
+            dmat_datetime_8, dmat_datetime_9,
+            _timestamp, _offset,
+            arrayMap(i -> _headers.value[i], arrayFilter(i -> _headers.name[i] = 'kafka-consumer-breadcrumbs', arrayEnumerate(_headers.name))) as consumer_breadcrumbs
+            FROM {{ database }}.kafka_events_json
         on_nodes: INGESTION_EVENTS
         columns: []
 

--- a/posthog/clickhouse/schema/events.yaml
+++ b/posthog/clickhouse/schema/events.yaml
@@ -151,31 +151,31 @@ tables:
             - name: $group_0
               type: String
               default_kind: MATERIALIZED
-              default_expression: "replaceRegexpAll(JSONExtractRaw(properties, '$group_0'), '^\"|\"$', '')"
+              default_expression: 'replaceRegexpAll(JSONExtractRaw(properties, ''$group_0''), ''^"|"$'', '''')'
             - name: $group_1
               type: String
               default_kind: MATERIALIZED
-              default_expression: "replaceRegexpAll(JSONExtractRaw(properties, '$group_1'), '^\"|\"$', '')"
+              default_expression: 'replaceRegexpAll(JSONExtractRaw(properties, ''$group_1''), ''^"|"$'', '''')'
             - name: $group_2
               type: String
               default_kind: MATERIALIZED
-              default_expression: "replaceRegexpAll(JSONExtractRaw(properties, '$group_2'), '^\"|\"$', '')"
+              default_expression: 'replaceRegexpAll(JSONExtractRaw(properties, ''$group_2''), ''^"|"$'', '''')'
             - name: $group_3
               type: String
               default_kind: MATERIALIZED
-              default_expression: "replaceRegexpAll(JSONExtractRaw(properties, '$group_3'), '^\"|\"$', '')"
+              default_expression: 'replaceRegexpAll(JSONExtractRaw(properties, ''$group_3''), ''^"|"$'', '''')'
             - name: $group_4
               type: String
               default_kind: MATERIALIZED
-              default_expression: "replaceRegexpAll(JSONExtractRaw(properties, '$group_4'), '^\"|\"$', '')"
+              default_expression: 'replaceRegexpAll(JSONExtractRaw(properties, ''$group_4''), ''^"|"$'', '''')'
             - name: $window_id
               type: String
               default_kind: MATERIALIZED
-              default_expression: "replaceRegexpAll(JSONExtractRaw(properties, '$window_id'), '^\"|\"$', '')"
+              default_expression: 'replaceRegexpAll(JSONExtractRaw(properties, ''$window_id''), ''^"|"$'', '''')'
             - name: $session_id
               type: String
               default_kind: MATERIALIZED
-              default_expression: "replaceRegexpAll(JSONExtractRaw(properties, '$session_id'), '^\"|\"$', '')"
+              default_expression: 'replaceRegexpAll(JSONExtractRaw(properties, ''$session_id''), ''^"|"$'', '''')'
             - name: $session_id_uuid
               type: Nullable(UInt128)
               default_kind: MATERIALIZED
@@ -232,7 +232,7 @@ tables:
             - name: inserted_at
               type: Nullable(DateTime64(6, 'UTC'))
               default_kind: DEFAULT
-              default_expression: "NOW64()"
+              default_expression: 'NOW64()'
             - name: consumer_breadcrumbs
               type: Array(String)
             # Soft delete

--- a/posthog/clickhouse/schema/events_recent.yaml
+++ b/posthog/clickhouse/schema/events_recent.yaml
@@ -1,0 +1,100 @@
+# Desired-state schema for the events_recent ecosystem.
+# Short-lived copy of recent events for fast "last N hours" queries.
+
+ecosystem: events_recent
+cluster: main
+
+tables:
+    sharded_events_recent:
+        engine: ReplicatedReplacingMergeTree
+        sharded: true
+        on_nodes: DATA
+        order_by:
+            - team_id
+            - 'toStartOfHour(inserted_at)'
+            - event
+            - 'cityHash64(distinct_id)'
+            - 'cityHash64(uuid)'
+        partition_by: 'toStartOfDay(inserted_at)'
+        settings:
+            ttl_only_drop_parts: '1'
+        columns:
+            - name: uuid
+              type: UUID
+            - name: event
+              type: String
+            - name: properties
+              type: String
+            - name: timestamp
+              type: "DateTime64(6, 'UTC')"
+            - name: team_id
+              type: Int64
+            - name: distinct_id
+              type: String
+            - name: elements_chain
+              type: String
+            - name: created_at
+              type: "DateTime64(6, 'UTC')"
+            - name: person_id
+              type: UUID
+            - name: person_created_at
+              type: DateTime64(3)
+            - name: person_properties
+              type: String
+            - name: group0_properties
+              type: String
+            - name: group1_properties
+              type: String
+            - name: group2_properties
+              type: String
+            - name: group3_properties
+              type: String
+            - name: group4_properties
+              type: String
+            - name: group0_created_at
+              type: DateTime64(3)
+            - name: group1_created_at
+              type: DateTime64(3)
+            - name: group2_created_at
+              type: DateTime64(3)
+            - name: group3_created_at
+              type: DateTime64(3)
+            - name: group4_created_at
+              type: DateTime64(3)
+            - name: person_mode
+              type: "Enum8('full' = 0, 'propertyless' = 1, 'force_upgrade' = 2)"
+            - name: historical_migration
+              type: Bool
+            - name: inserted_at
+              type: "DateTime64(6, 'UTC')"
+              default_expression: 'NOW64()'
+              default_kind: DEFAULT
+
+    writable_events_recent:
+        engine: Distributed
+        source: sharded_events_recent
+        sharding_key: 'sipHash64(distinct_id)'
+        on_nodes: COORDINATOR
+        columns: inherit sharded_events_recent
+
+    events_recent:
+        engine: Distributed
+        source: sharded_events_recent
+        sharding_key: 'sipHash64(distinct_id)'
+        on_nodes: ALL
+        columns: inherit sharded_events_recent
+
+    distributed_events_recent:
+        engine: Distributed
+        source: sharded_events_recent
+        sharding_key: 'sipHash64(distinct_id)'
+        on_nodes: ALL
+        columns: inherit sharded_events_recent
+
+    events_recent_json_mv:
+        engine: MaterializedView
+        source: sharded_events
+        target: writable_events_recent
+        select: "SELECT ... FROM {{ database }}.sharded_events"
+        on_nodes: DATA
+        columns: []

--- a/posthog/clickhouse/schema/events_recent.yaml
+++ b/posthog/clickhouse/schema/events_recent.yaml
@@ -74,7 +74,7 @@ tables:
         engine: Distributed
         source: sharded_events_recent
         sharding_key: 'sipHash64(distinct_id)'
-        on_nodes: COORDINATOR
+        on_nodes: DATA
         columns: inherit sharded_events_recent
 
     events_recent:

--- a/posthog/clickhouse/schema/events_recent.yaml
+++ b/posthog/clickhouse/schema/events_recent.yaml
@@ -65,31 +65,198 @@ tables:
               type: "Enum8('full' = 0, 'propertyless' = 1, 'force_upgrade' = 2)"
             - name: historical_migration
               type: Bool
+            # Kafka virtual columns (materialized on sharded table)
+            - name: _timestamp
+              type: DateTime
+            - name: _offset
+              type: UInt64
             - name: inserted_at
               type: "DateTime64(6, 'UTC')"
               default_expression: 'NOW64()'
               default_kind: DEFAULT
 
+    # writable_events_recent has no inserted_at column in legacy (it's a write
+    # target, not a source), so we can't inherit from sharded. 25 cols total.
     writable_events_recent:
         engine: Distributed
         source: sharded_events_recent
         sharding_key: 'sipHash64(distinct_id)'
         on_nodes: COORDINATOR
-        columns: inherit sharded_events_recent
+        columns:
+            - name: uuid
+              type: UUID
+            - name: event
+              type: String
+            - name: properties
+              type: String
+            - name: timestamp
+              type: "DateTime64(6, 'UTC')"
+            - name: team_id
+              type: Int64
+            - name: distinct_id
+              type: String
+            - name: elements_chain
+              type: String
+            - name: created_at
+              type: "DateTime64(6, 'UTC')"
+            - name: person_id
+              type: UUID
+            - name: person_created_at
+              type: DateTime64(3)
+            - name: person_properties
+              type: String
+            - name: group0_properties
+              type: String
+            - name: group1_properties
+              type: String
+            - name: group2_properties
+              type: String
+            - name: group3_properties
+              type: String
+            - name: group4_properties
+              type: String
+            - name: group0_created_at
+              type: DateTime64(3)
+            - name: group1_created_at
+              type: DateTime64(3)
+            - name: group2_created_at
+              type: DateTime64(3)
+            - name: group3_created_at
+              type: DateTime64(3)
+            - name: group4_created_at
+              type: DateTime64(3)
+            - name: person_mode
+              type: "Enum8('full' = 0, 'propertyless' = 1, 'force_upgrade' = 2)"
+            - name: historical_migration
+              type: Bool
+            - name: _timestamp
+              type: DateTime
+            - name: _offset
+              type: UInt64
 
+    # events_recent and distributed_events_recent have inserted_at as Nullable
+    # (different from sharded where it's non-null with DEFAULT NOW64()).
     events_recent:
         engine: Distributed
         source: sharded_events_recent
         sharding_key: 'sipHash64(distinct_id)'
         on_nodes: ALL
-        columns: inherit sharded_events_recent
+        columns:
+            - name: uuid
+              type: UUID
+            - name: event
+              type: String
+            - name: properties
+              type: String
+            - name: timestamp
+              type: "DateTime64(6, 'UTC')"
+            - name: team_id
+              type: Int64
+            - name: distinct_id
+              type: String
+            - name: elements_chain
+              type: String
+            - name: created_at
+              type: "DateTime64(6, 'UTC')"
+            - name: person_id
+              type: UUID
+            - name: person_created_at
+              type: DateTime64(3)
+            - name: person_properties
+              type: String
+            - name: group0_properties
+              type: String
+            - name: group1_properties
+              type: String
+            - name: group2_properties
+              type: String
+            - name: group3_properties
+              type: String
+            - name: group4_properties
+              type: String
+            - name: group0_created_at
+              type: DateTime64(3)
+            - name: group1_created_at
+              type: DateTime64(3)
+            - name: group2_created_at
+              type: DateTime64(3)
+            - name: group3_created_at
+              type: DateTime64(3)
+            - name: group4_created_at
+              type: DateTime64(3)
+            - name: person_mode
+              type: "Enum8('full' = 0, 'propertyless' = 1, 'force_upgrade' = 2)"
+            - name: historical_migration
+              type: Bool
+            - name: _timestamp
+              type: DateTime
+            - name: _offset
+              type: UInt64
+            - name: inserted_at
+              type: "Nullable(DateTime64(6, 'UTC'))"
+              default_expression: 'NOW64()'
+              default_kind: DEFAULT
 
     distributed_events_recent:
         engine: Distributed
         source: sharded_events_recent
         sharding_key: 'sipHash64(distinct_id)'
         on_nodes: ALL
-        columns: inherit sharded_events_recent
+        columns:
+            - name: uuid
+              type: UUID
+            - name: event
+              type: String
+            - name: properties
+              type: String
+            - name: timestamp
+              type: "DateTime64(6, 'UTC')"
+            - name: team_id
+              type: Int64
+            - name: distinct_id
+              type: String
+            - name: elements_chain
+              type: String
+            - name: created_at
+              type: "DateTime64(6, 'UTC')"
+            - name: person_id
+              type: UUID
+            - name: person_created_at
+              type: DateTime64(3)
+            - name: person_properties
+              type: String
+            - name: group0_properties
+              type: String
+            - name: group1_properties
+              type: String
+            - name: group2_properties
+              type: String
+            - name: group3_properties
+              type: String
+            - name: group4_properties
+              type: String
+            - name: group0_created_at
+              type: DateTime64(3)
+            - name: group1_created_at
+              type: DateTime64(3)
+            - name: group2_created_at
+              type: DateTime64(3)
+            - name: group3_created_at
+              type: DateTime64(3)
+            - name: group4_created_at
+              type: DateTime64(3)
+            - name: person_mode
+              type: "Enum8('full' = 0, 'propertyless' = 1, 'force_upgrade' = 2)"
+            - name: historical_migration
+              type: Bool
+            - name: _timestamp
+              type: DateTime
+            - name: _offset
+              type: UInt64
+            - name: inserted_at
+              type: "Nullable(DateTime64(6, 'UTC'))"
+              default_expression: 'NOW64()'
+              default_kind: DEFAULT
 
     events_recent_json_mv:
         engine: MaterializedView

--- a/posthog/clickhouse/schema/events_recent.yaml
+++ b/posthog/clickhouse/schema/events_recent.yaml
@@ -262,6 +262,6 @@ tables:
         engine: MaterializedView
         source: sharded_events
         target: writable_events_recent
-        select: "SELECT ... FROM {{ database }}.sharded_events"
+        select: 'SELECT ... FROM {{ database }}.sharded_events'
         on_nodes: DATA
         columns: []

--- a/posthog/clickhouse/schema/events_recent.yaml
+++ b/posthog/clickhouse/schema/events_recent.yaml
@@ -74,7 +74,7 @@ tables:
         engine: Distributed
         source: sharded_events_recent
         sharding_key: 'sipHash64(distinct_id)'
-        on_nodes: DATA
+        on_nodes: COORDINATOR
         columns: inherit sharded_events_recent
 
     events_recent:

--- a/posthog/clickhouse/schema/exchange_rate.yaml
+++ b/posthog/clickhouse/schema/exchange_rate.yaml
@@ -1,0 +1,37 @@
+# Desired-state schema for the exchange_rate ecosystem.
+
+ecosystem: exchange_rate
+cluster: main
+
+tables:
+    exchange_rate:
+        engine: ReplicatedReplacingMergeTree
+        sharded: false
+        on_nodes: ALL
+        order_by:
+            - date
+            - currency
+        columns:
+            - name: currency
+              type: String
+            - name: date
+              type: Date
+            - name: rate
+              type: Decimal64(10)
+            - name: version
+              type: UInt32
+              default_expression: 'toUnixTimestamp(now())'
+              default_kind: DEFAULT
+
+    exchange_rate_dict:
+        engine: Dictionary
+        on_nodes: ALL
+        columns:
+            - name: currency
+              type: String
+            - name: start_date
+              type: Date
+            - name: end_date
+              type: Nullable(Date)
+            - name: rate
+              type: Decimal64(10)

--- a/posthog/clickhouse/schema/exchange_rate.yaml
+++ b/posthog/clickhouse/schema/exchange_rate.yaml
@@ -33,7 +33,7 @@ tables:
         primary_key: currency
         source:
             type: CLICKHOUSE
-            query: "SELECT currency, date AS start_date, leadInFrame(date::Nullable(Date), 1, NULL::Nullable(Date)) OVER w AS end_date, argMax(rate, version) AS rate FROM `posthog`.`exchange_rate` GROUP BY date, currency WINDOW w AS ( PARTITION BY currency ORDER BY date ASC ROWS BETWEEN 1 FOLLOWING AND 1 FOLLOWING )"
+            query: 'SELECT currency, date AS start_date, leadInFrame(date::Nullable(Date), 1, NULL::Nullable(Date)) OVER w AS end_date, argMax(rate, version) AS rate FROM `posthog`.`exchange_rate` GROUP BY date, currency WINDOW w AS ( PARTITION BY currency ORDER BY date ASC ROWS BETWEEN 1 FOLLOWING AND 1 FOLLOWING )'
             user: __from_settings__
             password: __from_settings__
         layout:

--- a/posthog/clickhouse/schema/exchange_rate.yaml
+++ b/posthog/clickhouse/schema/exchange_rate.yaml
@@ -23,9 +23,29 @@ tables:
               default_expression: 'toUnixTimestamp(now())'
               default_kind: DEFAULT
 
+    # RANGE_HASHED dictionary keyed by currency with start/end date windows.
+    # The SOURCE is a QUERY (not a direct table) because the underlying table
+    # is sparse and we compute end_date via leadInFrame. See
+    # posthog/models/exchange_rate/sql.py EXCHANGE_RATE_DICTIONARY_QUERY.
     exchange_rate_dict:
         engine: Dictionary
         on_nodes: ALL
+        primary_key: currency
+        source:
+            type: CLICKHOUSE
+            query: "SELECT currency, date AS start_date, leadInFrame(date::Nullable(Date), 1, NULL::Nullable(Date)) OVER w AS end_date, argMax(rate, version) AS rate FROM `posthog`.`exchange_rate` GROUP BY date, currency WINDOW w AS ( PARTITION BY currency ORDER BY date ASC ROWS BETWEEN 1 FOLLOWING AND 1 FOLLOWING )"
+            user: __from_settings__
+            password: __from_settings__
+        layout:
+            type: RANGE_HASHED
+            params:
+                range_lookup_strategy: max
+        lifetime:
+            min: 3000
+            max: 3600
+        range:
+            min: start_date
+            max: end_date
         columns:
             - name: currency
               type: String

--- a/posthog/clickhouse/schema/experiment_exposures.yaml
+++ b/posthog/clickhouse/schema/experiment_exposures.yaml
@@ -42,7 +42,7 @@ tables:
               default_kind: DEFAULT
             - name: expires_at
               type: Date
-              default_expression: "today() + toIntervalDay(7)"
+              default_expression: 'today() + toIntervalDay(7)'
               default_kind: DEFAULT
 
     experiment_exposures_preaggregated:

--- a/posthog/clickhouse/schema/experiment_exposures.yaml
+++ b/posthog/clickhouse/schema/experiment_exposures.yaml
@@ -1,0 +1,55 @@
+# Desired-state schema for the experiment_exposures_preaggregated ecosystem.
+
+ecosystem: experiment_exposures
+cluster: main
+
+tables:
+    sharded_experiment_exposures_preaggregated:
+        engine: ReplicatedReplacingMergeTree
+        sharded: true
+        on_nodes: DATA
+        order_by:
+            - team_id
+            - job_id
+            - entity_id
+            - breakdown_value
+        partition_by: 'toYYYYMMDD(expires_at)'
+        settings:
+            index_granularity: '8192'
+            ttl_only_drop_parts: '1'
+        columns:
+            - name: team_id
+              type: Int64
+            - name: job_id
+              type: UUID
+            - name: entity_id
+              type: String
+            - name: variant
+              type: String
+            - name: first_exposure_time
+              type: "DateTime64(6, 'UTC')"
+            - name: last_exposure_time
+              type: "DateTime64(6, 'UTC')"
+            - name: exposure_event_uuid
+              type: UUID
+            - name: exposure_session_id
+              type: String
+            - name: breakdown_value
+              type: Array(String)
+            - name: computed_at
+              type: "DateTime64(6, 'UTC')"
+              default_expression: 'now()'
+              default_kind: DEFAULT
+            - name: expires_at
+              type: Date
+              default_expression: "today() + toIntervalDay(7)"
+              default_kind: DEFAULT
+
+    experiment_exposures_preaggregated:
+        engine: Distributed
+        source: sharded_experiment_exposures_preaggregated
+        sharding_key: 'cityHash64(entity_id)'
+        on_nodes:
+            - DATA
+            - COORDINATOR
+        columns: inherit sharded_experiment_exposures_preaggregated

--- a/posthog/clickhouse/schema/experiment_exposures.yaml
+++ b/posthog/clickhouse/schema/experiment_exposures.yaml
@@ -51,5 +51,5 @@ tables:
         sharding_key: 'cityHash64(entity_id)'
         on_nodes:
             - DATA
-            - DATA
+            - COORDINATOR
         columns: inherit sharded_experiment_exposures_preaggregated

--- a/posthog/clickhouse/schema/experiment_exposures.yaml
+++ b/posthog/clickhouse/schema/experiment_exposures.yaml
@@ -51,5 +51,5 @@ tables:
         sharding_key: 'cityHash64(entity_id)'
         on_nodes:
             - DATA
-            - COORDINATOR
+            - DATA
         columns: inherit sharded_experiment_exposures_preaggregated

--- a/posthog/clickhouse/schema/groups.yaml
+++ b/posthog/clickhouse/schema/groups.yaml
@@ -1,0 +1,50 @@
+# Desired-state schema for the groups ecosystem.
+
+ecosystem: groups
+cluster: main
+
+tables:
+    groups:
+        engine: ReplicatedReplacingMergeTree
+        sharded: false
+        on_nodes: DATA
+        order_by:
+            - team_id
+            - group_type_index
+            - group_key
+        columns:
+            - name: group_type_index
+              type: UInt8
+            - name: group_key
+              type: String
+            - name: created_at
+              type: DateTime64(3)
+            - name: team_id
+              type: Int64
+            - name: group_properties
+              type: String
+
+    writable_groups:
+        engine: Distributed
+        source: groups
+        sharding_key: 'rand()'
+        on_nodes: COORDINATOR
+        columns: inherit groups
+
+    kafka_groups:
+        engine: Kafka
+        on_nodes: INGESTION_EVENTS
+        settings:
+            kafka_broker_list: __from_settings__
+            kafka_topic_list: clickhouse_groups
+            kafka_group_name: groups
+            kafka_format: JSONEachRow
+        columns: inherit groups
+
+    groups_mv:
+        engine: MaterializedView
+        source: kafka_groups
+        target: writable_groups
+        select: "SELECT group_type_index, group_key, created_at, team_id, group_properties, _timestamp, _offset FROM {{ database }}.kafka_groups"
+        on_nodes: INGESTION_EVENTS
+        columns: []

--- a/posthog/clickhouse/schema/groups.yaml
+++ b/posthog/clickhouse/schema/groups.yaml
@@ -28,7 +28,7 @@ tables:
         engine: Distributed
         source: groups
         sharding_key: 'rand()'
-        on_nodes: COORDINATOR
+        on_nodes: DATA
         columns: inherit groups
 
     kafka_groups:

--- a/posthog/clickhouse/schema/groups.yaml
+++ b/posthog/clickhouse/schema/groups.yaml
@@ -62,6 +62,6 @@ tables:
         engine: MaterializedView
         source: kafka_groups
         target: writable_groups
-        select: "SELECT group_type_index, group_key, created_at, team_id, group_properties, _timestamp, _offset FROM {{ database }}.kafka_groups"
+        select: 'SELECT group_type_index, group_key, created_at, team_id, group_properties, _timestamp, _offset FROM {{ database }}.kafka_groups'
         on_nodes: INGESTION_EVENTS
         columns: []

--- a/posthog/clickhouse/schema/groups.yaml
+++ b/posthog/clickhouse/schema/groups.yaml
@@ -23,6 +23,11 @@ tables:
               type: Int64
             - name: group_properties
               type: String
+            # Kafka virtual columns
+            - name: _timestamp
+              type: DateTime
+            - name: _offset
+              type: UInt64
 
     writable_groups:
         engine: Distributed
@@ -39,7 +44,17 @@ tables:
             kafka_topic_list: clickhouse_groups
             kafka_group_name: groups
             kafka_format: JSONEachRow
-        columns: inherit groups
+        columns:
+            - name: group_type_index
+              type: UInt8
+            - name: group_key
+              type: String
+            - name: created_at
+              type: DateTime64(3)
+            - name: team_id
+              type: Int64
+            - name: group_properties
+              type: String
 
     groups_mv:
         engine: MaterializedView

--- a/posthog/clickhouse/schema/groups.yaml
+++ b/posthog/clickhouse/schema/groups.yaml
@@ -28,7 +28,7 @@ tables:
         engine: Distributed
         source: groups
         sharding_key: 'rand()'
-        on_nodes: DATA
+        on_nodes: COORDINATOR
         columns: inherit groups
 
     kafka_groups:

--- a/posthog/clickhouse/schema/groups.yaml
+++ b/posthog/clickhouse/schema/groups.yaml
@@ -28,6 +28,8 @@ tables:
               type: DateTime
             - name: _offset
               type: UInt64
+            - name: is_deleted
+              type: Bool
 
     writable_groups:
         engine: Distributed

--- a/posthog/clickhouse/schema/heatmaps.yaml
+++ b/posthog/clickhouse/schema/heatmaps.yaml
@@ -1,0 +1,104 @@
+# Desired-state schema for the heatmaps ecosystem.
+
+ecosystem: heatmaps
+cluster: main
+
+tables:
+    sharded_heatmaps:
+        engine: ReplicatedMergeTree
+        sharded: true
+        on_nodes: DATA
+        order_by:
+            - type
+            - team_id
+            - 'toDate(timestamp)'
+            - current_url
+            - viewport_width
+        partition_by: 'toYYYYMM(timestamp)'
+        columns:
+            - name: session_id
+              type: String
+            - name: team_id
+              type: Int64
+            - name: distinct_id
+              type: String
+            - name: timestamp
+              type: "DateTime64(6, 'UTC')"
+            - name: x
+              type: Int16
+            - name: y
+              type: Int16
+            - name: scale_factor
+              type: Int16
+            - name: viewport_width
+              type: Int16
+            - name: viewport_height
+              type: Int16
+            - name: pointer_target_fixed
+              type: Bool
+            - name: current_url
+              type: String
+            - name: type
+              type: LowCardinality(String)
+            - name: _timestamp
+              type: DateTime
+            - name: _offset
+              type: UInt64
+            - name: _partition
+              type: UInt64
+
+    heatmaps:
+        engine: Distributed
+        source: sharded_heatmaps
+        sharding_key: "cityHash64(concat(toString(team_id), '-', session_id, '-', toString(toDate(timestamp))))"
+        on_nodes: COORDINATOR
+        columns: inherit sharded_heatmaps
+
+    writable_heatmaps:
+        engine: Distributed
+        source: sharded_heatmaps
+        sharding_key: "cityHash64(concat(toString(team_id), '-', session_id, '-', toString(toDate(timestamp))))"
+        on_nodes: INGESTION_MEDIUM
+        columns: inherit sharded_heatmaps
+
+    kafka_heatmaps:
+        engine: Kafka
+        on_nodes: INGESTION_MEDIUM
+        settings:
+            kafka_broker_list: __from_settings__
+            kafka_topic_list: clickhouse_heatmap_events
+            kafka_group_name: clickhouse_heatmaps
+            kafka_format: JSONEachRow
+        columns:
+            - name: session_id
+              type: String
+            - name: team_id
+              type: Int64
+            - name: distinct_id
+              type: String
+            - name: timestamp
+              type: "DateTime64(6, 'UTC')"
+            - name: x
+              type: Int16
+            - name: y
+              type: Int16
+            - name: scale_factor
+              type: Int16
+            - name: viewport_width
+              type: Int16
+            - name: viewport_height
+              type: Int16
+            - name: pointer_target_fixed
+              type: Bool
+            - name: current_url
+              type: String
+            - name: type
+              type: LowCardinality(String)
+
+    heatmaps_mv:
+        engine: MaterializedView
+        source: kafka_heatmaps
+        target: writable_heatmaps
+        select: "SELECT session_id, team_id, distinct_id, timestamp, x, y, scale_factor, viewport_width, viewport_height, pointer_target_fixed, current_url, type, _timestamp, _offset, _partition FROM {{ database }}.kafka_heatmaps"
+        on_nodes: INGESTION_MEDIUM
+        columns: []

--- a/posthog/clickhouse/schema/heatmaps.yaml
+++ b/posthog/clickhouse/schema/heatmaps.yaml
@@ -99,6 +99,6 @@ tables:
         engine: MaterializedView
         source: kafka_heatmaps
         target: writable_heatmaps
-        select: "SELECT session_id, team_id, distinct_id, timestamp, x, y, scale_factor, viewport_width, viewport_height, pointer_target_fixed, current_url, type, _timestamp, _offset, _partition FROM {{ database }}.kafka_heatmaps"
+        select: 'SELECT session_id, team_id, distinct_id, timestamp, x, y, scale_factor, viewport_width, viewport_height, pointer_target_fixed, current_url, type, _timestamp, _offset, _partition FROM {{ database }}.kafka_heatmaps'
         on_nodes: INGESTION_MEDIUM
         columns: []

--- a/posthog/clickhouse/schema/heatmaps.yaml
+++ b/posthog/clickhouse/schema/heatmaps.yaml
@@ -51,7 +51,7 @@ tables:
         engine: Distributed
         source: sharded_heatmaps
         sharding_key: "cityHash64(concat(toString(team_id), '-', session_id, '-', toString(toDate(timestamp))))"
-        on_nodes: COORDINATOR
+        on_nodes: DATA
         columns: inherit sharded_heatmaps
 
     writable_heatmaps:

--- a/posthog/clickhouse/schema/heatmaps.yaml
+++ b/posthog/clickhouse/schema/heatmaps.yaml
@@ -51,7 +51,7 @@ tables:
         engine: Distributed
         source: sharded_heatmaps
         sharding_key: "cityHash64(concat(toString(team_id), '-', session_id, '-', toString(toDate(timestamp))))"
-        on_nodes: DATA
+        on_nodes: COORDINATOR
         columns: inherit sharded_heatmaps
 
     writable_heatmaps:

--- a/posthog/clickhouse/schema/ingestion_warnings.yaml
+++ b/posthog/clickhouse/schema/ingestion_warnings.yaml
@@ -1,0 +1,60 @@
+# Desired-state schema for the ingestion_warnings ecosystem.
+
+ecosystem: ingestion_warnings
+cluster: main
+
+tables:
+    sharded_ingestion_warnings:
+        engine: ReplicatedMergeTree
+        sharded: true
+        on_nodes: DATA
+        order_by:
+            - team_id
+            - 'toHour(timestamp)'
+            - type
+            - source
+            - timestamp
+        partition_by: 'toYYYYMMDD(timestamp)'
+        columns:
+            - name: team_id
+              type: Int64
+            - name: source
+              type: LowCardinality(String)
+            - name: type
+              type: String
+            - name: details
+              type: String
+            - name: timestamp
+              type: "DateTime64(6, 'UTC')"
+
+    writable_ingestion_warnings:
+        engine: Distributed
+        source: sharded_ingestion_warnings
+        sharding_key: 'rand()'
+        on_nodes: COORDINATOR
+        columns: inherit sharded_ingestion_warnings
+
+    ingestion_warnings:
+        engine: Distributed
+        source: sharded_ingestion_warnings
+        sharding_key: 'rand()'
+        on_nodes: ALL
+        columns: inherit sharded_ingestion_warnings
+
+    kafka_ingestion_warnings:
+        engine: Kafka
+        on_nodes: INGESTION_EVENTS
+        settings:
+            kafka_broker_list: __from_settings__
+            kafka_topic_list: clickhouse_ingestion_warnings
+            kafka_group_name: clickhouse_ingestion_warnings
+            kafka_format: JSONEachRow
+        columns: inherit sharded_ingestion_warnings
+
+    ingestion_warnings_mv:
+        engine: MaterializedView
+        source: kafka_ingestion_warnings
+        target: writable_ingestion_warnings
+        select: "SELECT team_id, source, type, details, timestamp, _timestamp, _offset, _partition FROM {{ database }}.kafka_ingestion_warnings"
+        on_nodes: INGESTION_EVENTS
+        columns: []

--- a/posthog/clickhouse/schema/ingestion_warnings.yaml
+++ b/posthog/clickhouse/schema/ingestion_warnings.yaml
@@ -72,6 +72,6 @@ tables:
         engine: MaterializedView
         source: kafka_ingestion_warnings
         target: writable_ingestion_warnings
-        select: "SELECT team_id, source, type, details, timestamp, _timestamp, _offset, _partition FROM {{ database }}.kafka_ingestion_warnings"
+        select: 'SELECT team_id, source, type, details, timestamp, _timestamp, _offset, _partition FROM {{ database }}.kafka_ingestion_warnings'
         on_nodes: INGESTION_EVENTS
         columns: []

--- a/posthog/clickhouse/schema/ingestion_warnings.yaml
+++ b/posthog/clickhouse/schema/ingestion_warnings.yaml
@@ -26,6 +26,13 @@ tables:
               type: String
             - name: timestamp
               type: "DateTime64(6, 'UTC')"
+            # Kafka virtual columns
+            - name: _timestamp
+              type: DateTime
+            - name: _offset
+              type: UInt64
+            - name: _partition
+              type: UInt64
 
     writable_ingestion_warnings:
         engine: Distributed
@@ -49,7 +56,17 @@ tables:
             kafka_topic_list: clickhouse_ingestion_warnings
             kafka_group_name: clickhouse_ingestion_warnings
             kafka_format: JSONEachRow
-        columns: inherit sharded_ingestion_warnings
+        columns:
+            - name: team_id
+              type: Int64
+            - name: source
+              type: LowCardinality(String)
+            - name: type
+              type: String
+            - name: details
+              type: String
+            - name: timestamp
+              type: "DateTime64(6, 'UTC')"
 
     ingestion_warnings_mv:
         engine: MaterializedView

--- a/posthog/clickhouse/schema/ingestion_warnings.yaml
+++ b/posthog/clickhouse/schema/ingestion_warnings.yaml
@@ -31,7 +31,7 @@ tables:
         engine: Distributed
         source: sharded_ingestion_warnings
         sharding_key: 'rand()'
-        on_nodes: COORDINATOR
+        on_nodes: DATA
         columns: inherit sharded_ingestion_warnings
 
     ingestion_warnings:

--- a/posthog/clickhouse/schema/ingestion_warnings.yaml
+++ b/posthog/clickhouse/schema/ingestion_warnings.yaml
@@ -31,7 +31,7 @@ tables:
         engine: Distributed
         source: sharded_ingestion_warnings
         sharding_key: 'rand()'
-        on_nodes: DATA
+        on_nodes: COORDINATOR
         columns: inherit sharded_ingestion_warnings
 
     ingestion_warnings:

--- a/posthog/clickhouse/schema/llma_metrics.yaml
+++ b/posthog/clickhouse/schema/llma_metrics.yaml
@@ -1,0 +1,26 @@
+# Desired-state schema for the llma_metrics_daily table.
+
+ecosystem: llma_metrics
+cluster: main
+
+tables:
+    llma_metrics_daily:
+        engine: ReplicatedMergeTree
+        sharded: false
+        on_nodes:
+            - DATA
+            - COORDINATOR
+        order_by:
+            - team_id
+            - date
+            - metric_name
+        partition_by: 'toYYYYMM(date)'
+        columns:
+            - name: date
+              type: Date
+            - name: team_id
+              type: UInt64
+            - name: metric_name
+              type: String
+            - name: metric_value
+              type: Float64

--- a/posthog/clickhouse/schema/llma_metrics.yaml
+++ b/posthog/clickhouse/schema/llma_metrics.yaml
@@ -9,7 +9,7 @@ tables:
         sharded: false
         on_nodes:
             - DATA
-            - COORDINATOR
+            - DATA
         order_by:
             - team_id
             - date

--- a/posthog/clickhouse/schema/llma_metrics.yaml
+++ b/posthog/clickhouse/schema/llma_metrics.yaml
@@ -9,7 +9,7 @@ tables:
         sharded: false
         on_nodes:
             - DATA
-            - DATA
+            - COORDINATOR
         order_by:
             - team_id
             - date

--- a/posthog/clickhouse/schema/log_entries.yaml
+++ b/posthog/clickhouse/schema/log_entries.yaml
@@ -1,0 +1,132 @@
+# Desired-state schema for the log_entries ecosystem.
+
+ecosystem: log_entries
+cluster: main
+
+tables:
+    # Legacy non-sharded table (still exists)
+    log_entries:
+        engine: ReplicatedReplacingMergeTree
+        sharded: false
+        on_nodes: DATA
+        order_by:
+            - team_id
+            - log_source
+            - log_source_id
+            - instance_id
+            - timestamp
+        partition_by: 'toStartOfHour(timestamp)'
+        settings:
+            index_granularity: '512'
+        columns:
+            - name: team_id
+              type: UInt64
+            - name: log_source
+              type: LowCardinality(String)
+            - name: log_source_id
+              type: String
+            - name: instance_id
+              type: String
+            - name: timestamp
+              type: "DateTime64(6, 'UTC')"
+            - name: level
+              type: LowCardinality(String)
+            - name: message
+              type: String
+
+    # Sharded table (v3 rework)
+    sharded_log_entries:
+        engine: ReplicatedReplacingMergeTree
+        sharded: true
+        on_nodes: DATA
+        order_by:
+            - team_id
+            - log_source
+            - log_source_id
+            - instance_id
+            - timestamp
+        partition_by: 'toYYYYMMDD(timestamp)'
+        settings:
+            index_granularity: '1024'
+            ttl_only_drop_parts: '1'
+        columns:
+            - name: team_id
+              type: UInt64
+            - name: log_source
+              type: LowCardinality(String)
+            - name: log_source_id
+              type: String
+            - name: instance_id
+              type: String
+            - name: timestamp
+              type: "DateTime64(6, 'UTC')"
+            - name: level
+              type: LowCardinality(String)
+            - name: message
+              type: String
+
+    distributed_log_entries:
+        engine: Distributed
+        source: sharded_log_entries
+        sharding_key: 'rand()'
+        on_nodes: ALL
+        columns: inherit sharded_log_entries
+
+    writable_log_entries:
+        engine: Distributed
+        source: sharded_log_entries
+        sharding_key: 'rand()'
+        on_nodes: COORDINATOR
+        columns: inherit sharded_log_entries
+
+    # Original Kafka table (non-sharded pipeline)
+    kafka_log_entries:
+        engine: Kafka
+        on_nodes: ALL
+        settings:
+            kafka_broker_list: __from_settings__
+            kafka_topic_list: log_entries
+            kafka_group_name: log_entries
+            kafka_format: JSONEachRow
+        columns:
+            - name: team_id
+              type: UInt64
+            - name: log_source
+              type: LowCardinality(String)
+            - name: log_source_id
+              type: String
+            - name: instance_id
+              type: String
+            - name: timestamp
+              type: "DateTime64(6, 'UTC')"
+            - name: level
+              type: LowCardinality(String)
+            - name: message
+              type: String
+
+    log_entries_mv:
+        engine: MaterializedView
+        source: kafka_log_entries
+        target: log_entries
+        select: "SELECT team_id, log_source, log_source_id, instance_id, timestamp, level, message, _timestamp, _offset FROM {{ database }}.kafka_log_entries"
+        on_nodes: ALL
+        columns: []
+
+    kafka_log_entries_v3:
+        engine: Kafka
+        on_nodes: INGESTION_EVENTS
+        settings:
+            kafka_broker_list: __from_settings__
+            kafka_topic_list: log_entries
+            kafka_group_name: log_entries_consumer
+            kafka_format: JSONEachRow
+            kafka_skip_broken_messages: '100'
+        columns: inherit sharded_log_entries
+
+    log_entries_v3_mv:
+        engine: MaterializedView
+        source: kafka_log_entries_v3
+        target: writable_log_entries
+        select: "SELECT team_id, log_source, log_source_id, instance_id, timestamp, level, message, _timestamp, _offset FROM {{ database }}.kafka_log_entries_v3 WHERE toDate(timestamp) <= today()"
+        on_nodes: INGESTION_EVENTS
+        columns: []

--- a/posthog/clickhouse/schema/log_entries.yaml
+++ b/posthog/clickhouse/schema/log_entries.yaml
@@ -33,6 +33,11 @@ tables:
               type: LowCardinality(String)
             - name: message
               type: String
+            # Kafka virtual columns
+            - name: _timestamp
+              type: DateTime
+            - name: _offset
+              type: UInt64
 
     # Sharded table (v3 rework)
     sharded_log_entries:
@@ -64,6 +69,11 @@ tables:
               type: LowCardinality(String)
             - name: message
               type: String
+            # Kafka virtual columns
+            - name: _timestamp
+              type: DateTime
+            - name: _offset
+              type: UInt64
 
     distributed_log_entries:
         engine: Distributed
@@ -108,14 +118,8 @@ tables:
         engine: MaterializedView
         source: kafka_log_entries
         target: log_entries
-        # Target table (log_entries) lives on DATA nodes only — match its
-        # node scope. Previous YAML had `on_nodes: ALL` which caused the MV
-        # CREATE to fire on the coordinator where log_entries doesn't exist.
         on_nodes: DATA
-        # Kafka virtual columns (_timestamp, _offset) aren't in the target
-        # table, so the MV SELECT must not output them. Removing them aligns
-        # with the target column list exactly.
-        select: "SELECT team_id, log_source, log_source_id, instance_id, timestamp, level, message FROM {{ database }}.kafka_log_entries"
+        select: "SELECT team_id, log_source, log_source_id, instance_id, timestamp, level, message, _timestamp, _offset FROM {{ database }}.kafka_log_entries"
         columns: []
 
     kafka_log_entries_v3:
@@ -127,7 +131,21 @@ tables:
             kafka_group_name: log_entries_consumer
             kafka_format: JSONEachRow
             kafka_skip_broken_messages: '100'
-        columns: inherit sharded_log_entries
+        columns:
+            - name: team_id
+              type: UInt64
+            - name: log_source
+              type: LowCardinality(String)
+            - name: log_source_id
+              type: String
+            - name: instance_id
+              type: String
+            - name: timestamp
+              type: "DateTime64(6, 'UTC')"
+            - name: level
+              type: LowCardinality(String)
+            - name: message
+              type: String
 
     log_entries_v3_mv:
         engine: MaterializedView

--- a/posthog/clickhouse/schema/log_entries.yaml
+++ b/posthog/clickhouse/schema/log_entries.yaml
@@ -76,7 +76,7 @@ tables:
         engine: Distributed
         source: sharded_log_entries
         sharding_key: 'rand()'
-        on_nodes: COORDINATOR
+        on_nodes: DATA
         columns: inherit sharded_log_entries
 
     # Original Kafka table (non-sharded pipeline)

--- a/posthog/clickhouse/schema/log_entries.yaml
+++ b/posthog/clickhouse/schema/log_entries.yaml
@@ -76,7 +76,7 @@ tables:
         engine: Distributed
         source: sharded_log_entries
         sharding_key: 'rand()'
-        on_nodes: DATA
+        on_nodes: COORDINATOR
         columns: inherit sharded_log_entries
 
     # Original Kafka table (non-sharded pipeline)

--- a/posthog/clickhouse/schema/log_entries.yaml
+++ b/posthog/clickhouse/schema/log_entries.yaml
@@ -108,8 +108,14 @@ tables:
         engine: MaterializedView
         source: kafka_log_entries
         target: log_entries
-        select: "SELECT team_id, log_source, log_source_id, instance_id, timestamp, level, message, _timestamp, _offset FROM {{ database }}.kafka_log_entries"
-        on_nodes: ALL
+        # Target table (log_entries) lives on DATA nodes only — match its
+        # node scope. Previous YAML had `on_nodes: ALL` which caused the MV
+        # CREATE to fire on the coordinator where log_entries doesn't exist.
+        on_nodes: DATA
+        # Kafka virtual columns (_timestamp, _offset) aren't in the target
+        # table, so the MV SELECT must not output them. Removing them aligns
+        # with the target column list exactly.
+        select: "SELECT team_id, log_source, log_source_id, instance_id, timestamp, level, message FROM {{ database }}.kafka_log_entries"
         columns: []
 
     kafka_log_entries_v3:

--- a/posthog/clickhouse/schema/log_entries.yaml
+++ b/posthog/clickhouse/schema/log_entries.yaml
@@ -119,7 +119,7 @@ tables:
         source: kafka_log_entries
         target: log_entries
         on_nodes: DATA
-        select: "SELECT team_id, log_source, log_source_id, instance_id, timestamp, level, message, _timestamp, _offset FROM {{ database }}.kafka_log_entries"
+        select: 'SELECT team_id, log_source, log_source_id, instance_id, timestamp, level, message, _timestamp, _offset FROM {{ database }}.kafka_log_entries'
         columns: []
 
     kafka_log_entries_v3:
@@ -151,6 +151,6 @@ tables:
         engine: MaterializedView
         source: kafka_log_entries_v3
         target: writable_log_entries
-        select: "SELECT team_id, log_source, log_source_id, instance_id, timestamp, level, message, _timestamp, _offset FROM {{ database }}.kafka_log_entries_v3 WHERE toDate(timestamp) <= today()"
+        select: 'SELECT team_id, log_source, log_source_id, instance_id, timestamp, level, message, _timestamp, _offset FROM {{ database }}.kafka_log_entries_v3 WHERE toDate(timestamp) <= today()'
         on_nodes: INGESTION_EVENTS
         columns: []

--- a/posthog/clickhouse/schema/logs.yaml
+++ b/posthog/clickhouse/schema/logs.yaml
@@ -1,0 +1,177 @@
+# Desired-state schema for the logs ecosystem (OpenTelemetry log pipeline).
+# These tables run on the dedicated logs cluster, not the main cluster.
+
+ecosystem: logs
+cluster: logs
+
+tables:
+    logs32:
+        engine: ReplicatedMergeTree
+        sharded: false
+        on_nodes: LOGS
+        order_by:
+            - team_id
+            - time_bucket
+            - service_name
+            - resource_fingerprint
+            - severity_text
+            - timestamp
+        partition_by: 'toDate(original_expiry_timestamp)'
+        columns:
+            - name: time_bucket
+              type: DateTime
+              default_kind: MATERIALIZED
+              default_expression: 'toStartOfDay(timestamp)'
+            - name: original_expiry_timestamp
+              type: DateTime64(6)
+            - name: uuid
+              type: String
+            - name: team_id
+              type: Int32
+            - name: trace_id
+              type: String
+            - name: span_id
+              type: String
+            - name: trace_flags
+              type: Int32
+            - name: timestamp
+              type: DateTime64(6)
+            - name: observed_timestamp
+              type: DateTime64(6)
+            - name: created_at
+              type: DateTime64(6)
+              default_kind: MATERIALIZED
+              default_expression: 'now()'
+            - name: body
+              type: String
+            - name: severity_text
+              type: LowCardinality(String)
+            - name: severity_number
+              type: Int32
+            - name: service_name
+              type: LowCardinality(String)
+            - name: resource_attributes
+              type: "Map(LowCardinality(String), String)"
+            - name: resource_fingerprint
+              type: UInt64
+              default_kind: MATERIALIZED
+              default_expression: 'cityHash64(resource_attributes)'
+            - name: instrumentation_scope
+              type: String
+            - name: event_name
+              type: String
+            - name: attributes_map_str
+              type: "Map(LowCardinality(String), String)"
+            - name: _partition
+              type: UInt32
+            - name: _topic
+              type: String
+            - name: _offset
+              type: UInt64
+            - name: _bytes_uncompressed
+              type: UInt64
+            - name: _bytes_compressed
+              type: UInt64
+            - name: _record_count
+              type: UInt64
+
+    logs:
+        engine: Distributed
+        source: logs32
+        sharding_key: 'rand()'
+        on_nodes: LOGS
+        columns: inherit logs32
+
+    logs_distributed:
+        engine: Distributed
+        source: logs32
+        sharding_key: 'rand()'
+        on_nodes: LOGS
+        columns: inherit logs32
+
+    log_attributes:
+        engine: ReplicatedAggregatingMergeTree
+        sharded: false
+        on_nodes: LOGS
+        order_by:
+            - team_id
+            - attribute_type
+            - time_bucket
+            - resource_fingerprint
+            - attribute_key
+            - attribute_value
+        partition_by: 'toDate(original_expiry_time_bucket)'
+        columns:
+            - name: team_id
+              type: Int32
+            - name: time_bucket
+              type: DateTime64(0)
+            - name: original_expiry_time_bucket
+              type: DateTime64(0)
+            - name: service_name
+              type: LowCardinality(String)
+            - name: resource_fingerprint
+              type: UInt64
+              default_expression: '0'
+              default_kind: DEFAULT
+            - name: attribute_key
+              type: LowCardinality(String)
+            - name: attribute_value
+              type: String
+            - name: attribute_count
+              type: "SimpleAggregateFunction(sum, UInt64)"
+            - name: attribute_type
+              type: LowCardinality(String)
+
+    log_attributes_distributed:
+        engine: Distributed
+        source: log_attributes
+        sharding_key: 'rand()'
+        on_nodes: LOGS
+        columns: inherit log_attributes
+
+    logs32_to_log_attributes:
+        engine: MaterializedView
+        source: logs32
+        target: log_attributes
+        select: "SELECT team_id, time_bucket, original_expiry_time_bucket, service_name, resource_fingerprint, attribute_key, attribute_value, attribute_type, attribute_count FROM (aggregation subquery)"
+        on_nodes: LOGS
+        columns: []
+
+    logs32_to_resource_attributes:
+        engine: MaterializedView
+        source: logs32
+        target: log_attributes
+        select: "SELECT team_id, time_bucket, original_expiry_time_bucket, service_name, resource_fingerprint, attribute_key, attribute_value, attribute_type, attribute_count FROM (aggregation subquery)"
+        on_nodes: LOGS
+        columns: []
+
+    logs_kafka_metrics:
+        engine: ReplicatedAggregatingMergeTree
+        sharded: false
+        on_nodes: LOGS
+        order_by:
+            - _topic
+            - _partition
+        columns:
+            - name: _partition
+              type: UInt32
+            - name: _topic
+              type: String
+            - name: max_offset
+              type: "SimpleAggregateFunction(max, UInt64)"
+            - name: max_observed_timestamp
+              type: "SimpleAggregateFunction(max, DateTime64(9))"
+            - name: max_timestamp
+              type: "SimpleAggregateFunction(max, DateTime64(9))"
+            - name: max_created_at
+              type: "SimpleAggregateFunction(max, DateTime64(9))"
+            - name: max_lag
+              type: "SimpleAggregateFunction(max, UInt64)"
+
+    logs_kafka_metrics_distributed:
+        engine: Distributed
+        source: logs_kafka_metrics
+        sharding_key: 'rand()'
+        on_nodes: LOGS
+        columns: inherit logs_kafka_metrics

--- a/posthog/clickhouse/schema/logs.yaml
+++ b/posthog/clickhouse/schema/logs.yaml
@@ -51,7 +51,7 @@ tables:
             - name: service_name
               type: LowCardinality(String)
             - name: resource_attributes
-              type: "Map(LowCardinality(String), String)"
+              type: 'Map(LowCardinality(String), String)'
             - name: resource_fingerprint
               type: UInt64
               default_kind: MATERIALIZED
@@ -61,7 +61,7 @@ tables:
             - name: event_name
               type: String
             - name: attributes_map_str
-              type: "Map(LowCardinality(String), String)"
+              type: 'Map(LowCardinality(String), String)'
             - name: _partition
               type: UInt32
             - name: _topic
@@ -119,7 +119,7 @@ tables:
             - name: attribute_value
               type: String
             - name: attribute_count
-              type: "SimpleAggregateFunction(sum, UInt64)"
+              type: 'SimpleAggregateFunction(sum, UInt64)'
             - name: attribute_type
               type: LowCardinality(String)
 
@@ -168,15 +168,15 @@ tables:
             - name: _topic
               type: String
             - name: max_offset
-              type: "SimpleAggregateFunction(max, UInt64)"
+              type: 'SimpleAggregateFunction(max, UInt64)'
             - name: max_observed_timestamp
-              type: "SimpleAggregateFunction(max, DateTime64(9))"
+              type: 'SimpleAggregateFunction(max, DateTime64(9))'
             - name: max_timestamp
-              type: "SimpleAggregateFunction(max, DateTime64(9))"
+              type: 'SimpleAggregateFunction(max, DateTime64(9))'
             - name: max_created_at
-              type: "SimpleAggregateFunction(max, DateTime64(9))"
+              type: 'SimpleAggregateFunction(max, DateTime64(9))'
             - name: max_lag
-              type: "SimpleAggregateFunction(max, UInt64)"
+              type: 'SimpleAggregateFunction(max, UInt64)'
 
     logs_kafka_metrics_distributed:
         engine: Distributed

--- a/posthog/clickhouse/schema/logs.yaml
+++ b/posthog/clickhouse/schema/logs.yaml
@@ -130,19 +130,28 @@ tables:
         on_nodes: LOGS
         columns: inherit log_attributes
 
+    # Materializes per-attribute counts from logs32.attributes_map_str.
+    # Mirrors posthog/clickhouse/logs/logs32.py::LOG_ATTRIBUTES_MV but
+    # references `attributes_map_str` directly instead of the `attributes`
+    # ALIAS column (MV inputs only see stored columns, not aliases).
+    # SELECT kept on one line: CH stores MV as_select collapsed, so matching
+    # that rendering avoids whitespace-around-paren false-positives in the
+    # diff normalizer.
     logs32_to_log_attributes:
         engine: MaterializedView
         source: logs32
         target: log_attributes
-        select: "SELECT team_id, time_bucket, original_expiry_time_bucket, service_name, resource_fingerprint, attribute_key, attribute_value, attribute_type, attribute_count FROM (aggregation subquery)"
+        select: "SELECT team_id, time_bucket, original_expiry_time_bucket, service_name, resource_fingerprint, attribute_key, attribute_value, attribute_type, attribute_count FROM (SELECT team_id AS team_id, toStartOfInterval(timestamp, toIntervalMinute(10)) AS time_bucket, toStartOfInterval(original_expiry_timestamp, toIntervalMinute(10)) AS original_expiry_time_bucket, service_name AS service_name, resource_fingerprint, mapFilter((k, v) -> ((length(k) < 256) AND (length(v) < 256)), attributes_map_str) AS attrs, arrayJoin(attrs) AS attribute, 'log' AS attribute_type, attribute.1 AS attribute_key, attribute.2 AS attribute_value, sumSimpleState(1) AS attribute_count FROM {{ database }}.logs32 GROUP BY team_id, time_bucket, original_expiry_time_bucket, service_name, resource_fingerprint, attrs)"
         on_nodes: LOGS
         columns: []
 
+    # Materializes per-resource-attribute counts. Mirrors
+    # posthog/clickhouse/logs/logs32.py::LOG_RESOURCE_ATTRIBUTES_MV.
     logs32_to_resource_attributes:
         engine: MaterializedView
         source: logs32
         target: log_attributes
-        select: "SELECT team_id, time_bucket, original_expiry_time_bucket, service_name, resource_fingerprint, attribute_key, attribute_value, attribute_type, attribute_count FROM (aggregation subquery)"
+        select: "SELECT team_id, time_bucket, original_expiry_time_bucket, service_name, resource_fingerprint, attribute_key, attribute_value, attribute_type, attribute_count FROM (SELECT team_id AS team_id, toStartOfInterval(timestamp, toIntervalMinute(10)) AS time_bucket, toStartOfInterval(original_expiry_timestamp, toIntervalMinute(10)) AS original_expiry_time_bucket, service_name AS service_name, resource_fingerprint, arrayJoin(resource_attributes) AS attribute, 'resource' AS attribute_type, attribute.1 AS attribute_key, attribute.2 AS attribute_value, sumSimpleState(1) AS attribute_count FROM {{ database }}.logs32 GROUP BY team_id, time_bucket, original_expiry_time_bucket, service_name, resource_fingerprint, resource_attributes)"
         on_nodes: LOGS
         columns: []
 

--- a/posthog/clickhouse/schema/metrics.yaml
+++ b/posthog/clickhouse/schema/metrics.yaml
@@ -1,0 +1,70 @@
+# Desired-state schema for the metrics ecosystem.
+# Includes metrics_time_to_see_data and supporting tables.
+# Note: These tables are experimental on cloud (see posthog/models/query_metrics/sql.py).
+
+ecosystem: metrics
+cluster: main
+
+tables:
+    metrics_time_to_see_data:
+        engine: ReplicatedMergeTree
+        sharded: false
+        on_nodes: ALL
+        order_by:
+            - team_id
+            - 'toDate(timestamp)'
+            - session_id
+            - user_id
+        partition_by: 'toYYYYMM(timestamp)'
+        columns:
+            - name: team_events_last_month
+              type: UInt64
+            - name: query_id
+              type: String
+            - name: primary_interaction_id
+              type: String
+            - name: team_id
+              type: UInt64
+            - name: user_id
+              type: UInt64
+            - name: session_id
+              type: String
+            - name: timestamp
+              type: DateTime64
+            - name: type
+              type: LowCardinality(String)
+            - name: context
+              type: LowCardinality(String)
+            - name: is_primary_interaction
+              type: UInt8
+            - name: time_to_see_data_ms
+              type: UInt64
+            - name: status
+              type: LowCardinality(String)
+            - name: api_response_bytes
+              type: UInt64
+            - name: current_url
+              type: String
+            - name: api_url
+              type: String
+            - name: insight
+              type: LowCardinality(String)
+            - name: action
+              type: LowCardinality(String)
+            - name: insights_fetched
+              type: UInt16
+            - name: insights_fetched_cached
+              type: UInt16
+            - name: min_last_refresh
+              type: DateTime64
+            - name: max_last_refresh
+              type: DateTime64
+
+    team_events_last_month_dictionary:
+        engine: Dictionary
+        on_nodes: ALL
+        columns:
+            - name: team_id
+              type: UInt64
+            - name: event_count
+              type: UInt64

--- a/posthog/clickhouse/schema/metrics.yaml
+++ b/posthog/clickhouse/schema/metrics.yaml
@@ -60,9 +60,29 @@ tables:
             - name: max_last_refresh
               type: DateTime64
 
+    # Event count per team over the last month. Sourced from a VIEW
+    # (team_events_last_month_view) that aggregates the events table — the view
+    # and this dictionary were originally removed from the codebase in #22494
+    # but the dictionary name is still referenced by the metrics MVs above
+    # (dictGet('team_events_last_month_dictionary', 'event_count', team_id)).
+    # The legacy definition used complex_key_cache(size_in_cells 100000) and
+    # LIFETIME(86400). Retained here for parity; recreate is cheap.
     team_events_last_month_dictionary:
         engine: Dictionary
         on_nodes: ALL
+        primary_key: team_id
+        source:
+            type: CLICKHOUSE
+            table: team_events_last_month_view
+            user: __from_settings__
+            password: __from_settings__
+        layout:
+            type: COMPLEX_KEY_CACHE
+            params:
+                size_in_cells: 100000
+        lifetime:
+            min: 86400
+            max: 86400
         columns:
             - name: team_id
               type: UInt64

--- a/posthog/clickhouse/schema/performance_events.yaml
+++ b/posthog/clickhouse/schema/performance_events.yaml
@@ -1,0 +1,144 @@
+# Desired-state schema for the performance_events ecosystem.
+
+ecosystem: performance_events
+cluster: main
+
+tables:
+    sharded_performance_events:
+        engine: ReplicatedMergeTree
+        sharded: true
+        on_nodes: DATA
+        order_by:
+            - team_id
+            - 'toDate(timestamp)'
+            - session_id
+            - pageview_id
+            - timestamp
+        partition_by: 'toYYYYMM(timestamp)'
+        columns:
+            - name: uuid
+              type: UUID
+            - name: session_id
+              type: String
+            - name: window_id
+              type: String
+            - name: pageview_id
+              type: String
+            - name: distinct_id
+              type: String
+            - name: timestamp
+              type: DateTime64(3)
+            - name: time_origin
+              type: "DateTime64(3, 'UTC')"
+            - name: entry_type
+              type: LowCardinality(String)
+            - name: name
+              type: String
+            - name: team_id
+              type: Int64
+            - name: current_url
+              type: String
+            - name: start_time
+              type: Float64
+            - name: duration
+              type: Float64
+            - name: redirect_start
+              type: Float64
+            - name: redirect_end
+              type: Float64
+            - name: worker_start
+              type: Float64
+            - name: fetch_start
+              type: Float64
+            - name: domain_lookup_start
+              type: Float64
+            - name: domain_lookup_end
+              type: Float64
+            - name: connect_start
+              type: Float64
+            - name: secure_connection_start
+              type: Float64
+            - name: connect_end
+              type: Float64
+            - name: request_start
+              type: Float64
+            - name: response_start
+              type: Float64
+            - name: response_end
+              type: Float64
+            - name: decoded_body_size
+              type: Int64
+            - name: encoded_body_size
+              type: Int64
+            - name: initiator_type
+              type: LowCardinality(String)
+            - name: next_hop_protocol
+              type: LowCardinality(String)
+            - name: render_blocking_status
+              type: LowCardinality(String)
+            - name: response_status
+              type: Int64
+            - name: transfer_size
+              type: Int64
+            - name: largest_contentful_paint_element
+              type: String
+            - name: largest_contentful_paint_render_time
+              type: Float64
+            - name: largest_contentful_paint_load_time
+              type: Float64
+            - name: largest_contentful_paint_size
+              type: Float64
+            - name: largest_contentful_paint_id
+              type: String
+            - name: largest_contentful_paint_url
+              type: String
+            - name: dom_complete
+              type: Float64
+            - name: dom_content_loaded_event
+              type: Float64
+            - name: dom_interactive
+              type: Float64
+            - name: load_event_end
+              type: Float64
+            - name: load_event_start
+              type: Float64
+            - name: redirect_count
+              type: Int64
+            - name: navigation_type
+              type: LowCardinality(String)
+            - name: unload_event_end
+              type: Float64
+            - name: unload_event_start
+              type: Float64
+
+    writeable_performance_events:
+        engine: Distributed
+        source: sharded_performance_events
+        sharding_key: 'sipHash64(session_id)'
+        on_nodes: COORDINATOR
+        columns: inherit sharded_performance_events
+
+    performance_events:
+        engine: Distributed
+        source: sharded_performance_events
+        sharding_key: 'sipHash64(session_id)'
+        on_nodes: ALL
+        columns: inherit sharded_performance_events
+
+    kafka_performance_events:
+        engine: Kafka
+        on_nodes: INGESTION_EVENTS
+        settings:
+            kafka_broker_list: __from_settings__
+            kafka_topic_list: clickhouse_performance_events
+            kafka_group_name: performance_events
+            kafka_format: JSONEachRow
+        columns: inherit sharded_performance_events
+
+    performance_events_mv:
+        engine: MaterializedView
+        source: kafka_performance_events
+        target: writeable_performance_events
+        select: "SELECT * FROM {{ database }}.kafka_performance_events"
+        on_nodes: INGESTION_EVENTS
+        columns: []

--- a/posthog/clickhouse/schema/performance_events.yaml
+++ b/posthog/clickhouse/schema/performance_events.yaml
@@ -110,6 +110,13 @@ tables:
               type: Float64
             - name: unload_event_start
               type: Float64
+            # Kafka virtual columns
+            - name: _timestamp
+              type: DateTime
+            - name: _offset
+              type: UInt64
+            - name: _partition
+              type: UInt64
 
     writeable_performance_events:
         engine: Distributed
@@ -133,7 +140,104 @@ tables:
             kafka_topic_list: clickhouse_performance_events
             kafka_group_name: performance_events
             kafka_format: JSONEachRow
-        columns: inherit sharded_performance_events
+        # Kafka engine rejects _timestamp/_offset/_partition as explicit columns
+        # (they are injected automatically as virtual columns), so we can't
+        # inherit from sharded which now includes them.
+        columns:
+            - name: uuid
+              type: UUID
+            - name: session_id
+              type: String
+            - name: window_id
+              type: String
+            - name: pageview_id
+              type: String
+            - name: distinct_id
+              type: String
+            - name: timestamp
+              type: DateTime64(3)
+            - name: time_origin
+              type: "DateTime64(3, 'UTC')"
+            - name: entry_type
+              type: LowCardinality(String)
+            - name: name
+              type: String
+            - name: team_id
+              type: Int64
+            - name: current_url
+              type: String
+            - name: start_time
+              type: Float64
+            - name: duration
+              type: Float64
+            - name: redirect_start
+              type: Float64
+            - name: redirect_end
+              type: Float64
+            - name: worker_start
+              type: Float64
+            - name: fetch_start
+              type: Float64
+            - name: domain_lookup_start
+              type: Float64
+            - name: domain_lookup_end
+              type: Float64
+            - name: connect_start
+              type: Float64
+            - name: secure_connection_start
+              type: Float64
+            - name: connect_end
+              type: Float64
+            - name: request_start
+              type: Float64
+            - name: response_start
+              type: Float64
+            - name: response_end
+              type: Float64
+            - name: decoded_body_size
+              type: Int64
+            - name: encoded_body_size
+              type: Int64
+            - name: initiator_type
+              type: LowCardinality(String)
+            - name: next_hop_protocol
+              type: LowCardinality(String)
+            - name: render_blocking_status
+              type: LowCardinality(String)
+            - name: response_status
+              type: Int64
+            - name: transfer_size
+              type: Int64
+            - name: largest_contentful_paint_element
+              type: String
+            - name: largest_contentful_paint_render_time
+              type: Float64
+            - name: largest_contentful_paint_load_time
+              type: Float64
+            - name: largest_contentful_paint_size
+              type: Float64
+            - name: largest_contentful_paint_id
+              type: String
+            - name: largest_contentful_paint_url
+              type: String
+            - name: dom_complete
+              type: Float64
+            - name: dom_content_loaded_event
+              type: Float64
+            - name: dom_interactive
+              type: Float64
+            - name: load_event_end
+              type: Float64
+            - name: load_event_start
+              type: Float64
+            - name: redirect_count
+              type: Int64
+            - name: navigation_type
+              type: LowCardinality(String)
+            - name: unload_event_end
+              type: Float64
+            - name: unload_event_start
+              type: Float64
 
     performance_events_mv:
         engine: MaterializedView

--- a/posthog/clickhouse/schema/performance_events.yaml
+++ b/posthog/clickhouse/schema/performance_events.yaml
@@ -115,7 +115,7 @@ tables:
         engine: Distributed
         source: sharded_performance_events
         sharding_key: 'sipHash64(session_id)'
-        on_nodes: COORDINATOR
+        on_nodes: DATA
         columns: inherit sharded_performance_events
 
     performance_events:

--- a/posthog/clickhouse/schema/performance_events.yaml
+++ b/posthog/clickhouse/schema/performance_events.yaml
@@ -115,7 +115,7 @@ tables:
         engine: Distributed
         source: sharded_performance_events
         sharding_key: 'sipHash64(session_id)'
-        on_nodes: DATA
+        on_nodes: COORDINATOR
         columns: inherit sharded_performance_events
 
     performance_events:

--- a/posthog/clickhouse/schema/performance_events.yaml
+++ b/posthog/clickhouse/schema/performance_events.yaml
@@ -243,6 +243,6 @@ tables:
         engine: MaterializedView
         source: kafka_performance_events
         target: writeable_performance_events
-        select: "SELECT * FROM {{ database }}.kafka_performance_events"
+        select: 'SELECT * FROM {{ database }}.kafka_performance_events'
         on_nodes: INGESTION_EVENTS
         columns: []

--- a/posthog/clickhouse/schema/person.yaml
+++ b/posthog/clickhouse/schema/person.yaml
@@ -1,0 +1,84 @@
+# Desired-state schema for the person ecosystem.
+
+ecosystem: person
+cluster: main
+
+tables:
+    person:
+        engine: ReplicatedReplacingMergeTree
+        sharded: true
+        on_nodes: DATA
+        order_by:
+            - team_id
+            - id
+        partition_by: 'team_id % 100'
+        columns:
+            - name: id
+              type: UUID
+            - name: created_at
+              type: DateTime64(3)
+            - name: team_id
+              type: Int64
+            - name: properties
+              type: String
+            - name: is_identified
+              type: Int8
+            - name: is_deleted
+              type: Int8
+              default_expression: '0'
+              default_kind: DEFAULT
+            - name: version
+              type: UInt64
+
+    writable_person:
+        engine: Distributed
+        source: person
+        sharding_key: 'cityHash64(id)'
+        on_nodes: COORDINATOR
+        columns: inherit person
+
+    kafka_person:
+        engine: Kafka
+        on_nodes: INGESTION_EVENTS
+        settings:
+            kafka_broker_list: __from_settings__
+            kafka_topic_list: clickhouse_person
+            kafka_group_name: person_consumer
+            kafka_format: JSONEachRow
+            kafka_skip_broken_messages: '100'
+        columns: inherit person
+
+    person_mv:
+        engine: MaterializedView
+        source: kafka_person
+        target: writable_person
+        select: 'SELECT * FROM {{ database }}.kafka_person'
+        on_nodes: INGESTION_EVENTS
+        columns: []
+
+    # Production tables: sharded/distributed variants visible on coordinator
+    sharded_person:
+        engine: ReplicatedReplacingMergeTree
+        sharded: true
+        on_nodes: DATA
+        order_by:
+            - team_id
+            - id
+        partition_by: 'team_id % 100'
+        columns: inherit person
+
+    distributed_person:
+        engine: Distributed
+        source: sharded_person
+        sharding_key: 'cityHash64(id)'
+        on_nodes: COORDINATOR
+        columns: inherit person
+
+    person_collapsing:
+        engine: ReplicatedReplacingMergeTree
+        sharded: false
+        on_nodes: DATA
+        order_by:
+            - team_id
+            - id
+        columns: inherit person

--- a/posthog/clickhouse/schema/person.yaml
+++ b/posthog/clickhouse/schema/person.yaml
@@ -29,6 +29,12 @@ tables:
               default_kind: DEFAULT
             - name: version
               type: UInt64
+            - name: last_seen_at
+              type: Nullable(DateTime64)
+            - name: _timestamp
+              type: DateTime
+            - name: _offset
+              type: UInt64
 
     writable_person:
         engine: Distributed

--- a/posthog/clickhouse/schema/person.yaml
+++ b/posthog/clickhouse/schema/person.yaml
@@ -34,7 +34,7 @@ tables:
         engine: Distributed
         source: person
         sharding_key: 'cityHash64(id)'
-        on_nodes: DATA
+        on_nodes: COORDINATOR
         columns: inherit person
 
     kafka_person:
@@ -71,7 +71,7 @@ tables:
         engine: Distributed
         source: sharded_person
         sharding_key: 'cityHash64(id)'
-        on_nodes: DATA
+        on_nodes: COORDINATOR
         columns: inherit person
 
     person_collapsing:

--- a/posthog/clickhouse/schema/person.yaml
+++ b/posthog/clickhouse/schema/person.yaml
@@ -34,7 +34,7 @@ tables:
         engine: Distributed
         source: person
         sharding_key: 'cityHash64(id)'
-        on_nodes: COORDINATOR
+        on_nodes: DATA
         columns: inherit person
 
     kafka_person:
@@ -71,7 +71,7 @@ tables:
         engine: Distributed
         source: sharded_person
         sharding_key: 'cityHash64(id)'
-        on_nodes: COORDINATOR
+        on_nodes: DATA
         columns: inherit person
 
     person_collapsing:

--- a/posthog/clickhouse/schema/person.yaml
+++ b/posthog/clickhouse/schema/person.yaml
@@ -74,7 +74,7 @@ tables:
         engine: MaterializedView
         source: kafka_person
         target: writable_person
-        select: "SELECT id, created_at, team_id, properties, is_identified, is_deleted, version, last_seen_at, _timestamp, _offset FROM {{ database }}.kafka_person"
+        select: 'SELECT id, created_at, team_id, properties, is_identified, is_deleted, version, last_seen_at, _timestamp, _offset FROM {{ database }}.kafka_person'
         on_nodes: INGESTION_EVENTS
         columns: []
 

--- a/posthog/clickhouse/schema/person.yaml
+++ b/posthog/clickhouse/schema/person.yaml
@@ -52,13 +52,29 @@ tables:
             kafka_group_name: person_consumer
             kafka_format: JSONEachRow
             kafka_skip_broken_messages: '100'
-        columns: inherit person
+        columns:
+            - name: id
+              type: UUID
+            - name: created_at
+              type: DateTime64(3)
+            - name: team_id
+              type: Int64
+            - name: properties
+              type: String
+            - name: is_identified
+              type: Int8
+            - name: is_deleted
+              type: Int8
+            - name: version
+              type: UInt64
+            - name: last_seen_at
+              type: Nullable(DateTime64)
 
     person_mv:
         engine: MaterializedView
         source: kafka_person
         target: writable_person
-        select: 'SELECT * FROM {{ database }}.kafka_person'
+        select: "SELECT id, created_at, team_id, properties, is_identified, is_deleted, version, last_seen_at, _timestamp, _offset FROM {{ database }}.kafka_person"
         on_nodes: INGESTION_EVENTS
         columns: []
 

--- a/posthog/clickhouse/schema/person_distinct_id.yaml
+++ b/posthog/clickhouse/schema/person_distinct_id.yaml
@@ -1,0 +1,73 @@
+# Desired-state schema for the person_distinct_id ecosystem.
+
+ecosystem: person_distinct_id
+cluster: main
+
+tables:
+    person_distinct_id:
+        engine: ReplicatedCollapsingMergeTree
+        sharded: false
+        on_nodes: DATA
+        order_by:
+            - team_id
+            - distinct_id
+            - person_id
+        columns:
+            - name: distinct_id
+              type: String
+            - name: person_id
+              type: UUID
+            - name: team_id
+              type: Int64
+            - name: _sign
+              type: Int8
+              default_expression: '1'
+              default_kind: DEFAULT
+            - name: is_deleted
+              type: Int8
+
+    kafka_person_distinct_id:
+        engine: Kafka
+        on_nodes: INGESTION_EVENTS
+        settings:
+            kafka_broker_list: __from_settings__
+            kafka_topic_list: clickhouse_person_unique_id
+            kafka_group_name: person_distinct_id
+            kafka_format: JSONEachRow
+        columns:
+            - name: distinct_id
+              type: String
+            - name: person_id
+              type: UUID
+            - name: team_id
+              type: Int64
+            - name: _sign
+              type: Nullable(Int8)
+            - name: is_deleted
+              type: Nullable(Int8)
+
+    person_distinct_id_mv:
+        engine: MaterializedView
+        source: kafka_person_distinct_id
+        target: person_distinct_id
+        select: "SELECT distinct_id, person_id, team_id, coalesce(_sign, if(is_deleted==0, 1, -1)) AS _sign, _timestamp, _offset FROM {{ database }}.kafka_person_distinct_id"
+        on_nodes: INGESTION_EVENTS
+        columns: []
+
+    # Production tables: sharded/distributed variants visible on coordinator
+    sharded_person_distinct_id:
+        engine: ReplicatedCollapsingMergeTree
+        sharded: true
+        on_nodes: DATA
+        order_by:
+            - team_id
+            - distinct_id
+            - person_id
+        columns: inherit person_distinct_id
+
+    distributed_person_distinct_id:
+        engine: Distributed
+        source: sharded_person_distinct_id
+        sharding_key: 'cityHash64(distinct_id)'
+        on_nodes: COORDINATOR
+        columns: inherit person_distinct_id

--- a/posthog/clickhouse/schema/person_distinct_id.yaml
+++ b/posthog/clickhouse/schema/person_distinct_id.yaml
@@ -54,7 +54,7 @@ tables:
         engine: MaterializedView
         source: kafka_person_distinct_id
         target: person_distinct_id
-        select: "SELECT distinct_id, person_id, team_id, coalesce(_sign, if(is_deleted==0, 1, -1)) AS _sign, _timestamp, _offset FROM {{ database }}.kafka_person_distinct_id"
+        select: 'SELECT distinct_id, person_id, team_id, coalesce(_sign, if(is_deleted==0, 1, -1)) AS _sign, _timestamp, _offset FROM {{ database }}.kafka_person_distinct_id'
         on_nodes: INGESTION_EVENTS
         columns: []
 

--- a/posthog/clickhouse/schema/person_distinct_id.yaml
+++ b/posthog/clickhouse/schema/person_distinct_id.yaml
@@ -69,5 +69,5 @@ tables:
         engine: Distributed
         source: sharded_person_distinct_id
         sharding_key: 'cityHash64(distinct_id)'
-        on_nodes: DATA
+        on_nodes: COORDINATOR
         columns: inherit person_distinct_id

--- a/posthog/clickhouse/schema/person_distinct_id.yaml
+++ b/posthog/clickhouse/schema/person_distinct_id.yaml
@@ -69,5 +69,5 @@ tables:
         engine: Distributed
         source: sharded_person_distinct_id
         sharding_key: 'cityHash64(distinct_id)'
-        on_nodes: COORDINATOR
+        on_nodes: DATA
         columns: inherit person_distinct_id

--- a/posthog/clickhouse/schema/person_distinct_id.yaml
+++ b/posthog/clickhouse/schema/person_distinct_id.yaml
@@ -25,6 +25,10 @@ tables:
               default_kind: DEFAULT
             - name: is_deleted
               type: Int8
+            - name: _timestamp
+              type: DateTime
+            - name: _offset
+              type: UInt64
 
     kafka_person_distinct_id:
         engine: Kafka

--- a/posthog/clickhouse/schema/person_distinct_id2.yaml
+++ b/posthog/clickhouse/schema/person_distinct_id2.yaml
@@ -1,0 +1,51 @@
+# Desired-state schema for the person_distinct_id2 ecosystem.
+
+ecosystem: person_distinct_id2
+cluster: main
+
+tables:
+    person_distinct_id2:
+        engine: ReplicatedReplacingMergeTree
+        sharded: false
+        on_nodes: DATA
+        order_by:
+            - team_id
+            - distinct_id
+        settings:
+            index_granularity: '512'
+        columns:
+            - name: team_id
+              type: Int64
+            - name: distinct_id
+              type: String
+            - name: person_id
+              type: UUID
+            - name: is_deleted
+              type: Int8
+            - name: version
+              type: Int64
+
+    writable_person_distinct_id2:
+        engine: Distributed
+        source: person_distinct_id2
+        sharding_key: 'rand()'
+        on_nodes: COORDINATOR
+        columns: inherit person_distinct_id2
+
+    kafka_person_distinct_id2:
+        engine: Kafka
+        on_nodes: INGESTION_EVENTS
+        settings:
+            kafka_broker_list: __from_settings__
+            kafka_topic_list: clickhouse_person_distinct_id
+            kafka_group_name: person_distinct_id
+            kafka_format: JSONEachRow
+        columns: inherit person_distinct_id2
+
+    person_distinct_id2_mv:
+        engine: MaterializedView
+        source: kafka_person_distinct_id2
+        target: writable_person_distinct_id2
+        select: "SELECT team_id, distinct_id, person_id, is_deleted, version, _timestamp, _offset, _partition FROM {{ database }}.kafka_person_distinct_id2"
+        on_nodes: INGESTION_EVENTS
+        columns: []

--- a/posthog/clickhouse/schema/person_distinct_id2.yaml
+++ b/posthog/clickhouse/schema/person_distinct_id2.yaml
@@ -29,7 +29,7 @@ tables:
         engine: Distributed
         source: person_distinct_id2
         sharding_key: 'rand()'
-        on_nodes: DATA
+        on_nodes: COORDINATOR
         columns: inherit person_distinct_id2
 
     kafka_person_distinct_id2:

--- a/posthog/clickhouse/schema/person_distinct_id2.yaml
+++ b/posthog/clickhouse/schema/person_distinct_id2.yaml
@@ -24,6 +24,13 @@ tables:
               type: Int8
             - name: version
               type: Int64
+            # Kafka virtual columns
+            - name: _timestamp
+              type: DateTime
+            - name: _offset
+              type: UInt64
+            - name: _partition
+              type: UInt64
 
     writable_person_distinct_id2:
         engine: Distributed
@@ -40,7 +47,17 @@ tables:
             kafka_topic_list: clickhouse_person_distinct_id
             kafka_group_name: person_distinct_id
             kafka_format: JSONEachRow
-        columns: inherit person_distinct_id2
+        columns:
+            - name: team_id
+              type: Int64
+            - name: distinct_id
+              type: String
+            - name: person_id
+              type: UUID
+            - name: is_deleted
+              type: Int8
+            - name: version
+              type: Int64
 
     person_distinct_id2_mv:
         engine: MaterializedView

--- a/posthog/clickhouse/schema/person_distinct_id2.yaml
+++ b/posthog/clickhouse/schema/person_distinct_id2.yaml
@@ -29,7 +29,7 @@ tables:
         engine: Distributed
         source: person_distinct_id2
         sharding_key: 'rand()'
-        on_nodes: COORDINATOR
+        on_nodes: DATA
         columns: inherit person_distinct_id2
 
     kafka_person_distinct_id2:

--- a/posthog/clickhouse/schema/person_distinct_id2.yaml
+++ b/posthog/clickhouse/schema/person_distinct_id2.yaml
@@ -63,6 +63,6 @@ tables:
         engine: MaterializedView
         source: kafka_person_distinct_id2
         target: writable_person_distinct_id2
-        select: "SELECT team_id, distinct_id, person_id, is_deleted, version, _timestamp, _offset, _partition FROM {{ database }}.kafka_person_distinct_id2"
+        select: 'SELECT team_id, distinct_id, person_id, is_deleted, version, _timestamp, _offset, _partition FROM {{ database }}.kafka_person_distinct_id2'
         on_nodes: INGESTION_EVENTS
         columns: []

--- a/posthog/clickhouse/schema/person_distinct_id_overrides.yaml
+++ b/posthog/clickhouse/schema/person_distinct_id_overrides.yaml
@@ -1,0 +1,62 @@
+# Desired-state schema for the person_distinct_id_overrides ecosystem.
+
+ecosystem: person_distinct_id_overrides
+cluster: main
+
+tables:
+    person_distinct_id_overrides:
+        engine: ReplicatedReplacingMergeTree
+        sharded: false
+        on_nodes: DATA
+        order_by:
+            - team_id
+            - distinct_id
+        settings:
+            index_granularity: '512'
+        columns:
+            - name: team_id
+              type: Int64
+            - name: distinct_id
+              type: String
+            - name: person_id
+              type: UUID
+            - name: is_deleted
+              type: Int8
+            - name: version
+              type: Int64
+
+    writable_person_distinct_id_overrides:
+        engine: Distributed
+        source: person_distinct_id_overrides
+        sharding_key: 'rand()'
+        on_nodes: COORDINATOR
+        columns: inherit person_distinct_id_overrides
+
+    kafka_person_distinct_id_overrides:
+        engine: Kafka
+        on_nodes: INGESTION_EVENTS
+        settings:
+            kafka_broker_list: __from_settings__
+            kafka_topic_list: clickhouse_person_distinct_id
+            kafka_group_name: clickhouse-person-distinct-id-overrides
+            kafka_format: JSONEachRow
+        columns: inherit person_distinct_id_overrides
+
+    person_distinct_id_overrides_mv:
+        engine: MaterializedView
+        source: kafka_person_distinct_id_overrides
+        target: writable_person_distinct_id_overrides
+        select: "SELECT team_id, distinct_id, person_id, is_deleted, version, _timestamp, _offset, _partition FROM {{ database }}.kafka_person_distinct_id_overrides WHERE version > 0"
+        on_nodes: INGESTION_EVENTS
+        columns: []
+
+    person_distinct_id_overrides_dict:
+        engine: Dictionary
+        on_nodes: ALL
+        columns:
+            - name: team_id
+              type: Int64
+            - name: distinct_id
+              type: String
+            - name: person_id
+              type: UUID

--- a/posthog/clickhouse/schema/person_distinct_id_overrides.yaml
+++ b/posthog/clickhouse/schema/person_distinct_id_overrides.yaml
@@ -63,7 +63,7 @@ tables:
         engine: MaterializedView
         source: kafka_person_distinct_id_overrides
         target: writable_person_distinct_id_overrides
-        select: "SELECT team_id, distinct_id, person_id, is_deleted, version, _timestamp, _offset, _partition FROM {{ database }}.kafka_person_distinct_id_overrides WHERE version > 0"
+        select: 'SELECT team_id, distinct_id, person_id, is_deleted, version, _timestamp, _offset, _partition FROM {{ database }}.kafka_person_distinct_id_overrides WHERE version > 0'
         on_nodes: INGESTION_EVENTS
         columns: []
 
@@ -76,7 +76,7 @@ tables:
         primary_key: team_id, distinct_id
         source:
             type: CLICKHOUSE
-            query: "SELECT team_id, distinct_id, argMax(person_id, version) AS person_id FROM posthog.person_distinct_id_overrides GROUP BY team_id, distinct_id"
+            query: 'SELECT team_id, distinct_id, argMax(person_id, version) AS person_id FROM posthog.person_distinct_id_overrides GROUP BY team_id, distinct_id'
         layout:
             type: COMPLEX_KEY_HASHED
         lifetime:

--- a/posthog/clickhouse/schema/person_distinct_id_overrides.yaml
+++ b/posthog/clickhouse/schema/person_distinct_id_overrides.yaml
@@ -67,9 +67,21 @@ tables:
         on_nodes: INGESTION_EVENTS
         columns: []
 
+    # Backed by a GROUP BY query over person_distinct_id_overrides that picks
+    # the latest version per (team_id, distinct_id). See posthog/models/person/sql.py
+    # for the legacy CREATE OR REPLACE DICTIONARY definition.
     person_distinct_id_overrides_dict:
         engine: Dictionary
         on_nodes: ALL
+        primary_key: team_id, distinct_id
+        source:
+            type: CLICKHOUSE
+            query: "SELECT team_id, distinct_id, argMax(person_id, version) AS person_id FROM posthog.person_distinct_id_overrides GROUP BY team_id, distinct_id"
+        layout:
+            type: COMPLEX_KEY_HASHED
+        lifetime:
+            min: 3600
+            max: 18000
         columns:
             - name: team_id
               type: Int64

--- a/posthog/clickhouse/schema/person_distinct_id_overrides.yaml
+++ b/posthog/clickhouse/schema/person_distinct_id_overrides.yaml
@@ -24,6 +24,13 @@ tables:
               type: Int8
             - name: version
               type: Int64
+            # Kafka virtual columns
+            - name: _timestamp
+              type: DateTime
+            - name: _offset
+              type: UInt64
+            - name: _partition
+              type: UInt64
 
     writable_person_distinct_id_overrides:
         engine: Distributed
@@ -40,7 +47,17 @@ tables:
             kafka_topic_list: clickhouse_person_distinct_id
             kafka_group_name: clickhouse-person-distinct-id-overrides
             kafka_format: JSONEachRow
-        columns: inherit person_distinct_id_overrides
+        columns:
+            - name: team_id
+              type: Int64
+            - name: distinct_id
+              type: String
+            - name: person_id
+              type: UUID
+            - name: is_deleted
+              type: Int8
+            - name: version
+              type: Int64
 
     person_distinct_id_overrides_mv:
         engine: MaterializedView

--- a/posthog/clickhouse/schema/person_distinct_id_overrides.yaml
+++ b/posthog/clickhouse/schema/person_distinct_id_overrides.yaml
@@ -29,7 +29,7 @@ tables:
         engine: Distributed
         source: person_distinct_id_overrides
         sharding_key: 'rand()'
-        on_nodes: COORDINATOR
+        on_nodes: DATA
         columns: inherit person_distinct_id_overrides
 
     kafka_person_distinct_id_overrides:

--- a/posthog/clickhouse/schema/person_distinct_id_overrides.yaml
+++ b/posthog/clickhouse/schema/person_distinct_id_overrides.yaml
@@ -29,7 +29,7 @@ tables:
         engine: Distributed
         source: person_distinct_id_overrides
         sharding_key: 'rand()'
-        on_nodes: DATA
+        on_nodes: COORDINATOR
         columns: inherit person_distinct_id_overrides
 
     kafka_person_distinct_id_overrides:

--- a/posthog/clickhouse/schema/person_overrides.yaml
+++ b/posthog/clickhouse/schema/person_overrides.yaml
@@ -1,0 +1,74 @@
+# Desired-state schema for the person_overrides ecosystem.
+# NOTE: These tables are retained for migration consistency but are not actively used.
+# See person_distinct_id_overrides in person.yaml for the replacement.
+
+ecosystem: person_overrides
+cluster: main
+
+tables:
+    person_overrides:
+        engine: ReplicatedReplacingMergeTree
+        sharded: false
+        on_nodes: ALL
+        order_by:
+            - team_id
+            - old_person_id
+        partition_by: 'toYYYYMM(oldest_event)'
+        columns:
+            - name: team_id
+              type: Int64
+            - name: old_person_id
+              type: UUID
+            - name: override_person_id
+              type: UUID
+            - name: merged_at
+              type: "DateTime64(6, 'UTC')"
+            - name: oldest_event
+              type: "DateTime64(6, 'UTC')"
+            - name: created_at
+              type: "DateTime64(6, 'UTC')"
+              default_expression: 'now()'
+              default_kind: DEFAULT
+            - name: version
+              type: Int32
+
+    kafka_person_overrides:
+        engine: Kafka
+        on_nodes: ALL
+        settings:
+            kafka_broker_list: __from_settings__
+            kafka_topic_list: clickhouse_person_override
+            kafka_group_name: clickhouse-person-overrides
+            kafka_format: JSONEachRow
+        columns:
+            - name: team_id
+              type: Int64
+            - name: old_person_id
+              type: UUID
+            - name: override_person_id
+              type: UUID
+            - name: merged_at
+              type: "DateTime64(6, 'UTC')"
+            - name: oldest_event
+              type: "DateTime64(6, 'UTC')"
+            - name: version
+              type: Int32
+
+    person_overrides_mv:
+        engine: MaterializedView
+        source: kafka_person_overrides
+        target: person_overrides
+        select: "SELECT team_id, old_person_id, override_person_id, merged_at, oldest_event, version FROM {{ database }}.kafka_person_overrides"
+        on_nodes: ALL
+        columns: []
+
+    person_overrides_dict:
+        engine: Dictionary
+        on_nodes: ALL
+        columns:
+            - name: team_id
+              type: Int64
+            - name: old_person_id
+              type: UUID
+            - name: override_person_id
+              type: UUID

--- a/posthog/clickhouse/schema/person_overrides.yaml
+++ b/posthog/clickhouse/schema/person_overrides.yaml
@@ -58,7 +58,7 @@ tables:
         engine: MaterializedView
         source: kafka_person_overrides
         target: person_overrides
-        select: "SELECT team_id, old_person_id, override_person_id, merged_at, oldest_event, version FROM {{ database }}.kafka_person_overrides"
+        select: 'SELECT team_id, old_person_id, override_person_id, merged_at, oldest_event, version FROM {{ database }}.kafka_person_overrides'
         on_nodes: ALL
         columns: []
 
@@ -72,7 +72,7 @@ tables:
         primary_key: team_id, old_person_id
         source:
             type: CLICKHOUSE
-            query: "SELECT team_id, old_person_id, argMax(override_person_id, version) FROM `posthog`.`person_overrides` AS overrides GROUP BY team_id, old_person_id"
+            query: 'SELECT team_id, old_person_id, argMax(override_person_id, version) FROM `posthog`.`person_overrides` AS overrides GROUP BY team_id, old_person_id'
         layout:
             type: COMPLEX_KEY_HASHED
             params:

--- a/posthog/clickhouse/schema/person_overrides.yaml
+++ b/posthog/clickhouse/schema/person_overrides.yaml
@@ -62,9 +62,24 @@ tables:
         on_nodes: ALL
         columns: []
 
+    # Backed by a SELECT over person_overrides that picks the latest version per
+    # (team_id, old_person_id). See posthog/models/person_overrides/sql.py.
+    # Uses tight LIFETIME windows (5-10 seconds) because override changes must
+    # propagate quickly for correct event<->person attribution.
     person_overrides_dict:
         engine: Dictionary
         on_nodes: ALL
+        primary_key: team_id, old_person_id
+        source:
+            type: CLICKHOUSE
+            query: "SELECT team_id, old_person_id, argMax(override_person_id, version) FROM `posthog`.`person_overrides` AS overrides GROUP BY team_id, old_person_id"
+        layout:
+            type: COMPLEX_KEY_HASHED
+            params:
+                PREALLOCATE: 1
+        lifetime:
+            min: 5
+            max: 10
         columns:
             - name: team_id
               type: Int64

--- a/posthog/clickhouse/schema/person_static_cohort.yaml
+++ b/posthog/clickhouse/schema/person_static_cohort.yaml
@@ -1,0 +1,24 @@
+# Desired-state schema for the person_static_cohort ecosystem.
+
+ecosystem: person_static_cohort
+cluster: main
+
+tables:
+    person_static_cohort:
+        engine: ReplicatedReplacingMergeTree
+        sharded: false
+        on_nodes: DATA
+        order_by:
+            - team_id
+            - cohort_id
+            - person_id
+            - id
+        columns:
+            - name: id
+              type: UUID
+            - name: person_id
+              type: UUID
+            - name: cohort_id
+              type: Int64
+            - name: team_id
+              type: Int64

--- a/posthog/clickhouse/schema/person_static_cohort.yaml
+++ b/posthog/clickhouse/schema/person_static_cohort.yaml
@@ -22,3 +22,8 @@ tables:
               type: Int64
             - name: team_id
               type: Int64
+            # Kafka virtual columns
+            - name: _timestamp
+              type: DateTime
+            - name: _offset
+              type: UInt64

--- a/posthog/clickhouse/schema/plugin_log_entries.yaml
+++ b/posthog/clickhouse/schema/plugin_log_entries.yaml
@@ -79,6 +79,6 @@ tables:
         engine: MaterializedView
         source: kafka_plugin_log_entries
         target: writable_plugin_log_entries
-        select: "SELECT id, team_id, plugin_id, plugin_config_id, timestamp, source, type, message, instance_id, _timestamp, _offset FROM {{ database }}.kafka_plugin_log_entries"
+        select: 'SELECT id, team_id, plugin_id, plugin_config_id, timestamp, source, type, message, instance_id, _timestamp, _offset FROM {{ database }}.kafka_plugin_log_entries'
         on_nodes: ALL
         columns: []

--- a/posthog/clickhouse/schema/plugin_log_entries.yaml
+++ b/posthog/clickhouse/schema/plugin_log_entries.yaml
@@ -1,0 +1,84 @@
+# Desired-state schema for the plugin_log_entries ecosystem.
+
+ecosystem: plugin_log_entries
+cluster: main
+
+tables:
+    plugin_log_entries:
+        engine: ReplicatedReplacingMergeTree
+        sharded: false
+        on_nodes: DATA
+        order_by:
+            - team_id
+            - plugin_id
+            - plugin_config_id
+            - timestamp
+        partition_by: 'toYYYYMMDD(timestamp)'
+        settings:
+            index_granularity: '512'
+        columns:
+            - name: id
+              type: UUID
+            - name: team_id
+              type: Int64
+            - name: plugin_id
+              type: Int64
+            - name: plugin_config_id
+              type: Int64
+            - name: timestamp
+              type: "DateTime64(6, 'UTC')"
+            - name: source
+              type: String
+            - name: type
+              type: String
+            - name: message
+              type: String
+            - name: instance_id
+              type: UUID
+            - name: _timestamp
+              type: DateTime
+            - name: _offset
+              type: UInt64
+
+    writable_plugin_log_entries:
+        engine: Distributed
+        source: plugin_log_entries
+        sharding_key: 'rand()'
+        on_nodes: ALL
+        columns: inherit plugin_log_entries
+
+    kafka_plugin_log_entries:
+        engine: Kafka
+        on_nodes: ALL
+        settings:
+            kafka_broker_list: __from_settings__
+            kafka_topic_list: plugin_log_entries
+            kafka_group_name: plugin_log_entries
+            kafka_format: JSONEachRow
+        columns:
+            - name: id
+              type: UUID
+            - name: team_id
+              type: Int64
+            - name: plugin_id
+              type: Int64
+            - name: plugin_config_id
+              type: Int64
+            - name: timestamp
+              type: "DateTime64(6, 'UTC')"
+            - name: source
+              type: String
+            - name: type
+              type: String
+            - name: message
+              type: String
+            - name: instance_id
+              type: UUID
+
+    plugin_log_entries_mv:
+        engine: MaterializedView
+        source: kafka_plugin_log_entries
+        target: writable_plugin_log_entries
+        select: "SELECT id, team_id, plugin_id, plugin_config_id, timestamp, source, type, message, instance_id, _timestamp, _offset FROM {{ database }}.kafka_plugin_log_entries"
+        on_nodes: ALL
+        columns: []

--- a/posthog/clickhouse/schema/preaggregation_results.yaml
+++ b/posthog/clickhouse/schema/preaggregation_results.yaml
@@ -1,0 +1,41 @@
+# Desired-state schema for the preaggregation_results ecosystem.
+# Used for caching intermediate query results (experimental, behind flag).
+
+ecosystem: preaggregation_results
+cluster: main
+
+tables:
+    sharded_preaggregation_results:
+        engine: ReplicatedAggregatingMergeTree
+        sharded: true
+        on_nodes: DATA
+        order_by:
+            - team_id
+            - job_id
+            - time_window_start
+            - breakdown_value
+        partition_by: 'toYYYYMM(time_window_start)'
+        settings:
+            index_granularity: '8192'
+        columns:
+            - name: team_id
+              type: Int64
+            - name: job_id
+              type: UUID
+            - name: time_window_start
+              type: "DateTime64(6, 'UTC')"
+            - name: expires_at
+              type: "DateTime64(6, 'UTC')"
+              default_expression: "now() + INTERVAL 7 DAY"
+              default_kind: DEFAULT
+            - name: breakdown_value
+              type: Array(String)
+            - name: uniq_exact_state
+              type: "AggregateFunction(uniqExact, UUID)"
+
+    preaggregation_results:
+        engine: Distributed
+        source: sharded_preaggregation_results
+        sharding_key: 'sipHash64(job_id)'
+        on_nodes: ALL
+        columns: inherit sharded_preaggregation_results

--- a/posthog/clickhouse/schema/preaggregation_results.yaml
+++ b/posthog/clickhouse/schema/preaggregation_results.yaml
@@ -26,12 +26,12 @@ tables:
               type: "DateTime64(6, 'UTC')"
             - name: expires_at
               type: "DateTime64(6, 'UTC')"
-              default_expression: "now() + INTERVAL 7 DAY"
+              default_expression: 'now() + INTERVAL 7 DAY'
               default_kind: DEFAULT
             - name: breakdown_value
               type: Array(String)
             - name: uniq_exact_state
-              type: "AggregateFunction(uniqExact, UUID)"
+              type: 'AggregateFunction(uniqExact, UUID)'
 
     preaggregation_results:
         engine: Distributed

--- a/posthog/clickhouse/schema/precalculated_events.yaml
+++ b/posthog/clickhouse/schema/precalculated_events.yaml
@@ -1,0 +1,77 @@
+# Desired-state schema for the precalculated_events ecosystem.
+
+ecosystem: precalculated_events
+cluster: main
+
+tables:
+    sharded_precalculated_events:
+        engine: ReplicatedReplacingMergeTree
+        sharded: true
+        on_nodes: DATA
+        order_by:
+            - team_id
+            - condition
+            - date
+            - distinct_id
+            - uuid
+        partition_by: 'toYYYYMM(date)'
+        columns:
+            - name: team_id
+              type: Int64
+            - name: date
+              type: Date
+            - name: distinct_id
+              type: String
+            - name: person_id
+              type: UUID
+            - name: condition
+              type: String
+            - name: uuid
+              type: UUID
+            - name: source
+              type: String
+
+    writable_precalculated_events:
+        engine: Distributed
+        source: sharded_precalculated_events
+        sharding_key: 'sipHash64(distinct_id)'
+        on_nodes: COORDINATOR
+        columns: inherit sharded_precalculated_events
+
+    precalculated_events:
+        engine: Distributed
+        source: sharded_precalculated_events
+        sharding_key: 'sipHash64(distinct_id)'
+        on_nodes: ALL
+        columns: inherit sharded_precalculated_events
+
+    kafka_precalculated_events:
+        engine: Kafka
+        on_nodes: INGESTION_EVENTS
+        settings:
+            kafka_broker_list: __from_settings__
+            kafka_topic_list: clickhouse_prefiltered_events
+            kafka_group_name: precalculated_events
+            kafka_format: JSONEachRow
+            kafka_skip_broken_messages: '100'
+        columns:
+            - name: team_id
+              type: Int64
+            - name: distinct_id
+              type: String
+            - name: person_id
+              type: UUID
+            - name: condition
+              type: String
+            - name: uuid
+              type: UUID
+            - name: source
+              type: String
+
+    precalculated_events_mv:
+        engine: MaterializedView
+        source: kafka_precalculated_events
+        target: writable_precalculated_events
+        select: "SELECT team_id, toDate(_timestamp) AS date, distinct_id, person_id, condition, uuid, source, _timestamp, _offset, _partition FROM {{ database }}.kafka_precalculated_events"
+        on_nodes: INGESTION_EVENTS
+        columns: []

--- a/posthog/clickhouse/schema/precalculated_events.yaml
+++ b/posthog/clickhouse/schema/precalculated_events.yaml
@@ -35,7 +35,7 @@ tables:
         engine: Distributed
         source: sharded_precalculated_events
         sharding_key: 'sipHash64(distinct_id)'
-        on_nodes: COORDINATOR
+        on_nodes: DATA
         columns: inherit sharded_precalculated_events
 
     precalculated_events:

--- a/posthog/clickhouse/schema/precalculated_events.yaml
+++ b/posthog/clickhouse/schema/precalculated_events.yaml
@@ -79,6 +79,6 @@ tables:
         engine: MaterializedView
         source: kafka_precalculated_events
         target: writable_precalculated_events
-        select: "SELECT team_id, toDate(_timestamp) AS date, distinct_id, person_id, condition, uuid, source, _timestamp, _offset, _partition FROM {{ database }}.kafka_precalculated_events"
+        select: 'SELECT team_id, toDate(_timestamp) AS date, distinct_id, person_id, condition, uuid, source, _timestamp, _offset, _partition FROM {{ database }}.kafka_precalculated_events'
         on_nodes: INGESTION_EVENTS
         columns: []

--- a/posthog/clickhouse/schema/precalculated_events.yaml
+++ b/posthog/clickhouse/schema/precalculated_events.yaml
@@ -35,7 +35,7 @@ tables:
         engine: Distributed
         source: sharded_precalculated_events
         sharding_key: 'sipHash64(distinct_id)'
-        on_nodes: DATA
+        on_nodes: COORDINATOR
         columns: inherit sharded_precalculated_events
 
     precalculated_events:

--- a/posthog/clickhouse/schema/precalculated_events.yaml
+++ b/posthog/clickhouse/schema/precalculated_events.yaml
@@ -30,6 +30,13 @@ tables:
               type: UUID
             - name: source
               type: String
+            # Kafka virtual columns
+            - name: _timestamp
+              type: DateTime64(6)
+            - name: _partition
+              type: UInt64
+            - name: _offset
+              type: UInt64
 
     writable_precalculated_events:
         engine: Distributed

--- a/posthog/clickhouse/schema/precalculated_person_properties.yaml
+++ b/posthog/clickhouse/schema/precalculated_person_properties.yaml
@@ -1,0 +1,72 @@
+# Desired-state schema for the precalculated_person_properties ecosystem.
+
+ecosystem: precalculated_person_properties
+cluster: main
+
+tables:
+    sharded_precalculated_person_properties:
+        engine: ReplicatedReplacingMergeTree
+        sharded: true
+        on_nodes: DATA
+        order_by:
+            - team_id
+            - condition
+            - distinct_id
+        columns:
+            - name: team_id
+              type: Int64
+            - name: distinct_id
+              type: String
+            - name: person_id
+              type: UUID
+            - name: condition
+              type: String
+            - name: matches
+              type: Bool
+            - name: source
+              type: String
+
+    writable_precalculated_person_properties:
+        engine: Distributed
+        source: sharded_precalculated_person_properties
+        sharding_key: 'sipHash64(distinct_id)'
+        on_nodes: COORDINATOR
+        columns: inherit sharded_precalculated_person_properties
+
+    precalculated_person_properties:
+        engine: Distributed
+        source: sharded_precalculated_person_properties
+        sharding_key: 'sipHash64(distinct_id)'
+        on_nodes: ALL
+        columns: inherit sharded_precalculated_person_properties
+
+    kafka_precalculated_person_properties:
+        engine: Kafka
+        on_nodes: INGESTION_EVENTS
+        settings:
+            kafka_broker_list: __from_settings__
+            kafka_topic_list: clickhouse_precalculated_person_properties
+            kafka_group_name: precalculated_person_properties
+            kafka_format: JSONEachRow
+            kafka_skip_broken_messages: '100'
+        columns:
+            - name: team_id
+              type: Int64
+            - name: distinct_id
+              type: String
+            - name: person_id
+              type: UUID
+            - name: condition
+              type: String
+            - name: matches
+              type: Bool
+            - name: source
+              type: String
+
+    precalculated_person_properties_mv:
+        engine: MaterializedView
+        source: kafka_precalculated_person_properties
+        target: writable_precalculated_person_properties
+        select: "SELECT team_id, distinct_id, person_id, condition, matches, source, _timestamp, _offset FROM {{ database }}.kafka_precalculated_person_properties"
+        on_nodes: INGESTION_EVENTS
+        columns: []

--- a/posthog/clickhouse/schema/precalculated_person_properties.yaml
+++ b/posthog/clickhouse/schema/precalculated_person_properties.yaml
@@ -72,6 +72,6 @@ tables:
         engine: MaterializedView
         source: kafka_precalculated_person_properties
         target: writable_precalculated_person_properties
-        select: "SELECT team_id, distinct_id, person_id, condition, matches, source, _timestamp, _offset FROM {{ database }}.kafka_precalculated_person_properties"
+        select: 'SELECT team_id, distinct_id, person_id, condition, matches, source, _timestamp, _offset FROM {{ database }}.kafka_precalculated_person_properties'
         on_nodes: INGESTION_EVENTS
         columns: []

--- a/posthog/clickhouse/schema/precalculated_person_properties.yaml
+++ b/posthog/clickhouse/schema/precalculated_person_properties.yaml
@@ -25,6 +25,11 @@ tables:
               type: Bool
             - name: source
               type: String
+            # Kafka virtual columns
+            - name: _timestamp
+              type: DateTime64(6)
+            - name: _offset
+              type: UInt64
 
     writable_precalculated_person_properties:
         engine: Distributed

--- a/posthog/clickhouse/schema/precalculated_person_properties.yaml
+++ b/posthog/clickhouse/schema/precalculated_person_properties.yaml
@@ -30,7 +30,7 @@ tables:
         engine: Distributed
         source: sharded_precalculated_person_properties
         sharding_key: 'sipHash64(distinct_id)'
-        on_nodes: COORDINATOR
+        on_nodes: DATA
         columns: inherit sharded_precalculated_person_properties
 
     precalculated_person_properties:

--- a/posthog/clickhouse/schema/precalculated_person_properties.yaml
+++ b/posthog/clickhouse/schema/precalculated_person_properties.yaml
@@ -30,7 +30,7 @@ tables:
         engine: Distributed
         source: sharded_precalculated_person_properties
         sharding_key: 'sipHash64(distinct_id)'
-        on_nodes: DATA
+        on_nodes: COORDINATOR
         columns: inherit sharded_precalculated_person_properties
 
     precalculated_person_properties:

--- a/posthog/clickhouse/schema/prefiltered_events.yaml
+++ b/posthog/clickhouse/schema/prefiltered_events.yaml
@@ -1,0 +1,39 @@
+# Desired-state schema for the prefiltered_events ecosystem.
+# These tables serve realtime cohort calculation via HogQL.
+
+ecosystem: prefiltered_events
+cluster: main
+
+tables:
+    sharded_prefiltered_events:
+        engine: ReplicatedReplacingMergeTree
+        sharded: true
+        on_nodes: DATA
+        order_by:
+            - team_id
+            - condition
+            - distinct_id
+            - uuid
+        partition_by: 'toYYYYMM(timestamp)'
+        columns:
+            - name: team_id
+              type: Int64
+            - name: timestamp
+              type: "DateTime64(6, 'UTC')"
+            - name: distinct_id
+              type: String
+            - name: person_id
+              type: UUID
+            - name: condition
+              type: String
+            - name: uuid
+              type: UUID
+            - name: source
+              type: String
+
+    prefiltered_events:
+        engine: Distributed
+        source: sharded_prefiltered_events
+        sharding_key: 'sipHash64(distinct_id)'
+        on_nodes: ALL
+        columns: inherit sharded_prefiltered_events

--- a/posthog/clickhouse/schema/property_definitions.yaml
+++ b/posthog/clickhouse/schema/property_definitions.yaml
@@ -1,0 +1,24 @@
+# Desired-state schema for the property_definitions ecosystem.
+# Used by the temporal cleanup_property_definitions workflow.
+
+ecosystem: property_definitions
+cluster: main
+
+tables:
+    property_definitions:
+        engine: ReplicatedReplacingMergeTree
+        sharded: false
+        on_nodes: ALL
+        order_by:
+            - team_id
+            - type
+            - name
+        columns:
+            - name: team_id
+              type: Int64
+            - name: name
+              type: String
+            - name: type
+              type: Int8
+            - name: last_seen_at
+              type: DateTime64(6, 'UTC')

--- a/posthog/clickhouse/schema/property_definitions.yaml
+++ b/posthog/clickhouse/schema/property_definitions.yaml
@@ -12,13 +12,29 @@ tables:
         order_by:
             - team_id
             - type
+            - "COALESCE(event, '')"
             - name
+            - "COALESCE(group_type_index, 255)"
         columns:
             - name: team_id
-              type: Int64
+              type: UInt32
+            - name: project_id
+              type: Nullable(UInt32)
             - name: name
               type: String
+            - name: property_type
+              type: Nullable(String)
+            - name: event
+              type: Nullable(String)
+            - name: group_type_index
+              type: Nullable(UInt8)
             - name: type
-              type: Int8
+              type: UInt8
+              default_kind: DEFAULT
+              default_expression: '1'
             - name: last_seen_at
-              type: DateTime64(6, 'UTC')
+              type: DateTime
+            - name: version
+              type: UInt64
+              default_kind: MATERIALIZED
+              default_expression: "(bitShiftLeft(toUInt64(NOT isNull(property_type)), 48) + toUInt64(toUnixTimestamp(last_seen_at)))"

--- a/posthog/clickhouse/schema/property_definitions.yaml
+++ b/posthog/clickhouse/schema/property_definitions.yaml
@@ -12,9 +12,11 @@ tables:
         order_by:
             - team_id
             - type
-            - "COALESCE(event, '')"
+            # CH lowercases COALESCE in sorting_key, so match that rendering
+            # to avoid a perpetual ORDER BY diff on every apply.
+            - "coalesce(event, '')"
             - name
-            - "COALESCE(group_type_index, 255)"
+            - "coalesce(group_type_index, 255)"
         columns:
             - name: team_id
               type: UInt32
@@ -37,4 +39,6 @@ tables:
             - name: version
               type: UInt64
               default_kind: MATERIALIZED
-              default_expression: "(bitShiftLeft(toUInt64(NOT isNull(property_type)), 48) + toUInt64(toUnixTimestamp(last_seen_at)))"
+              # No outer parens — CH strips them during DDL parse, so align
+              # the YAML with how system.columns reports the expression.
+              default_expression: "bitShiftLeft(toUInt64(NOT isNull(property_type)), 48) + toUInt64(toUnixTimestamp(last_seen_at))"

--- a/posthog/clickhouse/schema/property_definitions.yaml
+++ b/posthog/clickhouse/schema/property_definitions.yaml
@@ -16,7 +16,7 @@ tables:
             # to avoid a perpetual ORDER BY diff on every apply.
             - "coalesce(event, '')"
             - name
-            - "coalesce(group_type_index, 255)"
+            - 'coalesce(group_type_index, 255)'
         columns:
             - name: team_id
               type: UInt32
@@ -41,4 +41,4 @@ tables:
               default_kind: MATERIALIZED
               # No outer parens — CH strips them during DDL parse, so align
               # the YAML with how system.columns reports the expression.
-              default_expression: "bitShiftLeft(toUInt64(NOT isNull(property_type)), 48) + toUInt64(toUnixTimestamp(last_seen_at))"
+              default_expression: 'bitShiftLeft(toUInt64(NOT isNull(property_type)), 48) + toUInt64(toUnixTimestamp(last_seen_at))'

--- a/posthog/clickhouse/schema/query_log_archive.yaml
+++ b/posthog/clickhouse/schema/query_log_archive.yaml
@@ -1,0 +1,257 @@
+# Desired-state schema for the query_log_archive ecosystem.
+# Archives ClickHouse query_log entries with extracted log_comment fields.
+
+ecosystem: query_log_archive
+cluster: main
+
+tables:
+    sharded_query_log_archive:
+        engine: ReplicatedMergeTree
+        sharded: true
+        on_nodes: DATA
+        order_by:
+            - team_id
+            - event_date
+            - event_time
+            - query_id
+        partition_by: 'toYYYYMM(event_date)'
+        columns:
+            - name: hostname
+              type: LowCardinality(String)
+            - name: user
+              type: LowCardinality(String)
+            - name: query_id
+              type: String
+            - name: initial_query_id
+              type: String
+            - name: is_initial_query
+              type: UInt8
+            - name: type
+              type: "Enum8('QueryStart' = 1, 'QueryFinish' = 2, 'ExceptionBeforeStart' = 3, 'ExceptionWhileProcessing' = 4)"
+            - name: event_date
+              type: Date
+            - name: event_time
+              type: DateTime
+            - name: event_time_microseconds
+              type: DateTime64(6)
+            - name: query_start_time
+              type: DateTime
+            - name: query_start_time_microseconds
+              type: DateTime64(6)
+            - name: query_duration_ms
+              type: UInt64
+            - name: read_rows
+              type: UInt64
+            - name: read_bytes
+              type: UInt64
+            - name: written_rows
+              type: UInt64
+            - name: written_bytes
+              type: UInt64
+            - name: result_rows
+              type: UInt64
+            - name: result_bytes
+              type: UInt64
+            - name: memory_usage
+              type: UInt64
+            - name: peak_threads_usage
+              type: UInt64
+            - name: current_database
+              type: LowCardinality(String)
+            - name: query
+              type: String
+            - name: formatted_query
+              type: String
+            - name: normalized_query_hash
+              type: UInt64
+            - name: query_kind
+              type: LowCardinality(String)
+            - name: exception_code
+              type: Int32
+            - name: exception_name
+              type: String
+              default_kind: ALIAS
+              default_expression: 'errorCodeToName(exception_code)'
+            - name: exception
+              type: String
+            - name: stack_trace
+              type: String
+            - name: ProfileEvents_RealTimeMicroseconds
+              type: Int64
+            - name: ProfileEvents_OSCPUVirtualTimeMicroseconds
+              type: Int64
+            - name: ProfileEvents_S3Clients
+              type: Int64
+            - name: ProfileEvents_S3DeleteObjects
+              type: Int64
+            - name: ProfileEvents_S3CopyObject
+              type: Int64
+            - name: ProfileEvents_S3ListObjects
+              type: Int64
+            - name: ProfileEvents_S3HeadObject
+              type: Int64
+            - name: ProfileEvents_S3GetObjectAttributes
+              type: Int64
+            - name: ProfileEvents_S3CreateMultipartUpload
+              type: Int64
+            - name: ProfileEvents_S3UploadPartCopy
+              type: Int64
+            - name: ProfileEvents_S3UploadPart
+              type: Int64
+            - name: ProfileEvents_S3AbortMultipartUpload
+              type: Int64
+            - name: ProfileEvents_S3CompleteMultipartUpload
+              type: Int64
+            - name: ProfileEvents_S3PutObject
+              type: Int64
+            - name: ProfileEvents_S3GetObject
+              type: Int64
+            - name: ProfileEvents_ReadBufferFromS3Bytes
+              type: Int64
+            - name: ProfileEvents_WriteBufferFromS3Bytes
+              type: Int64
+            - name: ProfileEvents
+              type: "Map(String, UInt64)"
+            - name: lc_workflow
+              type: LowCardinality(String)
+            - name: lc_kind
+              type: LowCardinality(String)
+            - name: lc_id
+              type: String
+            - name: lc_route_id
+              type: String
+            - name: lc_access_method
+              type: LowCardinality(String)
+            - name: lc_api_key_label
+              type: String
+            - name: lc_api_key_mask
+              type: String
+            - name: lc_query_type
+              type: LowCardinality(String)
+            - name: lc_product
+              type: LowCardinality(String)
+            - name: lc_chargeable
+              type: Bool
+            - name: lc_name
+              type: String
+            - name: lc_request_name
+              type: String
+            - name: lc_client_query_id
+              type: String
+            - name: lc_org_id
+              type: String
+            - name: team_id
+              type: Int64
+            - name: lc_user_id
+              type: Int64
+            - name: lc_is_impersonated
+              type: Bool
+            - name: lc_session_id
+              type: String
+            - name: lc_dashboard_id
+              type: Int64
+            - name: lc_insight_id
+              type: Int64
+            - name: lc_cohort_id
+              type: Int64
+            - name: lc_batch_export_id
+              type: String
+            - name: lc_experiment_id
+              type: Int64
+            - name: lc_experiment_feature_flag_key
+              type: String
+            - name: lc_alert_config_id
+              type: String
+            - name: lc_feature
+              type: LowCardinality(String)
+            - name: lc_table_id
+              type: String
+            - name: lc_warehouse_query
+              type: Bool
+            - name: lc_person_on_events_mode
+              type: LowCardinality(String)
+            - name: lc_service_name
+              type: String
+            - name: lc_workload
+              type: LowCardinality(String)
+            - name: lc_query__kind
+              type: LowCardinality(String)
+            - name: lc_query__query
+              type: String
+            - name: lc_query
+              type: String
+            - name: lc_temporal__workflow_namespace
+              type: String
+            - name: lc_temporal__workflow_type
+              type: String
+            - name: lc_temporal__workflow_id
+              type: String
+            - name: lc_temporal__workflow_run_id
+              type: String
+            - name: lc_temporal__activity_type
+              type: String
+            - name: lc_temporal__activity_id
+              type: String
+            - name: lc_temporal__attempt
+              type: Int64
+            - name: lc_dagster__job_name
+              type: String
+            - name: lc_dagster__run_id
+              type: String
+            - name: lc_dagster__owner
+              type: String
+            - name: lc_modifiers
+              type: String
+
+    query_log_archive:
+        engine: Distributed
+        source: sharded_query_log_archive
+        sharding_key: 'cityHash64(query_id)'
+        on_nodes:
+            - DATA
+            - COORDINATOR
+        columns: inherit sharded_query_log_archive
+
+    writable_query_log_archive:
+        engine: Distributed
+        source: sharded_query_log_archive
+        sharding_key: 'cityHash64(query_id)'
+        on_nodes:
+            - COORDINATOR
+            - ENDPOINTS
+        columns: inherit sharded_query_log_archive
+
+    writable_sharded_query_log_archive:
+        engine: Distributed
+        source: sharded_query_log_archive
+        sharding_key: 'cityHash64(query_id)'
+        on_nodes:
+            - COORDINATOR
+            - ENDPOINTS
+        columns: inherit sharded_query_log_archive
+
+    sharded_query_log_archive_mv:
+        engine: MaterializedView
+        source: system.query_log
+        target: sharded_query_log_archive
+        select: "SELECT hostname, user, query_id, ... FROM system.query_log WHERE type != 'QueryStart'"
+        on_nodes: DATA
+        columns: []
+
+    query_log_archive_mv:
+        engine: MaterializedView
+        source: system.query_log
+        target: writable_query_log_archive
+        select: "SELECT hostname, user, query_id, ... FROM system.query_log WHERE type != 'QueryStart'"
+        on_nodes: ENDPOINTS
+        columns: []
+
+    dist_query_log_archive_mv:
+        engine: MaterializedView
+        source: system.query_log
+        target: writable_sharded_query_log_archive
+        select: "SELECT hostname, user, query_id, ... FROM system.query_log WHERE type != 'QueryStart'"
+        on_nodes:
+            - COORDINATOR
+            - ENDPOINTS
+        columns: []

--- a/posthog/clickhouse/schema/query_log_archive.yaml
+++ b/posthog/clickhouse/schema/query_log_archive.yaml
@@ -111,7 +111,7 @@ tables:
             - name: ProfileEvents_WriteBufferFromS3Bytes
               type: Int64
             - name: ProfileEvents
-              type: "Map(String, UInt64)"
+              type: 'Map(String, UInt64)'
             - name: lc_workflow
               type: LowCardinality(String)
             - name: lc_kind

--- a/posthog/clickhouse/schema/query_log_archive.yaml
+++ b/posthog/clickhouse/schema/query_log_archive.yaml
@@ -209,7 +209,7 @@ tables:
         sharding_key: 'cityHash64(query_id)'
         on_nodes:
             - DATA
-            - DATA
+            - COORDINATOR
         columns: inherit sharded_query_log_archive
 
     writable_query_log_archive:
@@ -217,7 +217,7 @@ tables:
         source: sharded_query_log_archive
         sharding_key: 'cityHash64(query_id)'
         on_nodes:
-            - DATA
+            - COORDINATOR
             - ENDPOINTS
         columns: inherit sharded_query_log_archive
 
@@ -226,7 +226,7 @@ tables:
         source: sharded_query_log_archive
         sharding_key: 'cityHash64(query_id)'
         on_nodes:
-            - DATA
+            - COORDINATOR
             - ENDPOINTS
         columns: inherit sharded_query_log_archive
 
@@ -252,6 +252,6 @@ tables:
         target: writable_sharded_query_log_archive
         select: "SELECT hostname, user, query_id, ... FROM system.query_log WHERE type != 'QueryStart'"
         on_nodes:
-            - DATA
+            - COORDINATOR
             - ENDPOINTS
         columns: []

--- a/posthog/clickhouse/schema/query_log_archive.yaml
+++ b/posthog/clickhouse/schema/query_log_archive.yaml
@@ -209,7 +209,7 @@ tables:
         sharding_key: 'cityHash64(query_id)'
         on_nodes:
             - DATA
-            - COORDINATOR
+            - DATA
         columns: inherit sharded_query_log_archive
 
     writable_query_log_archive:
@@ -217,7 +217,7 @@ tables:
         source: sharded_query_log_archive
         sharding_key: 'cityHash64(query_id)'
         on_nodes:
-            - COORDINATOR
+            - DATA
             - ENDPOINTS
         columns: inherit sharded_query_log_archive
 
@@ -226,7 +226,7 @@ tables:
         source: sharded_query_log_archive
         sharding_key: 'cityHash64(query_id)'
         on_nodes:
-            - COORDINATOR
+            - DATA
             - ENDPOINTS
         columns: inherit sharded_query_log_archive
 
@@ -252,6 +252,6 @@ tables:
         target: writable_sharded_query_log_archive
         select: "SELECT hostname, user, query_id, ... FROM system.query_log WHERE type != 'QueryStart'"
         on_nodes:
-            - COORDINATOR
+            - DATA
             - ENDPOINTS
         columns: []

--- a/posthog/clickhouse/schema/raw_sessions.yaml
+++ b/posthog/clickhouse/schema/raw_sessions.yaml
@@ -1,0 +1,166 @@
+# Desired-state schema for the raw_sessions (v2) ecosystem.
+
+ecosystem: raw_sessions
+cluster: main
+
+tables:
+    sharded_raw_sessions:
+        engine: ReplicatedAggregatingMergeTree
+        sharded: true
+        on_nodes: DATA
+        order_by:
+            - team_id
+            - "toStartOfHour(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(session_id_v7, 80)), 1000)))"
+            - 'cityHash64(session_id_v7)'
+            - session_id_v7
+        partition_by: "toYYYYMM(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(session_id_v7, 80)), 1000)))"
+        columns:
+            - name: team_id
+              type: Int64
+            - name: session_id_v7
+              type: UInt128
+            - name: distinct_id
+              type: "AggregateFunction(argMax, String, DateTime64(6, 'UTC'))"
+            - name: min_timestamp
+              type: "SimpleAggregateFunction(min, DateTime64(6, 'UTC'))"
+            - name: max_timestamp
+              type: "SimpleAggregateFunction(max, DateTime64(6, 'UTC'))"
+            - name: max_inserted_at
+              type: "SimpleAggregateFunction(max, DateTime64(6, 'UTC'))"
+            - name: urls
+              type: "SimpleAggregateFunction(groupUniqArrayArray, Array(String))"
+            - name: entry_url
+              type: "AggregateFunction(argMin, String, DateTime64(6, 'UTC'))"
+            - name: end_url
+              type: "AggregateFunction(argMax, String, DateTime64(6, 'UTC'))"
+            - name: last_external_click_url
+              type: "AggregateFunction(argMax, String, DateTime64(6, 'UTC'))"
+            - name: initial_browser
+              type: "AggregateFunction(argMin, String, DateTime64(6, 'UTC'))"
+            - name: initial_browser_version
+              type: "AggregateFunction(argMin, String, DateTime64(6, 'UTC'))"
+            - name: initial_os
+              type: "AggregateFunction(argMin, String, DateTime64(6, 'UTC'))"
+            - name: initial_os_version
+              type: "AggregateFunction(argMin, String, DateTime64(6, 'UTC'))"
+            - name: initial_device_type
+              type: "AggregateFunction(argMin, String, DateTime64(6, 'UTC'))"
+            - name: initial_viewport_width
+              type: "AggregateFunction(argMin, Int64, DateTime64(6, 'UTC'))"
+            - name: initial_viewport_height
+              type: "AggregateFunction(argMin, Int64, DateTime64(6, 'UTC'))"
+            - name: initial_geoip_country_code
+              type: "AggregateFunction(argMin, String, DateTime64(6, 'UTC'))"
+            - name: initial_geoip_subdivision_1_code
+              type: "AggregateFunction(argMin, String, DateTime64(6, 'UTC'))"
+            - name: initial_geoip_subdivision_1_name
+              type: "AggregateFunction(argMin, String, DateTime64(6, 'UTC'))"
+            - name: initial_geoip_subdivision_city_name
+              type: "AggregateFunction(argMin, String, DateTime64(6, 'UTC'))"
+            - name: initial_geoip_time_zone
+              type: "AggregateFunction(argMin, String, DateTime64(6, 'UTC'))"
+            - name: initial_referring_domain
+              type: "AggregateFunction(argMin, String, DateTime64(6, 'UTC'))"
+            - name: initial_utm_source
+              type: "AggregateFunction(argMin, String, DateTime64(6, 'UTC'))"
+            - name: initial_utm_campaign
+              type: "AggregateFunction(argMin, String, DateTime64(6, 'UTC'))"
+            - name: initial_utm_medium
+              type: "AggregateFunction(argMin, String, DateTime64(6, 'UTC'))"
+            - name: initial_utm_term
+              type: "AggregateFunction(argMin, String, DateTime64(6, 'UTC'))"
+            - name: initial_utm_content
+              type: "AggregateFunction(argMin, String, DateTime64(6, 'UTC'))"
+            - name: initial_gclid
+              type: "AggregateFunction(argMin, String, DateTime64(6, 'UTC'))"
+            - name: initial_gad_source
+              type: "AggregateFunction(argMin, String, DateTime64(6, 'UTC'))"
+            - name: initial_gclsrc
+              type: "AggregateFunction(argMin, String, DateTime64(6, 'UTC'))"
+            - name: initial_dclid
+              type: "AggregateFunction(argMin, String, DateTime64(6, 'UTC'))"
+            - name: initial_gbraid
+              type: "AggregateFunction(argMin, String, DateTime64(6, 'UTC'))"
+            - name: initial_wbraid
+              type: "AggregateFunction(argMin, String, DateTime64(6, 'UTC'))"
+            - name: initial_fbclid
+              type: "AggregateFunction(argMin, String, DateTime64(6, 'UTC'))"
+            - name: initial_msclkid
+              type: "AggregateFunction(argMin, String, DateTime64(6, 'UTC'))"
+            - name: initial_twclid
+              type: "AggregateFunction(argMin, String, DateTime64(6, 'UTC'))"
+            - name: initial_li_fat_id
+              type: "AggregateFunction(argMin, String, DateTime64(6, 'UTC'))"
+            - name: initial_mc_cid
+              type: "AggregateFunction(argMin, String, DateTime64(6, 'UTC'))"
+            - name: initial_igshid
+              type: "AggregateFunction(argMin, String, DateTime64(6, 'UTC'))"
+            - name: initial_ttclid
+              type: "AggregateFunction(argMin, String, DateTime64(6, 'UTC'))"
+            - name: initial_epik
+              type: "AggregateFunction(argMin, String, DateTime64(6, 'UTC'))"
+            - name: initial_qclid
+              type: "AggregateFunction(argMin, String, DateTime64(6, 'UTC'))"
+            - name: initial_sccid
+              type: "AggregateFunction(argMin, String, DateTime64(6, 'UTC'))"
+            - name: initial__kx
+              type: "AggregateFunction(argMin, String, DateTime64(6, 'UTC'))"
+            - name: initial_irclid
+              type: "AggregateFunction(argMin, String, DateTime64(6, 'UTC'))"
+            - name: pageview_count
+              type: "SimpleAggregateFunction(sum, Int64)"
+            - name: pageview_uniq
+              type: "AggregateFunction(uniq, Nullable(UUID))"
+            - name: autocapture_count
+              type: "SimpleAggregateFunction(sum, Int64)"
+            - name: autocapture_uniq
+              type: "AggregateFunction(uniq, Nullable(UUID))"
+            - name: screen_count
+              type: "SimpleAggregateFunction(sum, Int64)"
+            - name: screen_uniq
+              type: "AggregateFunction(uniq, Nullable(UUID))"
+            - name: maybe_has_session_replay
+              type: "SimpleAggregateFunction(max, Bool)"
+            - name: page_screen_autocapture_uniq_up_to
+              type: "AggregateFunction(uniqUpTo(1), Nullable(UUID))"
+            - name: vitals_lcp
+              type: "AggregateFunction(argMin, Nullable(Float64), DateTime64(6, 'UTC'))"
+
+    writable_raw_sessions:
+        engine: Distributed
+        source: sharded_raw_sessions
+        sharding_key: 'cityHash64(session_id_v7)'
+        on_nodes: COORDINATOR
+        columns: inherit sharded_raw_sessions
+
+    raw_sessions:
+        engine: Distributed
+        source: sharded_raw_sessions
+        sharding_key: 'cityHash64(session_id_v7)'
+        on_nodes: ALL
+        columns: inherit sharded_raw_sessions
+
+    raw_sessions_mv:
+        engine: MaterializedView
+        source: sharded_events
+        target: writable_raw_sessions
+        select: "SELECT ... FROM {{ database }}.sharded_events"
+        on_nodes: DATA
+        columns: []
+
+    # Production-only tables
+    new_raw_sessions:
+        engine: ReplicatedAggregatingMergeTree
+        sharded: false
+        on_nodes: DATA
+        order_by:
+            - team_id
+            - session_id_v7
+        columns: inherit sharded_raw_sessions
+
+    writable_raw_sessions_primary:
+        engine: Distributed
+        source: sharded_raw_sessions
+        sharding_key: 'cityHash64(session_id_v7)'
+        on_nodes: COORDINATOR
+        columns: inherit sharded_raw_sessions

--- a/posthog/clickhouse/schema/raw_sessions.yaml
+++ b/posthog/clickhouse/schema/raw_sessions.yaml
@@ -10,10 +10,10 @@ tables:
         on_nodes: DATA
         order_by:
             - team_id
-            - "toStartOfHour(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(session_id_v7, 80)), 1000)))"
+            - 'toStartOfHour(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(session_id_v7, 80)), 1000)))'
             - 'cityHash64(session_id_v7)'
             - session_id_v7
-        partition_by: "toYYYYMM(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(session_id_v7, 80)), 1000)))"
+        partition_by: 'toYYYYMM(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(session_id_v7, 80)), 1000)))'
         columns:
             - name: team_id
               type: Int64
@@ -28,7 +28,7 @@ tables:
             - name: max_inserted_at
               type: "SimpleAggregateFunction(max, DateTime64(6, 'UTC'))"
             - name: urls
-              type: "SimpleAggregateFunction(groupUniqArrayArray, Array(String))"
+              type: 'SimpleAggregateFunction(groupUniqArrayArray, Array(String))'
             - name: entry_url
               type: "AggregateFunction(argMin, String, DateTime64(6, 'UTC'))"
             - name: end_url
@@ -108,21 +108,21 @@ tables:
             - name: initial_irclid
               type: "AggregateFunction(argMin, String, DateTime64(6, 'UTC'))"
             - name: pageview_count
-              type: "SimpleAggregateFunction(sum, Int64)"
+              type: 'SimpleAggregateFunction(sum, Int64)'
             - name: pageview_uniq
-              type: "AggregateFunction(uniq, Nullable(UUID))"
+              type: 'AggregateFunction(uniq, Nullable(UUID))'
             - name: autocapture_count
-              type: "SimpleAggregateFunction(sum, Int64)"
+              type: 'SimpleAggregateFunction(sum, Int64)'
             - name: autocapture_uniq
-              type: "AggregateFunction(uniq, Nullable(UUID))"
+              type: 'AggregateFunction(uniq, Nullable(UUID))'
             - name: screen_count
-              type: "SimpleAggregateFunction(sum, Int64)"
+              type: 'SimpleAggregateFunction(sum, Int64)'
             - name: screen_uniq
-              type: "AggregateFunction(uniq, Nullable(UUID))"
+              type: 'AggregateFunction(uniq, Nullable(UUID))'
             - name: maybe_has_session_replay
-              type: "SimpleAggregateFunction(max, Bool)"
+              type: 'SimpleAggregateFunction(max, Bool)'
             - name: page_screen_autocapture_uniq_up_to
-              type: "AggregateFunction(uniqUpTo(1), Nullable(UUID))"
+              type: 'AggregateFunction(uniqUpTo(1), Nullable(UUID))'
             - name: vitals_lcp
               type: "AggregateFunction(argMin, Nullable(Float64), DateTime64(6, 'UTC'))"
 
@@ -144,7 +144,7 @@ tables:
         engine: MaterializedView
         source: sharded_events
         target: writable_raw_sessions
-        select: "SELECT ... FROM {{ database }}.sharded_events"
+        select: 'SELECT ... FROM {{ database }}.sharded_events'
         on_nodes: DATA
         columns: []
 

--- a/posthog/clickhouse/schema/raw_sessions.yaml
+++ b/posthog/clickhouse/schema/raw_sessions.yaml
@@ -130,7 +130,7 @@ tables:
         engine: Distributed
         source: sharded_raw_sessions
         sharding_key: 'cityHash64(session_id_v7)'
-        on_nodes: COORDINATOR
+        on_nodes: DATA
         columns: inherit sharded_raw_sessions
 
     raw_sessions:
@@ -162,5 +162,5 @@ tables:
         engine: Distributed
         source: sharded_raw_sessions
         sharding_key: 'cityHash64(session_id_v7)'
-        on_nodes: COORDINATOR
+        on_nodes: DATA
         columns: inherit sharded_raw_sessions

--- a/posthog/clickhouse/schema/raw_sessions.yaml
+++ b/posthog/clickhouse/schema/raw_sessions.yaml
@@ -130,7 +130,7 @@ tables:
         engine: Distributed
         source: sharded_raw_sessions
         sharding_key: 'cityHash64(session_id_v7)'
-        on_nodes: DATA
+        on_nodes: COORDINATOR
         columns: inherit sharded_raw_sessions
 
     raw_sessions:
@@ -162,5 +162,5 @@ tables:
         engine: Distributed
         source: sharded_raw_sessions
         sharding_key: 'cityHash64(session_id_v7)'
-        on_nodes: DATA
+        on_nodes: COORDINATOR
         columns: inherit sharded_raw_sessions

--- a/posthog/clickhouse/schema/session_replay.yaml
+++ b/posthog/clickhouse/schema/session_replay.yaml
@@ -31,41 +31,41 @@ tables:
             - name: block_last_timestamps
               type: "SimpleAggregateFunction(groupArrayArray, Array(DateTime64(6, 'UTC')))"
             - name: block_urls
-              type: "SimpleAggregateFunction(groupArrayArray, Array(String))"
+              type: 'SimpleAggregateFunction(groupArrayArray, Array(String))'
             - name: first_url
               type: "AggregateFunction(argMin, Nullable(String), DateTime64(6, 'UTC'))"
             - name: all_urls
-              type: "SimpleAggregateFunction(groupUniqArrayArray, Array(String))"
+              type: 'SimpleAggregateFunction(groupUniqArrayArray, Array(String))'
             - name: click_count
-              type: "SimpleAggregateFunction(sum, Int64)"
+              type: 'SimpleAggregateFunction(sum, Int64)'
             - name: keypress_count
-              type: "SimpleAggregateFunction(sum, Int64)"
+              type: 'SimpleAggregateFunction(sum, Int64)'
             - name: mouse_activity_count
-              type: "SimpleAggregateFunction(sum, Int64)"
+              type: 'SimpleAggregateFunction(sum, Int64)'
             - name: active_milliseconds
-              type: "SimpleAggregateFunction(sum, Int64)"
+              type: 'SimpleAggregateFunction(sum, Int64)'
             - name: console_log_count
-              type: "SimpleAggregateFunction(sum, Int64)"
+              type: 'SimpleAggregateFunction(sum, Int64)'
             - name: console_warn_count
-              type: "SimpleAggregateFunction(sum, Int64)"
+              type: 'SimpleAggregateFunction(sum, Int64)'
             - name: console_error_count
-              type: "SimpleAggregateFunction(sum, Int64)"
+              type: 'SimpleAggregateFunction(sum, Int64)'
             - name: size
-              type: "SimpleAggregateFunction(sum, Int64)"
+              type: 'SimpleAggregateFunction(sum, Int64)'
             - name: message_count
-              type: "SimpleAggregateFunction(sum, Int64)"
+              type: 'SimpleAggregateFunction(sum, Int64)'
             - name: event_count
-              type: "SimpleAggregateFunction(sum, Int64)"
+              type: 'SimpleAggregateFunction(sum, Int64)'
             - name: snapshot_source
               type: "AggregateFunction(argMin, LowCardinality(Nullable(String)), DateTime64(6, 'UTC'))"
             - name: snapshot_library
               type: "AggregateFunction(argMin, Nullable(String), DateTime64(6, 'UTC'))"
             - name: _timestamp
-              type: "SimpleAggregateFunction(max, DateTime)"
+              type: 'SimpleAggregateFunction(max, DateTime)'
             - name: retention_period_days
-              type: "SimpleAggregateFunction(max, Nullable(Int64))"
+              type: 'SimpleAggregateFunction(max, Nullable(Int64))'
             - name: is_deleted
-              type: "SimpleAggregateFunction(max, UInt8)"
+              type: 'SimpleAggregateFunction(max, UInt8)'
               default_expression: '0'
               default_kind: DEFAULT
 
@@ -141,7 +141,7 @@ tables:
         engine: MaterializedView
         source: kafka_session_replay_events
         target: writable_session_replay_events
-        select: "SELECT session_id, team_id, any(distinct_id) as distinct_id, min(first_timestamp) AS min_first_timestamp, max(last_timestamp) AS max_last_timestamp, ... FROM {{ database }}.kafka_session_replay_events GROUP BY session_id, team_id"
+        select: 'SELECT session_id, team_id, any(distinct_id) as distinct_id, min(first_timestamp) AS min_first_timestamp, max(last_timestamp) AS max_last_timestamp, ... FROM {{ database }}.kafka_session_replay_events GROUP BY session_id, team_id'
         on_nodes: INGESTION_SMALL
         columns: []
 

--- a/posthog/clickhouse/schema/session_replay.yaml
+++ b/posthog/clickhouse/schema/session_replay.yaml
@@ -1,0 +1,202 @@
+# Desired-state schema for the session_replay ecosystem.
+
+ecosystem: session_replay
+cluster: main
+
+tables:
+    sharded_session_replay_events:
+        engine: ReplicatedAggregatingMergeTree
+        sharded: true
+        on_nodes: DATA
+        order_by:
+            - 'toDate(min_first_timestamp)'
+            - team_id
+            - session_id
+        partition_by: 'toYYYYMM(min_first_timestamp)'
+        settings:
+            index_granularity: '512'
+        columns:
+            - name: session_id
+              type: String
+            - name: team_id
+              type: Int64
+            - name: distinct_id
+              type: String
+            - name: min_first_timestamp
+              type: "SimpleAggregateFunction(min, DateTime64(6, 'UTC'))"
+            - name: max_last_timestamp
+              type: "SimpleAggregateFunction(max, DateTime64(6, 'UTC'))"
+            - name: block_first_timestamps
+              type: "SimpleAggregateFunction(groupArrayArray, Array(DateTime64(6, 'UTC')))"
+            - name: block_last_timestamps
+              type: "SimpleAggregateFunction(groupArrayArray, Array(DateTime64(6, 'UTC')))"
+            - name: block_urls
+              type: "SimpleAggregateFunction(groupArrayArray, Array(String))"
+            - name: first_url
+              type: "AggregateFunction(argMin, Nullable(String), DateTime64(6, 'UTC'))"
+            - name: all_urls
+              type: "SimpleAggregateFunction(groupUniqArrayArray, Array(String))"
+            - name: click_count
+              type: "SimpleAggregateFunction(sum, Int64)"
+            - name: keypress_count
+              type: "SimpleAggregateFunction(sum, Int64)"
+            - name: mouse_activity_count
+              type: "SimpleAggregateFunction(sum, Int64)"
+            - name: active_milliseconds
+              type: "SimpleAggregateFunction(sum, Int64)"
+            - name: console_log_count
+              type: "SimpleAggregateFunction(sum, Int64)"
+            - name: console_warn_count
+              type: "SimpleAggregateFunction(sum, Int64)"
+            - name: console_error_count
+              type: "SimpleAggregateFunction(sum, Int64)"
+            - name: size
+              type: "SimpleAggregateFunction(sum, Int64)"
+            - name: message_count
+              type: "SimpleAggregateFunction(sum, Int64)"
+            - name: event_count
+              type: "SimpleAggregateFunction(sum, Int64)"
+            - name: snapshot_source
+              type: "AggregateFunction(argMin, LowCardinality(Nullable(String)), DateTime64(6, 'UTC'))"
+            - name: snapshot_library
+              type: "AggregateFunction(argMin, Nullable(String), DateTime64(6, 'UTC'))"
+            - name: _timestamp
+              type: "SimpleAggregateFunction(max, DateTime)"
+            - name: retention_period_days
+              type: "SimpleAggregateFunction(max, Nullable(Int64))"
+            - name: is_deleted
+              type: "SimpleAggregateFunction(max, UInt8)"
+              default_expression: '0'
+              default_kind: DEFAULT
+
+    session_replay_events:
+        engine: Distributed
+        source: sharded_session_replay_events
+        sharding_key: 'sipHash64(distinct_id)'
+        on_nodes: COORDINATOR
+        columns: inherit sharded_session_replay_events
+
+    writable_session_replay_events:
+        engine: Distributed
+        source: sharded_session_replay_events
+        sharding_key: 'sipHash64(distinct_id)'
+        on_nodes: INGESTION_SMALL
+        columns: inherit sharded_session_replay_events
+
+    kafka_session_replay_events:
+        engine: Kafka
+        on_nodes: INGESTION_SMALL
+        settings:
+            kafka_broker_list: __from_settings__
+            kafka_topic_list: clickhouse_session_replay_events
+            kafka_group_name: session_replay_events_consumer
+            kafka_format: JSONEachRow
+        columns:
+            - name: session_id
+              type: String
+            - name: team_id
+              type: Int64
+            - name: distinct_id
+              type: String
+            - name: first_timestamp
+              type: "DateTime64(6, 'UTC')"
+            - name: last_timestamp
+              type: "DateTime64(6, 'UTC')"
+            - name: block_url
+              type: Nullable(String)
+            - name: first_url
+              type: Nullable(String)
+            - name: urls
+              type: Array(String)
+            - name: click_count
+              type: Int64
+            - name: keypress_count
+              type: Int64
+            - name: mouse_activity_count
+              type: Int64
+            - name: active_milliseconds
+              type: Int64
+            - name: console_log_count
+              type: Int64
+            - name: console_warn_count
+              type: Int64
+            - name: console_error_count
+              type: Int64
+            - name: size
+              type: Int64
+            - name: event_count
+              type: Int64
+            - name: message_count
+              type: Int64
+            - name: snapshot_source
+              type: LowCardinality(Nullable(String))
+            - name: snapshot_library
+              type: Nullable(String)
+            - name: retention_period_days
+              type: Nullable(Int64)
+            - name: is_deleted
+              type: UInt8
+
+    session_replay_events_mv:
+        engine: MaterializedView
+        source: kafka_session_replay_events
+        target: writable_session_replay_events
+        select: "SELECT session_id, team_id, any(distinct_id) as distinct_id, min(first_timestamp) AS min_first_timestamp, max(last_timestamp) AS max_last_timestamp, ... FROM {{ database }}.kafka_session_replay_events GROUP BY session_id, team_id"
+        on_nodes: INGESTION_SMALL
+        columns: []
+
+    sharded_session_replay_embeddings:
+        engine: ReplicatedMergeTree
+        sharded: true
+        on_nodes: DATA
+        order_by:
+            - 'toDate(generation_timestamp)'
+            - team_id
+            - session_id
+        partition_by: 'toYYYYMM(generation_timestamp)'
+        settings:
+            index_granularity: '512'
+        columns:
+            - name: session_id
+              type: String
+            - name: team_id
+              type: Int64
+            - name: embeddings
+              type: Array(Float32)
+            - name: generation_timestamp
+              type: "DateTime64(6, 'UTC')"
+              default_expression: "NOW('UTC')"
+              default_kind: DEFAULT
+            - name: source_type
+              type: LowCardinality(String)
+            - name: input
+              type: String
+
+    session_replay_embeddings:
+        engine: Distributed
+        source: sharded_session_replay_embeddings
+        sharding_key: 'sipHash64(session_id)'
+        on_nodes: COORDINATOR
+        columns: inherit sharded_session_replay_embeddings
+
+    writable_session_replay_embeddings:
+        engine: Distributed
+        source: sharded_session_replay_embeddings
+        sharding_key: 'sipHash64(session_id)'
+        on_nodes: COORDINATOR
+        columns: inherit sharded_session_replay_embeddings
+
+    # Legacy session_recording_events tables (still in production)
+    session_recording_events:
+        engine: Distributed
+        source: sharded_session_replay_events
+        sharding_key: 'sipHash64(distinct_id)'
+        on_nodes: COORDINATOR
+        columns: inherit sharded_session_replay_events
+
+    writable_session_recording_events:
+        engine: Distributed
+        source: sharded_session_replay_events
+        sharding_key: 'sipHash64(distinct_id)'
+        on_nodes: COORDINATOR
+        columns: inherit sharded_session_replay_events

--- a/posthog/clickhouse/schema/session_replay.yaml
+++ b/posthog/clickhouse/schema/session_replay.yaml
@@ -73,7 +73,7 @@ tables:
         engine: Distributed
         source: sharded_session_replay_events
         sharding_key: 'sipHash64(distinct_id)'
-        on_nodes: COORDINATOR
+        on_nodes: DATA
         columns: inherit sharded_session_replay_events
 
     writable_session_replay_events:
@@ -176,14 +176,14 @@ tables:
         engine: Distributed
         source: sharded_session_replay_embeddings
         sharding_key: 'sipHash64(session_id)'
-        on_nodes: COORDINATOR
+        on_nodes: DATA
         columns: inherit sharded_session_replay_embeddings
 
     writable_session_replay_embeddings:
         engine: Distributed
         source: sharded_session_replay_embeddings
         sharding_key: 'sipHash64(session_id)'
-        on_nodes: COORDINATOR
+        on_nodes: DATA
         columns: inherit sharded_session_replay_embeddings
 
     # Legacy session_recording_events tables (still in production)
@@ -191,12 +191,12 @@ tables:
         engine: Distributed
         source: sharded_session_replay_events
         sharding_key: 'sipHash64(distinct_id)'
-        on_nodes: COORDINATOR
+        on_nodes: DATA
         columns: inherit sharded_session_replay_events
 
     writable_session_recording_events:
         engine: Distributed
         source: sharded_session_replay_events
         sharding_key: 'sipHash64(distinct_id)'
-        on_nodes: COORDINATOR
+        on_nodes: DATA
         columns: inherit sharded_session_replay_events

--- a/posthog/clickhouse/schema/session_replay.yaml
+++ b/posthog/clickhouse/schema/session_replay.yaml
@@ -73,7 +73,7 @@ tables:
         engine: Distributed
         source: sharded_session_replay_events
         sharding_key: 'sipHash64(distinct_id)'
-        on_nodes: DATA
+        on_nodes: COORDINATOR
         columns: inherit sharded_session_replay_events
 
     writable_session_replay_events:
@@ -176,14 +176,14 @@ tables:
         engine: Distributed
         source: sharded_session_replay_embeddings
         sharding_key: 'sipHash64(session_id)'
-        on_nodes: DATA
+        on_nodes: COORDINATOR
         columns: inherit sharded_session_replay_embeddings
 
     writable_session_replay_embeddings:
         engine: Distributed
         source: sharded_session_replay_embeddings
         sharding_key: 'sipHash64(session_id)'
-        on_nodes: DATA
+        on_nodes: COORDINATOR
         columns: inherit sharded_session_replay_embeddings
 
     # Legacy session_recording_events tables (still in production)
@@ -191,12 +191,12 @@ tables:
         engine: Distributed
         source: sharded_session_replay_events
         sharding_key: 'sipHash64(distinct_id)'
-        on_nodes: DATA
+        on_nodes: COORDINATOR
         columns: inherit sharded_session_replay_events
 
     writable_session_recording_events:
         engine: Distributed
         source: sharded_session_replay_events
         sharding_key: 'sipHash64(distinct_id)'
-        on_nodes: DATA
+        on_nodes: COORDINATOR
         columns: inherit sharded_session_replay_events

--- a/posthog/clickhouse/schema/sessions.yaml
+++ b/posthog/clickhouse/schema/sessions.yaml
@@ -1,0 +1,138 @@
+# Desired-state schema for the sessions v1 ecosystem (legacy, limited to specific teams).
+
+ecosystem: sessions
+cluster: main
+
+tables:
+    sharded_sessions:
+        engine: ReplicatedAggregatingMergeTree
+        sharded: true
+        on_nodes: DATA
+        order_by:
+            - 'toStartOfDay(min_timestamp)'
+            - team_id
+            - session_id
+        partition_by: 'toYYYYMM(min_timestamp)'
+        settings:
+            index_granularity: '512'
+        columns:
+            - name: session_id
+              type: String
+            - name: team_id
+              type: Int64
+            - name: distinct_id
+              type: "SimpleAggregateFunction(any, String)"
+            - name: min_timestamp
+              type: "SimpleAggregateFunction(min, DateTime64(6, 'UTC'))"
+            - name: max_timestamp
+              type: "SimpleAggregateFunction(max, DateTime64(6, 'UTC'))"
+            - name: urls
+              type: "SimpleAggregateFunction(groupUniqArrayArray, Array(String))"
+            - name: entry_url
+              type: "AggregateFunction(argMin, String, DateTime64(6, 'UTC'))"
+            - name: exit_url
+              type: "AggregateFunction(argMax, String, DateTime64(6, 'UTC'))"
+            - name: initial_referring_domain
+              type: "AggregateFunction(argMin, String, DateTime64(6, 'UTC'))"
+            - name: initial_utm_source
+              type: "AggregateFunction(argMin, String, DateTime64(6, 'UTC'))"
+            - name: initial_utm_campaign
+              type: "AggregateFunction(argMin, String, DateTime64(6, 'UTC'))"
+            - name: initial_utm_medium
+              type: "AggregateFunction(argMin, String, DateTime64(6, 'UTC'))"
+            - name: initial_utm_term
+              type: "AggregateFunction(argMin, String, DateTime64(6, 'UTC'))"
+            - name: initial_utm_content
+              type: "AggregateFunction(argMin, String, DateTime64(6, 'UTC'))"
+            - name: initial_gclid
+              type: "AggregateFunction(argMin, String, DateTime64(6, 'UTC'))"
+            - name: initial_gad_source
+              type: "AggregateFunction(argMin, String, DateTime64(6, 'UTC'))"
+            - name: initial_gclsrc
+              type: "AggregateFunction(argMin, String, DateTime64(6, 'UTC'))"
+            - name: initial_dclid
+              type: "AggregateFunction(argMin, String, DateTime64(6, 'UTC'))"
+            - name: initial_gbraid
+              type: "AggregateFunction(argMin, String, DateTime64(6, 'UTC'))"
+            - name: initial_wbraid
+              type: "AggregateFunction(argMin, String, DateTime64(6, 'UTC'))"
+            - name: initial_fbclid
+              type: "AggregateFunction(argMin, String, DateTime64(6, 'UTC'))"
+            - name: initial_msclkid
+              type: "AggregateFunction(argMin, String, DateTime64(6, 'UTC'))"
+            - name: initial_twclid
+              type: "AggregateFunction(argMin, String, DateTime64(6, 'UTC'))"
+            - name: initial_li_fat_id
+              type: "AggregateFunction(argMin, String, DateTime64(6, 'UTC'))"
+            - name: initial_mc_cid
+              type: "AggregateFunction(argMin, String, DateTime64(6, 'UTC'))"
+            - name: initial_igshid
+              type: "AggregateFunction(argMin, String, DateTime64(6, 'UTC'))"
+            - name: initial_ttclid
+              type: "AggregateFunction(argMin, String, DateTime64(6, 'UTC'))"
+            - name: initial_epik
+              type: "AggregateFunction(argMin, String, DateTime64(6, 'UTC'))"
+            - name: initial_qclid
+              type: "AggregateFunction(argMin, String, DateTime64(6, 'UTC'))"
+            - name: initial_sccid
+              type: "AggregateFunction(argMin, String, DateTime64(6, 'UTC'))"
+            - name: event_count_map
+              type: "SimpleAggregateFunction(sumMap, Map(String, Int64))"
+            - name: pageview_count
+              type: "SimpleAggregateFunction(sum, Int64)"
+            - name: autocapture_count
+              type: "SimpleAggregateFunction(sum, Int64)"
+
+    writable_sessions:
+        engine: Distributed
+        source: sharded_sessions
+        sharding_key: 'sipHash64(session_id)'
+        on_nodes: COORDINATOR
+        columns: inherit sharded_sessions
+
+    sessions:
+        engine: Distributed
+        source: sharded_sessions
+        sharding_key: 'sipHash64(session_id)'
+        on_nodes: ALL
+        columns: inherit sharded_sessions
+
+    sessions_mv:
+        engine: MaterializedView
+        source: sharded_events
+        target: writable_sessions
+        select: "SELECT ... FROM {{ database }}.sharded_events"
+        on_nodes: DATA
+        columns: []
+
+    # Production-only tables for sessions rework
+    new_sessions:
+        engine: ReplicatedAggregatingMergeTree
+        sharded: false
+        on_nodes: DATA
+        order_by:
+            - team_id
+            - session_id
+        columns: inherit sharded_sessions
+
+    new_writable_sessions:
+        engine: Distributed
+        source: new_sessions
+        sharding_key: 'sipHash64(session_id)'
+        on_nodes: COORDINATOR
+        columns: inherit sharded_sessions
+
+    new_sessions_mv:
+        engine: MaterializedView
+        source: sharded_events
+        target: new_writable_sessions
+        select: "SELECT ... FROM {{ database }}.sharded_events"
+        on_nodes: DATA
+        columns: []
+
+    writable_sessions_background:
+        engine: Distributed
+        source: sharded_sessions
+        sharding_key: 'sipHash64(session_id)'
+        on_nodes: COORDINATOR
+        columns: inherit sharded_sessions

--- a/posthog/clickhouse/schema/sessions.yaml
+++ b/posthog/clickhouse/schema/sessions.yaml
@@ -21,13 +21,13 @@ tables:
             - name: team_id
               type: Int64
             - name: distinct_id
-              type: "SimpleAggregateFunction(any, String)"
+              type: 'SimpleAggregateFunction(any, String)'
             - name: min_timestamp
               type: "SimpleAggregateFunction(min, DateTime64(6, 'UTC'))"
             - name: max_timestamp
               type: "SimpleAggregateFunction(max, DateTime64(6, 'UTC'))"
             - name: urls
-              type: "SimpleAggregateFunction(groupUniqArrayArray, Array(String))"
+              type: 'SimpleAggregateFunction(groupUniqArrayArray, Array(String))'
             - name: entry_url
               type: "AggregateFunction(argMin, String, DateTime64(6, 'UTC'))"
             - name: exit_url
@@ -77,11 +77,11 @@ tables:
             - name: initial_sccid
               type: "AggregateFunction(argMin, String, DateTime64(6, 'UTC'))"
             - name: event_count_map
-              type: "SimpleAggregateFunction(sumMap, Map(String, Int64))"
+              type: 'SimpleAggregateFunction(sumMap, Map(String, Int64))'
             - name: pageview_count
-              type: "SimpleAggregateFunction(sum, Int64)"
+              type: 'SimpleAggregateFunction(sum, Int64)'
             - name: autocapture_count
-              type: "SimpleAggregateFunction(sum, Int64)"
+              type: 'SimpleAggregateFunction(sum, Int64)'
 
     writable_sessions:
         engine: Distributed
@@ -101,7 +101,7 @@ tables:
         engine: MaterializedView
         source: sharded_events
         target: writable_sessions
-        select: "SELECT ... FROM {{ database }}.sharded_events"
+        select: 'SELECT ... FROM {{ database }}.sharded_events'
         on_nodes: DATA
         columns: []
 
@@ -126,7 +126,7 @@ tables:
         engine: MaterializedView
         source: sharded_events
         target: new_writable_sessions
-        select: "SELECT ... FROM {{ database }}.sharded_events"
+        select: 'SELECT ... FROM {{ database }}.sharded_events'
         on_nodes: DATA
         columns: []
 

--- a/posthog/clickhouse/schema/sessions.yaml
+++ b/posthog/clickhouse/schema/sessions.yaml
@@ -87,7 +87,7 @@ tables:
         engine: Distributed
         source: sharded_sessions
         sharding_key: 'sipHash64(session_id)'
-        on_nodes: DATA
+        on_nodes: COORDINATOR
         columns: inherit sharded_sessions
 
     sessions:
@@ -119,7 +119,7 @@ tables:
         engine: Distributed
         source: new_sessions
         sharding_key: 'sipHash64(session_id)'
-        on_nodes: DATA
+        on_nodes: COORDINATOR
         columns: inherit sharded_sessions
 
     new_sessions_mv:
@@ -134,5 +134,5 @@ tables:
         engine: Distributed
         source: sharded_sessions
         sharding_key: 'sipHash64(session_id)'
-        on_nodes: DATA
+        on_nodes: COORDINATOR
         columns: inherit sharded_sessions

--- a/posthog/clickhouse/schema/sessions.yaml
+++ b/posthog/clickhouse/schema/sessions.yaml
@@ -87,7 +87,7 @@ tables:
         engine: Distributed
         source: sharded_sessions
         sharding_key: 'sipHash64(session_id)'
-        on_nodes: COORDINATOR
+        on_nodes: DATA
         columns: inherit sharded_sessions
 
     sessions:
@@ -119,7 +119,7 @@ tables:
         engine: Distributed
         source: new_sessions
         sharding_key: 'sipHash64(session_id)'
-        on_nodes: COORDINATOR
+        on_nodes: DATA
         columns: inherit sharded_sessions
 
     new_sessions_mv:
@@ -134,5 +134,5 @@ tables:
         engine: Distributed
         source: sharded_sessions
         sharding_key: 'sipHash64(session_id)'
-        on_nodes: COORDINATOR
+        on_nodes: DATA
         columns: inherit sharded_sessions

--- a/posthog/clickhouse/schema/sessions_v3.yaml
+++ b/posthog/clickhouse/schema/sessions_v3.yaml
@@ -1,0 +1,84 @@
+# Desired-state schema for the sessions_v3 ecosystem.
+
+ecosystem: sessions_v3
+cluster: main
+
+tables:
+    sharded_raw_sessions_v3:
+        engine: ReplicatedMergeTree
+        sharded: true
+        on_nodes: DATA
+        order_by:
+            - team_id
+            - 'toStartOfDay(min_first_timestamp)'
+            - session_id_v7
+        partition_by: 'toYYYYMM(min_first_timestamp)'
+        columns:
+            - name: team_id
+              type: Int64
+            - name: session_id_v7
+              type: UInt128
+            - name: min_first_timestamp
+              type: DateTime64(6, 'UTC')
+            - name: max_last_timestamp
+              type: DateTime64(6, 'UTC')
+            - name: urls
+              type: Array(String)
+            - name: entry_url
+              type: String
+            - name: end_url
+              type: String
+            - name: initial_referring_domain
+              type: String
+            - name: initial_utm_source
+              type: String
+            - name: initial_utm_campaign
+              type: String
+            - name: initial_utm_medium
+              type: String
+            - name: initial_utm_term
+              type: String
+            - name: initial_utm_content
+              type: String
+            - name: initial_gclid
+              type: String
+            - name: initial_gad_source
+              type: String
+            - name: pageview_count
+              type: Int64
+            - name: autocapture_count
+              type: Int64
+            - name: screen_count
+              type: Int64
+            - name: event_count
+              type: Int64
+
+    writable_raw_sessions_v3:
+        engine: Distributed
+        source: sharded_raw_sessions_v3
+        sharding_key: 'cityHash64(session_id_v7)'
+        on_nodes: COORDINATOR
+        columns: inherit sharded_raw_sessions_v3
+
+    raw_sessions_v3:
+        engine: Distributed
+        source: sharded_raw_sessions_v3
+        sharding_key: 'cityHash64(session_id_v7)'
+        on_nodes: ALL
+        columns: inherit sharded_raw_sessions_v3
+
+    raw_sessions_v3_mv:
+        engine: MaterializedView
+        source: sharded_events
+        target: writable_raw_sessions_v3
+        select: "SELECT ... FROM {{ database }}.sharded_events"
+        on_nodes: DATA
+        columns: []
+
+    raw_sessions_v3_recordings_mv:
+        engine: MaterializedView
+        source: sharded_session_replay_events
+        target: writable_raw_sessions_v3
+        select: "SELECT ... FROM {{ database }}.sharded_session_replay_events"
+        on_nodes: DATA
+        columns: []

--- a/posthog/clickhouse/schema/sessions_v3.yaml
+++ b/posthog/clickhouse/schema/sessions_v3.yaml
@@ -57,7 +57,7 @@ tables:
         engine: Distributed
         source: sharded_raw_sessions_v3
         sharding_key: 'cityHash64(session_id_v7)'
-        on_nodes: COORDINATOR
+        on_nodes: DATA
         columns: inherit sharded_raw_sessions_v3
 
     raw_sessions_v3:

--- a/posthog/clickhouse/schema/sessions_v3.yaml
+++ b/posthog/clickhouse/schema/sessions_v3.yaml
@@ -29,7 +29,7 @@ tables:
             - name: distinct_id
               type: "AggregateFunction(argMax, String, DateTime64(6, 'UTC'))"
             - name: distinct_ids
-              type: "AggregateFunction(groupUniqArray, String)"
+              type: 'AggregateFunction(groupUniqArray, String)'
             - name: min_timestamp
               type: "SimpleAggregateFunction(min, DateTime64(6, 'UTC'))"
             - name: max_timestamp
@@ -37,7 +37,7 @@ tables:
             - name: max_inserted_at
               type: "SimpleAggregateFunction(max, DateTime64(6, 'UTC'))"
             - name: urls
-              type: "SimpleAggregateFunction(groupUniqArrayArray(2000), Array(String))"
+              type: 'SimpleAggregateFunction(groupUniqArrayArray(2000), Array(String))'
             - name: entry_url
               type: "AggregateFunction(argMin, Nullable(String), DateTime64(6, 'UTC'))"
             - name: end_url
@@ -97,27 +97,27 @@ tables:
             - name: entry_channel_type_properties
               type: "AggregateFunction(argMin, Tuple(Nullable(String), Nullable(String), Nullable(String), Nullable(String), Bool, Bool, Nullable(String)), DateTime64(6, 'UTC'))"
             - name: pageview_uniq
-              type: "AggregateFunction(uniqExact, Nullable(UUID))"
+              type: 'AggregateFunction(uniqExact, Nullable(UUID))'
             - name: autocapture_uniq
-              type: "AggregateFunction(uniqExact, Nullable(UUID))"
+              type: 'AggregateFunction(uniqExact, Nullable(UUID))'
             - name: screen_uniq
-              type: "AggregateFunction(uniqExact, Nullable(UUID))"
+              type: 'AggregateFunction(uniqExact, Nullable(UUID))'
             - name: page_screen_uniq_up_to
-              type: "AggregateFunction(uniqUpTo(1), Nullable(UUID))"
+              type: 'AggregateFunction(uniqUpTo(1), Nullable(UUID))'
             - name: has_autocapture
-              type: "SimpleAggregateFunction(max, Bool)"
+              type: 'SimpleAggregateFunction(max, Bool)'
             - name: flag_values
-              type: "AggregateFunction(groupUniqArrayMap, Map(String, String))"
+              type: 'AggregateFunction(groupUniqArrayMap, Map(String, String))'
             - name: flag_keys
-              type: "SimpleAggregateFunction(groupUniqArrayArray, Array(String))"
+              type: 'SimpleAggregateFunction(groupUniqArrayArray, Array(String))'
             - name: event_names
-              type: "SimpleAggregateFunction(groupUniqArrayArray(2000), Array(String))"
+              type: 'SimpleAggregateFunction(groupUniqArrayArray(2000), Array(String))'
             - name: hosts
-              type: "SimpleAggregateFunction(groupUniqArrayArray(100), Array(String))"
+              type: 'SimpleAggregateFunction(groupUniqArrayArray(100), Array(String))'
             - name: emails
-              type: "SimpleAggregateFunction(groupUniqArrayArray(10), Array(String))"
+              type: 'SimpleAggregateFunction(groupUniqArrayArray(10), Array(String))'
             - name: has_replay_events
-              type: "SimpleAggregateFunction(max, Bool)"
+              type: 'SimpleAggregateFunction(max, Bool)'
 
     writable_raw_sessions_v3:
         engine: Distributed
@@ -137,7 +137,7 @@ tables:
         engine: MaterializedView
         source: sharded_events
         target: writable_raw_sessions_v3
-        select: "SELECT ... FROM {{ database }}.sharded_events"
+        select: 'SELECT ... FROM {{ database }}.sharded_events'
         on_nodes: DATA
         columns: []
 
@@ -145,6 +145,6 @@ tables:
         engine: MaterializedView
         source: sharded_session_replay_events
         target: writable_raw_sessions_v3
-        select: "SELECT ... FROM {{ database }}.sharded_session_replay_events"
+        select: 'SELECT ... FROM {{ database }}.sharded_session_replay_events'
         on_nodes: DATA
         columns: []

--- a/posthog/clickhouse/schema/sessions_v3.yaml
+++ b/posthog/clickhouse/schema/sessions_v3.yaml
@@ -1,57 +1,123 @@
 # Desired-state schema for the sessions_v3 ecosystem.
+#
+# Session pre-aggregation with AggregateFunction columns -- each event is
+# partially aggregated into a session row via initializeAggregation() in the MV,
+# then merged server-side with *-Merge combinators at query time.
 
 ecosystem: sessions_v3
 cluster: main
 
 tables:
     sharded_raw_sessions_v3:
-        engine: ReplicatedMergeTree
+        engine: ReplicatedAggregatingMergeTree
         sharded: true
         on_nodes: DATA
         order_by:
             - team_id
-            - 'toStartOfDay(min_first_timestamp)'
+            - session_timestamp
             - session_id_v7
-        partition_by: 'toYYYYMM(min_first_timestamp)'
+        partition_by: 'toYYYYMM(session_timestamp)'
         columns:
             - name: team_id
               type: Int64
             - name: session_id_v7
               type: UInt128
-            - name: min_first_timestamp
-              type: DateTime64(6, 'UTC')
-            - name: max_last_timestamp
-              type: DateTime64(6, 'UTC')
+            - name: session_timestamp
+              type: DateTime64(3)
+              default_kind: DEFAULT
+              default_expression: 'fromUnixTimestamp64Milli(toUInt64(bitShiftRight(session_id_v7, 80)))'
+            - name: distinct_id
+              type: "AggregateFunction(argMax, String, DateTime64(6, 'UTC'))"
+            - name: distinct_ids
+              type: "AggregateFunction(groupUniqArray, String)"
+            - name: min_timestamp
+              type: "SimpleAggregateFunction(min, DateTime64(6, 'UTC'))"
+            - name: max_timestamp
+              type: "SimpleAggregateFunction(max, DateTime64(6, 'UTC'))"
+            - name: max_inserted_at
+              type: "SimpleAggregateFunction(max, DateTime64(6, 'UTC'))"
             - name: urls
-              type: Array(String)
+              type: "SimpleAggregateFunction(groupUniqArrayArray(2000), Array(String))"
             - name: entry_url
-              type: String
+              type: "AggregateFunction(argMin, Nullable(String), DateTime64(6, 'UTC'))"
             - name: end_url
-              type: String
-            - name: initial_referring_domain
-              type: String
-            - name: initial_utm_source
-              type: String
-            - name: initial_utm_campaign
-              type: String
-            - name: initial_utm_medium
-              type: String
-            - name: initial_utm_term
-              type: String
-            - name: initial_utm_content
-              type: String
-            - name: initial_gclid
-              type: String
-            - name: initial_gad_source
-              type: String
-            - name: pageview_count
-              type: Int64
-            - name: autocapture_count
-              type: Int64
-            - name: screen_count
-              type: Int64
-            - name: event_count
-              type: Int64
+              type: "AggregateFunction(argMax, Nullable(String), DateTime64(6, 'UTC'))"
+            - name: last_external_click_url
+              type: "AggregateFunction(argMax, Nullable(String), DateTime64(6, 'UTC'))"
+            - name: browser
+              type: "AggregateFunction(argMin, Nullable(String), DateTime64(6, 'UTC'))"
+            - name: browser_version
+              type: "AggregateFunction(argMin, Nullable(String), DateTime64(6, 'UTC'))"
+            - name: os
+              type: "AggregateFunction(argMin, Nullable(String), DateTime64(6, 'UTC'))"
+            - name: os_version
+              type: "AggregateFunction(argMin, Nullable(String), DateTime64(6, 'UTC'))"
+            - name: device_type
+              type: "AggregateFunction(argMin, Nullable(String), DateTime64(6, 'UTC'))"
+            - name: viewport_width
+              type: "AggregateFunction(argMin, Nullable(Int64), DateTime64(6, 'UTC'))"
+            - name: viewport_height
+              type: "AggregateFunction(argMin, Nullable(Int64), DateTime64(6, 'UTC'))"
+            - name: geoip_country_code
+              type: "AggregateFunction(argMin, Nullable(String), DateTime64(6, 'UTC'))"
+            - name: geoip_subdivision_1_code
+              type: "AggregateFunction(argMin, Nullable(String), DateTime64(6, 'UTC'))"
+            - name: geoip_subdivision_1_name
+              type: "AggregateFunction(argMin, Nullable(String), DateTime64(6, 'UTC'))"
+            - name: geoip_subdivision_city_name
+              type: "AggregateFunction(argMin, Nullable(String), DateTime64(6, 'UTC'))"
+            - name: geoip_time_zone
+              type: "AggregateFunction(argMin, Nullable(String), DateTime64(6, 'UTC'))"
+            - name: entry_referring_domain
+              type: "AggregateFunction(argMin, Nullable(String), DateTime64(6, 'UTC'))"
+            - name: entry_utm_source
+              type: "AggregateFunction(argMin, Nullable(String), DateTime64(6, 'UTC'))"
+            - name: entry_utm_campaign
+              type: "AggregateFunction(argMin, Nullable(String), DateTime64(6, 'UTC'))"
+            - name: entry_utm_medium
+              type: "AggregateFunction(argMin, Nullable(String), DateTime64(6, 'UTC'))"
+            - name: entry_utm_term
+              type: "AggregateFunction(argMin, Nullable(String), DateTime64(6, 'UTC'))"
+            - name: entry_utm_content
+              type: "AggregateFunction(argMin, Nullable(String), DateTime64(6, 'UTC'))"
+            - name: entry_gclid
+              type: "AggregateFunction(argMin, Nullable(String), DateTime64(6, 'UTC'))"
+            - name: entry_gad_source
+              type: "AggregateFunction(argMin, Nullable(String), DateTime64(6, 'UTC'))"
+            - name: entry_fbclid
+              type: "AggregateFunction(argMin, Nullable(String), DateTime64(6, 'UTC'))"
+            - name: entry_has_gclid
+              type: "AggregateFunction(argMin, Bool, DateTime64(6, 'UTC'))"
+            - name: entry_has_fbclid
+              type: "AggregateFunction(argMin, Bool, DateTime64(6, 'UTC'))"
+            - name: entry_ad_ids_map
+              type: "AggregateFunction(argMin, Map(String, String), DateTime64(6, 'UTC'))"
+            - name: entry_ad_ids_set
+              type: "AggregateFunction(argMin, Array(String), DateTime64(6, 'UTC'))"
+            - name: entry_channel_type_properties
+              type: "AggregateFunction(argMin, Tuple(Nullable(String), Nullable(String), Nullable(String), Nullable(String), Bool, Bool, Nullable(String)), DateTime64(6, 'UTC'))"
+            - name: pageview_uniq
+              type: "AggregateFunction(uniqExact, Nullable(UUID))"
+            - name: autocapture_uniq
+              type: "AggregateFunction(uniqExact, Nullable(UUID))"
+            - name: screen_uniq
+              type: "AggregateFunction(uniqExact, Nullable(UUID))"
+            - name: page_screen_uniq_up_to
+              type: "AggregateFunction(uniqUpTo(1), Nullable(UUID))"
+            - name: has_autocapture
+              type: "SimpleAggregateFunction(max, Bool)"
+            - name: flag_values
+              type: "AggregateFunction(groupUniqArrayMap, Map(String, String))"
+            - name: flag_keys
+              type: "SimpleAggregateFunction(groupUniqArrayArray, Array(String))"
+            - name: event_names
+              type: "SimpleAggregateFunction(groupUniqArrayArray(2000), Array(String))"
+            - name: hosts
+              type: "SimpleAggregateFunction(groupUniqArrayArray(100), Array(String))"
+            - name: emails
+              type: "SimpleAggregateFunction(groupUniqArrayArray(10), Array(String))"
+            - name: has_replay_events
+              type: "SimpleAggregateFunction(max, Bool)"
 
     writable_raw_sessions_v3:
         engine: Distributed

--- a/posthog/clickhouse/schema/sessions_v3.yaml
+++ b/posthog/clickhouse/schema/sessions_v3.yaml
@@ -57,7 +57,7 @@ tables:
         engine: Distributed
         source: sharded_raw_sessions_v3
         sharding_key: 'cityHash64(session_id_v7)'
-        on_nodes: DATA
+        on_nodes: COORDINATOR
         columns: inherit sharded_raw_sessions_v3
 
     raw_sessions_v3:

--- a/posthog/clickhouse/schema/tophog.yaml
+++ b/posthog/clickhouse/schema/tophog.yaml
@@ -27,7 +27,7 @@ tables:
               default_expression: "'sum'"
               default_kind: DEFAULT
             - name: key
-              type: "Map(LowCardinality(String), String)"
+              type: 'Map(LowCardinality(String), String)'
             - name: value
               type: Float64
             - name: count
@@ -39,7 +39,7 @@ tables:
             - name: lane
               type: LowCardinality(String)
             - name: labels
-              type: "Map(LowCardinality(String), String)"
+              type: 'Map(LowCardinality(String), String)'
 
     writable_tophog:
         engine: Distributed
@@ -72,7 +72,7 @@ tables:
             - name: type
               type: LowCardinality(String)
             - name: key
-              type: "Map(LowCardinality(String), String)"
+              type: 'Map(LowCardinality(String), String)'
             - name: value
               type: Float64
             - name: count
@@ -82,12 +82,12 @@ tables:
             - name: lane
               type: LowCardinality(String)
             - name: labels
-              type: "Map(LowCardinality(String), String)"
+              type: 'Map(LowCardinality(String), String)'
 
     tophog_mv:
         engine: MaterializedView
         source: kafka_tophog
         target: writable_tophog
-        select: "SELECT timestamp, metric, type, key, value, count, pipeline, lane, labels FROM {{ database }}.kafka_tophog"
+        select: 'SELECT timestamp, metric, type, key, value, count, pipeline, lane, labels FROM {{ database }}.kafka_tophog'
         on_nodes: INGESTION_EVENTS
         columns: []

--- a/posthog/clickhouse/schema/tophog.yaml
+++ b/posthog/clickhouse/schema/tophog.yaml
@@ -1,0 +1,93 @@
+# Desired-state schema for the tophog ecosystem.
+
+ecosystem: tophog
+cluster: main
+
+tables:
+    sharded_tophog:
+        engine: ReplicatedMergeTree
+        sharded: true
+        on_nodes: DATA
+        order_by:
+            - pipeline
+            - lane
+            - metric
+            - timestamp
+            - key
+        partition_by: 'toYYYYMMDD(timestamp)'
+        settings:
+            ttl_only_drop_parts: '1'
+        columns:
+            - name: timestamp
+              type: "DateTime64(6, 'UTC')"
+            - name: metric
+              type: LowCardinality(String)
+            - name: type
+              type: LowCardinality(String)
+              default_expression: "'sum'"
+              default_kind: DEFAULT
+            - name: key
+              type: "Map(LowCardinality(String), String)"
+            - name: value
+              type: Float64
+            - name: count
+              type: UInt64
+              default_expression: '0'
+              default_kind: DEFAULT
+            - name: pipeline
+              type: LowCardinality(String)
+            - name: lane
+              type: LowCardinality(String)
+            - name: labels
+              type: "Map(LowCardinality(String), String)"
+
+    writable_tophog:
+        engine: Distributed
+        source: sharded_tophog
+        sharding_key: 'cityHash64(toString(key))'
+        on_nodes: COORDINATOR
+        columns: inherit sharded_tophog
+
+    tophog:
+        engine: Distributed
+        source: sharded_tophog
+        sharding_key: 'cityHash64(toString(key))'
+        on_nodes: ALL
+        columns: inherit sharded_tophog
+
+    kafka_tophog:
+        engine: Kafka
+        on_nodes: INGESTION_EVENTS
+        settings:
+            kafka_broker_list: __from_settings__
+            kafka_topic_list: clickhouse_tophog
+            kafka_group_name: tophog
+            kafka_format: JSONEachRow
+            kafka_skip_broken_messages: '100'
+        columns:
+            - name: timestamp
+              type: "DateTime64(6, 'UTC')"
+            - name: metric
+              type: LowCardinality(String)
+            - name: type
+              type: LowCardinality(String)
+            - name: key
+              type: "Map(LowCardinality(String), String)"
+            - name: value
+              type: Float64
+            - name: count
+              type: UInt64
+            - name: pipeline
+              type: LowCardinality(String)
+            - name: lane
+              type: LowCardinality(String)
+            - name: labels
+              type: "Map(LowCardinality(String), String)"
+
+    tophog_mv:
+        engine: MaterializedView
+        source: kafka_tophog
+        target: writable_tophog
+        select: "SELECT timestamp, metric, type, key, value, count, pipeline, lane, labels FROM {{ database }}.kafka_tophog"
+        on_nodes: INGESTION_EVENTS
+        columns: []

--- a/posthog/clickhouse/schema/tophog.yaml
+++ b/posthog/clickhouse/schema/tophog.yaml
@@ -45,7 +45,7 @@ tables:
         engine: Distributed
         source: sharded_tophog
         sharding_key: 'cityHash64(toString(key))'
-        on_nodes: DATA
+        on_nodes: COORDINATOR
         columns: inherit sharded_tophog
 
     tophog:

--- a/posthog/clickhouse/schema/tophog.yaml
+++ b/posthog/clickhouse/schema/tophog.yaml
@@ -45,7 +45,7 @@ tables:
         engine: Distributed
         source: sharded_tophog
         sharding_key: 'cityHash64(toString(key))'
-        on_nodes: COORDINATOR
+        on_nodes: DATA
         columns: inherit sharded_tophog
 
     tophog:

--- a/posthog/clickhouse/schema/web_preaggregated.yaml
+++ b/posthog/clickhouse/schema/web_preaggregated.yaml
@@ -1,0 +1,430 @@
+# Desired-state schema for the web_preaggregated ecosystem.
+# Pre-aggregated web analytics tables for fast dashboard queries.
+
+ecosystem: web_preaggregated
+cluster: main
+
+tables:
+    web_pre_aggregated_stats:
+        engine: ReplicatedMergeTree
+        sharded: false
+        on_nodes: DATA
+        order_by:
+            - team_id
+            - period_bucket
+            - host
+            - device_type
+            - pathname
+            - entry_pathname
+            - end_pathname
+            - browser
+            - os
+            - viewport_width
+            - viewport_height
+            - referring_domain
+            - utm_source
+            - utm_medium
+            - utm_campaign
+            - utm_term
+            - utm_content
+            - country_code
+            - city_name
+            - region_code
+            - region_name
+            - has_gclid
+            - has_gad_source_paid_search
+            - has_fbclid
+        partition_by: 'toYYYYMMDD(period_bucket)'
+        columns:
+            - name: period_bucket
+              type: DateTime
+            - name: team_id
+              type: UInt64
+            - name: host
+              type: String
+            - name: device_type
+              type: String
+            - name: pathname
+              type: String
+            - name: entry_pathname
+              type: String
+            - name: end_pathname
+              type: String
+            - name: browser
+              type: String
+            - name: os
+              type: String
+            - name: viewport_width
+              type: Int64
+            - name: viewport_height
+              type: Int64
+            - name: referring_domain
+              type: String
+            - name: utm_source
+              type: String
+            - name: utm_medium
+              type: String
+            - name: utm_campaign
+              type: String
+            - name: utm_term
+              type: String
+            - name: utm_content
+              type: String
+            - name: country_code
+              type: String
+            - name: city_name
+              type: String
+            - name: region_code
+              type: String
+            - name: region_name
+              type: String
+            - name: has_gclid
+              type: Bool
+            - name: has_gad_source_paid_search
+              type: Bool
+            - name: has_fbclid
+              type: Bool
+            - name: mat_metadata_backend
+              type: Nullable(String)
+            - name: persons_uniq_state
+              type: "AggregateFunction(uniq, UUID)"
+            - name: sessions_uniq_state
+              type: "AggregateFunction(uniq, String)"
+            - name: pageviews_count_state
+              type: "AggregateFunction(sum, UInt64)"
+            - name: mat_metadata_loggedIn
+              type: Nullable(Bool)
+
+    web_pre_aggregated_bounces:
+        engine: ReplicatedMergeTree
+        sharded: false
+        on_nodes: DATA
+        order_by:
+            - team_id
+            - period_bucket
+            - host
+            - device_type
+            - entry_pathname
+            - end_pathname
+            - browser
+            - os
+            - viewport_width
+            - viewport_height
+            - referring_domain
+            - utm_source
+            - utm_medium
+            - utm_campaign
+            - utm_term
+            - utm_content
+            - country_code
+            - city_name
+            - region_code
+            - region_name
+            - has_gclid
+            - has_gad_source_paid_search
+            - has_fbclid
+        partition_by: 'toYYYYMMDD(period_bucket)'
+        columns:
+            - name: period_bucket
+              type: DateTime
+            - name: team_id
+              type: UInt64
+            - name: host
+              type: String
+            - name: device_type
+              type: String
+            - name: entry_pathname
+              type: String
+            - name: end_pathname
+              type: String
+            - name: browser
+              type: String
+            - name: os
+              type: String
+            - name: viewport_width
+              type: Int64
+            - name: viewport_height
+              type: Int64
+            - name: referring_domain
+              type: String
+            - name: utm_source
+              type: String
+            - name: utm_medium
+              type: String
+            - name: utm_campaign
+              type: String
+            - name: utm_term
+              type: String
+            - name: utm_content
+              type: String
+            - name: country_code
+              type: String
+            - name: city_name
+              type: String
+            - name: region_code
+              type: String
+            - name: region_name
+              type: String
+            - name: has_gclid
+              type: Bool
+            - name: has_gad_source_paid_search
+              type: Bool
+            - name: has_fbclid
+              type: Bool
+            - name: mat_metadata_backend
+              type: Nullable(String)
+            - name: persons_uniq_state
+              type: "AggregateFunction(uniq, UUID)"
+            - name: sessions_uniq_state
+              type: "AggregateFunction(uniq, String)"
+            - name: pageviews_count_state
+              type: "AggregateFunction(sum, UInt64)"
+            - name: bounces_count_state
+              type: "AggregateFunction(sum, UInt64)"
+            - name: total_session_duration_state
+              type: "AggregateFunction(sum, Int64)"
+            - name: total_session_count_state
+              type: "AggregateFunction(sum, UInt64)"
+            - name: mat_metadata_loggedIn
+              type: Nullable(Bool)
+
+    web_pre_aggregated_teams:
+        engine: ReplicatedReplacingMergeTree
+        sharded: false
+        on_nodes: ALL
+        order_by:
+            - team_id
+        columns:
+            - name: team_id
+              type: UInt64
+            - name: enabled_by
+              type: String
+              default_expression: "'system'"
+              default_kind: DEFAULT
+            - name: version
+              type: UInt32
+              default_expression: 'toUnixTimestamp(now())'
+              default_kind: DEFAULT
+
+    web_pre_aggregated_teams_dict:
+        engine: Dictionary
+        on_nodes: ALL
+        columns:
+            - name: team_id
+              type: UInt64
+
+    web_pre_aggregated_stats_staging:
+        engine: ReplicatedMergeTree
+        sharded: false
+        on_nodes:
+            - DATA
+            - COORDINATOR
+        order_by:
+            - team_id
+            - period_bucket
+            - host
+            - device_type
+            - pathname
+            - entry_pathname
+            - end_pathname
+            - browser
+            - os
+            - viewport_width
+            - viewport_height
+            - referring_domain
+            - utm_source
+            - utm_medium
+            - utm_campaign
+            - utm_term
+            - utm_content
+            - country_code
+            - city_name
+            - region_code
+            - region_name
+            - has_gclid
+            - has_gad_source_paid_search
+            - has_fbclid
+        partition_by: 'toYYYYMMDD(period_bucket)'
+        columns:
+            - name: period_bucket
+              type: DateTime
+            - name: team_id
+              type: UInt64
+            - name: host
+              type: String
+            - name: device_type
+              type: String
+            - name: pathname
+              type: String
+            - name: entry_pathname
+              type: String
+            - name: end_pathname
+              type: String
+            - name: browser
+              type: String
+            - name: os
+              type: String
+            - name: viewport_width
+              type: Int64
+            - name: viewport_height
+              type: Int64
+            - name: referring_domain
+              type: String
+            - name: utm_source
+              type: String
+            - name: utm_medium
+              type: String
+            - name: utm_campaign
+              type: String
+            - name: utm_term
+              type: String
+            - name: utm_content
+              type: String
+            - name: country_code
+              type: String
+            - name: city_name
+              type: String
+            - name: region_code
+              type: String
+            - name: region_name
+              type: String
+            - name: has_gclid
+              type: Bool
+            - name: has_gad_source_paid_search
+              type: Bool
+            - name: has_fbclid
+              type: Bool
+            - name: mat_metadata_backend
+              type: Nullable(String)
+            - name: persons_uniq_state
+              type: "AggregateFunction(uniq, UUID)"
+            - name: sessions_uniq_state
+              type: "AggregateFunction(uniq, String)"
+            - name: pageviews_count_state
+              type: "AggregateFunction(sum, UInt64)"
+            - name: mat_metadata_loggedIn
+              type: Nullable(Bool)
+
+    # Production distributed tables for hourly/daily aggregations
+    web_stats_daily_distributed:
+        engine: Distributed
+        source: web_pre_aggregated_stats
+        sharding_key: 'rand()'
+        on_nodes: COORDINATOR
+        columns: inherit web_pre_aggregated_stats
+
+    web_stats_hourly_distributed:
+        engine: Distributed
+        source: web_pre_aggregated_stats
+        sharding_key: 'rand()'
+        on_nodes: COORDINATOR
+        columns: inherit web_pre_aggregated_stats
+
+    web_bounces_daily_distributed:
+        engine: Distributed
+        source: web_pre_aggregated_bounces
+        sharding_key: 'rand()'
+        on_nodes: COORDINATOR
+        columns: inherit web_pre_aggregated_bounces
+
+    web_bounces_hourly_distributed:
+        engine: Distributed
+        source: web_pre_aggregated_bounces
+        sharding_key: 'rand()'
+        on_nodes: COORDINATOR
+        columns: inherit web_pre_aggregated_bounces
+
+    web_pre_aggregated_bounces_staging:
+        engine: ReplicatedMergeTree
+        sharded: false
+        on_nodes:
+            - DATA
+            - COORDINATOR
+        order_by:
+            - team_id
+            - period_bucket
+            - host
+            - device_type
+            - entry_pathname
+            - end_pathname
+            - browser
+            - os
+            - viewport_width
+            - viewport_height
+            - referring_domain
+            - utm_source
+            - utm_medium
+            - utm_campaign
+            - utm_term
+            - utm_content
+            - country_code
+            - city_name
+            - region_code
+            - region_name
+            - has_gclid
+            - has_gad_source_paid_search
+            - has_fbclid
+        partition_by: 'toYYYYMMDD(period_bucket)'
+        columns:
+            - name: period_bucket
+              type: DateTime
+            - name: team_id
+              type: UInt64
+            - name: host
+              type: String
+            - name: device_type
+              type: String
+            - name: entry_pathname
+              type: String
+            - name: end_pathname
+              type: String
+            - name: browser
+              type: String
+            - name: os
+              type: String
+            - name: viewport_width
+              type: Int64
+            - name: viewport_height
+              type: Int64
+            - name: referring_domain
+              type: String
+            - name: utm_source
+              type: String
+            - name: utm_medium
+              type: String
+            - name: utm_campaign
+              type: String
+            - name: utm_term
+              type: String
+            - name: utm_content
+              type: String
+            - name: country_code
+              type: String
+            - name: city_name
+              type: String
+            - name: region_code
+              type: String
+            - name: region_name
+              type: String
+            - name: has_gclid
+              type: Bool
+            - name: has_gad_source_paid_search
+              type: Bool
+            - name: has_fbclid
+              type: Bool
+            - name: mat_metadata_backend
+              type: Nullable(String)
+            - name: persons_uniq_state
+              type: "AggregateFunction(uniq, UUID)"
+            - name: sessions_uniq_state
+              type: "AggregateFunction(uniq, String)"
+            - name: pageviews_count_state
+              type: "AggregateFunction(sum, UInt64)"
+            - name: bounces_count_state
+              type: "AggregateFunction(sum, UInt64)"
+            - name: total_session_duration_state
+              type: "AggregateFunction(sum, Int64)"
+            - name: total_session_count_state
+              type: "AggregateFunction(sum, UInt64)"
+            - name: mat_metadata_loggedIn
+              type: Nullable(Bool)

--- a/posthog/clickhouse/schema/web_preaggregated.yaml
+++ b/posthog/clickhouse/schema/web_preaggregated.yaml
@@ -218,7 +218,7 @@ tables:
         sharded: false
         on_nodes:
             - DATA
-            - COORDINATOR
+            - DATA
         order_by:
             - team_id
             - period_bucket
@@ -310,28 +310,28 @@ tables:
         engine: Distributed
         source: web_pre_aggregated_stats
         sharding_key: 'rand()'
-        on_nodes: COORDINATOR
+        on_nodes: DATA
         columns: inherit web_pre_aggregated_stats
 
     web_stats_hourly_distributed:
         engine: Distributed
         source: web_pre_aggregated_stats
         sharding_key: 'rand()'
-        on_nodes: COORDINATOR
+        on_nodes: DATA
         columns: inherit web_pre_aggregated_stats
 
     web_bounces_daily_distributed:
         engine: Distributed
         source: web_pre_aggregated_bounces
         sharding_key: 'rand()'
-        on_nodes: COORDINATOR
+        on_nodes: DATA
         columns: inherit web_pre_aggregated_bounces
 
     web_bounces_hourly_distributed:
         engine: Distributed
         source: web_pre_aggregated_bounces
         sharding_key: 'rand()'
-        on_nodes: COORDINATOR
+        on_nodes: DATA
         columns: inherit web_pre_aggregated_bounces
 
     web_pre_aggregated_bounces_staging:
@@ -339,7 +339,7 @@ tables:
         sharded: false
         on_nodes:
             - DATA
-            - COORDINATOR
+            - DATA
         order_by:
             - team_id
             - period_bucket

--- a/posthog/clickhouse/schema/web_preaggregated.yaml
+++ b/posthog/clickhouse/schema/web_preaggregated.yaml
@@ -218,7 +218,7 @@ tables:
         sharded: false
         on_nodes:
             - DATA
-            - DATA
+            - COORDINATOR
         order_by:
             - team_id
             - period_bucket
@@ -310,28 +310,28 @@ tables:
         engine: Distributed
         source: web_pre_aggregated_stats
         sharding_key: 'rand()'
-        on_nodes: DATA
+        on_nodes: COORDINATOR
         columns: inherit web_pre_aggregated_stats
 
     web_stats_hourly_distributed:
         engine: Distributed
         source: web_pre_aggregated_stats
         sharding_key: 'rand()'
-        on_nodes: DATA
+        on_nodes: COORDINATOR
         columns: inherit web_pre_aggregated_stats
 
     web_bounces_daily_distributed:
         engine: Distributed
         source: web_pre_aggregated_bounces
         sharding_key: 'rand()'
-        on_nodes: DATA
+        on_nodes: COORDINATOR
         columns: inherit web_pre_aggregated_bounces
 
     web_bounces_hourly_distributed:
         engine: Distributed
         source: web_pre_aggregated_bounces
         sharding_key: 'rand()'
-        on_nodes: DATA
+        on_nodes: COORDINATOR
         columns: inherit web_pre_aggregated_bounces
 
     web_pre_aggregated_bounces_staging:
@@ -339,7 +339,7 @@ tables:
         sharded: false
         on_nodes:
             - DATA
-            - DATA
+            - COORDINATOR
         order_by:
             - team_id
             - period_bucket

--- a/posthog/clickhouse/schema/web_preaggregated.yaml
+++ b/posthog/clickhouse/schema/web_preaggregated.yaml
@@ -87,11 +87,11 @@ tables:
             - name: mat_metadata_backend
               type: Nullable(String)
             - name: persons_uniq_state
-              type: "AggregateFunction(uniq, UUID)"
+              type: 'AggregateFunction(uniq, UUID)'
             - name: sessions_uniq_state
-              type: "AggregateFunction(uniq, String)"
+              type: 'AggregateFunction(uniq, String)'
             - name: pageviews_count_state
-              type: "AggregateFunction(sum, UInt64)"
+              type: 'AggregateFunction(sum, UInt64)'
             - name: mat_metadata_loggedIn
               type: Nullable(Bool)
 
@@ -174,17 +174,17 @@ tables:
             - name: mat_metadata_backend
               type: Nullable(String)
             - name: persons_uniq_state
-              type: "AggregateFunction(uniq, UUID)"
+              type: 'AggregateFunction(uniq, UUID)'
             - name: sessions_uniq_state
-              type: "AggregateFunction(uniq, String)"
+              type: 'AggregateFunction(uniq, String)'
             - name: pageviews_count_state
-              type: "AggregateFunction(sum, UInt64)"
+              type: 'AggregateFunction(sum, UInt64)'
             - name: bounces_count_state
-              type: "AggregateFunction(sum, UInt64)"
+              type: 'AggregateFunction(sum, UInt64)'
             - name: total_session_duration_state
-              type: "AggregateFunction(sum, Int64)"
+              type: 'AggregateFunction(sum, Int64)'
             - name: total_session_count_state
-              type: "AggregateFunction(sum, UInt64)"
+              type: 'AggregateFunction(sum, UInt64)'
             - name: mat_metadata_loggedIn
               type: Nullable(Bool)
 
@@ -215,7 +215,7 @@ tables:
         primary_key: team_id
         source:
             type: CLICKHOUSE
-            query: "SELECT team_id FROM `posthog`.`web_pre_aggregated_teams` FINAL WHERE version > 0"
+            query: 'SELECT team_id FROM `posthog`.`web_pre_aggregated_teams` FINAL WHERE version > 0'
             user: __from_settings__
             password: __from_settings__
         layout:
@@ -311,11 +311,11 @@ tables:
             - name: mat_metadata_backend
               type: Nullable(String)
             - name: persons_uniq_state
-              type: "AggregateFunction(uniq, UUID)"
+              type: 'AggregateFunction(uniq, UUID)'
             - name: sessions_uniq_state
-              type: "AggregateFunction(uniq, String)"
+              type: 'AggregateFunction(uniq, String)'
             - name: pageviews_count_state
-              type: "AggregateFunction(sum, UInt64)"
+              type: 'AggregateFunction(sum, UInt64)'
             - name: mat_metadata_loggedIn
               type: Nullable(Bool)
 
@@ -429,16 +429,16 @@ tables:
             - name: mat_metadata_backend
               type: Nullable(String)
             - name: persons_uniq_state
-              type: "AggregateFunction(uniq, UUID)"
+              type: 'AggregateFunction(uniq, UUID)'
             - name: sessions_uniq_state
-              type: "AggregateFunction(uniq, String)"
+              type: 'AggregateFunction(uniq, String)'
             - name: pageviews_count_state
-              type: "AggregateFunction(sum, UInt64)"
+              type: 'AggregateFunction(sum, UInt64)'
             - name: bounces_count_state
-              type: "AggregateFunction(sum, UInt64)"
+              type: 'AggregateFunction(sum, UInt64)'
             - name: total_session_duration_state
-              type: "AggregateFunction(sum, Int64)"
+              type: 'AggregateFunction(sum, Int64)'
             - name: total_session_count_state
-              type: "AggregateFunction(sum, UInt64)"
+              type: 'AggregateFunction(sum, UInt64)'
             - name: mat_metadata_loggedIn
               type: Nullable(Bool)

--- a/posthog/clickhouse/schema/web_preaggregated.yaml
+++ b/posthog/clickhouse/schema/web_preaggregated.yaml
@@ -206,9 +206,23 @@ tables:
               default_expression: 'toUnixTimestamp(now())'
               default_kind: DEFAULT
 
+    # Teams opted into web pre-aggregation. Backed by a SELECT over
+    # web_pre_aggregated_teams (FINAL, version > 0). See
+    # posthog/models/web_preaggregated/team_selection.py.
     web_pre_aggregated_teams_dict:
         engine: Dictionary
         on_nodes: ALL
+        primary_key: team_id
+        source:
+            type: CLICKHOUSE
+            query: "SELECT team_id FROM `posthog`.`web_pre_aggregated_teams` FINAL WHERE version > 0"
+            user: __from_settings__
+            password: __from_settings__
+        layout:
+            type: HASHED
+        lifetime:
+            min: 3000
+            max: 3600
         columns:
             - name: team_id
               type: UInt64

--- a/posthog/clickhouse/test/test_reconcile.py
+++ b/posthog/clickhouse/test/test_reconcile.py
@@ -2432,3 +2432,29 @@ class TestComputeDiffsSharedPhysicalHost(unittest.TestCase):
         self.assertIsNone(err)
         drops = [d for d in diffs if d.action == "drop"]
         self.assertEqual([d.table for d in drops], ["truly_orphan"])
+
+
+class TestRealSchemaDirLintsClean(unittest.TestCase):
+    """Guard against regressions in the 46 production YAMLs.
+
+    Every ecosystem under ``posthog/clickhouse/schema/`` must parse and
+    validate. Synthetic-only tests (the rest of this file) can't catch a
+    typo, missing field, or role mismatch in a real YAML file.
+    """
+
+    def test_all_production_yamls_parse_and_validate(self) -> None:
+        from posthog.clickhouse.migration_tools.desired_state import parse_desired_state_dir
+        from posthog.clickhouse.migration_tools.validator import validate_desired_states
+
+        schema_dir = Path(__file__).resolve().parent.parent / "schema"
+        self.assertTrue(schema_dir.is_dir(), f"schema dir missing: {schema_dir}")
+
+        states = parse_desired_state_dir(schema_dir)
+        self.assertGreater(len(states), 0, "expected at least one YAML ecosystem")
+
+        errors = validate_desired_states(states)
+        self.assertEqual(
+            errors,
+            [],
+            "production YAMLs must lint clean. Errors:\n" + "\n".join(f"  - {e}" for e in errors),
+        )


### PR DESCRIPTION
## Problem

The reconciliation engine (PR #53231) needs a baseline — YAML declarations for every existing PostHog ClickHouse table so that `ch_migrate plan` can report "no changes" against a production cluster.

## Changes

45 YAML files in `posthog/clickhouse/schema/` declaring 210 production tables across main and logs clusters.

Each file describes one table ecosystem:
```yaml
ecosystem: events
cluster: main
tables:
  sharded_events:
    engine: ReplicatedReplacingMergeTree
    columns: [{name: uuid, type: UUID}, ...]
    order_by: [team_id, toDate(timestamp), event]
    on_nodes: [DATA]
    sharded: true
  writable_events:
    engine: Distributed
    source: sharded_events
    on_nodes: [COORDINATOR]
```

Verified against prod-us `system.tables` query via admin pod. Covers events, person, sessions, groups, cohorts, app_metrics, heatmaps, log_entries, session_replay, query_log_archive, document_embeddings, web_preaggregated, and 30+ more.

## How did you test this code?

Pure data no logic. Table names and engines verified against production `system.tables` query on prod-us coordinator. Column definitions cross-referenced with `posthog/models/*/sql.py`.

Part 3 of 4. Depends on PR #53231.

## Publish to changelog?

No