### PR TITLE
feat: Add funnel exclusion steps to experiment metrics

### DIFF
--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -3301,6 +3301,8 @@ export type ExperimentFunnelMetric = ExperimentMetricBaseProperties & {
     metric_type: ExperimentMetricType.FUNNEL
     series: ExperimentFunnelMetricStep[]
     funnel_order_type?: StepOrderValue
+    /** @default [] */
+    exclusions?: FunnelExclusion[]
 }
 
 export const isExperimentFunnelMetric = (metric: ExperimentMetric): metric is ExperimentFunnelMetric =>

--- a/frontend/src/scenes/experiments/ExperimentMetricForm.tsx
+++ b/frontend/src/scenes/experiments/ExperimentMetricForm.tsx
@@ -36,6 +36,7 @@ import {
 import { ExperimentMetricGoal, ExperimentMetricMathType, FilterType, FunnelConversionWindowTimeUnit } from '~/types'
 
 import { ExperimentMetricConversionWindowFilter } from './ExperimentMetricConversionWindowFilter'
+import { ExperimentMetricFunnelExclusionsFilter } from './ExperimentMetricFunnelExclusionsFilter'
 import { ExperimentMetricFunnelOrderSelector } from './ExperimentMetricFunnelOrderSelector'
 import { ExperimentMetricOutlierHandling } from './ExperimentMetricOutlierHandling'
 import { filterToMetricConfig, filterToMetricSource } from './metricQueryUtils'
@@ -633,6 +634,8 @@ export function ExperimentMetricForm({
             {isExperimentFunnelMetric(metric) && (
                 <>
                     <ExperimentMetricFunnelOrderSelector metric={metric} handleSetMetric={handleSetMetric} />
+                    <SceneDivider />
+                    <ExperimentMetricFunnelExclusionsFilter metric={metric} handleSetMetric={handleSetMetric} />
                     <SceneDivider />
                 </>
             )}

--- a/frontend/src/scenes/experiments/ExperimentMetricFunnelExclusionsFilter.tsx
+++ b/frontend/src/scenes/experiments/ExperimentMetricFunnelExclusionsFilter.tsx
@@ -1,0 +1,147 @@
+import { LemonButton, LemonSelect } from '@posthog/lemon-ui'
+
+import { IconPlus, IconTrash } from '@posthog/icons'
+import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
+import { TaxonomicPopover } from 'lib/components/TaxonomicPopover/TaxonomicPopover'
+
+import { SceneSection } from '~/layout/scenes/components/SceneSection'
+import {
+    EventsNode,
+    ExperimentFunnelMetric,
+    ExperimentMetric,
+    FunnelExclusion,
+    NodeKind,
+} from '~/queries/schema/schema-general'
+
+function ExclusionStepInfo(): JSX.Element {
+    return (
+        <div className="flex flex-col gap-2">
+            <div>
+                Exclusion steps let you filter out users who performed a specific event between funnel steps. Users who
+                trigger the excluded event in the specified step range will not count as conversions.
+            </div>
+            <div>
+                For example, exclude users who viewed a help article between signing up and purchasing to measure
+                self-serve conversion.
+            </div>
+        </div>
+    )
+}
+
+export function ExperimentMetricFunnelExclusionsFilter({
+    metric,
+    handleSetMetric,
+}: {
+    metric: ExperimentFunnelMetric
+    handleSetMetric: (newMetric: ExperimentMetric) => void
+}): JSX.Element {
+    const exclusions = metric.exclusions || []
+    const numSteps = metric.series.length
+
+    const handleAddExclusion = (): void => {
+        const newExclusion: FunnelExclusion = {
+            kind: NodeKind.EventsNode,
+            event: '$pageview',
+            funnelFromStep: 0,
+            funnelToStep: Math.max(numSteps - 1, 1),
+        }
+        handleSetMetric({
+            ...metric,
+            exclusions: [...exclusions, newExclusion],
+        })
+    }
+
+    const handleRemoveExclusion = (index: number): void => {
+        handleSetMetric({
+            ...metric,
+            exclusions: exclusions.filter((_, i) => i !== index),
+        })
+    }
+
+    const handleUpdateExclusionEvent = (index: number, eventName: string): void => {
+        const updated = [...exclusions]
+        updated[index] = {
+            ...updated[index],
+            kind: NodeKind.EventsNode,
+            event: eventName,
+        } as FunnelExclusion
+        handleSetMetric({
+            ...metric,
+            exclusions: updated,
+        })
+    }
+
+    const handleUpdateExclusionRange = (
+        index: number,
+        field: 'funnelFromStep' | 'funnelToStep',
+        value: number
+    ): void => {
+        const updated = [...exclusions]
+        updated[index] = {
+            ...updated[index],
+            [field]: value,
+        } as FunnelExclusion
+        handleSetMetric({
+            ...metric,
+            exclusions: updated,
+        })
+    }
+
+    const stepOptions = Array.from({ length: numSteps }, (_, i) => ({
+        value: i,
+        label: `Step ${i + 1}`,
+    }))
+
+    // Need at least 2 funnel steps to use exclusions
+    if (numSteps < 2) {
+        return <></>
+    }
+
+    return (
+        <SceneSection title="Exclusion steps" titleHelper={<ExclusionStepInfo />} className="max-w-prose">
+            <div className="flex flex-col gap-2">
+                {exclusions.map((exclusion, index) => (
+                    <div key={index} className="flex items-center gap-2 border rounded p-2">
+                        <TaxonomicPopover
+                            groupType={TaxonomicFilterGroupType.Events}
+                            value={(exclusion as EventsNode).event || '$pageview'}
+                            onChange={(value) => handleUpdateExclusionEvent(index, value as string)}
+                            placeholder="Select event"
+                            type="secondary"
+                            size="small"
+                        />
+                        <span className="text-muted text-xs whitespace-nowrap">between</span>
+                        <LemonSelect
+                            size="small"
+                            value={exclusion.funnelFromStep}
+                            onChange={(value) => handleUpdateExclusionRange(index, 'funnelFromStep', value)}
+                            options={stepOptions.filter((o) => o.value < (exclusion.funnelToStep ?? numSteps - 1))}
+                        />
+                        <span className="text-muted text-xs whitespace-nowrap">and</span>
+                        <LemonSelect
+                            size="small"
+                            value={exclusion.funnelToStep}
+                            onChange={(value) => handleUpdateExclusionRange(index, 'funnelToStep', value)}
+                            options={stepOptions.filter((o) => o.value > (exclusion.funnelFromStep ?? 0))}
+                        />
+                        <LemonButton
+                            icon={<IconTrash />}
+                            size="small"
+                            type="tertiary"
+                            onClick={() => handleRemoveExclusion(index)}
+                        />
+                    </div>
+                ))}
+                <LemonButton
+                    icon={<IconPlus />}
+                    type="secondary"
+                    size="small"
+                    onClick={handleAddExclusion}
+                    className="self-start"
+                >
+                    Add exclusion step
+                </LemonButton>
+            </div>
+        </SceneSection>
+    )
+}

--- a/posthog/hogql_queries/experiments/base_query_utils.py
+++ b/posthog/hogql_queries/experiments/base_query_utils.py
@@ -16,6 +16,8 @@ from posthog.schema import (
     ExperimentMetricMathType,
     ExperimentRatioMetric,
     FunnelConversionWindowTimeUnit,
+    FunnelExclusionActionsNode,
+    FunnelExclusionEventsNode,
     FunnelMathType,
     PropertyMathType,
 )
@@ -403,7 +405,20 @@ def funnel_evaluation_expr(
     # When using an alias, assume step conditions are pre-calculated
     step_conditions = [f"{i + 1} * {events_alias}.step_{i}" for i in range(num_steps)]
 
+    # Add exclusion conditions as negative values if exclusions are defined.
+    # The aggregate_funnel_array UDF interprets negative step values as exclusion
+    # signals — if a user performs an excluded event between the specified funnel
+    # steps, they are disqualified from converting through that path.
+    has_exclusions = getattr(funnel_metric, "exclusions", None) and len(funnel_metric.exclusions) > 0
+    if has_exclusions:
+        for i in range(1, num_steps):
+            step_conditions.append(f"-{i + 1} * {events_alias}.exclusion_{i}")
+
     step_conditions_str = ", ".join(step_conditions)
+
+    # When exclusions are present, use != 0 filter to preserve negative exclusion
+    # values. Without exclusions, > 0 is sufficient and matches prior behavior.
+    array_filter_predicate = "x != 0" if has_exclusions else "x > 0"
 
     # Determine funnel order type - default to "ordered" for backward compatibility
     funnel_order_type = funnel_metric.funnel_order_type or "ordered"
@@ -436,7 +451,7 @@ def funnel_evaluation_expr(
                     toFloat({timestamp_field}),
                     {uuid_field},
                     array(''),
-                    arrayFilter(x -> x > 0, [{step_conditions_str}])
+                    arrayFilter(x -> {array_filter_predicate}, [{step_conditions_str}])
                 )))
             )
         )

