### PR TITLE
fix(cohorts): exclude null values from 'is set' operator on materialized properties

### DIFF
--- a/ee/clickhouse/queries/test/test_cohort_query.py
+++ b/ee/clickhouse/queries/test/test_cohort_query.py
@@ -1398,6 +1398,40 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
 
         assert [p1.uuid] == [r[0] for r in res]
 
+    @also_test_with_materialized_columns(person_properties=["$some_prop"])
+    @snapshot_clickhouse_queries
+    def test_is_set_operator_excludes_null_values_for_materialized_columns(self):
+        p1 = _create_person(
+            team_id=self.team.pk,
+            distinct_ids=["p1"],
+            properties={"$some_prop": "a_value"},
+        )
+        _create_person(
+            team_id=self.team.pk,
+            distinct_ids=["p2"],
+            properties={},
+        )
+        filter = Filter(
+            data={
+                "properties": {
+                    "type": "AND",
+                    "values": [
+                        {
+                            "key": "$some_prop",
+                            "type": "person",
+                            "operator": "is_set",
+                            "value": "is_set",
+                        },
+                    ],
+                }
+            }
+        )
+        flush_persons_and_events()
+
+        res, q, params = execute(filter, self.team)
+
+        assert [p1.uuid] == [r[0] for r in res]
+
     def test_earliest_date_clause(self):
         filter = Filter(
             data={

--- a/posthog/models/property/util.py
+++ b/posthog/models/property/util.py
@@ -491,7 +491,7 @@ def prop_filter_json_extract(
         }
         if is_denormalized:
             return (
-                " {property_operator} notEmpty({left})".format(left=property_expr, property_operator=property_operator),
+                " {property_operator} isNotNull({left})".format(left=property_expr, property_operator=property_operator),
                 params,
             )
         return (
@@ -510,7 +510,7 @@ def prop_filter_json_extract(
         }
         if is_denormalized:
             return (
-                " {property_operator} empty({left})".format(left=property_expr, property_operator=property_operator),
+                " {property_operator} isNull({left})".format(left=property_expr, property_operator=property_operator),
                 params,
             )
         return (


### PR DESCRIPTION
## Problem

Fixes #29916

When using the `is_set` operator in cohort person property filters with denormalized (materialized) columns, null values are incorrectly included. The code was using ClickHouse's `notEmpty()` function which doesn't properly distinguish between "property was never set" (null) and "property exists but is empty string."

## Changes

Changed the denormalized path in `posthog/models/property/util.py`:
- `is_set`: `notEmpty(col)` → `isNotNull(col)`
- `is_not_set`: `empty(col)` → `isNull(col)`

The non-denormalized (JSON) path using `JSONHas` is unaffected and was already correct.

## How did you test this code?

- Added test case `test_is_set_operator_excludes_null_values_for_materialized_columns` in `ee/clickhouse/queries/test/test_cohort_query.py` that verifies:
  - A person with the property set to a value IS included in an `is_set` cohort
  - A person without the property (null) is NOT included
- Test uses `@also_test_with_materialized_columns` decorator to run against both materialized and non-materialized paths

## Publish to changelog?

no

## Docs update

no