### PR TITLE
fix(admin): Allow querying in read-only impersonation 

### DIFF
--- a/posthog/middleware.py
+++ b/posthog/middleware.py
@@ -953,7 +953,7 @@ READ_ONLY_IMPERSONATION_ALLOWLISTED_PATHS: list[str | re.Pattern] = [
     # These endpoints use POST but are read-only:
     # /query/[A-Z][A-Za-z]* matches query-kind segments, while the schema-upgrade POST action
     # /query/upgrade/ needs an explicit "|upgrade" branch as that starts with a lowercase letter
-    re.compile(r"^/api/(environments|projects)/([0-9]+|@current)/query(?:/(?:[A-Z][A-Za-z]*|upgrade))?/?$"),
+    re.compile(r"^/api/(environments|projects)/([0-9]+|@current)/query(?:/[A-Za-z]+)?/?$"),
     re.compile(r"^/api/(environments|projects)/([0-9]+|@current)/insights/viewed/?$"),
     re.compile(r"^/api/(environments|projects)/([0-9]+|@current)/metalytics/?$"),
     re.compile(r"^/api/(environments|projects)/([0-9]+|@current)/endpoints/[^/]+/run/?$"),

--- a/posthog/middleware.py
+++ b/posthog/middleware.py
@@ -950,8 +950,10 @@ IMPERSONATION_SAFE_METHODS = frozenset({"GET", "HEAD", "OPTIONS", "TRACE"})
 # These should be paths that are safe or necessary for the impersonated session to function.
 # Supports both prefix strings and compiled regex patterns.
 READ_ONLY_IMPERSONATION_ALLOWLISTED_PATHS: list[str | re.Pattern] = [
-    # These endpoints use POST but are read-only
-    re.compile(r"^/api/(environments|projects)/([0-9]+|@current)/query/?$"),
+    # These endpoints use POST but are read-only:
+    # /query/[A-Z][A-Za-z]* matches query-kind segments, while the schema-upgrade POST action
+    # /query/upgrade/ needs an explicit "|upgrade" branch as that starts with a lowercase letter
+    re.compile(r"^/api/(environments|projects)/([0-9]+|@current)/query(?:/(?:[A-Z][A-Za-z]*|upgrade))?/?$"),
     re.compile(r"^/api/(environments|projects)/([0-9]+|@current)/insights/viewed/?$"),
     re.compile(r"^/api/(environments|projects)/([0-9]+|@current)/metalytics/?$"),
     re.compile(r"^/api/(environments|projects)/([0-9]+|@current)/endpoints/[^/]+/run/?$"),

--- a/posthog/test/test_middleware.py
+++ b/posthog/test/test_middleware.py
@@ -780,6 +780,20 @@ class TestImpersonationReadOnlyMiddleware(APIBaseTest):
         # Should not be blocked by impersonation middleware (might get other errors)
         assert response.status_code != 403 or response.json().get("code") != "impersonation_read_only"
 
+    def test_read_only_impersonation_allows_query_kind_endpoint(self):
+        """POST to /query/<kind>/ must be allowlisted (same as /query/), not blocked as non-idempotent."""
+        self.login_as_other_user_read_only()
+
+        assert self.client.get("/api/users/@me").json()["email"] == "other-user@posthog.com"
+
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/query/HogQLQuery/",
+            data={"query": {"kind": "HogQLQuery", "query": "select 1"}},
+            content_type="application/json",
+        )
+
+        assert response.status_code != 403 or response.json().get("code") != "impersonation_read_only"
+
     def test_regular_impersonation_allows_write(self):
         """Verify regular (non-read-only) impersonation can still write."""
         dashboard = Dashboard.objects.create(team=self.team, name="Test Dashboard")


### PR DESCRIPTION
## Problem

Staff read-only impersonation returned 403 `impersonation_read_only` on `POST /api/environments/:id/query/HogQLQuery/` (and similar). The middleware allowlist only matched `/query/`, not `/query/<QueryKind>/` added for the query-kind-in-URL API.

Saw while debugging a customer issue: [Slack](https://posthog.slack.com/archives/C03PB072FMJ/p1775230409610949?thread_ts=1775229897.712559&cid=C03PB072FMJ).

`/query/upgrade/` also needs an explicit branch because `upgrade` is lowercase and does not match the PascalCase query-kind segment.

## Changes

Extending `READ_ONLY_IMPERSONATION_ALLOWLISTED_PATHS` regex for `/query/<QueryKind>/` and `/query/upgrade/`.

## How did you test this code?

Added `test_read_only_impersonation_allows_query_kind_endpoint` in `TestImpersonationReadOnlyMiddleware`.

## Publish to changelog?

no

## Docs update

N/A — internal admin behavior
