### PR TITLE
feat(mcp): group spans in traces

### DIFF
--- a/services/mcp/src/lib/SessionManager.ts
+++ b/services/mcp/src/lib/SessionManager.ts
@@ -42,6 +42,34 @@ export class SessionManager {
         await this.cache.delete(key)
     }
 
+    async getTraceId(sessionId: string): Promise<string> {
+        const key = this._getKey(sessionId)
+        const existingSession = await this.cache.get(key)
+
+        if (existingSession?.traceId) {
+            return existingSession.traceId
+        }
+
+        const traceId = uuidv7()
+        await this.cache.set(key, { ...existingSession, uuid: existingSession?.uuid ?? uuidv7(), traceId })
+
+        return traceId
+    }
+
+    async isTraceEmitted(sessionId: string): Promise<boolean> {
+        const key = this._getKey(sessionId)
+        const session = await this.cache.get(key)
+        return !!session?.traceEmitted
+    }
+
+    async markTraceEmitted(sessionId: string): Promise<void> {
+        const key = this._getKey(sessionId)
+        const session = await this.cache.get(key)
+        if (session) {
+            await this.cache.set(key, { ...session, traceEmitted: true })
+        }
+    }
+
     async clearAllSessions(): Promise<void> {
         await this.cache.clear()
     }