--- a/posthog/hogql_queries/experiments/experiment_query_builder.py
+++ b/posthog/hogql_queries/experiments/experiment_query_builder.py
@@ -15,6 +15,8 @@ from posthog.schema import (
     ExperimentRatioMetric,
     ExperimentRetentionMetric,
     FunnelConversionWindowTimeUnit,
+    FunnelExclusionActionsNode,
+    FunnelExclusionEventsNode,
     MultipleVariantHandling,
     StartHandling,
     StepOrderValue,
@@ -1405,6 +1407,9 @@ class ExperimentQueryBuilder:
     def _build_funnel_step_columns(self) -> list[ast.Alias]:
         """
         Builds list of step column AST expressions: step_0, step_1, etc.
+        Also builds exclusion columns (exclusion_1, exclusion_2, ...) when exclusions
+        are defined on the metric. Exclusion columns are boolean flags indicating
+        whether the exclusion event occurred for that row.
         """
         assert isinstance(self.metric, ExperimentFunnelMetric)
 
@@ -1419,12 +1424,51 @@ class ExperimentQueryBuilder:
                 )
             )
 
+        # Build exclusion columns if exclusions are defined.
+        # Each exclusion has funnelFromStep/funnelToStep defining which step range
+        # the exclusion applies to. We group exclusions by step index and create
+        # one exclusion_N column per step.
+        exclusions = getattr(self.metric, "exclusions", None) or []
+        if exclusions:
+            num_steps = len(self.metric.series) + 1  # +1 for exposure step
+            exclusions_by_step: list[list[ast.Expr]] = [[] for _ in range(num_steps)]
+
+            for exclusion in exclusions:
+                exclusion_filter = event_or_action_to_filter(self.team, exclusion)
+                from_step = exclusion.funnelFromStep
+                to_step = exclusion.funnelToStep
+                # Apply exclusion to each step in the range (from_step+1 to to_step inclusive)
+                for step_idx in range(from_step + 1, min(to_step + 1, num_steps)):
+                    exclusions_by_step[step_idx].append(exclusion_filter)
+
+            for i in range(1, num_steps):  # Skip step_0 (exposure)
+                if exclusions_by_step[i]:
+                    step_columns.append(
+                        ast.Alias(
+                            alias=f"exclusion_{i}",
+                            expr=ast.Call(
+                                name="if",
+                                args=[
+                                    ast.Or(exprs=exclusions_by_step[i]),
+                                    ast.Constant(value=1),
+                                    ast.Constant(value=0),
+                                ],
+                            ),
+                        )
+                    )
+                else:
+                    step_columns.append(
+                        ast.Alias(alias=f"exclusion_{i}", expr=ast.Constant(value=0))
+                    )
+
         return step_columns
 
     def _build_funnel_steps_filter(self) -> ast.Expr:
         """
         Returns the expression to filter funnel steps (matches ANY step) within
         the time period of the experiment + the conversion window if set.
+        Also includes exclusion events in the filter so they are fetched from
+        the events table and available for exclusion column evaluation.
         """
         assert isinstance(self.metric, ExperimentFunnelMetric)
 
