### PR TITLE
fix(llma): fix LLM analytics onboarding docs for Mirascope and AWS Bedrock

### DIFF
--- a/docs/onboarding/llm-analytics/aws-bedrock.tsx
+++ b/docs/onboarding/llm-analytics/aws-bedrock.tsx
@@ -125,7 +125,7 @@ export const getAWSBedrockSteps = (ctx: OnboardingComponentsContext): StepDefini
                                     client = boto3.client("bedrock-runtime", region_name="us-east-1")
 
                                     response = client.converse(
-                                        modelId="us.anthropic.claude-3-5-haiku-20241022-v1:0",
+                                        modelId="openai.gpt-oss-20b-1:0",
                                         messages=[
                                             {
                                                 "role": "user",
@@ -134,7 +134,10 @@ export const getAWSBedrockSteps = (ctx: OnboardingComponentsContext): StepDefini
                                         ],
                                     )
 
-                                    print(response["output"]["message"]["content"][0]["text"])
+                                    for block in response["output"]["message"]["content"]:
+                                        if "text" in block:
+                                            print(block["text"])
+                                            break
                                 `,
                             },
                             {
@@ -152,7 +155,7 @@ export const getAWSBedrockSteps = (ctx: OnboardingComponentsContext): StepDefini
 
                                     const response = await client.send(
                                       new ConverseCommand({
-                                        modelId: 'us.anthropic.claude-3-5-haiku-20241022-v1:0',
+                                        modelId: 'openai.gpt-oss-20b-1:0',
                                         messages: [
                                           {
                                             role: 'user',
@@ -162,7 +165,8 @@ export const getAWSBedrockSteps = (ctx: OnboardingComponentsContext): StepDefini
                                       })
                                     )
 
-                                    console.log(response.output?.message?.content?.[0]?.text)
+                                    const textBlock = response.output?.message?.content?.find((b) => 'text' in b)
+                                    console.log(textBlock?.text)
 
                                     await sdk.shutdown()
                                 `,

--- a/docs/onboarding/llm-analytics/mirascope.tsx
+++ b/docs/onboarding/llm-analytics/mirascope.tsx
@@ -104,12 +104,7 @@ export const getMirascopeSteps = (ctx: OnboardingComponentsContext): StepDefinit
                             def recommend_book(genre: str):
                                 return f"Recommend a {genre} book."
 
-                            response = recommend_book(
-                                "fantasy",
-                                posthog_distinct_id="user_123",
-                                posthog_trace_id="trace_123",
-                                posthog_properties={"conversation_id": "abc123"},
-                            )
+                            response = recommend_book("fantasy")
 
                             print(response.content)
                         `}


### PR DESCRIPTION
## Problem

Some LLM analytics onboarding doc code snippets had runtime errors when users followed them.

## Changes

- **Mirascope** (`mirascope.tsx`): Remove `posthog_distinct_id`/`posthog_trace_id`/`posthog_properties` kwargs from the `recommend_book()` call — Mirascope doesn't forward extra kwargs to the OpenAI client, causing a `TypeError` at runtime
- **AWS Bedrock** (`aws-bedrock.tsx`): Update model ID from `us.anthropic.claude-3-5-haiku-20241022-v1:0` to `openai.gpt-oss-20b-1:0`, and fix response parsing to find the text content block instead of assuming `content[0]` (some models include reasoning blocks before the text)

## How did you test this code?

Ran the corresponding examples in posthog-python and posthog-js repos via the llm-analytics-apps example runner and verified both produce correct output.

## Publish to changelog?

No

## Docs update

N/A — this PR is the docs update.