### PR TITLE
feat(cymbal): add cache warming on startup

### DIFF
--- a/rust/common/symbol_data/src/lib.rs
+++ b/rust/common/symbol_data/src/lib.rs
@@ -9,8 +9,10 @@ pub use error::Error as SymbolDataError;
 // The core data type
 pub use symbol_data::read_as as read_symbol_data;
 pub use symbol_data::read_as_with_byte_count as read_symbol_data_with_byte_count;
+pub use symbol_data::sniff_data_type;
 pub use symbol_data::write as write_symbol_data;
 pub use symbol_data::write_uncompressed as write_symbol_data_uncompressed;
+pub use symbol_data::SymbolDataType;
 
 // Javascript
 pub use data_types::sourcemap::SourceAndMap;

--- a/rust/common/symbol_data/src/symbol_data.rs
+++ b/rust/common/symbol_data/src/symbol_data.rs
@@ -14,6 +14,31 @@ pub enum SymbolDataType {
     AppleDsym = 5,
 }
 
+impl TryFrom<u32> for SymbolDataType {
+    type Error = Error;
+
+    fn try_from(value: u32) -> Result<Self, Self::Error> {
+        match value {
+            2 => Ok(SymbolDataType::SourceAndMap),
+            3 => Ok(SymbolDataType::HermesMap),
+            4 => Ok(SymbolDataType::ProguardMapping),
+            5 => Ok(SymbolDataType::AppleDsym),
+            other => Err(Error::InvalidDataType(other, "any".to_string())),
+        }
+    }
+}
+
+/// Reads the type discriminator from a `posthog_symbol_data` byte slice without
+/// performing decompression or deserialization. The type field sits at the same
+/// offset in both v1 and v2 formats (after the magic bytes and version u32).
+pub fn sniff_data_type(data: &[u8]) -> Result<SymbolDataType, Error> {
+    let type_offset = MAGIC.len() + 4;
+    assert_at_least_as_long_as(type_offset + 4, data.len())?;
+    assert_has_magic(data)?;
+    let raw = u32::from_le_bytes(data[type_offset..type_offset + 4].try_into().unwrap());
+    SymbolDataType::try_from(raw)
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
 pub enum Compression {

--- a/rust/cymbal/src/app_context.rs
+++ b/rust/cymbal/src/app_context.rs
@@ -9,7 +9,8 @@ use health::{HealthHandle, HealthRegistry};
 use limiters::redis::{QuotaResource, RedisLimiter, ServiceName, QUOTA_LIMITER_CACHE_KEY};
 use rdkafka::producer::FutureProducer;
 use sqlx::{postgres::PgPoolOptions, PgPool};
-use std::{sync::Arc, time::Duration};
+use std::sync::{atomic::AtomicBool, Arc};
+use std::time::Duration;
 use tokio::sync::Mutex;
 use tracing::info;
 use uuid::Uuid;
@@ -58,6 +59,10 @@ pub struct AppContext {
     pub filtered_teams: Vec<i32>,
     pub filter_mode: FilterMode,
     pub signal_client: MaybeSignalClient,
+
+    pub ss_cache: Arc<Mutex<SymbolSetCache>>,
+    pub s3_client: Arc<dyn BlobClient>,
+    pub cache_warmed: Arc<AtomicBool>,
 }
 
 impl AppContext {
@@ -111,7 +116,7 @@ impl AppContext {
 
         AppContext::new(
             config,
-            s3_client,
+            s3_client.clone(),
             posthog_pool,
             persons_pool,
             redis_client,
@@ -262,6 +267,8 @@ impl AppContext {
             posthog_pool.clone(),
         ));
 
+        let cache_warmed = Arc::new(AtomicBool::new(!config.cache_warming_enabled));
+
         Ok(Self {
             health_registry,
             worker_liveness,
@@ -280,6 +287,9 @@ impl AppContext {
             filter_mode,
             signal_client,
             symbol_resolver,
+            ss_cache,
+            s3_client,
+            cache_warmed,
         })
     }
 }

--- a/rust/cymbal/src/config.rs
+++ b/rust/cymbal/src/config.rs
@@ -190,7 +190,7 @@ pub struct Config {
     #[envconfig(default = "1")]
     pub cache_warming_lookback_hours: u64,
 
-    #[envconfig(default = "5000")]
+    #[envconfig(default = "1000")]
     pub cache_warming_max_entries: usize,
 
     #[envconfig(default = "32")]
@@ -198,6 +198,16 @@ pub struct Config {
 
     #[envconfig(default = "180")]
     pub cache_warming_timeout_seconds: u64,
+
+    // Peer-aware warming: only warm symbol sets for teams routed to this pod.
+    // Set to the headless K8s Service hostname to enable (e.g. "cymbal-headless.posthog.svc.cluster.local").
+    #[envconfig(default = "")]
+    pub cache_warming_peer_hostname: String,
+
+    // This pod's IP address, set via K8s Downward API (fieldRef: status.podIP).
+    // Required for peer-aware warming to identify this pod in the DNS result.
+    #[envconfig(from = "POD_IP", default = "")]
+    pub pod_ip: String,
 }
 
 impl Config {

--- a/rust/cymbal/src/config.rs
+++ b/rust/cymbal/src/config.rs
@@ -198,7 +198,6 @@ pub struct Config {
 
     #[envconfig(default = "180")]
     pub cache_warming_timeout_seconds: u64,
-
 }
 
 impl Config {

--- a/rust/cymbal/src/config.rs
+++ b/rust/cymbal/src/config.rs
@@ -190,7 +190,7 @@ pub struct Config {
     #[envconfig(default = "1")]
     pub cache_warming_lookback_hours: u64,
 
-    #[envconfig(default = "1000")]
+    #[envconfig(default = "10000")]
     pub cache_warming_max_entries: usize,
 
     #[envconfig(default = "32")]
@@ -199,15 +199,6 @@ pub struct Config {
     #[envconfig(default = "180")]
     pub cache_warming_timeout_seconds: u64,
 
-    // Peer-aware warming: only warm symbol sets for teams routed to this pod.
-    // Set to the headless K8s Service hostname to enable (e.g. "cymbal-headless.posthog.svc.cluster.local").
-    #[envconfig(default = "")]
-    pub cache_warming_peer_hostname: String,
-
-    // This pod's IP address, set via K8s Downward API (fieldRef: status.podIP).
-    // Required for peer-aware warming to identify this pod in the DNS result.
-    #[envconfig(from = "POD_IP", default = "")]
-    pub pod_ip: String,
 }
 
 impl Config {

--- a/rust/cymbal/src/config.rs
+++ b/rust/cymbal/src/config.rs
@@ -182,6 +182,22 @@ pub struct Config {
 
     #[envconfig(default = "")]
     pub internal_api_secret: String,
+
+    // Cache warming: pre-populate the symbol set cache from DB+S3 on startup
+    #[envconfig(default = "true")]
+    pub cache_warming_enabled: bool,
+
+    #[envconfig(default = "1")]
+    pub cache_warming_lookback_hours: u64,
+
+    #[envconfig(default = "5000")]
+    pub cache_warming_max_entries: usize,
+
+    #[envconfig(default = "32")]
+    pub cache_warming_concurrency: usize,
+
+    #[envconfig(default = "180")]
+    pub cache_warming_timeout_seconds: u64,
 }
 
 impl Config {

--- a/rust/cymbal/src/main.rs
+++ b/rust/cymbal/src/main.rs
@@ -1,6 +1,7 @@
-use std::sync::Arc;
+use std::sync::{atomic::Ordering, Arc};
 
 use cymbal::consumer::start_consumer;
+use cymbal::symbol_store::warming::warm_cache;
 use cymbal::{app_context::AppContext, config::Config, server::start_server};
 use tracing::level_filters::LevelFilter;
 use tracing::{error, info, warn};
@@ -56,8 +57,31 @@ async fn main() {
 
     let context = Arc::new(AppContext::from_config(&config).await.unwrap());
 
+    // Start the HTTP server immediately so liveness probes work during warming.
+    // Readiness will return 503 until warming completes.
+    let server_handle = tokio::spawn(start_server(config.clone(), context.clone()));
+
+    if config.cache_warming_enabled {
+        info!("Starting cache warming\u{2026}");
+        match warm_cache(
+            &context.posthog_pool,
+            &context.s3_client,
+            &config.object_storage_bucket,
+            &context.ss_cache,
+            &config,
+        )
+        .await
+        {
+            Ok(()) => info!("Cache warming complete"),
+            Err(e) => error!("Cache warming failed: {e}, proceeding with cold cache"),
+        }
+    }
+
+    context.cache_warmed.store(true, Ordering::Relaxed);
+    info!("Pod is ready to serve traffic");
+
     tokio::join!(
-        start_server(config.clone(), context.clone()),
+        async { server_handle.await.unwrap() },
         start_consumer(&config, context.clone())
     );
 }

--- a/rust/cymbal/src/metric_consts.rs
+++ b/rust/cymbal/src/metric_consts.rs
@@ -115,3 +115,9 @@ pub const FINGERPRINT_GENERATOR_OPERATOR: &str = "cymbal_exception_fingerprint_g
 pub const RULE_SUPPRESSED_EVENTS: &str = "cymbal_rule_suppressed_events";
 pub const SUPPRESSION_RULES_TRIED: &str = "cymbal_suppression_rules_tried";
 pub const SUPPRESSION_RULES_DISABLED: &str = "cymbal_suppression_rules_disabled";
+
+// Cache warming metrics
+pub const CACHE_WARMING_DURATION: &str = "cymbal_cache_warming_duration";
+pub const CACHE_WARMING_ENTRIES_LOADED: &str = "cymbal_cache_warming_entries_loaded";
+pub const CACHE_WARMING_ENTRIES_FAILED: &str = "cymbal_cache_warming_entries_failed";
+pub const CACHE_WARMING_BYTES_LOADED: &str = "cymbal_cache_warming_bytes_loaded";

--- a/rust/cymbal/src/router/mod.rs
+++ b/rust/cymbal/src/router/mod.rs
@@ -8,12 +8,21 @@ pub use event::*;
 use health::HealthStatus;
 use reqwest::StatusCode;
 use std::future::ready;
+use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
 use crate::app_context::AppContext;
 
 async fn index() -> &'static str {
     "error tracking service"
+}
+
+async fn readiness(State(ctx): State<Arc<AppContext>>) -> impl IntoResponse {
+    if ctx.cache_warmed.load(Ordering::Relaxed) {
+        (StatusCode::OK, "ready")
+    } else {
+        (StatusCode::SERVICE_UNAVAILABLE, "warming cache")
+    }
 }
 
 async fn liveness(State(ctx): State<Arc<AppContext>>) -> HealthStatus {
@@ -28,7 +37,7 @@ pub fn get_router(context: Arc<AppContext>) -> Router {
     Router::new()
         .route("/", get(index))
         .route("/process", post(process_events))
-        .route("/_readiness", get(index))
+        .route("/_readiness", get(readiness))
         .route("/_liveness", get(liveness))
         .fallback(not_found)
         .with_state(context.clone())

--- a/rust/cymbal/src/symbol_store/caching.rs
+++ b/rust/cymbal/src/symbol_store/caching.rs
@@ -93,6 +93,10 @@ impl SymbolSetCache {
         }
     }
 
+    pub fn held_bytes(&self) -> usize {
+        self.held_bytes
+    }
+
     pub fn insert<T>(&mut self, key: String, value: Arc<T>, bytes: usize)
     where
         T: Any + Send + Sync,
@@ -167,5 +171,40 @@ pub trait Countable {
 impl Countable for Vec<u8> {
     fn byte_count(&self) -> usize {
         self.len()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn held_bytes_starts_at_zero() {
+        let cache = SymbolSetCache::new(1_000_000);
+        assert_eq!(cache.held_bytes(), 0);
+    }
+
+    #[test]
+    fn held_bytes_tracks_inserts() {
+        let mut cache = SymbolSetCache::new(1_000_000);
+        cache.insert("a".to_string(), Arc::new(vec![0u8; 100]), 100);
+        assert_eq!(cache.held_bytes(), 100);
+        cache.insert("b".to_string(), Arc::new(vec![0u8; 200]), 200);
+        assert_eq!(cache.held_bytes(), 300);
+    }
+
+    #[test]
+    fn held_bytes_decreases_after_eviction() {
+        let mut cache = SymbolSetCache::new(250);
+        cache.insert("a".to_string(), Arc::new(vec![0u8; 100]), 100);
+        cache.insert("b".to_string(), Arc::new(vec![0u8; 100]), 100);
+        assert_eq!(cache.held_bytes(), 200);
+
+        // Pushing past 250 bytes triggers eviction of the oldest entry
+        cache.insert("c".to_string(), Arc::new(vec![0u8; 200]), 200);
+        assert!(cache.held_bytes() <= 250);
+        // "a" should have been evicted (oldest), leaving "b" + "c" = 300,
+        // but 300 > 250 so "b" gets evicted too, leaving just "c" = 200
+        assert_eq!(cache.held_bytes(), 200);
     }
 }

--- a/rust/cymbal/src/symbol_store/mod.rs
+++ b/rust/cymbal/src/symbol_store/mod.rs
@@ -25,6 +25,7 @@ pub mod hermesmap;
 pub mod proguard;
 pub mod saving;
 pub mod sourcemap;
+pub mod warming;
 
 mod s3;
 pub use s3::BlobClient;

--- a/rust/cymbal/src/symbol_store/warming.rs
+++ b/rust/cymbal/src/symbol_store/warming.rs
@@ -87,6 +87,10 @@ where
     };
 
     let mut ips = ips;
+    // Include our own IP so we can find our index even if DNS hasn't
+    // registered us yet (e.g. during a rolling deploy when the pod
+    // isn't ready and the headless service excludes not-ready pods).
+    ips.push(config.pod_ip.clone());
     ips.sort();
     ips.dedup();
 
@@ -95,25 +99,15 @@ where
         return None;
     }
 
-    match ips.iter().position(|ip| ip == &config.pod_ip) {
-        Some(index) => {
-            info!(
-                my_index = index,
-                num_peers = ips.len(),
-                pod_ip = %config.pod_ip,
-                "Resolved peer position for routing-aware warming"
-            );
-            Some((index as u32, ips.len() as u32))
-        }
-        None => {
-            warn!(
-                pod_ip = %config.pod_ip,
-                peers = ?ips,
-                "Pod IP not found in DNS results, warming all candidates"
-            );
-            None
-        }
-    }
+    // Safe to unwrap: we just ensured our IP is in the list above.
+    let index = ips.iter().position(|ip| ip == &config.pod_ip).unwrap();
+    info!(
+        my_index = index,
+        num_peers = ips.len(),
+        pod_ip = %config.pod_ip,
+        "Resolved peer position for routing-aware warming"
+    );
+    Some((index as u32, ips.len() as u32))
 }
 
 /// Queries for distinct team_ids with recent symbol sets, then filters to only those
@@ -558,13 +552,14 @@ mod test {
     }
 
     #[tokio::test]
-    async fn resolve_peer_index_returns_none_when_pod_ip_not_in_results() {
+    async fn resolve_peer_index_adds_own_ip_when_not_in_dns() {
         let config = peer_config("10.0.0.99", "cymbal-headless");
         let result = resolve_peer_index_with(&config, || async {
             Ok(vec!["10.0.0.1".to_string(), "10.0.0.2".to_string()])
         })
         .await;
-        assert!(result.is_none());
+        // Pod IP 10.0.0.99 added to list, sorted: [10.0.0.1, 10.0.0.2, 10.0.0.99] → index 2 of 3
+        assert_eq!(result, Some((2, 3)));
     }
 
     #[tokio::test]

--- a/rust/cymbal/src/symbol_store/warming.rs
+++ b/rust/cymbal/src/symbol_store/warming.rs
@@ -25,6 +25,13 @@ use crate::{
     },
 };
 
+// NOTE: We considered sharded warming where each pod only warms symbol sets
+// for teams routed to it via sticky routing. This doesn't work with Deployments
+// because pod IPs change on every restart, shifting the routing assignments.
+// The only viable path to sharded warming is StatefulSets (stable ordinals).
+// For now, every pod warms the same top-N entries globally, which provides
+// broad cache coverage regardless of routing assignment.
+
 struct WarmingParsers {
     smp: SourcemapProvider,
     hmp: HermesMapProvider,
@@ -35,146 +42,15 @@ struct WarmingParsers {
 /// Leave 15% headroom in the cache for incoming traffic after the consumer starts.
 const WARMING_FILL_FRACTION: f64 = 0.85;
 
-/// Jump consistent hash — maps a key to one of `num_buckets` slots with minimal
-/// reassignment when the bucket count changes. Uses a 31-bit linear congruential
-/// generator, matching the TypeScript implementation in the Node ingestion pipeline's
-/// CymbalClient. Both must produce identical results for sticky routing to work.
-fn jump_consistent_hash(key: u32, num_buckets: u32) -> u32 {
-    let mut b: i64 = -1;
-    let mut j: i64 = 0;
-    let mut seed = key;
-    while j < num_buckets as i64 {
-        b = j;
-        seed = seed.wrapping_mul(1103515245).wrapping_add(12345) & 0x7FFF_FFFF;
-        j = (((b + 1) as f64 * 2_147_483_648.0) / (seed as f64 + 1.0)).floor() as i64;
-    }
-    b as u32
-}
-
-/// Resolves the headless service hostname and finds this pod's index in the
-/// sorted peer list. Returns `(my_index, num_peers)` or None if peer-aware
-/// warming isn't configured or DNS resolution fails.
-async fn resolve_peer_index(config: &Config) -> Option<(u32, u32)> {
-    let hostname = config.cache_warming_peer_hostname.clone();
-    resolve_peer_index_with(config, move || async move {
-        let addrs = tokio::net::lookup_host(format!("{hostname}:0")).await?;
-        Ok(addrs.map(|a| a.ip().to_string()).collect())
-    })
-    .await
-}
-
-/// Resolves peer index using an injectable DNS resolver. The resolver returns
-/// a list of IP strings for the configured peer hostname — injectable for testing.
-async fn resolve_peer_index_with<F, Fut>(config: &Config, dns_resolve: F) -> Option<(u32, u32)>
-where
-    F: FnOnce() -> Fut,
-    Fut: std::future::Future<Output = std::io::Result<Vec<String>>>,
-{
-    if config.cache_warming_peer_hostname.is_empty() || config.pod_ip.is_empty() {
-        return None;
-    }
-
-    let ips = match dns_resolve().await {
-        Ok(ips) => ips,
-        Err(e) => {
-            warn!(
-                hostname = %config.cache_warming_peer_hostname,
-                error = %e,
-                "Failed to resolve peer hostname, warming all candidates"
-            );
-            return None;
-        }
-    };
-
-    let mut ips = ips;
-    // Include our own IP so we can find our index even if DNS hasn't
-    // registered us yet (e.g. during a rolling deploy when the pod
-    // isn't ready and the headless service excludes not-ready pods).
-    ips.push(config.pod_ip.clone());
-    ips.sort();
-    ips.dedup();
-
-    if ips.len() <= 1 {
-        info!("Single peer detected, warming all candidates");
-        return None;
-    }
-
-    // Safe to unwrap: we just ensured our IP is in the list above.
-    let index = ips.iter().position(|ip| ip == &config.pod_ip).unwrap();
-    info!(
-        my_index = index,
-        num_peers = ips.len(),
-        pod_ip = %config.pod_ip,
-        "Resolved peer position for routing-aware warming"
-    );
-    Some((index as u32, ips.len() as u32))
-}
-
-/// Queries for distinct team_ids with recent symbol sets, then filters to only those
-/// assigned to this pod via jump consistent hash. Returns None if peer-aware warming
-/// is disabled, meaning the caller should fetch all records without a team filter.
-async fn resolve_team_filter(
-    pool: &PgPool,
-    config: &Config,
-    lookback_hours: i64,
-) -> Result<Option<Vec<i32>>, UnhandledError> {
-    let (my_index, num_peers) = match resolve_peer_index(config).await {
-        Some(peer_info) => peer_info,
-        None => return Ok(None),
-    };
-
-    let all_team_ids: Vec<(i32,)> = sqlx::query_as(
-        r#"SELECT DISTINCT team_id
-        FROM posthog_errortrackingsymbolset
-        WHERE content_hash IS NOT NULL
-          AND storage_ptr IS NOT NULL
-          AND last_used > NOW() - make_interval(hours => $1::integer)"#,
-    )
-    .bind(lookback_hours)
-    .fetch_all(pool)
-    .await?;
-
-    let filtered: Vec<i32> = all_team_ids
-        .into_iter()
-        .map(|(tid,)| tid)
-        .filter(|&tid| jump_consistent_hash(tid as u32, num_peers) == my_index)
-        .collect();
-
-    info!(
-        my_index,
-        num_peers,
-        total_teams = filtered.len(),
-        "Resolved team filter for routing-aware warming"
-    );
-
-    Ok(Some(filtered))
-}
-
-/// Pre-populates the symbol set cache from DB + S3 on startup. Resolves peer
-/// awareness via DNS, then delegates to `warm_cache_with_filter`.
+/// Pre-populates the symbol set cache from DB + S3 on startup. Fetches the most
+/// recently used symbol sets across all teams and parses them into the cache.
+/// Stops early once the cache reaches 85% of its byte capacity.
 pub async fn warm_cache(
     pool: &PgPool,
     s3_client: &Arc<dyn BlobClient>,
     bucket: &str,
     ss_cache: &Arc<Mutex<SymbolSetCache>>,
     config: &Config,
-) -> Result<(), UnhandledError> {
-    let lookback_hours = config.cache_warming_lookback_hours as i64;
-    let team_filter = resolve_team_filter(pool, config, lookback_hours).await?;
-    warm_cache_with_filter(pool, s3_client, bucket, ss_cache, config, team_filter).await
-}
-
-/// Core warming logic. Queries for recently-used symbol sets (optionally filtered
-/// to specific team_ids), fetches their raw data from S3, parses them, and inserts
-/// the results into the shared cache. Stops early once the cache reaches 85% of
-/// its byte capacity.
-async fn warm_cache_with_filter(
-    pool: &PgPool,
-    s3_client: &Arc<dyn BlobClient>,
-    bucket: &str,
-    ss_cache: &Arc<Mutex<SymbolSetCache>>,
-    config: &Config,
-    team_filter: Option<Vec<i32>>,
 ) -> Result<(), UnhandledError> {
     let start = Instant::now();
 
@@ -186,13 +62,11 @@ async fn warm_cache_with_filter(
         WHERE content_hash IS NOT NULL
           AND storage_ptr IS NOT NULL
           AND last_used > NOW() - make_interval(hours => $1::integer)
-          AND ($3::int[] IS NULL OR team_id = ANY($3))
         ORDER BY last_used DESC
         LIMIT $2"#,
     )
     .bind(lookback_hours)
     .bind(config.cache_warming_max_entries as i64)
-    .bind(team_filter.as_deref())
     .fetch_all(pool)
     .await?;
 
@@ -448,151 +322,6 @@ mod test {
         }
     }
 
-    #[test]
-    fn jump_consistent_hash_deterministic() {
-        // Same key always maps to the same bucket
-        assert_eq!(jump_consistent_hash(42, 3), jump_consistent_hash(42, 3));
-        assert_eq!(jump_consistent_hash(1, 10), jump_consistent_hash(1, 10));
-    }
-
-    #[test]
-    fn jump_consistent_hash_in_range() {
-        for key in 0..1000 {
-            for buckets in 1..20 {
-                let result = jump_consistent_hash(key, buckets);
-                assert!(
-                    result < buckets,
-                    "key={key}, buckets={buckets}, result={result}"
-                );
-            }
-        }
-    }
-
-    #[test]
-    fn jump_consistent_hash_single_bucket() {
-        // With one bucket, everything maps to bucket 0
-        for key in 0..100 {
-            assert_eq!(jump_consistent_hash(key, 1), 0);
-        }
-    }
-
-    #[test]
-    fn jump_consistent_hash_matches_typescript() {
-        // These expected values were computed by running the TypeScript
-        // jumpConsistentHash implementation from the Node ingestion pipeline.
-        // If these fail, the Rust and TypeScript implementations have diverged
-        // and sticky routing will misroute traffic.
-        assert_eq!(jump_consistent_hash(1, 3), 1);
-        assert_eq!(jump_consistent_hash(2, 3), 0);
-        assert_eq!(jump_consistent_hash(3, 3), 1);
-        assert_eq!(jump_consistent_hash(10, 3), 0);
-        assert_eq!(jump_consistent_hash(100, 3), 2);
-        assert_eq!(jump_consistent_hash(1000, 3), 1);
-        assert_eq!(jump_consistent_hash(1, 5), 1);
-        assert_eq!(jump_consistent_hash(2, 5), 0);
-        assert_eq!(jump_consistent_hash(42, 10), 8);
-        assert_eq!(jump_consistent_hash(12345, 30), 10);
-    }
-
-    #[test]
-    fn jump_consistent_hash_distributes_evenly() {
-        // With 1000 keys across 3 buckets, each should get roughly 1/3
-        let mut counts = [0u32; 3];
-        for key in 1..=1000 {
-            counts[jump_consistent_hash(key, 3) as usize] += 1;
-        }
-        for (i, &count) in counts.iter().enumerate() {
-            assert!(
-                (280..=390).contains(&count),
-                "Bucket {i} has {count} entries, expected ~333"
-            );
-        }
-    }
-
-    fn peer_config(pod_ip: &str, hostname: &str) -> Config {
-        let mut config = Config::init_with_defaults().unwrap();
-        config.pod_ip = pod_ip.to_string();
-        config.cache_warming_peer_hostname = hostname.to_string();
-        config
-    }
-
-    #[tokio::test]
-    async fn resolve_peer_index_returns_none_when_not_configured() {
-        let config = Config::init_with_defaults().unwrap();
-        let result = resolve_peer_index_with(&config, || async { unreachable!() }).await;
-        assert!(result.is_none());
-    }
-
-    #[tokio::test]
-    async fn resolve_peer_index_returns_none_when_pod_ip_empty() {
-        let config = peer_config("", "some-hostname");
-        let result = resolve_peer_index_with(&config, || async { unreachable!() }).await;
-        assert!(result.is_none());
-    }
-
-    #[tokio::test]
-    async fn resolve_peer_index_returns_none_on_dns_failure() {
-        let config = peer_config("10.0.0.1", "bad-hostname");
-        let result = resolve_peer_index_with(&config, || async {
-            Err(std::io::Error::new(
-                std::io::ErrorKind::NotFound,
-                "DNS failed",
-            ))
-        })
-        .await;
-        assert!(result.is_none());
-    }
-
-    #[tokio::test]
-    async fn resolve_peer_index_returns_none_for_single_peer() {
-        let config = peer_config("10.0.0.1", "cymbal-headless");
-        let result =
-            resolve_peer_index_with(&config, || async { Ok(vec!["10.0.0.1".to_string()]) }).await;
-        assert!(result.is_none());
-    }
-
-    #[tokio::test]
-    async fn resolve_peer_index_adds_own_ip_when_not_in_dns() {
-        let config = peer_config("10.0.0.99", "cymbal-headless");
-        let result = resolve_peer_index_with(&config, || async {
-            Ok(vec!["10.0.0.1".to_string(), "10.0.0.2".to_string()])
-        })
-        .await;
-        // Pod IP 10.0.0.99 added to list, sorted: [10.0.0.1, 10.0.0.2, 10.0.0.99] → index 2 of 3
-        assert_eq!(result, Some((2, 3)));
-    }
-
-    #[tokio::test]
-    async fn resolve_peer_index_finds_correct_index() {
-        let config = peer_config("10.0.0.2", "cymbal-headless");
-        let result = resolve_peer_index_with(&config, || async {
-            Ok(vec![
-                "10.0.0.3".to_string(),
-                "10.0.0.1".to_string(),
-                "10.0.0.2".to_string(),
-            ])
-        })
-        .await;
-        // Sorted: [10.0.0.1, 10.0.0.2, 10.0.0.3] → pod 10.0.0.2 is index 1
-        assert_eq!(result, Some((1, 3)));
-    }
-
-    #[tokio::test]
-    async fn resolve_peer_index_deduplicates_ips() {
-        let config = peer_config("10.0.0.1", "cymbal-headless");
-        let result = resolve_peer_index_with(&config, || async {
-            Ok(vec![
-                "10.0.0.2".to_string(),
-                "10.0.0.1".to_string(),
-                "10.0.0.2".to_string(),
-                "10.0.0.1".to_string(),
-            ])
-        })
-        .await;
-        // Deduped + sorted: [10.0.0.1, 10.0.0.2] → index 0 of 2
-        assert_eq!(result, Some((0, 2)));
-    }
-
     #[tokio::test]
     async fn skips_entry_when_over_byte_budget() {
         let parsers = make_parsers();
@@ -784,45 +513,7 @@ mod test {
     }
 
     #[sqlx::test(migrations = "./tests/test_migrations")]
-    async fn warm_cache_with_team_filter_only_warms_matching_teams(db: PgPool) {
-        // Insert records for 3 different teams
-        insert_symbol_set(&db, 1, "team1-a").await;
-        insert_symbol_set(&db, 1, "team1-b").await;
-        insert_symbol_set(&db, 2, "team2-a").await;
-        insert_symbol_set(&db, 3, "team3-a").await;
-
-        // Track which S3 keys are fetched
-        let fetched_keys = Arc::new(std::sync::Mutex::new(Vec::new()));
-        let fetched_keys_clone = fetched_keys.clone();
-        let data = test_symbol_data();
-        let mut s3_client = MockS3Client::new();
-        s3_client.expect_get().returning(move |_, key| {
-            fetched_keys_clone.lock().unwrap().push(key.to_string());
-            Ok(Some(data.clone()))
-        });
-
-        let s3_client: Arc<dyn BlobClient> = Arc::new(s3_client);
-        let cache = Arc::new(Mutex::new(SymbolSetCache::new(100_000_000)));
-
-        let mut config = Config::init_with_defaults().unwrap();
-        config.cache_warming_lookback_hours = 1;
-        config.cache_warming_max_entries = 100;
-        config.cache_warming_concurrency = 1;
-        config.cache_warming_timeout_seconds = 30;
-        config.symbol_store_cache_max_bytes = 100_000_000;
-
-        // Only warm team_id 1 — team 2 and 3 should be excluded
-        warm_cache_with_filter(&db, &s3_client, "bucket", &cache, &config, Some(vec![1]))
-            .await
-            .unwrap();
-
-        let keys = fetched_keys.lock().unwrap();
-        assert_eq!(keys.len(), 2, "Should fetch exactly 2 records for team 1");
-        assert!(keys.iter().all(|k| k.starts_with("symbolsets/team1-")));
-    }
-
-    #[sqlx::test(migrations = "./tests/test_migrations")]
-    async fn warm_cache_without_filter_warms_all_teams(db: PgPool) {
+    async fn warm_cache_warms_all_teams(db: PgPool) {
         insert_symbol_set(&db, 1, "team1-a").await;
         insert_symbol_set(&db, 2, "team2-a").await;
         insert_symbol_set(&db, 3, "team3-a").await;
@@ -843,55 +534,18 @@ mod test {
         config.cache_warming_timeout_seconds = 30;
         config.symbol_store_cache_max_bytes = 100_000_000;
 
-        // No team filter — should warm all 3 records
-        warm_cache_with_filter(&db, &s3_client, "bucket", &cache, &config, None)
+        warm_cache(&db, &s3_client, "bucket", &cache, &config)
             .await
             .unwrap();
 
-        // 3 records means 3 cache entries
-        let cache = cache.lock().await;
-        assert!(cache.held_bytes() > 0);
+        assert!(cache.lock().await.held_bytes() > 0);
     }
 
     #[sqlx::test(migrations = "./tests/test_migrations")]
-    async fn warm_cache_with_empty_filter_warms_nothing(db: PgPool) {
-        insert_symbol_set(&db, 1, "team1-a").await;
-        insert_symbol_set(&db, 2, "team2-a").await;
-
-        // No S3 expectations — empty filter means no records to fetch
-        let s3_client: Arc<dyn BlobClient> = Arc::new(MockS3Client::new());
-        let cache = Arc::new(Mutex::new(SymbolSetCache::new(100_000_000)));
-
-        let mut config = Config::init_with_defaults().unwrap();
-        config.cache_warming_lookback_hours = 1;
-        config.cache_warming_max_entries = 100;
-        config.cache_warming_concurrency = 1;
-        config.cache_warming_timeout_seconds = 30;
-        config.symbol_store_cache_max_bytes = 100_000_000;
-
-        // Empty team filter — no teams assigned to this pod
-        warm_cache_with_filter(&db, &s3_client, "bucket", &cache, &config, Some(vec![]))
-            .await
-            .unwrap();
-
-        assert_eq!(cache.lock().await.held_bytes(), 0);
-    }
-
-    #[sqlx::test(migrations = "./tests/test_migrations")]
-    async fn warm_cache_with_filter_respects_limit(db: PgPool) {
-        // Insert 5 records for team 1
+    async fn warm_cache_respects_max_entries_limit(db: PgPool) {
         for i in 0..5 {
             insert_symbol_set(&db, 1, &format!("team1-{i}")).await;
         }
-
-        let cache = Arc::new(Mutex::new(SymbolSetCache::new(100_000_000)));
-
-        let mut config = Config::init_with_defaults().unwrap();
-        config.cache_warming_lookback_hours = 1;
-        config.cache_warming_max_entries = 3; // Limit to 3
-        config.cache_warming_concurrency = 1;
-        config.cache_warming_timeout_seconds = 30;
-        config.symbol_store_cache_max_bytes = 100_000_000;
 
         let fetched_keys = Arc::new(std::sync::Mutex::new(Vec::new()));
         let fetched_keys_clone = fetched_keys.clone();
@@ -902,16 +556,20 @@ mod test {
             Ok(Some(data.clone()))
         });
         let s3_client: Arc<dyn BlobClient> = Arc::new(s3_client);
+        let cache = Arc::new(Mutex::new(SymbolSetCache::new(100_000_000)));
 
-        warm_cache_with_filter(&db, &s3_client, "bucket", &cache, &config, Some(vec![1]))
+        let mut config = Config::init_with_defaults().unwrap();
+        config.cache_warming_lookback_hours = 1;
+        config.cache_warming_max_entries = 3;
+        config.cache_warming_concurrency = 1;
+        config.cache_warming_timeout_seconds = 30;
+        config.symbol_store_cache_max_bytes = 100_000_000;
+
+        warm_cache(&db, &s3_client, "bucket", &cache, &config)
             .await
             .unwrap();
 
         let keys = fetched_keys.lock().unwrap();
-        assert_eq!(
-            keys.len(),
-            3,
-            "Should respect max_entries limit even with team filter"
-        );
+        assert_eq!(keys.len(), 3, "Should respect max_entries limit");
     }
 }

--- a/rust/cymbal/src/symbol_store/warming.rs
+++ b/rust/cymbal/src/symbol_store/warming.rs
@@ -4,6 +4,7 @@ use std::time::Instant;
 use posthog_symbol_data::{sniff_data_type, SymbolDataType};
 use sqlx::PgPool;
 use tokio::sync::{Mutex, Semaphore};
+use tokio::time::{error::Elapsed, timeout_at, Duration, Instant as TokioInstant};
 use tracing::{info, warn};
 
 use crate::{
@@ -109,12 +110,11 @@ pub async fn warm_cache(
     // Collect results one at a time under a shared deadline. If we exceed the
     // timeout, abort remaining tasks so they don't compete with real traffic
     // after the pod is marked ready.
-    let deadline =
-        tokio::time::Instant::now() + tokio::time::Duration::from_secs(config.cache_warming_timeout_seconds);
+    let deadline = TokioInstant::now() + Duration::from_secs(config.cache_warming_timeout_seconds);
     let mut timed_out = false;
 
     for handle in handles.iter_mut() {
-        match tokio::time::timeout_at(deadline, handle).await {
+        match timeout_at(deadline, handle).await {
             Ok(Ok((_, Ok(Some(bytes))))) => {
                 loaded += 1;
                 bytes_loaded += bytes as u64;
@@ -130,7 +130,7 @@ pub async fn warm_cache(
                 warn!(error = %e, "Warming task panicked");
                 failed += 1;
             }
-            Err(_) => {
+            Err(Elapsed { .. }) => {
                 timed_out = true;
                 break;
             }
@@ -410,5 +410,77 @@ mod test {
             .unwrap();
 
         assert!(cache.lock().await.held_bytes() > 0);
+    }
+
+    /// A BlobClient that sleeps before returning, simulating slow S3 fetches.
+    struct SlowBlobClient {
+        data: Vec<u8>,
+        delay: std::time::Duration,
+    }
+
+    #[async_trait::async_trait]
+    impl BlobClient for SlowBlobClient {
+        async fn get(
+            &self,
+            _bucket: &str,
+            _key: &str,
+        ) -> Result<Option<Vec<u8>>, crate::error::UnhandledError> {
+            tokio::time::sleep(self.delay).await;
+            Ok(Some(self.data.clone()))
+        }
+        async fn put(
+            &self,
+            _bucket: &str,
+            _key: &str,
+            _data: Vec<u8>,
+        ) -> Result<(), crate::error::UnhandledError> {
+            Ok(())
+        }
+        async fn ping_bucket(&self, _bucket: &str) -> Result<(), crate::error::UnhandledError> {
+            Ok(())
+        }
+    }
+
+    #[sqlx::test(migrations = "./tests/test_migrations")]
+    async fn warm_cache_aborts_on_timeout(db: PgPool) {
+        for i in 0..5 {
+            sqlx::query(
+                "INSERT INTO posthog_errortrackingsymbolset \
+                 (id, team_id, ref, storage_ptr, content_hash, last_used, created_at) \
+                 VALUES ($1, $2, $3, $4, $5, NOW(), NOW())",
+            )
+            .bind(Uuid::now_v7())
+            .bind(1i32)
+            .bind(format!("http://example.com/test-{i}.js"))
+            .bind(format!("symbolsets/test-{i}"))
+            .bind("somehash")
+            .execute(&db)
+            .await
+            .unwrap();
+        }
+
+        let s3_client: Arc<dyn BlobClient> = Arc::new(SlowBlobClient {
+            data: test_symbol_data(),
+            delay: std::time::Duration::from_secs(5),
+        });
+        let cache = Arc::new(Mutex::new(SymbolSetCache::new(100_000_000)));
+
+        let mut config = Config::init_with_defaults().unwrap();
+        config.cache_warming_lookback_hours = 1;
+        config.cache_warming_max_entries = 100;
+        config.cache_warming_concurrency = 1; // Sequential so the first task blocks
+        config.cache_warming_timeout_seconds = 1;
+        config.symbol_store_cache_max_bytes = 100_000_000;
+
+        let before = Instant::now();
+        warm_cache(&db, &s3_client, "bucket", &cache, &config)
+            .await
+            .unwrap();
+        let elapsed = before.elapsed();
+
+        // Should return after ~1s (the timeout), not ~25s (5 entries * 5s each)
+        assert!(elapsed.as_secs() < 3);
+        // No entries should have loaded since every S3 fetch takes 5s but the timeout is 1s
+        assert_eq!(cache.lock().await.held_bytes(), 0);
     }
 }

--- a/rust/cymbal/src/symbol_store/warming.rs
+++ b/rust/cymbal/src/symbol_store/warming.rs
@@ -35,10 +35,129 @@ struct WarmingParsers {
 /// Leave 15% headroom in the cache for incoming traffic after the consumer starts.
 const WARMING_FILL_FRACTION: f64 = 0.85;
 
-/// Pre-populates the symbol set cache from DB + S3 on startup. Queries for recently-used
-/// symbol sets, fetches their raw data from S3, parses them using the type discriminator
-/// in the `posthog_symbol_data` binary format, and inserts the results into the shared cache.
-/// Stops early once the cache reaches 85% of its byte capacity.
+/// Jump consistent hash — maps a key to one of `num_buckets` slots with minimal
+/// reassignment when the bucket count changes. Uses a 31-bit linear congruential
+/// generator, matching the TypeScript implementation in the Node ingestion pipeline's
+/// CymbalClient. Both must produce identical results for sticky routing to work.
+fn jump_consistent_hash(key: u32, num_buckets: u32) -> u32 {
+    let mut b: i64 = -1;
+    let mut j: i64 = 0;
+    let mut seed = key;
+    while j < num_buckets as i64 {
+        b = j;
+        seed = seed.wrapping_mul(1103515245).wrapping_add(12345) & 0x7FFF_FFFF;
+        j = (((b + 1) as f64 * 2_147_483_648.0) / (seed as f64 + 1.0)).floor() as i64;
+    }
+    b as u32
+}
+
+/// Resolves the headless service hostname and finds this pod's index in the
+/// sorted peer list. Returns `(my_index, num_peers)` or None if peer-aware
+/// warming isn't configured or DNS resolution fails.
+async fn resolve_peer_index(config: &Config) -> Option<(u32, u32)> {
+    let hostname = config.cache_warming_peer_hostname.clone();
+    resolve_peer_index_with(config, move || async move {
+        let addrs = tokio::net::lookup_host(format!("{hostname}:0")).await?;
+        Ok(addrs.map(|a| a.ip().to_string()).collect())
+    })
+    .await
+}
+
+/// Resolves peer index using an injectable DNS resolver. The resolver returns
+/// a list of IP strings for the configured peer hostname — injectable for testing.
+async fn resolve_peer_index_with<F, Fut>(config: &Config, dns_resolve: F) -> Option<(u32, u32)>
+where
+    F: FnOnce() -> Fut,
+    Fut: std::future::Future<Output = std::io::Result<Vec<String>>>,
+{
+    if config.cache_warming_peer_hostname.is_empty() || config.pod_ip.is_empty() {
+        return None;
+    }
+
+    let ips = match dns_resolve().await {
+        Ok(ips) => ips,
+        Err(e) => {
+            warn!(
+                hostname = %config.cache_warming_peer_hostname,
+                error = %e,
+                "Failed to resolve peer hostname, warming all candidates"
+            );
+            return None;
+        }
+    };
+
+    let mut ips = ips;
+    ips.sort();
+    ips.dedup();
+
+    if ips.len() <= 1 {
+        info!("Single peer detected, warming all candidates");
+        return None;
+    }
+
+    match ips.iter().position(|ip| ip == &config.pod_ip) {
+        Some(index) => {
+            info!(
+                my_index = index,
+                num_peers = ips.len(),
+                pod_ip = %config.pod_ip,
+                "Resolved peer position for routing-aware warming"
+            );
+            Some((index as u32, ips.len() as u32))
+        }
+        None => {
+            warn!(
+                pod_ip = %config.pod_ip,
+                peers = ?ips,
+                "Pod IP not found in DNS results, warming all candidates"
+            );
+            None
+        }
+    }
+}
+
+/// Queries for distinct team_ids with recent symbol sets, then filters to only those
+/// assigned to this pod via jump consistent hash. Returns None if peer-aware warming
+/// is disabled, meaning the caller should fetch all records without a team filter.
+async fn resolve_team_filter(
+    pool: &PgPool,
+    config: &Config,
+    lookback_hours: i64,
+) -> Result<Option<Vec<i32>>, UnhandledError> {
+    let (my_index, num_peers) = match resolve_peer_index(config).await {
+        Some(peer_info) => peer_info,
+        None => return Ok(None),
+    };
+
+    let all_team_ids: Vec<(i32,)> = sqlx::query_as(
+        r#"SELECT DISTINCT team_id
+        FROM posthog_errortrackingsymbolset
+        WHERE content_hash IS NOT NULL
+          AND storage_ptr IS NOT NULL
+          AND last_used > NOW() - make_interval(hours => $1::integer)"#,
+    )
+    .bind(lookback_hours)
+    .fetch_all(pool)
+    .await?;
+
+    let filtered: Vec<i32> = all_team_ids
+        .into_iter()
+        .map(|(tid,)| tid)
+        .filter(|&tid| jump_consistent_hash(tid as u32, num_peers) == my_index)
+        .collect();
+
+    info!(
+        my_index,
+        num_peers,
+        total_teams = filtered.len(),
+        "Resolved team filter for routing-aware warming"
+    );
+
+    Ok(Some(filtered))
+}
+
+/// Pre-populates the symbol set cache from DB + S3 on startup. Resolves peer
+/// awareness via DNS, then delegates to `warm_cache_with_filter`.
 pub async fn warm_cache(
     pool: &PgPool,
     s3_client: &Arc<dyn BlobClient>,
@@ -46,20 +165,40 @@ pub async fn warm_cache(
     ss_cache: &Arc<Mutex<SymbolSetCache>>,
     config: &Config,
 ) -> Result<(), UnhandledError> {
+    let lookback_hours = config.cache_warming_lookback_hours as i64;
+    let team_filter = resolve_team_filter(pool, config, lookback_hours).await?;
+    warm_cache_with_filter(pool, s3_client, bucket, ss_cache, config, team_filter).await
+}
+
+/// Core warming logic. Queries for recently-used symbol sets (optionally filtered
+/// to specific team_ids), fetches their raw data from S3, parses them, and inserts
+/// the results into the shared cache. Stops early once the cache reaches 85% of
+/// its byte capacity.
+async fn warm_cache_with_filter(
+    pool: &PgPool,
+    s3_client: &Arc<dyn BlobClient>,
+    bucket: &str,
+    ss_cache: &Arc<Mutex<SymbolSetCache>>,
+    config: &Config,
+    team_filter: Option<Vec<i32>>,
+) -> Result<(), UnhandledError> {
     let start = Instant::now();
 
     let lookback_hours = config.cache_warming_lookback_hours as i64;
+
     let records: Vec<SymbolSetRecord> = sqlx::query_as::<_, SymbolSetRecord>(
         r#"SELECT id, team_id, ref AS set_ref, storage_ptr, failure_reason, created_at, content_hash, last_used
         FROM posthog_errortrackingsymbolset
         WHERE content_hash IS NOT NULL
           AND storage_ptr IS NOT NULL
           AND last_used > NOW() - make_interval(hours => $1::integer)
+          AND ($3::int[] IS NULL OR team_id = ANY($3))
         ORDER BY last_used DESC
         LIMIT $2"#,
     )
     .bind(lookback_hours)
     .bind(config.cache_warming_max_entries as i64)
+    .bind(team_filter.as_deref())
     .fetch_all(pool)
     .await?;
 
@@ -273,9 +412,13 @@ mod test {
     }
 
     fn make_record(key: &str) -> SymbolSetRecord {
+        make_record_for_team(1, key)
+    }
+
+    fn make_record_for_team(team_id: i32, key: &str) -> SymbolSetRecord {
         SymbolSetRecord {
             id: Uuid::now_v7(),
-            team_id: 1,
+            team_id,
             set_ref: format!("http://example.com/{key}"),
             storage_ptr: Some(key.to_string()),
             failure_reason: None,
@@ -283,6 +426,22 @@ mod test {
             content_hash: Some("abc123".to_string()),
             last_used: Some(Utc::now()),
         }
+    }
+
+    async fn insert_symbol_set(db: &PgPool, team_id: i32, key: &str) {
+        sqlx::query(
+            "INSERT INTO posthog_errortrackingsymbolset \
+             (id, team_id, ref, storage_ptr, content_hash, last_used, created_at) \
+             VALUES ($1, $2, $3, $4, $5, NOW(), NOW())",
+        )
+        .bind(Uuid::now_v7())
+        .bind(team_id)
+        .bind(format!("http://example.com/{key}"))
+        .bind(format!("symbolsets/{key}"))
+        .bind("somehash")
+        .execute(db)
+        .await
+        .unwrap();
     }
 
     fn make_parsers() -> WarmingParsers {
@@ -293,6 +452,150 @@ mod test {
             pgp: ProguardProvider {},
             apple: AppleProvider {},
         }
+    }
+
+    #[test]
+    fn jump_consistent_hash_deterministic() {
+        // Same key always maps to the same bucket
+        assert_eq!(jump_consistent_hash(42, 3), jump_consistent_hash(42, 3));
+        assert_eq!(jump_consistent_hash(1, 10), jump_consistent_hash(1, 10));
+    }
+
+    #[test]
+    fn jump_consistent_hash_in_range() {
+        for key in 0..1000 {
+            for buckets in 1..20 {
+                let result = jump_consistent_hash(key, buckets);
+                assert!(
+                    result < buckets,
+                    "key={key}, buckets={buckets}, result={result}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn jump_consistent_hash_single_bucket() {
+        // With one bucket, everything maps to bucket 0
+        for key in 0..100 {
+            assert_eq!(jump_consistent_hash(key, 1), 0);
+        }
+    }
+
+    #[test]
+    fn jump_consistent_hash_matches_typescript() {
+        // These expected values were computed by running the TypeScript
+        // jumpConsistentHash implementation from the Node ingestion pipeline.
+        // If these fail, the Rust and TypeScript implementations have diverged
+        // and sticky routing will misroute traffic.
+        assert_eq!(jump_consistent_hash(1, 3), 1);
+        assert_eq!(jump_consistent_hash(2, 3), 0);
+        assert_eq!(jump_consistent_hash(3, 3), 1);
+        assert_eq!(jump_consistent_hash(10, 3), 0);
+        assert_eq!(jump_consistent_hash(100, 3), 2);
+        assert_eq!(jump_consistent_hash(1000, 3), 1);
+        assert_eq!(jump_consistent_hash(1, 5), 1);
+        assert_eq!(jump_consistent_hash(2, 5), 0);
+        assert_eq!(jump_consistent_hash(42, 10), 8);
+        assert_eq!(jump_consistent_hash(12345, 30), 10);
+    }
+
+    #[test]
+    fn jump_consistent_hash_distributes_evenly() {
+        // With 1000 keys across 3 buckets, each should get roughly 1/3
+        let mut counts = [0u32; 3];
+        for key in 1..=1000 {
+            counts[jump_consistent_hash(key, 3) as usize] += 1;
+        }
+        for (i, &count) in counts.iter().enumerate() {
+            assert!(
+                (280..=390).contains(&count),
+                "Bucket {i} has {count} entries, expected ~333"
+            );
+        }
+    }
+
+    fn peer_config(pod_ip: &str, hostname: &str) -> Config {
+        let mut config = Config::init_with_defaults().unwrap();
+        config.pod_ip = pod_ip.to_string();
+        config.cache_warming_peer_hostname = hostname.to_string();
+        config
+    }
+
+    #[tokio::test]
+    async fn resolve_peer_index_returns_none_when_not_configured() {
+        let config = Config::init_with_defaults().unwrap();
+        let result = resolve_peer_index_with(&config, || async { unreachable!() }).await;
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn resolve_peer_index_returns_none_when_pod_ip_empty() {
+        let config = peer_config("", "some-hostname");
+        let result = resolve_peer_index_with(&config, || async { unreachable!() }).await;
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn resolve_peer_index_returns_none_on_dns_failure() {
+        let config = peer_config("10.0.0.1", "bad-hostname");
+        let result = resolve_peer_index_with(&config, || async {
+            Err(std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                "DNS failed",
+            ))
+        })
+        .await;
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn resolve_peer_index_returns_none_for_single_peer() {
+        let config = peer_config("10.0.0.1", "cymbal-headless");
+        let result =
+            resolve_peer_index_with(&config, || async { Ok(vec!["10.0.0.1".to_string()]) }).await;
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn resolve_peer_index_returns_none_when_pod_ip_not_in_results() {
+        let config = peer_config("10.0.0.99", "cymbal-headless");
+        let result = resolve_peer_index_with(&config, || async {
+            Ok(vec!["10.0.0.1".to_string(), "10.0.0.2".to_string()])
+        })
+        .await;
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn resolve_peer_index_finds_correct_index() {
+        let config = peer_config("10.0.0.2", "cymbal-headless");
+        let result = resolve_peer_index_with(&config, || async {
+            Ok(vec![
+                "10.0.0.3".to_string(),
+                "10.0.0.1".to_string(),
+                "10.0.0.2".to_string(),
+            ])
+        })
+        .await;
+        // Sorted: [10.0.0.1, 10.0.0.2, 10.0.0.3] → pod 10.0.0.2 is index 1
+        assert_eq!(result, Some((1, 3)));
+    }
+
+    #[tokio::test]
+    async fn resolve_peer_index_deduplicates_ips() {
+        let config = peer_config("10.0.0.1", "cymbal-headless");
+        let result = resolve_peer_index_with(&config, || async {
+            Ok(vec![
+                "10.0.0.2".to_string(),
+                "10.0.0.1".to_string(),
+                "10.0.0.2".to_string(),
+                "10.0.0.1".to_string(),
+            ])
+        })
+        .await;
+        // Deduped + sorted: [10.0.0.1, 10.0.0.2] → index 0 of 2
+        assert_eq!(result, Some((0, 2)));
     }
 
     #[tokio::test]
@@ -483,5 +786,137 @@ mod test {
         assert!(elapsed.as_secs() < 3);
         // No entries should have loaded since every S3 fetch takes 5s but the timeout is 1s
         assert_eq!(cache.lock().await.held_bytes(), 0);
+    }
+
+    #[sqlx::test(migrations = "./tests/test_migrations")]
+    async fn warm_cache_with_team_filter_only_warms_matching_teams(db: PgPool) {
+        // Insert records for 3 different teams
+        insert_symbol_set(&db, 1, "team1-a").await;
+        insert_symbol_set(&db, 1, "team1-b").await;
+        insert_symbol_set(&db, 2, "team2-a").await;
+        insert_symbol_set(&db, 3, "team3-a").await;
+
+        // Track which S3 keys are fetched
+        let fetched_keys = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let fetched_keys_clone = fetched_keys.clone();
+        let data = test_symbol_data();
+        let mut s3_client = MockS3Client::new();
+        s3_client.expect_get().returning(move |_, key| {
+            fetched_keys_clone.lock().unwrap().push(key.to_string());
+            Ok(Some(data.clone()))
+        });
+
+        let s3_client: Arc<dyn BlobClient> = Arc::new(s3_client);
+        let cache = Arc::new(Mutex::new(SymbolSetCache::new(100_000_000)));
+
+        let mut config = Config::init_with_defaults().unwrap();
+        config.cache_warming_lookback_hours = 1;
+        config.cache_warming_max_entries = 100;
+        config.cache_warming_concurrency = 1;
+        config.cache_warming_timeout_seconds = 30;
+        config.symbol_store_cache_max_bytes = 100_000_000;
+
+        // Only warm team_id 1 — team 2 and 3 should be excluded
+        warm_cache_with_filter(&db, &s3_client, "bucket", &cache, &config, Some(vec![1]))
+            .await
+            .unwrap();
+
+        let keys = fetched_keys.lock().unwrap();
+        assert_eq!(keys.len(), 2, "Should fetch exactly 2 records for team 1");
+        assert!(keys.iter().all(|k| k.starts_with("symbolsets/team1-")));
+    }
+
+    #[sqlx::test(migrations = "./tests/test_migrations")]
+    async fn warm_cache_without_filter_warms_all_teams(db: PgPool) {
+        insert_symbol_set(&db, 1, "team1-a").await;
+        insert_symbol_set(&db, 2, "team2-a").await;
+        insert_symbol_set(&db, 3, "team3-a").await;
+
+        let data = test_symbol_data();
+        let mut s3_client = MockS3Client::new();
+        s3_client
+            .expect_get()
+            .returning(move |_, _| Ok(Some(data.clone())));
+
+        let s3_client: Arc<dyn BlobClient> = Arc::new(s3_client);
+        let cache = Arc::new(Mutex::new(SymbolSetCache::new(100_000_000)));
+
+        let mut config = Config::init_with_defaults().unwrap();
+        config.cache_warming_lookback_hours = 1;
+        config.cache_warming_max_entries = 100;
+        config.cache_warming_concurrency = 1;
+        config.cache_warming_timeout_seconds = 30;
+        config.symbol_store_cache_max_bytes = 100_000_000;
+
+        // No team filter — should warm all 3 records
+        warm_cache_with_filter(&db, &s3_client, "bucket", &cache, &config, None)
+            .await
+            .unwrap();
+
+        // 3 records means 3 cache entries
+        let cache = cache.lock().await;
+        assert!(cache.held_bytes() > 0);
+    }
+
+    #[sqlx::test(migrations = "./tests/test_migrations")]
+    async fn warm_cache_with_empty_filter_warms_nothing(db: PgPool) {
+        insert_symbol_set(&db, 1, "team1-a").await;
+        insert_symbol_set(&db, 2, "team2-a").await;
+
+        // No S3 expectations — empty filter means no records to fetch
+        let s3_client: Arc<dyn BlobClient> = Arc::new(MockS3Client::new());
+        let cache = Arc::new(Mutex::new(SymbolSetCache::new(100_000_000)));
+
+        let mut config = Config::init_with_defaults().unwrap();
+        config.cache_warming_lookback_hours = 1;
+        config.cache_warming_max_entries = 100;
+        config.cache_warming_concurrency = 1;
+        config.cache_warming_timeout_seconds = 30;
+        config.symbol_store_cache_max_bytes = 100_000_000;
+
+        // Empty team filter — no teams assigned to this pod
+        warm_cache_with_filter(&db, &s3_client, "bucket", &cache, &config, Some(vec![]))
+            .await
+            .unwrap();
+
+        assert_eq!(cache.lock().await.held_bytes(), 0);
+    }
+
+    #[sqlx::test(migrations = "./tests/test_migrations")]
+    async fn warm_cache_with_filter_respects_limit(db: PgPool) {
+        // Insert 5 records for team 1
+        for i in 0..5 {
+            insert_symbol_set(&db, 1, &format!("team1-{i}")).await;
+        }
+
+        let cache = Arc::new(Mutex::new(SymbolSetCache::new(100_000_000)));
+
+        let mut config = Config::init_with_defaults().unwrap();
+        config.cache_warming_lookback_hours = 1;
+        config.cache_warming_max_entries = 3; // Limit to 3
+        config.cache_warming_concurrency = 1;
+        config.cache_warming_timeout_seconds = 30;
+        config.symbol_store_cache_max_bytes = 100_000_000;
+
+        let fetched_keys = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let fetched_keys_clone = fetched_keys.clone();
+        let data = test_symbol_data();
+        let mut s3_client = MockS3Client::new();
+        s3_client.expect_get().returning(move |_, key| {
+            fetched_keys_clone.lock().unwrap().push(key.to_string());
+            Ok(Some(data.clone()))
+        });
+        let s3_client: Arc<dyn BlobClient> = Arc::new(s3_client);
+
+        warm_cache_with_filter(&db, &s3_client, "bucket", &cache, &config, Some(vec![1]))
+            .await
+            .unwrap();
+
+        let keys = fetched_keys.lock().unwrap();
+        assert_eq!(
+            keys.len(),
+            3,
+            "Should respect max_entries limit even with team filter"
+        );
     }
 }

--- a/rust/cymbal/src/symbol_store/warming.rs
+++ b/rust/cymbal/src/symbol_store/warming.rs
@@ -83,64 +83,68 @@ pub async fn warm_cache(
 
     let mut handles = Vec::with_capacity(total);
 
+    // Spawn all tasks immediately — the semaphore is acquired inside each task
+    // so the spawn loop doesn't block. This ensures the timeout below covers
+    // the full warming duration, not just the result-collection phase.
     for record in records {
-        let permit = semaphore.clone().acquire_owned().await.unwrap();
+        let sem = semaphore.clone();
         let s3 = s3_client.clone();
         let bucket = bucket.to_string();
         let cache = ss_cache.clone();
         let parsers = parsers.clone();
 
         handles.push(tokio::spawn(async move {
-            let _permit = permit;
+            let _permit = sem.acquire_owned().await.unwrap();
             let result =
                 warm_single_entry(&s3, &bucket, &cache, &parsers, &record, byte_budget).await;
             (record.set_ref, result)
         }));
     }
 
-    let timeout = tokio::time::Duration::from_secs(config.cache_warming_timeout_seconds);
     let mut loaded: u64 = 0;
     let mut failed: u64 = 0;
     let mut skipped: u64 = 0;
     let mut bytes_loaded: u64 = 0;
 
-    let results = match tokio::time::timeout(timeout, async {
-        let mut results = Vec::with_capacity(handles.len());
-        for handle in handles {
-            results.push(handle.await);
-        }
-        results
-    })
-    .await
-    {
-        Ok(results) => results,
-        Err(_) => {
-            warn!(
-                timeout_seconds = config.cache_warming_timeout_seconds,
-                loaded, failed, skipped, "Cache warming timed out, proceeding with partial warm"
-            );
-            return Ok(());
-        }
-    };
+    // Collect results one at a time under a shared deadline. If we exceed the
+    // timeout, abort remaining tasks so they don't compete with real traffic
+    // after the pod is marked ready.
+    let deadline =
+        tokio::time::Instant::now() + tokio::time::Duration::from_secs(config.cache_warming_timeout_seconds);
+    let mut timed_out = false;
 
-    for result in results {
-        match result {
-            Ok((_, Ok(Some(bytes)))) => {
+    for handle in handles.iter_mut() {
+        match tokio::time::timeout_at(deadline, handle).await {
+            Ok(Ok((_, Ok(Some(bytes))))) => {
                 loaded += 1;
                 bytes_loaded += bytes as u64;
             }
-            Ok((_, Ok(None))) => {
+            Ok(Ok((_, Ok(None)))) => {
                 skipped += 1;
             }
-            Ok((ref_name, Err(e))) => {
+            Ok(Ok((ref_name, Err(e)))) => {
                 warn!(set_ref = %ref_name, error = %e, "Failed to warm symbol set");
                 failed += 1;
             }
-            Err(e) => {
+            Ok(Err(e)) => {
                 warn!(error = %e, "Warming task panicked");
                 failed += 1;
             }
+            Err(_) => {
+                timed_out = true;
+                break;
+            }
         }
+    }
+
+    if timed_out {
+        for handle in &handles {
+            handle.abort();
+        }
+        warn!(
+            timeout_seconds = config.cache_warming_timeout_seconds,
+            loaded, failed, skipped, "Cache warming timed out, aborting remaining tasks"
+        );
     }
 
     let elapsed = start.elapsed();

--- a/rust/cymbal/src/symbol_store/warming.rs
+++ b/rust/cymbal/src/symbol_store/warming.rs
@@ -1,0 +1,410 @@
+use std::sync::Arc;
+use std::time::Instant;
+
+use posthog_symbol_data::{sniff_data_type, SymbolDataType};
+use sqlx::PgPool;
+use tokio::sync::{Mutex, Semaphore};
+use tracing::{info, warn};
+
+use crate::{
+    config::Config,
+    error::UnhandledError,
+    metric_consts::{
+        CACHE_WARMING_BYTES_LOADED, CACHE_WARMING_DURATION, CACHE_WARMING_ENTRIES_FAILED,
+        CACHE_WARMING_ENTRIES_LOADED,
+    },
+    symbol_store::{
+        apple::{AppleProvider, ParsedAppleSymbols},
+        caching::{Countable, SymbolSetCache},
+        hermesmap::{HermesMapProvider, ParsedHermesMap},
+        proguard::{FetchedMapping, ProguardProvider},
+        saving::SymbolSetRecord,
+        sourcemap::{OwnedSourceMapCache, SourcemapProvider},
+        BlobClient, Parser,
+    },
+};
+
+struct WarmingParsers {
+    smp: SourcemapProvider,
+    hmp: HermesMapProvider,
+    pgp: ProguardProvider,
+    apple: AppleProvider,
+}
+
+/// Leave 15% headroom in the cache for incoming traffic after the consumer starts.
+const WARMING_FILL_FRACTION: f64 = 0.85;
+
+/// Pre-populates the symbol set cache from DB + S3 on startup. Queries for recently-used
+/// symbol sets, fetches their raw data from S3, parses them using the type discriminator
+/// in the `posthog_symbol_data` binary format, and inserts the results into the shared cache.
+/// Stops early once the cache reaches 85% of its byte capacity.
+pub async fn warm_cache(
+    pool: &PgPool,
+    s3_client: &Arc<dyn BlobClient>,
+    bucket: &str,
+    ss_cache: &Arc<Mutex<SymbolSetCache>>,
+    config: &Config,
+) -> Result<(), UnhandledError> {
+    let start = Instant::now();
+
+    let lookback_hours = config.cache_warming_lookback_hours as i64;
+    let records: Vec<SymbolSetRecord> = sqlx::query_as::<_, SymbolSetRecord>(
+        r#"SELECT id, team_id, ref AS set_ref, storage_ptr, failure_reason, created_at, content_hash, last_used
+        FROM posthog_errortrackingsymbolset
+        WHERE content_hash IS NOT NULL
+          AND storage_ptr IS NOT NULL
+          AND last_used > NOW() - make_interval(hours => $1::integer)
+        ORDER BY last_used DESC
+        LIMIT $2"#,
+    )
+    .bind(lookback_hours)
+    .bind(config.cache_warming_max_entries as i64)
+    .fetch_all(pool)
+    .await?;
+
+    let total = records.len();
+    let byte_budget = (config.symbol_store_cache_max_bytes as f64 * WARMING_FILL_FRACTION) as usize;
+    info!(
+        count = total,
+        byte_budget, "Fetched warming candidates from DB"
+    );
+
+    if total == 0 {
+        return Ok(());
+    }
+
+    let semaphore = Arc::new(Semaphore::new(config.cache_warming_concurrency));
+    let parsers = Arc::new(WarmingParsers {
+        smp: SourcemapProvider::new(config),
+        hmp: HermesMapProvider {},
+        pgp: ProguardProvider {},
+        apple: AppleProvider {},
+    });
+
+    let mut handles = Vec::with_capacity(total);
+
+    for record in records {
+        let permit = semaphore.clone().acquire_owned().await.unwrap();
+        let s3 = s3_client.clone();
+        let bucket = bucket.to_string();
+        let cache = ss_cache.clone();
+        let parsers = parsers.clone();
+
+        handles.push(tokio::spawn(async move {
+            let _permit = permit;
+            let result =
+                warm_single_entry(&s3, &bucket, &cache, &parsers, &record, byte_budget).await;
+            (record.set_ref, result)
+        }));
+    }
+
+    let timeout = tokio::time::Duration::from_secs(config.cache_warming_timeout_seconds);
+    let mut loaded: u64 = 0;
+    let mut failed: u64 = 0;
+    let mut skipped: u64 = 0;
+    let mut bytes_loaded: u64 = 0;
+
+    let results = match tokio::time::timeout(timeout, async {
+        let mut results = Vec::with_capacity(handles.len());
+        for handle in handles {
+            results.push(handle.await);
+        }
+        results
+    })
+    .await
+    {
+        Ok(results) => results,
+        Err(_) => {
+            warn!(
+                timeout_seconds = config.cache_warming_timeout_seconds,
+                loaded, failed, skipped, "Cache warming timed out, proceeding with partial warm"
+            );
+            return Ok(());
+        }
+    };
+
+    for result in results {
+        match result {
+            Ok((_, Ok(Some(bytes)))) => {
+                loaded += 1;
+                bytes_loaded += bytes as u64;
+            }
+            Ok((_, Ok(None))) => {
+                skipped += 1;
+            }
+            Ok((ref_name, Err(e))) => {
+                warn!(set_ref = %ref_name, error = %e, "Failed to warm symbol set");
+                failed += 1;
+            }
+            Err(e) => {
+                warn!(error = %e, "Warming task panicked");
+                failed += 1;
+            }
+        }
+    }
+
+    let elapsed = start.elapsed();
+    info!(
+        loaded,
+        failed,
+        skipped,
+        total,
+        bytes_loaded,
+        byte_budget,
+        elapsed_ms = elapsed.as_millis() as u64,
+        "Cache warming complete"
+    );
+
+    metrics::counter!(CACHE_WARMING_ENTRIES_LOADED).increment(loaded);
+    metrics::counter!(CACHE_WARMING_ENTRIES_FAILED).increment(failed);
+    metrics::counter!(CACHE_WARMING_BYTES_LOADED).increment(bytes_loaded);
+    metrics::histogram!(CACHE_WARMING_DURATION).record(elapsed.as_secs_f64());
+
+    Ok(())
+}
+
+async fn warm_single_entry(
+    s3_client: &Arc<dyn BlobClient>,
+    bucket: &str,
+    cache: &Arc<Mutex<SymbolSetCache>>,
+    parsers: &WarmingParsers,
+    record: &SymbolSetRecord,
+    byte_budget: usize,
+) -> Result<Option<usize>, UnhandledError> {
+    // Check byte budget before doing any expensive S3/parse work. Concurrent tasks may
+    // slightly overshoot, but the cache's own eviction handles that gracefully.
+    if cache.lock().await.held_bytes() >= byte_budget {
+        return Ok(None);
+    }
+
+    let storage_ptr = record
+        .storage_ptr
+        .as_ref()
+        .ok_or_else(|| UnhandledError::Other("missing storage_ptr".to_string()))?;
+
+    let data = s3_client
+        .get(bucket, storage_ptr)
+        .await?
+        .ok_or_else(|| UnhandledError::Other("S3 object not found".to_string()))?;
+
+    let data_type = sniff_data_type(&data)
+        .map_err(|e| UnhandledError::Other(format!("failed to sniff data type: {e}")))?;
+
+    let cache_key = format!("{}:{}", record.team_id, record.set_ref);
+    let bytes;
+
+    match data_type {
+        SymbolDataType::SourceAndMap => {
+            let parsed = parsers
+                .smp
+                .parse(data)
+                .await
+                .map_err(|e| UnhandledError::Other(format!("sourcemap parse failed: {e}")))?;
+            bytes = parsed.byte_count();
+            cache
+                .lock()
+                .await
+                .insert::<OwnedSourceMapCache>(cache_key, Arc::new(parsed), bytes);
+        }
+        SymbolDataType::HermesMap => {
+            let parsed = parsers
+                .hmp
+                .parse(data)
+                .await
+                .map_err(|e| UnhandledError::Other(format!("hermes parse failed: {e}")))?;
+            bytes = parsed.byte_count();
+            cache
+                .lock()
+                .await
+                .insert::<ParsedHermesMap>(cache_key, Arc::new(parsed), bytes);
+        }
+        SymbolDataType::ProguardMapping => {
+            let parsed = parsers
+                .pgp
+                .parse(data)
+                .await
+                .map_err(|e| UnhandledError::Other(format!("proguard parse failed: {e}")))?;
+            bytes = parsed.byte_count();
+            cache
+                .lock()
+                .await
+                .insert::<FetchedMapping>(cache_key, Arc::new(parsed), bytes);
+        }
+        SymbolDataType::AppleDsym => {
+            let parsed = parsers
+                .apple
+                .parse(data)
+                .await
+                .map_err(|e| UnhandledError::Other(format!("apple parse failed: {e}")))?;
+            bytes = parsed.byte_count();
+            cache
+                .lock()
+                .await
+                .insert::<ParsedAppleSymbols>(cache_key, Arc::new(parsed), bytes);
+        }
+    }
+
+    Ok(Some(bytes))
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use chrono::Utc;
+    use posthog_symbol_data::write_symbol_data;
+    use uuid::Uuid;
+
+    use crate::symbol_store::{saving::SymbolSetRecord, MockS3Client};
+
+    const MINIFIED: &[u8] = include_bytes!("../../tests/static/chunk-PGUQKT6S.js");
+    const MAP: &[u8] = include_bytes!("../../tests/static/chunk-PGUQKT6S.js.map");
+
+    fn test_symbol_data() -> Vec<u8> {
+        write_symbol_data(posthog_symbol_data::SourceAndMap {
+            minified_source: String::from_utf8(MINIFIED.to_vec()).unwrap(),
+            sourcemap: String::from_utf8(MAP.to_vec()).unwrap(),
+        })
+        .unwrap()
+    }
+
+    fn make_record(key: &str) -> SymbolSetRecord {
+        SymbolSetRecord {
+            id: Uuid::now_v7(),
+            team_id: 1,
+            set_ref: format!("http://example.com/{key}"),
+            storage_ptr: Some(key.to_string()),
+            failure_reason: None,
+            created_at: Utc::now(),
+            content_hash: Some("abc123".to_string()),
+            last_used: Some(Utc::now()),
+        }
+    }
+
+    fn make_parsers() -> WarmingParsers {
+        let config = Config::init_with_defaults().unwrap();
+        WarmingParsers {
+            smp: SourcemapProvider::new(&config),
+            hmp: HermesMapProvider {},
+            pgp: ProguardProvider {},
+            apple: AppleProvider {},
+        }
+    }
+
+    #[tokio::test]
+    async fn skips_entry_when_over_byte_budget() {
+        let parsers = make_parsers();
+        let cache = Arc::new(Mutex::new(SymbolSetCache::new(1000)));
+        cache
+            .lock()
+            .await
+            .insert("prefill".to_string(), Arc::new(vec![0u8; 500]), 500);
+
+        // MockS3Client::new() panics on any unexpected call, verifying S3 is never touched
+        let s3_client: Arc<dyn BlobClient> = Arc::new(MockS3Client::new());
+        let record = make_record("test-key");
+
+        let result = warm_single_entry(&s3_client, "bucket", &cache, &parsers, &record, 100).await;
+
+        assert!(result.unwrap().is_none());
+        assert_eq!(cache.lock().await.held_bytes(), 500);
+    }
+
+    #[tokio::test]
+    async fn loads_entry_when_under_byte_budget() {
+        let parsers = make_parsers();
+        let cache = Arc::new(Mutex::new(SymbolSetCache::new(100_000_000)));
+
+        let data = test_symbol_data();
+        let mut s3_client = MockS3Client::new();
+        s3_client
+            .expect_get()
+            .returning(move |_, _| Ok(Some(data.clone())));
+
+        let s3_client: Arc<dyn BlobClient> = Arc::new(s3_client);
+        let record = make_record("test-key");
+
+        let result =
+            warm_single_entry(&s3_client, "bucket", &cache, &parsers, &record, 100_000_000).await;
+
+        let bytes = result.unwrap().unwrap();
+        assert!(bytes > 0);
+        assert_eq!(cache.lock().await.held_bytes(), bytes);
+    }
+
+    #[sqlx::test(migrations = "./tests/test_migrations")]
+    async fn warm_cache_skips_all_when_budget_is_zero(db: PgPool) {
+        for i in 0..3 {
+            sqlx::query(
+                "INSERT INTO posthog_errortrackingsymbolset \
+                 (id, team_id, ref, storage_ptr, content_hash, last_used, created_at) \
+                 VALUES ($1, $2, $3, $4, $5, NOW(), NOW())",
+            )
+            .bind(Uuid::now_v7())
+            .bind(1i32)
+            .bind(format!("http://example.com/test-{i}.js"))
+            .bind(format!("symbolsets/test-{i}"))
+            .bind("somehash")
+            .execute(&db)
+            .await
+            .unwrap();
+        }
+
+        // No S3 expectations — budget is zero so nothing should be fetched
+        let s3_client: Arc<dyn BlobClient> = Arc::new(MockS3Client::new());
+        let cache = Arc::new(Mutex::new(SymbolSetCache::new(1)));
+
+        let mut config = Config::init_with_defaults().unwrap();
+        config.cache_warming_lookback_hours = 1;
+        config.cache_warming_max_entries = 100;
+        config.cache_warming_concurrency = 1;
+        config.cache_warming_timeout_seconds = 30;
+        config.symbol_store_cache_max_bytes = 1;
+
+        warm_cache(&db, &s3_client, "bucket", &cache, &config)
+            .await
+            .unwrap();
+
+        assert_eq!(cache.lock().await.held_bytes(), 0);
+    }
+
+    #[sqlx::test(migrations = "./tests/test_migrations")]
+    async fn warm_cache_loads_entries(db: PgPool) {
+        for i in 0..2 {
+            sqlx::query(
+                "INSERT INTO posthog_errortrackingsymbolset \
+                 (id, team_id, ref, storage_ptr, content_hash, last_used, created_at) \
+                 VALUES ($1, $2, $3, $4, $5, NOW(), NOW())",
+            )
+            .bind(Uuid::now_v7())
+            .bind(1i32)
+            .bind(format!("http://example.com/test-{i}.js"))
+            .bind(format!("symbolsets/test-{i}"))
+            .bind("somehash")
+            .execute(&db)
+            .await
+            .unwrap();
+        }
+
+        let data = test_symbol_data();
+        let mut s3_client = MockS3Client::new();
+        s3_client
+            .expect_get()
+            .returning(move |_, _| Ok(Some(data.clone())));
+
+        let s3_client: Arc<dyn BlobClient> = Arc::new(s3_client);
+        let cache = Arc::new(Mutex::new(SymbolSetCache::new(100_000_000)));
+
+        let mut config = Config::init_with_defaults().unwrap();
+        config.cache_warming_lookback_hours = 1;
+        config.cache_warming_max_entries = 100;
+        config.cache_warming_concurrency = 1;
+        config.cache_warming_timeout_seconds = 30;
+        config.symbol_store_cache_max_bytes = 100_000_000;
+
+        warm_cache(&db, &s3_client, "bucket", &cache, &config)
+            .await
+            .unwrap();
+
+        assert!(cache.lock().await.held_bytes() > 0);
+    }
+}

--- a/rust/cymbal/src/symbol_store/warming.rs
+++ b/rust/cymbal/src/symbol_store/warming.rs
@@ -138,12 +138,13 @@ pub async fn warm_cache(
     }
 
     if timed_out {
+        let aborted = total as u64 - loaded - failed - skipped;
         for handle in &handles {
             handle.abort();
         }
         warn!(
             timeout_seconds = config.cache_warming_timeout_seconds,
-            loaded, failed, skipped, "Cache warming timed out, aborting remaining tasks"
+            loaded, failed, skipped, aborted, "Cache warming timed out, aborting remaining tasks"
         );
     }
 

--- a/rust/cymbal/tests/readiness.rs
+++ b/rust/cymbal/tests/readiness.rs
@@ -1,0 +1,108 @@
+use std::sync::{atomic::Ordering, Arc};
+
+use axum::{body::Body, http::Request};
+use common_redis::MockRedisClient;
+use cymbal::{app_context::AppContext, config::Config, router::get_router};
+use reqwest::StatusCode;
+use sqlx::PgPool;
+use tower::ServiceExt;
+
+use crate::utils::MockS3Client;
+
+mod utils;
+
+#[sqlx::test(migrations = "./tests/test_migrations")]
+async fn readiness_returns_503_before_warming_and_200_after(db: PgPool) {
+    let mut config = Config::init_with_defaults().unwrap();
+    config.cache_warming_enabled = true;
+    config.object_storage_bucket = "test-bucket".to_string();
+
+    let mut s3_client = MockS3Client::default();
+    s3_client.expect_ping_bucket().returning(|_| Ok(()));
+
+    let redis_client = Arc::new(MockRedisClient::new());
+    let issue_buckets_redis_client = Arc::new(MockRedisClient::new());
+
+    let ctx = Arc::new(
+        AppContext::new(
+            &config,
+            Arc::new(s3_client),
+            db.clone(),
+            db.clone(),
+            redis_client,
+            issue_buckets_redis_client,
+        )
+        .await
+        .unwrap(),
+    );
+
+    let router = get_router(ctx.clone());
+
+    // Before warming completes: readiness gate should reject with 503
+    let res = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/_readiness")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::SERVICE_UNAVAILABLE);
+
+    // Simulate warming completion (this is what main.rs does after warm_cache returns)
+    ctx.cache_warmed.store(true, Ordering::Relaxed);
+
+    // After warming: readiness gate should pass with 200
+    let res = router
+        .oneshot(
+            Request::builder()
+                .uri("/_readiness")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+}
+
+#[sqlx::test(migrations = "./tests/test_migrations")]
+async fn readiness_returns_200_immediately_when_warming_disabled(db: PgPool) {
+    let mut config = Config::init_with_defaults().unwrap();
+    config.cache_warming_enabled = false;
+    config.object_storage_bucket = "test-bucket".to_string();
+
+    let mut s3_client = MockS3Client::default();
+    s3_client.expect_ping_bucket().returning(|_| Ok(()));
+
+    let redis_client = Arc::new(MockRedisClient::new());
+    let issue_buckets_redis_client = Arc::new(MockRedisClient::new());
+
+    let ctx = Arc::new(
+        AppContext::new(
+            &config,
+            Arc::new(s3_client),
+            db.clone(),
+            db.clone(),
+            redis_client,
+            issue_buckets_redis_client,
+        )
+        .await
+        .unwrap(),
+    );
+
+    let router = get_router(ctx);
+
+    // With warming disabled, cache_warmed starts true — should be ready immediately
+    let res = router
+        .oneshot(
+            Request::builder()
+                .uri("/_readiness")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+}


### PR DESCRIPTION
## Problem

restarts have a bit of a degrading effect on cymbal because of the cache loss - cache misses require db queries and s3 downloads. adding a cache warming step won't solve it perfectly, but can definitely help soften the cliff on restart. if in the future cymbal instances become sharded, each respective cache warming can become much more efficient.

## Changes

- add a cache warming step on start up (this will block the pod accepting traffic until it runs or times out)
- query pg for the most recently used symbol sets, and download and parse relevant files from s3 until we warm the cache.
- bails on downloads once we hit a size cap

## How did you test this code?

added some tests, but it was hard to test this locally. i'd love to throw this branch on dev and see how it goes.