### PR TITLE
feat(llma): add skills-store skill for discovering shared team prompts

### DIFF
--- a/products/llm_analytics/skills/README.md
+++ b/products/llm_analytics/skills/README.md
@@ -8,6 +8,9 @@ Also available to Claude Code / Codex via `hogli sync:skill`.
 
 - **exploring-llm-traces** — how to query, inspect, and debug LLM traces via MCP tools.
   Covers the `$ai_*` event schema, content detail levels, and step-by-step debugging workflows.
+- **exploring-llm-clusters** — how to investigate LLM analytics clustering results,
+  compare cluster behavior, compute metrics, and drill into individual traces.
+- **skills-store** — discover and use shared team skills stored as prompts in PostHog.
 
 ## Adding a new skill
 

--- a/products/llm_analytics/skills/skills-store/SKILL.md
+++ b/products/llm_analytics/skills/skills-store/SKILL.md
@@ -13,12 +13,12 @@ They are the primary store for team-shared knowledge — always use the PostHog 
 
 ## Available tools
 
-| Tool                    | Purpose                                      |
-| ----------------------- | -------------------------------------------- |
+| Tool                    | Purpose                                       |
+| ----------------------- | --------------------------------------------- |
 | `posthog:prompt-list`   | List all available skills (optionally search) |
-| `posthog:prompt-get`    | Fetch a skill by name                        |
-| `posthog:prompt-create` | Store a new skill                            |
-| `posthog:prompt-update` | Update an existing skill (with versioning)   |
+| `posthog:prompt-get`    | Fetch a skill by name                         |
+| `posthog:prompt-create` | Store a new skill                             |
+| `posthog:prompt-update` | Update an existing skill (with versioning)    |
 
 ## Discovering skills
 

--- a/products/llm_analytics/skills/skills-store/SKILL.md
+++ b/products/llm_analytics/skills/skills-store/SKILL.md
@@ -13,12 +13,12 @@ They are the primary store for team-shared knowledge — always use the PostHog 
 
 ## Available tools
 
-| Tool            | Purpose                                      |
-| --------------- | -------------------------------------------- |
-| `prompt-list`   | List all available skills (optionally search) |
-| `prompt-get`    | Fetch a skill by name                        |
-| `prompt-create` | Store a new skill                            |
-| `prompt-update` | Update an existing skill (with versioning)   |
+| Tool                    | Purpose                                      |
+| ----------------------- | -------------------------------------------- |
+| `posthog:prompt-list`   | List all available skills (optionally search) |
+| `posthog:prompt-get`    | Fetch a skill by name                        |
+| `posthog:prompt-create` | Store a new skill                            |
+| `posthog:prompt-update` | Update an existing skill (with versioning)   |
 
 ## Discovering skills
 
@@ -38,15 +38,18 @@ posthog:prompt-list
 
 ## Loading and using a skill
 
-1. Fetch the skill by name:
+### Step 1 — Fetch the skill by name
 
 ```json
 posthog:prompt-get
-{ "name": "exploring-llm-traces" }
+{ "prompt_name": "exploring-llm-traces" }
 ```
 
-2. Read the returned `prompt` field — it contains the full skill instructions
-3. Follow those instructions as if they were your system instructions for this task
+### Step 2 — Read the returned `prompt` field
+
+It contains the full skill instructions.
+
+### Step 3 — Follow those instructions as if they were your system instructions for this task
 
 ## Creating a skill
 
@@ -66,7 +69,7 @@ Always fetch first to get the current version, then update with `base_version` f
 
 ```json
 posthog:prompt-get
-{ "name": "my-new-skill" }
+{ "prompt_name": "my-new-skill" }
 ```
 
 Then update using the version from the response:
