### PR TITLE
fix(mcp): exclude tools from billing

### DIFF
--- a/ee/api/max_tools.py
+++ b/ee/api/max_tools.py
@@ -64,6 +64,7 @@ class MaxToolsViewSet(TeamAndOrgViewSetMixin, GenericViewSet):
             user=cast(User, request.user),
             is_new_conversation=False,  # we don't care about the conversation id being sent back to the client
             initial_state=serializer.validated_data["state"],
+            is_agent_billable=False,
         )
 
         return Response(

--- a/ee/hogai/insights_assistant.py
+++ b/ee/hogai/insights_assistant.py
@@ -54,6 +54,7 @@ class InsightsAssistant(BaseAgentRunner):
         trace_id: Optional[str | UUID] = None,
         billing_context: Optional[MaxBillingContext] = None,
         initial_state: Optional[AssistantState | PartialAssistantState] = None,
+        is_agent_billable: bool = True,
     ):
         super().__init__(
             team,
@@ -69,6 +70,7 @@ class InsightsAssistant(BaseAgentRunner):
             trace_id=trace_id,
             billing_context=billing_context,
             initial_state=initial_state,
+            is_agent_billable=is_agent_billable,
             stream_processor=ChatAgentStreamProcessor(
                 team=team,
                 user=user,


### PR DESCRIPTION
## Problem

The insights assistant needs to support configurable billing behavior for different use cases. Specifically, when the assistant is used internally (e.g., via the max_tools API), it should not be billable, while normal usage should be billable by default.

## Changes

- Added `is_agent_billable` parameter to `InsightsAssistant.__init__()` with a default value of `True`
- Passed the parameter through to the parent class initialization
- Set `is_agent_billable=False` when creating an `InsightsAssistant` instance in `MaxToolsAPI.create_and_query_insight()` to prevent internal tool usage from being billed

## How did you test this code?

This is a straightforward parameter addition with a sensible default. Existing tests should continue to pass, and the new parameter is only explicitly set to `False` in the internal max_tools API endpoint where it's needed.

https://claude.ai/code/session_01UgNxg1zzL9E2URDjAaVQEd