### PR TITLE
feat(activity): add pageview, screen, and email property filter sections

### DIFF
--- a/frontend/src/scenes/activity/explore/eventsSceneLogic.tsx
+++ b/frontend/src/scenes/activity/explore/eventsSceneLogic.tsx
@@ -2,6 +2,7 @@ import equal from 'fast-deep-equal'
 import { actions, connect, kea, path, reducers, selectors } from 'kea'
 import { UrlToActionPayload } from 'kea-router/lib/types'
 
+import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { tabAwareActionToUrl } from 'lib/logic/scenes/tabAwareActionToUrl'
@@ -14,8 +15,9 @@ import { Scene } from 'scenes/sceneTypes'
 import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
 
+import { groupsModel } from '~/models/groupsModel'
 import { getDefaultEventsQueryForTeam } from '~/queries/nodes/DataTable/defaultEventsQuery'
-import { Node } from '~/queries/schema/schema-general'
+import { DataTableNode, Node } from '~/queries/schema/schema-general'
 import { ActivityTab, Breadcrumb } from '~/types'
 
 import type { eventsSceneLogicType } from './eventsSceneLogicType'
@@ -23,17 +25,37 @@ import type { eventsSceneLogicType } from './eventsSceneLogicType'
 export const eventsSceneLogic = kea<eventsSceneLogicType>([
     path(['scenes', 'events', 'eventsSceneLogic']),
     tabAwareScene(),
-    connect(() => ({ values: [teamLogic, ['currentTeam'], featureFlagLogic, ['featureFlags']] })),
+    connect(() => ({
+        values: [teamLogic, ['currentTeam'], featureFlagLogic, ['featureFlags'], groupsModel, ['groupsTaxonomicTypes']],
+    })),
 
     actions({ setQuery: (query: Node) => ({ query }) }),
     reducers({ savedQuery: [null as Node | null, { setQuery: (_, { query }) => query }] }),
     selectors({
         defaultQuery: [
-            (s) => [s.currentTeam],
-            (currentTeam) => {
+            (s) => [s.currentTeam, s.groupsTaxonomicTypes],
+            (currentTeam, groupsTaxonomicTypes): DataTableNode => {
                 const defaultSourceForTeam = currentTeam && getDefaultEventsQueryForTeam(currentTeam)
                 const defaultForScene = getDefaultEventsSceneQuery()
-                return defaultSourceForTeam ? { ...defaultForScene, source: defaultSourceForTeam } : defaultForScene
+                const base = defaultSourceForTeam
+                    ? { ...defaultForScene, source: defaultSourceForTeam }
+                    : defaultForScene
+                return {
+                    ...base,
+                    showPropertyFilter: [
+                        TaxonomicFilterGroupType.EventProperties,
+                        TaxonomicFilterGroupType.PersonProperties,
+                        TaxonomicFilterGroupType.EventFeatureFlags,
+                        TaxonomicFilterGroupType.EventMetadata,
+                        ...(groupsTaxonomicTypes ?? []),
+                        TaxonomicFilterGroupType.Cohorts,
+                        TaxonomicFilterGroupType.Elements,
+                        TaxonomicFilterGroupType.HogQLExpression,
+                        TaxonomicFilterGroupType.PageviewUrls,
+                        TaxonomicFilterGroupType.Screens,
+                        TaxonomicFilterGroupType.EmailAddresses,
+                    ],
+                }
             },
         ],
         query: [(s) => [s.savedQuery, s.defaultQuery], (savedQuery, defaultQuery) => savedQuery || defaultQuery],


### PR DESCRIPTION
## Problem

The activity page's Explore Events property filters only show basic event/person property types. Users looking to filter by pageview URLs, screen names, or email addresses have to use the generic event properties tab and manually search for these — despite dedicated, user-friendly sections existing in the taxonomic filter for exactly this purpose.

## Changes

Updated `eventsSceneLogic.tsx` to set an explicit `showPropertyFilter` array on the DataTableNode, adding `PageviewUrls`, `Screens`, and `EmailAddresses` sections alongside the existing defaults. Follows the same pattern used by LLM analytics — connects to `groupsModel` to preserve dynamic group types.

## How did you test this code?

This was authored by an agent. No manual testing was performed. The change follows an established pattern (see `llmAnalyticsGenerationsLogic.ts`). To verify:

1. Navigate to Activity > Explore events
2. Click "Property filters"
3. Confirm Pageview URLs, Screens, and Email addresses sections appear in the taxonomic filter popup

## Publish to changelog?

No

## Docs update

No docs changes needed.

## 🤖 LLM context

Agent-authored PR. Single file change to `eventsSceneLogic.tsx` adding three taxonomic filter group types to the activity page property filters, scoped to only the activity page (not modifying shared `EventPropertyFilters` defaults).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*