### PR TITLE
fix: add static/ prefix to posthog-js S3 artifact paths

### DIFF
--- a/posthog/models/js_snippet_versioning.py
+++ b/posthog/models/js_snippet_versioning.py
@@ -38,7 +38,7 @@ S3_JS_ENTRY_POINT = "array.js"
 
 
 def array_js_path(version: str) -> str:
-    return f"{version}/{S3_JS_ENTRY_POINT}"
+    return f"static/{version}/{S3_JS_ENTRY_POINT}"
 
 
 REDIS_JS_CONTENT_TTL = 60 * 60 * 24 * 30  # 30 days — version content is immutable

--- a/posthog/test/test_js_snippet_versioning.py
+++ b/posthog/test/test_js_snippet_versioning.py
@@ -152,7 +152,7 @@ class TestGetJsContent(SimpleTestCase):
         try:
             content = get_js_content("1.358.0")
             assert content == "s3-js-content"
-            mock_read.assert_called_once_with("1.358.0/array.js", bucket="test-bucket", missing_ok=True)
+            mock_read.assert_called_once_with("static/1.358.0/array.js", bucket="test-bucket", missing_ok=True)
             assert cache.get(f"{REDIS_JS_KEY_PREFIX}:1.358.0") == "s3-js-content"
         finally:
             cache.delete(f"{REDIS_JS_KEY_PREFIX}:1.358.0")
@@ -194,7 +194,7 @@ class TestValidateArtifacts(SimpleTestCase):
     def test_returns_true_when_array_js_exists(self, mock_head):
         mock_head.return_value = {"ContentLength": 12345}
         assert validate_version_artifacts("1.358.0") is True
-        mock_head.assert_called_once_with("1.358.0/array.js", bucket="test-bucket")
+        mock_head.assert_called_once_with("static/1.358.0/array.js", bucket="test-bucket")
 
     @override_settings(POSTHOG_JS_S3_BUCKET="test-bucket")
     @patch("posthog.models.js_snippet_versioning.object_storage.head_object")


### PR DESCRIPTION
## Problem

Versioned posthog-js bundles will be served via CDN at `/static/{version}/{file}.js` (see [posthog-cloud-infra#7346](https://github.com/PostHog/posthog-cloud-infra/pull/7346)). The CDN proxies to S3 without rewriting the path, so the S3 object keys need to include the `/static/` prefix to match.

The `/static/` prefix ensures versioned paths are unambiguously distinguishable from API routes when served through reverse proxies on shared hosts.

## Changes

One-line change to `array_js_path()`, the single function that controls S3 keys for versioned JS artifacts:

- `{version}/array.js` → `static/{version}/array.js`

This flows through to both:
- **Celery manifest sync** (`sync_manifest_from_s3`) — artifact validation via `validate_version_artifacts()`
- **Content serving** (`get_js_content`) — reading JS content for `array.js` responses

Updated two test assertions to match the new path.

Buckets are currently empty so no data migration is needed. The corresponding posthog-js CI upload script change will land in parallel.

## How did you test this code?

All related test suites pass:
- `pytest posthog/test/test_js_snippet_versioning.py` — 51 passed
- `pytest posthog/management/commands/test/test_js_snippet_version.py` — 15 passed
- `pytest posthog/models/test/test_remote_config.py` — 45 passed

## Publish to changelog?

No