### PR TITLE
feat(flags): add remote config support for mobile SDKs

### DIFF
--- a/frontend/src/scenes/feature-flags/FeatureFlagCodeOptions.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagCodeOptions.tsx
@@ -202,6 +202,10 @@ export const REMOTE_CONFIGURATION_LIBRARIES: string[] = [
     SDKKey.GO,
     SDKKey.RUBY,
     SDKKey.DOTNET,
+    SDKKey.IOS,
+    SDKKey.ANDROID,
+    SDKKey.REACT_NATIVE,
+    SDKKey.FLUTTER,
 ]
 
 export const BOOTSTRAPPING_OPTIONS: InstructionOption[] = [

--- a/frontend/src/scenes/feature-flags/FeatureFlagInstructions.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagInstructions.tsx
@@ -184,7 +184,7 @@ export function CodeInstructions({
     const allFlagLibraries = [
         {
             title: 'Client libraries',
-            options: OPTIONS.filter((option) => option.type == LibraryType.Client).map((option) => ({
+            options: OPTIONS.filter((option) => option.type === LibraryType.Client).map((option) => ({
                 value: option.key,
                 label: option.value,
                 'data-attr': `feature-flag-instructions-select-option-${option.key}`,
@@ -198,7 +198,7 @@ export function CodeInstructions({
         },
         {
             title: 'Server libraries',
-            options: OPTIONS.filter((option) => option.type == LibraryType.Server).map((option) => ({
+            options: OPTIONS.filter((option) => option.type === LibraryType.Server).map((option) => ({
                 value: option.key,
                 label: option.value,
                 'data-attr': `feature-flag-instructions-select-option-${option.key}`,
@@ -215,7 +215,7 @@ export function CodeInstructions({
         {
             title: 'Client libraries',
             options: OPTIONS.filter(
-                (option) => option.type == LibraryType.Client && REMOTE_CONFIGURATION_LIBRARIES.includes(option.key)
+                (option) => option.type === LibraryType.Client && REMOTE_CONFIGURATION_LIBRARIES.includes(option.key)
             ).map((option) => ({
                 value: option.key,
                 label: option.value,
@@ -231,7 +231,7 @@ export function CodeInstructions({
         {
             title: 'Server libraries',
             options: OPTIONS.filter(
-                (option) => option.type == LibraryType.Server && REMOTE_CONFIGURATION_LIBRARIES.includes(option.key)
+                (option) => option.type === LibraryType.Server && REMOTE_CONFIGURATION_LIBRARIES.includes(option.key)
             ).map((option) => ({
                 value: option.key,
                 label: option.value,

--- a/frontend/src/scenes/feature-flags/FeatureFlagInstructions.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagInstructions.tsx
@@ -213,8 +213,26 @@ export function CodeInstructions({
     ]
     const remoteConfigurationLibraries = [
         {
+            title: 'Client libraries',
+            options: OPTIONS.filter(
+                (option) => option.type == LibraryType.Client && REMOTE_CONFIGURATION_LIBRARIES.includes(option.key)
+            ).map((option) => ({
+                value: option.key,
+                label: option.value,
+                'data-attr': `feature-flag-instructions-select-option-${option.key}`,
+                labelInMenu: (
+                    <div className="flex items-center deprecated-space-x-2">
+                        <option.Icon />
+                        <span>{option.value}</span>
+                    </div>
+                ),
+            })),
+        },
+        {
             title: 'Server libraries',
-            options: OPTIONS.filter((option) => REMOTE_CONFIGURATION_LIBRARIES.includes(option.key)).map((option) => ({
+            options: OPTIONS.filter(
+                (option) => option.type == LibraryType.Server && REMOTE_CONFIGURATION_LIBRARIES.includes(option.key)
+            ).map((option) => ({
                 value: option.key,
                 label: option.value,
                 'data-attr': `feature-flag-instructions-select-option-${option.key}`,

--- a/frontend/src/scenes/feature-flags/FeatureFlagSnippets.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagSnippets.tsx
@@ -1,6 +1,7 @@
 import { useValues } from 'kea'
 
 import { CodeSnippet, Language } from 'lib/components/CodeSnippet'
+import { Link } from 'lib/lemon-ui/Link'
 import { apiHostOrigin } from 'lib/utils/apiHost'
 import { teamLogic } from 'scenes/teamLogic'
 
@@ -509,8 +510,35 @@ if ("example-variant".equals(flagValue)) {
     )
 }
 
-export function AndroidSnippet({ flagKey, multivariant, payload }: FeatureFlagSnippet): JSX.Element {
+export function AndroidSnippet({
+    flagKey,
+    multivariant,
+    payload,
+    remoteConfiguration,
+    encryptedPayload,
+}: FeatureFlagSnippet): JSX.Element {
     const clientSuffix = 'PostHog.'
+
+    if (remoteConfiguration) {
+        const warning = encryptedPayload ? `// ${ENCRYPTED_PAYLOAD_REMINDER}` : ''
+
+        return (
+            <>
+                <CodeSnippet language={Language.Kotlin} wrap>
+                    {`${warning ? warning + '\n' : ''}val remoteConfig = ${clientSuffix}getFeatureFlagPayload("${flagKey}")
+remoteConfig?.let { config ->
+    // Handle remote configuration payload
+    println("Remote config: $config")
+}`}
+                </CodeSnippet>
+                <div className="mt-2">
+                    <Link to="https://posthog.com/tutorials/android-remote-config" target="_blank">
+                        View complete Android remote config tutorial
+                    </Link>
+                </div>
+            </>
+        )
+    }
 
     if (payload) {
         return (
@@ -533,8 +561,35 @@ export function AndroidSnippet({ flagKey, multivariant, payload }: FeatureFlagSn
     )
 }
 
-export function FlutterSnippet({ flagKey, multivariant, payload }: FeatureFlagSnippet): JSX.Element {
+export function FlutterSnippet({
+    flagKey,
+    multivariant,
+    payload,
+    remoteConfiguration,
+    encryptedPayload,
+}: FeatureFlagSnippet): JSX.Element {
     const clientSuffix = 'await Posthog().'
+
+    if (remoteConfiguration) {
+        const warning = encryptedPayload ? `// ${ENCRYPTED_PAYLOAD_REMINDER}` : ''
+
+        return (
+            <>
+                <CodeSnippet language={Language.Dart} wrap>
+                    {`${warning ? warning + '\n' : ''}final remoteConfig = ${clientSuffix}getFeatureFlagPayload('${flagKey}');
+if (remoteConfig != null) {
+  // Handle remote configuration payload
+  print('Remote config: $remoteConfig');
+}`}
+                </CodeSnippet>
+                <div className="mt-2">
+                    <Link to="https://posthog.com/tutorials/flutter-remote-config" target="_blank">
+                        View complete Flutter remote config tutorial
+                    </Link>
+                </div>
+            </>
+        )
+    }
 
     if (payload) {
         return (
@@ -558,8 +613,34 @@ export function FlutterSnippet({ flagKey, multivariant, payload }: FeatureFlagSn
     )
 }
 
-export function iOSSnippet({ flagKey, multivariant, payload }: FeatureFlagSnippet): JSX.Element {
+export function iOSSnippet({
+    flagKey,
+    multivariant,
+    payload,
+    remoteConfiguration,
+    encryptedPayload,
+}: FeatureFlagSnippet): JSX.Element {
     const clientSuffix = 'PostHogSDK.shared.'
+
+    if (remoteConfiguration) {
+        const warning = encryptedPayload ? `// ${ENCRYPTED_PAYLOAD_REMINDER}` : ''
+
+        return (
+            <>
+                <CodeSnippet language={Language.Swift} wrap>
+                    {`${warning ? warning + '\n' : ''}if let remoteConfig = ${clientSuffix}getFeatureFlagPayload("${flagKey}") {
+    // Handle remote configuration payload
+    print("Remote config: \\(remoteConfig)")
+}`}
+                </CodeSnippet>
+                <div className="mt-2">
+                    <Link to="https://posthog.com/tutorials/ios-remote-config" target="_blank">
+                        View complete iOS remote config tutorial
+                    </Link>
+                </div>
+            </>
+        )
+    }
 
     if (payload) {
         return (
@@ -581,8 +662,42 @@ export function iOSSnippet({ flagKey, multivariant, payload }: FeatureFlagSnippe
     )
 }
 
-export function ReactNativeSnippet({ flagKey, multivariant, payload }: FeatureFlagSnippet): JSX.Element {
+export function ReactNativeSnippet({
+    flagKey,
+    multivariant,
+    payload,
+    remoteConfiguration,
+    encryptedPayload,
+}: FeatureFlagSnippet): JSX.Element {
     const clientSuffix = 'posthog.'
+
+    if (remoteConfiguration) {
+        const warning = encryptedPayload ? `// ${ENCRYPTED_PAYLOAD_REMINDER}` : ''
+
+        return (
+            <>
+                <CodeSnippet language={Language.JSX} wrap>
+                    {`${warning ? warning + '\n' : ''}import { useFeatureFlagWithPayload } from 'posthog-react-native'
+
+const MyComponent = () => {
+    const [flagValue, payload] = useFeatureFlagWithPayload('${flagKey}')
+    
+    if (payload) {
+        // Handle remote configuration payload
+        console.log('Remote config:', payload)
+    }
+    
+    return <YourComponent />
+}`}
+                </CodeSnippet>
+                <div className="mt-2">
+                    <Link to="https://posthog.com/tutorials/react-native-remote-config" target="_blank">
+                        View complete React Native remote config tutorial
+                    </Link>
+                </div>
+            </>
+        )
+    }
 
     if (payload) {
         return (

--- a/frontend/src/scenes/feature-flags/FeatureFlagSnippets.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagSnippets.tsx
@@ -628,9 +628,10 @@ export function iOSSnippet({
         return (
             <>
                 <CodeSnippet language={Language.Swift} wrap>
-                    {`${warning ? warning + '\n' : ''}if let remoteConfig = ${clientSuffix}getFeatureFlagPayload("${flagKey}") {
+                    {`${warning ? warning + '\n' : ''}let result = ${clientSuffix}getFeatureFlagResult("${flagKey}")
+if let payload = result.payload {
     // Handle remote configuration payload
-    print("Remote config: \\(remoteConfig)")
+    print("Remote config: \\(payload)")
 }`}
                 </CodeSnippet>
                 <div className="mt-2">
@@ -645,7 +646,11 @@ export function iOSSnippet({
     if (payload) {
         return (
             <CodeSnippet language={Language.Swift} wrap>
-                {`${clientSuffix}getFeatureFlagPayload("${flagKey}")`}
+                {`let result = ${clientSuffix}getFeatureFlagResult("${flagKey}")
+if let payload = result.payload {
+    // Handle the payload
+    print("Payload: \\(payload)")
+}`}
             </CodeSnippet>
         )
     }

--- a/frontend/src/scenes/feature-flags/FeatureFlagSnippets.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagSnippets.tsx
@@ -532,7 +532,11 @@ remoteConfig?.let { config ->
 }`}
                 </CodeSnippet>
                 <div className="mt-2">
-                    <Link to="https://posthog.com/tutorials/android-remote-config" target="_blank">
+                    <Link
+                        to="https://posthog.com/tutorials/android-remote-config"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                    >
                         View complete Android remote config tutorial
                     </Link>
                 </div>
@@ -583,7 +587,11 @@ if (remoteConfig != null) {
 }`}
                 </CodeSnippet>
                 <div className="mt-2">
-                    <Link to="https://posthog.com/tutorials/flutter-remote-config" target="_blank">
+                    <Link
+                        to="https://posthog.com/tutorials/flutter-remote-config"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                    >
                         View complete Flutter remote config tutorial
                     </Link>
                 </div>
@@ -635,7 +643,11 @@ if let payload = result.payload {
 }`}
                 </CodeSnippet>
                 <div className="mt-2">
-                    <Link to="https://posthog.com/tutorials/ios-remote-config" target="_blank">
+                    <Link
+                        to="https://posthog.com/tutorials/ios-remote-config"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                    >
                         View complete iOS remote config tutorial
                     </Link>
                 </div>
@@ -692,7 +704,11 @@ const MyComponent = () => {
 }`}
                 </CodeSnippet>
                 <div className="mt-2">
-                    <Link to="https://posthog.com/tutorials/react-native-remote-config" target="_blank">
+                    <Link
+                        to="https://posthog.com/tutorials/react-native-remote-config"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                    >
                         View complete React Native remote config tutorial
                     </Link>
                 </div>

--- a/frontend/src/scenes/feature-flags/FeatureFlagSnippets.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagSnippets.tsx
@@ -532,11 +532,7 @@ remoteConfig?.let { config ->
 }`}
                 </CodeSnippet>
                 <div className="mt-2">
-                    <Link
-                        to="https://posthog.com/tutorials/android-remote-config"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                    >
+                    <Link to="https://posthog.com/tutorials/android-remote-config" target="_blank">
                         View complete Android remote config tutorial
                     </Link>
                 </div>
@@ -587,11 +583,7 @@ if (remoteConfig != null) {
 }`}
                 </CodeSnippet>
                 <div className="mt-2">
-                    <Link
-                        to="https://posthog.com/tutorials/flutter-remote-config"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                    >
+                    <Link to="https://posthog.com/tutorials/flutter-remote-config" target="_blank">
                         View complete Flutter remote config tutorial
                     </Link>
                 </div>
@@ -643,11 +635,7 @@ if let payload = result.payload {
 }`}
                 </CodeSnippet>
                 <div className="mt-2">
-                    <Link
-                        to="https://posthog.com/tutorials/ios-remote-config"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                    >
+                    <Link to="https://posthog.com/tutorials/ios-remote-config" target="_blank">
                         View complete iOS remote config tutorial
                     </Link>
                 </div>
@@ -704,11 +692,7 @@ const MyComponent = () => {
 }`}
                 </CodeSnippet>
                 <div className="mt-2">
-                    <Link
-                        to="https://posthog.com/tutorials/react-native-remote-config"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                    >
+                    <Link to="https://posthog.com/tutorials/react-native-remote-config" target="_blank">
                         View complete React Native remote config tutorial
                     </Link>
                 </div>

--- a/frontend/src/scenes/feature-flags/FeatureFlagSnippets.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagSnippets.tsx
@@ -525,10 +525,10 @@ export function AndroidSnippet({
         return (
             <>
                 <CodeSnippet language={Language.Kotlin} wrap>
-                    {`${warning ? warning + '\n' : ''}val remoteConfig = ${clientSuffix}getFeatureFlagPayload("${flagKey}")
-remoteConfig?.let { config ->
+                    {`${warning ? warning + '\n' : ''}val result = ${clientSuffix}getFeatureFlagResult("${flagKey}")
+result.payload?.let { payload ->
     // Handle remote configuration payload
-    println("Remote config: $config")
+    println("Remote config: $payload")
 }`}
                 </CodeSnippet>
                 <div className="mt-2">
@@ -576,10 +576,10 @@ export function FlutterSnippet({
         return (
             <>
                 <CodeSnippet language={Language.Dart} wrap>
-                    {`${warning ? warning + '\n' : ''}final remoteConfig = ${clientSuffix}getFeatureFlagPayload('${flagKey}');
-if (remoteConfig != null) {
+                    {`${warning ? warning + '\n' : ''}final result = ${clientSuffix}getFeatureFlagResult('${flagKey}');
+if (result.payload != null) {
   // Handle remote configuration payload
-  print('Remote config: $remoteConfig');
+  print('Remote config: \${result.payload}');
 }`}
                 </CodeSnippet>
                 <div className="mt-2">
@@ -678,14 +678,14 @@ export function ReactNativeSnippet({
         return (
             <>
                 <CodeSnippet language={Language.JSX} wrap>
-                    {`${warning ? warning + '\n' : ''}import { useFeatureFlagWithPayload } from 'posthog-react-native'
+                    {`${warning ? warning + '\n' : ''}import { useFeatureFlagResult } from 'posthog-react-native'
 
 const MyComponent = () => {
-    const [flagValue, payload] = useFeatureFlagWithPayload('${flagKey}')
+    const result = useFeatureFlagResult('${flagKey}')
     
-    if (payload) {
+    if (result.payload) {
         // Handle remote configuration payload
-        console.log('Remote config:', payload)
+        console.log('Remote config:', result.payload)
     }
     
     return <YourComponent />

--- a/frontend/src/scenes/feature-flags/FeatureFlagSnippets.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagSnippets.tsx
@@ -520,7 +520,7 @@ export function AndroidSnippet({
     const clientSuffix = 'PostHog.'
 
     if (remoteConfiguration) {
-        const warning = encryptedPayload ? `// ${ENCRYPTED_PAYLOAD_REMINDER}` : ''
+        const warning = `// ${REMOTE_CONFIG_REMINDER}` + (encryptedPayload ? `\n// ${ENCRYPTED_PAYLOAD_REMINDER}` : '')
 
         return (
             <>
@@ -571,7 +571,7 @@ export function FlutterSnippet({
     const clientSuffix = 'await Posthog().'
 
     if (remoteConfiguration) {
-        const warning = encryptedPayload ? `// ${ENCRYPTED_PAYLOAD_REMINDER}` : ''
+        const warning = `// ${REMOTE_CONFIG_REMINDER}` + (encryptedPayload ? `\n// ${ENCRYPTED_PAYLOAD_REMINDER}` : '')
 
         return (
             <>
@@ -623,7 +623,7 @@ export function iOSSnippet({
     const clientSuffix = 'PostHogSDK.shared.'
 
     if (remoteConfiguration) {
-        const warning = encryptedPayload ? `// ${ENCRYPTED_PAYLOAD_REMINDER}` : ''
+        const warning = `// ${REMOTE_CONFIG_REMINDER}` + (encryptedPayload ? `\n// ${ENCRYPTED_PAYLOAD_REMINDER}` : '')
 
         return (
             <>
@@ -646,11 +646,7 @@ if let payload = result.payload {
     if (payload) {
         return (
             <CodeSnippet language={Language.Swift} wrap>
-                {`let result = ${clientSuffix}getFeatureFlagResult("${flagKey}")
-if let payload = result.payload {
-    // Handle the payload
-    print("Payload: \\(payload)")
-}`}
+                {`${clientSuffix}getFeatureFlagPayload("${flagKey}")`}
             </CodeSnippet>
         )
     }
@@ -677,7 +673,7 @@ export function ReactNativeSnippet({
     const clientSuffix = 'posthog.'
 
     if (remoteConfiguration) {
-        const warning = encryptedPayload ? `// ${ENCRYPTED_PAYLOAD_REMINDER}` : ''
+        const warning = `// ${REMOTE_CONFIG_REMINDER}` + (encryptedPayload ? `\n// ${ENCRYPTED_PAYLOAD_REMINDER}` : '')
 
         return (
             <>


### PR DESCRIPTION
## Problem

Remote configuration for feature flags currently only supports server-side SDKs. Mobile SDKs (iOS, Android, React Native, Flutter) are missing from the remote config UI.

## Changes

- Add mobile SDKs to remote configuration options
- Update mobile SDK snippets with remote config code examples
- Add clickable tutorial links below each code snippet
- Maintain client/server library separation in UI
- Docs change: https://github.com/PostHog/posthog.com/pull/16160

<img width="1529" height="499" alt="image" src="https://github.com/user-attachments/assets/315ce48d-348e-4490-bc41-094d5130b487" />

## How did you test this code?

- Verified TypeScript compilation and formatting
- Confirmed mobile SDKs appear in remote config UI
- Tested tutorial links are clickable and functional

## Publish to changelog?

no