--- a/services/mcp/src/mcp.ts
+++ b/services/mcp/src/mcp.ts
@@ -222,6 +222,9 @@ export class MCP extends McpAgent<Env> {
                     ...(this.requestProperties.sessionId
                         ? {
                               $session_id: await this.sessionManager.getSessionUuid(this.requestProperties.sessionId),
+                              $ai_session_id: await this.sessionManager.getSessionUuid(
+                                  this.requestProperties.sessionId
+                              ),
                           }
                         : {}),
                     ...(clientName ? { mcp_oauth_client_name: clientName } : {}),
@@ -242,7 +245,8 @@ export class MCP extends McpAgent<Env> {
         handler: (params: z.infer<TSchema>) => Promise<any>
     ): void {
         const wrappedHandler = async (params: z.infer<TSchema>): Promise<any> => {
-            const traceId = generateId()
+            const sessionId = this.requestProperties.sessionId
+            const traceId = sessionId ? await this.sessionManager.getTraceId(sessionId) : generateId()
             const spanId = generateId()
             const spanName = `mcp/${tool.name}`
             const startTime = performance.now()
@@ -258,13 +262,19 @@ export class MCP extends McpAgent<Env> {
                 const latency = (performance.now() - startTime) / 1000
                 const errorOutput = `Invalid input: ${validation.error.message}`
                 const outputState = { error: errorOutput }
-                await this.trackEvent(AnalyticsEvent.AI_TRACE, {
-                    $ai_trace_id: traceId,
-                    $ai_span_name: spanName,
-                    $ai_latency: latency,
-                    $ai_is_error: true,
-                    ai_product: 'mcp',
-                })
+                const shouldEmitTrace = !sessionId || !(await this.sessionManager.isTraceEmitted(sessionId))
+                if (shouldEmitTrace) {
+                    await this.trackEvent(AnalyticsEvent.AI_TRACE, {
+                        $ai_trace_id: traceId,
+                        $ai_span_name: sessionId ? 'mcp/session' : spanName,
+                        $ai_latency: latency,
+                        $ai_is_error: true,
+                        ai_product: 'mcp',
+                    })
+                    if (sessionId) {
+                        await this.sessionManager.markTraceEmitted(sessionId)
+                    }
+                }
                 await this.trackEvent(AnalyticsEvent.AI_SPAN, {
                     $ai_trace_id: traceId,
                     $ai_span_id: spanId,
@@ -299,12 +309,18 @@ export class MCP extends McpAgent<Env> {
                 await this.trackEvent(AnalyticsEvent.MCP_TOOL_RESPONSE, {
                     tool: tool.name,
                 })
-                await this.trackEvent(AnalyticsEvent.AI_TRACE, {
-                    $ai_trace_id: traceId,
-                    $ai_span_name: spanName,
-                    $ai_latency: latency,
-                    ai_product: 'mcp',
-                })
+                const shouldEmitTrace = !sessionId || !(await this.sessionManager.isTraceEmitted(sessionId))
+                if (shouldEmitTrace) {
+                    await this.trackEvent(AnalyticsEvent.AI_TRACE, {
+                        $ai_trace_id: traceId,
+                        $ai_span_name: sessionId ? 'mcp/session' : spanName,
+                        $ai_latency: latency,
+                        ai_product: 'mcp',
+                    })
+                    if (sessionId) {
+                        await this.sessionManager.markTraceEmitted(sessionId)
+                    }
+                }
                 await this.trackEvent(AnalyticsEvent.AI_SPAN, {
                     $ai_trace_id: traceId,
                     $ai_span_id: spanId,
@@ -352,13 +368,19 @@ export class MCP extends McpAgent<Env> {
                 const latency = (performance.now() - startTime) / 1000
                 const errorMessage = error instanceof Error ? error.message : String(error)
                 const outputState = { error: errorMessage }
-                await this.trackEvent(AnalyticsEvent.AI_TRACE, {
-                    $ai_trace_id: traceId,
-                    $ai_span_name: spanName,
-                    $ai_latency: latency,
-                    $ai_is_error: true,
-                    ai_product: 'mcp',
-                })
+                const shouldEmitTrace = !sessionId || !(await this.sessionManager.isTraceEmitted(sessionId))
+                if (shouldEmitTrace) {
+                    await this.trackEvent(AnalyticsEvent.AI_TRACE, {
+                        $ai_trace_id: traceId,
+                        $ai_span_name: sessionId ? 'mcp/session' : spanName,
+                        $ai_latency: latency,
+                        $ai_is_error: true,
+                        ai_product: 'mcp',
+                    })
+                    if (sessionId) {
+                        await this.sessionManager.markTraceEmitted(sessionId)
+                    }
+                }
                 await this.trackEvent(AnalyticsEvent.AI_SPAN, {
                     $ai_trace_id: traceId,
                     $ai_span_id: spanId,

--- a/services/mcp/src/mcp.ts
+++ b/services/mcp/src/mcp.ts
@@ -215,18 +215,15 @@ export class MCP extends McpAgent<Env> {
 
             const clientName = await this.cache.get('clientName')
 
+            const sessionUuid = this.requestProperties.sessionId
+                ? await this.sessionManager.getSessionUuid(this.requestProperties.sessionId)
+                : undefined
+
             client.capture({
                 distinctId,
                 event,
                 properties: {
-                    ...(this.requestProperties.sessionId
-                        ? {
-                              $session_id: await this.sessionManager.getSessionUuid(this.requestProperties.sessionId),
-                              $ai_session_id: await this.sessionManager.getSessionUuid(
-                                  this.requestProperties.sessionId
-                              ),
-                          }
-                        : {}),
+                    ...(sessionUuid ? { $session_id: sessionUuid, $ai_session_id: sessionUuid } : {}),
                     ...(clientName ? { mcp_oauth_client_name: clientName } : {}),
                     ...(this._mcpClientName ? { mcp_client_name: this._mcpClientName } : {}),
                     ...(this._mcpClientVersion ? { mcp_client_version: this._mcpClientVersion } : {}),

--- a/services/mcp/src/tools/types.ts
+++ b/services/mcp/src/tools/types.ts
@@ -11,6 +11,8 @@ export type CloudRegion = 'us' | 'eu'
 
 export type SessionState = {
     uuid: string
+    traceId?: string
+    traceEmitted?: boolean
 }
 
 export type State = {

--- a/services/mcp/tests/unit/SessionManager.test.ts
+++ b/services/mcp/tests/unit/SessionManager.test.ts
@@ -168,6 +168,106 @@ describe('SessionManager', () => {
         })
     })
 
+    describe('getTraceId', () => {
+        it('should return existing trace id if it exists', async () => {
+            const sessionId = 'test-session-123'
+
+            ;(mockCache.get as any).mockResolvedValue({ uuid: 'existing-uuid', traceId: 'existing-trace-id' })
+
+            const result = await sessionManager.getTraceId(sessionId)
+
+            expect(result).toBe('existing-trace-id')
+            expect(mockCache.get).toHaveBeenCalledWith('session:test-session-123')
+            expect(mockCache.set).not.toHaveBeenCalled()
+        })
+
+        it('should create and return new trace id if none exists', async () => {
+            const sessionId = 'test-session-123'
+
+            ;(mockCache.get as any).mockResolvedValue({ uuid: 'existing-uuid' })
+
+            const result = await sessionManager.getTraceId(sessionId)
+
+            expect(result).toBe('test-uuid-12345')
+            expect(mockCache.set).toHaveBeenCalledWith('session:test-session-123', {
+                uuid: 'existing-uuid',
+                traceId: 'test-uuid-12345',
+            })
+        })
+
+        it('should create both uuid and trace id if session does not exist', async () => {
+            const sessionId = 'test-session-123'
+
+            ;(mockCache.get as any).mockResolvedValue(null)
+
+            const result = await sessionManager.getTraceId(sessionId)
+
+            expect(result).toBe('test-uuid-12345')
+            expect(mockCache.set).toHaveBeenCalledWith('session:test-session-123', {
+                uuid: 'test-uuid-12345',
+                traceId: 'test-uuid-12345',
+            })
+        })
+    })
+
+    describe('isTraceEmitted', () => {
+        it('should return true if trace has been emitted', async () => {
+            const sessionId = 'test-session-123'
+
+            ;(mockCache.get as any).mockResolvedValue({ uuid: 'uuid', traceEmitted: true })
+
+            const result = await sessionManager.isTraceEmitted(sessionId)
+
+            expect(result).toBe(true)
+        })
+
+        it('should return false if trace has not been emitted', async () => {
+            const sessionId = 'test-session-123'
+
+            ;(mockCache.get as any).mockResolvedValue({ uuid: 'uuid' })
+
+            const result = await sessionManager.isTraceEmitted(sessionId)
+
+            expect(result).toBe(false)
+        })
+
+        it('should return false if session does not exist', async () => {
+            const sessionId = 'test-session-123'
+
+            ;(mockCache.get as any).mockResolvedValue(null)
+
+            const result = await sessionManager.isTraceEmitted(sessionId)
+
+            expect(result).toBe(false)
+        })
+    })
+
+    describe('markTraceEmitted', () => {
+        it('should set traceEmitted to true on existing session', async () => {
+            const sessionId = 'test-session-123'
+
+            ;(mockCache.get as any).mockResolvedValue({ uuid: 'uuid', traceId: 'trace-id' })
+
+            await sessionManager.markTraceEmitted(sessionId)
+
+            expect(mockCache.set).toHaveBeenCalledWith('session:test-session-123', {
+                uuid: 'uuid',
+                traceId: 'trace-id',
+                traceEmitted: true,
+            })
+        })
+
+        it('should not set traceEmitted if session does not exist', async () => {
+            const sessionId = 'test-session-123'
+
+            ;(mockCache.get as any).mockResolvedValue(null)
+
+            await sessionManager.markTraceEmitted(sessionId)
+
+            expect(mockCache.set).not.toHaveBeenCalled()
+        })
+    })
+
     describe('integration scenarios', () => {
         it('should handle multiple sequential operations', async () => {
             const sessionId = 'test-session'


### PR DESCRIPTION
## Problem

Currently, MCP tool execution traces are emitted for every tool call without considering session context. This can lead to duplicate trace events when the same session executes multiple tools, making it difficult to correlate tool executions within a session and inflating trace metrics.

## Changes

Added session-aware trace ID management to the MCP tool handler:

1. **SessionManager enhancements** (`SessionManager.ts`):
   - `getTraceId(sessionId)`: Returns existing trace ID for a session or generates a new one, ensuring all tools in a session share the same trace ID
   - `isTraceEmitted(sessionId)`: Checks if a trace has already been emitted for a session
   - `markTraceEmitted(sessionId)`: Marks a session's trace as emitted to prevent duplicate trace events

2. **MCP trace emission logic** (`mcp.ts`):
   - Modified tool handler to use session-based trace IDs when available, falling back to generated IDs for non-session requests
   - Added conditional trace emission: only emit `AI_TRACE` events once per session (on first tool execution or error)
   - Changed span name to `mcp/session` for session-based traces to distinguish them from individual tool traces
   - Added `$ai_session_id` field to request properties for better session correlation

3. **Type updates** (`types.ts`):
   - Extended `SessionState` type to include optional `traceId` and `traceEmitted` fields

## How did you test this code?

Added comprehensive unit tests covering:
- `getTraceId`: Returns existing trace ID, creates new trace ID when missing, handles non-existent sessions
- `isTraceEmitted`: Returns correct emission status for existing/non-existent sessions
- `markTraceEmitted`: Updates session state correctly, handles non-existent sessions gracefully

All new tests pass and validate the session trace management behavior.

## Publish to changelog?

no

https://claude.ai/code/session_01DvTiJS4TqSquaxqCJ1W8dP