### PR TITLE
fix(logs): use inclusive timestamp bounds in alert check query

### DIFF
--- a/products/logs/backend/alert_check_query.py
+++ b/products/logs/backend/alert_check_query.py
@@ -6,7 +6,7 @@ from zoneinfo import ZoneInfo
 from posthog.schema import (
     DateRange,
     FilterLogicalOperator,
-    HogQLFilters,
+    HogQLQueryModifiers,
     HogQLQueryResponse,
     IntervalType,
     LogsQuery,
@@ -16,7 +16,7 @@ from posthog.schema import (
 
 from posthog.hogql import ast
 from posthog.hogql.constants import HogQLGlobalSettings, LimitContext
-from posthog.hogql.parser import parse_select
+from posthog.hogql.parser import parse_expr, parse_select
 from posthog.hogql.query import execute_hogql_query
 
 from posthog.clickhouse.client.connection import Workload
@@ -83,7 +83,24 @@ class AlertCheckQuery:
             exact_timerange=True,
         )
         builder = LogsFilterBuilder(logs_query, team, query_date_range)
-        self.where_expr = builder.where()
+        base_where = builder.where()
+
+        # Add explicit timestamp bounds using a half-open interval [from, to).
+        # This ensures adjacent alert windows don't double-count logs at the boundary.
+        # LogsFilterBuilder.where() includes a {filters} placeholder that resolves
+        # to `true` when no HogQLFilters are passed to execute_hogql_query.
+        self.where_expr = ast.And(
+            exprs=[
+                base_where,
+                parse_expr(
+                    "timestamp >= {date_from} AND timestamp < {date_to}",
+                    placeholders={
+                        "date_from": ast.Constant(value=date_from),
+                        "date_to": ast.Constant(value=date_to),
+                    },
+                ),
+            ]
+        )
 
     def execute(self) -> AlertCheckCountResult:
         """Return a single aggregate count for the alert window."""
@@ -148,7 +165,7 @@ class AlertCheckQuery:
             workload=Workload.LOGS,
             settings=self.SETTINGS,
             limit_context=LimitContext.QUERY,
-            filters=HogQLFilters(dateRange=self.date_range),
+            modifiers=HogQLQueryModifiers(convertToProjectTimezone=False),
         )
 
     def _tag(self) -> None:


### PR DESCRIPTION
## Problem

The alert check query returns **0 results** for teams with a non-UTC timezone (e.g. `US/Pacific`).

**Root cause:** `AlertCheckQuery` calls `execute_hogql_query` without setting `convertToProjectTimezone = False`. The HogQL printer wraps every timestamp field in `toTimeZone(field, 'US/Pacific')`, which shifts the day-level `time_bucket` filter boundary. For example, `toStartOfDay(toTimeZone(time_bucket_utc, 'US/Pacific'))` lands on the previous calendar day, causing the WHERE clause to exclude all data.

Every other logs query runner (`LogsQueryRunner`, `SparklineQueryRunner`, `LogAttributesQueryRunner`) disables this via `self.modifiers.convertToProjectTimezone = False`, but `AlertCheckQuery` bypasses the query runner framework.

A secondary issue: the query relied on the `{filters}` HogQL placeholder for date bounds, which uses `timestamp < date_to` (exclusive). This is fine for correctness but is implicit and fragile — the alert should own its own timestamp filtering.

## Changes

In `products/logs/backend/alert_check_query.py`:

- Added `modifiers=HogQLQueryModifiers(convertToProjectTimezone=False)` to `_run_query` — prevents HogQL from wrapping timestamp/time_bucket fields in `toTimeZone()`, matching all other logs query runners
- Removed `filters=HogQLFilters(dateRange=self.date_range)` from `_run_query` — the `{filters}` placeholder now resolves to `true`
- Added explicit `timestamp >= date_from AND timestamp < date_to` bounds in `__init__` — half-open interval `[from, to)` prevents double-counting across adjacent alert windows

## How did you test this code?

- Verified the generated ClickHouse SQL no longer contains `toTimeZone` wrapping when team timezone is `US/Pacific`
- Ran the alert query against real local ClickHouse data across 32 scenarios (various time windows, service filters, severity filters, combined filters, boundary stress tests) — all matched raw `SELECT count()` exactly
- Reproduced the 0-count bug on prod-us by running the old alert query against team 2 (`US/Pacific`) — confirmed all 3 enabled alerts returned `alert_query_count=0` while sparkline returned millions
- Confirmed temporal worker is scheduling and executing checks (the query itself was broken, not the scheduling)

## Publish to changelog?

No