### PR TITLE
feat(flags): emit $feature_flag_changed internal event for webhook/workflow triggers

### DIFF
--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -3301,9 +3301,9 @@ def handle_feature_flag_change(
                 else None
             ),
         )
-    except Exception:
+    except Exception as e:
         # Don't let event emission failures block the flag change
-        pass
+        capture_exception(e)
 
 
 class LegacyFeatureFlagViewSet(FeatureFlagViewSet):

--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -55,6 +55,7 @@ from posthog.helpers.encrypted_flag_payloads import (
     encrypt_flag_payloads,
     get_decrypted_flag_payloads_protected,
 )
+from posthog.cdp.internal_events import InternalEventEvent, InternalEventPerson, produce_internal_event
 from posthog.models import FeatureFlag, Team
 from posthog.models.activity_logging.activity_log import Detail, changes_between, load_activity, log_activity
 from posthog.models.activity_logging.activity_page import ActivityLogPaginatedResponseSerializer, activity_page_response
@@ -3268,6 +3269,41 @@ def handle_feature_flag_change(
             trigger=trigger,
         ),
     )
+
+    # Emit a dedicated internal event for feature flag changes
+    # so users can trigger HogFunctions (webhooks, Slack, etc.) on flag changes
+    try:
+        produce_internal_event(
+            team_id=after_update.team_id,
+            event=InternalEventEvent(
+                event="$feature_flag_changed",
+                distinct_id=(
+                    after_update.last_modified_by.distinct_id
+                    if after_update.last_modified_by
+                    else f"team_{after_update.team_id}"
+                ),
+                properties={
+                    "flag_key": after_update.key,
+                    "flag_name": after_update.name or after_update.key,
+                    "flag_id": after_update.id,
+                    "active": after_update.active,
+                    "activity": resolved_activity,
+                    "changed_by": after_update.last_modified_by.email if after_update.last_modified_by else None,
+                    "changes": [change.field for change in changes] if changes else [],
+                },
+            ),
+            person=(
+                InternalEventPerson(
+                    id=str(after_update.last_modified_by.id),
+                    properties={"email": after_update.last_modified_by.email},
+                )
+                if after_update.last_modified_by
+                else None
+            ),
+        )
+    except Exception:
+        # Don't let event emission failures block the flag change
+        pass
 
 
 class LegacyFeatureFlagViewSet(FeatureFlagViewSet):

--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -3303,6 +3303,7 @@ def handle_feature_flag_change(
         )
     except Exception as e:
         # Don't let event emission failures block the flag change
+        logger.exception("Failed to emit $feature_flag_changed internal event for flag %s", after_update.key)
         capture_exception(e)
 
 

--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -44,6 +44,7 @@ from posthog.auth import (
     ProjectSecretAPIKeyAuthentication,
     SessionAuthentication,
 )
+from posthog.cdp.internal_events import InternalEventEvent, InternalEventPerson, produce_internal_event
 from posthog.constants import PRODUCT_TOUR_TARGETING_FLAG_PREFIX, SURVEY_TARGETING_FLAG_PREFIX, FlagRequestType
 from posthog.date_util import thirty_days_ago
 from posthog.event_usage import report_user_action
@@ -55,7 +56,6 @@ from posthog.helpers.encrypted_flag_payloads import (
     encrypt_flag_payloads,
     get_decrypted_flag_payloads_protected,
 )
-from posthog.cdp.internal_events import InternalEventEvent, InternalEventPerson, produce_internal_event
 from posthog.models import FeatureFlag, Team
 from posthog.models.activity_logging.activity_log import Detail, changes_between, load_activity, log_activity
 from posthog.models.activity_logging.activity_page import ActivityLogPaginatedResponseSerializer, activity_page_response

--- a/posthog/api/test/test_feature_flag.py
+++ b/posthog/api/test/test_feature_flag.py
@@ -90,25 +90,43 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
             r.delete(key)
         return super().setUp()
 
+    @parameterized.expand(
+        [
+            ("created", "post", None, "created"),
+            ("updated", "patch", {"active": False}, "updated"),
+        ]
+    )
     @patch("posthog.api.feature_flag.produce_internal_event")
