### PR TITLE
feat(logs): fix service filter jank with virtualisation

### DIFF
--- a/products/logs/frontend/components/LogsViewer/Filters/ServiceFilter.tsx
+++ b/products/logs/frontend/components/LogsViewer/Filters/ServiceFilter.tsx
@@ -1,4 +1,6 @@
 import { BindLogic, useActions, useValues } from 'kea'
+import { CSSProperties, useCallback, useMemo } from 'react'
+import { List } from 'react-window'
 
 import { IconChevronDown } from '@posthog/icons'
 import { LemonButton, LemonCheckbox, LemonDropdown, LemonInput, LemonTag } from '@posthog/lemon-ui'
@@ -7,26 +9,42 @@ import { DateRange, LogsQuery } from '~/queries/schema/schema-general'
 
 import { serviceFilterLogic, ServiceFilterLogicProps } from './serviceFilterLogic'
 
-function ServiceOption({
-    name,
-    checked,
-    onClick,
+const SERVICE_OPTION_HEIGHT = 33
+const MAX_DROPDOWN_HEIGHT = 300
+const DROPDOWN_WIDTH = 300
+
+interface ServiceOptionRowProps {
+    serviceNames: string[]
+    selected: string[]
+    onToggle: (name: string) => void
+}
+
+function ServiceOptionRow({
+    index,
+    style,
+    serviceNames: names,
+    selected,
+    onToggle,
 }: {
-    name: string
-    checked: boolean
-    onClick: () => void
-}): JSX.Element {
+    ariaAttributes: Record<string, unknown>
+    index: number
+    style: CSSProperties
+} & ServiceOptionRowProps): JSX.Element {
+    const name = names[index]
+    const isSelected = selected.includes(name)
     return (
-        <LemonButton
-            type="tertiary"
-            size="small"
-            fullWidth
-            icon={<LemonCheckbox checked={checked} className="pointer-events-none" />}
-            onClick={onClick}
-            data-attr={`logs-service-option-${name}`}
-        >
-            {name}
-        </LemonButton>
+        <div style={style}>
+            <LemonButton
+                type="tertiary"
+                size="small"
+                fullWidth
+                icon={<LemonCheckbox checked={isSelected} className="pointer-events-none" />}
+                onClick={() => onToggle(name)}
+                data-attr={`logs-service-option-${name}`}
+            >
+                {name}
+            </LemonButton>
+        </div>
     )
 }
 
@@ -59,6 +77,25 @@ function ServiceFilterInner({
 
     const selected = value ?? []
 
+    const onToggle = useCallback(
+        (name: string) => {
+            const isSelected = selected.includes(name)
+            const newNames = isSelected ? selected.filter((n) => n !== name) : [...selected, name]
+            onChange(newNames)
+        },
+        [selected, onChange]
+    )
+
+    const rowProps = useMemo<ServiceOptionRowProps>(
+        () => ({ serviceNames, selected, onToggle }),
+        [serviceNames, selected, onToggle]
+    )
+
+    const listHeight = useMemo(() => {
+        const height = serviceNames.length * SERVICE_OPTION_HEIGHT
+        return Math.min(height, MAX_DROPDOWN_HEIGHT)
+    }, [serviceNames.length])
+
     return (
         <LemonDropdown
             closeOnClickInside={false}
@@ -75,7 +112,7 @@ function ServiceFilterInner({
                             autoFocus
                         />
                     </div>
-                    <div className="max-h-[300px] overflow-y-auto">
+                    <div>
                         {allServiceNamesLoading && allServiceNames.length === 0 ? (
                             <div className="p-2 text-muted text-center text-xs">Loading...</div>
                         ) : serviceNames.length === 0 ? (
@@ -104,22 +141,14 @@ function ServiceFilterInner({
                                         <div className="border-b border-border my-1" />
                                     </>
                                 )}
-                                {serviceNames.map((name: string) => {
-                                    const isSelected = selected.includes(name)
-                                    return (
-                                        <ServiceOption
-                                            key={name}
-                                            name={name}
-                                            checked={isSelected}
-                                            onClick={() => {
-                                                const newNames = isSelected
-                                                    ? selected.filter((n) => n !== name)
-                                                    : [...selected, name]
-                                                onChange(newNames)
-                                            }}
-                                        />
-                                    )
-                                })}
+                                <List<ServiceOptionRowProps>
+                                    style={{ width: DROPDOWN_WIDTH, height: listHeight }}
+                                    rowCount={serviceNames.length}
+                                    rowHeight={SERVICE_OPTION_HEIGHT}
+                                    overscanCount={5}
+                                    rowComponent={ServiceOptionRow}
+                                    rowProps={rowProps}
+                                />
                             </>
                         )}
                     </div>


### PR DESCRIPTION
## Problem

The service filter dropdown in the logs viewer can become slow and unresponsive when displaying a large number of services, as all service options are rendered simultaneously in the DOM regardless of visibility.

## Changes

Implemented virtualization for the service filter dropdown using `react-window` to improve performance:

- Replaced the direct mapping of service options with a virtualized `List` component
- Added `ServiceOptionRow` component to handle individual row rendering within the virtualized list
- Introduced constants for consistent sizing: `SERVICE_OPTION_HEIGHT` (33px), `MAX_DROPDOWN_HEIGHT` (300px), and `DROPDOWN_WIDTH` (300px)
- Implemented `onToggle` callback with `useCallback` to optimize re-renders
- Added dynamic height calculation that respects the maximum dropdown height
- Configured the virtualized list with 5 items of overscan for smooth scrolling

## How did you test this code?

Local dev testing & e2e tests

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Publish to changelog?

No