@@ -1440,6 +1484,16 @@ class ExperimentQueryBuilder:
         else:
             date_to = self.date_range_query.date_to_as_hogql()
 
+        # Include both funnel steps AND exclusion events in the filter
+        # so that exclusion events are fetched and available for evaluation
+        all_series: list[EventsNode | ActionsNode] = list(self.metric.series)
+        exclusions = getattr(self.metric, "exclusions", None) or []
+        for exclusion in exclusions:
+            if isinstance(exclusion, FunnelExclusionEventsNode):
+                all_series.append(EventsNode(event=exclusion.event))
+            elif isinstance(exclusion, FunnelExclusionActionsNode):
+                all_series.append(ActionsNode(id=exclusion.id))
+
         return parse_expr(
             """
             timestamp >= {date_from} AND timestamp <= {date_to}
@@ -1448,7 +1502,7 @@ class ExperimentQueryBuilder:
             placeholders={
                 "date_from": self.date_range_query.date_from_as_hogql(),
                 "date_to": date_to,
-                "funnel_steps_filter": funnel_steps_to_filter(self.team, self.metric.series),
+                "funnel_steps_filter": funnel_steps_to_filter(self.team, all_series),
             },
         )
 

--- a/posthog/hogql_queries/experiments/test/experiment_query_runner/test_funnel_exclusion_metric.py
+++ b/posthog/hogql_queries/experiments/test/experiment_query_runner/test_funnel_exclusion_metric.py
@@ -1,0 +1,317 @@
+import uuid
+from typing import cast
+
+from freezegun import freeze_time
+from posthog.test.base import (
+    _create_event,
+    _create_person,
+    flush_persons_and_events,
+)
+
+from django.test import override_settings
+
+from posthog.schema import (
+    EventsNode,
+    ExperimentFunnelMetric,
+    ExperimentQuery,
+    ExperimentQueryResponse,
+    FunnelExclusionEventsNode,
+)
+
+from posthog.hogql_queries.experiments.experiment_query_runner import ExperimentQueryRunner
+from posthog.hogql_queries.experiments.test.experiment_query_runner.base import ExperimentQueryRunnerBaseTest
+
+
+@override_settings(IN_UNIT_TESTING=True)
+class TestExperimentFunnelExclusionMetric(ExperimentQueryRunnerBaseTest):
+    """
+    Tests for funnel exclusion steps in experiment metrics.
+
+    Exclusion steps filter out users who performed a specific event between
+    funnel steps. Users who trigger the excluded event are disqualified from
+    counting as conversions.
+    """
+
+    @freeze_time("2020-01-01T12:00:00Z")
+    def test_funnel_metric_with_exclusion_step(self):
+        """
+        Test that users who perform the excluded event between funnel steps
+        are not counted as conversions.
+
+        Setup:
+        - 3-step funnel: $feature_flag_called → $pageview → purchase
+        - Exclusion: "help_article_viewed" between step 0 and step 2
+        - Control: 10 users, 6 purchase, 2 of those 6 also view help article
+        - Test: 10 users, 8 purchase, 1 of those 8 also views help article
+
+        Expected:
+        - Control: 4 conversions (6 purchases - 2 excluded)
+        - Test: 7 conversions (8 purchases - 1 excluded)
+        """
+        feature_flag = self.create_feature_flag()
+        experiment = self.create_experiment(feature_flag=feature_flag)
+        experiment.stats_config = {"method": "frequentist"}
+        experiment.save()
+
+        feature_flag_property = f"$feature/{feature_flag.key}"
+
+        metric = ExperimentFunnelMetric(
+            series=[
+                EventsNode(event="$pageview"),
+                EventsNode(event="purchase"),
+            ],
+            exclusions=[
+                FunnelExclusionEventsNode(
+                    event="help_article_viewed",
+                    funnelFromStep=0,
+                    funnelToStep=2,
+                ),
+            ],
+        )
+
+        experiment_query = ExperimentQuery(
+            experiment_id=experiment.id,
+            kind="ExperimentQuery",
+            metric=metric,
+        )
+
+        experiment.metrics = [metric.model_dump(mode="json")]
+        experiment.save()
+
+        # Control: 10 users
+        for i in range(10):
+            _create_person(distinct_ids=[f"user_control_{i}"], team_id=self.team.pk)
+            # Exposure event
+            _create_event(
+                team=self.team,
+                event="$feature_flag_called",
+                distinct_id=f"user_control_{i}",
+                timestamp="2020-01-02T12:00:00Z",
+                properties={
+                    feature_flag_property: "control",
+                    "$feature_flag_response": "control",
+                    "$feature_flag": feature_flag.key,
+                },
+            )
+            # Step 1: pageview
+            _create_event(
+                team=self.team,
+                event="$pageview",
+                distinct_id=f"user_control_{i}",
+                timestamp="2020-01-02T12:01:00Z",
+                properties={feature_flag_property: "control"},
+            )
+            # First 6 users purchase
+            if i < 6:
+                _create_event(
+                    team=self.team,
+                    event="purchase",
+                    distinct_id=f"user_control_{i}",
+                    timestamp="2020-01-02T12:02:00Z",
+                    properties={feature_flag_property: "control"},
+                )
+            # Users 4 and 5 also view help article (should be excluded)
+            if i in (4, 5):
+                _create_event(
+                    team=self.team,
+                    event="help_article_viewed",
+                    distinct_id=f"user_control_{i}",
+                    timestamp="2020-01-02T12:01:30Z",
+                    properties={feature_flag_property: "control"},
+                )
+
+        # Test: 10 users
+        for i in range(10):
+            _create_person(distinct_ids=[f"user_test_{i}"], team_id=self.team.pk)
+            # Exposure event
+            _create_event(
+                team=self.team,
+                event="$feature_flag_called",
+                distinct_id=f"user_test_{i}",
+                timestamp="2020-01-02T12:00:00Z",
+                properties={
+                    feature_flag_property: "test",
+                    "$feature_flag_response": "test",
+                    "$feature_flag": feature_flag.key,
+                },
+            )
+            # Step 1: pageview
+            _create_event(
+                team=self.team,
+                event="$pageview",
+                distinct_id=f"user_test_{i}",
+                timestamp="2020-01-02T12:01:00Z",
+                properties={feature_flag_property: "test"},
+            )
+            # First 8 users purchase
+            if i < 8:
+                _create_event(
+                    team=self.team,
+                    event="purchase",
+                    distinct_id=f"user_test_{i}",
+                    timestamp="2020-01-02T12:02:00Z",
+                    properties={feature_flag_property: "test"},
+                )
+            # User 7 also views help article (should be excluded)
+            if i == 7:
+                _create_event(
+                    team=self.team,
+                    event="help_article_viewed",
+                    distinct_id=f"user_test_{i}",
+                    timestamp="2020-01-02T12:01:30Z",
+                    properties={feature_flag_property: "test"},
+                )
+
+        flush_persons_and_events()
+
+        query_runner = ExperimentQueryRunner(
+            query=experiment_query, team=self.team
+        )
+        result = cast(ExperimentQueryResponse, query_runner.calculate())
+
+        control_result = result.variants["control"]
+        test_result = result.variants["test"]
+
+        # Control: 10 exposed, 4 converted (6 purchased - 2 excluded)
+        self.assertEqual(control_result["count"], 10)
+        self.assertEqual(control_result["absolute_exposure"], 10)
+        self.assertEqual(control_result["success_count"], 4)
+
+        # Test: 10 exposed, 7 converted (8 purchased - 1 excluded)
+        self.assertEqual(test_result["count"], 10)
+        self.assertEqual(test_result["absolute_exposure"], 10)
+        self.assertEqual(test_result["success_count"], 7)
+
+    @freeze_time("2020-01-01T12:00:00Z")
+    def test_funnel_metric_without_exclusions_unchanged(self):
+        """
+        Verify that funnels without exclusions produce the same results as before.
+        This is a regression test to ensure the exclusion code path doesn't
+        affect existing behavior.
+        """
+        feature_flag = self.create_feature_flag()
+        experiment = self.create_experiment(feature_flag=feature_flag)
+        experiment.stats_config = {"method": "frequentist"}
+        experiment.save()
+
+        feature_flag_property = f"$feature/{feature_flag.key}"
+
+        # Metric WITHOUT exclusions
+        metric = ExperimentFunnelMetric(
+            series=[
+                EventsNode(event="purchase"),
+            ],
+        )
+
+        experiment_query = ExperimentQuery(
+            experiment_id=experiment.id,
+            kind="ExperimentQuery",
+            metric=metric,
+        )
+
+        experiment.metrics = [metric.model_dump(mode="json")]
+        experiment.save()
+
+        for variant, success_count in [("control", 8), ("test", 10)]:
+            for i in range(15):
+                _create_person(distinct_ids=[f"user_{variant}_{i}"], team_id=self.team.pk)
+                _create_event(
+                    team=self.team,
+                    event="$feature_flag_called",
+                    distinct_id=f"user_{variant}_{i}",
+                    timestamp="2020-01-02T12:00:00Z",
+                    properties={
+                        feature_flag_property: variant,
+                        "$feature_flag_response": variant,
+                        "$feature_flag": feature_flag.key,
+                    },
+                )
+                if i < success_count:
+                    _create_event(
+                        team=self.team,
+                        event="purchase",
+                        distinct_id=f"user_{variant}_{i}",
+                        timestamp="2020-01-02T12:01:00Z",
+                        properties={feature_flag_property: variant},
+                    )
+
+        flush_persons_and_events()
+
+        query_runner = ExperimentQueryRunner(
+            query=experiment_query, team=self.team
+        )
+        result = cast(ExperimentQueryResponse, query_runner.calculate())
+
+        control_result = result.variants["control"]
+        test_result = result.variants["test"]
+
+        self.assertEqual(control_result["count"], 15)
+        self.assertEqual(control_result["success_count"], 8)
+        self.assertEqual(test_result["count"], 15)
+        self.assertEqual(test_result["success_count"], 10)
+
+    @freeze_time("2020-01-01T12:00:00Z")
+    def test_funnel_metric_exclusion_empty_list(self):
+        """
+        Verify that an empty exclusions list behaves identically to no exclusions.
+        """
+        feature_flag = self.create_feature_flag()
+        experiment = self.create_experiment(feature_flag=feature_flag)
+        experiment.stats_config = {"method": "frequentist"}
+        experiment.save()
+
+        feature_flag_property = f"$feature/{feature_flag.key}"
+
+        metric = ExperimentFunnelMetric(
+            series=[
+                EventsNode(event="purchase"),
+            ],
+            exclusions=[],  # Empty list
+        )
+
+        experiment_query = ExperimentQuery(
+            experiment_id=experiment.id,
+            kind="ExperimentQuery",
+            metric=metric,
+        )
+
+        experiment.metrics = [metric.model_dump(mode="json")]
+        experiment.save()
+
+        for variant, success_count in [("control", 5), ("test", 7)]:
+            for i in range(10):
+                _create_person(distinct_ids=[f"user_{variant}_{i}"], team_id=self.team.pk)
+                _create_event(
+                    team=self.team,
+                    event="$feature_flag_called",
+                    distinct_id=f"user_{variant}_{i}",
+                    timestamp="2020-01-02T12:00:00Z",
+                    properties={
+                        feature_flag_property: variant,
+                        "$feature_flag_response": variant,
+                        "$feature_flag": feature_flag.key,
+                    },
+                )
+                if i < success_count:
+                    _create_event(
+                        team=self.team,
+                        event="purchase",
+                        distinct_id=f"user_{variant}_{i}",
+                        timestamp="2020-01-02T12:01:00Z",
+                        properties={feature_flag_property: variant},
+                    )
+
+        flush_persons_and_events()
+
+        query_runner = ExperimentQueryRunner(
+            query=experiment_query, team=self.team
+        )
+        result = cast(ExperimentQueryResponse, query_runner.calculate())
+
+        control_result = result.variants["control"]
+        test_result = result.variants["test"]
+
+        self.assertEqual(control_result["count"], 10)
+        self.assertEqual(control_result["success_count"], 5)
+        self.assertEqual(test_result["count"], 10)
+        self.assertEqual(test_result["success_count"], 7)

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -17828,6 +17828,7 @@ class ExperimentFunnelMetricTypeProps(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
+    exclusions: list[FunnelExclusionEventsNode | FunnelExclusionActionsNode] | None = None
     funnel_order_type: StepOrderValue | None = None
     metric_type: Literal["funnel"] = "funnel"
     series: list[EventsNode | ActionsNode]
@@ -18935,6 +18936,7 @@ class ExperimentFunnelMetric(BaseModel):
     breakdownFilter: BreakdownFilter | None = None
     conversion_window: int | None = None
     conversion_window_unit: FunnelConversionWindowTimeUnit | None = None
+    exclusions: list[FunnelExclusionEventsNode | FunnelExclusionActionsNode] | None = None
     fingerprint: str | None = None
     funnel_order_type: StepOrderValue | None = None
     goal: ExperimentMetricGoal | None = None


### PR DESCRIPTION
## Problem

PostHog's funnel insights support exclusion steps via `funnelsFilter.exclusions`, but the experiment metrics engine (`ExperimentFunnelMetric`) does not. There's no way to define "users who did step A but NOT event X between steps A and B" as an experiment metric.

Closes #53257
References #9475, #5074

## Use case

Measuring non-inviter conversion in an onboarding experiment:
```
invite_screen_viewed → (did NOT fire invite_sent) → trial_started
```

## Changes

| Layer | File | Change |
|-------|------|--------|
| Schema (TS) | `frontend/src/queries/schema/schema-general.ts` | Add `exclusions?: FunnelExclusion[]` to `ExperimentFunnelMetric` |
| Schema (Python) | `posthog/schema.py` | Mirror exclusions field (will be regenerated by `schema:build`) |
| Query builder | `posthog/hogql_queries/experiments/experiment_query_builder.py` | Build exclusion columns in `_build_funnel_step_columns()`, include exclusion events in `_build_funnel_steps_filter()` |
| UDF integration | `posthog/hogql_queries/experiments/base_query_utils.py` | Pass negative step values for exclusions to `aggregate_funnel_array` + use `x != 0` filter (matching regular funnel behavior) |
| Frontend | `ExperimentMetricFunnelExclusionsFilter.tsx` | New component for configuring exclusion steps in experiment metric form |
| Frontend | `ExperimentMetricForm.tsx` | Integrate exclusion filter into funnel metric configuration |
| Tests | `test_funnel_exclusion_metric.py` | 3 test cases: exclusion filtering, no-exclusion regression, empty exclusions |

## How it works

The implementation mirrors how regular funnels handle exclusions:

1. **Exclusion columns** (`exclusion_1`, `exclusion_2`, ...) are added to the `metric_events` CTE, each being a boolean flag for whether the exclusion event occurred at that row
2. **Negative step values** are appended to the step conditions array (e.g., `-2 * exclusion_1`), which the `aggregate_funnel_array` UDF interprets as exclusion signals
3. The array filter predicate changes from `x > 0` to `x != 0` when exclusions are present, preserving the negative values for the UDF

## How did you test this code?

- Added 3 unit tests in `test_funnel_exclusion_metric.py`:
  - `test_funnel_metric_with_exclusion_step` — validates excluded users don't count as conversions
  - `test_funnel_metric_without_exclusions_unchanged` — regression test for existing behavior
  - `test_funnel_metric_exclusion_empty_list` — empty exclusions behave like no exclusions

**Note:** `posthog/schema.py` includes a manual edit that should be regenerated via `pnpm schema:build:json` in CI. The TypeScript schema is the source of truth.