### PR TITLE
fix(remote-config): drop POSTHOG_JS_SCRIPTS_BASE_URL and scriptBaseUrl

### DIFF
--- a/posthog/models/remote_config.py
+++ b/posthog/models/remote_config.py
@@ -437,8 +437,6 @@ class RemoteConfig(UUIDTModel):
             return config
 
         enriched = {**sdk_version, "resolved": resolved}
-        if settings.POSTHOG_JS_SCRIPTS_BASE_URL:
-            enriched["scriptBaseUrl"] = f"{settings.POSTHOG_JS_SCRIPTS_BASE_URL.rstrip('/')}/{resolved}"
         return {**config, "sdkVersion": enriched}
 
     @classmethod

--- a/posthog/models/test/test_remote_config.py
+++ b/posthog/models/test/test_remote_config.py
@@ -290,37 +290,6 @@ class TestRemoteConfigSdkVersion(_RemoteConfigBase):
         assert config["sdkVersion"]["requested"] == "1"
         assert config["sdkVersion"]["resolved"] == "1.360.1"
 
-    @override_settings(POSTHOG_JS_S3_BUCKET="test-bucket", POSTHOG_JS_SCRIPTS_BASE_URL="https://cdn.example.com/js")
-    def test_sdk_version_includes_script_base_url(self):
-        import json
-
-        from django.core.cache import cache
-
-        from posthog.models.js_snippet_versioning import REDIS_POINTER_MAP_KEY
-
-        manifest = {"versions": ["1.360.1"], "pointers": {"1": "1.360.1", "1.360": "1.360.1"}}
-        cache.set(REDIS_POINTER_MAP_KEY, json.dumps(manifest), timeout=None)
-        self.sync_remote_config()
-
-        config = RemoteConfig.get_config_via_token(self.team.api_token)
-        assert config["sdkVersion"]["scriptBaseUrl"] == "https://cdn.example.com/js/1.360.1"
-
-    @override_settings(POSTHOG_JS_S3_BUCKET="test-bucket", POSTHOG_JS_SCRIPTS_BASE_URL="")
-    def test_sdk_version_omits_script_base_url_when_not_configured(self):
-        import json
-
-        from django.core.cache import cache
-
-        from posthog.models.js_snippet_versioning import REDIS_POINTER_MAP_KEY
-
-        manifest = {"versions": ["1.360.1"], "pointers": {"1": "1.360.1", "1.360": "1.360.1"}}
-        cache.set(REDIS_POINTER_MAP_KEY, json.dumps(manifest), timeout=None)
-        self.sync_remote_config()
-
-        config = RemoteConfig.get_config_via_token(self.team.api_token)
-        assert "sdkVersion" in config
-        assert "scriptBaseUrl" not in config["sdkVersion"]
-
     @override_settings(POSTHOG_JS_S3_BUCKET="test-bucket")
     def test_sdk_version_reflects_team_pin(self):
         import json

--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -493,8 +493,6 @@ REMOTE_CONFIG_CDN_PURGE_DOMAINS = get_list(os.getenv("REMOTE_CONFIG_CDN_PURGE_DO
 
 # Versioned posthog-js S3 bucket — enables versioned JS content serving when set
 POSTHOG_JS_S3_BUCKET = get_from_env("POSTHOG_JS_S3_BUCKET", "")
-# Base URL for CDN-fronted bucket (used in scriptsBaseUrl config field)
-POSTHOG_JS_SCRIPTS_BASE_URL = get_from_env("POSTHOG_JS_SCRIPTS_BASE_URL", "")
 # CDN cache control for array.js responses
 POSTHOG_JS_CDN_MAX_AGE = int(os.getenv("POSTHOG_JS_CDN_MAX_AGE", "3600"))
 POSTHOG_JS_CDN_STALE_WHILE_REVALIDATE = int(os.getenv("POSTHOG_JS_CDN_STALE_WHILE_REVALIDATE", "86400"))


### PR DESCRIPTION
## Problem

The `POSTHOG_JS_SCRIPTS_BASE_URL` env var and `sdkVersion.scriptBaseUrl` remote config field exist to tell the client SDK which CDN origin to load versioned extension scripts from. But since the versioned files will be served from the same `(us|eu)-assets.i.posthog.com` origin (see [posthog-cloud-infra#7346](https://github.com/PostHog/posthog-cloud-infra/pull/7346)), the client can derive the URL itself using `endpointFor("assets", "/{version}/{kind}.js")`. No server-side override needed.

Additionally, `scriptBaseUrl` is problematic for reverse proxy / custom domain setups: it bypasses the proxy and points directly at `posthog.com`, which adblockers catch. Removing it lets the client always resolve assets through whatever host it was configured with.

## Changes

- Remove `POSTHOG_JS_SCRIPTS_BASE_URL` setting from `posthog/settings/web.py`
- Stop adding `scriptBaseUrl` to the `sdkVersion` response in `remote_config.py`
- Remove two related tests (`test_sdk_version_includes_script_base_url`, `test_sdk_version_omits_script_base_url_when_not_configured`)
- `sdkVersion.resolved` continues to be sent — the client already has everything it needs

**Backward compatible**: client SDKs don't yet read `sdkVersion`.

## How did you test this code?

`pytest posthog/models/test/test_remote_config.py::TestRemoteConfigSdkVersion` — all 4 remaining tests pass.

## Publish to changelog?

No