### PR TITLE
chore: remove unused ENVIRONMENTS from AvailableFeature enum

### DIFF
--- a/posthog/constants.py
+++ b/posthog/constants.py
@@ -12,7 +12,6 @@ INTERNAL_BOT_EMAIL_SUFFIX = "@posthogbot.user"
 class AvailableFeature(StrEnum):
     ZAPIER = "zapier"
     ORGANIZATIONS_PROJECTS = "organizations_projects"
-    ENVIRONMENTS = "environments"
     SOCIAL_SSO = "social_sso"
     SAML = "saml"
     SCIM = "scim"


### PR DESCRIPTION
## Problem

`AvailableFeature.ENVIRONMENTS` is defined in `posthog/constants.py` but is never referenced anywhere in the codebase — no feature gate, no `has_feature` check, no frontend guard. The corresponding entitlement is also being removed from the billing service.

PENDING: A [PR](https://github.com/PostHog/billing/pull/1839) to remove the feature on `billing`.

## Changes

- Remove `ENVIRONMENTS = "environments"` from the `AvailableFeature` enum in `posthog/constants.py`

## How did you test this code?

- Grepped the entire codebase (Python + TypeScript) for any reference to `AvailableFeature.ENVIRONMENTS` — zero matches found
- No tests needed as the enum member was completely unused

## Publish to changelog?

no