### PR TITLE
feat(replay): modal / warning when deleting last trigger group

### DIFF
--- a/frontend/src/lib/components/IngestionControls/triggers/triggerGroups/TriggerGroupCard.tsx
+++ b/frontend/src/lib/components/IngestionControls/triggers/triggerGroups/TriggerGroupCard.tsx
@@ -2,7 +2,6 @@ import { IconTrash, IconPencil } from '@posthog/icons'
 import { LemonButton, LemonTag, LemonSnack } from '@posthog/lemon-ui'
 
 import { IconSubArrowRight } from 'lib/lemon-ui/icons'
-import { LemonDialog } from 'lib/lemon-ui/LemonDialog'
 
 import { SessionRecordingTriggerGroup } from '~/lib/components/IngestionControls/types'
 
@@ -106,23 +105,7 @@ export function TriggerGroupCard({ group, onEdit, onDelete }: TriggerGroupCardPr
                             size="small"
                             icon={<IconTrash />}
                             status="danger"
-                            onClick={() => {
-                                if (!onDelete) {
-                                    return
-                                }
-                                LemonDialog.open({
-                                    title: 'Delete trigger group?',
-                                    description: `Are you sure you want to delete "${displayName}"? This cannot be undone.`,
-                                    primaryButton: {
-                                        children: 'Delete',
-                                        status: 'danger',
-                                        onClick: () => onDelete(id),
-                                    },
-                                    secondaryButton: {
-                                        children: 'Cancel',
-                                    },
-                                })
-                            }}
+                            onClick={onDelete ? () => onDelete(id) : undefined}
                             disabledReason={!onDelete ? 'Delete not yet implemented' : undefined}
                         >
                             Delete

--- a/frontend/src/lib/components/IngestionControls/triggers/triggerGroups/TriggerGroupsEditor.tsx
+++ b/frontend/src/lib/components/IngestionControls/triggers/triggerGroups/TriggerGroupsEditor.tsx
@@ -1,6 +1,5 @@
 import { useValues, useActions } from 'kea'
 import { Form } from 'kea-forms'
-import { useState } from 'react'
 
 import { IconPlus, IconTrash } from '@posthog/icons'
 import {
@@ -30,12 +29,11 @@ import { TriggerGroupCard } from './TriggerGroupCard'
 import { triggerGroupFormLogic } from './triggerGroupFormLogic'
 
 export function TriggerGroupsEditor(): JSX.Element {
-    const [deleteModalGroupId, setDeleteModalGroupId] = useState<string | null>(null)
-
     const {
         triggerGroups,
         isAddingGroup,
         editingGroupId,
+        deleteModalGroupId,
         showLegacyModal,
         previewLegacyGroups,
         _savingStateLoading,
@@ -47,6 +45,7 @@ export function TriggerGroupsEditor(): JSX.Element {
         deleteTriggerGroup,
         setIsAddingGroup,
         setEditingGroupId,
+        setDeleteModalGroupId,
         showCreateFromLegacyModal,
         hideCreateFromLegacyModal,
         confirmCreateFromLegacy,
@@ -54,7 +53,6 @@ export function TriggerGroupsEditor(): JSX.Element {
 
     const handleDeleteTriggerGroup = (id: string): void => {
         if (triggerGroups.length === 1) {
-            // Show modal with legacy trigger preview
             setDeleteModalGroupId(id)
         } else {
             // Standard confirmation for non-last groups
@@ -176,7 +174,6 @@ export function TriggerGroupsEditor(): JSX.Element {
                 onConfirm={() => {
                     if (deleteModalGroupId) {
                         deleteTriggerGroup(deleteModalGroupId)
-                        setDeleteModalGroupId(null)
                     }
                 }}
                 groupName={
@@ -413,18 +410,9 @@ interface DeleteLastGroupModalProps {
 }
 
 function DeleteLastGroupModal({ isOpen, onClose, onConfirm, groupName }: DeleteLastGroupModalProps): JSX.Element {
-    const { currentTeam } = useValues(replayTriggersV2Logic)
+    const { legacyTriggersPreview } = useValues(replayTriggersV2Logic)
 
-    const sampleRate = currentTeam?.session_recording_sample_rate
-        ? parseFloat(currentTeam.session_recording_sample_rate)
-        : 1
-    const minDurationMs = currentTeam?.session_recording_minimum_duration_milliseconds
-    const matchType = currentTeam?.session_recording_trigger_match_type_config || 'all'
-    const urls = currentTeam?.session_recording_url_trigger_config || []
-    const events = currentTeam?.session_recording_event_trigger_config || []
-    const flag = currentTeam?.session_recording_linked_flag
-
-    const hasConditions = urls.length > 0 || events.length > 0 || !!flag
+    const { sampleRate, minDurationMs, matchType, urls, events, flag, hasConditions } = legacyTriggersPreview
 
     return (
         <LemonModal isOpen={isOpen} onClose={onClose} title="Delete last trigger group?">

--- a/frontend/src/lib/components/IngestionControls/triggers/triggerGroups/TriggerGroupsEditor.tsx
+++ b/frontend/src/lib/components/IngestionControls/triggers/triggerGroups/TriggerGroupsEditor.tsx
@@ -1,12 +1,23 @@
 import { useValues, useActions } from 'kea'
 import { Form } from 'kea-forms'
+import { useState } from 'react'
 
 import { IconPlus, IconTrash } from '@posthog/icons'
-import { LemonBanner, LemonButton, LemonInput, LemonLabel, LemonSelect, LemonSnack } from '@posthog/lemon-ui'
+import {
+    LemonBanner,
+    LemonButton,
+    LemonInput,
+    LemonLabel,
+    LemonModal,
+    LemonSelect,
+    LemonSnack,
+    LemonTag,
+} from '@posthog/lemon-ui'
 
 import { FlagSelector } from 'lib/components/FlagSelector'
 import { EventTriggerSelect } from 'lib/components/IngestionControls/triggers/EventTrigger'
 import { SESSION_REPLAY_MINIMUM_DURATION_OPTIONS } from 'lib/constants'
+import { LemonDialog } from 'lib/lemon-ui/LemonDialog'
 import { LemonField } from 'lib/lemon-ui/LemonField'
 import { TRIGGER_GROUPS_MIN_SDK_VERSION } from 'scenes/settings/environment/ReplayTriggers'
 import { Since } from 'scenes/settings/environment/SessionRecordingSettings'
@@ -19,8 +30,17 @@ import { TriggerGroupCard } from './TriggerGroupCard'
 import { triggerGroupFormLogic } from './triggerGroupFormLogic'
 
 export function TriggerGroupsEditor(): JSX.Element {
-    const { triggerGroups, isAddingGroup, editingGroupId, showLegacyModal, previewLegacyGroups, _savingStateLoading } =
-        useValues(replayTriggersV2Logic)
+    const [deleteModalGroupId, setDeleteModalGroupId] = useState<string | null>(null)
+
+    const {
+        triggerGroups,
+        isAddingGroup,
+        editingGroupId,
+        showLegacyModal,
+        previewLegacyGroups,
+        _savingStateLoading,
+        shouldShowMigrationBanner,
+    } = useValues(replayTriggersV2Logic)
     const {
         addTriggerGroup,
         updateTriggerGroup,
@@ -31,6 +51,30 @@ export function TriggerGroupsEditor(): JSX.Element {
         hideCreateFromLegacyModal,
         confirmCreateFromLegacy,
     } = useActions(replayTriggersV2Logic)
+
+    const handleDeleteTriggerGroup = (id: string): void => {
+        if (triggerGroups.length === 1) {
+            // Show modal with legacy trigger preview
+            setDeleteModalGroupId(id)
+        } else {
+            // Standard confirmation for non-last groups
+            const group = triggerGroups.find((g) => g.id === id)
+            const displayName = group?.name || `Trigger group ${id.slice(0, 8)}`
+
+            LemonDialog.open({
+                title: 'Delete trigger group?',
+                description: `Are you sure you want to delete "${displayName}"? This cannot be undone.`,
+                primaryButton: {
+                    children: 'Delete',
+                    status: 'danger',
+                    onClick: () => deleteTriggerGroup(id),
+                },
+                secondaryButton: {
+                    children: 'Cancel',
+                },
+            })
+        }
+    }
 
     return (
         <div className="space-y-4">
@@ -43,9 +87,11 @@ export function TriggerGroupsEditor(): JSX.Element {
                 </div>
                 {!isAddingGroup && !editingGroupId && (
                     <div className="flex gap-2">
-                        <LemonButton type="secondary" size="small" onClick={showCreateFromLegacyModal}>
-                            Create from legacy triggers
-                        </LemonButton>
+                        {triggerGroups.length === 0 && (
+                            <LemonButton type="secondary" size="small" onClick={showCreateFromLegacyModal}>
+                                Migrate from legacy recording conditions
+                            </LemonButton>
+                        )}
                         <LemonButton
                             type="primary"
                             icon={<IconPlus />}
@@ -62,6 +108,16 @@ export function TriggerGroupsEditor(): JSX.Element {
                 Configure custom recording triggers with individual sampling rates per group. Recording will start if
                 any of the recording trigger groups match.
             </p>
+
+            {shouldShowMigrationBanner && (
+                <LemonBanner type="info">
+                    <strong>You're using legacy recording triggers</strong>
+                    <p className="mt-1">
+                        Trigger groups offer more flexibility, including individual sampling rates per group. Migrate
+                        your existing configuration by clicking the migrate button above.
+                    </p>
+                </LemonBanner>
+            )}
 
             {isAddingGroup && (
                 <GroupForm
@@ -98,7 +154,7 @@ export function TriggerGroupsEditor(): JSX.Element {
                                 <TriggerGroupCard
                                     group={group}
                                     onEdit={() => setEditingGroupId(group.id)}
-                                    onDelete={deleteTriggerGroup}
+                                    onDelete={handleDeleteTriggerGroup}
                                 />
                             )}
                         </div>
@@ -112,6 +168,21 @@ export function TriggerGroupsEditor(): JSX.Element {
                 onConfirm={confirmCreateFromLegacy}
                 previewGroups={previewLegacyGroups}
                 isCreating={_savingStateLoading}
+            />
+
+            <DeleteLastGroupModal
+                isOpen={!!deleteModalGroupId}
+                onClose={() => setDeleteModalGroupId(null)}
+                onConfirm={() => {
+                    if (deleteModalGroupId) {
+                        deleteTriggerGroup(deleteModalGroupId)
+                        setDeleteModalGroupId(null)
+                    }
+                }}
+                groupName={
+                    triggerGroups.find((g) => g.id === deleteModalGroupId)?.name ||
+                    `Trigger group ${deleteModalGroupId?.slice(0, 8)}`
+                }
             />
         </div>
     )
@@ -331,5 +402,109 @@ function GroupForm({ group, onSave, onCancel }: GroupFormProps): JSX.Element {
                 </div>
             </div>
         </Form>
+    )
+}
+
+interface DeleteLastGroupModalProps {
+    isOpen: boolean
+    onClose: () => void
+    onConfirm: () => void
+    groupName: string
+}
+
+function DeleteLastGroupModal({ isOpen, onClose, onConfirm, groupName }: DeleteLastGroupModalProps): JSX.Element {
+    const { currentTeam } = useValues(replayTriggersV2Logic)
+
+    const sampleRate = currentTeam?.session_recording_sample_rate
+        ? parseFloat(currentTeam.session_recording_sample_rate)
+        : 1
+    const minDurationMs = currentTeam?.session_recording_minimum_duration_milliseconds
+    const matchType = currentTeam?.session_recording_trigger_match_type_config || 'all'
+    const urls = currentTeam?.session_recording_url_trigger_config || []
+    const events = currentTeam?.session_recording_event_trigger_config || []
+    const flag = currentTeam?.session_recording_linked_flag
+
+    const hasConditions = urls.length > 0 || events.length > 0 || !!flag
+
+    return (
+        <LemonModal isOpen={isOpen} onClose={onClose} title="Delete last trigger group?">
+            <div className="space-y-4">
+                <p>
+                    Deleting "{groupName}" will remove all trigger groups and your project will revert to using{' '}
+                    <strong>legacy recording triggers</strong>.
+                </p>
+
+                <p className="text-sm text-muted">
+                    Your project will immediately use the following legacy trigger configuration:
+                </p>
+
+                <div className="border rounded p-3 bg-surface-primary">
+                    {hasConditions ? (
+                        <>
+                            <div className="mb-2">
+                                <span className="text-sm">
+                                    Match <b>sessions</b> against{' '}
+                                    <LemonTag type="success" className="uppercase">
+                                        {matchType}
+                                    </LemonTag>{' '}
+                                    criteria
+                                </span>
+                            </div>
+
+                            {/* Conditions */}
+                            <div className="space-y-2 text-sm mb-3">
+                                {urls.length > 0 && (
+                                    <div className="flex items-center gap-2 flex-wrap">
+                                        <span className="text-muted">URL matches pattern</span>
+                                        {urls.map((u) => (
+                                            <LemonSnack key={u.url}>{u.url}</LemonSnack>
+                                        ))}
+                                    </div>
+                                )}
+                                {events.length > 0 && (
+                                    <div className="flex items-center gap-2 flex-wrap">
+                                        <span className="text-muted">Event</span>
+                                        {events.map((event) => (
+                                            <LemonSnack key={event}>{event}</LemonSnack>
+                                        ))}
+                                        <span className="text-muted">occurred</span>
+                                    </div>
+                                )}
+                                {flag && (
+                                    <div className="flex items-center gap-2 flex-wrap">
+                                        <span className="text-muted">Feature flag</span>
+                                        <LemonSnack>{typeof flag === 'string' ? flag : flag.key}</LemonSnack>
+                                        <span className="text-muted">is enabled</span>
+                                    </div>
+                                )}
+                            </div>
+                        </>
+                    ) : null}
+
+                    {/* Sample rate - always shown */}
+                    <div className="flex items-center gap-2 text-sm">
+                        <span className="text-muted">Sample</span>
+                        <span className="font-semibold">{Math.round(sampleRate * 100)}%</span>
+                        <span className="text-muted">of all sessions</span>
+                    </div>
+
+                    {/* Minimum duration */}
+                    {minDurationMs !== undefined && minDurationMs !== null && minDurationMs > 0 && (
+                        <div className="text-sm text-muted mt-3">
+                            Minimum duration: <b>{minDurationMs / 1000}</b> seconds
+                        </div>
+                    )}
+                </div>
+
+                <div className="flex justify-end gap-2 pt-2 border-t">
+                    <LemonButton type="secondary" onClick={onClose}>
+                        Cancel
+                    </LemonButton>
+                    <LemonButton type="primary" status="danger" onClick={onConfirm}>
+                        Delete and use legacy trigger settings
+                    </LemonButton>
+                </div>
+            </div>
+        </LemonModal>
     )
 }

--- a/frontend/src/lib/components/IngestionControls/triggers/triggerGroups/replayTriggersV2Logic.test.ts
+++ b/frontend/src/lib/components/IngestionControls/triggers/triggerGroups/replayTriggersV2Logic.test.ts
@@ -29,7 +29,7 @@ describe('replayTriggersV2Logic', () => {
                 [
                     {
                         id: expect.any(String),
-                        name: 'Legacy trigger conditions',
+                        name: 'Migrated trigger conditions',
                         sampleRate: 0.5,
                         minDurationMs: 5000,
                         conditions: {
@@ -51,7 +51,7 @@ describe('replayTriggersV2Logic', () => {
                 [
                     {
                         id: expect.any(String),
-                        name: 'Legacy trigger conditions',
+                        name: 'Migrated trigger conditions',
                         sampleRate: 0.3,
                         minDurationMs: 10000,
                         conditions: {
@@ -73,7 +73,7 @@ describe('replayTriggersV2Logic', () => {
                 [
                     {
                         id: expect.any(String),
-                        name: 'Legacy trigger conditions',
+                        name: 'Migrated trigger conditions',
                         sampleRate: 1,
                         minDurationMs: undefined,
                         conditions: {
@@ -100,7 +100,7 @@ describe('replayTriggersV2Logic', () => {
                 [
                     {
                         id: expect.any(String),
-                        name: 'Trigger conditions (from legacy)',
+                        name: 'Migrated trigger conditions',
                         sampleRate: 1,
                         minDurationMs: 2000,
                         conditions: {
@@ -115,7 +115,7 @@ describe('replayTriggersV2Logic', () => {
                     },
                     {
                         id: expect.any(String),
-                        name: 'Baseline sampling (from legacy)',
+                        name: 'Migrated baseline sampling',
                         sampleRate: 0.1,
                         minDurationMs: 2000,
                         conditions: {

--- a/frontend/src/lib/components/IngestionControls/triggers/triggerGroups/replayTriggersV2Logic.ts
+++ b/frontend/src/lib/components/IngestionControls/triggers/triggerGroups/replayTriggersV2Logic.ts
@@ -139,6 +139,27 @@ export const replayTriggersV2Logic = kea<replayTriggersV2LogicType>([
                 return config !== null && config.version === 2
             },
         ],
+        hasLegacyTriggers: [
+            (s) => [s.currentTeam],
+            (team): boolean => {
+                if (!team) {
+                    return false
+                }
+                const hasUrlTriggers = (team.session_recording_url_trigger_config?.length ?? 0) > 0
+                const hasEventTriggers = (team.session_recording_event_trigger_config?.length ?? 0) > 0
+                const hasFeatureFlag = !!team.session_recording_linked_flag
+                const hasSampling =
+                    team.session_recording_sample_rate && parseFloat(team.session_recording_sample_rate) < 1
+                return hasUrlTriggers || hasEventTriggers || hasFeatureFlag || hasSampling
+            },
+        ],
+        shouldShowMigrationBanner: [
+            (s) => [s.triggerGroups, s.hasLegacyTriggers],
+            (triggerGroups, hasLegacyTriggers): boolean => {
+                // Show banner if there are legacy triggers configured but no V2 groups
+                return hasLegacyTriggers && triggerGroups.length === 0
+            },
+        ],
         previewLegacyGroups: [
             (s) => [s.currentTeam],
             (team): SessionRecordingTriggerGroup[] => {
@@ -182,7 +203,7 @@ export const replayTriggersV2Logic = kea<replayTriggersV2LogicType>([
                         // Group 1: All triggers combined with ANY match type
                         {
                             id: uuid(),
-                            name: 'Trigger conditions (from legacy)',
+                            name: 'Migrated trigger conditions',
                             sampleRate: 1,
                             minDurationMs,
                             conditions: {
@@ -195,7 +216,7 @@ export const replayTriggersV2Logic = kea<replayTriggersV2LogicType>([
                         // Group 2: Baseline sampling (no conditions)
                         {
                             id: uuid(),
-                            name: 'Baseline sampling (from legacy)',
+                            name: 'Migrated baseline sampling',
                             sampleRate,
                             minDurationMs,
                             conditions: {
@@ -209,7 +230,7 @@ export const replayTriggersV2Logic = kea<replayTriggersV2LogicType>([
                 return [
                     {
                         id: uuid(),
-                        name: 'Legacy trigger conditions',
+                        name: 'Migrated trigger conditions',
                         sampleRate,
                         minDurationMs,
                         conditions: {

--- a/frontend/src/lib/components/IngestionControls/triggers/triggerGroups/replayTriggersV2Logic.ts
+++ b/frontend/src/lib/components/IngestionControls/triggers/triggerGroups/replayTriggersV2Logic.ts
@@ -5,8 +5,10 @@ import { uuid } from 'lib/utils'
 import { teamLogic } from 'scenes/teamLogic'
 
 import {
+    LinkedFeatureFlag,
     SessionRecordingTriggerGroup,
     SessionRecordingTriggerGroupsConfig,
+    UrlTriggerConfig,
 } from '~/lib/components/IngestionControls/types'
 
 import type { replayTriggersV2LogicType } from './replayTriggersV2LogicType'
@@ -25,6 +27,7 @@ export const replayTriggersV2Logic = kea<replayTriggersV2LogicType>([
         updateTriggerGroup: (id: string, updates: Partial<SessionRecordingTriggerGroup>) => ({ id, updates }),
         setIsAddingGroup: (isAdding: boolean) => ({ isAdding }),
         setEditingGroupId: (id: string | null) => ({ id }),
+        setDeleteModalGroupId: (id: string | null) => ({ id }),
         showCreateFromLegacyModal: true,
         hideCreateFromLegacyModal: true,
         confirmCreateFromLegacy: true,
@@ -125,6 +128,13 @@ export const replayTriggersV2Logic = kea<replayTriggersV2LogicType>([
                 confirmCreateFromLegacySuccess: () => false,
             },
         ],
+        deleteModalGroupId: [
+            null as string | null,
+            {
+                setDeleteModalGroupId: (_, { id }) => id,
+                deleteTriggerGroup: () => null, // Close modal after deleting
+            },
+        ],
     }),
     selectors({
         triggerGroups: [
@@ -148,8 +158,9 @@ export const replayTriggersV2Logic = kea<replayTriggersV2LogicType>([
                 const hasUrlTriggers = (team.session_recording_url_trigger_config?.length ?? 0) > 0
                 const hasEventTriggers = (team.session_recording_event_trigger_config?.length ?? 0) > 0
                 const hasFeatureFlag = !!team.session_recording_linked_flag
-                const hasSampling =
+                const hasSampling = !!(
                     team.session_recording_sample_rate && parseFloat(team.session_recording_sample_rate) < 1
+                )
                 return hasUrlTriggers || hasEventTriggers || hasFeatureFlag || hasSampling
             },
         ],
@@ -241,6 +252,34 @@ export const replayTriggersV2Logic = kea<replayTriggersV2LogicType>([
                         },
                     },
                 ]
+            },
+        ],
+        legacyTriggersPreview: [
+            (s) => [s.currentTeam],
+            (
+                team
+            ): {
+                sampleRate: number
+                minDurationMs: number | undefined
+                matchType: 'any' | 'all'
+                urls: UrlTriggerConfig[]
+                events: string[]
+                flag: string | LinkedFeatureFlag | null
+                hasConditions: boolean
+            } => {
+                const sampleRate = team?.session_recording_sample_rate
+                    ? parseFloat(team.session_recording_sample_rate)
+                    : 1
+                const minDurationMs = team?.session_recording_minimum_duration_milliseconds ?? undefined
+                const matchType = team?.session_recording_trigger_match_type_config || 'all'
+                const urls = team?.session_recording_url_trigger_config || []
+                const events: string[] = (team?.session_recording_event_trigger_config || []).filter(
+                    (e): e is string => typeof e === 'string' && e.length > 0
+                )
+                const flag = team?.session_recording_linked_flag || null
+                const hasConditions = urls.length > 0 || events.length > 0 || !!flag
+
+                return { sampleRate, minDurationMs, matchType, urls, events, flag, hasConditions }
             },
         ],
     }),


### PR DESCRIPTION
## Problem

Want to be extra clear if a user is going to delete a trigger group that its not as if there are no "filters" on triggers anymore, but rather it will fallback to V1 triggers. Give a preview on what that is

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

## Changes

- modal warning about deleting last trigger group
- preview of what settings will be if deleted (v1 trigger settings preview)
- small tweaks to copy 
- hide "migrate from v1" button if there are trigger groups already in v2 (basically only show migrate button if groups are empty) 

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?  
![Screenshot 2026-04-02 at 3.50.41 PM.png](https://app.graphite.com/user-attachments/assets/234365aa-bbd2-49d6-975b-3cacc35bd6e5.png)![Screenshot 2026-04-02 at 3.41.59 PM.png](https://app.graphite.com/user-attachments/assets/428a0776-4a0f-46a1-8639-44854df5decd.png)



<!-- Briefly describe the steps you took, and what steps reviewers must take to get to where changes are, and what is the expected behavior. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->