### PR TITLE
feat(deduplicator): use targeted fadv_dontneed and limit BufWriter automatic extension

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -5059,6 +5059,7 @@ dependencies = [
  "health",
  "itertools 0.14.0",
  "kafka-assigner-proto",
+ "libc",
  "metrics",
  "metrics-exporter-prometheus",
  "object_store",

--- a/rust/kafka-deduplicator/Cargo.toml
+++ b/rust/kafka-deduplicator/Cargo.toml
@@ -50,6 +50,9 @@ tracing-opentelemetry = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter", "json"] }
 uuid = { workspace = true }
 
+[target.'cfg(target_os = "linux")'.dependencies]
+libc = "0.2"
+
 [dev-dependencies]
 aws-config = { workspace = true }
 aws-sdk-s3 = { workspace = true }

--- a/rust/kafka-deduplicator/src/checkpoint/config.rs
+++ b/rust/kafka-deduplicator/src/checkpoint/config.rs
@@ -85,6 +85,13 @@ pub struct CheckpointConfig {
     /// Each active buffer consumes ~18MB (8MB read buffer + ~10MB BufWriter).
     pub max_upload_buffers_per_partition: usize,
 
+    /// Maximum number of in-flight multipart upload parts per BufWriter.
+    /// The object_store BufWriter defaults to max_concurrency=8, meaning each writer
+    /// can hold up to 8 * 10MB = 80MB of in-flight parts. Setting this to 1 reduces
+    /// per-writer overhead to ~10MB while file-level parallelism from
+    /// buffer_unordered still provides overall upload throughput.
+    pub upload_writer_max_concurrency: usize,
+
     /// Maximum time allowed for a complete checkpoint import for a single partition.
     /// This includes listing checkpoints, downloading metadata, and downloading all files.
     /// Should be less than kafka max.poll.interval.ms to prevent consumer group kicks.
@@ -123,6 +130,7 @@ impl Default for CheckpointConfig {
             max_concurrent_checkpoint_file_downloads: 40,
             max_concurrent_checkpoint_file_uploads: 40,
             max_upload_buffers_per_partition: 40,
+            upload_writer_max_concurrency: 1,
             checkpoint_partition_import_timeout: Duration::from_secs(240),
             local_checkpoint_max_staleness: Duration::from_secs(
                 DEFAULT_LOCAL_CHECKPOINT_MAX_STALENESS_SECS,

--- a/rust/kafka-deduplicator/src/checkpoint/s3_uploader.rs
+++ b/rust/kafka-deduplicator/src/checkpoint/s3_uploader.rs
@@ -60,6 +60,33 @@ async fn read_chunk_cancellable(
     }
 }
 
+/// Hint the kernel to evict page cache for the byte range [0, len) of an open file.
+///
+/// Checkpoint SST files are hardlinked to live RocksDB inodes. Reading them for upload
+/// fills the kernel page cache, inflating container_memory_working_set_bytes. Calling
+/// this incrementally after each chunk read keeps page cache per file to ~chunk_size
+/// instead of accumulating the entire file (e.g. 256MB) before eviction.
+///
+/// Best-effort: failure is logged at debug level and does not abort the upload.
+/// Only effective on Linux; a no-op on other platforms.
+fn advise_dontneed_range(file: &File, path: &Path, offset: i64, len: i64) {
+    #[cfg(target_os = "linux")]
+    {
+        use std::os::unix::io::AsRawFd;
+        let fd = file.as_raw_fd();
+        // SAFETY: posix_fadvise is safe to call with any fd/offset/len combination;
+        // invalid values simply return an error code.
+        let ret = unsafe { libc::posix_fadvise(fd, offset, len, libc::POSIX_FADV_DONTNEED) };
+        if ret != 0 {
+            tracing::debug!("posix_fadvise(DONTNEED) returned {ret} for {path:?} (non-fatal)");
+        }
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        let _ = (file, path, offset, len);
+    }
+}
+
 /// S3Uploader using `object_store` crate with `LimitStore` for bounded concurrency.
 /// The LimitStore wraps the S3 client with a semaphore that limits concurrent requests.
 #[derive(Debug)]
@@ -118,9 +145,13 @@ impl S3Uploader {
 
         // BufWriter implements AsyncWrite and handles multipart upload internally.
         // It buffers data and automatically uses multipart upload for large files.
-        let mut upload = BufWriter::new(Arc::clone(&self.store), path.clone());
+        // Default max_concurrency is 8 (up to 8 in-flight 10MB multipart parts per writer).
+        // We cap it to limit per-upload RSS from ~98MB down to ~28MB.
+        let mut upload = BufWriter::new(Arc::clone(&self.store), path.clone())
+            .with_max_concurrency(self.config.upload_writer_max_concurrency);
 
         let mut buf = vec![0u8; UPLOAD_CHUNK_SIZE];
+        let mut bytes_read: i64 = 0;
 
         loop {
             let chunk_result = read_chunk_cancellable(&mut file, &mut buf, cancel_token).await;
@@ -134,6 +165,10 @@ impl S3Uploader {
                         return Err(anyhow::Error::new(e))
                             .with_context(|| format!("Failed to write chunk to S3: {s3_key}"));
                     }
+                    bytes_read += n as i64;
+                    // Incrementally evict pages we just read — keeps page cache to ~chunk_size
+                    // per file instead of accumulating the full file (up to 256MB SSTs).
+                    advise_dontneed_range(&file, local_path, 0, bytes_read);
                 }
                 ChunkResult::EndOfStream => break,
                 ChunkResult::Cancelled => {
@@ -156,6 +191,9 @@ impl S3Uploader {
                 }
             }
         }
+
+        // Final eviction for any trailing pages / kernel read-ahead
+        advise_dontneed_range(&file, local_path, 0, bytes_read);
 
         // Finalize the upload (triggers CompleteMultipartUpload API call for large files)
         upload
@@ -217,7 +255,7 @@ impl CheckpointUploader for S3Uploader {
         // buffer_unordered(N) only polls N futures concurrently, so only N files
         // are open with read buffers and BufWriters allocated at any time.
         // Futures outside the window aren't started, bounding memory to
-        // N * ~18MB (8MB read buffer + ~10MB BufWriter) instead of all files at once.
+        // N * (8MB read buf + 10MB BufWriter chunk + max_concurrency * 10MB in-flight parts).
         //
         // Pre-collect owned (src, dest) pairs to avoid lifetime issues with
         // buffer_unordered's lazy stream requiring closures general over all lifetimes.

--- a/rust/kafka-deduplicator/src/config.rs
+++ b/rust/kafka-deduplicator/src/config.rs
@@ -302,6 +302,13 @@ pub struct Config {
     #[envconfig(default = "40")]
     pub max_upload_buffers_per_partition: usize,
 
+    // Maximum in-flight multipart upload parts per BufWriter instance.
+    // The object_store BufWriter defaults to 8, holding up to 80MB per writer.
+    // Set to 1 to minimize per-writer memory; file-level parallelism from
+    // buffer_unordered still provides overall upload throughput.
+    #[envconfig(default = "1")]
+    pub upload_writer_max_concurrency: usize,
+
     // Maximum time allowed for a complete checkpoint import for a single partition (seconds).
     // This includes listing checkpoints, downloading metadata, and downloading all files.
     // Should be less than kafka max.poll.interval.ms to prevent consumer group kicks.

--- a/rust/kafka-deduplicator/src/service.rs
+++ b/rust/kafka-deduplicator/src/service.rs
@@ -206,6 +206,7 @@ impl KafkaDeduplicatorService {
                 .max_concurrent_checkpoint_file_downloads,
             max_concurrent_checkpoint_file_uploads: config.max_concurrent_checkpoint_file_uploads,
             max_upload_buffers_per_partition: config.max_upload_buffers_per_partition,
+            upload_writer_max_concurrency: config.upload_writer_max_concurrency,
             checkpoint_partition_import_timeout: config.checkpoint_partition_import_timeout(),
             local_checkpoint_max_staleness: config.local_checkpoint_max_staleness(),
         };


### PR DESCRIPTION
## Problem
Turns out after much digging, we still have two bottlenecks besides the new export pipeline limits that were causing excessive preallocations:
* `FADV_DONTNEED` running at the end of the process; needs to be more targeted application to clear the active page cache from file export which appears to be the main culprit for the unexpected 5GBs
* BufWriter usage in upload sequence has an untuned knob - despite controlling buffer size, there is a concurrency default of 8 which was 8x'ing allocated buffer mem. This is exacerbated by the fact that the buffers can be `extend_from_slice`'d when fully utilized

These two changes together should more effectively limit how much memory we can utilize during export per pod, but will undoubtedly also slow down exports. This is probably the tradeoff we have to tolerate to avoid memory utilization variance during exports 🤷 but most importantly, let's see if these knobs work before we worry about that

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
* Targeted `FADV_DONTNEED` during uploads
* `BufWriter` concurrency limit applied explicitly (no default of 8)
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally and in CI. Smoke test in PoC env to come
<!-- Briefly describe the steps you took, and what steps reviewers must take to get to where changes are, and what is the expected behavior. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
N/A
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update
N/A
<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
