### PR TITLE
feat: add person_id filter to backfill_precalculated_person_properties

### DIFF
--- a/posthog/admin/admins/backfill_precalculated_person_properties_admin.py
+++ b/posthog/admin/admins/backfill_precalculated_person_properties_admin.py
@@ -29,9 +29,8 @@ class BackfillPrecalculatedPersonPropertiesForm(forms.Form):
         help_text="Number of concurrent child workflows to run (1-100, default: 5)",
         label="Concurrent workflows",
     )
-    person_id = forms.CharField(
+    person_id = forms.UUIDField(
         required=False,
-        max_length=36,
         help_text="Optional: Specific person ID (UUID) to filter the backfill for. If provided, only processes properties for this person",
         label="Person ID",
     )

--- a/posthog/admin/admins/backfill_precalculated_person_properties_admin.py
+++ b/posthog/admin/admins/backfill_precalculated_person_properties_admin.py
@@ -29,6 +29,12 @@ class BackfillPrecalculatedPersonPropertiesForm(forms.Form):
         help_text="Number of concurrent child workflows to run (1-100, default: 5)",
         label="Concurrent workflows",
     )
+    person_id = forms.CharField(
+        required=False,
+        max_length=36,
+        help_text="Optional: Specific person ID (UUID) to filter the backfill for. If provided, only processes properties for this person",
+        label="Person ID",
+    )
 
 
 def backfill_precalculated_person_properties_view(request):
@@ -52,6 +58,10 @@ def backfill_precalculated_person_properties_view(request):
             command_args.extend(["--batch-size", str(form.cleaned_data["batch_size"])])
             command_args.extend(["--concurrent-workflows", str(form.cleaned_data["concurrent_workflows"])])
 
+            # Only add person_id if provided
+            if form.cleaned_data.get("person_id"):
+                command_args.extend(["--person-id", str(form.cleaned_data["person_id"])])
+
             try:
                 call_command("backfill_precalculated_person_properties", *command_args)
 
@@ -60,9 +70,14 @@ def backfill_precalculated_person_properties_view(request):
                     if form.cleaned_data.get("cohort_id")
                     else "all realtime cohorts"
                 )
+                person_info = (
+                    f" (filtered to person {form.cleaned_data['person_id']})"
+                    if form.cleaned_data.get("person_id")
+                    else ""
+                )
                 messages.success(
                     request,
-                    f"Backfill started successfully for {cohort_info} "
+                    f"Backfill started successfully for {cohort_info}{person_info} "
                     f"(team {form.cleaned_data['team_id']}) "
                     f"using ID-range based batching with {form.cleaned_data['batch_size']} persons per batch "
                     f"and {form.cleaned_data['concurrent_workflows']} concurrent workflows. "

--- a/posthog/management/commands/backfill_precalculated_person_properties.py
+++ b/posthog/management/commands/backfill_precalculated_person_properties.py
@@ -106,12 +106,19 @@ class Command(BaseCommand):
             default=5,
             help="Number of concurrent child workflows to run (default: 5)",
         )
+        parser.add_argument(
+            "--person-id",
+            type=str,
+            required=False,
+            help="Optional: Specific person ID (UUID) to filter the backfill for. If provided, only processes properties for this person",
+        )
 
     def handle(self, *args, **options):
         team_id = options["team_id"]
         cohort_id = options.get("cohort_id")
         batch_size = options["batch_size"]
         concurrent_workflows = options["concurrent_workflows"]
+        person_id = options.get("person_id")
 
         # Get cohorts to process
         if cohort_id:
@@ -214,6 +221,7 @@ class Command(BaseCommand):
             cohort_ids=cohort_ids,
             batch_size=batch_size,
             concurrent_workflows=concurrent_workflows,
+            person_id=person_id,
         )
 
         self.stdout.write(
@@ -237,6 +245,7 @@ class Command(BaseCommand):
         cohort_ids: list[int],
         batch_size: int,
         concurrent_workflows: int,
+        person_id: str | None = None,
     ) -> str:
         """Run the Temporal coordinator workflow for the team."""
 
