### PR TITLE
chore(workflows): Lift schedule state from RecurringSchedulePicker into workflowLogic

### DIFF
--- a/products/workflows/frontend/Workflows/hogflows/steps/StepTrigger.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/steps/StepTrigger.tsx
@@ -573,18 +573,11 @@ function StepTriggerAffectedUsers({ actionId, filters }: { actionId: string; fil
 }
 
 function BatchScheduleSection(): JSX.Element {
-    const { setPendingSchedule } = useActions(workflowLogic)
-    const { currentSchedule, pendingSchedule } = useValues(workflowLogic)
-
     return (
         <>
             <LemonDivider />
             <LemonLabel>Schedule</LemonLabel>
-            <RecurringSchedulePicker
-                key={currentSchedule?.id ?? 'new'}
-                schedule={pendingSchedule !== false ? pendingSchedule : (currentSchedule ?? null)}
-                onChange={(schedule) => setPendingSchedule(schedule)}
-            />
+            <RecurringSchedulePicker />
         </>
     )
 }

--- a/products/workflows/frontend/Workflows/hogflows/steps/components/RecurringSchedulePicker.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/steps/components/RecurringSchedulePicker.tsx
@@ -1,38 +1,24 @@
-import { useMemo, useState } from 'react'
+import { useActions, useValues } from 'kea'
+import { useMemo } from 'react'
 
 import { IconCalendar } from '@posthog/icons'
 import { LemonButton, LemonCalendarSelectInput, LemonInput, LemonSelect, LemonSwitch } from '@posthog/lemon-ui'
 
 import { dayjs } from 'lib/dayjs'
 
+import { workflowLogic } from '../../../workflowLogic'
 import { OccurrencesList } from './OccurrencesList'
 import {
     buildSummary,
     computePreviewOccurrences,
-    DEFAULT_STATE,
     FREQUENCY_OPTIONS,
     getNthWeekdayOfMonth,
-    isOneTimeSchedule,
-    ONE_TIME_RRULE,
     NTH_LABELS,
-    parseRRuleToState,
-    stateToRRule,
     WEEKDAY_FULL_LABELS,
     WEEKDAY_LABELS,
     WEEKDAY_PILL_LABELS,
 } from './rrule-helpers'
 import type { FrequencyOption, MonthlyMode, ScheduleState } from './rrule-helpers'
-
-type ScheduleConfig = {
-    rrule: string
-    starts_at: string
-    timezone?: string
-}
-
-interface RecurringSchedulePickerProps {
-    schedule?: ScheduleConfig | null
-    onChange: (schedule: ScheduleConfig | null) => void
-}
 
 interface FrequencyPickerProps {
     state: ScheduleState
@@ -228,7 +214,7 @@ function SchedulePreview({ state, summary, previewOccurrences, timezone }: Sched
                                 ? `${previewOccurrences.length} occurrences`
                                 : 'Next occurrences'}
                         </span>
-                        {timezone && timezone !== dayjs.tz.guess() ? ` in ${timezone}` : ''}
+                        {timezone ? ` in ${timezone}` : ''}
                     </div>
                     <div className="space-y-1.5">
                         <OccurrencesList occurrences={previewOccurrences} isFinite={state.endType !== 'never'} />
@@ -239,61 +225,38 @@ function SchedulePreview({ state, summary, previewOccurrences, timezone }: Sched
     )
 }
 
-export function RecurringSchedulePicker({ schedule, onChange }: RecurringSchedulePickerProps): JSX.Element {
-    const isOneTime = schedule ? isOneTimeSchedule(schedule.rrule) : false
-    const isRepeating = !!schedule && !isOneTime
-    const [state, setState] = useState<ScheduleState>(() =>
-        schedule && !isOneTime ? parseRRuleToState(schedule.rrule) : { ...DEFAULT_STATE }
-    )
-
-    // Keep start date and timezone in local state so they persist when toggling repeat off
-    const [localStartsAt, setLocalStartsAt] = useState<string | null>(schedule?.starts_at || null)
-    const [localTimezone, setLocalTimezone] = useState<string>(schedule?.timezone || dayjs.tz.guess())
-
-    const startsAt = schedule?.starts_at || localStartsAt
-    const timezone = schedule?.timezone || localTimezone
-
-    const emitChange = (newState: ScheduleState, newStartsAt: string | null, newTimezone: string): void => {
-        if (!newStartsAt) {
-            return
-        }
-        const rrule = stateToRRule(newState, newStartsAt)
-        onChange({ rrule, starts_at: newStartsAt, timezone: newTimezone })
-    }
+export function RecurringSchedulePicker(): JSX.Element {
+    const { scheduleState, scheduleStartsAt, scheduleTimezone, isScheduleRepeating } = useValues(workflowLogic)
+    const { setScheduleState, setScheduleStartsAt, setScheduleRepeating } = useActions(workflowLogic)
 
     const previewOccurrences = useMemo(() => {
-        if (!isRepeating || !startsAt) {
+        if (!isScheduleRepeating || !scheduleStartsAt) {
             return []
         }
-        return computePreviewOccurrences(state, startsAt, timezone)
+        return computePreviewOccurrences(scheduleState, scheduleStartsAt, scheduleTimezone)
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [
-        isRepeating,
-        startsAt,
-        timezone,
-        state.frequency,
-        state.interval,
-        state.weekdays,
-        state.monthlyMode,
-        state.endType,
-        state.endDate,
-        state.endCount,
+        isScheduleRepeating,
+        scheduleStartsAt,
+        scheduleTimezone,
+        scheduleState.frequency,
+        scheduleState.interval,
+        scheduleState.weekdays,
+        scheduleState.monthlyMode,
+        scheduleState.endType,
+        scheduleState.endDate,
+        scheduleState.endCount,
     ])
 
-    const summary = isRepeating ? buildSummary(state, startsAt) : null
+    const summary = isScheduleRepeating ? buildSummary(scheduleState, scheduleStartsAt) : null
 
-    const monthlyDayLabel = startsAt ? `Day ${dayjs(startsAt).date()}` : 'Day N'
-    const monthlyNthLabel = startsAt
+    const monthlyDayLabel = scheduleStartsAt ? `Day ${dayjs(scheduleStartsAt).date()}` : 'Day N'
+    const monthlyNthLabel = scheduleStartsAt
         ? (() => {
-              const { n, weekday } = getNthWeekdayOfMonth(dayjs(startsAt))
+              const { n, weekday } = getNthWeekdayOfMonth(dayjs(scheduleStartsAt))
               return `${NTH_LABELS[n - 1]} ${WEEKDAY_FULL_LABELS[weekday]}`
           })()
         : 'Nth weekday'
-
-    const handleStateChange = (newState: ScheduleState): void => {
-        setState(newState)
-        emitChange(newState, startsAt, timezone)
-    }
 
     return (
         <div className="flex flex-col gap-3 w-full">
@@ -301,99 +264,73 @@ export function RecurringSchedulePicker({ schedule, onChange }: RecurringSchedul
                 <div className="flex-1 min-w-0">
                     <LemonCalendarSelectInput
                         buttonProps={{ fullWidth: true }}
+                        format="MMMM D, YYYY h:mm A"
                         clearable
-                        value={startsAt ? dayjs(startsAt) : null}
+                        value={scheduleStartsAt ? dayjs(scheduleStartsAt) : null}
                         onChange={(date) => {
-                            const newStartsAt = date ? date.startOf('minute').toISOString() : null
-                            const browserTimezone = dayjs.tz.guess()
-                            setLocalStartsAt(newStartsAt)
-                            setLocalTimezone(browserTimezone)
-                            if (newStartsAt) {
-                                if (isRepeating) {
-                                    emitChange(state, newStartsAt, browserTimezone)
-                                } else {
-                                    onChange({
-                                        rrule: ONE_TIME_RRULE,
-                                        starts_at: newStartsAt,
-                                        timezone: browserTimezone,
-                                    })
-                                }
-                            } else {
-                                onChange(null)
-                            }
+                            setScheduleStartsAt(date ? date.startOf('minute').toISOString() : null)
                         }}
                         granularity="minute"
                         selectionPeriod="upcoming"
                         showTimeToggle={false}
                     />
                 </div>
-                <div className="flex items-center gap-2 shrink-0">
-                    <span className="text-muted text-sm">Repeat</span>
-                    <LemonSwitch
-                        checked={isRepeating}
-                        onChange={(checked) => {
-                            const startDate = localStartsAt || startsAt || new Date().toISOString()
-                            setLocalStartsAt(startDate)
-                            if (checked) {
-                                emitChange(state, startDate, timezone)
-                            } else if (startDate) {
-                                // Downgrade to one-time schedule
-                                onChange({
-                                    rrule: ONE_TIME_RRULE,
-                                    starts_at: startDate,
-                                    timezone,
-                                })
-                            }
-                        }}
-                    />
-                </div>
+                {scheduleStartsAt && (
+                    <div className="w-22 shrink-0">
+                        <LemonSwitch
+                            label="Repeat"
+                            checked={isScheduleRepeating}
+                            onChange={(checked) => setScheduleRepeating(checked)}
+                        />
+                    </div>
+                )}
             </div>
-            {startsAt && (
+            {scheduleStartsAt && (
                 <div className="text-xs text-muted -mt-1">
-                    Schedule timezone: {timezone} ({dayjs(startsAt).tz(timezone).format('h:mm A')})
-                    {timezone !== dayjs.tz.guess() && (
+                    Schedule timezone: {scheduleTimezone} (
+                    {dayjs(scheduleStartsAt).tz(scheduleTimezone).format('h:mm A')})
+                    {scheduleTimezone !== dayjs.tz.guess() && (
                         <>
                             {' '}
-                            · Your time: {dayjs(startsAt).format('h:mm A')} {dayjs.tz.guess()}
+                            · Your time: {dayjs(scheduleStartsAt).format('h:mm A')} {dayjs.tz.guess()}
                         </>
                     )}
                 </div>
             )}
-
-            {isRepeating && (
+            {scheduleStartsAt && isScheduleRepeating && (
                 <>
                     <div className="flex items-center gap-2 flex-wrap">
-                        <FrequencyPicker state={state} onStateChange={handleStateChange} />
-                        {state.frequency === 'weekly' && (
-                            <WeekdayPicker state={state} onStateChange={handleStateChange} />
+                        <FrequencyPicker state={scheduleState} onStateChange={setScheduleState} />
+                        {scheduleState.frequency === 'weekly' && (
+                            <WeekdayPicker state={scheduleState} onStateChange={setScheduleState} />
                         )}
-                        {state.frequency === 'monthly' && (
+                        {scheduleState.frequency === 'monthly' && (
                             <MonthlyModePicker
-                                state={state}
-                                onStateChange={handleStateChange}
+                                state={scheduleState}
+                                onStateChange={setScheduleState}
                                 monthlyDayLabel={monthlyDayLabel}
                                 monthlyNthLabel={monthlyNthLabel}
                             />
                         )}
                     </div>
 
-                    <EndTypePicker state={state} onStateChange={handleStateChange} />
+                    <EndTypePicker state={scheduleState} onStateChange={setScheduleState} />
 
-                    {state.frequency === 'monthly' &&
-                        state.monthlyMode === 'day_of_month' &&
-                        startsAt &&
-                        dayjs(startsAt).date() >= 29 && (
+                    {scheduleState.frequency === 'monthly' &&
+                        scheduleState.monthlyMode === 'day_of_month' &&
+                        scheduleStartsAt &&
+                        dayjs(scheduleStartsAt).date() >= 29 && (
                             <div className="text-xs text-warning">
-                                Some months don't have a {dayjs(startsAt).format('Do')}. Those months will be skipped.
-                                Use "Last day" to run on the last day of every month instead.
+                                Some months don't have a {dayjs(scheduleStartsAt).format('Do')}. Those months will be
+                                skipped. Use "Last day" to run on the last day of every month instead.
                             </div>
                         )}
 
                     <SchedulePreview
-                        state={state}
+                        state={scheduleState}
                         summary={summary}
                         previewOccurrences={previewOccurrences}
-                        timezone={timezone}
+                        timezone={scheduleTimezone}
                     />
                 </>
             )}

--- a/products/workflows/frontend/Workflows/workflowLogic.schedule.test.ts
+++ b/products/workflows/frontend/Workflows/workflowLogic.schedule.test.ts
@@ -1,0 +1,308 @@
+import { expectLogic } from 'kea-test-utils'
+
+import { initKeaTests } from '~/test/init'
+
+import { DEFAULT_STATE, ONE_TIME_RRULE } from './hogflows/steps/components/rrule-helpers'
+import { HogFlowSchedule } from './hogflows/types'
+import { workflowLogic } from './workflowLogic'
+
+const WEEKLY_MONDAY_RRULE = 'FREQ=WEEKLY;INTERVAL=1;BYDAY=MO'
+const STARTS_AT = '2026-04-10T09:00:00.000Z'
+
+const makeSchedule = (overrides: Partial<HogFlowSchedule> = {}): HogFlowSchedule => ({
+    id: 'schedule-1',
+    rrule: WEEKLY_MONDAY_RRULE,
+    starts_at: STARTS_AT,
+    timezone: 'UTC',
+    ...overrides,
+})
+
+describe('workflowLogic schedule reducers', () => {
+    let logic: ReturnType<typeof workflowLogic.build>
+
+    beforeEach(() => {
+        initKeaTests()
+        logic = workflowLogic({ id: 'new', tabId: 'default' })
+        logic.mount()
+    })
+
+    describe('initial state', () => {
+        it('has default schedule state', () => {
+            expect(logic.values.scheduleState).toEqual(DEFAULT_STATE)
+            expect(logic.values.scheduleStartsAt).toBeNull()
+            expect(logic.values.isScheduleRepeating).toBe(false)
+            expect(logic.values.pendingSchedule).toBe(false)
+        })
+    })
+
+    describe('setSchedules', () => {
+        it('initializes reducers from a repeating schedule', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.setSchedules([makeSchedule()])
+            }).toMatchValues({
+                scheduleStartsAt: STARTS_AT,
+                scheduleTimezone: 'UTC',
+                isScheduleRepeating: true,
+            })
+
+            expect(logic.values.scheduleState.frequency).toBe('weekly')
+            expect(logic.values.scheduleState.weekdays).toContain(0) // Monday
+        })
+
+        it('initializes reducers from a one-time schedule', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.setSchedules([makeSchedule({ rrule: ONE_TIME_RRULE })])
+            }).toMatchValues({
+                scheduleStartsAt: STARTS_AT,
+                isScheduleRepeating: false,
+                scheduleState: DEFAULT_STATE,
+            })
+        })
+
+        it('resets to defaults when schedules list is empty', async () => {
+            logic.actions.setSchedules([makeSchedule()])
+
+            await expectLogic(logic, () => {
+                logic.actions.setSchedules([])
+            }).toMatchValues({
+                scheduleStartsAt: null,
+                isScheduleRepeating: false,
+                scheduleState: DEFAULT_STATE,
+            })
+        })
+    })
+
+    describe('pendingSchedule selector', () => {
+        it('returns false when no changes have been made', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.setSchedules([makeSchedule()])
+            }).toMatchValues({
+                pendingSchedule: false,
+            })
+        })
+
+        it('returns schedule config when starts_at changes', async () => {
+            logic.actions.setSchedules([makeSchedule()])
+            const newStartsAt = '2026-05-01T10:00:00.000Z'
+
+            await expectLogic(logic, () => {
+                logic.actions.setScheduleStartsAt(newStartsAt)
+            }).toMatchValues({
+                pendingSchedule: {
+                    rrule: expect.any(String),
+                    starts_at: newStartsAt,
+                    timezone: 'UTC',
+                },
+            })
+        })
+
+        it('returns schedule config when timezone changes', async () => {
+            logic.actions.setSchedules([makeSchedule()])
+
+            await expectLogic(logic, () => {
+                logic.actions.setScheduleTimezone('US/Eastern')
+            }).toMatchValues({
+                pendingSchedule: {
+                    rrule: expect.any(String),
+                    starts_at: STARTS_AT,
+                    timezone: 'US/Eastern',
+                },
+            })
+        })
+
+        it('returns ONE_TIME_RRULE when repeating is toggled off', async () => {
+            logic.actions.setSchedules([makeSchedule()])
+
+            await expectLogic(logic, () => {
+                logic.actions.setScheduleRepeating(false)
+            }).toMatchValues({
+                pendingSchedule: {
+                    rrule: ONE_TIME_RRULE,
+                    starts_at: STARTS_AT,
+                    timezone: 'UTC',
+                },
+            })
+        })
+
+        it('returns null when starts_at is cleared on existing schedule', async () => {
+            logic.actions.setSchedules([makeSchedule()])
+
+            await expectLogic(logic, () => {
+                logic.actions.setScheduleStartsAt(null)
+            }).toMatchValues({
+                pendingSchedule: null,
+            })
+        })
+
+        it('returns false when starts_at is null and no saved schedule exists', () => {
+            expect(logic.values.pendingSchedule).toBe(false)
+        })
+
+        it('returns new schedule for a new workflow with no saved schedule', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.setScheduleStartsAt(STARTS_AT)
+                logic.actions.setScheduleRepeating(true)
+            }).toMatchValues({
+                pendingSchedule: {
+                    rrule: expect.any(String),
+                    starts_at: STARTS_AT,
+                    timezone: expect.any(String),
+                },
+            })
+        })
+    })
+
+    describe('hasUnsavedChanges', () => {
+        it('is false after loading a saved schedule', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.setSchedules([makeSchedule()])
+            }).toMatchValues({
+                hasUnsavedChanges: false,
+            })
+        })
+
+        it.each([
+            ['timezone changes', () => logic.actions.setScheduleTimezone('US/Eastern')],
+            ['frequency changes', () => logic.actions.setScheduleState({ ...DEFAULT_STATE, frequency: 'daily' })],
+            ['date changes', () => logic.actions.setScheduleStartsAt('2026-05-01T10:00:00.000Z')],
+            ['repeat is toggled off', () => logic.actions.setScheduleRepeating(false)],
+            ['date is cleared', () => logic.actions.setScheduleStartsAt(null)],
+        ])('is true when %s', (_, applyChange) => {
+            logic.actions.setSchedules([makeSchedule()])
+            applyChange()
+            expect(logic.values.hasUnsavedChanges).toBe(true)
+        })
+
+        it('is false after resetting changes', async () => {
+            logic.actions.setSchedules([makeSchedule()])
+            logic.actions.setScheduleTimezone('US/Eastern')
+            expect(logic.values.hasUnsavedChanges).toBe(true)
+
+            logic.actions.resetWorkflow(logic.values.workflow)
+            expect(logic.values.hasUnsavedChanges).toBe(false)
+        })
+    })
+
+    describe('end-to-end scenarios', () => {
+        it('scenario 1: new workflow - create schedule from scratch', async () => {
+            // Pick a date, toggle repeat on, select weekly on Monday
+            logic.actions.setScheduleStartsAt(STARTS_AT)
+            logic.actions.setScheduleRepeating(true)
+            logic.actions.setScheduleState({
+                ...DEFAULT_STATE,
+                frequency: 'weekly',
+                weekdays: [0], // Monday
+            })
+
+            const pending = logic.values.pendingSchedule
+            expect(pending).not.toBe(false)
+            expect(pending).not.toBeNull()
+            expect((pending as any).rrule).toContain('FREQ=WEEKLY')
+            expect((pending as any).rrule).toContain('BYDAY=MO')
+            expect((pending as any).starts_at).toBe(STARTS_AT)
+        })
+
+        it('scenario 2: edit existing schedule produces updated pendingSchedule', async () => {
+            logic.actions.setSchedules([makeSchedule()])
+
+            // Change frequency to daily
+            logic.actions.setScheduleState({ ...DEFAULT_STATE, frequency: 'daily', interval: 1 })
+            // Change timezone
+            logic.actions.setScheduleTimezone('US/Eastern')
+
+            const pending = logic.values.pendingSchedule
+            expect(pending).not.toBe(false)
+            expect((pending as any).rrule).toContain('FREQ=DAILY')
+            expect((pending as any).rrule).not.toContain('BYDAY')
+            expect((pending as any).timezone).toBe('US/Eastern')
+            expect((pending as any).starts_at).toBe(STARTS_AT)
+        })
+
+        it('scenario 3: clear changes reverts end type and count', async () => {
+            logic.actions.setSchedules([makeSchedule()])
+
+            // Change end type to after_count with count 5
+            logic.actions.setScheduleState({
+                ...logic.values.scheduleState,
+                endType: 'after_count',
+                endCount: 5,
+            })
+            expect(logic.values.hasUnsavedChanges).toBe(true)
+
+            // Clear changes
+            logic.actions.resetWorkflow(logic.values.workflow)
+
+            expect(logic.values.scheduleState.endType).toBe('never')
+            expect(logic.values.hasUnsavedChanges).toBe(false)
+            expect(logic.values.pendingSchedule).toBe(false)
+        })
+
+        it('scenario 4: toggle repeat off produces one-time rrule', async () => {
+            logic.actions.setSchedules([makeSchedule()])
+            logic.actions.setScheduleRepeating(false)
+
+            const pending = logic.values.pendingSchedule
+            expect(pending).not.toBe(false)
+            expect((pending as any).rrule).toBe(ONE_TIME_RRULE)
+            expect((pending as any).starts_at).toBe(STARTS_AT)
+        })
+
+        it('scenario 5: clearing date on existing schedule produces null (delete)', async () => {
+            logic.actions.setSchedules([makeSchedule()])
+            logic.actions.setScheduleStartsAt(null)
+
+            expect(logic.values.pendingSchedule).toBeNull()
+        })
+
+        it('scenario 6: no false dirty state after loading schedule', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.setSchedules([makeSchedule()])
+            }).toMatchValues({
+                hasUnsavedChanges: false,
+                pendingSchedule: false,
+            })
+        })
+    })
+
+    describe('resetWorkflow', () => {
+        it('restores schedule state from saved repeating schedule', async () => {
+            logic.actions.setSchedules([makeSchedule()])
+            logic.actions.setScheduleTimezone('US/Eastern')
+            logic.actions.setScheduleRepeating(false)
+
+            await expectLogic(logic, () => {
+                logic.actions.resetWorkflow(logic.values.workflow)
+            }).toMatchValues({
+                scheduleTimezone: 'UTC',
+                isScheduleRepeating: true,
+                pendingSchedule: false,
+            })
+        })
+
+        it('restores schedule state from saved one-time schedule', async () => {
+            logic.actions.setSchedules([makeSchedule({ rrule: ONE_TIME_RRULE })])
+            logic.actions.setScheduleRepeating(true)
+
+            await expectLogic(logic, () => {
+                logic.actions.resetWorkflow(logic.values.workflow)
+            }).toMatchValues({
+                isScheduleRepeating: false,
+                scheduleStartsAt: STARTS_AT,
+                pendingSchedule: false,
+            })
+        })
+
+        it('clears schedule state when no saved schedule', async () => {
+            logic.actions.setScheduleStartsAt(STARTS_AT)
+            logic.actions.setScheduleRepeating(true)
+
+            await expectLogic(logic, () => {
+                logic.actions.resetWorkflow(logic.values.workflow)
+            }).toMatchValues({
+                scheduleStartsAt: null,
+                isScheduleRepeating: false,
+                pendingSchedule: false,
+            })
+        })
+    })
+})

--- a/products/workflows/frontend/Workflows/workflowLogic.schedule.test.ts
+++ b/products/workflows/frontend/Workflows/workflowLogic.schedule.test.ts
@@ -178,8 +178,11 @@ describe('workflowLogic schedule reducers', () => {
             logic.actions.setScheduleTimezone('US/Eastern')
             expect(logic.values.hasUnsavedChanges).toBe(true)
 
-            logic.actions.resetWorkflow(logic.values.workflow)
-            expect(logic.values.hasUnsavedChanges).toBe(false)
+            await expectLogic(logic, () => {
+                logic.actions.resetWorkflow(logic.values.workflow)
+            }).toMatchValues({
+                hasUnsavedChanges: false,
+            })
         })
     })
 

