### PR TITLE
feat(surveys): polish guided survey wizard

### DIFF
--- a/frontend/src/scenes/scenes.ts
+++ b/frontend/src/scenes/scenes.ts
@@ -570,6 +570,7 @@ export const sceneConfigurations: Record<Scene | string, SceneConfig> = {
     [Scene.SurveyWizard]: {
         projectBased: true,
         name: 'Create survey',
+        layout: 'app-raw-no-header',
         defaultDocsPath: '/docs/surveys/creating-surveys',
     },
     [Scene.SurveyFormBuilder]: {

--- a/frontend/src/scenes/surveys/SurveyAppearanceUtils.tsx
+++ b/frontend/src/scenes/surveys/SurveyAppearanceUtils.tsx
@@ -153,12 +153,14 @@ export function HTMLEditor({
     onTabChange,
     activeTab,
     textPlaceholder,
+    textMinRows = 2,
 }: {
     value?: string
     onChange: (value: any) => void
     onTabChange: (key: SurveyQuestionDescriptionContentType) => void
     activeTab: SurveyQuestionDescriptionContentType
     textPlaceholder?: string
+    textMinRows?: number
 }): JSX.Element {
     return (
         <>
@@ -171,7 +173,7 @@ export function HTMLEditor({
                         label: <span className="text-sm">Text</span>,
                         content: (
                             <LemonTextArea
-                                minRows={2}
+                                minRows={textMinRows}
                                 value={value}
                                 onChange={(v) => onChange(v)}
                                 placeholder={textPlaceholder}

--- a/frontend/src/scenes/surveys/SurveyEventTrigger.test.tsx
+++ b/frontend/src/scenes/surveys/SurveyEventTrigger.test.tsx
@@ -10,6 +10,7 @@ import { initKeaTests } from '~/test/init'
 import { SurveyEventTrigger } from './SurveyEventTrigger'
 import { surveyLogic } from './surveyLogic'
 import { WhenStep } from './wizard/steps/WhenStep'
+import { surveyWizardLogic } from './wizard/surveyWizardLogic'
 
 jest.mock('lib/components/PropertyFilters/PropertyFilters', () => ({
     PropertyFilters: ({
@@ -53,6 +54,8 @@ describe('Survey event trigger property filters', () => {
     })
 
     function mountSurveyWithTriggerEvent(): ReturnType<typeof surveyLogic.build> {
+        const wizardLogic = surveyWizardLogic({ id: 'new' })
+        wizardLogic.mount()
         const logic = surveyLogic({ id: 'new' })
         logic.mount()
         logic.actions.setSurveyValue('conditions', {
@@ -86,7 +89,9 @@ describe('Survey event trigger property filters', () => {
         render(
             <Provider>
                 <BindLogic logic={surveyLogic} props={{ id: 'new' }}>
-                    <WhenStep />
+                    <BindLogic logic={surveyWizardLogic} props={{ id: 'new' }}>
+                        <WhenStep />
+                    </BindLogic>
                 </BindLogic>
             </Provider>
         )

--- a/frontend/src/scenes/surveys/utils.test.ts
+++ b/frontend/src/scenes/surveys/utils.test.ts
@@ -3,6 +3,7 @@ import { SurveyRatingResults } from 'scenes/surveys/surveyLogic'
 
 import {
     EventPropertyFilter,
+    FeatureFlagFilters,
     PropertyFilterType,
     Survey,
     SurveyAppearance,
@@ -500,7 +501,7 @@ describe('survey utils', () => {
         })
 
         it('detects advanced audience targeting', () => {
-            const filters = {
+            const filters: FeatureFlagFilters = {
                 groups: [
                     {
                         properties: [

--- a/frontend/src/scenes/surveys/utils.test.ts
+++ b/frontend/src/scenes/surveys/utils.test.ts
@@ -4,6 +4,7 @@ import { SurveyRatingResults } from 'scenes/surveys/surveyLogic'
 import {
     EventPropertyFilter,
     FeatureFlagFilters,
+    PropertyOperator,
     PropertyFilterType,
     Survey,
     SurveyAppearance,
@@ -508,7 +509,7 @@ describe('survey utils', () => {
                             {
                                 key: 'email',
                                 value: ['@posthog.com'],
-                                operator: 'icontains',
+                                operator: PropertyOperator.IContains,
                                 type: PropertyFilterType.Person,
                             },
                         ],

--- a/frontend/src/scenes/surveys/utils.test.ts
+++ b/frontend/src/scenes/surveys/utils.test.ts
@@ -18,9 +18,12 @@ import {
     calculateNpsBreakdown,
     createAnswerFilterHogQLExpression,
     getResolvedSurveyDateRange,
+    getSurveyAudienceSummaryValue,
+    getSurveyDisplayConditionsSummary,
     getSurveyEndDateForQuery,
     getSurveyResponse,
     getSurveyStartDateForQuery,
+    isSimpleSurveyAudienceTargeting,
     sanitizeColor,
     sanitizeSurvey,
     sanitizeSurveyAppearance,
@@ -405,6 +408,125 @@ describe('survey utils', () => {
             const result = sanitizeSurvey(inputSurvey, { keepEmptyConditions: true })
 
             expect(result.conditions).toBeNull()
+        })
+    })
+
+    describe('audience targeting summaries', () => {
+        const baseSurvey = {
+            id: 'survey-id',
+            created_at: '2024-01-01T00:00:00Z',
+            end_date: null,
+            conditions: null,
+            linked_flag: null,
+            linked_flag_id: null,
+            targeting_flag: null,
+            targeting_flag_filters: undefined,
+        } as unknown as Survey
+
+        it('summarizes simple person-property audience rules', () => {
+            const survey = {
+                ...baseSurvey,
+                targeting_flag_filters: {
+                    groups: [
+                        {
+                            properties: [
+                                {
+                                    key: 'email',
+                                    value: ['@posthog.com'],
+                                    operator: 'icontains',
+                                    type: PropertyFilterType.Person,
+                                },
+                                {
+                                    key: 'plan',
+                                    value: ['paid'],
+                                    operator: 'exact',
+                                    type: PropertyFilterType.Person,
+                                },
+                            ],
+                            rollout_percentage: 100,
+                            variant: null,
+                        },
+                    ],
+                },
+            } as Survey
+
+            expect(getSurveyAudienceSummaryValue(survey)).toBe('2 audience rules')
+            expect(getSurveyDisplayConditionsSummary(survey)).toContainEqual({
+                type: 'targeting',
+                label: 'Targeting',
+                value: '2 audience rules',
+            })
+        })
+
+        it('supports simple cohort targeting with rollout', () => {
+            const survey = {
+                ...baseSurvey,
+                targeting_flag_filters: {
+                    groups: [
+                        {
+                            properties: [
+                                {
+                                    key: 'id',
+                                    value: 17,
+                                    type: PropertyFilterType.Cohort,
+                                },
+                            ],
+                            rollout_percentage: 50,
+                            variant: null,
+                        },
+                    ],
+                },
+            } as Survey
+
+            expect(getSurveyAudienceSummaryValue(survey)).toBe('1 audience rule · 50% shown')
+            expect(isSimpleSurveyAudienceTargeting(survey.targeting_flag_filters)).toBe(true)
+        })
+
+        it('summarizes rollout-only targeting', () => {
+            const survey = {
+                ...baseSurvey,
+                targeting_flag_filters: {
+                    groups: [
+                        {
+                            properties: [],
+                            rollout_percentage: 50,
+                            variant: null,
+                        },
+                    ],
+                },
+            } as Survey
+
+            expect(getSurveyAudienceSummaryValue(survey)).toBe('50% of matching users')
+        })
+
+        it('detects advanced audience targeting', () => {
+            const filters = {
+                groups: [
+                    {
+                        properties: [
+                            {
+                                key: 'email',
+                                value: ['@posthog.com'],
+                                operator: 'icontains',
+                                type: PropertyFilterType.Person,
+                            },
+                        ],
+                        rollout_percentage: 100,
+                    },
+                    {
+                        properties: [],
+                        rollout_percentage: 100,
+                    },
+                ],
+            }
+
+            expect(isSimpleSurveyAudienceTargeting(filters)).toBe(false)
+            expect(
+                getSurveyAudienceSummaryValue({
+                    ...baseSurvey,
+                    targeting_flag_filters: filters,
+                } as Survey)
+            ).toBe('Advanced audience targeting')
         })
     })
 

--- a/frontend/src/scenes/surveys/utils.ts
+++ b/frontend/src/scenes/surveys/utils.ts
@@ -13,6 +13,7 @@ import { urls } from 'scenes/urls'
 import {
     BasicSurveyQuestion,
     EventPropertyFilter,
+    FeatureFlagFilters,
     LinkSurveyQuestion,
     MultipleSurveyQuestion,
     PropertyFilterType,
@@ -851,6 +852,80 @@ export interface SurveyCollectionLimitSummary {
     value: string
 }
 
+export function getSurveyTargetingFilters(survey: Survey | NewSurvey): FeatureFlagFilters | undefined {
+    if (survey.targeting_flag_filters) {
+        return survey.targeting_flag_filters
+    }
+
+    return survey.targeting_flag?.filters || undefined
+}
+
+export function getSurveyAudienceRuleCount(filters?: FeatureFlagFilters | null): number {
+    return filters?.groups.reduce((count, group) => count + (group.properties?.length ?? 0), 0) ?? 0
+}
+
+export function getSurveyAudienceRolloutPercentage(filters?: FeatureFlagFilters | null): number | null {
+    if (!filters || filters.groups.length !== 1) {
+        return null
+    }
+
+    return filters.groups[0].rollout_percentage ?? 100
+}
+
+export function isSimpleSurveyAudienceTargeting(filters?: FeatureFlagFilters | null): boolean {
+    if (!filters) {
+        return true
+    }
+
+    if (filters.groups.length !== 1 || filters.aggregation_group_type_index != null || filters.super_groups?.length) {
+        return false
+    }
+
+    if (filters.multivariate?.variants?.length) {
+        return false
+    }
+
+    const [group] = filters.groups
+
+    if (group.aggregation_group_type_index != null || group.variant != null) {
+        return false
+    }
+
+    return (group.properties || []).every(
+        (property) => property.type === PropertyFilterType.Person || property.type === PropertyFilterType.Cohort
+    )
+}
+
+export function getSurveyAudienceSummaryValue(survey: Survey | NewSurvey): string | null {
+    const filters = getSurveyTargetingFilters(survey)
+
+    if (!filters) {
+        return null
+    }
+
+    if (!isSimpleSurveyAudienceTargeting(filters)) {
+        return 'Advanced audience targeting'
+    }
+
+    const ruleCount = getSurveyAudienceRuleCount(filters)
+    const rolloutPercentage = getSurveyAudienceRolloutPercentage(filters)
+    const isPartialRollout = rolloutPercentage != null && rolloutPercentage < 100
+
+    if (ruleCount === 0 && !isPartialRollout) {
+        return null
+    }
+
+    if (ruleCount === 0) {
+        return `${rolloutPercentage}% of matching users`
+    }
+
+    if (isPartialRollout) {
+        return `${ruleCount} audience rule${ruleCount === 1 ? '' : 's'} · ${rolloutPercentage}% shown`
+    }
+
+    return `${ruleCount} audience rule${ruleCount === 1 ? '' : 's'}`
+}
+
 export function getSurveyCollectionLimitSummary(survey: Survey | NewSurvey): SurveyCollectionLimitSummary | null {
     if (survey.responses_limit && survey.responses_limit > 0) {
         return {
@@ -911,11 +986,9 @@ export function getSurveyDisplayConditionsSummary(survey: Survey | NewSurvey): S
     } else if (survey.linked_flag_id) {
         parts.push({ type: 'flag', label: 'Feature flag', value: 'Linked' })
     }
-    if (
-        (survey.targeting_flag_filters && Object.keys(survey.targeting_flag_filters).length > 0) ||
-        (survey.targeting_flag && Object.keys(survey.targeting_flag).length > 0)
-    ) {
-        parts.push({ type: 'targeting', label: 'Targeting', value: 'User properties' })
+    const audienceSummary = getSurveyAudienceSummaryValue(survey)
+    if (audienceSummary) {
+        parts.push({ type: 'targeting', label: 'Targeting', value: audienceSummary })
     }
     if (conditions?.seenSurveyWaitPeriodInDays) {
         parts.push({

--- a/frontend/src/scenes/surveys/wizard/SurveyAudienceFilters.tsx
+++ b/frontend/src/scenes/surveys/wizard/SurveyAudienceFilters.tsx
@@ -1,0 +1,241 @@
+import { useActions, useValues } from 'kea'
+import { useEffect, useState } from 'react'
+
+import { LemonButton, LemonInput } from '@posthog/lemon-ui'
+
+import { PropertyFilters } from 'lib/components/PropertyFilters/PropertyFilters'
+import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
+import { LemonRadio } from 'lib/lemon-ui/LemonRadio'
+import { LemonSlider } from 'lib/lemon-ui/LemonSlider'
+
+import { AnyPropertyFilter, FeatureFlagFilters } from '~/types'
+
+import { surveyLogic } from '../surveyLogic'
+import {
+    getSurveyAudienceRuleCount,
+    getSurveyAudienceRolloutPercentage,
+    getSurveyAudienceSummaryValue,
+    getSurveyTargetingFilters,
+    isSimpleSurveyAudienceTargeting,
+} from '../utils'
+import { WizardPanel, WizardSection } from './WizardLayout'
+
+function buildSimpleAudienceFilters(properties: AnyPropertyFilter[], rolloutPercentage: number): FeatureFlagFilters {
+    return {
+        groups: [
+            {
+                properties,
+                rollout_percentage: rolloutPercentage,
+                variant: null,
+            },
+        ],
+        multivariate: null,
+        payloads: {},
+    }
+}
+
+export function SurveyAudienceFilters({ onOpenFullEditor }: { onOpenFullEditor?: () => void }): JSX.Element {
+    const { survey } = useValues(surveyLogic)
+    const { setSurveyValue, setFlagPropertyErrors } = useActions(surveyLogic)
+
+    const targetingFilters = getSurveyTargetingFilters(survey)
+    const isSimpleTargeting = isSimpleSurveyAudienceTargeting(targetingFilters)
+    const simpleAudienceFilters = isSimpleTargeting ? targetingFilters?.groups[0]?.properties || [] : []
+    const audienceRuleCount = getSurveyAudienceRuleCount(targetingFilters)
+    const rolloutPercentage = isSimpleTargeting ? (getSurveyAudienceRolloutPercentage(targetingFilters) ?? 100) : 100
+    const hasAdvancedTargeting = !!targetingFilters && !isSimpleTargeting
+    const hasAudienceRules = audienceRuleCount > 0
+    const hasGuidedAudienceConfig = hasAudienceRules || rolloutPercentage < 100
+
+    const [audienceMode, setAudienceMode] = useState<'all' | 'specific'>(hasGuidedAudienceConfig ? 'specific' : 'all')
+
+    useEffect(() => {
+        if (hasAdvancedTargeting) {
+            setAudienceMode('specific')
+            return
+        }
+
+        if (hasGuidedAudienceConfig) {
+            setAudienceMode('specific')
+            return
+        }
+
+        setAudienceMode((current) => (current === 'specific' ? current : 'all'))
+    }, [hasAdvancedTargeting, hasGuidedAudienceConfig])
+
+    const clearAudienceFilters = (): void => {
+        setSurveyValue('targeting_flag_filters', null)
+        setSurveyValue('targeting_flag', null)
+        setSurveyValue('remove_targeting_flag', true)
+        setFlagPropertyErrors(null)
+    }
+
+    const handleAudienceModeChange = (mode: 'all' | 'specific'): void => {
+        setAudienceMode(mode)
+
+        if (mode === 'all') {
+            clearAudienceFilters()
+            return
+        }
+
+        setSurveyValue('remove_targeting_flag', false)
+        setFlagPropertyErrors(null)
+    }
+
+    const handleRolloutChange = (value: number): void => {
+        const nextValue = Math.max(0, Math.min(100, value))
+
+        setFlagPropertyErrors(null)
+
+        if (simpleAudienceFilters.length === 0 && nextValue === 100) {
+            clearAudienceFilters()
+            return
+        }
+
+        setSurveyValue('targeting_flag_filters', buildSimpleAudienceFilters(simpleAudienceFilters, nextValue))
+        setSurveyValue('remove_targeting_flag', false)
+    }
+
+    const handleFiltersChange = (filters: AnyPropertyFilter[]): void => {
+        setFlagPropertyErrors(null)
+
+        if (filters.length === 0 && rolloutPercentage === 100) {
+            clearAudienceFilters()
+            return
+        }
+
+        setSurveyValue('targeting_flag_filters', buildSimpleAudienceFilters(filters, rolloutPercentage))
+        setSurveyValue('remove_targeting_flag', false)
+    }
+
+    const headerSummary = getSurveyAudienceSummaryValue(survey) || (audienceMode === 'all' ? 'Everyone' : null)
+
+    return (
+        <WizardSection
+            title="Who should see this?"
+            description="Narrow this survey to people or cohorts, and control how broadly it rolls out."
+            className="space-y-2.5"
+            badge={
+                headerSummary ? (
+                    <span className="rounded bg-surface-secondary px-2 py-1 text-xs text-secondary">
+                        {headerSummary}
+                    </span>
+                ) : null
+            }
+        >
+            {hasAdvancedTargeting ? (
+                <div className="space-y-2.5">
+                    <WizardPanel>
+                        <div className="text-sm font-medium text-primary">Advanced audience targeting</div>
+                        <div className="mt-1 text-xs text-secondary">
+                            This survey already uses targeting rules that are more advanced than the guided editor
+                            supports.
+                        </div>
+                    </WizardPanel>
+                    <div className="flex items-center justify-between gap-3">
+                        <p className="m-0 text-xs text-muted">Use the full editor to review or change these rules.</p>
+                        {onOpenFullEditor && (
+                            <LemonButton type="secondary" size="small" onClick={onOpenFullEditor}>
+                                Open full editor
+                            </LemonButton>
+                        )}
+                    </div>
+                </div>
+            ) : (
+                <div className="space-y-2.5">
+                    <LemonRadio
+                        value={audienceMode}
+                        onChange={handleAudienceModeChange}
+                        options={[
+                            {
+                                value: 'all',
+                                label: 'Everyone',
+                                description: 'Show this survey to anyone who matches the display conditions.',
+                            },
+                            {
+                                value: 'specific',
+                                label: 'Specific people',
+                                description:
+                                    'Only show this survey to matching people or cohorts, with an optional rollout.',
+                            },
+                        ]}
+                    />
+
+                    {audienceMode === 'specific' && (
+                        <div className="ml-6 space-y-2.5">
+                            <WizardPanel>
+                                <div className="text-xs font-medium uppercase tracking-wide text-muted-alt">
+                                    Rollout
+                                </div>
+                                <div className="mt-1 text-xs text-secondary">
+                                    Show this survey to {rolloutPercentage}% of matching users. Default is 100%.
+                                </div>
+                                <div className="mt-3 flex items-center gap-3">
+                                    <LemonSlider
+                                        value={rolloutPercentage}
+                                        onChange={handleRolloutChange}
+                                        min={0}
+                                        max={100}
+                                        step={1}
+                                        className="flex-1"
+                                        ticks={[
+                                            { value: 0, label: '0%' },
+                                            { value: 25, label: '25%' },
+                                            { value: 50, label: '50%' },
+                                            { value: 100, label: '100%' },
+                                        ]}
+                                    />
+                                    <LemonInput
+                                        type="number"
+                                        min={0}
+                                        max={100}
+                                        step="1"
+                                        value={rolloutPercentage}
+                                        onChange={(value) => handleRolloutChange(value ?? 100)}
+                                        className="w-24"
+                                        suffix={<span>%</span>}
+                                    />
+                                </div>
+                            </WizardPanel>
+
+                            <WizardPanel>
+                                <div className="text-xs font-medium uppercase tracking-wide text-muted-alt">
+                                    Audience rules
+                                </div>
+                                <div className="mt-1 text-xs text-secondary">
+                                    Match people whose properties meet all of these rules. You can also target saved
+                                    cohorts.
+                                </div>
+                                <div className="mt-3">
+                                    <PropertyFilters
+                                        propertyFilters={simpleAudienceFilters}
+                                        onChange={handleFiltersChange}
+                                        pageKey="survey-wizard-audience-filters"
+                                        taxonomicGroupTypes={[
+                                            TaxonomicFilterGroupType.PersonProperties,
+                                            TaxonomicFilterGroupType.Cohorts,
+                                        ]}
+                                        buttonText="Add audience rule"
+                                        buttonSize="small"
+                                        openOnInsert
+                                    />
+                                </div>
+                            </WizardPanel>
+
+                            <div className="flex items-center justify-between gap-3">
+                                <p className="m-0 text-xs text-muted">
+                                    Need OR groups or more advanced targeting? Use the full editor.
+                                </p>
+                                {onOpenFullEditor && (
+                                    <LemonButton type="tertiary" size="small" onClick={onOpenFullEditor}>
+                                        Open full editor
+                                    </LemonButton>
+                                )}
+                            </div>
+                        </div>
+                    )}
+                </div>
+            )}
+        </WizardSection>
+    )
+}

--- a/frontend/src/scenes/surveys/wizard/SurveyWizard.tsx
+++ b/frontend/src/scenes/surveys/wizard/SurveyWizard.tsx
@@ -22,7 +22,7 @@ import { NewSurvey } from '../constants'
 import { SurveyAppearancePreview } from '../SurveyAppearancePreview'
 import { getEventPropertyFilterCount } from '../SurveyEventTrigger'
 import { surveyLogic } from '../surveyLogic'
-import { doesSurveyHaveDisplayConditions } from '../utils'
+import { doesSurveyHaveDisplayConditions, getSurveyAudienceSummaryValue } from '../utils'
 import { MaxTip } from './MaxTip'
 import { AppearanceStep } from './steps/AppearanceStep'
 import { QuestionsStep } from './steps/QuestionsStep'
@@ -96,8 +96,8 @@ function SurveyWizard({ id }: SurveyWizardLogicProps): JSX.Element {
     // Show loading state while loading existing survey
     if (isEditing && surveyLoading) {
         return (
-            <div className="min-h-screen bg-bg-light">
-                <div className="max-w-6xl mx-auto px-6 py-6 space-y-6">
+            <div className="min-h-full w-full shrink-0 bg-bg-light">
+                <div className="mx-auto max-w-6xl space-y-5 px-6 py-6">
                     <LemonSkeleton className="h-10 w-full" />
                     <LemonSkeleton className="h-64 w-full" />
                 </div>
@@ -108,8 +108,8 @@ function SurveyWizard({ id }: SurveyWizardLogicProps): JSX.Element {
     // Template selection step - only for new surveys
     if (currentStep === 'template' && !isEditing) {
         return (
-            <div className="min-h-screen bg-bg-light">
-                <div className="max-w-3xl mx-auto p-8">
+            <div className="min-h-full w-full shrink-0 bg-bg-light">
+                <div className="mx-auto max-w-3xl space-y-5 p-8">
                     <div className="mb-6">
                         <LemonButton type="tertiary" size="small" icon={<IconArrowLeft />} to={urls.surveys()}>
                             Surveys
@@ -131,7 +131,7 @@ function SurveyWizard({ id }: SurveyWizardLogicProps): JSX.Element {
         const summary: string[] = []
 
         if (conditions?.url) {
-            summary.push(`URL contains "${conditions.url}"`)
+            summary.push(`URL ${conditions.urlMatchType === 'exact' ? 'is exactly' : 'contains'} "${conditions.url}"`)
         }
 
         if (conditions?.selector) {
@@ -154,19 +154,33 @@ function SurveyWizard({ id }: SurveyWizardLogicProps): JSX.Element {
             summary.push(`User performed event: ${eventNames}`)
         }
 
+        if (survey.linked_flag?.key) {
+            summary.push(
+                survey.conditions?.linkedFlagVariant
+                    ? `Feature flag: ${survey.linked_flag.key} (${survey.conditions.linkedFlagVariant} variant)`
+                    : `Feature flag: ${survey.linked_flag.key}`
+            )
+        }
+
+        const audienceSummary = getSurveyAudienceSummaryValue(survey)
+        if (audienceSummary) {
+            summary.push(`Audience: ${audienceSummary}`)
+        }
+
         return summary
     }
 
     const showLaunchConfirmation = (onConfirm: () => void): void => {
         const hasConditions = doesSurveyHaveDisplayConditions(survey)
         const conditionsSummary = getConditionsSummary()
+        const hasAudienceConditions = conditionsSummary.length > 0
 
         LemonDialog.open({
             title: 'Launch this survey?',
             content: (
                 <div className="space-y-2">
                     <SdkVersionWarnings warnings={surveyWarnings} />
-                    {hasConditions && conditionsSummary.length > 0 ? (
+                    {hasConditions || hasAudienceConditions ? (
                         <>
                             <p className="text-secondary">
                                 The survey will be shown to users who match these conditions:
@@ -232,8 +246,8 @@ function SurveyWizard({ id }: SurveyWizardLogicProps): JSX.Element {
 
     if (currentStep === 'success' && createdSurvey) {
         return (
-            <div className="min-h-screen bg-bg-light">
-                <div className="max-w-2xl mx-auto p-8">
+            <div className="min-h-full w-full shrink-0 bg-bg-light">
+                <div className="mx-auto max-w-2xl p-8">
                     <SuccessStep survey={createdSurvey} />
                 </div>
             </div>
@@ -253,7 +267,7 @@ function SurveyWizard({ id }: SurveyWizardLogicProps): JSX.Element {
 
     // Shared header for all main steps
     const header = (
-        <div className="space-y-4">
+        <div className="space-y-3">
             <div className="space-y-1">
                 {backButton}
                 <div>
@@ -283,8 +297,8 @@ function SurveyWizard({ id }: SurveyWizardLogicProps): JSX.Element {
     // Appearance step - full width with built-in preview
     if (currentStep === 'appearance') {
         return (
-            <div className="min-h-screen bg-bg-light">
-                <div className="max-w-6xl mx-auto px-6 py-6 space-y-6">
+            <div className="min-h-full w-full shrink-0 bg-bg-light">
+                <div className="mx-auto max-w-6xl space-y-5 px-6 py-6">
                     {header}
                     <AppearanceStep />
 
@@ -319,16 +333,16 @@ function SurveyWizard({ id }: SurveyWizardLogicProps): JSX.Element {
     }
 
     return (
-        <div className="min-h-screen bg-bg-light">
-            <div className="max-w-6xl mx-auto px-6 py-6 space-y-6">
+        <div className="min-h-full w-full shrink-0 bg-bg-light">
+            <div className="mx-auto max-w-6xl space-y-5 px-6 py-6">
                 {header}
 
                 <div className="grid grid-cols-1 lg:grid-cols-5 gap-8">
                     {/* Left: Form */}
-                    <div className="lg:col-span-3 space-y-6">
+                    <div className="space-y-5 lg:col-span-3">
                         <div>
                             {currentStep === 'questions' && <QuestionsStep />}
-                            {currentStep === 'where' && <WhereStep />}
+                            {currentStep === 'where' && <WhereStep onOpenFullEditor={handleCustomizeMore} />}
                             {currentStep === 'when' && <WhenStep />}
                         </div>
 

--- a/frontend/src/scenes/surveys/wizard/WizardLayout.tsx
+++ b/frontend/src/scenes/surveys/wizard/WizardLayout.tsx
@@ -1,0 +1,97 @@
+import { ReactNode } from 'react'
+
+import { cn } from 'lib/utils/css-classes'
+
+interface WizardStepLayoutProps {
+    children: ReactNode
+    className?: string
+}
+
+export function WizardStepLayout({ children, className }: WizardStepLayoutProps): JSX.Element {
+    return <div className={cn('space-y-5', className)}>{children}</div>
+}
+
+interface WizardSectionProps {
+    title: ReactNode
+    description?: ReactNode
+    children?: ReactNode
+    className?: string
+    headerClassName?: string
+    contentClassName?: string
+    titleClassName?: string
+    descriptionClassName?: string
+    badge?: ReactNode
+    actions?: ReactNode
+}
+
+export function WizardSection({
+    title,
+    description,
+    children,
+    className,
+    headerClassName,
+    contentClassName,
+    titleClassName,
+    descriptionClassName,
+    badge,
+    actions,
+}: WizardSectionProps): JSX.Element {
+    return (
+        <section className={cn('space-y-3', className)}>
+            <div className={cn('space-y-1', headerClassName)}>
+                <div className="flex items-center justify-between gap-4">
+                    <div className="flex min-w-0 items-center gap-2">
+                        <h2 className={cn('m-0 text-xl font-semibold', titleClassName)}>{title}</h2>
+                        {badge}
+                    </div>
+                    {actions}
+                </div>
+                {description ? <p className={cn('m-0 text-secondary', descriptionClassName)}>{description}</p> : null}
+            </div>
+            {children ? <div className={contentClassName}>{children}</div> : null}
+        </section>
+    )
+}
+
+interface WizardPanelProps {
+    children: ReactNode
+    className?: string
+}
+
+export function WizardPanel({ children, className }: WizardPanelProps): JSX.Element {
+    return <div className={cn('rounded-lg border border-border bg-surface-primary p-3', className)}>{children}</div>
+}
+
+interface WizardDividerSectionProps {
+    title?: ReactNode
+    description?: ReactNode
+    children: ReactNode
+    className?: string
+    contentClassName?: string
+    titleClassName?: string
+    descriptionClassName?: string
+}
+
+export function WizardDividerSection({
+    title,
+    description,
+    children,
+    className,
+    contentClassName,
+    titleClassName,
+    descriptionClassName,
+}: WizardDividerSectionProps): JSX.Element {
+    return (
+        <section className={cn('border-t border-border pt-5', className)}>
+            {(title || description) && (
+                <div className="space-y-1">
+                    {title ? <h2 className={cn('m-0 text-xl font-semibold', titleClassName)}>{title}</h2> : null}
+                    {description ? (
+                        <p className={cn('m-0 text-secondary', descriptionClassName)}>{description}</p>
+                    ) : null}
+                </div>
+            )}
+            <div className={cn(title || description ? 'mt-4' : undefined, contentClassName)}>{children}</div>
+        </section>
+    )
+}

--- a/frontend/src/scenes/surveys/wizard/steps/AppearanceStep.tsx
+++ b/frontend/src/scenes/surveys/wizard/steps/AppearanceStep.tsx
@@ -26,6 +26,7 @@ import { surveyLogic } from '../../surveyLogic'
 import { surveysLogic } from '../../surveysLogic'
 import { ColorInput } from '../ColorInput'
 import { SurveyThemeSelector } from '../SurveyThemeSelector'
+import { WizardSection } from '../WizardLayout'
 
 export function AppearanceStep(): JSX.Element {
     const { survey } = useValues(surveyLogic)
@@ -76,16 +77,14 @@ export function AppearanceStep(): JSX.Element {
     const totalPreviewPages = survey.questions.length + (appearance.displayThankYouMessage ? 1 : 0)
 
     return (
-        <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+        <div className="grid grid-cols-1 gap-5 lg:grid-cols-3">
             {/* Left: Controls */}
-            <div className="lg:col-span-2 space-y-4">
-                <div>
-                    <h2 className="text-xl font-semibold mb-1">How should it look?</h2>
-                    <p className="text-secondary text-sm">
-                        Customize colors and styling. You can use CSS variables (e.g. var(--brand-color)) for dynamic
-                        theming.
-                    </p>
-                </div>
+            <div className="space-y-3.5 lg:col-span-2">
+                <WizardSection
+                    title="How should it look?"
+                    description="Customize colors and styling. You can use CSS variables (e.g. var(--brand-color)) for dynamic theming."
+                    descriptionClassName="text-sm"
+                />
 
                 {/* Paywall */}
                 {!surveysStylingAvailable && (
@@ -102,8 +101,7 @@ export function AppearanceStep(): JSX.Element {
                 />
 
                 {/* Color customization */}
-                <div className="space-y-2">
-                    <h3 className="font-medium m-0 text-sm">Fine-tune colors</h3>
+                <WizardSection title="Fine-tune colors" titleClassName="text-sm font-medium">
                     <div className="grid grid-cols-2 gap-x-4 gap-y-2">
                         <LemonField.Pure label="Background" className="gap-1">
                             <ColorInput
@@ -159,7 +157,7 @@ export function AppearanceStep(): JSX.Element {
                             </>
                         )}
                     </div>
-                </div>
+                </WizardSection>
 
                 {/* Branding */}
                 <LemonCheckbox
@@ -184,7 +182,7 @@ export function AppearanceStep(): JSX.Element {
                             header: 'Advanced options',
                             className: 'p-2',
                             content: (
-                                <div className="space-y-4">
+                                <div className="space-y-3">
                                     <div className="grid grid-cols-2 gap-x-4 gap-y-2">
                                         <LemonField.Pure label="Position" className="gap-1">
                                             <LemonSelect

--- a/frontend/src/scenes/surveys/wizard/steps/QuestionsStep.tsx
+++ b/frontend/src/scenes/surveys/wizard/steps/QuestionsStep.tsx
@@ -7,7 +7,7 @@ import { useState } from 'react'
 import { createPortal } from 'react-dom'
 
 import { IconEmoji, IconPlusSmall, IconRevert, IconTrash } from '@posthog/icons'
-import { LemonButton, LemonCheckbox, LemonInput, LemonSwitch, LemonTag } from '@posthog/lemon-ui'
+import { LemonButton, LemonCheckbox, LemonInput, LemonSegmentedButton, LemonSwitch, LemonTag } from '@posthog/lemon-ui'
 
 import { EditableField } from 'lib/components/EditableField/EditableField'
 import { SortableDragIcon } from 'lib/lemon-ui/icons'
@@ -455,23 +455,20 @@ function SortableQuestionCard({
                         }
                         textPlaceholder="Add description (optional)"
                     />
-                    <div className="flex items-center gap-2">
+                    <div className="flex items-center gap-2 flex-wrap">
                         <QuestionTypeChip type={question.type} onChange={(newType) => onChangeType(index, newType)} />
-                        {question.optional && (
-                            <LemonTag type="highlight" size="small">
-                                Optional
-                            </LemonTag>
+                        {index > 0 && (
+                            <LemonSegmentedButton
+                                size="small"
+                                value={question.optional ? 'optional' : 'mandatory'}
+                                onChange={(value) => onUpdate(index, { optional: value === 'optional' })}
+                                options={[
+                                    { value: 'mandatory', label: 'Mandatory' },
+                                    { value: 'optional', label: 'Optional' },
+                                ]}
+                            />
                         )}
                     </div>
-                    {index > 0 && (
-                        <LemonCheckbox
-                            size="small"
-                            checked={!!question.optional}
-                            onChange={(checked) => onUpdate(index, { optional: checked })}
-                            label="Optional"
-                        />
-                    )}
-
                     <QuestionOptions question={question} onUpdate={(updates) => onUpdate(index, updates)} />
                 </div>
                 {canDelete && (

--- a/frontend/src/scenes/surveys/wizard/steps/QuestionsStep.tsx
+++ b/frontend/src/scenes/surveys/wizard/steps/QuestionsStep.tsx
@@ -18,14 +18,17 @@ import {
     RatingSurveyQuestion,
     SurveyAppearance,
     SurveyQuestion,
+    SurveyQuestionDescriptionContentType,
     SurveyQuestionType,
 } from '~/types'
 
-import { SURVEY_RATING_SCALE, defaultSurveyAppearance, defaultSurveyFieldValues } from '../../constants'
+import { SCALE_OPTIONS, SURVEY_RATING_SCALE, defaultSurveyAppearance, defaultSurveyFieldValues } from '../../constants'
+import { HTMLEditor } from '../../SurveyAppearanceUtils'
 import { surveyLogic } from '../../surveyLogic'
 import { AddQuestionButton } from '../AddQuestionButton'
 import { QuestionTypeChip } from '../QuestionTypeChip'
 import { surveyWizardLogic } from '../surveyWizardLogic'
+import { WizardSection, WizardStepLayout } from '../WizardLayout'
 
 const MAX_CHOICES = 10
 
@@ -43,13 +46,19 @@ function QuestionOptions({ question, onUpdate }: QuestionOptionsProps): JSX.Elem
         // Scale options depend on display type
         const numberScales = [
             { value: 10, label: '0-10', sublabel: 'NPS' },
-            { value: 5, label: '1-5', sublabel: null },
-            { value: 7, label: '1-7', sublabel: 'CSAT' },
+            { value: 5, label: '1-5', sublabel: 'CSAT' },
+            { value: 7, label: '1-7', sublabel: 'CES' },
         ]
-        const emojiScales = [
-            { value: 3, label: '3', sublabel: null },
-            { value: 5, label: '5', sublabel: null },
-        ]
+        const emojiScales = SCALE_OPTIONS.EMOJI.map((option) => ({
+            value: option.value,
+            label: option.value === SURVEY_RATING_SCALE.THUMB_2_POINT ? 'Thumbs' : 'Emoji',
+            sublabel:
+                option.value === SURVEY_RATING_SCALE.THUMB_2_POINT
+                    ? '2-point'
+                    : option.value === SURVEY_RATING_SCALE.EMOJI_3_POINT
+                      ? '3-point'
+                      : '5-point',
+        }))
         const scaleOptions = isEmoji ? emojiScales : numberScales
 
         return (
@@ -109,7 +118,7 @@ function QuestionOptions({ question, onUpdate }: QuestionOptionsProps): JSX.Elem
                                 >
                                     <div className="text-sm font-medium">{option.label}</div>
                                     {option.sublabel && (
-                                        <div className="text-[10px] text-secondary uppercase">{option.sublabel}</div>
+                                        <div className="text-[10px] text-secondary">{option.sublabel}</div>
                                     )}
                                 </button>
                             ))}
@@ -400,6 +409,7 @@ function SortableQuestionCard({
     const style = {
         transform: CSS.Translate.toString(transform),
     }
+    const descriptionContentType = (question.descriptionContentType || 'text') as SurveyQuestionDescriptionContentType
 
     return (
         <div
@@ -434,16 +444,16 @@ function SortableQuestionCard({
                         compactIcon
                         showEditIconOnHover
                     />
-                    <EditableField
-                        name={`description-${index}`}
+                    <HTMLEditor
                         value={question.description || ''}
-                        onSave={(text) => onUpdate(index, { description: text })}
-                        placeholder="Add description (optional)"
-                        className="text-secondary text-sm"
-                        saveOnBlur
-                        clickToEdit
-                        compactIcon
-                        showEditIconOnHover
+                        onChange={(text) => onUpdate(index, { description: text })}
+                        activeTab={descriptionContentType}
+                        onTabChange={(key) =>
+                            onUpdate(index, {
+                                descriptionContentType: key,
+                            })
+                        }
+                        textPlaceholder="Add description (optional)"
                     />
                     <div className="flex items-center gap-2">
                         <QuestionTypeChip type={question.type} onChange={(newType) => onChangeType(index, newType)} />
@@ -453,6 +463,14 @@ function SortableQuestionCard({
                             </LemonTag>
                         )}
                     </div>
+                    {index > 0 && (
+                        <LemonCheckbox
+                            size="small"
+                            checked={!!question.optional}
+                            onChange={(checked) => onUpdate(index, { optional: checked })}
+                            label="Optional"
+                        />
+                    )}
 
                     <QuestionOptions question={question} onUpdate={(updates) => onUpdate(index, updates)} />
                 </div>
@@ -543,19 +561,24 @@ export function QuestionsStep(): JSX.Element {
     const activeQuestion = activeIndex !== null ? questions[activeIndex] : null
 
     return (
-        <div className="space-y-6">
-            <div className="flex items-start justify-between gap-4">
-                <div className="space-y-1">
-                    <h2 className="text-xl font-semibold">Your survey questions</h2>
-                    <p className="text-secondary text-sm">Click any question to edit it</p>
-                </div>
-                {hasChanges && (
-                    <LemonButton type="tertiary" size="small" icon={<IconRevert />} onClick={restoreDefaultQuestions}>
-                        Restore defaults
-                    </LemonButton>
-                )}
-            </div>
-
+        <WizardStepLayout>
+            <WizardSection
+                title="Your survey questions"
+                description="Click any question to edit it"
+                descriptionClassName="text-sm"
+                actions={
+                    hasChanges ? (
+                        <LemonButton
+                            type="tertiary"
+                            size="small"
+                            icon={<IconRevert />}
+                            onClick={restoreDefaultQuestions}
+                        >
+                            Restore defaults
+                        </LemonButton>
+                    ) : null
+                }
+            />
             <DndContext onDragStart={handleDragStart} onDragEnd={handleDragEnd}>
                 <SortableContext items={sortedItemIds} strategy={verticalListSortingStrategy} disabled={!canReorder}>
                     <div className="space-y-3">
@@ -595,6 +618,6 @@ export function QuestionsStep(): JSX.Element {
                 appearance={{ ...defaultSurveyAppearance, ...survey.appearance }}
                 onUpdate={(updates) => setSurveyValue('appearance', { ...survey.appearance, ...updates })}
             />
-        </div>
+        </WizardStepLayout>
     )
 }

--- a/frontend/src/scenes/surveys/wizard/steps/QuestionsStep.tsx
+++ b/frontend/src/scenes/surveys/wizard/steps/QuestionsStep.tsx
@@ -454,12 +454,13 @@ function SortableQuestionCard({
                             })
                         }
                         textPlaceholder="Add description (optional)"
+                        textMinRows={1}
                     />
                     <div className="flex items-center gap-2 flex-wrap">
                         <QuestionTypeChip type={question.type} onChange={(newType) => onChangeType(index, newType)} />
                         {index > 0 && (
                             <LemonSegmentedButton
-                                size="small"
+                                size="xsmall"
                                 value={question.optional ? 'optional' : 'mandatory'}
                                 onChange={(value) => onUpdate(index, { optional: value === 'optional' })}
                                 options={[

--- a/frontend/src/scenes/surveys/wizard/steps/WhenStep.tsx
+++ b/frontend/src/scenes/surveys/wizard/steps/WhenStep.tsx
@@ -1,14 +1,20 @@
 import { useActions, useValues } from 'kea'
 
 import { IconX } from '@posthog/icons'
-import { LemonButton, LemonCheckbox, LemonInput } from '@posthog/lemon-ui'
+import { LemonButton, LemonCheckbox, LemonInput, LemonSegmentedButton } from '@posthog/lemon-ui'
 
 import { PropertyFilters } from 'lib/components/PropertyFilters/PropertyFilters'
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 import { LemonRadio } from 'lib/lemon-ui/LemonRadio'
 import { AddEventButton } from 'scenes/surveys/AddEventButton'
 
-import { AnyPropertyFilter, SurveyAppearance, SurveyDisplayConditions, SurveyEventsWithProperties } from '~/types'
+import {
+    AnyPropertyFilter,
+    SurveyAppearance,
+    SurveyDisplayConditions,
+    SurveyEventsWithProperties,
+    SurveySchedule,
+} from '~/types'
 
 import {
     SUPPORTED_OPERATORS,
@@ -18,10 +24,20 @@ import {
     useExcludedObjectProperties,
 } from '../../SurveyEventTrigger'
 import { surveyLogic } from '../../surveyLogic'
+import { surveyWizardLogic } from '../surveyWizardLogic'
+import { WizardDividerSection, WizardPanel, WizardSection, WizardStepLayout } from '../WizardLayout'
+
+const FREQUENCY_OPTIONS: { value: string; days: number | undefined; label: string }[] = [
+    { value: 'once', days: undefined, label: 'Once ever' },
+    { value: 'yearly', days: 365, label: 'Every year' },
+    { value: 'quarterly', days: 90, label: 'Every 3 months' },
+    { value: 'monthly', days: 30, label: 'Every month' },
+]
 
 export function WhenStep(): JSX.Element {
     const { survey } = useValues(surveyLogic)
     const { setSurveyValue } = useActions(surveyLogic)
+    const { recommendedFrequency } = useValues(surveyWizardLogic)
 
     const conditions: Partial<SurveyDisplayConditions> = survey.conditions || {}
     const appearance: Partial<SurveyAppearance> = survey.appearance || {}
@@ -31,6 +47,11 @@ export function WhenStep(): JSX.Element {
     const repeatedActivation = conditions.events?.repeatedActivation ?? false
     const delaySeconds = appearance.surveyPopupDelaySeconds ?? 0
     const excludedObjectProperties = useExcludedObjectProperties()
+    const daysToFrequency = (days: number | undefined): string => {
+        const option = FREQUENCY_OPTIONS.find((opt) => opt.days === days)
+        return option?.value || 'monthly'
+    }
+    const frequency = daysToFrequency(conditions.seenSurveyWaitPeriodInDays)
 
     const setTriggerMode = (mode: 'pageview' | 'event'): void => {
         if (mode === 'pageview') {
@@ -43,6 +64,13 @@ export function WhenStep(): JSX.Element {
 
     const setDelaySeconds = (seconds: number): void => {
         setSurveyValue('appearance', { ...appearance, surveyPopupDelaySeconds: seconds })
+    }
+
+    const setFrequency = (value: string): void => {
+        const option = FREQUENCY_OPTIONS.find((opt) => opt.value === value)
+        const isOnce = value === 'once'
+        setSurveyValue('schedule', isOnce ? SurveySchedule.Once : SurveySchedule.Always)
+        setSurveyValue('conditions', { ...conditions, seenSurveyWaitPeriodInDays: option?.days })
     }
 
     const setRepeatedActivation = (enabled: boolean): void => {
@@ -94,94 +122,118 @@ export function WhenStep(): JSX.Element {
     }
 
     return (
-        <div className="space-y-6">
-            <div className="space-y-1">
-                <h2 className="text-xl font-semibold">When should this appear?</h2>
-                <p className="text-secondary text-sm">Choose when to show this survey to your users</p>
-            </div>
+        <WizardStepLayout>
+            <WizardSection
+                title="When should this appear?"
+                description="Choose when to show this survey to your users"
+                descriptionClassName="text-sm"
+            >
+                <LemonRadio
+                    value={triggerMode}
+                    onChange={setTriggerMode}
+                    options={[
+                        {
+                            value: 'pageview',
+                            label: 'On page load',
+                            description: 'Shows when the user visits the page',
+                        },
+                        {
+                            value: 'event',
+                            label: 'When an event is captured',
+                            description: 'Trigger the survey after specific events occur',
+                        },
+                    ]}
+                />
 
-            <LemonRadio
-                value={triggerMode}
-                onChange={setTriggerMode}
-                options={[
-                    {
-                        value: 'pageview',
-                        label: 'On page load',
-                        description: 'Shows when the user visits the page',
-                    },
-                    {
-                        value: 'event',
-                        label: 'When an event is captured',
-                        description: 'Trigger the survey after specific events occur',
-                    },
-                ]}
-            />
+                {triggerMode === 'event' && (
+                    <div className="ml-6 space-y-2.5 mt-2">
+                        {triggerEvents.length > 0 && (
+                            <div className="space-y-2.5">
+                                <div className="text-xs text-muted">
+                                    Each event can be narrowed with optional property filters right below it.
+                                </div>
+                                {triggerEvents.map((event) => {
+                                    const propertyFilterCount = getEventPropertyFilterCount(event.propertyFilters)
 
-            {triggerMode === 'event' && (
-                <div className="ml-6 space-y-3">
-                    {triggerEvents.length > 0 && (
-                        <div className="space-y-3">
-                            <div className="text-xs text-muted">
-                                Each event can be narrowed with optional property filters right below it.
-                            </div>
-                            {triggerEvents.map((event) => {
-                                const propertyFilterCount = getEventPropertyFilterCount(event.propertyFilters)
-
-                                return (
-                                    <div key={event.name} className="border border-border rounded-lg bg-bg-light p-3">
-                                        <div className="flex items-start justify-between gap-3 mb-3">
-                                            <div className="space-y-1">
-                                                <div className="flex flex-wrap items-center gap-2">
-                                                    <code className="text-sm font-mono">{event.name}</code>
-                                                    <span className="text-xs text-muted bg-border px-1.5 py-0.5 rounded">
-                                                        {propertyFilterCount > 0
-                                                            ? `${propertyFilterCount} filter${propertyFilterCount !== 1 ? 's' : ''}`
-                                                            : 'No filters yet'}
-                                                    </span>
+                                    return (
+                                        <WizardPanel key={event.name} className="bg-bg-light">
+                                            <div className="flex items-start justify-between gap-3 mb-3">
+                                                <div className="space-y-1">
+                                                    <div className="flex flex-wrap items-center gap-2">
+                                                        <code className="text-sm font-mono">{event.name}</code>
+                                                        <span className="text-xs text-muted bg-border px-1.5 py-0.5 rounded">
+                                                            {propertyFilterCount > 0
+                                                                ? `${propertyFilterCount} filter${propertyFilterCount !== 1 ? 's' : ''}`
+                                                                : 'No filters yet'}
+                                                        </span>
+                                                    </div>
+                                                    <div className="text-xs text-muted">
+                                                        Show the survey only when this event matches the properties
+                                                        below.
+                                                    </div>
                                                 </div>
-                                                <div className="text-xs text-muted">
-                                                    Show the survey only when this event matches the properties below.
-                                                </div>
+                                                <LemonButton
+                                                    size="xsmall"
+                                                    icon={<IconX />}
+                                                    onClick={() => removeTriggerEvent(event.name)}
+                                                    type="tertiary"
+                                                />
                                             </div>
-                                            <LemonButton
-                                                size="xsmall"
-                                                icon={<IconX />}
-                                                onClick={() => removeTriggerEvent(event.name)}
-                                                type="tertiary"
+                                            <PropertyFilters
+                                                propertyFilters={convertPropertyFiltersToArray(event.propertyFilters)}
+                                                onChange={(filters: AnyPropertyFilter[]) =>
+                                                    updateTriggerEventFilters(event, filters)
+                                                }
+                                                pageKey={`survey-wizard-event-${event.name}`}
+                                                taxonomicGroupTypes={[TaxonomicFilterGroupType.EventProperties]}
+                                                excludedProperties={excludedObjectProperties}
+                                                eventNames={[event.name]}
+                                                buttonText="Add property filter"
+                                                buttonSize="small"
+                                                operatorAllowlist={SUPPORTED_OPERATORS}
                                             />
-                                        </div>
-                                        <PropertyFilters
-                                            propertyFilters={convertPropertyFiltersToArray(event.propertyFilters)}
-                                            onChange={(filters: AnyPropertyFilter[]) =>
-                                                updateTriggerEventFilters(event, filters)
-                                            }
-                                            pageKey={`survey-wizard-event-${event.name}`}
-                                            taxonomicGroupTypes={[TaxonomicFilterGroupType.EventProperties]}
-                                            excludedProperties={excludedObjectProperties}
-                                            eventNames={[event.name]}
-                                            buttonText="Add property filter"
-                                            buttonSize="small"
-                                            operatorAllowlist={SUPPORTED_OPERATORS}
-                                        />
-                                        <div className="text-xs text-muted mt-2">
-                                            Only primitive types are supported here. Array and object properties are
-                                            excluded.
-                                        </div>
-                                    </div>
-                                )
-                            })}
+                                            <div className="text-xs text-muted mt-2">
+                                                Only primitive types are supported here. Array and object properties are
+                                                excluded.
+                                            </div>
+                                        </WizardPanel>
+                                    )
+                                })}
+                            </div>
+                        )}
+                        <AddEventButton onEventSelect={addTriggerEvent} addButtonText="Add event" />
+                        <div className="pt-1">
+                            <LemonCheckbox
+                                checked={repeatedActivation}
+                                onChange={setRepeatedActivation}
+                                label="Show every time the event is captured"
+                            />
                         </div>
-                    )}
-                    <AddEventButton onEventSelect={addTriggerEvent} addButtonText="Add event" />
-                    <LemonCheckbox
-                        checked={repeatedActivation}
-                        onChange={setRepeatedActivation}
-                        label="Show every time the event is captured"
-                    />
-                </div>
-            )}
+                    </div>
+                )}
+            </WizardSection>
 
-            <div className="border-t border-border pt-6 space-y-2">
+            <WizardDividerSection
+                title="How often can the same person see this?"
+                description="Control how frequently the same person can be shown this survey again."
+            >
+                <LemonSegmentedButton
+                    value={frequency}
+                    onChange={setFrequency}
+                    options={FREQUENCY_OPTIONS.map((opt) => ({
+                        ...opt,
+                        tooltip:
+                            opt.value === recommendedFrequency.value ? `Recommended for this survey type` : undefined,
+                    }))}
+                    fullWidth
+                />
+
+                {recommendedFrequency.value === frequency && (
+                    <p className="text-sm text-success mt-3">{recommendedFrequency.reason}</p>
+                )}
+            </WizardDividerSection>
+
+            <WizardDividerSection contentClassName="space-y-2">
                 <label className="text-sm font-medium">Delay before showing</label>
                 <div className="flex items-center gap-2">
                     <LemonInput
@@ -196,7 +248,7 @@ export function WhenStep(): JSX.Element {
                 <p className="text-muted text-xs">
                     Once a user matches the targeting conditions, wait this long before displaying the survey
                 </p>
-            </div>
-        </div>
+            </WizardDividerSection>
+        </WizardStepLayout>
     )
 }

--- a/frontend/src/scenes/surveys/wizard/steps/WhenStep.tsx
+++ b/frontend/src/scenes/surveys/wizard/steps/WhenStep.tsx
@@ -37,7 +37,7 @@ const FREQUENCY_OPTIONS: { value: string; days: number | undefined; label: strin
 export function WhenStep(): JSX.Element {
     const { survey } = useValues(surveyLogic)
     const { setSurveyValue } = useActions(surveyLogic)
-    const { recommendedFrequency } = useValues(surveyWizardLogic)
+    const { recommendedFrequency } = useValues(surveyWizardLogic({ id: survey.id || 'new' }))
 
     const conditions: Partial<SurveyDisplayConditions> = survey.conditions || {}
     const appearance: Partial<SurveyAppearance> = survey.appearance || {}

--- a/frontend/src/scenes/surveys/wizard/steps/WhereStep.tsx
+++ b/frontend/src/scenes/surveys/wizard/steps/WhereStep.tsx
@@ -1,27 +1,27 @@
 import { useActions, useValues } from 'kea'
 import { useEffect } from 'react'
 
-import { LemonInputSelect, LemonSegmentedButton } from '@posthog/lemon-ui'
+import { IconTrash } from '@posthog/icons'
+import { LemonButton, LemonInputSelect, LemonSegmentedButton } from '@posthog/lemon-ui'
 
+import { FlagSelector } from 'lib/components/FlagSelector'
+import { ANY_VARIANT, variantOptions } from 'lib/components/IngestionControls/triggers/FlagTrigger/VariantSelector'
 import { LemonRadio } from 'lib/lemon-ui/LemonRadio'
+import { featureFlagLogic } from 'scenes/feature-flags/featureFlagLogic'
 
 import { propertyDefinitionsModel } from '~/models/propertyDefinitionsModel'
-import { PropertyDefinitionType, SurveyDisplayConditions, SurveyMatchType, SurveySchedule } from '~/types'
+import { PropertyDefinitionType, SurveyDisplayConditions, SurveyMatchType } from '~/types'
 
 import { surveyLogic } from '../../surveyLogic'
-import { surveyWizardLogic } from '../surveyWizardLogic'
+import { SurveyAudienceFilters } from '../SurveyAudienceFilters'
+import { WizardSection, WizardStepLayout } from '../WizardLayout'
 
-const FREQUENCY_OPTIONS: { value: string; days: number | undefined; label: string }[] = [
-    { value: 'once', days: undefined, label: 'Once ever' },
-    { value: 'yearly', days: 365, label: 'Every year' },
-    { value: 'quarterly', days: 90, label: 'Every 3 months' },
-    { value: 'monthly', days: 30, label: 'Every month' },
-]
+const DEVICE_OPTIONS = ['Desktop', 'Mobile', 'Tablet']
 
-export function WhereStep(): JSX.Element {
+export function WhereStep({ onOpenFullEditor }: { onOpenFullEditor?: () => void }): JSX.Element {
     const { survey } = useValues(surveyLogic)
     const { setSurveyValue } = useActions(surveyLogic)
-    const { recommendedFrequency } = useValues(surveyWizardLogic)
+    const { featureFlag } = useValues(featureFlagLogic({ id: survey.linked_flag_id || 'link' }))
 
     const { options } = useValues(propertyDefinitionsModel)
     const { loadPropertyValues } = useActions(propertyDefinitionsModel)
@@ -30,13 +30,46 @@ export function WhereStep(): JSX.Element {
     const conditions: Partial<SurveyDisplayConditions> = survey.conditions || {}
     const targetingMode = conditions.urlMatchType ? 'specific' : 'all'
     const urlPattern = conditions.url || ''
+    const urlMatchMode =
+        conditions.urlMatchType === SurveyMatchType.Exact ? SurveyMatchType.Exact : SurveyMatchType.Contains
+    const isPathInputInExactMode = urlMatchMode === SurveyMatchType.Exact && urlPattern.trim().startsWith('/')
+    const selectedDevices = conditions.deviceTypes || []
+    const resolvedLinkedFlag = survey.linked_flag || (survey.linked_flag_id ? featureFlag : null)
+    const urlInputPlaceholder =
+        urlMatchMode === SurveyMatchType.Exact
+            ? 'Select a page or type the full URL'
+            : 'Select a page or type a path like /pricing'
+    const urlSuggestions = (() => {
+        const seen = new Set<string>()
 
-    // Convert days to frequency string value
-    const daysToFrequency = (days: number | undefined): string => {
-        const option = FREQUENCY_OPTIONS.find((opt) => opt.days === days)
-        return option?.value || 'monthly'
-    }
-    const frequency = daysToFrequency(conditions.seenSurveyWaitPeriodInDays)
+        return (urlOptions?.values || [])
+            .map(({ name }) => {
+                const rawValue = String(name)
+
+                if (urlMatchMode === SurveyMatchType.Exact) {
+                    try {
+                        return new URL(rawValue).toString()
+                    } catch {
+                        return null
+                    }
+                }
+
+                try {
+                    return new URL(rawValue).pathname || '/'
+                } catch {
+                    return rawValue
+                }
+            })
+            .filter((value): value is string => !!value)
+            .filter((value) => {
+                if (seen.has(value)) {
+                    return false
+                }
+                seen.add(value)
+                return true
+            })
+            .map((value) => ({ key: value, label: value }))
+    })()
 
     useEffect(() => {
         if (targetingMode === 'specific' && urlOptions?.status !== 'loading' && urlOptions?.status !== 'loaded') {
@@ -60,23 +93,38 @@ export function WhereStep(): JSX.Element {
     }
 
     const setUrlPattern = (pattern: string): void => {
-        setSurveyValue('conditions', { ...conditions, url: pattern, urlMatchType: SurveyMatchType.Contains })
+        setSurveyValue('conditions', { ...conditions, url: pattern, urlMatchType: urlMatchMode })
     }
 
-    const setFrequency = (value: string): void => {
-        const option = FREQUENCY_OPTIONS.find((opt) => opt.value === value)
-        const isOnce = value === 'once'
-        setSurveyValue('schedule', isOnce ? SurveySchedule.Once : SurveySchedule.Always)
-        setSurveyValue('conditions', { ...conditions, seenSurveyWaitPeriodInDays: option?.days })
+    const setUrlMatchMode = (matchType: SurveyMatchType.Exact | SurveyMatchType.Contains): void => {
+        setSurveyValue('conditions', {
+            ...conditions,
+            urlMatchType: matchType,
+        })
+    }
+
+    const toggleDeviceType = (device: string): void => {
+        const nextDeviceTypes = selectedDevices.includes(device)
+            ? selectedDevices.filter((current) => current !== device)
+            : [...selectedDevices, device]
+
+        setSurveyValue('conditions', {
+            ...conditions,
+            deviceTypes: nextDeviceTypes.length > 0 ? nextDeviceTypes : undefined,
+            deviceTypesMatchType: nextDeviceTypes.length > 0 ? SurveyMatchType.Exact : undefined,
+        })
+    }
+
+    const clearLinkedFlag = (): void => {
+        const { linkedFlagVariant, ...restConditions } = conditions
+        setSurveyValue('linked_flag_id', null)
+        setSurveyValue('linked_flag', null)
+        setSurveyValue('conditions', restConditions)
     }
 
     return (
-        <div className="space-y-10">
-            {/* Page targeting */}
-            <div>
-                <h2 className="text-xl font-semibold mb-2">Where should this appear?</h2>
-                <p className="text-secondary mb-6">Choose which pages will show this survey</p>
-
+        <WizardStepLayout className="space-y-6">
+            <WizardSection title="Where should this appear?" description="Choose which pages will show this survey">
                 <LemonRadio
                     value={targetingMode}
                     onChange={setTargetingMode}
@@ -89,13 +137,26 @@ export function WhereStep(): JSX.Element {
                         {
                             value: 'specific',
                             label: 'Specific pages',
-                            description: 'Only show on pages matching a URL pattern',
+                            description: 'Only show on pages matching a path or full URL',
                         },
                     ]}
                 />
 
                 {targetingMode === 'specific' && (
-                    <div className="mt-4 ml-6">
+                    <div className="mt-3 ml-6">
+                        <div className="mb-2">
+                            <LemonSegmentedButton
+                                value={urlMatchMode}
+                                onChange={(value) =>
+                                    setUrlMatchMode(value as SurveyMatchType.Exact | SurveyMatchType.Contains)
+                                }
+                                options={[
+                                    { value: SurveyMatchType.Contains, label: 'Contains path' },
+                                    { value: SurveyMatchType.Exact, label: 'Exact URL' },
+                                ]}
+                                size="small"
+                            />
+                        </div>
                         <LemonInputSelect
                             mode="single"
                             value={urlPattern ? [urlPattern] : []}
@@ -110,60 +171,100 @@ export function WhereStep(): JSX.Element {
                                     properties: [],
                                 })
                             }}
-                            placeholder="Select a page or type a path like /pricing"
+                            placeholder={urlInputPlaceholder}
                             allowCustomValues
+                            status={isPathInputInExactMode ? 'danger' : undefined}
                             loading={urlOptions?.status === 'loading'}
-                            options={(() => {
-                                const seen = new Set<string>()
-                                return (urlOptions?.values || [])
-                                    .map(({ name }) => {
-                                        const url = String(name)
-                                        let path = url
-                                        try {
-                                            const parsed = new URL(url)
-                                            path = parsed.pathname
-                                        } catch {
-                                            // Keep as-is if not a valid URL
-                                        }
-                                        return path
-                                    })
-                                    .filter((path) => {
-                                        if (seen.has(path)) {
-                                            return false
-                                        }
-                                        seen.add(path)
-                                        return true
-                                    })
-                                    .map((path) => ({ key: path, label: path }))
-                            })()}
+                            options={urlSuggestions}
                         />
-                        <p className="text-xs text-muted mt-2">
-                            Select from your most visited pages or type a custom pattern
-                        </p>
+                        {isPathInputInExactMode ? (
+                            <p className="text-xs text-danger mt-1.5">
+                                Exact URL requires the full URL, including protocol and host. Use Contains path for
+                                entries like /pricing.
+                            </p>
+                        ) : (
+                            <p className="text-xs text-muted mt-1.5">
+                                {urlMatchMode === SurveyMatchType.Exact
+                                    ? 'Select from your most visited pages or type the full URL, including protocol and host.'
+                                    : 'Select from your most visited pages or type a path like /pricing.'}
+                            </p>
+                        )}
                     </div>
                 )}
-            </div>
+            </WizardSection>
 
-            {/* Frequency */}
-            <div>
-                <h2 className="text-xl font-semibold mb-2">How often can someone see this?</h2>
-                <p className="text-secondary mb-6">Control how frequently the same person can be shown this survey</p>
+            <SurveyAudienceFilters onOpenFullEditor={onOpenFullEditor} />
 
-                <LemonSegmentedButton
-                    value={frequency}
-                    onChange={setFrequency}
-                    options={FREQUENCY_OPTIONS.map((opt) => ({
-                        ...opt,
-                        tooltip:
-                            opt.value === recommendedFrequency.value ? `Recommended for this survey type` : undefined,
-                    }))}
-                    fullWidth
-                />
+            <WizardSection
+                title="Which devices should this appear on?"
+                description="Choose whether this survey should show on desktop, mobile, tablet, or any combination."
+            >
+                <div className="flex flex-wrap gap-2">
+                    {DEVICE_OPTIONS.map((device) => {
+                        const selected = selectedDevices.includes(device)
 
-                {recommendedFrequency.value === frequency && (
-                    <p className="text-sm text-success mt-3">{recommendedFrequency.reason}</p>
-                )}
-            </div>
-        </div>
+                        return (
+                            <LemonButton
+                                key={device}
+                                type={selected ? 'primary' : 'secondary'}
+                                size="small"
+                                onClick={() => toggleDeviceType(device)}
+                            >
+                                {device}
+                            </LemonButton>
+                        )
+                    })}
+                </div>
+                <p className="text-xs text-muted mt-1.5">
+                    Leave all unselected to show the survey on every device type.
+                </p>
+            </WizardSection>
+
+            <WizardSection
+                title="Feature flag targeting"
+                description="Optionally limit this survey to users who have a specific feature flag enabled."
+            >
+                <div className="space-y-2.5">
+                    <div className="flex items-center gap-2">
+                        <FlagSelector
+                            value={survey.linked_flag_id || undefined}
+                            onChange={(id, _key, flag) => {
+                                const { linkedFlagVariant, ...restConditions } = conditions
+                                setSurveyValue('linked_flag_id', id)
+                                setSurveyValue('linked_flag', flag)
+                                setSurveyValue('conditions', restConditions)
+                            }}
+                            initialButtonLabel="Select feature flag"
+                        />
+                        {survey.linked_flag_id && (
+                            <LemonButton type="tertiary" size="small" icon={<IconTrash />} onClick={clearLinkedFlag}>
+                                Clear
+                            </LemonButton>
+                        )}
+                    </div>
+
+                    {resolvedLinkedFlag?.filters.multivariate && (
+                        <div className="ml-6 space-y-3">
+                            <div>
+                                <div className="text-sm font-medium mb-2">Flag variant</div>
+                                <LemonSegmentedButton
+                                    value={conditions.linkedFlagVariant ?? ANY_VARIANT}
+                                    options={variantOptions(resolvedLinkedFlag.filters.multivariate)}
+                                    onChange={(variant) => {
+                                        setSurveyValue('conditions', {
+                                            ...conditions,
+                                            linkedFlagVariant: variant === ANY_VARIANT ? null : String(variant),
+                                        })
+                                    }}
+                                />
+                            </div>
+                            <p className="text-xs text-muted">
+                                Choose a specific variant or keep it on any enabled variant.
+                            </p>
+                        </div>
+                    )}
+                </div>
+            </WizardSection>
+        </WizardStepLayout>
     )
 }


### PR DESCRIPTION
## Problem

The guided survey wizard was missing several common targeting controls from the full editor, had inconsistent step layout and spacing, and gave misleading URL guidance in exact-match mode by suggesting path-only values.

## Changes

- add guided audience targeting for person properties and cohorts, including rollout percentage controls
- add device and feature flag targeting, move repeat cadence into the When step, and standardize wizard layout and spacing with shared primitives
- improve guided question editing with optional and HTML descriptions, cleaner metadata controls, clearer rating scale labels, and URL suggestions/help text that match the selected URL mode

## How did you test this code?

- `pnpm --filter=@posthog/frontend jest frontend/src/scenes/surveys/utils.test.ts --runInBand --watchman=false`
- `pnpm --filter=@posthog/frontend exec oxlint src/scenes/scenes.ts src/scenes/surveys/SurveyAppearanceUtils.tsx src/scenes/surveys/wizard/SurveyWizard.tsx src/scenes/surveys/wizard/SurveyAudienceFilters.tsx src/scenes/surveys/wizard/WizardLayout.tsx src/scenes/surveys/wizard/steps/AppearanceStep.tsx src/scenes/surveys/wizard/steps/QuestionsStep.tsx src/scenes/surveys/wizard/steps/WhenStep.tsx src/scenes/surveys/wizard/steps/WhereStep.tsx src/scenes/surveys/utils.ts src/scenes/surveys/utils.test.ts`
- I did not run a full frontend typecheck or manual QA.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

no

## Docs update

No docs update needed.

## 🤖 LLM context

Authored with Codex in the local workspace. Main focus was guided survey wizard parity and UX polish, especially around targeting controls and exact URL matching guidance.
