### PR TITLE
feat(messaging): combine HogVM filter bytecodes into single execution per person

### DIFF
--- a/posthog/temporal/messaging/backfill_precalculated_person_properties_workflow.py
+++ b/posthog/temporal/messaging/backfill_precalculated_person_properties_workflow.py
@@ -24,6 +24,7 @@ from posthog.temporal.messaging.filter_storage import get_filters_and_properties
 from posthog.temporal.messaging.types import PersonPropertyFilter
 
 from common.hogvm.python.execute import BytecodeResult, execute_bytecode
+from common.hogvm.python.operation import HOGQL_BYTECODE_IDENTIFIER, Operation
 
 if TYPE_CHECKING:
     pass
@@ -198,44 +199,56 @@ class BackfillPrecalculatedPersonPropertiesInputs:
         }
 
 
-def evaluate_single_filter_sync(
-    filter_obj: PersonPropertyFilter,
+def combine_filter_bytecodes(filters: list[PersonPropertyFilter]) -> list[Any]:
+    """Combine multiple filter bytecodes into a single bytecode returning a dict.
+
+    Strips the header from each filter's bytecode body, interleaves condition_hash
+    keys, and appends a DICT opcode to collect all results into
+    {condition_hash: bool_result, ...}.
+
+    Built once at activity startup and reused for every person.
+    """
+    combined: list[Any] = [HOGQL_BYTECODE_IDENTIFIER, 1]
+
+    valid_count = 0
+    for f in filters:
+        if len(f.bytecode) <= 2:
+            continue
+        combined.append(Operation.STRING)
+        combined.append(f.condition_hash)
+        combined.extend(f.bytecode[2:])
+        valid_count += 1
+
+    combined.append(Operation.DICT)
+    combined.append(valid_count)
+
+    return combined
+
+
+def evaluate_combined_filters_sync(
+    combined_bytecode: list[Any],
     hog_globals: dict[str, Any],
     person_id: str,
-    inputs: BackfillPrecalculatedPersonPropertiesInputs,
-) -> dict[str, Any] | None:
-    """
-    Evaluate a single filter for a person and return event data if it matches.
+) -> dict[str, Any]:
+    """Execute combined bytecode for all filters, returning {condition_hash: result}.
 
-    This is a synchronous function that will be run in a thread pool for concurrency.
-
-    Returns:
-        Event dict if filter matches, None otherwise
+    Returns empty dict on error so the person is skipped without crashing the activity.
     """
     try:
-        # Execute the filter bytecode to get the result
-        bytecode_result: BytecodeResult = execute_bytecode(filter_obj.bytecode, hog_globals)
+        bytecode_result: BytecodeResult = execute_bytecode(combined_bytecode, hog_globals)
         result = bytecode_result.result
-
-        # If filter matches, return event data
-        if result:
-            return {
-                "team_id": inputs.team_id,
-                "distinct_id": person_id,
-                "person_id": person_id,
-                "condition": filter_obj.condition_hash,
-                "matches": result,
-                "source": f"cohort_filter_{filter_obj.condition_hash}",
-            }
+        if isinstance(result, dict):
+            return result
+        return {}
     except Exception as e:
         LOGGER.warning(
-            f"Failed to execute filter bytecode for person {person_id}: {e}",
+            "Failed to execute combined filter bytecode for person %s: %s",
+            person_id,
+            e,
             person_id=person_id,
-            condition_hash=filter_obj.condition_hash,
             error=str(e),
         )
-
-    return None
+        return {}
 
 
 @temporalio.activity.defn
@@ -399,19 +412,8 @@ async def backfill_precalculated_person_properties_activity(
         last_person_id = inputs.start_person_id
         batch_count = 0
 
-        # Initialize semaphore and async function outside the loop
-        MAX_CONCURRENT_FILTERS = min(20, len(filters))  # Cap at 20 concurrent threads
-        semaphore = asyncio.Semaphore(MAX_CONCURRENT_FILTERS)
-
-        async def run_filter_in_thread(filter_obj, hog_globals_bound, person_id_bound):
-            async with semaphore:
-                return await asyncio.to_thread(
-                    evaluate_single_filter_sync,
-                    filter_obj,
-                    hog_globals_bound,
-                    person_id_bound,
-                    inputs,
-                )
+        # Build combined bytecode once for all filters
+        combined_bytecode = combine_filter_bytecodes(filters)
 
         with tags_context(
             team_id=inputs.team_id,
@@ -442,44 +444,40 @@ async def backfill_precalculated_person_properties_activity(
                         # Fallback format: use full properties JSON
                         parsed_properties = parse_person_properties(row.get("properties"), person_id)
 
-                    # Evaluate all filters concurrently for this person using thread pool
+                    # Evaluate all filters in a single VM call
                     person_filter_start = time.monotonic()
                     hog_globals = {"person": {"properties": parsed_properties}}
 
-                    # Create tasks for concurrent filter evaluation
-                    filter_tasks = [run_filter_in_thread(filter_obj, hog_globals, person_id) for filter_obj in filters]
+                    filter_results = await asyncio.to_thread(
+                        evaluate_combined_filters_sync,
+                        combined_bytecode,
+                        hog_globals,
+                        person_id,
+                    )
 
-                    # Execute all filters concurrently
-                    filter_results = await asyncio.gather(*filter_tasks, return_exceptions=True)
-
-                    # Collect matching events and produce to Kafka sequentially (thread-safe)
-                    matching_events = []
-                    for result in filter_results:
-                        if isinstance(result, dict):  # Successful result with event data
-                            matching_events.append(result)
-                        elif isinstance(result, Exception):
-                            logger.error(
-                                "Error while evaluating filter for person_id %s: %r",
-                                person_id,
-                                result,
-                            )
-                        # None results (no match) are ignored
-
-                    # Produce all matching events to Kafka sequentially in main thread
-                    for event in matching_events:
-                        try:
-                            produce_result = kafka_producer.produce(
-                                topic=KAFKA_CDP_CLICKHOUSE_PRECALCULATED_PERSON_PROPERTIES,
-                                data=event,
-                            )
-                            kafka_results.append(produce_result)
-                            total_events_produced += 1
-                        except Exception as e:
-                            logger.warning(
-                                f"Failed to produce Kafka message for person {person_id}: {e}",
-                                person_id=person_id,
-                                error=str(e),
-                            )
+                    # Produce Kafka messages for matching conditions
+                    for condition_hash, matches in filter_results.items():
+                        if matches:
+                            try:
+                                produce_result = kafka_producer.produce(
+                                    topic=KAFKA_CDP_CLICKHOUSE_PRECALCULATED_PERSON_PROPERTIES,
+                                    data={
+                                        "team_id": inputs.team_id,
+                                        "distinct_id": person_id,
+                                        "person_id": person_id,
+                                        "condition": condition_hash,
+                                        "matches": matches,
+                                        "source": f"cohort_filter_{condition_hash}",
+                                    },
+                                )
+                                kafka_results.append(produce_result)
+                                total_events_produced += 1
+                            except Exception as e:
+                                logger.warning(
+                                    f"Failed to produce Kafka message for person {person_id}: {e}",
+                                    person_id=person_id,
+                                    error=str(e),
+                                )
 
                     # Periodically flush Kafka batches to avoid memory buildup
                     if len(kafka_results) >= KAFKA_FLUSH_BATCH_SIZE:

--- a/posthog/temporal/messaging/backfill_precalculated_person_properties_workflow.py
+++ b/posthog/temporal/messaging/backfill_precalculated_person_properties_workflow.py
@@ -24,7 +24,6 @@ from posthog.temporal.messaging.filter_storage import get_filters_and_properties
 from posthog.temporal.messaging.types import PersonPropertyFilter
 
 from common.hogvm.python.execute import BytecodeResult, execute_bytecode
-from common.hogvm.python.operation import HOGQL_BYTECODE_IDENTIFIER, Operation
 
 if TYPE_CHECKING:
     pass
@@ -199,32 +198,6 @@ class BackfillPrecalculatedPersonPropertiesInputs:
         }
 
 
-def combine_filter_bytecodes(filters: list[PersonPropertyFilter]) -> list[Any]:
-    """Combine multiple filter bytecodes into a single bytecode returning a dict.
-
-    Strips the header from each filter's bytecode body, interleaves condition_hash
-    keys, and appends a DICT opcode to collect all results into
-    {condition_hash: bool_result, ...}.
-
-    Built once at activity startup and reused for every person.
-    """
-    combined: list[Any] = [HOGQL_BYTECODE_IDENTIFIER, 1]
-
-    valid_count = 0
-    for f in filters:
-        if len(f.bytecode) <= 2:
-            continue
-        combined.append(Operation.STRING)
-        combined.append(f.condition_hash)
-        combined.extend(f.bytecode[2:])
-        valid_count += 1
-
-    combined.append(Operation.DICT)
-    combined.append(valid_count)
-
-    return combined
-
-
 def evaluate_combined_filters_sync(
     combined_bytecode: list[Any],
     hog_globals: dict[str, Any],
@@ -269,7 +242,7 @@ async def backfill_precalculated_person_properties_activity(
         team_id=inputs.team_id, cohort_count=len(cohort_ids), cohort_ids=format_cohort_ids_for_logging(cohort_ids)
     )
 
-    # Load filters and person properties from Redis storage without blocking the event loop
+    # Load filters, person properties, and combined bytecode from Redis storage without blocking the event loop
     storage_result = await asyncio.to_thread(get_filters_and_properties, inputs.filter_storage_key)
     if storage_result is None:
         raise temporalio.exceptions.ApplicationError(
@@ -279,7 +252,7 @@ async def backfill_precalculated_person_properties_activity(
             non_retryable=True,
         )
 
-    filters, person_properties = storage_result
+    filters, person_properties, combined_bytecode = storage_result
     logger.info(f"Loaded {len(filters)} filters from storage key: {inputs.filter_storage_key}")
 
     # Early abort if no filters to process
@@ -411,9 +384,6 @@ async def backfill_precalculated_person_properties_activity(
 
         last_person_id = inputs.start_person_id
         batch_count = 0
-
-        # Build combined bytecode once for all filters
-        combined_bytecode = combine_filter_bytecodes(filters)
 
         with tags_context(
             team_id=inputs.team_id,

--- a/posthog/temporal/messaging/filter_storage.py
+++ b/posthog/temporal/messaging/filter_storage.py
@@ -45,6 +45,11 @@ def combine_filter_bytecodes(filters: list[PersonPropertyFilter]) -> list[Any]:
     valid_count = 0
     for f in filters:
         if len(f.bytecode) <= 2:
+            logger.warning(
+                "Skipping malformed bytecode for filter",
+                condition_hash=f.condition_hash,
+                bytecode_length=len(f.bytecode),
+            )
             continue
         combined.append(Operation.STRING)
         combined.append(f.condition_hash)

--- a/posthog/temporal/messaging/filter_storage.py
+++ b/posthog/temporal/messaging/filter_storage.py
@@ -14,11 +14,14 @@ TTL Considerations:
 
 import json
 import hashlib
+from typing import Any
 
 import structlog
 
 from posthog.redis import get_client
 from posthog.temporal.messaging.types import PersonPropertyFilter
+
+from common.hogvm.python.operation import HOGQL_BYTECODE_IDENTIFIER, Operation
 
 KEY_PREFIX = "backfill_person_properties_filters:"
 # TTL sizing: Worst case workflow duration ~48h (3 × 12h retries + batch delays)
@@ -26,6 +29,32 @@ KEY_PREFIX = "backfill_person_properties_filters:"
 DEFAULT_TTL = 72 * 60 * 60  # 3 days
 
 logger = structlog.get_logger(__name__)
+
+
+def combine_filter_bytecodes(filters: list[PersonPropertyFilter]) -> list[Any]:
+    """Combine multiple filter bytecodes into a single bytecode returning a dict.
+
+    Strips the header from each filter's bytecode body, interleaves condition_hash
+    keys, and appends a DICT opcode to collect all results into
+    {condition_hash: bool_result, ...}.
+
+    Built once at coordinator startup and reused for every person.
+    """
+    combined: list[Any] = [HOGQL_BYTECODE_IDENTIFIER, 1]
+
+    valid_count = 0
+    for f in filters:
+        if len(f.bytecode) <= 2:
+            continue
+        combined.append(Operation.STRING)
+        combined.append(f.condition_hash)
+        combined.extend(f.bytecode[2:])
+        valid_count += 1
+
+    combined.append(Operation.DICT)
+    combined.append(valid_count)
+
+    return combined
 
 
 def store_filters(filters: list[PersonPropertyFilter], team_id: int, ttl: int = DEFAULT_TTL) -> str:
@@ -57,10 +86,14 @@ def store_filters(filters: list[PersonPropertyFilter], team_id: int, ttl: int = 
         if f.property_key:
             person_properties.add(f.property_key)
 
-    # Create storage object containing both filters and properties
+    # Combine all filter bytecodes into a single optimized bytecode
+    combined_bytecode = combine_filter_bytecodes(filters)
+
+    # Create storage object containing filters, properties, and combined bytecode
     storage_data = {
         "filters": filter_data,
         "person_properties": sorted(person_properties),  # Sort for consistent ordering
+        "combined_bytecode": combined_bytecode,
     }
 
     # Create hash of the storage data for the key
@@ -74,15 +107,15 @@ def store_filters(filters: list[PersonPropertyFilter], team_id: int, ttl: int = 
     return storage_key
 
 
-def get_filters_and_properties(storage_key: str) -> tuple[list[PersonPropertyFilter], list[str]] | None:
+def get_filters_and_properties(storage_key: str) -> tuple[list[PersonPropertyFilter], list[str], list[Any]] | None:
     """
-    Retrieve both filters and person properties using a storage key.
+    Retrieve filters, person properties, and combined bytecode using a storage key.
 
     Args:
         storage_key: Key returned by store_filters
 
     Returns:
-        Tuple of (filters, person_properties), or None if not found
+        Tuple of (filters, person_properties, combined_bytecode), or None if not found
 
     Note:
         If workflows consistently exceed 48h and TTL becomes an issue,
@@ -95,6 +128,7 @@ def get_filters_and_properties(storage_key: str) -> tuple[list[PersonPropertyFil
     storage_data = json.loads(data.decode("utf-8"))
     filter_data = storage_data["filters"]
     person_properties = storage_data["person_properties"]
+    combined_bytecode = storage_data.get("combined_bytecode")
 
     # Reconstruct PersonPropertyFilter objects
     filters = [
@@ -107,4 +141,8 @@ def get_filters_and_properties(storage_key: str) -> tuple[list[PersonPropertyFil
         for item in filter_data
     ]
 
-    return filters, person_properties
+    # If combined_bytecode is not present (backward compatibility), generate it
+    if combined_bytecode is None:
+        combined_bytecode = combine_filter_bytecodes(filters)
+
+    return filters, person_properties, combined_bytecode

--- a/posthog/temporal/messaging/test/test_backfill_precalculated_person_properties_workflow.py
+++ b/posthog/temporal/messaging/test/test_backfill_precalculated_person_properties_workflow.py
@@ -2,6 +2,7 @@ import pytest
 from unittest.mock import Mock, patch
 
 import temporalio.exceptions
+from parameterized import parameterized
 
 from posthog.temporal.messaging.backfill_precalculated_person_properties_workflow import (
     BackfillPrecalculatedPersonPropertiesInputs,
@@ -234,7 +235,13 @@ class TestCombineFilterBytecodes:
         result = execute_bytecode(combined, {})
         assert result.result == {"h1": True, "h2": False}
 
-    def test_executes_with_person_properties(self):
+    @parameterized.expand(
+        [
+            ({"person": {"properties": {"$browser": "Chrome"}}}, {"browser_set": True}),
+            ({"person": {"properties": {}}}, {"browser_set": False}),
+        ]
+    )
+    def test_executes_with_person_properties(self, globals_input, expected_result):
         # Bytecode for: person.properties.$browser != NULL (is_set check)
         browser_bytecode = ["_H", 1, 31, 32, "$browser", 32, "properties", 32, "person", 1, 3, 12]
         filters = [
@@ -247,13 +254,19 @@ class TestCombineFilterBytecodes:
         ]
         combined = combine_filter_bytecodes(filters)
 
-        result = execute_bytecode(combined, {"person": {"properties": {"$browser": "Chrome"}}})
-        assert result.result == {"browser_set": True}
+        result = execute_bytecode(combined, globals_input)
+        assert result.result == expected_result
 
-        result = execute_bytecode(combined, {"person": {"properties": {}}})
-        assert result.result == {"browser_set": False}
-
-    def test_executes_multiple_property_filters(self):
+    @parameterized.expand(
+        [
+            ({"person": {"properties": {"$browser": "Chrome"}}}, {"browser_set": True, "host_set": False}),
+            (
+                {"person": {"properties": {"$browser": "Chrome", "$host": "example.com"}}},
+                {"browser_set": True, "host_set": True},
+            ),
+        ]
+    )
+    def test_executes_multiple_property_filters(self, globals_input, expected_result):
         browser_bytecode = ["_H", 1, 31, 32, "$browser", 32, "properties", 32, "person", 1, 3, 12]
         host_bytecode = ["_H", 1, 31, 32, "$host", 32, "properties", 32, "person", 1, 3, 12]
         filters = [
@@ -266,11 +279,8 @@ class TestCombineFilterBytecodes:
         ]
         combined = combine_filter_bytecodes(filters)
 
-        result = execute_bytecode(combined, {"person": {"properties": {"$browser": "Chrome"}}})
-        assert result.result == {"browser_set": True, "host_set": False}
-
-        result = execute_bytecode(combined, {"person": {"properties": {"$browser": "Chrome", "$host": "example.com"}}})
-        assert result.result == {"browser_set": True, "host_set": True}
+        result = execute_bytecode(combined, globals_input)
+        assert result.result == expected_result
 
 
 class TestEvaluateCombinedFiltersSync:

--- a/posthog/temporal/messaging/test/test_backfill_precalculated_person_properties_workflow.py
+++ b/posthog/temporal/messaging/test/test_backfill_precalculated_person_properties_workflow.py
@@ -6,11 +6,10 @@ import temporalio.exceptions
 from posthog.temporal.messaging.backfill_precalculated_person_properties_workflow import (
     BackfillPrecalculatedPersonPropertiesInputs,
     backfill_precalculated_person_properties_activity,
-    combine_filter_bytecodes,
     evaluate_combined_filters_sync,
     flush_kafka_batch_async,
 )
-from posthog.temporal.messaging.filter_storage import store_filters
+from posthog.temporal.messaging.filter_storage import combine_filter_bytecodes, store_filters
 from posthog.temporal.messaging.types import PersonPropertyFilter
 
 from common.hogvm.python.execute import execute_bytecode

--- a/posthog/temporal/messaging/test/test_backfill_precalculated_person_properties_workflow.py
+++ b/posthog/temporal/messaging/test/test_backfill_precalculated_person_properties_workflow.py
@@ -6,10 +6,15 @@ import temporalio.exceptions
 from posthog.temporal.messaging.backfill_precalculated_person_properties_workflow import (
     BackfillPrecalculatedPersonPropertiesInputs,
     backfill_precalculated_person_properties_activity,
+    combine_filter_bytecodes,
+    evaluate_combined_filters_sync,
     flush_kafka_batch_async,
 )
 from posthog.temporal.messaging.filter_storage import store_filters
 from posthog.temporal.messaging.types import PersonPropertyFilter
+
+from common.hogvm.python.execute import execute_bytecode
+from common.hogvm.python.operation import Operation
 
 
 class TestFlushKafkaBatchAsync:
@@ -180,3 +185,103 @@ class TestBackfillPrecalculatedPersonPropertiesActivity:
 
         # Basic verification that the filter was stored correctly
         assert inputs.filter_storage_key == storage_key
+
+
+class TestCombineFilterBytecodes:
+    """Tests for combine_filter_bytecodes."""
+
+    def test_single_filter(self):
+        filters = [
+            PersonPropertyFilter(
+                condition_hash="h1",
+                bytecode=["_H", 1, 31, 32, "$browser", 32, "properties", 32, "person", 1, 3, 12],
+                cohort_ids=[10],
+                property_key="$browser",
+            ),
+        ]
+        result = combine_filter_bytecodes(filters)
+        assert result[0] == "_H"
+        assert result[1] == 1
+        assert result[2] == Operation.STRING
+        assert result[3] == "h1"
+        # Body without header
+        assert result[4:-2] == [31, 32, "$browser", 32, "properties", 32, "person", 1, 3, 12]
+        # Trailing DICT
+        assert result[-2] == Operation.DICT
+        assert result[-1] == 1
+
+    def test_multiple_filters(self):
+        filters = [
+            PersonPropertyFilter(condition_hash="h1", bytecode=["_H", 1, 29], cohort_ids=[1], property_key=None),
+            PersonPropertyFilter(condition_hash="h2", bytecode=["_H", 1, 30], cohort_ids=[2], property_key=None),
+        ]
+        result = combine_filter_bytecodes(filters)
+        assert result == ["_H", 1, Operation.STRING, "h1", 29, Operation.STRING, "h2", 30, Operation.DICT, 2]
+
+    def test_skips_malformed_bytecodes(self):
+        filters = [
+            PersonPropertyFilter(condition_hash="bad", bytecode=["_H", 1], cohort_ids=[1], property_key=None),
+            PersonPropertyFilter(condition_hash="good", bytecode=["_H", 1, 29], cohort_ids=[2], property_key=None),
+        ]
+        result = combine_filter_bytecodes(filters)
+        assert result == ["_H", 1, Operation.STRING, "good", 29, Operation.DICT, 1]
+
+    def test_executes_and_returns_dict(self):
+        filters = [
+            PersonPropertyFilter(condition_hash="h1", bytecode=["_H", 1, 29], cohort_ids=[1], property_key=None),
+            PersonPropertyFilter(condition_hash="h2", bytecode=["_H", 1, 30], cohort_ids=[2], property_key=None),
+        ]
+        combined = combine_filter_bytecodes(filters)
+        result = execute_bytecode(combined, {})
+        assert result.result == {"h1": True, "h2": False}
+
+    def test_executes_with_person_properties(self):
+        # Bytecode for: person.properties.$browser != NULL (is_set check)
+        browser_bytecode = ["_H", 1, 31, 32, "$browser", 32, "properties", 32, "person", 1, 3, 12]
+        filters = [
+            PersonPropertyFilter(
+                condition_hash="browser_set",
+                bytecode=browser_bytecode,
+                cohort_ids=[10],
+                property_key="$browser",
+            ),
+        ]
+        combined = combine_filter_bytecodes(filters)
+
+        result = execute_bytecode(combined, {"person": {"properties": {"$browser": "Chrome"}}})
+        assert result.result == {"browser_set": True}
+
+        result = execute_bytecode(combined, {"person": {"properties": {}}})
+        assert result.result == {"browser_set": False}
+
+    def test_executes_multiple_property_filters(self):
+        browser_bytecode = ["_H", 1, 31, 32, "$browser", 32, "properties", 32, "person", 1, 3, 12]
+        host_bytecode = ["_H", 1, 31, 32, "$host", 32, "properties", 32, "person", 1, 3, 12]
+        filters = [
+            PersonPropertyFilter(
+                condition_hash="browser_set", bytecode=browser_bytecode, cohort_ids=[10], property_key="$browser"
+            ),
+            PersonPropertyFilter(
+                condition_hash="host_set", bytecode=host_bytecode, cohort_ids=[10], property_key="$host"
+            ),
+        ]
+        combined = combine_filter_bytecodes(filters)
+
+        result = execute_bytecode(combined, {"person": {"properties": {"$browser": "Chrome"}}})
+        assert result.result == {"browser_set": True, "host_set": False}
+
+        result = execute_bytecode(combined, {"person": {"properties": {"$browser": "Chrome", "$host": "example.com"}}})
+        assert result.result == {"browser_set": True, "host_set": True}
+
+
+class TestEvaluateCombinedFiltersSync:
+    """Tests for evaluate_combined_filters_sync."""
+
+    def test_returns_dict_on_success(self):
+        combined = ["_H", 1, Operation.STRING, "h1", 29, Operation.DICT, 1]
+        result = evaluate_combined_filters_sync(combined, {}, "person-1")
+        assert result == {"h1": True}
+
+    def test_returns_empty_dict_on_error(self):
+        result = evaluate_combined_filters_sync(["_H", 1, 999], {}, "person-1")
+        assert result == {}

--- a/posthog/temporal/messaging/test/test_filter_storage.py
+++ b/posthog/temporal/messaging/test/test_filter_storage.py
@@ -52,7 +52,7 @@ class TestFilterStorage:
 
         # Verify round-trip correctness
         assert result is not None
-        retrieved_filters, person_properties = result
+        retrieved_filters, person_properties, combined_bytecode = result
         assert len(retrieved_filters) == 3
 
         for i, retrieved_filter in enumerate(retrieved_filters):
@@ -88,7 +88,7 @@ class TestFilterStorage:
         # Verify filters can be retrieved immediately
         result = get_filters_and_properties(storage_key)
         assert result is not None
-        retrieved_filters, person_properties = result
+        retrieved_filters, person_properties, combined_bytecode = result
         assert len(retrieved_filters) == 3
 
         # Simulate TTL expiry by deleting the key
@@ -119,8 +119,8 @@ class TestFilterStorage:
 
         assert result1 is not None
         assert result2 is not None
-        filters1, _ = result1
-        filters2, _ = result2
+        filters1, _, _ = result1
+        filters2, _, _ = result2
         assert len(filters1) == len(filters2) == 3
 
     @patch("posthog.temporal.messaging.filter_storage.get_client")
@@ -148,7 +148,7 @@ class TestFilterStorage:
         # Retrieve and verify
         result = get_filters_and_properties(storage_key)
         assert result is not None
-        retrieved_filters, person_properties = result
+        retrieved_filters, person_properties, combined_bytecode = result
         assert len(retrieved_filters) == 0
         assert person_properties == []  # Empty filters should result in empty properties
 
@@ -198,7 +198,7 @@ class TestFilterStorage:
         result = get_filters_and_properties(storage_key)
         assert result is not None
 
-        retrieved_filters, person_properties = result
+        retrieved_filters, person_properties, combined_bytecode = result
 
         # Verify person properties only includes non-None keys
         assert person_properties == ["age"]


### PR DESCRIPTION
## Problem

The backfill workflow calls `execute_bytecode()` N times per person (once per filter), each dispatched via `asyncio.to_thread` with a semaphore. For simple property checks that execute in microseconds, the VM setup and thread scheduling overhead dominates.

## Changes

Combine all N filter bytecodes into a single bytecode program that returns a `{condition_hash: result}` dict using HogVM's DICT opcode. This reduces N VM initializations + N thread dispatches per person to just 1.

- Add `combine_filter_bytecodes()` to build a single bytecode at activity startup
- Add `evaluate_combined_filters_sync()` to run one VM call per person
- Remove `evaluate_single_filter_sync()`, semaphore, and thread pool infrastructure

## How did you test this code?

All 115 messaging tests pass, including 8 new tests covering bytecode combination, end-to-end execution with person properties, malformed bytecode handling, and error cases.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

no