### PR TITLE
fix(session-replay): allow retention period changes when no billing exists (hobby)

### DIFF
--- a/posthog/api/team.py
+++ b/posthog/api/team.py
@@ -1207,7 +1207,9 @@ class TeamSerializer(serializers.ModelSerializer, UserPermissionsSerializerMixin
         highest_retention_entitlement = parse_feature_to_entitlement(retention_feature)
 
         if highest_retention_entitlement is None:
-            raise exceptions.APIException(detail="Invalid retention entitlement.")  # HTTP 500
+            # No entitlement configured means no billing restriction (e.g. self-hosted without a license).
+            # Allow any valid retention period rather than blocking the update entirely.
+            return
 
         # Should be validated already, but let's be extra sure to avoid IndexErrors below
         if not validate_retention_period(new_retention_period):

--- a/posthog/api/test/test_team.py
+++ b/posthog/api/test/test_team.py
@@ -3010,6 +3010,20 @@ class TestTeamAPI(team_api_test_factory()):  # type: ignore
         assert "session_recording_sample_rate" in data
         assert data["session_recording_masking_config"] is None
 
+    @parameterized.expand(["30d", "90d", "1y", "5y"])
+    def test_session_recording_retention_period_allowed_without_billing_entitlement(self, period):
+        # On self-hosted deployments with no license, available_product_features is empty.
+        # All valid retention periods should be accepted rather than returning a 500.
+        self.organization.available_product_features = []
+        self.organization.save()
+
+        response = self.client.patch(
+            "/api/environments/@current/",
+            {"session_recording_retention_period": period},
+        )
+        assert response.status_code == status.HTTP_200_OK, response.json()
+        assert response.json()["session_recording_retention_period"] == period
+
     def test_settings_as_of_scope_only_includes_requested_keys(self):
         with freeze_time("2025-03-01T00:00:00Z"):
             r = self.client.patch(


### PR DESCRIPTION

  ## Problem

  On self-hosted hobby deployments without a license, attempting to change the
  session recording retention period from the default (5 years) fails with
  `"Invalid retention entitlement."` (HTTP 500).

  `get_available_feature(SESSION_REPLAY_DATA_RETENTION)` returns `None` for orgs
  with no billing/license, which propagates through `parse_feature_to_entitlement`
  as `None`. The previous code treated `None` as a hard block rather than
  "no restriction", preventing hobby users from ever adjusting their retention
  settings via the UI.

  ## Changes

  In `_verify_update_session_recording_retention_period`: when
  `highest_retention_entitlement` is `None` (no billing feature configured),
  return early and allow any valid retention period instead of raising a 500.

  ## How did you test this code?

  Reproduced on a live hobby deployment — the API returned 500 before this
  change and succeeds after. No existing tests covered this code path.

  ## Publish to changelog?

  No

  ## 🤖 LLM context

  Diagnosed and authored by Claude Sonnet 4.6 via Claude Code from a live
  self-hosted debugging session. Root cause: `None` entitlement was treated as
  a block rather than "no billing restriction".