### PR TITLE
fix: Handle custom URI schemes in OAuth error redirects

### DIFF
--- a/posthog/api/oauth/test_views.py
+++ b/posthog/api/oauth/test_views.py
@@ -2568,6 +2568,37 @@ class TestOAuthAPI(APIBaseTest):
         old_db_token = OAuthRefreshToken.objects.get(token=original_refresh_token)
         self.assertIsNotNone(old_db_token.revoked)
 
+    @parameterized.expand(["vscode", "obsidian", "myapp"])
+    def test_error_redirect_with_custom_scheme_does_not_500(self, scheme):
+        custom_scheme_app = OAuthApplication.objects.create(
+            name=f"{scheme} App",
+            client_id=f"{scheme}_client_id",
+            client_secret=f"{scheme}_client_secret",
+            client_type=OAuthApplication.CLIENT_PUBLIC,
+            authorization_grant_type=OAuthApplication.GRANT_AUTHORIZATION_CODE,
+            redirect_uris=f"{scheme}://posthog/callback",
+            user=self.user,
+            hash_client_secret=True,
+            algorithm="RS256",
+        )
+
+        # Request with an invalid scope to trigger an error redirect
+        url = (
+            f"/oauth/authorize/?client_id={custom_scheme_app.client_id}"
+            f"&redirect_uri={scheme}://posthog/callback"
+            f"&response_type=code"
+            f"&code_challenge={self.code_challenge}"
+            f"&code_challenge_method=S256"
+            f"&scope=nonexistent_scope"
+        )
+
+        response = self.client.get(url)
+
+        # Should redirect back to the client with the error, not 500
+        self.assertEqual(response.status_code, status.HTTP_302_FOUND)
+        self.assertTrue(response["Location"].startswith(f"{scheme}://posthog/callback"))
+        self.assertIn("error=invalid_scope", response["Location"])
+
     @freeze_time("2025-01-01 00:00:00")
     @override_settings(CLOUD_DEPLOYMENT="US", SITE_URL="https://us.posthog.com")
     def test_token_response_includes_region_for_us_cloud(self):

--- a/posthog/api/oauth/views.py
+++ b/posthog/api/oauth/views.py
@@ -7,6 +7,7 @@ from typing import TypedDict, cast
 from urllib.parse import urlparse
 
 from django.conf import settings
+from django.core.exceptions import DisallowedRedirect
 from django.http import JsonResponse
 from django.utils import timezone
 from django.utils.decorators import method_decorator
@@ -430,7 +431,16 @@ class OAuthAuthorizationView(OAuthLibMixin, APIView):
         try:
             scopes, credentials = self.validate_authorization_request(request)
         except OAuthToolkitError as error:
-            return self.error_response(error, application=None, state=request.query_params.get("state"))
+            # Try to resolve the application so error redirects can use its allowed schemes
+            # (e.g. vscode:// or other custom schemes registered by the client)
+            error_application = None
+            client_id = request.query_params.get("client_id")
+            if client_id:
+                try:
+                    error_application = get_application_by_client_id(client_id)
+                except OAuthApplication.DoesNotExist:
+                    pass
+            return self.error_response(error, application=error_application, state=request.query_params.get("state"))
 
         # Handle login prompt
         if request.query_params.get("prompt") == "login":
@@ -589,7 +599,14 @@ class OAuthAuthorizationView(OAuthLibMixin, APIView):
                     },
                     status=status.HTTP_200_OK,
                 )
-            return self.redirect(error_response["url"], application)
+            try:
+                return self.redirect(error_response["url"], application)
+            except DisallowedRedirect:
+                logger.warning(
+                    "oauth_disallowed_redirect_scheme",
+                    redirect_url=error_response["url"],
+                )
+                # Fall through to JSON error response below
 
         return Response(
             {


### PR DESCRIPTION
## Problem

OAuth applications using custom URI schemes (like `vscode://`) were causing 500 errors when OAuth authorization errors occurred. This prevented proper error handling for desktop applications and browser extensions that rely on custom schemes for OAuth callbacks.

## Changes

- Modified OAuth error handling to resolve the application by client_id when validation fails, allowing custom URI schemes to be properly recognized
- Added exception handling for `DisallowedRedirect` errors that occur when Django's security middleware blocks custom schemes, gracefully falling back to JSON error responses
- Added logging for disallowed redirect attempts to help with debugging

## How did you test this code?

Added a new test case `test_error_redirect_with_custom_scheme_does_not_500` that:
- Creates an OAuth application with a custom `vscode://` scheme
- Triggers an authorization error by requesting an invalid scope
- Verifies the response is a proper 302 redirect (not a 500 error) with the error parameters included in the callback URL

The test confirms that custom scheme redirects work correctly and error information is properly passed back to the client application.

## Publish to changelog?

No

## Docs update

No docs update needed - this is a bug fix for existing OAuth functionality.