### PR TITLE
fix(cymbal): preserve source code indentation in context lines

### DIFF
--- a/rust/cymbal/src/frames/mod.rs
+++ b/rust/cymbal/src/frames/mod.rs
@@ -22,7 +22,7 @@ use crate::{
         ruby::RawRubyFrame,
     },
     metric_consts::{FRAME_NOT_RESOLVED, FRAME_RESOLVED, LEGACY_JS_FRAME_RESOLVED, PER_FRAME_TIME},
-    sanitize_string,
+    sanitize_source_line, sanitize_string,
     symbol_store::Catalog,
 };
 
@@ -318,10 +318,11 @@ impl ContextLine {
         if line.len() > constrained.len() {
             constrained.push_str("...✂️");
         }
-
+        // Use sanitize_source_line, not sanitize_string: source code indentation
+        // (spaces, tabs) is meaningful and must not be collapsed.
         Self {
             number,
-            line: sanitize_string(constrained),
+            line: sanitize_source_line(constrained),
         }
     }
 
@@ -339,9 +340,11 @@ impl ContextLine {
             baseline.saturating_sub((-offset) as u32)
         };
 
+        // Use sanitize_source_line, not sanitize_string: source code indentation
+        // (spaces, tabs) is meaningful and must not be collapsed.
         Self {
             number,
-            line: sanitize_string(constrained),
+            line: sanitize_source_line(constrained),
         }
     }
 }

--- a/rust/cymbal/src/frames/mod.rs
+++ b/rust/cymbal/src/frames/mod.rs
@@ -22,7 +22,7 @@ use crate::{
         ruby::RawRubyFrame,
     },
     metric_consts::{FRAME_NOT_RESOLVED, FRAME_RESOLVED, LEGACY_JS_FRAME_RESOLVED, PER_FRAME_TIME},
-    sanitize_source_line, sanitize_string,
+    sanitize_source_line,
     symbol_store::Catalog,
 };
 

--- a/rust/cymbal/src/lib.rs
+++ b/rust/cymbal/src/lib.rs
@@ -75,6 +75,12 @@ pub fn sanitize_string(s: String) -> String {
         .to_string()
 }
 
+/// Sanitize a source code line: replace only null bytes, leave all whitespace intact.
+/// Source context lines have meaningful indentation that must be preserved.
+pub fn sanitize_source_line(s: String) -> String {
+    s.replace('\u{0000}', "\u{FFFD}")
+}
+
 pub fn needs_sanitization(s: &str) -> bool {
     s.contains('\u{0000}') || s.len() > 512
 }
@@ -109,6 +115,21 @@ mod test {
         let input = "hello     world".to_string();
         let result = sanitize_string(input);
         assert_eq!(result, "hello     world");
+    }
+
+    #[test]
+    fn test_sanitize_source_line_preserves_indentation() {
+        // 65 leading spaces (e.g. Obj-C multi-line method call) must be preserved.
+        let input = format!("{:>65}reason:@\"value\"", "");
+        let result = sanitize_source_line(input.clone());
+        assert_eq!(result, input);
+    }
+
+    #[test]
+    fn test_sanitize_source_line_strips_nulls() {
+        let input = "hello\u{0000}world".to_string();
+        let result = sanitize_source_line(input);
+        assert_eq!(result, "hello\u{FFFD}world");
     }
 
     #[test]


### PR DESCRIPTION
## What

Source context lines with deep indentation were being replaced with `<ws trimmed>` in the UI.

## Why

`ContextLine::new()` was calling `sanitize_string()`, which collapses any run of 50+ whitespace characters. Objective-C multi-line method calls use alignment indentation that can exceed 50 spaces, so those lines were mangled.

`sanitize_string()` is the right tool for arbitrary event properties (preventing huge blank-line runs from bloating Postgres). It is the wrong tool for source code lines where whitespace is semantically meaningful.

## How

Introduce `sanitize_source_line()` that strips null bytes only, leaving all whitespace intact. `ContextLine::new()` and `ContextLine::new_rel()` use it instead of `sanitize_string()`. The existing 300-char truncation already handles unbounded line length.