### PR TITLE
fix(mcp): preserve DataVisualizationNode chartSettings on insight create

### DIFF
--- a/services/mcp/src/schema/insights.ts
+++ b/services/mcp/src/schema/insights.ts
@@ -51,6 +51,20 @@ export const CreateInsightInputSchema = z.object({
             .describe(
                 'For new insights, use the query from your successful query-run tool call. For updates, the existing query can optionally be reused.'
             ), // NOTE: This is intentionally z.any() to avoid populating the context with the complicated query schema, but we prompt the LLM to use 'query-run' to check queries, before creating insights.
+        // DataVisualizationNode fields — intentionally z.any() like source to avoid bloating context
+        display: z
+            .any()
+            .optional()
+            .describe(
+                'Chart display type for DataVisualizationNode queries (e.g. "ActionsLineGraph", "ActionsTable", "ActionsPie")'
+            ),
+        chartSettings: z
+            .any()
+            .optional()
+            .describe(
+                'Chart visualization settings for DataVisualizationNode queries — controls axis configuration, formatting, colors, and display options'
+            ),
+        tableSettings: z.any().optional().describe('Table display settings for DataVisualizationNode queries'),
     }),
     description: z.string().optional(),
     favorited: z.boolean(),
@@ -69,6 +83,20 @@ export const UpdateInsightInputSchema = z.object({
                 .describe(
                     'For new insights, use the query from your successful query-run tool call. For updates, the existing query can optionally be reused'
                 ), // NOTE: This is intentionally z.any() to avoid populating the context with the complicated query schema, and to allow the LLM to make a change to an existing insight whose schema we do not support in our simplified subset of the full insight schema.
+            // DataVisualizationNode fields — intentionally z.any() like source to avoid bloating context
+            display: z
+                .any()
+                .optional()
+                .describe(
+                    'Chart display type for DataVisualizationNode queries (e.g. "ActionsLineGraph", "ActionsTable", "ActionsPie")'
+                ),
+            chartSettings: z
+                .any()
+                .optional()
+                .describe(
+                    'Chart visualization settings for DataVisualizationNode queries — controls axis configuration, formatting, colors, and display options'
+                ),
+            tableSettings: z.any().optional().describe('Table display settings for DataVisualizationNode queries'),
         })
         .optional(),
     favorited: z.boolean().optional(),

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/insight-create-from-query.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/insight-create-from-query.json
@@ -14,6 +14,12 @@
                 },
                 "query": {
                     "properties": {
+                        "chartSettings": {
+                            "description": "Chart visualization settings for DataVisualizationNode queries — controls axis configuration, formatting, colors, and display options"
+                        },
+                        "display": {
+                            "description": "Chart display type for DataVisualizationNode queries (e.g. \"ActionsLineGraph\", \"ActionsTable\", \"ActionsPie\")"
+                        },
                         "kind": {
                             "anyOf": [
                                 {
@@ -28,6 +34,9 @@
                         },
                         "source": {
                             "description": "For new insights, use the query from your successful query-run tool call. For updates, the existing query can optionally be reused."
+                        },
+                        "tableSettings": {
+                            "description": "Table display settings for DataVisualizationNode queries"
                         }
                     },
                     "required": ["kind", "source"],

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/insight-update.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/insight-update.json
@@ -28,6 +28,12 @@
                 },
                 "query": {
                     "properties": {
+                        "chartSettings": {
+                            "description": "Chart visualization settings for DataVisualizationNode queries — controls axis configuration, formatting, colors, and display options"
+                        },
+                        "display": {
+                            "description": "Chart display type for DataVisualizationNode queries (e.g. \"ActionsLineGraph\", \"ActionsTable\", \"ActionsPie\")"
+                        },
                         "kind": {
                             "anyOf": [
                                 {
@@ -42,6 +48,9 @@
                         },
                         "source": {
                             "description": "For new insights, use the query from your successful query-run tool call. For updates, the existing query can optionally be reused"
+                        },
+                        "tableSettings": {
+                            "description": "Table display settings for DataVisualizationNode queries"
                         }
                     },
                     "required": ["kind", "source"],


### PR DESCRIPTION
## Problem

When creating SQL-based insights (`DataVisualizationNode`) via `insight-create-from-query`, the `display`, `chartSettings`, and `tableSettings` fields are silently stripped from the query payload. The insight is created successfully but always renders as a table — chart type, axis configuration, and formatting are lost.

Root cause: `client.ts:815` calls `CreateInsightInputSchema.parse(data)` which runs Zod validation. The Zod schema for `query` only declares `kind` and `source`, so `.parse()` strips all other keys before the data reaches the API.

`insight-update` is not functionally affected (the update client method uses `data: any` without re-parsing), but the update schema is also missing these fields, which means LLM clients don't know they can send them.

## Changes

Added three optional fields to the `query` object in both `CreateInsightInputSchema` and `UpdateInsightInputSchema`:

- `display` — chart display type (e.g. `ActionsLineGraph`)
- `chartSettings` — axis configuration, formatting, colors
- `tableSettings` — table display settings

Uses `z.any()` to match the existing pattern for `source`, which is intentionally untyped to avoid bloating LLM context.

## How did you test this code?

Traced the full data flow from MCP tool call → Zod validation → API client → HTTP request:

1. `mcp.ts:250` calls `tool.schema.safeParse(params)` for validation but passes original `params` to handler (line 295) — so the MCP layer doesn't strip fields
2. `client.ts:815` calls `CreateInsightInputSchema.parse(data)` and uses the **parsed result** (`validatedInput`) on line 819 — this is where fields are stripped
3. The Python model (`posthog/schema.py:18997`) and generated TypeScript types (`generated.ts:11561`) both support `chartSettings`, `display`, `tableSettings` — the backend accepts them fine, only the MCP input validation was dropping them

Updated snapshot files for the affected tool schemas.

## Publish to changelog?

No