### PR TITLE
fix(hobby): add missing env vars for session replay and logs tab

### DIFF
--- a/docker-compose.hobby.yml
+++ b/docker-compose.hobby.yml
@@ -85,6 +85,9 @@ services:
             RECORDING_API_URL: http://recording-api:6738
             ENCRYPTION_SALT_KEYS: $ENCRYPTION_SALT_KEYS
             POSTHOG_SKIP_MIGRATION_CHECKS: '1'
+            CLICKHOUSE_LOGS_CLUSTER_HOST: clickhouse
+            CLICKHOUSE_LOGS_CLUSTER_SECURE: 'false'
+            CLICKHOUSE_LOGS_DATABASE: posthog
         image: $REGISTRY_URL:$POSTHOG_APP_TAG
         depends_on:
             db:
@@ -126,6 +129,9 @@ services:
             GRANIAN_WORKERS: '2'
             OPT_OUT_CAPTURE: ${OPT_OUT_CAPTURE:-false}
             DEPLOYMENT: 'hobby'
+            CLICKHOUSE_LOGS_CLUSTER_HOST: clickhouse
+            CLICKHOUSE_LOGS_CLUSTER_SECURE: 'false'
+            CLICKHOUSE_LOGS_DATABASE: posthog
         depends_on:
             - db
             - redis7
@@ -203,6 +209,9 @@ services:
         image: ${REGISTRY_URL}-node:${POSTHOG_NODE_TAG:-latest}
         environment:
             ENCRYPTION_SALT_KEYS: $ENCRYPTION_SALT_KEYS
+            SESSION_RECORDING_V2_S3_ENDPOINT: http://seaweedfs:8333
+            SESSION_RECORDING_V2_S3_ACCESS_KEY_ID: 'any'
+            SESSION_RECORDING_V2_S3_SECRET_ACCESS_KEY: 'any'
         depends_on:
             - db
             - redis7

--- a/docker-compose.hobby.yml
+++ b/docker-compose.hobby.yml
@@ -210,8 +210,6 @@ services:
         environment:
             ENCRYPTION_SALT_KEYS: $ENCRYPTION_SALT_KEYS
             SESSION_RECORDING_V2_S3_ENDPOINT: http://seaweedfs:8333
-            SESSION_RECORDING_V2_S3_ACCESS_KEY_ID: 'any'
-            SESSION_RECORDING_V2_S3_SECRET_ACCESS_KEY: 'any'
         depends_on:
             - db
             - redis7

--- a/docker-compose.hobby.yml
+++ b/docker-compose.hobby.yml
@@ -210,6 +210,8 @@ services:
         environment:
             ENCRYPTION_SALT_KEYS: $ENCRYPTION_SALT_KEYS
             SESSION_RECORDING_V2_S3_ENDPOINT: http://seaweedfs:8333
+            SESSION_RECORDING_V2_S3_ACCESS_KEY_ID: 'any'
+            SESSION_RECORDING_V2_S3_SECRET_ACCESS_KEY: 'any'
         depends_on:
             - db
             - redis7


### PR DESCRIPTION
## Problem

  Two features are broken out of the box in the hobby Docker Compose deployment:

  1. **Session replay playback fails** with a 500 error on snapshot requests.
     `recording-api` defaulted to `localhost:8333` for its S3 endpoint instead
     of `seaweedfs:8333` because the S3 env vars present in `web`/ `worker` were
     never passed to the `recording-api` service.

		Related: #41581

  2. **Logs tab fails entirely** with connection refused, SSL, and missing table
     errors. \`web\` and \`worker\` were missing three env vars with defaults that
     don't work in the Docker Compose environment:
     - `CLICKHOUSE_LOGS_CLUSTER_HOST` defaults to `localhost` (should be `clickhouse`)
     - `CLICKHOUSE_LOGS_CLUSTER_SECURE` defaults to `true` (ClickHouse runs without SSL)
     - `CLICKHOUSE_LOGS_DATABASE` defaults to `default` (logs tables live in `posthog`)


## Changes

  - Add `SESSION_RECORDING_V2_S3_ENDPOINT`, `SESSION_RECORDING_V2_S3_ACCESS_KEY_ID`, and `SESSION_RECORDING_V2_S3_SECRET_ACCESS_KEY` to `recording-api` in
  `docker-compose.hobby.yml`
  - Add `CLICKHOUSE_LOGS_CLUSTER_HOST`, `CLICKHOUSE_LOGS_CLUSTER_SECURE`, and
  `CLICKHOUSE_LOGS_DATABASE` to `web` and `worker` in `docker-compose.hobby.yml`


## How did you test this code?

  Reproduced and fixed on a live hobby deployment (EC2, Docker Compose). Both features work correctly
  after applying these env vars.

<!-- Briefly describe the steps you took, and what steps reviewers must take to get to where changes are, and what is the expected behavior. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

No 
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 LLM context

  Diagnosed and authored by Claude Sonnet 4.6 via Claude Code based on a real hobby deployment debugging
  session. The broken defaults were discovered by tracing live 500 errors through \`recording-api\` logs
  and ClickHouse connection errors in \`web\` logs.