-    def test_feature_flag_change_emits_internal_event(self, mock_produce_internal_event):
-        response = self.client.post(
+    def test_feature_flag_change_emits_internal_event(
+        self, _name, method, update_payload, expected_activity, mock_produce_internal_event
+    ):
+        # Create the flag first
+        create_response = self.client.post(
             f"/api/projects/{self.team.id}/feature_flags/",
             {"key": "test-flag", "name": "Test Flag", "filters": {"groups": [{"rollout_percentage": 100}]}},
             format="json",
         )
+        self.assertEqual(create_response.status_code, status.HTTP_201_CREATED)
 
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        if method == "patch":
+            # Reset mock to only capture the update event
+            mock_produce_internal_event.reset_mock()
+            flag_id = create_response.json()["id"]
+            response = self.client.patch(
+                f"/api/projects/{self.team.id}/feature_flags/{flag_id}/",
+                update_payload,
+                format="json",
+            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+
         mock_produce_internal_event.assert_called_once()
-
         _, kwargs = mock_produce_internal_event.call_args
         event = kwargs["event"]
 
         self.assertEqual(kwargs["team_id"], self.team.id)
         self.assertEqual(event.event, "$feature_flag_changed")
         self.assertEqual(event.properties["flag_key"], "test-flag")
-        self.assertEqual(event.properties["flag_name"], "Test Flag")
-        self.assertEqual(event.properties["activity"], "created")
+        self.assertEqual(event.properties["activity"], expected_activity)
         self.assertIn("active", event.properties)
 
     def test_cant_create_flag_with_duplicate_key(self):

--- a/posthog/api/test/test_feature_flag.py
+++ b/posthog/api/test/test_feature_flag.py
@@ -94,6 +94,8 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
         [
             ("created", "post", None, "created"),
             ("updated", "patch", {"active": False}, "updated"),
+            ("deleted", "patch", {"deleted": True}, "deleted"),
+            ("restored", "patch", {"deleted": False}, "restored"),
         ]
     )
     @patch("posthog.api.feature_flag.produce_internal_event")
@@ -109,9 +111,18 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
         self.assertEqual(create_response.status_code, status.HTTP_201_CREATED)
 
         if method == "patch":
-            # Reset mock to only capture the update event
-            mock_produce_internal_event.reset_mock()
             flag_id = create_response.json()["id"]
+
+            if expected_activity == "restored":
+                # Soft-delete the flag first so we can restore it
+                self.client.patch(
+                    f"/api/projects/{self.team.id}/feature_flags/{flag_id}/",
+                    {"deleted": True},
+                    format="json",
+                )
+
+            # Reset mock to only capture the target event
+            mock_produce_internal_event.reset_mock()
             response = self.client.patch(
                 f"/api/projects/{self.team.id}/feature_flags/{flag_id}/",
                 update_payload,

--- a/posthog/api/test/test_feature_flag.py
+++ b/posthog/api/test/test_feature_flag.py
@@ -90,6 +90,27 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
             r.delete(key)
         return super().setUp()
 
+    @patch("posthog.api.feature_flag.produce_internal_event")
+    def test_feature_flag_change_emits_internal_event(self, mock_produce_internal_event):
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/feature_flags/",
+            {"key": "test-flag", "name": "Test Flag", "filters": {"groups": [{"rollout_percentage": 100}]}},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        mock_produce_internal_event.assert_called_once()
+
+        _, kwargs = mock_produce_internal_event.call_args
+        event = kwargs["event"]
+
+        self.assertEqual(kwargs["team_id"], self.team.id)
+        self.assertEqual(event.event, "$feature_flag_changed")
+        self.assertEqual(event.properties["flag_key"], "test-flag")
+        self.assertEqual(event.properties["flag_name"], "Test Flag")
+        self.assertEqual(event.properties["activity"], "created")
+        self.assertIn("active", event.properties)
+
     def test_cant_create_flag_with_duplicate_key(self):
         FeatureFlag.objects.create(team=self.team, created_by=self.user, key="red_button")
         count = FeatureFlag.objects.count()


### PR DESCRIPTION
## Problem

When a feature flag is toggled, renamed, or has its rollout percentage changed, there's no dedicated event users can hook into for webhooks or workflow automation. The existing `$activity_log_entry_created` event fires on flag changes, but its properties mirror the raw activity log serialization, which requires filtering by scope and isn't discoverable.

This has been requested for over 2 years in #17361 (28 reactions, 13 comments). LaunchDarkly and Flagsmith both offer flag-change webhooks as first-class features.

Closes #17361

## Changes

Added a `$feature_flag_changed` internal event that fires through the existing CDP pipeline whenever a feature flag is created, updated, or deleted. The event is emitted from `handle_feature_flag_change` in `posthog/api/feature_flag.py`, right after the existing `log_activity` call.

The event includes structured properties:
- `flag_key`, `flag_name`, `flag_id`
- `active` (current state)
- `activity` ("created", "updated", "deleted", "restored")
- `changed_by` (user email)
- `changes` (list of changed field names)

Users can create HogFunctions or Workflows triggered by `$feature_flag_changed` to send Slack messages, hit webhooks, or automate CI/CD actions when flags change.

The event emission is wrapped in a try/except so failures don't block the flag change itself. This follows the same `produce_internal_event` pattern used in `posthog/models/activity_logging/activity_log.py` for `$activity_log_entry_created`.

## How did you test this code?

Added a unit test `test_feature_flag_change_emits_internal_event` in `posthog/api/test/test_feature_flag.py` that:
1. Creates a feature flag via the API
2. Asserts `produce_internal_event` was called with the correct `team_id`, event name `$feature_flag_changed`, and expected properties (`flag_key`, `flag_name`, `activity`)

This is an agent-authored PR. I haven't run the full PostHog stack locally, only verified via the unit test and ruff lint/format checks.

## Publish to changelog?

no

## Docs update

No docs changes needed. The event follows existing internal event patterns.

## 🤖 LLM context

This PR was authored with AI assistance (Codex + Claude Code). The implementation follows the existing `produce_internal_event` pattern from `posthog/models/activity_logging/activity_log.py:1001-1040` where `$activity_log_entry_created` is emitted on every activity log save.

This contribution was developed with AI assistance (Codex).