### PR TITLE
fix(phrocs): correct brand stripe color order

### DIFF
--- a/tools/phrocs/internal/tui/styles.go
+++ b/tools/phrocs/internal/tui/styles.go
@@ -58,8 +58,8 @@ var (
 			PaddingLeft(1).
 			Render(
 			lipgloss.NewStyle().Background(brandBlue).Render(" ") +
-				lipgloss.NewStyle().Background(brandYellow).Render(" ") +
 				lipgloss.NewStyle().Background(brandRed).Render(" ") +
+				lipgloss.NewStyle().Background(brandYellow).Render(" ") +
 				lipgloss.NewStyle().Background(brandBlack).Render(" "),
 		)
 


### PR DESCRIPTION
## Problem

The phrocs TUI header stripe rendered brand colors in the wrong order (blue, yellow, red) — PostHog's correct brand order is blue, red, yellow.

## Changes

Swapped the render order of `brandRed` and `brandYellow` in `tools/phrocs/internal/tui/styles.go` so the stripe matches PostHog branding.

## How did you test this code?

Built phrocs locally and ran it to visually confirm the stripe order is now blue, red, yellow, black.

## Publish to changelog?

No

## Docs update

N/A

## 🤖 LLM context

Agent-authored PR. Single two-line swap in the TUI styles file.