### PR TITLE
feat(logs): add services list view MVP with per-service volume, error rate and sparklines

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -744,6 +744,10 @@ export class ApiRequest {
         return this.logs(projectId).addPathComponent('sparkline')
     }
 
+    public logsServices(projectId?: ProjectType['id']): ApiRequest {
+        return this.logs(projectId).addPathComponent('services')
+    }
+
     public logsHasLogs(projectId?: ProjectType['id']): ApiRequest {
         return this.logs(projectId).addPathComponent('has_logs')
     }
@@ -2569,6 +2573,17 @@ const api = {
         },
         async sparkline({ query, signal }: { query: Omit<LogsQuery, 'kind'>; signal?: AbortSignal }): Promise<any[]> {
             return new ApiRequest().logsSparkline().create({ signal, data: { query } })
+        },
+        async services({ query, signal }: { query: Omit<LogsQuery, 'kind'>; signal?: AbortSignal }): Promise<{
+            services: {
+                service_name: string
+                log_count: number
+                error_count: number
+                error_rate: number
+            }[]
+            sparkline: { time: string; service_name: string; count: number }[]
+        }> {
+            return new ApiRequest().logsServices().create({ signal, data: { query } })
         },
         async hasLogs(): Promise<boolean> {
             return new ApiRequest()

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -342,6 +342,7 @@ export const FEATURE_FLAGS = {
     LOGS_SPARKLINE_SERVICE_BREAKDOWN: 'logs-sparkline-service-breakdown', // owner: #team-logs
     LOGS_ALERTING: 'logs-alerting', // owner: #team-logs
     LOGS_SAVED_VIEWS: 'logs-saved-views', // owner: #team-logs
+    LOGS_SERVICES_VIEW: 'logs-services-view', // owner: #team-logs
     LOGS_TABBED_VIEW: 'logs-tabbed-view', // owner: #team-logs
     MCP_SERVERS: 'mcp-servers', // owner: #team-posthog-ai
     MANAGED_VIEWSETS: 'managed-viewsets', // owner: @rafaeelaudibert #team-revenue-analytics

--- a/products/logs/backend/api.py
+++ b/products/logs/backend/api.py
@@ -13,7 +13,15 @@ from rest_framework.exceptions import ParseError
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from posthog.schema import DateRange, LogAttributesQuery, LogsOrderBy, LogsQuery, LogValuesQuery, PropertyGroupFilter
+from posthog.schema import (
+    DateRange,
+    FilterLogicalOperator,
+    LogAttributesQuery,
+    LogsOrderBy,
+    LogsQuery,
+    LogValuesQuery,
+    PropertyGroupFilter,
+)
 
 from posthog.api.mixins import PydanticModelMixin
 from posthog.api.routing import TeamAndOrgViewSetMixin
@@ -29,6 +37,7 @@ from products.logs.backend.has_logs_query_runner import HasLogsQueryRunner
 from products.logs.backend.log_attributes_query_runner import LogAttributesQueryRunner
 from products.logs.backend.log_values_query_runner import LogValuesQueryRunner
 from products.logs.backend.logs_query_runner import CachedLogsQueryResponse, LogsQueryResponse, LogsQueryRunner
+from products.logs.backend.services_query_runner import ServicesQueryRunner
 from products.logs.backend.sparkline_query_runner import SparklineQueryRunner
 from products.logs.backend.views_api import LogsViewViewSet
 
@@ -274,6 +283,46 @@ class LogsViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.ViewSet):
                 "severity_levels_count": len(query_data.get("severityLevels", [])),
                 "service_names_count": len(query_data.get("serviceNames", [])),
                 "breakdown_by": query_data.get("sparklineBreakdownBy"),
+            },
+            team=self.team,
+            request=request,
+        )
+
+        return Response(response.results, status=status.HTTP_200_OK)
+
+    @action(detail=False, methods=["POST"], required_scopes=["logs:read"])
+    def services(self, request: Request, *args, **kwargs) -> Response:
+        query_data = request.data.get("query", {})
+
+        filter_group = query_data.get("filterGroup", None)
+        if filter_group is None:
+            filter_group = PropertyGroupFilter(type=FilterLogicalOperator.AND_, values=[])
+
+        query = LogsQuery(
+            dateRange=self.get_model(query_data.get("dateRange"), DateRange),
+            severityLevels=query_data.get("severityLevels", []),
+            serviceNames=query_data.get("serviceNames", []),
+            searchTerm=query_data.get("searchTerm", None),
+            filterGroup=filter_group,
+        )
+
+        runner = ServicesQueryRunner(team=self.team, query=query)
+        response = runner.run(
+            ExecutionMode.CALCULATE_BLOCKING_ALWAYS,
+            analytics_props=get_request_analytics_properties(request),
+        )
+        assert isinstance(response, LogsQueryResponse | CachedLogsQueryResponse)
+
+        report_user_action(
+            request.user,
+            "logs services queried",
+            {
+                "services_count": len(response.results.get("services", []))
+                if isinstance(response.results, dict)
+                else 0,
+                "has_search_term": bool(query_data.get("searchTerm")),
+                "severity_levels_count": len(query_data.get("severityLevels", [])),
+                "service_names_count": len(query_data.get("serviceNames", [])),
             },
             team=self.team,
             request=request,

--- a/products/logs/backend/services_query_runner.py
+++ b/products/logs/backend/services_query_runner.py
@@ -1,0 +1,114 @@
+from posthog.schema import CachedLogsQueryResponse, LogsQuery
+
+from posthog.hogql import ast
+from posthog.hogql.parser import parse_select
+from posthog.hogql.query import execute_hogql_query
+
+from posthog.clickhouse.client.connection import Workload
+from posthog.hogql_queries.query_runner import AnalyticsQueryRunner
+
+from products.logs.backend.logs_query_runner import LogsQueryResponse, LogsQueryRunnerMixin
+
+
+class ServicesQueryRunner(AnalyticsQueryRunner[LogsQueryResponse], LogsQueryRunnerMixin):
+    """Returns per-service aggregates (volume, error count, error rate) and sparkline data."""
+
+    query: LogsQuery
+    cached_response: CachedLogsQueryResponse
+
+    def _calculate(self) -> LogsQueryResponse:
+        aggregates_response = execute_hogql_query(
+            query_type="LogsQuery",
+            query=self._aggregates_query(),
+            modifiers=self.modifiers,
+            team=self.team,
+            workload=Workload.LOGS,
+            timings=self.timings,
+            limit_context=self.limit_context,
+            settings=self.settings,
+        )
+
+        sparkline_response = execute_hogql_query(
+            query_type="LogsQuery",
+            query=self._sparkline_query(),
+            modifiers=self.modifiers,
+            team=self.team,
+            workload=Workload.LOGS,
+            timings=self.timings,
+            limit_context=self.limit_context,
+            settings=self.settings,
+        )
+
+        services = []
+        for row in aggregates_response.results:
+            service_name = row[0] if row[0] else "(no service)"
+            log_count = row[1]
+            error_count = row[2]
+            error_rate = error_count / log_count if log_count > 0 else 0.0
+            services.append(
+                {
+                    "service_name": service_name,
+                    "log_count": log_count,
+                    "error_count": error_count,
+                    "error_rate": round(error_rate, 4),
+                }
+            )
+
+        sparkline = []
+        for row in sparkline_response.results:
+            sparkline.append(
+                {
+                    "time": row[0],
+                    "service_name": row[1] if row[1] else "(no service)",
+                    "count": row[2],
+                }
+            )
+
+        return LogsQueryResponse(results={"services": services, "sparkline": sparkline})
+
+    def to_query(self) -> ast.SelectQuery:
+        return self._aggregates_query()
+
+    def _aggregates_query(self) -> ast.SelectQuery:
+        query = parse_select(
+            """
+            SELECT
+                service_name,
+                count() AS log_count,
+                countIf(lower(severity_text) IN ('error', 'fatal')) AS error_count
+            FROM logs
+            WHERE {where}
+            GROUP BY service_name
+            ORDER BY log_count DESC
+            LIMIT 1000
+            """,
+            placeholders={
+                "where": self.where(),
+            },
+        )
+        assert isinstance(query, ast.SelectQuery)
+        return query
+
+    def _sparkline_query(self) -> ast.SelectQuery:
+        query = parse_select(
+            """
+            SELECT
+                toStartOfInterval({time_field}, {one_interval_period}) AS time,
+                service_name,
+                count() AS event_count
+            FROM logs
+            WHERE {where}
+            GROUP BY service_name, time
+            ORDER BY time ASC, service_name ASC
+            LIMIT 10000
+            """,
+            placeholders={
+                **self.query_date_range.to_placeholders(),
+                "time_field": ast.Call(name="toStartOfMinute", args=[ast.Field(chain=["timestamp"])])
+                if self.query_date_range.interval_name != "second"
+                else ast.Field(chain=["timestamp"]),
+                "where": self.where(),
+            },
+        )
+        assert isinstance(query, ast.SelectQuery)
+        return query

--- a/products/logs/frontend/LogsScene.tsx
+++ b/products/logs/frontend/LogsScene.tsx
@@ -14,7 +14,9 @@ import { SceneContent } from '~/layout/scenes/components/SceneContent'
 import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
 import { ProductKey } from '~/queries/schema/schema-general'
 
+import { LogsServices } from 'products/logs/frontend/components/LogsServices/LogsServices'
 import { LogsViewer } from 'products/logs/frontend/components/LogsViewer'
+import { LogsViewerModal } from 'products/logs/frontend/components/LogsViewer/LogsViewerModal'
 import { logsIngestionLogic } from 'products/logs/frontend/components/SetupPrompt/logsIngestionLogic'
 import { LogsSetupPrompt } from 'products/logs/frontend/components/SetupPrompt/SetupPrompt'
 
@@ -87,6 +89,13 @@ const LogsSceneTabbedContent = (): JSX.Element => {
     const { tabId, activeTab } = useValues(logsSceneLogic)
     const { setActiveTab } = useActions(logsSceneLogic)
     const { hasLogs, teamHasLogsCheckFailed } = useValues(logsIngestionLogic)
+    const showServicesView = useFeatureFlag('LOGS_SERVICES_VIEW')
+
+    const tabs: { key: LogsSceneActiveTab; label: string }[] = [
+        { key: 'viewer', label: 'Viewer' },
+        ...(showServicesView ? [{ key: 'services' as const, label: 'Services' }] : []),
+        { key: 'configuration', label: 'Configuration' },
+    ]
 
     return (
         <>
@@ -113,10 +122,7 @@ const LogsSceneTabbedContent = (): JSX.Element => {
             <LemonTabs<LogsSceneActiveTab>
                 activeKey={activeTab}
                 onChange={(key) => setActiveTab(key)}
-                tabs={[
-                    { key: 'viewer', label: 'Viewer' },
-                    { key: 'configuration', label: 'Configuration' },
-                ]}
+                tabs={tabs}
                 sceneInset
             />
             {activeTab === 'viewer' && (
@@ -125,6 +131,12 @@ const LogsSceneTabbedContent = (): JSX.Element => {
                         <LogsViewer id={tabId} showSavedViewsButton />
                     </div>
                 </LogsSetupPrompt>
+            )}
+            {activeTab === 'services' && showServicesView && (
+                <>
+                    <LogsServices />
+                    <LogsViewerModal />
+                </>
             )}
             {activeTab === 'configuration' && (
                 <Settings logicKey={LOGS_LOGIC_KEY} sectionId="environment-logs" settingId="logs" handleLocally />

--- a/products/logs/frontend/components/LogsServices/LogsServices.tsx
+++ b/products/logs/frontend/components/LogsServices/LogsServices.tsx
@@ -1,0 +1,106 @@
+import { useActions, useValues } from 'kea'
+
+import { LemonSelect, LemonTable, LemonTag } from '@posthog/lemon-ui'
+import type { LemonTableColumns } from '@posthog/lemon-ui'
+
+import { Sparkline } from 'lib/components/Sparkline'
+import { humanFriendlyNumber } from 'lib/utils'
+
+import { logsViewerModalLogic } from 'products/logs/frontend/components/LogsViewer/LogsViewerModal/logsViewerModalLogic'
+
+import { logsServicesLogic, ServiceRow } from './logsServicesLogic'
+
+const DATE_OPTIONS = [
+    { value: '-1h', label: 'Last hour' },
+    { value: '-24h', label: 'Last 24 hours' },
+    { value: '-7d', label: 'Last 7 days' },
+    { value: '-30d', label: 'Last 30 days' },
+]
+
+export function LogsServices(): JSX.Element {
+    const { services, servicesDataLoading, sparklineByService, dateFrom } = useValues(logsServicesLogic)
+    const { setDateFrom } = useActions(logsServicesLogic)
+    const { openLogsViewerModal } = useActions(logsViewerModalLogic)
+
+    const columns: LemonTableColumns<ServiceRow> = [
+        {
+            title: 'Service name',
+            dataIndex: 'service_name',
+            render: (_, row) => (
+                <span
+                    className="font-medium cursor-pointer text-link"
+                    onClick={() =>
+                        openLogsViewerModal({
+                            fullScreen: false,
+                            initialFilters: { serviceNames: [row.service_name] },
+                        })
+                    }
+                >
+                    {row.service_name}
+                </span>
+            ),
+            sorter: (a, b) => a.service_name.localeCompare(b.service_name),
+        },
+        {
+            title: 'Log volume',
+            dataIndex: 'log_count',
+            render: (_, row) => humanFriendlyNumber(row.log_count),
+            sorter: (a, b) => a.log_count - b.log_count,
+            align: 'right',
+        },
+        {
+            title: 'Error rate',
+            dataIndex: 'error_rate',
+            render: (_, row) => {
+                const pct = (row.error_rate * 100).toFixed(1)
+                const type = row.error_rate > 0.1 ? 'danger' : row.error_rate > 0.01 ? 'warning' : 'success'
+                return <LemonTag type={type}>{pct}%</LemonTag>
+            },
+            sorter: (a, b) => a.error_rate - b.error_rate,
+            align: 'right',
+        },
+        {
+            title: 'Volume trend',
+            key: 'sparkline',
+            render: (_, row) => {
+                const sparkline = sparklineByService[row.service_name]
+                if (!sparkline || sparkline.values.length === 0) {
+                    return <span className="text-muted">-</span>
+                }
+                return (
+                    <div className="w-24 h-6">
+                        <Sparkline
+                            data={sparkline.values}
+                            labels={sparkline.labels}
+                            className="w-full h-full"
+                            maximumIndicator={false}
+                        />
+                    </div>
+                )
+            },
+        },
+    ]
+
+    return (
+        <div className="flex flex-col gap-2 py-2 flex-1 min-h-0">
+            <div className="flex items-center justify-between">
+                <h3 className="m-0">Services</h3>
+                <LemonSelect
+                    size="small"
+                    value={dateFrom}
+                    onChange={(value) => value && setDateFrom(value)}
+                    options={DATE_OPTIONS}
+                />
+            </div>
+            <LemonTable
+                columns={columns}
+                dataSource={services}
+                loading={servicesDataLoading}
+                defaultSorting={{ columnKey: 'log_count', order: -1 }}
+                emptyState="No services found in this time range"
+                rowKey="service_name"
+                size="small"
+            />
+        </div>
+    )
+}

--- a/products/logs/frontend/components/LogsServices/logsServicesLogic.ts
+++ b/products/logs/frontend/components/LogsServices/logsServicesLogic.ts
@@ -1,0 +1,104 @@
+import { actions, afterMount, kea, listeners, path, reducers, selectors } from 'kea'
+import { loaders } from 'kea-loaders'
+
+import api from 'lib/api'
+
+import { FilterLogicalOperator } from '~/types'
+
+import type { logsServicesLogicType } from './logsServicesLogicType'
+
+export interface ServiceRow {
+    service_name: string
+    log_count: number
+    error_count: number
+    error_rate: number
+}
+
+export interface ServiceSparklinePoint {
+    time: string
+    service_name: string
+    count: number
+}
+
+export interface ServicesResponse {
+    services: ServiceRow[]
+    sparkline: ServiceSparklinePoint[]
+}
+
+export const logsServicesLogic = kea<logsServicesLogicType>([
+    path(['products', 'logs', 'frontend', 'components', 'LogsServices', 'logsServicesLogic']),
+
+    actions({
+        setDateFrom: (dateFrom: string) => ({ dateFrom }),
+    }),
+
+    reducers({
+        dateFrom: [
+            '-24h' as string,
+            {
+                setDateFrom: (_, { dateFrom }) => dateFrom,
+            },
+        ],
+    }),
+
+    loaders(({ values }) => ({
+        servicesData: [
+            { services: [], sparkline: [] } as ServicesResponse,
+            {
+                loadServicesData: async () => {
+                    const response = await api.logs.services({
+                        query: {
+                            dateRange: { date_from: values.dateFrom },
+                            severityLevels: [],
+                            filterGroup: { type: FilterLogicalOperator.And, values: [] },
+                            serviceNames: [],
+                        },
+                    })
+                    return response
+                },
+            },
+        ],
+    })),
+
+    selectors({
+        services: [(s) => [s.servicesData], (data: ServicesResponse): ServiceRow[] => data.services],
+
+        sparklineByService: [
+            (s) => [s.servicesData],
+            (data: ServicesResponse): Record<string, { values: number[]; labels: string[] }> => {
+                const byService: Record<string, Map<string, number>> = {}
+                const allTimes = new Set<string>()
+
+                for (const point of data.sparkline) {
+                    allTimes.add(point.time)
+                    if (!byService[point.service_name]) {
+                        byService[point.service_name] = new Map()
+                    }
+                    byService[point.service_name].set(point.time, point.count)
+                }
+
+                const sortedTimes = Array.from(allTimes).sort()
+                const result: Record<string, { values: number[]; labels: string[] }> = {}
+
+                for (const [serviceName, timeMap] of Object.entries(byService)) {
+                    result[serviceName] = {
+                        values: sortedTimes.map((t) => timeMap.get(t) ?? 0),
+                        labels: sortedTimes,
+                    }
+                }
+
+                return result
+            },
+        ],
+    }),
+
+    listeners(({ actions }) => ({
+        setDateFrom: () => {
+            actions.loadServicesData()
+        },
+    })),
+
+    afterMount(({ actions }) => {
+        actions.loadServicesData()
+    }),
+])

--- a/products/logs/frontend/generated/api.ts
+++ b/products/logs/frontend/generated/api.ts
@@ -332,6 +332,17 @@ export const logsQueryCreate = async (projectId: string, options?: RequestInit):
     })
 }
 
+export const getLogsServicesCreateUrl = (projectId: string) => {
+    return `/api/projects/${projectId}/logs/services/`
+}
+
+export const logsServicesCreate = async (projectId: string, options?: RequestInit): Promise<void> => {
+    return apiMutator<void>(getLogsServicesCreateUrl(projectId), {
+        ...options,
+        method: 'POST',
+    })
+}
+
 export const getLogsSparklineCreateUrl = (projectId: string) => {
     return `/api/projects/${projectId}/logs/sparkline/`
 }

--- a/products/logs/frontend/logsSceneLogic.tsx
+++ b/products/logs/frontend/logsSceneLogic.tsx
@@ -31,8 +31,8 @@ import {
 
 import type { logsSceneLogicType } from './logsSceneLogicType'
 
-export type LogsSceneActiveTab = 'viewer' | 'configuration'
-const VALID_ACTIVE_TABS: LogsSceneActiveTab[] = ['viewer', 'configuration']
+export type LogsSceneActiveTab = 'viewer' | 'services' | 'configuration'
+const VALID_ACTIVE_TABS: LogsSceneActiveTab[] = ['viewer', 'services', 'configuration']
 export const DEFAULT_ACTIVE_TAB: LogsSceneActiveTab = 'viewer'
 
 export interface LogsLogicProps {


### PR DESCRIPTION
## Problem

Services only exist as filter values in the logs product today. There's no way to get a bird's-eye view of all services, compare their log volumes, or spot which service has the highest error rate without manually filtering one by one.

## Changes

Adds a new in-dev **Services** tab to the logs tabbed view (behind `LOGS_SERVICES_VIEW` feature flag) that shows a table of all services with:

- Log volume (total count in time range)
- Error rate (% of error/fatal logs, color-coded)
- Volume trend sparkline (inline chart per service)
- Click-through to LogsViewer with the service pre-filtered

**Backend:**

- New `ServicesQueryRunner` that runs two ClickHouse queries against the `logs` table — one for per-service aggregates, one for time-bucketed sparkline data
- New `POST /api/environments/:id/logs/services/` endpoint on `LogsViewSet`

**Frontend:**

- New `LogsServices` component with `LemonTable`, date range selector, and inline sparklines
- New `logsServicesLogic` kea logic for data fetching and sparkline-per-service transformation
- Extended `LogsSceneActiveTab` type to include `'services'`

![image.png](https://app.graphite.com/user-attachments/assets/f7301f31-0b4c-4392-b976-d581d722ed99.png)



## How did you test this code?

local dev & unit tests - currently feature flagged

## Publish to changelog?

No