### PR TITLE
fix(flags): validate mixed-targeting flags per condition aggregation type

### DIFF
--- a/posthog/api/test/test_feature_flag.py
+++ b/posthog/api/test/test_feature_flag.py
@@ -5343,6 +5343,51 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
         self.assertIsNone(filters["groups"][0]["aggregation_group_type_index"])
         self.assertEqual(filters["groups"][1]["aggregation_group_type_index"], 0)
 
+    @patch("posthog.api.feature_flag.posthoganalytics.feature_enabled")
+    def test_mixed_aggregation_with_properties(self, mock_feature_enabled):
+        mock_feature_enabled.return_value = True
+
+        GroupTypeMapping.objects.create(
+            team=self.team, project_id=self.team.project_id, group_type="organization", group_type_index=0
+        )
+
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/feature_flags/",
+            {
+                "name": "Mixed flag with properties",
+                "key": "mixed-with-props",
+                "filters": {
+                    "groups": [
+                        {
+                            "properties": [
+                                {"key": "email", "value": ["user@example.com"], "operator": "exact", "type": "person"}
+                            ],
+                            "rollout_percentage": 100,
+                            "aggregation_group_type_index": None,
+                        },
+                        {
+                            "properties": [
+                                {
+                                    "key": "created_at",
+                                    "value": "2026-03-10",
+                                    "operator": "is_date_after",
+                                    "type": "group",
+                                    "group_type_index": 0,
+                                }
+                            ],
+                            "rollout_percentage": 100,
+                            "aggregation_group_type_index": 0,
+                        },
+                    ]
+                },
+            },
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        groups = response.json()["filters"]["groups"]
+        self.assertIsNone(groups[0]["aggregation_group_type_index"])
+        self.assertEqual(groups[1]["aggregation_group_type_index"], 0)
+
     @parameterized.expand(
         [
             ("flag_enabled", True, status.HTTP_200_OK),

--- a/posthog/api/test/test_feature_flag.py
+++ b/posthog/api/test/test_feature_flag.py
@@ -5343,9 +5343,17 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
         self.assertIsNone(filters["groups"][0]["aggregation_group_type_index"])
         self.assertEqual(filters["groups"][1]["aggregation_group_type_index"], 0)
 
+    @parameterized.expand(
+        [
+            ("flag_enabled", True, status.HTTP_201_CREATED),
+            ("flag_disabled", False, status.HTTP_400_BAD_REQUEST),
+        ]
+    )
     @patch("posthog.api.feature_flag.posthoganalytics.feature_enabled")
-    def test_mixed_aggregation_with_properties(self, mock_feature_enabled):
-        mock_feature_enabled.return_value = True
+    def test_mixed_aggregation_with_properties(
+        self, _name, mixed_targeting_enabled, expected_status, mock_feature_enabled
+    ):
+        mock_feature_enabled.return_value = mixed_targeting_enabled
 
         GroupTypeMapping.objects.create(
             team=self.team, project_id=self.team.project_id, group_type="organization", group_type_index=0
@@ -5383,10 +5391,14 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
             },
             format="json",
         )
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        groups = response.json()["filters"]["groups"]
-        self.assertIsNone(groups[0]["aggregation_group_type_index"])
-        self.assertEqual(groups[1]["aggregation_group_type_index"], 0)
+        self.assertEqual(response.status_code, expected_status)
+
+        if expected_status == status.HTTP_201_CREATED:
+            groups = response.json()["filters"]["groups"]
+            self.assertIsNone(groups[0]["aggregation_group_type_index"])
+            self.assertEqual(groups[1]["aggregation_group_type_index"], 0)
+        else:
+            self.assertIn("Mixed aggregation types", response.json()["detail"])
 
     @parameterized.expand(
         [

--- a/posthog/models/feature_flag/flag_validation.py
+++ b/posthog/models/feature_flag/flag_validation.py
@@ -5,7 +5,7 @@ These functions validate that feature flags can be evaluated without timing out
 by testing the underlying database queries.
 """
 
-from typing import Union, cast
+from typing import Optional, Union, cast
 
 from django.db.models import BooleanField, CharField, Expression, F, Func
 from django.db.models.expressions import ExpressionWrapper, RawSQL
@@ -118,6 +118,15 @@ def _exclude_realtime_backfilled_cohort_properties(
     return result
 
 
+def _base_query_for_aggregation(group_type_index: Optional[int], team_id: int) -> QuerySet:
+    """Return the appropriate Person or Group queryset for a given aggregation type."""
+    if group_type_index is None:
+        return Person.objects.db_manager(READ_ONLY_DATABASE_FOR_PERSONS).filter(team_id=team_id)
+    return Group.objects.db_manager(READ_ONLY_DATABASE_FOR_PERSONS).filter(
+        team_id=team_id, group_type_index=group_type_index
+    )
+
+
 def check_flag_evaluation_query_is_ok(
     feature_flag: FeatureFlag, team_id: int, project_id: int, *, allow_realtime_backfilled: bool = False
 ) -> bool:
@@ -129,6 +138,9 @@ def check_flag_evaluation_query_is_ok(
     - Regex patterns valid in RE2 but not PostgreSQL
     - Property filters that cause query timeouts
     - Malformed property conditions
+
+    Each condition is validated against the queryset matching its own aggregation type,
+    which allows flags with mixed person and group conditions to be validated correctly.
 
     NOTE: This validation is primarily for the admin UI to prevent users from creating
     flags that will fail at evaluation time. Once all flag evaluation moves to the Rust
@@ -145,44 +157,46 @@ def check_flag_evaluation_query_is_ok(
     Raises:
         Any database errors that occur during query execution
     """
-    group_type_index = feature_flag.aggregation_group_type_index
-
-    base_query: QuerySet = (
-        Person.objects.db_manager(READ_ONLY_DATABASE_FOR_PERSONS).filter(team_id=team_id)
-        if group_type_index is None
-        else Group.objects.db_manager(READ_ONLY_DATABASE_FOR_PERSONS).filter(
-            team_id=team_id, group_type_index=group_type_index
-        )
-    )
-    query_fields = []
-
+    # Group conditions by aggregation type so each set of conditions is validated
+    # against the correct base queryset (Person for None, Group for a group_type_index).
+    conditions_by_aggregation: dict[Optional[int], list[tuple[int, dict]]] = {}
     for index, condition in enumerate(feature_flag.conditions):
-        key = f"flag_0_condition_{index}"
-        property_list = Filter(data=condition).property_groups.flat
-        # When realtime cohort flag targeting is enabled, realtime cohorts that have been
-        # backfilled are evaluated by the Rust service via cohort_membership lookups, not
-        # Django ORM queries. Skip them here so validation doesn't fail trying to translate
-        # behavioral filters into SQL.
-        property_list = _exclude_realtime_backfilled_cohort_properties(
-            property_list, project_id, allow_realtime_backfilled=allow_realtime_backfilled
-        )
-        expr = properties_to_Q(
-            project_id,
-            property_list,
-        )
-        properties_with_math_operators = get_all_properties_with_math_operators(property_list, {}, project_id)
-        type_property_annotations = _get_property_type_annotations(properties_with_math_operators)
-        base_query = base_query.annotate(
-            **type_property_annotations,
-            **{
-                key: ExpressionWrapper(
-                    # nosemgrep: python.django.security.audit.raw-query.avoid-raw-sql (literal "true", no user input)
-                    cast(Expression, expr if expr else RawSQL("true", [])),
-                    output_field=BooleanField(),
-                ),
-            },
-        )
-        query_fields.append(key)
+        aggregation = condition.get("aggregation_group_type_index")
+        conditions_by_aggregation.setdefault(aggregation, []).append((index, condition))
 
-    values = base_query.values(*query_fields)[:10]
-    return len(values) > 0
+    for aggregation, conditions in conditions_by_aggregation.items():
+        base_query = _base_query_for_aggregation(aggregation, team_id)
+        query_fields = []
+
+        for index, condition in conditions:
+            key = f"flag_0_condition_{index}"
+            property_list = Filter(data=condition).property_groups.flat
+            # When realtime cohort flag targeting is enabled, realtime cohorts that have been
+            # backfilled are evaluated by the Rust service via cohort_membership lookups, not
+            # Django ORM queries. Skip them here so validation doesn't fail trying to translate
+            # behavioral filters into SQL.
+            property_list = _exclude_realtime_backfilled_cohort_properties(
+                property_list, project_id, allow_realtime_backfilled=allow_realtime_backfilled
+            )
+            expr = properties_to_Q(
+                project_id,
+                property_list,
+            )
+            properties_with_math_operators = get_all_properties_with_math_operators(property_list, {}, project_id)
+            type_property_annotations = _get_property_type_annotations(properties_with_math_operators)
+            base_query = base_query.annotate(
+                **type_property_annotations,
+                **{
+                    key: ExpressionWrapper(
+                        # nosemgrep: python.django.security.audit.raw-query.avoid-raw-sql (literal "true", no user input)
+                        cast(Expression, expr if expr else RawSQL("true", [])),
+                        output_field=BooleanField(),
+                    ),
+                },
+            )
+            query_fields.append(key)
+
+        values = base_query.values(*query_fields)[:10]
+        len(values)  # Force query execution to surface any database errors
+
+    return True

--- a/posthog/models/feature_flag/flag_validation.py
+++ b/posthog/models/feature_flag/flag_validation.py
@@ -129,7 +129,7 @@ def _base_query_for_aggregation(group_type_index: Optional[int], team_id: int) -
 
 def check_flag_evaluation_query_is_ok(
     feature_flag: FeatureFlag, team_id: int, project_id: int, *, allow_realtime_backfilled: bool = False
-) -> bool:
+) -> None:
     """
     Validate that a feature flag's conditions can be evaluated without errors.
 
@@ -150,9 +150,6 @@ def check_flag_evaluation_query_is_ok(
         feature_flag: The FeatureFlag instance to validate
         team_id: The team ID the flag belongs to
         project_id: The project ID the flag belongs to
-
-    Returns:
-        True if the query executes successfully, False otherwise
 
     Raises:
         Any database errors that occur during query execution
@@ -198,5 +195,3 @@ def check_flag_evaluation_query_is_ok(
 
         values = base_query.values(*query_fields)[:10]
         len(values)  # Force query execution to surface any database errors
-
-    return True


### PR DESCRIPTION
## Problem

Saving a feature flag with mixed person + group targeting (from #52503) fails with "Can't evaluate flag - please check release conditions". This happens on create but not on update, because `check_flag_evaluation` is only called in the create path.

The root cause is that `check_flag_evaluation_query_is_ok` reads a single flag-level `aggregation_group_type_index` to decide whether to validate against the `Person` or `Group` table. For mixed flags this is `None`, so all conditions — including group conditions with operators like `is_date_after` on `group_properties` — get validated against the `Person` table, which fails.

## Changes

- Partition conditions by their per-condition `aggregation_group_type_index` and validate each partition against the correct queryset (`Person` for `None`, `Group` for a group type index)
- Add a test that reproduces the exact failure: a mixed flag with person email filter + group `created_at` date filter

## How did you test this code?

Added `test_mixed_aggregation_with_properties` which reproduces the exact payload that was failing. Existing mixed-targeting tests only used empty properties, which didn't exercise the validation query path.

No

## 🤖 LLM context

Agent-authored fix.