### PR TITLE
chore(replay): better loading state for player

### DIFF
--- a/frontend/src/scenes/session-recordings/playlist/SessionRecordingsPlaylist.tsx
+++ b/frontend/src/scenes/session-recordings/playlist/SessionRecordingsPlaylist.tsx
@@ -2,9 +2,12 @@ import { BindLogic, useActions, useValues } from 'kea'
 import { useCallback, useRef } from 'react'
 
 import { EmptyMessage } from 'lib/components/EmptyMessage/EmptyMessage'
+import { FilmCameraHog } from 'lib/components/hedgehogs'
 import { Resizer } from 'lib/components/Resizer/Resizer'
 import { ResizerLogicProps, resizerLogic } from 'lib/components/Resizer/resizerLogic'
 import { useWindowSize } from 'lib/hooks/useWindowSize'
+import { LemonSkeleton } from 'lib/lemon-ui/LemonSkeleton'
+import { Spinner } from 'lib/lemon-ui/Spinner'
 import { cn } from 'lib/utils/css-classes'
 import { Playlist } from 'scenes/session-recordings/playlist/Playlist'
 
@@ -178,6 +181,7 @@ function PlayerWrapper({
         totalFiltersCount,
         nextSessionRecording,
         pinnedFilters,
+        sessionRecordingsResponseLoading,
     } = useValues(sessionRecordingsPlaylistLogic)
     const { setFilters, resetFilters, setSelectedRecordingId, loadAllRecordings } =
         useActions(sessionRecordingsPlaylistLogic)
@@ -231,6 +235,29 @@ function PlayerWrapper({
                     }
                     playNextRecording={nextSessionRecording?.id ? onPlayNextRecording : undefined}
                 />
+            ) : sessionRecordingsResponseLoading ? (
+                <div className="relative flex flex-col h-full p-4">
+                    {/* Player skeleton background */}
+                    <div className="flex-1 flex flex-col gap-2">
+                        {/* Video area skeleton */}
+                        <LemonSkeleton className="flex-1 w-full rounded" />
+                        {/* Controller bar skeleton */}
+                        <div className="flex gap-2">
+                            <LemonSkeleton className="h-10 w-20" />
+                            <LemonSkeleton className="h-10 flex-1" />
+                            <LemonSkeleton className="h-10 w-32" />
+                        </div>
+                    </div>
+
+                    {/* Centered hedgehog overlay */}
+                    <div className="absolute inset-0 flex flex-col items-center justify-center pointer-events-none">
+                        <FilmCameraHog height={150} />
+                        <div className="mt-4 flex items-center gap-2">
+                            <Spinner textColored />
+                            <span className="text-secondary">Loading recordings...</span>
+                        </div>
+                    </div>
+                </div>
             ) : (
                 <div className="mt-20">
                     <EmptyMessage


### PR DESCRIPTION
## Problem

loading state was unclear since its copy said "no recording selected" which isnt really right

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

## Changes

instead have Max in the loading state and actually say we're loading recordings

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?  
  
![Screenshot 2026-04-02 at 11.07.48 AM.png](https://app.graphite.com/user-attachments/assets/d0e01bee-6ed4-4e67-a854-d2ea1a0d9739.png)

forced loading screen to show up (usually videos on left would NOT have been loaded in already)



<!-- Briefly describe the steps you took, and what steps reviewers must take to get to where changes are, and what is the expected behavior. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->