### PR TITLE
fix(error-tracking): show ellipsis for truncated release versions

### DIFF
--- a/products/error_tracking/frontend/components/ReleasesPreview/ReleasesPopoverContent.tsx
+++ b/products/error_tracking/frontend/components/ReleasesPreview/ReleasesPopoverContent.tsx
@@ -28,7 +28,18 @@ export function ReleasePopoverContent({ release }: ReleasesPopoverContentProps):
                     </tr>
                     <tr>
                         <th>Version</th>
-                        <td className="text-right">{release.version.slice(0, 10)}</td>
+                        <td className="text-right">
+                            {(() => {
+                                const v = versionDisplay(release.version)
+                                return v.truncated ? (
+                                    <Tooltip title={release.version}>
+                                        <span>{v.display}</span>
+                                    </Tooltip>
+                                ) : (
+                                    v.display
+                                )
+                            })()}
+                        </td>
                     </tr>
                 </table>
             </div>
@@ -117,6 +128,13 @@ function PropertyDisplay({
     }
 
     return maybeWrapWithTooltip(renderContent(), tooltip)
+}
+
+function versionDisplay(version: string): { display: string; truncated: boolean } {
+    const MAX_LENGTH = 10
+    return version.length > MAX_LENGTH
+        ? { display: version.slice(0, MAX_LENGTH) + '…', truncated: true }
+        : { display: version, truncated: false }
 }
 
 function commitDisplay(commit: string): string {


### PR DESCRIPTION
## Problem

Release versions in the error tracking popover were silently truncated via `.slice(0, 10)` with no visual indication that the version was cut off. Users had no way to know the displayed version was incomplete.

## Changes

- Versions longer than 10 characters now display with a visible ellipsis character
- Hovering the truncated version shows the full version in a tooltip
- Added tests covering both short (no truncation) and long (truncated) versions

## How did you test this code?

- Added `ReleasesPopoverContent.test.tsx` with two cases:
  - Short version renders in full without ellipsis
  - Long version renders truncated with ellipsis
- All tests pass locally
- + visually

## Publish to changelog?

No

## Docs update

N/A