@@ -257,6 +266,7 @@ class Command(BaseCommand):
                 cohort_ids=cohort_ids,
                 batch_size=batch_size,
                 concurrent_workflows=concurrent_workflows,
+                person_id=person_id,
             )
 
             # Generate unique workflow ID (one per team, based on timestamp)

--- a/posthog/management/commands/backfill_precalculated_person_properties.py
+++ b/posthog/management/commands/backfill_precalculated_person_properties.py
@@ -267,6 +267,7 @@ class Command(BaseCommand):
                 batch_size=batch_size,
                 concurrent_workflows=concurrent_workflows,
                 person_id=person_id,
+                single_cohort_mode=len(cohort_ids) == 1,  # True when exactly one cohort is being processed
             )
 
             # Generate unique workflow ID (one per team, based on timestamp)

--- a/posthog/templates/admin/backfill_precalculated_person_properties.html
+++ b/posthog/templates/admin/backfill_precalculated_person_properties.html
@@ -69,6 +69,17 @@
             {% endif %}
             {{ form.cohort_id.errors }}
         </div>
+
+        <div class="form-row">
+            <label for="{{ form.person_id.id_for_label }}">
+                {{ form.person_id.label }}:
+            </label>
+            {{ form.person_id }}
+            {% if form.person_id.help_text %}
+                <p class="help">{{ form.person_id.help_text }}</p>
+            {% endif %}
+            {{ form.person_id.errors }}
+        </div>
     </fieldset>
 
     <fieldset class="module aligned">

--- a/posthog/temporal/messaging/backfill_precalculated_person_properties_coordinator_workflow.py
+++ b/posthog/temporal/messaging/backfill_precalculated_person_properties_coordinator_workflow.py
@@ -25,6 +25,7 @@ class PersonIdRangesPageInputs:
     batch_size: int  # persons per range
     page_size: int  # number of ranges to return per page
     after_person_id: str | None  # cursor: fetch persons with ID > this value, None for first page
+    person_id: str | None = None  # Optional specific person ID to filter for
 
 
 @dataclasses.dataclass
@@ -50,12 +51,14 @@ async def get_person_id_ranges_page_activity(inputs: PersonIdRangesPageInputs) -
     query_limit = limit + 1
 
     after_clause = "AND id > %(after_person_id)s" if inputs.after_person_id is not None else ""
