### PR TITLE
fix(cohorts): show dual inputs for between operator and date picker for date properties

### DIFF
--- a/frontend/src/lib/components/PropertyFilters/components/PropertyFilterBetween.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/PropertyFilterBetween.tsx
@@ -1,9 +1,12 @@
 import { useActions, useValues } from 'kea'
-import { useMemo } from 'react'
+import { useMemo, useState } from 'react'
 
+import { LemonCalendarSelectInput } from '@posthog/lemon-ui'
+
+import { dayjs } from 'lib/dayjs'
 import { LemonInput } from 'lib/lemon-ui/LemonInput/LemonInput'
 
-import { PropertyFilterValue } from '~/types'
+import { PropertyFilterValue, PropertyType } from '~/types'
 
 import { propertyFilterBetweenLogic } from './propertyFilterBetweenLogic'
 
@@ -12,6 +15,7 @@ export interface PropertyFilterBetweenProps {
     value: PropertyFilterValue
     onSet: (newValue: PropertyFilterValue) => void
     size?: 'xsmall' | 'small' | 'medium'
+    propertyType?: PropertyType
 }
 
 let uniqueMemoizedIndex = 0
@@ -22,7 +26,68 @@ const usePropertyFilterBetweenLogic = (
     return propertyFilterBetweenLogic({ ...props, key: logicKey })
 }
 
-export function PropertyFilterBetween({ logicKey, value, onSet, size }: PropertyFilterBetweenProps): JSX.Element {
+const dateFormat = 'YYYY-MM-DD'
+
+function DateBetweenInput({
+    value,
+    onSet,
+}: {
+    value: PropertyFilterValue
+    onSet: (newValue: PropertyFilterValue) => void
+}): JSX.Element {
+    const values = Array.isArray(value) ? value : [null, null]
+    const [minOpen, setMinOpen] = useState(false)
+    const [maxOpen, setMaxOpen] = useState(false)
+
+    const minValue = values[0] ? dayjs(String(values[0])) : undefined
+    const maxValue = values[1] ? dayjs(String(values[1])) : undefined
+
+    return (
+        <div className="flex items-center gap-2">
+            <LemonCalendarSelectInput
+                value={minValue}
+                format={dateFormat}
+                visible={minOpen}
+                placeholder="min date"
+                onClickOutside={() => setMinOpen(false)}
+                onChange={(date) => {
+                    const formatted = date ? date.format(dateFormat) : null
+                    onSet([formatted, values[1] ?? null])
+                    setMinOpen(false)
+                }}
+                onClose={() => setMinOpen(false)}
+                granularity="day"
+                buttonProps={{
+                    'data-attr': 'prop-val-min',
+                    fullWidth: true,
+                    onClick: () => setMinOpen(true),
+                }}
+            />
+            <span className="font-medium">and</span>
+            <LemonCalendarSelectInput
+                value={maxValue}
+                format={dateFormat}
+                visible={maxOpen}
+                placeholder="max date"
+                onClickOutside={() => setMaxOpen(false)}
+                onChange={(date) => {
+                    const formatted = date ? date.format(dateFormat) : null
+                    onSet([values[0] ?? null, formatted])
+                    setMaxOpen(false)
+                }}
+                onClose={() => setMaxOpen(false)}
+                granularity="day"
+                buttonProps={{
+                    'data-attr': 'prop-val-max',
+                    fullWidth: true,
+                    onClick: () => setMaxOpen(true),
+                }}
+            />
+        </div>
+    )
+}
+
+function NumericBetweenInput({ logicKey, value, onSet, size }: PropertyFilterBetweenProps): JSX.Element {
     const logic = usePropertyFilterBetweenLogic({ logicKey, value, onSet, size })
     const { localMin, localMax } = useValues(logic)
     const { setLocalMin, setLocalMax } = useActions(logic)
@@ -50,4 +115,12 @@ export function PropertyFilterBetween({ logicKey, value, onSet, size }: Property
             />
         </div>
     )
+}
+
+export function PropertyFilterBetween(props: PropertyFilterBetweenProps): JSX.Element {
+    if (props.propertyType === PropertyType.DateTime) {
+        return <DateBetweenInput value={props.value} onSet={props.onSet} />
+    }
+
+    return <NumericBetweenInput {...props} />
 }

--- a/frontend/src/lib/components/PropertyFilters/components/PropertyValue.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/PropertyValue.tsx
@@ -287,7 +287,17 @@ export function PropertyValue({
     }
 
     if (isBetweenProperty) {
-        return <PropertyFilterBetween value={value ?? null} onSet={setValue} size={size} />
+        const betweenPropertyType = propertyKey
+            ? describeProperty(propertyKey, propertyDefinitionType) ?? undefined
+            : undefined
+        return (
+            <PropertyFilterBetween
+                value={value ?? null}
+                onSet={setValue}
+                size={size}
+                propertyType={betweenPropertyType}
+            />
+        )
     }
 
     if (isDateTimeProperty) {


### PR DESCRIPTION
## Problem

Fixes #20821

Cohort property filters have two issues:
1. The "between" operator shows only a single input field instead of the expected min/max dual inputs
2. Date-type properties don't show a date picker when used in cohort filters

## Changes

- **PropertyFilterBetween.tsx**: Added `propertyType` prop and a new `DateBetweenInput` component that renders two `LemonCalendarSelectInput` date pickers (min date / max date) when the property type is `DateTime`. Extracted the existing numeric inputs into a `NumericBetweenInput` component for clean separation.
- **PropertyValue.tsx**: When rendering the between filter, now looks up the property type via `describeProperty` and passes it to `PropertyFilterBetween` so it can choose the correct input type.

## How did you test this code?

I'm an agent and haven't tested this manually. The changes follow existing patterns in the codebase (`PropertyFilterDatePicker` uses the same `LemonCalendarSelectInput` component). The files pass `oxlint` and `oxfmt` checks.

## Publish to changelog?

No

## Docs update

No docs update needed.

## 🤖 LLM context

Agent-authored PR fixing the cohort between input and date picker issues described in #20821.