--- a/products/workflows/frontend/Workflows/workflowLogic.ts
+++ b/products/workflows/frontend/Workflows/workflowLogic.ts
@@ -9,6 +9,7 @@ import { LemonDialog } from '@posthog/lemon-ui'
 import api from 'lib/api'
 import { CyclotronJobInputsValidation } from 'lib/components/CyclotronJob/CyclotronJobInputsValidation'
 import { SetupTaskId, globalSetupLogic } from 'lib/components/ProductSetup'
+import { dayjs } from 'lib/dayjs'
 import { lemonToast } from 'lib/lemon-ui/LemonToast'
 import { publicWebhooksHostOrigin } from 'lib/utils/apiHost'
 import { LiquidRenderer } from 'lib/utils/liquid'
@@ -21,6 +22,14 @@ import { userLogic } from 'scenes/userLogic'
 import { HogFunctionTemplateType } from '~/types'
 
 import { getRegisteredTriggerTypes } from './hogflows/registry/triggers/triggerTypeRegistry'
+import {
+    DEFAULT_STATE,
+    isOneTimeSchedule,
+    ONE_TIME_RRULE,
+    parseRRuleToState,
+    stateToRRule,
+} from './hogflows/steps/components/rrule-helpers'
+import type { ScheduleState } from './hogflows/steps/components/rrule-helpers'
 import { HogFlowActionSchema, isFunctionAction, isTriggerFunction } from './hogflows/steps/types'
 import {
     type HogFlow,
@@ -140,9 +149,10 @@ export const workflowLogic = kea<workflowLogicType>([
         setWorkflowActionEdges: (actionId: string, edges: HogFlow['edges']) => ({ actionId, edges }),
         // NOTE: This is a wrapper for setWorkflowValues, to get around some weird typegen issues
         setWorkflowInfo: (workflow: Partial<HogFlow>) => ({ workflow }),
-        setPendingSchedule: (schedule: { rrule: string; starts_at: string; timezone?: string } | null) => ({
-            schedule,
-        }),
+        setScheduleState: (scheduleState: ScheduleState) => ({ scheduleState }),
+        setScheduleStartsAt: (startsAt: string | null) => ({ startsAt }),
+        setScheduleTimezone: (timezone: string) => ({ timezone }),
+        setScheduleRepeating: (repeating: boolean) => ({ repeating }),
         setSchedules: (schedules: HogFlowSchedule[]) => ({ schedules }),
         saveWorkflowPartial: (workflow: Partial<HogFlow>) => ({ workflow }),
         triggerManualWorkflow: (variables: Record<string, any>, scheduledAt?: string | null) => ({
@@ -270,18 +280,82 @@ export const workflowLogic = kea<workflowLogicType>([
                 setSchedules: (_, { schedules }) => schedules,
             },
         ],
-        pendingSchedule: [
-            false as { rrule: string; starts_at: string; timezone?: string } | null | false,
+        scheduleState: [
+            { ...DEFAULT_STATE } as ScheduleState,
             {
-                setPendingSchedule: (_, { schedule }) => schedule,
-                setSchedules: () => false,
-                resetWorkflow: () => false,
+                setScheduleState: (_, { scheduleState }) => scheduleState,
+                setSchedules: (_, { schedules }) => {
+                    const schedule = schedules[0]
+                    if (schedule && !isOneTimeSchedule(schedule.rrule)) {
+                        return parseRRuleToState(schedule.rrule)
+                    }
+                    return { ...DEFAULT_STATE }
+                },
+            },
+        ],
+        scheduleStartsAt: [
+            null as string | null,
+            {
+                setScheduleStartsAt: (_, { startsAt }) => startsAt,
+                setSchedules: (_, { schedules }) => schedules[0]?.starts_at ?? null,
+            },
+        ],
+        scheduleTimezone: [
+            dayjs.tz.guess() as string,
+            {
+                setScheduleTimezone: (_, { timezone }) => timezone,
+                setSchedules: (_, { schedules }) => schedules[0]?.timezone ?? dayjs.tz.guess(),
+            },
+        ],
+        isScheduleRepeating: [
+            false as boolean,
+            {
+                setScheduleRepeating: (_, { repeating }) => repeating,
+                setSchedules: (_, { schedules }) => {
+                    const schedule = schedules[0]
+                    return !!schedule && !isOneTimeSchedule(schedule.rrule)
+                },
             },
         ],
     }),
     selectors({
         logicProps: [() => [(_, props: WorkflowLogicProps) => props], (props): WorkflowLogicProps => props],
         currentSchedule: [(s) => [s.schedules], (schedules): HogFlowSchedule | null => schedules[0] ?? null],
+        pendingSchedule: [
+            (s) => [s.currentSchedule, s.scheduleState, s.scheduleStartsAt, s.scheduleTimezone, s.isScheduleRepeating],
+            (
+                currentSchedule,
+                scheduleState,
+                scheduleStartsAt,
+                scheduleTimezone,
+                isScheduleRepeating
+            ): { rrule: string; starts_at: string; timezone?: string } | null | false => {
+                // Build what the schedule would look like from current reducer state
+                if (!scheduleStartsAt) {
+                    // No start date set - if there was a saved schedule, this means delete it
+                    return currentSchedule ? null : false
+                }
+
+                const rrule = isScheduleRepeating ? stateToRRule(scheduleState, scheduleStartsAt) : ONE_TIME_RRULE
+                const newSchedule = { rrule, starts_at: scheduleStartsAt, timezone: scheduleTimezone }
+
+                // Compare with saved schedule to detect changes
+                if (!currentSchedule) {
+                    // No saved schedule exists, so any non-null value is a pending change
+                    return newSchedule
+                }
+
+                const savedRRule = currentSchedule.rrule
+                const savedStartsAt = currentSchedule.starts_at
+                const savedTimezone = currentSchedule.timezone ?? dayjs.tz.guess()
+
+                if (rrule === savedRRule && scheduleStartsAt === savedStartsAt && scheduleTimezone === savedTimezone) {
+                    return false // No changes
+                }
+
+                return newSchedule
+            },
+        ],
         hasUnsavedChanges: [
             (s) => [s.workflowChanged, s.pendingSchedule],
             (formChanged, pendingSchedule): boolean => formChanged || pendingSchedule !== false,
@@ -455,6 +529,10 @@ export const workflowLogic = kea<workflowLogicType>([
         ],
     }),
     listeners(({ actions, values, props }) => ({
+        resetWorkflow: () => {
+            // Re-initialize all schedule reducers atomically from the saved schedule.
+            actions.setSchedules(values.schedules)
+        },
         saveWorkflowPartial: async ({ workflow }) => {
             const merged = { ...values.workflow, ...workflow }
             if (merged.status === 'active' && values.workflowHasActionErrors) {


### PR DESCRIPTION
## Problem

The `RecurringSchedulePicker` component stores all schedule state (frequency, weekdays, start date, timezone, repeating flag) in React `useState` hooks. This causes two issues:

1. **"Clear changes" doesn't fully reset the picker** - since the state lives in the component, the only way to reset it is by remounting via a React `key` prop. This caused a bug where the first user interaction (e.g. clicking "On date") would remount the component because `pendingSchedule` changed from `false` to an object, and the rrule roundtrip would lose state that hasn't been persisted yet (like `endType: 'on_date'` with no end date set).

2. **Schedule state is harder to test** - being in React `useState`, the schedule logic (dirty detection, rrule generation, reset behavior) can't be unit tested without rendering the component. This is even more relevant for adding the timezone picking support.

## Changes

- **Lifted schedule state into `workflowLogic`**: Replaced `useState` hooks with 4 kea reducers (`scheduleState`, `scheduleStartsAt`, `scheduleTimezone`, `isScheduleRepeating`). Each reducer initializes from the saved schedule via `setSchedules` and resets atomically via `resetWorkflow`.
- **`pendingSchedule` is now a derived selector**: Instead of being a manually-tracked reducer, it computes the rrule from current state and compares with the saved schedule. Returns `false` (no changes), `null` (delete schedule), or the pending schedule config.
- **`RecurringSchedulePicker` is now stateless**: Reads from and dispatches to `workflowLogic`. No more `key`-based remounting.
- **`BatchScheduleSection` simplified**: Just renders `<RecurringSchedulePicker />` with no props.

## How did you test this code?

Unit tests covering reducer initialization, `pendingSchedule` dirty detection, parameterized `hasUnsavedChanges` scenarios, `resetWorkflow` behavior, and end-to-end scenarios matching manual test cases (create from scratch, edit existing, clear changes, toggle repeat off, delete by clearing date, no false dirty state on load).

## Publish to changelog?

No (behind feature flag)