+    person_filter_clause = "AND id = %(person_id)s" if inputs.person_id is not None else ""
     query = f"""
         SELECT id as person_id
         FROM person FINAL
         WHERE team_id = %(team_id)s
           AND is_deleted = 0
           {after_clause}
+          {person_filter_clause}
         ORDER BY id
         LIMIT %(limit)s
         FORMAT JSONEachRow
@@ -63,6 +66,8 @@ async def get_person_id_ranges_page_activity(inputs: PersonIdRangesPageInputs) -
     query_params: dict[str, object] = {"team_id": inputs.team_id, "limit": query_limit}
     if inputs.after_person_id is not None:
         query_params["after_person_id"] = inputs.after_person_id
+    if inputs.person_id is not None:
+        query_params["person_id"] = inputs.person_id
 
     ranges: list[tuple[str, str]] = []
     current_batch_start: str | None = None
@@ -126,6 +131,7 @@ class BackfillPrecalculatedPersonPropertiesCoordinatorInputs:
     cohort_ids: list[int]  # All cohort IDs being processed
     batch_size: int = 1000  # Persons per batch
     concurrent_workflows: int = 5  # Number of concurrent workflows to run
+    person_id: str | None = None  # Optional specific person ID to filter for
 
     @property
     def properties_to_log(self) -> dict[str, Any]:
@@ -173,6 +179,7 @@ class BackfillPrecalculatedPersonPropertiesCoordinatorWorkflow(PostHogWorkflow):
             batch_size=inputs.batch_size,
             start_person_id=start_person_id,
             end_person_id=end_person_id,
+            person_id=inputs.person_id,
         )
 
         # Start child workflow
@@ -245,6 +252,7 @@ class BackfillPrecalculatedPersonPropertiesCoordinatorWorkflow(PostHogWorkflow):
                     batch_size=inputs.batch_size,
                     page_size=inputs.concurrent_workflows,
                     after_person_id=cursor,
+                    person_id=inputs.person_id,
                 ),
                 start_to_close_timeout=dt.timedelta(minutes=10),
                 heartbeat_timeout=dt.timedelta(minutes=5),

--- a/posthog/temporal/messaging/backfill_precalculated_person_properties_coordinator_workflow.py
+++ b/posthog/temporal/messaging/backfill_precalculated_person_properties_coordinator_workflow.py
@@ -132,6 +132,7 @@ class BackfillPrecalculatedPersonPropertiesCoordinatorInputs:
     batch_size: int = 1000  # Persons per batch
     concurrent_workflows: int = 5  # Number of concurrent workflows to run
     person_id: str | None = None  # Optional specific person ID to filter for
+    single_cohort_mode: bool = False  # True when --cohort-id was explicitly provided
 
     @property
     def properties_to_log(self) -> dict[str, Any]:
@@ -180,6 +181,7 @@ class BackfillPrecalculatedPersonPropertiesCoordinatorWorkflow(PostHogWorkflow):
             start_person_id=start_person_id,
             end_person_id=end_person_id,
             person_id=inputs.person_id,
+            single_cohort_mode=inputs.single_cohort_mode,
         )
 
         # Start child workflow

--- a/posthog/temporal/messaging/backfill_precalculated_person_properties_workflow.py
+++ b/posthog/temporal/messaging/backfill_precalculated_person_properties_workflow.py
@@ -184,6 +184,7 @@ class BackfillPrecalculatedPersonPropertiesInputs:
     batch_size: int = 1000
     start_person_id: str = "00000000-0000-0000-0000-000000000000"  # Starting person ID for this batch
     end_person_id: str = "ffffffff-ffff-ffff-ffff-ffffffffffff"  # Ending person ID for this batch
+    person_id: str | None = None  # Optional specific person ID to filter for
 
     @property
     def properties_to_log(self) -> dict[str, Any]:
@@ -202,6 +203,7 @@ def evaluate_combined_filters_sync(
     combined_bytecode: list[Any],
     hog_globals: dict[str, Any],
     person_id: str,
+    detailed_logging: bool = False,
 ) -> dict[str, Any]:
     """Execute combined bytecode for all filters, returning {condition_hash: result}.
 
