### PR TITLE
fix(signals): Increase httpx timeout for embedding requests

### DIFF
--- a/posthog/api/embedding_worker.py
+++ b/posthog/api/embedding_worker.py
@@ -73,8 +73,7 @@ async def async_generate_embedding(
     """Async equivalent of generate_embedding — uses httpx instead of requests to avoid blocking a thread."""
     logger.info(f"Generating ad-hoc embedding (async) for team {team.pk}")
     payload = _build_embedding_payload(team, content, model, no_truncate)
-    # TODO: Check if we need a larger timeout for embedding worker (avoid read timeouts)
-    async with internal_httpx_async_client() as client:
+    async with internal_httpx_async_client(timeout=30.0) as client:
         response = await client.post(_EMBEDDING_URL, json=payload)
         response.raise_for_status()
         return _parse_embedding_response(response.json())


### PR DESCRIPTION
## Problem

`async_generate_embedding` was hitting `ReadTimeout` errors in Temporal activities because the default httpx timeout (5s) is _sometimes_ too short for the embedding service to respond. Not sure what this depends on precisely, but I was seeing intermittent failures on a constant basis, and we've already had a TODO comment about this in the code.

## Changes

Timeout is now 30s instead of 5s in the `internal_httpx_async_client()` of `async_generate_embedding`.

## How did you test this code?

Have been running signal processing much more successfully locally now, no downsides I've observed.

## Publish to changelog?

no
