### PR TITLE
chore(modeling): disable node level scheduling for teams that have been migrated

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -256,6 +256,8 @@ export const FEATURE_FLAGS = {
     CUSTOMER_ANALYTICS: 'customer-analytics-roadmap', // owner: @arthurdedeus #team-customer-analytics
     CUSTOMER_ANALYTICS_JOURNEYS: 'customer-analytics-journeys', // owner: @arthurdedeus #team-customer-analytics
     CUSTOMER_PROFILE_CONFIG_BUTTON: 'customer-profile-config-button', // owner: @arthurdedeus #team-customer-analytics
+    DATA_MODELING_BACKEND_V2: 'data-modeling-backend-v2', // owner: #team-data-modeling
+    DATA_MODELING_MULTI_DAG: 'data-modeling-multi-dag', // owner: #team-data-modeling
     DATA_MODELING_TAB: 'data-modeling-tab', // owner: #team-data-modeling
     DATA_WAREHOUSE_SCENE: 'data-warehouse-scene', // owner: #team-data-modeling
     DEFAULT_EVALUATION_ENVIRONMENTS: 'default-evaluation-environments', // owner: @dmarticus #team-feature-flags

--- a/frontend/src/scenes/data-warehouse/editor/output-pane-tabs/QueryInfo.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/output-pane-tabs/QueryInfo.tsx
@@ -139,6 +139,7 @@ export function QueryInfo({ tabId, view }: QueryInfoProps): JSX.Element {
     const showDebugLogs = user?.is_staff || user?.is_impersonated
 
     const isLineageDependencyViewEnabled = featureFlags[FEATURE_FLAGS.LINEAGE_DEPENDENCY_VIEW]
+    const isDagSchedulesOnly = !!featureFlags[FEATURE_FLAGS.DATA_MODELING_BACKEND_V2]
 
     const { dataModelingJobs, dataModelingJobsLoading, hasMoreJobsToLoad, startingMaterialization } =
         useValues(infoLogic)
@@ -215,28 +216,30 @@ export function QueryInfo({ tabId, view }: QueryInfoProps): JSX.Element {
                                               ? 'Running...'
                                               : 'Sync now'}
                                     </LemonButton>
-                                    <LemonSelect
-                                        className="h-9"
-                                        disabledReason={sync}
-                                        value={
-                                            targetView
-                                                ? dataWarehouseSavedQueryMapById[targetView.id]?.sync_frequency ||
-                                                  'never'
-                                                : 'never'
-                                        }
-                                        onChange={(newValue) => {
-                                            if (targetView && newValue) {
-                                                updateDataWarehouseSavedQuery({
-                                                    id: targetView.id,
-                                                    sync_frequency: newValue,
-                                                    types: [[]],
-                                                    lifecycle: 'update',
-                                                })
+                                    {!isDagSchedulesOnly && (
+                                        <LemonSelect
+                                            className="h-9"
+                                            disabledReason={sync}
+                                            value={
+                                                targetView
+                                                    ? dataWarehouseSavedQueryMapById[targetView.id]?.sync_frequency ||
+                                                      'never'
+                                                    : 'never'
                                             }
-                                        }}
-                                        loading={updatingDataWarehouseSavedQuery}
-                                        options={OPTIONS}
-                                    />
+                                            onChange={(newValue) => {
+                                                if (targetView && newValue) {
+                                                    updateDataWarehouseSavedQuery({
+                                                        id: targetView.id,
+                                                        sync_frequency: newValue,
+                                                        types: [[]],
+                                                        lifecycle: 'update',
+                                                    })
+                                                }
+                                            }}
+                                            loading={updatingDataWarehouseSavedQuery}
+                                            options={OPTIONS}
+                                        />
+                                    )}
                                     {targetView && (
                                         <LemonButton
                                             type="secondary"

--- a/products/data_warehouse/backend/api/saved_query.py
+++ b/products/data_warehouse/backend/api/saved_query.py
@@ -366,6 +366,17 @@ class DataWarehouseSavedQuerySerializer(DataWarehouseSavedQuerySerializerMixin, 
             before_update = None
 
         sync_frequency = self.context["request"].data.get("sync_frequency", None)
+
+        if sync_frequency and posthoganalytics.feature_enabled(
+            "data-modeling-backend-v2",
+            str(instance.team.uuid),
+            groups={
+                "organization": str(instance.team.organization_id),
+                "project": str(instance.team.id),
+            },
+        ):
+            raise serializers.ValidationError("Schedule is managed by the DAG. Edit the DAG schedule instead.")
+
         soft_update = validated_data.pop("soft_update", False)
 
         with transaction.atomic():


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

51 teams have been migrated to v2 backend. but they can still modify the schedules at a query level

## Changes

don't let them do that

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took, and what steps reviewers must take to get to where changes are, and what is the expected behavior. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

didn't. will verify in prod since this is all feature flag related

## Publish to changelog?

no

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->