### PR TITLE
chore: add command to backfill user joined notification

### DIFF
--- a/posthog/management/commands/backfill_user_joined_notification_settings.py
+++ b/posthog/management/commands/backfill_user_joined_notification_settings.py
@@ -4,27 +4,31 @@ from django.core.management.base import BaseCommand
 from django.db import connection, transaction
 
 ORG_MEMBER_JOIN_KEY = "organization_member_join_email_disabled"
+BATCH_SIZE = 5000
 
-COUNT_SQL = """
+COUNT_SQL = f"""
 SELECT COUNT(*) FROM (
   SELECT m.user_id
   FROM posthog_organizationmembership m
   JOIN posthog_organization o ON o.id = m.organization_id
+  JOIN posthog_user u ON u.id = m.user_id
+  WHERE NOT COALESCE(u.partial_notification_settings, '{{}}')::jsonb ? '{ORG_MEMBER_JOIN_KEY}'
   GROUP BY m.user_id
 ) t
 """
 
-UPDATE_SQL = f"""
-UPDATE posthog_user u
-SET partial_notification_settings = (
-  COALESCE(u.partial_notification_settings::jsonb, '{{}}'::jsonb)
-  || jsonb_build_object(
-    '{ORG_MEMBER_JOIN_KEY}',
-    COALESCE(u.partial_notification_settings::jsonb #> '{{{ORG_MEMBER_JOIN_KEY}}}', '{{}}'::jsonb)
-    || org_map.from_orgs
+UPDATE_BATCH_SQL = f"""
+WITH eligible AS (
+  SELECT u.id
+  FROM posthog_user u
+  WHERE EXISTS (
+    SELECT 1 FROM posthog_organizationmembership m WHERE m.user_id = u.id
   )
-)
-FROM (
+  AND NOT COALESCE(u.partial_notification_settings, '{{}}')::jsonb ? '{ORG_MEMBER_JOIN_KEY}'
+  ORDER BY u.id
+  LIMIT {BATCH_SIZE}
+),
+org_map AS (
   SELECT
     m.user_id,
     jsonb_object_agg(
@@ -33,8 +37,18 @@ FROM (
     ) AS from_orgs
   FROM posthog_organizationmembership m
   JOIN posthog_organization o ON o.id = m.organization_id
+  INNER JOIN eligible e ON e.id = m.user_id
   GROUP BY m.user_id
-) org_map
+)
+UPDATE posthog_user u
+SET partial_notification_settings = (
+  COALESCE(u.partial_notification_settings::jsonb, '{{}}'::jsonb)
+  || jsonb_build_object(
+    '{ORG_MEMBER_JOIN_KEY}',
+    org_map.from_orgs
+  )
+)
+FROM org_map
 WHERE u.id = org_map.user_id
 """
 
@@ -61,15 +75,26 @@ class Command(BaseCommand):
             assert row is not None
             (would_update,) = row
 
-        self.stdout.write(f"Users with at least one organization membership to process: {would_update}")
+        self.stdout.write(
+            f"Users with at least one organization membership and no '{ORG_MEMBER_JOIN_KEY}' "
+            f"setting yet: {would_update}"
+        )
 
         if dry_run:
             self.stdout.write(self.style.WARNING("Dry run — no changes written."))
             return
 
-        with transaction.atomic():
-            with connection.cursor() as cursor:
-                cursor.execute(UPDATE_SQL)
-                updated = cursor.rowcount
+        total_updated = 0
+        batch_index = 0
+        while True:
+            with transaction.atomic():
+                with connection.cursor() as cursor:
+                    cursor.execute(UPDATE_BATCH_SQL)
+                    updated = cursor.rowcount
+            if updated == 0:
+                break
+            total_updated += updated
+            batch_index += 1
+            self.stdout.write(f"Batch {batch_index}: updated {updated} user(s) (running total: {total_updated}).")
 
-        self.stdout.write(self.style.SUCCESS(f"Updated {updated} user(s)."))
+        self.stdout.write(self.style.SUCCESS(f"Done. Updated {total_updated} user(s) in {batch_index} batch(es)."))

--- a/posthog/management/commands/backfill_user_joined_notification_settings.py
+++ b/posthog/management/commands/backfill_user_joined_notification_settings.py
@@ -1,0 +1,75 @@
+from typing import Any
+
+from django.core.management.base import BaseCommand
+from django.db import connection, transaction
+
+ORG_MEMBER_JOIN_KEY = "organization_member_join_email_disabled"
+
+COUNT_SQL = """
+SELECT COUNT(*) FROM (
+  SELECT m.user_id
+  FROM posthog_organizationmembership m
+  JOIN posthog_organization o ON o.id = m.organization_id
+  GROUP BY m.user_id
+) t
+"""
+
+UPDATE_SQL = f"""
+UPDATE posthog_user u
+SET partial_notification_settings = (
+  COALESCE(u.partial_notification_settings::jsonb, '{{}}'::jsonb)
+  || jsonb_build_object(
+    '{ORG_MEMBER_JOIN_KEY}',
+    COALESCE(u.partial_notification_settings::jsonb #> '{{{ORG_MEMBER_JOIN_KEY}}}', '{{}}'::jsonb)
+    || org_map.from_orgs
+  )
+)
+FROM (
+  SELECT
+    m.user_id,
+    jsonb_object_agg(
+      m.organization_id::text,
+      NOT COALESCE(o.is_member_join_email_enabled, true)
+    ) AS from_orgs
+  FROM posthog_organizationmembership m
+  JOIN posthog_organization o ON o.id = m.organization_id
+  GROUP BY m.user_id
+) org_map
+WHERE u.id = org_map.user_id
+"""
+
+
+class Command(BaseCommand):
+    help = (
+        "Backfill user partial_notification_settings.organization_member_join_email_disabled from each "
+        "organization's is_member_join_email_enabled for organizations the user belongs to."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Show how many users would be updated without writing changes.",
+        )
+
+    def handle(self, *args: Any, **options: Any) -> None:
+        dry_run: bool = options["dry_run"]
+
+        with connection.cursor() as cursor:
+            cursor.execute(COUNT_SQL)
+            row = cursor.fetchone()
+            assert row is not None
+            (would_update,) = row
+
+        self.stdout.write(f"Users with at least one organization membership to process: {would_update}")
+
+        if dry_run:
+            self.stdout.write(self.style.WARNING("Dry run — no changes written."))
+            return
+
+        with transaction.atomic():
+            with connection.cursor() as cursor:
+                cursor.execute(UPDATE_SQL)
+                updated = cursor.rowcount
+
+        self.stdout.write(self.style.SUCCESS(f"Updated {updated} user(s)."))

--- a/posthog/management/commands/test/test_backfill_user_joined_notification_settings.py
+++ b/posthog/management/commands/test/test_backfill_user_joined_notification_settings.py
@@ -66,7 +66,7 @@ class TestBackfillUserJoinedNotificationSettingsCommand(BaseTest):
         join_map = pns.get(ORG_MEMBER_JOIN_KEY, {})
         self.assertEqual(join_map[str(self.organization.id)], False)
 
-    def test_backfill_preserves_stale_join_map_entries_for_non_memberships(self) -> None:
+    def test_backfill_skips_users_who_already_have_join_notification_key(self) -> None:
         stale_org_id = str(uuid.uuid4())
         self.user.partial_notification_settings = {
             ORG_MEMBER_JOIN_KEY: {
@@ -80,4 +80,4 @@ class TestBackfillUserJoinedNotificationSettingsCommand(BaseTest):
         self.user.refresh_from_db(fields=["partial_notification_settings"])
         join_map = (self.user.partial_notification_settings or {}).get(ORG_MEMBER_JOIN_KEY, {})
         self.assertEqual(join_map.get(stale_org_id), True)
-        self.assertEqual(join_map[str(self.organization.id)], False)
+        self.assertNotIn(str(self.organization.id), join_map)

--- a/posthog/management/commands/test/test_backfill_user_joined_notification_settings.py
+++ b/posthog/management/commands/test/test_backfill_user_joined_notification_settings.py
@@ -1,0 +1,83 @@
+import uuid
+from io import StringIO
+
+from posthog.test.base import BaseTest
+
+from django.core.management import call_command
+
+from posthog.management.commands.backfill_user_joined_notification_settings import ORG_MEMBER_JOIN_KEY
+from posthog.models import Organization
+
+
+class TestBackfillUserJoinedNotificationSettingsCommand(BaseTest):
+    def setUp(self) -> None:
+        super().setUp()
+        self.stdout = StringIO()
+
+    def test_backfill_sets_flags_from_org_is_member_join_email_enabled(self) -> None:
+        self.user.partial_notification_settings = {"plugin_disabled": False}
+        self.user.save()
+
+        org_disabled = Organization.objects.create(
+            name="No join emails",
+            is_member_join_email_enabled=False,
+        )
+        self.user.join(organization=org_disabled)
+
+        self.organization.is_member_join_email_enabled = True
+        self.organization.save()
+
+        call_command("backfill_user_joined_notification_settings", stdout=self.stdout)
+
+        self.user.refresh_from_db(fields=["partial_notification_settings"])
+        pns = self.user.partial_notification_settings or {}
+        self.assertEqual(pns.get("plugin_disabled"), False)
+        join_map = pns.get(ORG_MEMBER_JOIN_KEY, {})
+        self.assertEqual(join_map[str(self.organization.id)], False)
+        self.assertEqual(join_map[str(org_disabled.id)], True)
+
+    def test_dry_run_does_not_write(self) -> None:
+        self.user.partial_notification_settings = None
+        self.user.save()
+
+        call_command("backfill_user_joined_notification_settings", "--dry-run", stdout=self.stdout)
+
+        self.user.refresh_from_db(fields=["partial_notification_settings"])
+        self.assertIsNone(self.user.partial_notification_settings)
+
+    def test_backfill_preserves_other_top_level_notification_keys(self) -> None:
+        before = {
+            "plugin_disabled": False,
+            "discussions_mentioned": False,
+            "all_weekly_digest_disabled": True,
+            "data_pipeline_error_threshold": 0.05,
+            "project_weekly_digest_disabled": {str(self.team.id): True},
+            "error_tracking_weekly_digest_project_enabled": {str(self.team.id): True},
+        }
+        self.user.partial_notification_settings = dict(before)
+        self.user.save()
+
+        call_command("backfill_user_joined_notification_settings", stdout=self.stdout)
+
+        self.user.refresh_from_db(fields=["partial_notification_settings"])
+        pns = self.user.partial_notification_settings or {}
+        for key, value in before.items():
+            self.assertEqual(pns.get(key), value, msg=f"expected {key!r} unchanged")
+        join_map = pns.get(ORG_MEMBER_JOIN_KEY, {})
+        self.assertEqual(join_map[str(self.organization.id)], False)
+
+    def test_backfill_preserves_stale_join_map_entries_for_non_memberships(self) -> None:
+        stale_org_id = str(uuid.uuid4())
+        self.user.partial_notification_settings = {
+            ORG_MEMBER_JOIN_KEY: {
+                stale_org_id: True,
+            },
+        }
+        self.user.save()
+
+        call_command("backfill_user_joined_notification_settings", stdout=self.stdout)
+
+        self.user.refresh_from_db(fields=["partial_notification_settings"])
+        join_map = (self.user.partial_notification_settings or {}).get(ORG_MEMBER_JOIN_KEY, {})
+        self.assertEqual(join_map.get(stale_org_id), True)
+        self.assertEqual(join_map[str(self.organization.id)], False)


### PR DESCRIPTION
## Problem

Need to run a migration to backfill the user joined notification setting from the existing organization settings to the individual user settings.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

1. Add new `backfill_user_joined_notification_settings` command
2. Add tests for ^^^

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Tests

<!-- Briefly describe the steps you took, and what steps reviewers must take to get to where changes are, and what is the expected behavior. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