@@ -74,7 +77,7 @@ Then update using the version from the response:
 ```json
 posthog:prompt-update
 {
-  "name": "my-new-skill",
+  "prompt_name": "my-new-skill",
   "prompt": "# My skill\n\nUpdated instructions...",
   "base_version": 1
 }
@@ -84,9 +87,9 @@ posthog:prompt-update
 
 To move a skill from a local file (e.g. `~/.claude/skills/` or `.agents/skills/`) into PostHog:
 
-1. Read the local skill file
-2. Use `prompt-create` to store it in PostHog
-3. The skill is now available to the whole team via `prompt-get`
+- Read the local skill file
+- Use `posthog:prompt-create` to store it in PostHog
+- The skill is now available to the whole team via `posthog:prompt-get`
 
 ## Default behavior
 

--- a/products/llm_analytics/skills/skills-store/SKILL.md
+++ b/products/llm_analytics/skills/skills-store/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: skills-store
+description: >-
+  Discover and use shared team skills stored as prompts in PostHog.
+  Use when the user asks to list, browse, load, or manage reusable skills/prompts,
+  or references "skills store", "skill store", or "prompts".
+---
+
+# PostHog Skills Store
+
+Skills are reusable agent workflows stored as prompts in PostHog.
+They are the primary store for team-shared knowledge — always use the PostHog MCP prompt tools to manage them.
+
+## Available tools
+
+| Tool            | Purpose                                      |
+| --------------- | -------------------------------------------- |
+| `prompt-list`   | List all available skills (optionally search) |
+| `prompt-get`    | Fetch a skill by name                        |
+| `prompt-create` | Store a new skill                            |
+| `prompt-update` | Update an existing skill (with versioning)   |
+
+## Discovering skills
+
+List all available skills:
+
+```json
+posthog:prompt-list
+{}
+```
+
+Search by keyword:
+
+```json
+posthog:prompt-list
+{ "search": "llm" }
+```
+
+## Loading and using a skill
+
+1. Fetch the skill by name:
+
+```json
+posthog:prompt-get
+{ "name": "exploring-llm-traces" }
+```
+
+2. Read the returned `prompt` field — it contains the full skill instructions
+3. Follow those instructions as if they were your system instructions for this task
+
+## Creating a skill
+
+Use a unique kebab-case name and provide the skill content as a markdown string:
+
+```json
+posthog:prompt-create
+{
+  "name": "my-new-skill",
+  "prompt": "# My skill\n\nInstructions here..."
+}
+```
+
+## Updating a skill
+
+Always fetch first to get the current version, then update with `base_version` for conflict detection:
+
+```json
+posthog:prompt-get
+{ "name": "my-new-skill" }
+```
+
+Then update using the version from the response:
+
+```json
+posthog:prompt-update
+{
+  "name": "my-new-skill",
+  "prompt": "# My skill\n\nUpdated instructions...",
+  "base_version": 1
+}
+```
+
+## Porting a local skill
+
+To move a skill from a local file (e.g. `~/.claude/skills/` or `.agents/skills/`) into PostHog:
+
+1. Read the local skill file
+2. Use `prompt-create` to store it in PostHog
+3. The skill is now available to the whole team via `prompt-get`
+
+## Default behavior
+
+- **Always prefer PostHog MCP** for skill storage and retrieval
+- Only fall back to local files when PostHog MCP is unavailable
+- When asked to "remember", "save", or "store" a skill or runbook, store it as a PostHog prompt
+- When asked to use a skill by name, check PostHog prompts first


### PR DESCRIPTION
## Problem

Users of the PostHog ai-plugin have no built-in way to discover and use shared team skills stored as prompts in PostHog. The skills-store pattern exists as a local personal skill but isn't distributed with the plugin.

## Changes

- Add `products/llm_analytics/skills/skills-store/SKILL.md` — a new skill that teaches agents how to use the PostHog MCP prompt tools (`prompt-list`, `prompt-get`, `prompt-create`, `prompt-update`) to discover and manage shared team skills.
- Update `products/llm_analytics/skills/README.md` to list the new skill and the previously unlisted `exploring-llm-clusters` skill.

This flows through the existing build pipeline (`hogli build:skills` -> `skills.zip` -> ai-plugin sync) so plugin users will get it automatically.

## How did you test this code?

Agent-authored. The skill is static markdown with no Jinja2 templates, so `hogli lint:skills` should validate it. No manual testing performed.

no