@@ -210,8 +212,29 @@ def evaluate_combined_filters_sync(
     try:
         bytecode_result: BytecodeResult = execute_bytecode(combined_bytecode, hog_globals)
         result = bytecode_result.result
+
+        if detailed_logging:
+            LOGGER.info(
+                "HogVM evaluation completed",
+                person_id=person_id,
+                result=result,
+                result_type=type(result).__name__,
+                person_properties=hog_globals.get("person", {}).get("properties", {}),
+                execution_successful=True,
+                execution_stdout=bytecode_result.stdout,
+            )
+
         if isinstance(result, dict):
             return result
+
+        if detailed_logging:
+            LOGGER.warning(
+                "HogVM evaluation returned non-dict result",
+                person_id=person_id,
+                result=result,
+                result_type=type(result).__name__,
+            )
+
         return {}
     except Exception as e:
         LOGGER.warning(
@@ -274,6 +297,9 @@ async def backfill_precalculated_person_properties_activity(
         f"processing {len(filters)} total filters from person ID {inputs.start_person_id} to {inputs.end_person_id} "
         f"with batch size {inputs.batch_size} ({len(filters)} filters = ~{inputs.batch_size * len(filters)} events per batch)"
     )
+
+    # Enable detailed logging when both cohort_id and person_id are set (single cohort + single person mode)
+    detailed_logging_enabled = inputs.person_id is not None and len(cohort_ids) == 1
 
     async with Heartbeater(
         details=(f"Processing persons from {inputs.start_person_id} to {inputs.end_person_id}",)
@@ -361,6 +387,7 @@ async def backfill_precalculated_person_properties_activity(
                     "Falling back to fetching all properties - could not determine specific properties needed"
                 )
 
+        person_filter_clause = "AND id = %(person_id)s" if inputs.person_id is not None else ""
         persons_query = f"""
             SELECT
                 id as person_id,
@@ -370,6 +397,7 @@ async def backfill_precalculated_person_properties_activity(
               AND id >= %(start_person_id)s
               AND id <= %(end_person_id)s
               AND is_deleted = 0
+              {person_filter_clause}
             ORDER BY id
             FORMAT JSONEachRow
         """
@@ -379,6 +407,8 @@ async def backfill_precalculated_person_properties_activity(
             "start_person_id": inputs.start_person_id,
             "end_person_id": inputs.end_person_id,
         }
+        if inputs.person_id is not None:
+            query_params["person_id"] = inputs.person_id
 
         last_person_id = inputs.start_person_id
         batch_count = 0
@@ -421,7 +451,23 @@ async def backfill_precalculated_person_properties_activity(
                         combined_bytecode,
                         hog_globals,
                         person_id,
+                        detailed_logging_enabled,
                     )
+
+                    # Detailed logging for filter results when in single cohort + single person mode
+                    if detailed_logging_enabled:
+                        person_filter_duration = time.monotonic() - person_filter_start
+                        matching_conditions = [hash for hash, matches in filter_results.items() if matches]
+                        logger.info(
+                            "Filter evaluation results",
+                            person_id=person_id,
+                            total_conditions=len(filter_results),
+                            matching_conditions=len(matching_conditions),
+                            matching_condition_hashes=matching_conditions,
+                            all_results=filter_results,
+                            evaluation_duration_ms=round(person_filter_duration * 1000, 2),
+                            person_properties_count=len(parsed_properties),
+                        )
 
                     # Produce Kafka messages for matching conditions
                     for condition_hash, matches in filter_results.items():
@@ -440,10 +486,20 @@ async def backfill_precalculated_person_properties_activity(
                                 )
                                 kafka_results.append(produce_result)
                                 total_events_produced += 1
+
+                                if detailed_logging_enabled:
+                                    logger.info(
+                                        "Kafka message produced for matching condition",
+                                        person_id=person_id,
+                                        condition_hash=condition_hash,
+                                        matches=matches,
+                                        kafka_topic=KAFKA_CDP_CLICKHOUSE_PRECALCULATED_PERSON_PROPERTIES,
+                                    )
                             except Exception as e:
                                 logger.warning(
                                     f"Failed to produce Kafka message for person {person_id}: {e}",
                                     person_id=person_id,
+                                    condition_hash=condition_hash,
                                     error=str(e),
                                 )
 

--- a/posthog/temporal/messaging/backfill_precalculated_person_properties_workflow.py
+++ b/posthog/temporal/messaging/backfill_precalculated_person_properties_workflow.py
@@ -452,7 +452,7 @@ async def backfill_precalculated_person_properties_activity(
                         combined_bytecode,
                         hog_globals,
                         person_id,
-                        detailed_logging_enabled,
+                        detailed_logging=detailed_logging_enabled,
                     )
 
                     # Detailed logging for filter results when in single cohort + single person mode

--- a/posthog/temporal/messaging/backfill_precalculated_person_properties_workflow.py
+++ b/posthog/temporal/messaging/backfill_precalculated_person_properties_workflow.py
@@ -185,6 +185,7 @@ class BackfillPrecalculatedPersonPropertiesInputs:
     start_person_id: str = "00000000-0000-0000-0000-000000000000"  # Starting person ID for this batch
     end_person_id: str = "ffffffff-ffff-ffff-ffff-ffffffffffff"  # Ending person ID for this batch
     person_id: str | None = None  # Optional specific person ID to filter for
+    single_cohort_mode: bool = False  # True when --cohort-id was explicitly provided
 
     @property
     def properties_to_log(self) -> dict[str, Any]:
@@ -299,7 +300,7 @@ async def backfill_precalculated_person_properties_activity(
     )
 
     # Enable detailed logging when both cohort_id and person_id are set (single cohort + single person mode)
-    detailed_logging_enabled = inputs.person_id is not None and len(cohort_ids) == 1
+    detailed_logging_enabled = inputs.person_id is not None and inputs.single_cohort_mode
 
     async with Heartbeater(
         details=(f"Processing persons from {inputs.start_person_id} to {inputs.end_person_id}",)
@@ -457,7 +458,9 @@ async def backfill_precalculated_person_properties_activity(
                     # Detailed logging for filter results when in single cohort + single person mode
                     if detailed_logging_enabled:
                         person_filter_duration = time.monotonic() - person_filter_start
-                        matching_conditions = [hash for hash, matches in filter_results.items() if matches]
+                        matching_conditions = [
+                            condition_hash for condition_hash, matches in filter_results.items() if matches
+                        ]
                         logger.info(
                             "Filter evaluation results",
                             person_id=person_id,

--- a/posthog/temporal/messaging/test/test_backfill_precalculated_person_properties_workflow.py
+++ b/posthog/temporal/messaging/test/test_backfill_precalculated_person_properties_workflow.py
@@ -299,7 +299,7 @@ class TestEvaluateCombinedFiltersSync:
         [
             ("enabled_success", True, {"test_condition": True}, True, False),
             ("disabled", False, {"test_condition": True}, False, False),
-            ("enabled_non_dict", True, {}, False, True),
+            ("enabled_non_dict", True, {}, True, True),
         ]
     )
     @patch("posthog.temporal.messaging.backfill_precalculated_person_properties_workflow.LOGGER")

--- a/posthog/temporal/messaging/test/test_backfill_precalculated_person_properties_workflow.py
+++ b/posthog/temporal/messaging/test/test_backfill_precalculated_person_properties_workflow.py
@@ -301,9 +301,7 @@ class TestEvaluateCombinedFiltersSync:
         combined = ["_H", 1, Operation.STRING, "test_condition", 29, Operation.DICT, 1]
         hog_globals = {"person": {"properties": {"$browser": "Chrome"}}}
 
-        result = evaluate_combined_filters_sync(
-            combined, hog_globals, "person-123", detailed_logging=True, cohort_id=456
-        )
+        result = evaluate_combined_filters_sync(combined, hog_globals, "person-123", detailed_logging=True)
 
         # Verify the function still works correctly
         assert result == {"test_condition": True}
@@ -316,7 +314,6 @@ class TestEvaluateCombinedFiltersSync:
         # Verify the logged parameters include our expected values
         logged_kwargs = call_args[1]
         assert logged_kwargs["person_id"] == "person-123"
-        assert logged_kwargs["cohort_id"] == 456
         assert logged_kwargs["result"] == {"test_condition": True}
         assert logged_kwargs["execution_successful"] is True
         assert logged_kwargs["person_properties"] == {"$browser": "Chrome"}
@@ -340,7 +337,7 @@ class TestEvaluateCombinedFiltersSync:
         # Create bytecode that returns a non-dict result
         combined = ["_H", 1, Operation.STRING, "not_a_dict"]
 
-        result = evaluate_combined_filters_sync(combined, {}, "person-123", detailed_logging=True, cohort_id=456)
+        result = evaluate_combined_filters_sync(combined, {}, "person-123", detailed_logging=True)
 
         # Verify the function returns empty dict for non-dict result
         assert result == {}
@@ -352,5 +349,4 @@ class TestEvaluateCombinedFiltersSync:
 
         logged_kwargs = call_args[1]
         assert logged_kwargs["person_id"] == "person-123"
-        assert logged_kwargs["cohort_id"] == 456
         assert logged_kwargs["result"] == "not_a_dict"

--- a/posthog/temporal/messaging/test/test_backfill_precalculated_person_properties_workflow.py
+++ b/posthog/temporal/messaging/test/test_backfill_precalculated_person_properties_workflow.py
@@ -295,58 +295,38 @@ class TestEvaluateCombinedFiltersSync:
         result = evaluate_combined_filters_sync(["_H", 1, 999], {}, "person-1")
         assert result == {}
 
+    @parameterized.expand(
+        [
+            ("enabled_success", True, {"test_condition": True}, True, False),
+            ("disabled", False, {"test_condition": True}, False, False),
+            ("enabled_non_dict", True, {}, False, True),
+        ]
+    )
     @patch("posthog.temporal.messaging.backfill_precalculated_person_properties_workflow.LOGGER")
-    def test_detailed_logging_enabled_logs_execution_details(self, mock_logger):
-        """When detailed_logging=True, should log detailed execution information."""
-        combined = ["_H", 1, Operation.STRING, "test_condition", 29, Operation.DICT, 1]
-        hog_globals = {"person": {"properties": {"$browser": "Chrome"}}}
+    def test_detailed_logging(self, _name, detailed, expected_result, expect_info, expect_warning, mock_logger):
+        if detailed and expect_warning:
+            combined = ["_H", 1, Operation.STRING, "not_a_dict"]
+        else:
+            combined = ["_H", 1, Operation.STRING, "test_condition", 29, Operation.DICT, 1]
 
-        result = evaluate_combined_filters_sync(combined, hog_globals, "person-123", detailed_logging=True)
+        hog_globals = {"person": {"properties": {"$browser": "Chrome"}}} if detailed and not expect_warning else {}
 
-        # Verify the function still works correctly
-        assert result == {"test_condition": True}
+        result = evaluate_combined_filters_sync(combined, hog_globals, "person-123", detailed_logging=detailed)
 
-        # Verify detailed logging was called
-        mock_logger.info.assert_called_once()
-        call_args = mock_logger.info.call_args
-        assert call_args[0][0] == "HogVM evaluation completed"
+        assert result == expected_result
 
-        # Verify the logged parameters include our expected values
-        logged_kwargs = call_args[1]
-        assert logged_kwargs["person_id"] == "person-123"
-        assert logged_kwargs["result"] == {"test_condition": True}
-        assert logged_kwargs["execution_successful"] is True
-        assert logged_kwargs["person_properties"] == {"$browser": "Chrome"}
+        if expect_info:
+            mock_logger.info.assert_called_once()
+            call_args = mock_logger.info.call_args
+            assert call_args[0][0] == "HogVM evaluation completed"
+            logged_kwargs = call_args[1]
+            assert logged_kwargs["person_id"] == "person-123"
+        else:
+            mock_logger.info.assert_not_called()
 
-    @patch("posthog.temporal.messaging.backfill_precalculated_person_properties_workflow.LOGGER")
-    def test_detailed_logging_disabled_does_not_log_details(self, mock_logger):
-        """When detailed_logging=False (default), should not log detailed execution information."""
-        combined = ["_H", 1, Operation.STRING, "test_condition", 29, Operation.DICT, 1]
-
-        result = evaluate_combined_filters_sync(combined, {}, "person-123")
-
-        # Verify the function still works correctly
-        assert result == {"test_condition": True}
-
-        # Verify no detailed logging occurred
-        mock_logger.info.assert_not_called()
-
-    @patch("posthog.temporal.messaging.backfill_precalculated_person_properties_workflow.LOGGER")
-    def test_detailed_logging_non_dict_result_warning(self, mock_logger):
-        """When detailed_logging=True and result is not a dict, should log warning."""
-        # Create bytecode that returns a non-dict result
-        combined = ["_H", 1, Operation.STRING, "not_a_dict"]
-
-        result = evaluate_combined_filters_sync(combined, {}, "person-123", detailed_logging=True)
-
-        # Verify the function returns empty dict for non-dict result
-        assert result == {}
-
-        # Verify warning was logged
-        mock_logger.warning.assert_called_once()
-        call_args = mock_logger.warning.call_args
-        assert call_args[0][0] == "HogVM evaluation returned non-dict result"
-
-        logged_kwargs = call_args[1]
-        assert logged_kwargs["person_id"] == "person-123"
-        assert logged_kwargs["result"] == "not_a_dict"
+        if expect_warning:
+            mock_logger.warning.assert_called_once()
+            call_args = mock_logger.warning.call_args
+            assert call_args[0][0] == "HogVM evaluation returned non-dict result"
+        else:
+            mock_logger.warning.assert_not_called()

--- a/posthog/temporal/messaging/test/test_backfill_precalculated_person_properties_workflow.py
+++ b/posthog/temporal/messaging/test/test_backfill_precalculated_person_properties_workflow.py
@@ -294,3 +294,63 @@ class TestEvaluateCombinedFiltersSync:
     def test_returns_empty_dict_on_error(self):
         result = evaluate_combined_filters_sync(["_H", 1, 999], {}, "person-1")
         assert result == {}
+
+    @patch("posthog.temporal.messaging.backfill_precalculated_person_properties_workflow.LOGGER")
+    def test_detailed_logging_enabled_logs_execution_details(self, mock_logger):
+        """When detailed_logging=True, should log detailed execution information."""
+        combined = ["_H", 1, Operation.STRING, "test_condition", 29, Operation.DICT, 1]
+        hog_globals = {"person": {"properties": {"$browser": "Chrome"}}}
+
+        result = evaluate_combined_filters_sync(
+            combined, hog_globals, "person-123", detailed_logging=True, cohort_id=456
+        )
+
+        # Verify the function still works correctly
+        assert result == {"test_condition": True}
+
+        # Verify detailed logging was called
+        mock_logger.info.assert_called_once()
+        call_args = mock_logger.info.call_args
+        assert call_args[0][0] == "HogVM evaluation completed"
+
+        # Verify the logged parameters include our expected values
+        logged_kwargs = call_args[1]
+        assert logged_kwargs["person_id"] == "person-123"
+        assert logged_kwargs["cohort_id"] == 456
+        assert logged_kwargs["result"] == {"test_condition": True}
+        assert logged_kwargs["execution_successful"] is True
+        assert logged_kwargs["person_properties"] == {"$browser": "Chrome"}
+
+    @patch("posthog.temporal.messaging.backfill_precalculated_person_properties_workflow.LOGGER")
+    def test_detailed_logging_disabled_does_not_log_details(self, mock_logger):
+        """When detailed_logging=False (default), should not log detailed execution information."""
+        combined = ["_H", 1, Operation.STRING, "test_condition", 29, Operation.DICT, 1]
+
+        result = evaluate_combined_filters_sync(combined, {}, "person-123")
+
+        # Verify the function still works correctly
+        assert result == {"test_condition": True}
+
+        # Verify no detailed logging occurred
+        mock_logger.info.assert_not_called()
+
+    @patch("posthog.temporal.messaging.backfill_precalculated_person_properties_workflow.LOGGER")
+    def test_detailed_logging_non_dict_result_warning(self, mock_logger):
+        """When detailed_logging=True and result is not a dict, should log warning."""
+        # Create bytecode that returns a non-dict result
+        combined = ["_H", 1, Operation.STRING, "not_a_dict"]
+
+        result = evaluate_combined_filters_sync(combined, {}, "person-123", detailed_logging=True, cohort_id=456)
+
+        # Verify the function returns empty dict for non-dict result
+        assert result == {}
+
+        # Verify warning was logged
+        mock_logger.warning.assert_called_once()
+        call_args = mock_logger.warning.call_args
+        assert call_args[0][0] == "HogVM evaluation returned non-dict result"
+
+        logged_kwargs = call_args[1]
+        assert logged_kwargs["person_id"] == "person-123"
+        assert logged_kwargs["cohort_id"] == 456
+        assert logged_kwargs["result"] == "not_a_dict"


### PR DESCRIPTION
## Problem

When debugging issues with specific person properties backfill operations, it's difficult to test and troubleshoot individual person records without processing entire cohorts or teams.

## Changes

- Added person_id filter to `backfill_precalculated_person_properties`
- When both `--cohort-id` and `--person-id` are specified (single cohort + single person mode), the system automatically enables detailed logging that includes:

## How did you test this code?

- Added unit tests for the enhanced `evaluate_combined_filters_sync` function with detailed logging scenarios
- Verified Django admin form properly handles person_id input and validation
- Tested command-line interface with new `--person-id` argument
- Validated that person filtering works correctly in database queries
- Confirmed detailed logging is only enabled when both cohort_id and person_id are specified

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

no