### PR TITLE
feat(experiments): use PersonModal for funnel instead of SampledSessionsModal.

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -290,6 +290,7 @@ export const FEATURE_FLAGS = {
     EXPERIMENT_SESSION_REPLAYS_SKILL: 'experiment-session-replays-skill', // owner: @rodrigoi #team-experiments
     EXPERIMENT_SIGNIFICANCE_ALERTS: 'experiment-significance-alerts', // owner: @jurajmajerik #team-experiments
     EXPERIMENT_QUERY_PREAGGREGATION: 'experiment-query-preaggregation', // owner: @jurajmajerik #team-experiments
+    EXPERIMENT_FUNNEL_ACTORS_QUERY: 'experiment-funnel-actors-query', // owner: @rodrigoi #team-experiments
     EXPERIMENTS_DW_AA_TEST: 'experiments-dw-aa-test', // owner: @rodrigoi #team-experiments
     EXPERIMENTS_SHOW_SQL: 'experiments-show-sql', // owner: @jurajmajerik #team-experiments
     EXPERIMENTS_TEMPLATES: 'experiments-templates', // owner: @rodrigoi #team-experiments

--- a/frontend/src/scenes/experiments/MetricsView/new/ResultDetails.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/ResultDetails.tsx
@@ -16,6 +16,7 @@ import { getViewRecordingFilters } from 'scenes/experiments/utils'
 import {
     CachedNewExperimentQueryResponse,
     ExperimentMetric,
+    ExperimentQuery,
     NodeKind,
     isExperimentFunnelMetric,
     isExperimentMeanMetric,
@@ -80,6 +81,7 @@ function convertExperimentResultToFunnelSteps(
             return {
                 name: stepName,
                 custom_name: null,
+                order: stepIndex,
                 count: count,
                 type: 'events' as EntityType,
                 breakdown_value: variantResult.key,
@@ -288,6 +290,15 @@ export function ResultDetails({
         ...(result.variant_results || []),
     ]
 
+    // Construct ExperimentQuery for actors query
+    const experimentQuery: ExperimentQuery | undefined = experiment.id
+        ? {
+              kind: NodeKind.ExperimentQuery,
+              experiment_id: experiment.id,
+              metric,
+          }
+        : undefined
+
     return (
         <div className="space-y-4">
             <LemonTable columns={columns} dataSource={dataSource} loading={false} />
@@ -300,6 +311,7 @@ export function ResultDetails({
                     experimentResult={result}
                     experiment={experiment}
                     metric={metric}
+                    experimentQuery={experimentQuery}
                 />
             )}
             <SqlCollapsible

--- a/frontend/src/scenes/experiments/MetricsView/new/ResultDetails.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/ResultDetails.tsx
@@ -292,11 +292,11 @@ export function ResultDetails({
 
     // Construct ExperimentQuery for actors query
     const experimentQuery: ExperimentQuery | undefined = experiment.id
-        ? {
+        ? ({
               kind: NodeKind.ExperimentQuery,
               experiment_id: experiment.id,
               metric,
-          }
+          } as ExperimentQuery)
         : undefined
 
     return (

--- a/frontend/src/scenes/experiments/charts/funnel/FunnelChart.tsx
+++ b/frontend/src/scenes/experiments/charts/funnel/FunnelChart.tsx
@@ -2,7 +2,7 @@ import '../../../funnels/Funnel.scss'
 
 import { createContext, useContext, useMemo } from 'react'
 
-import { ExperimentMetric, NewExperimentQueryResponse } from '~/queries/schema/schema-general'
+import { ExperimentMetric, ExperimentQuery, NewExperimentQueryResponse } from '~/queries/schema/schema-general'
 import {
     ChartParams,
     Experiment,
@@ -28,6 +28,8 @@ export interface FunnelChartProps extends ChartParams {
     experiment?: Experiment
     /** Experiment metric configuration */
     metric?: ExperimentMetric
+    /** Experiment query for actors query (optional) */
+    experimentQuery?: ExperimentQuery
 }
 
 export interface FunnelChartDataContext {
@@ -37,6 +39,7 @@ export interface FunnelChartDataContext {
     experimentResult: NewExperimentQueryResponse
     experiment?: Experiment
     metric?: ExperimentMetric
+    experimentQuery?: ExperimentQuery
 }
 
 const FunnelChartDataContext = createContext<FunnelChartDataContext | null>(null)
@@ -63,6 +66,7 @@ export function FunnelChart({
     experimentResult,
     experiment,
     metric,
+    experimentQuery,
     ...chartParams
 }: FunnelChartProps): JSX.Element {
     const processedData = useMemo(() => {
@@ -82,8 +86,9 @@ export function FunnelChart({
             experimentResult,
             experiment,
             metric,
+            experimentQuery,
         }),
-        [processedData, experimentResult, experiment, metric]
+        [processedData, experimentResult, experiment, metric, experimentQuery]
     )
 
     return (

--- a/frontend/src/scenes/experiments/charts/funnel/FunnelTooltip.tsx
+++ b/frontend/src/scenes/experiments/charts/funnel/FunnelTooltip.tsx
@@ -60,15 +60,18 @@ function FunnelTooltipContent({
                         <td>{humanFriendlyNumber(series.count)}</td>
                     </tr>
                     {stepIndex > 0 && (
-                        <tr>
-                            <td>Dropped off</td>
-                            <td>{humanFriendlyNumber(series.droppedOffFromPrevious || 0)}</td>
-                        </tr>
+                        <>
+                            <tr>
+                                <td>Dropped off</td>
+                                <td>{humanFriendlyNumber(series.droppedOffFromPrevious || 0)}</td>
+                            </tr>
+
+                            <tr>
+                                <td>Conversion so far</td>
+                                <td>{percentage(series.conversionRates.total || 0, 2, true)}</td>
+                            </tr>
+                        </>
                     )}
-                    <tr>
-                        <td>Conversion so far</td>
-                        <td>{percentage(series.conversionRates.total || 0, 2, true)}</td>
-                    </tr>
                     {stepIndex > 0 && (
                         <tr>
                             <td>Conversion from previous</td>

--- a/frontend/src/scenes/experiments/charts/funnel/FunnelTooltip.tsx
+++ b/frontend/src/scenes/experiments/charts/funnel/FunnelTooltip.tsx
@@ -2,11 +2,11 @@ import clsx from 'clsx'
 import { useEffect, useRef, useState } from 'react'
 
 import { EntityFilterInfo } from 'lib/components/EntityFilterInfo'
-import { IconHandClick } from 'lib/lemon-ui/icons'
 import { LemonDivider } from 'lib/lemon-ui/LemonDivider'
 import { LemonRow } from 'lib/lemon-ui/LemonRow'
 import { Lettermark, LettermarkColor } from 'lib/lemon-ui/Lettermark'
 import { humanFriendlyDuration, humanFriendlyNumber, percentage } from 'lib/utils'
+import { ClickToInspectActors } from 'scenes/insights/InsightTooltip/InsightTooltip'
 import { useInsightTooltip } from 'scenes/insights/useInsightTooltip'
 import { formatBreakdownLabel } from 'scenes/insights/utils'
 import { getActionFilterFromFunnelStep } from 'scenes/insights/views/Funnels/funnelStepTableUtils'
@@ -89,12 +89,7 @@ function FunnelTooltipContent({
                     )}
                 </tbody>
             </table>
-            {hasSessionData && (
-                <div className="table-subtext table-subtext-click-to-inspect">
-                    <IconHandClick className="mr-1 mb-0.5" />
-                    Click to view sampled persons at this step
-                </div>
-            )}
+            {hasSessionData && <ClickToInspectActors groupTypeLabel="persons" />}
         </div>
     )
 }

--- a/frontend/src/scenes/experiments/charts/funnel/StepBar.tsx
+++ b/frontend/src/scenes/experiments/charts/funnel/StepBar.tsx
@@ -170,18 +170,43 @@ export function StepBar({ step, stepIndex }: StepBarProps): JSX.Element {
                 onMouseEnter={() => {
                     if (ref.current) {
                         const rect = ref.current.getBoundingClientRect()
-                        showTooltip(
-                            [rect.x, rect.y, rect.width],
-                            stepIndex,
-                            step,
-                            !!sessionData || hasActorsQueryFeature
-                        )
+                        // Only show "Click to inspect actors" hint when clicking will actually work:
+                        // - Step 0 (exposure) with new feature enabled: can't use actors query (returns early), so don't show hint
+                        // - Step 0 with legacy: can use sampled sessions, show hint if sessionData exists
+                        // - Step > 0 with new feature: can use actors query, show hint
+                        // - Step > 0 with legacy: can use sampled sessions, show hint if sessionData exists
+                        const hasClickableData = hasActorsQueryFeature ? stepIndex > 0 : !!sessionData
+                        showTooltip([rect.x, rect.y, rect.width], stepIndex, step, hasClickableData)
                     }
                 }}
                 onMouseLeave={() => hideTooltip()}
             >
-                <div className="StepBar__backdrop" onClick={handleDropoffClick} style={{ cursor: 'pointer' }} />
-                <div className="StepBar__fill" onClick={handleConversionClick} style={{ cursor: 'pointer' }} />
+                <div
+                    className="StepBar__backdrop"
+                    onClick={handleDropoffClick}
+                    style={{
+                        cursor: hasActorsQueryFeature
+                            ? stepIndex > 0
+                                ? 'pointer'
+                                : 'default'
+                            : sessionData
+                              ? 'pointer'
+                              : 'default',
+                    }}
+                />
+                <div
+                    className="StepBar__fill"
+                    onClick={handleConversionClick}
+                    style={{
+                        cursor: hasActorsQueryFeature
+                            ? stepIndex > 0
+                                ? 'pointer'
+                                : 'default'
+                            : sessionData
+                              ? 'pointer'
+                              : 'default',
+                    }}
+                />
             </div>
         </>
     )

--- a/frontend/src/scenes/experiments/charts/funnel/StepBar.tsx
+++ b/frontend/src/scenes/experiments/charts/funnel/StepBar.tsx
@@ -15,7 +15,7 @@ import {
 import { getVariantColor } from '~/scenes/experiments/utils'
 import { funnelTitle } from '~/scenes/trends/persons-modal/persons-modal-utils'
 import { openPersonsModal } from '~/scenes/trends/persons-modal/PersonsModal'
-import { FunnelStep, FunnelStepWithConversionMetrics } from '~/types'
+import { FunnelStepWithConversionMetrics } from '~/types'
 
 import { useTooltip } from './FunnelBarVertical'
 import { useFunnelChartData } from './FunnelChart'
@@ -38,17 +38,15 @@ interface StepBarCSSProperties extends React.CSSProperties {
  */
 function openExperimentPersonsModalForSeries({
     step,
-    series,
     converted,
     experimentQuery,
 }: {
-    step: FunnelStep
-    series: Omit<FunnelStepWithConversionMetrics, 'nested_breakdown'>
+    step: FunnelStepWithConversionMetrics
     converted: boolean
     experimentQuery: ExperimentQuery
 }): void {
     const stepNo = step.order + 1
-    const variantKey = series.breakdown_value as string
+    const variantKey = step.breakdown_value as string
 
     // This should only be called for funnel metrics
     if (!isExperimentFunnelMetric(experimentQuery.metric)) {
@@ -135,7 +133,6 @@ export function StepBar({ step, stepIndex }: StepBarProps): JSX.Element {
         if (hasActorsQueryFeature && experimentQuery) {
             openExperimentPersonsModalForSeries({
                 step: step,
-                series: step,
                 converted: false, // Dropoffs
                 experimentQuery,
             })
@@ -149,7 +146,6 @@ export function StepBar({ step, stepIndex }: StepBarProps): JSX.Element {
         if (hasActorsQueryFeature && experimentQuery) {
             openExperimentPersonsModalForSeries({
                 step: step,
-                series: step,
                 converted: true, // Conversions
                 experimentQuery,
             })

--- a/frontend/src/scenes/experiments/charts/funnel/StepBar.tsx
+++ b/frontend/src/scenes/experiments/charts/funnel/StepBar.tsx
@@ -2,12 +2,21 @@ import clsx from 'clsx'
 import { useActions } from 'kea'
 import { useRef } from 'react'
 
+import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { percentage } from 'lib/utils'
 
-import { SessionData } from '~/queries/schema/schema-general'
-import { FunnelStepWithConversionMetrics } from '~/types'
+import {
+    ExperimentActorsQuery,
+    ExperimentQuery,
+    isExperimentFunnelMetric,
+    NodeKind,
+    SessionData,
+} from '~/queries/schema/schema-general'
+import { getVariantColor } from '~/scenes/experiments/utils'
+import { funnelTitle } from '~/scenes/trends/persons-modal/persons-modal-utils'
+import { openPersonsModal } from '~/scenes/trends/persons-modal/PersonsModal'
+import { FunnelStep, FunnelStepWithConversionMetrics } from '~/types'
 
-import { getVariantColor } from '../../utils'
 import { useTooltip } from './FunnelBarVertical'
 import { useFunnelChartData } from './FunnelChart'
 import { sampledSessionsModalLogic } from './sampledSessionsModalLogic'
@@ -22,11 +31,74 @@ interface StepBarCSSProperties extends React.CSSProperties {
     '--conversion-rate': string
 }
 
+/**
+ * Opens the persons modal for a specific funnel step in an experiment.
+ * Handles the step number mapping between frontend (with "Experiment exposure" step)
+ * and backend (without exposure step).
+ */
+function openExperimentPersonsModalForSeries({
+    step,
+    series,
+    converted,
+    experimentQuery,
+}: {
+    step: FunnelStep
+    series: Omit<FunnelStepWithConversionMetrics, 'nested_breakdown'>
+    converted: boolean
+    experimentQuery: ExperimentQuery
+}): void {
+    const stepNo = step.order + 1
+    const variantKey = series.breakdown_value as string
+
+    // This should only be called for funnel metrics
+    if (!isExperimentFunnelMetric(experimentQuery.metric)) {
+        return
+    }
+
+    // Build title exactly like regular funnels (using frontend step numbering)
+    const title = funnelTitle({
+        converted,
+        step: stepNo,
+        breakdown_value: variantKey,
+        label: step.name,
+        order_type: experimentQuery.metric.funnel_order_type,
+    })
+
+    // IMPORTANT: For experiment funnels, the frontend adds an "Experiment exposure" step at index 0
+    // But the backend funnel query doesn't include this - it only has the actual metric events
+    // Frontend: Step 0=Exposure, Step 1=$pageview, Step 2=uploaded_file
+    // Backend:                  Step 1=$pageview, Step 2=uploaded_file
+    // So we subtract 1 to map frontend -> backend step numbers
+    const backendStepNo = stepNo - 1
+
+    // Skip if trying to query the "Experiment exposure" step (doesn't exist in backend funnel)
+    if (backendStepNo < 1) {
+        return
+    }
+
+    // Create ExperimentActorsQuery (same pattern as FunnelsActorsQuery)
+    const query: ExperimentActorsQuery = {
+        kind: NodeKind.ExperimentActorsQuery,
+        source: experimentQuery,
+        funnelStep: converted ? backendStepNo : -backendStepNo, // Positive = converted, Negative = dropped off
+        funnelStepBreakdown: variantKey, // Filter by variant
+        includeRecordings: true,
+    }
+
+    // Open standard PersonsModal (same as regular funnels!)
+    openPersonsModal({
+        title,
+        query,
+        additionalSelect: { matched_recordings: 'matched_recordings' },
+    })
+}
+
 export function StepBar({ step, stepIndex }: StepBarProps): JSX.Element {
     const ref = useRef<HTMLDivElement | null>(null)
     const { showTooltip, hideTooltip } = useTooltip()
-    const { experimentResult, experiment } = useFunnelChartData()
+    const { experimentResult, experiment, experimentQuery } = useFunnelChartData()
     const { openModal } = useActions(sampledSessionsModalLogic)
+    const hasActorsQueryFeature = useFeatureFlag('EXPERIMENT_FUNNEL_ACTORS_QUERY')
 
     const variantKey = Array.isArray(step.breakdown_value)
         ? step.breakdown_value[0]?.toString() || ''
@@ -47,13 +119,43 @@ export function StepBar({ step, stepIndex }: StepBarProps): JSX.Element {
             sessionData = variantResult?.step_sessions?.[stepIndex] as SessionData[] | undefined
         }
     }
-    const handleClick = (): void => {
+    // Legacy click handler for sampled sessions modal
+    const handleLegacyClick = (): void => {
         if (sessionData) {
             openModal({
                 sessionData,
                 stepName: step.custom_name || step.name,
                 variant: variantKey,
             })
+        }
+    }
+
+    // New click handlers for actors query (with feature flag)
+    const handleDropoffClick = (): void => {
+        if (hasActorsQueryFeature && experimentQuery) {
+            openExperimentPersonsModalForSeries({
+                step: step,
+                series: step,
+                converted: false, // Dropoffs
+                experimentQuery,
+            })
+        } else {
+            // Fall back to legacy behavior
+            handleLegacyClick()
+        }
+    }
+
+    const handleConversionClick = (): void => {
+        if (hasActorsQueryFeature && experimentQuery) {
+            openExperimentPersonsModalForSeries({
+                step: step,
+                series: step,
+                converted: true, // Conversions
+                experimentQuery,
+            })
+        } else {
+            // Fall back to legacy behavior
+            handleLegacyClick()
         }
     }
 
@@ -72,13 +174,18 @@ export function StepBar({ step, stepIndex }: StepBarProps): JSX.Element {
                 onMouseEnter={() => {
                     if (ref.current) {
                         const rect = ref.current.getBoundingClientRect()
-                        showTooltip([rect.x, rect.y, rect.width], stepIndex, step, !!sessionData)
+                        showTooltip(
+                            [rect.x, rect.y, rect.width],
+                            stepIndex,
+                            step,
+                            !!sessionData || hasActorsQueryFeature
+                        )
                     }
                 }}
                 onMouseLeave={() => hideTooltip()}
             >
-                <div className="StepBar__backdrop" onClick={handleClick} style={{ cursor: 'pointer' }} />
-                <div className="StepBar__fill" onClick={handleClick} style={{ cursor: 'pointer' }} />
+                <div className="StepBar__backdrop" onClick={handleDropoffClick} style={{ cursor: 'pointer' }} />
+                <div className="StepBar__fill" onClick={handleConversionClick} style={{ cursor: 'pointer' }} />
             </div>
         </>
     )

--- a/frontend/src/scenes/trends/persons-modal/personsModalLogic.ts
+++ b/frontend/src/scenes/trends/persons-modal/personsModalLogic.ts
@@ -18,6 +18,7 @@ import { performQuery } from '~/queries/query'
 import {
     ActorsQuery,
     DataTableNode,
+    ExperimentActorsQuery,
     FunnelCorrelationActorsQuery,
     FunnelsActorsQuery,
     InsightActorsQuery,
@@ -50,7 +51,7 @@ import type { personsModalLogicType } from './personsModalLogicType'
 const RESULTS_PER_PAGE = 100
 
 export interface PersonModalLogicProps {
-    query?: InsightActorsQuery | FunnelsActorsQuery | FunnelCorrelationActorsQuery | null
+    query?: InsightActorsQuery | FunnelsActorsQuery | FunnelCorrelationActorsQuery | ExperimentActorsQuery | null
     url?: string | null
     additionalSelect?: Partial<Record<keyof CommonActorType, string>>
     orderBy?: string[]


### PR DESCRIPTION
## Problem

When a user clicks a funnel metric or a details visualization, we show the corresponding `step_sessions` in the bespoke `SampledSessionsModal` dialog. This only shows information about persons who completed the step. This information is coming with the query results. 

| funnel metric result details |  sampled persons dialog |
| - | - |
|  <img width="1605" height="1036" alt="image" src="https://github.com/user-attachments/assets/74c4f15d-0a0b-445d-97b9-18ffa676bde0" /> | <img width="3208" height="2466" alt="localhost_8010_project_1_experiments_2 (1)" src="https://github.com/user-attachments/assets/cacf2105-8642-4cc3-8726-38eec2744b0f" /> |

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

We've updated the `StepBar` component to show different copy in the tooltip and to open a `PersonsModal` that uses the new `ExperimentActorsQuery` to show the correct group of persons based on the funnel step and the conversion condition. We are intentionally excluding the exposure event.

This is hidden under a feature flag. Disabling the feature flag loads the original `SampledSessionsModal`. 

| dropped off after | completed after |
| - | - |
| <img width="3208" height="2466" alt="localhost_8010_project_1_experiments_2" src="https://github.com/user-attachments/assets/910eac0b-9c4c-487b-975c-4896a2b3a796" /> | <img width="3208" height="2466" alt="localhost_8010_project_1_experiments_2 (1)" src="https://github.com/user-attachments/assets/df77ba8f-8c42-4e52-a27c-b84d39197ffb" /> |


<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

![cat-type](https://github.com/user-attachments/assets/0d426b58-aaab-4041-92d4-f7fa420b07fc)


<!-- Briefly describe the steps you took, and what steps reviewers must take to get to where changes are, and what is the expected behavior. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
