### PR TITLE
chore(dev): Enable embedding-worker autostart in mprocs

### DIFF
--- a/bin/mprocs.yaml
+++ b/bin/mprocs.yaml
@@ -157,7 +157,6 @@ procs:
         shell: |-
             bin/wait-for-docker && \
             bin/start-rust-service embedding-worker
-        autostart: false
         capability: embedding_service
         ready_pattern: 'Generated embedding'
 


### PR DESCRIPTION
## Problem

The embedding-worker was set to `autostart: false` in mprocs for some reason, meaning it's been the one thing I've had to manually start every time recently. I think this changed in the last weeks, because I didn't have to do that. And it's not a useful mechanic, because this service is only enabled if you need it based on `hogli dev:setup`.

## Changes

Removing `autostart: false` from the `embedding-worker` mprocs entry so it starts with the rest of the services.

## How did you test this code?

`hogli start`'d

## Publish to changelog?

no