### PR TITLE
fix(llma): remove evaluations beta badge

### DIFF
--- a/frontend/src/products.tsx
+++ b/frontend/src/products.tsx
@@ -1341,7 +1341,6 @@ export const getTreeItemsProducts = (): FileSystemImport[] => [
         iconColor: ['var(--color-product-llm-evaluations-light)'] as FileSystemIconColor,
         href: urls.llmAnalyticsEvaluations(),
         flag: FEATURE_FLAGS.LLM_ANALYTICS_EVALUATIONS,
-        tags: ['beta'],
         sceneKey: 'LLMAnalyticsEvaluations',
         sceneKeys: [
             'LLMAnalytics',

--- a/products/llm_analytics/manifest.tsx
+++ b/products/llm_analytics/manifest.tsx
@@ -295,7 +295,6 @@ export const manifest: ProductManifest = {
             iconColor: ['var(--color-product-llm-evaluations-light)'] as FileSystemIconColor,
             href: urls.llmAnalyticsEvaluations(),
             flag: FEATURE_FLAGS.LLM_ANALYTICS_EVALUATIONS,
-            tags: ['beta'],
             sceneKey: 'LLMAnalyticsEvaluations',
         },
         {


### PR DESCRIPTION
## Problem

Evaluations still shows a beta badge in the sidebar even though it should now appear as a regular LLM analytics navigation item.

## Changes

- Remove the Evaluations `beta` tag from the LLM analytics product manifest
- Regenerate the frontend products metadata that powers the sidebar entry

## How did you test this code?

- Automated checks by regenerating the frontend products metadata

## Publish to changelog?

no

## Docs update

No docs update.

## 🤖 LLM context

- Authored with Codex in a dedicated git worktree
- Regenerated the derived frontend products metadata after updating the source manifest