### PR TITLE
chore: add RTL tests for Replay taxonomic filter group selection

### DIFF
--- a/frontend/src/lib/components/TaxonomicFilter/TaxonomicFilter.test.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/TaxonomicFilter.test.tsx
@@ -662,6 +662,37 @@ describe('TaxonomicFilter', () => {
         expect(onChangeMock.mock.calls[0][1]).toBe(expectedFirstProperty)
     })
 
+    describe('replay group selection', () => {
+        it.each([
+            { label: 'Visited page', expectedKey: 'visited_page', expectedPropertyFilterType: 'recording' },
+            { label: 'Platform', expectedKey: 'snapshot_source', expectedPropertyFilterType: 'recording' },
+            { label: 'Console log level', expectedKey: 'level', expectedPropertyFilterType: 'log_entry' },
+            { label: 'Console log message', expectedKey: 'message', expectedPropertyFilterType: 'log_entry' },
+            { label: 'Comment text', expectedKey: 'comment_text', expectedPropertyFilterType: 'recording' },
+        ])(
+            'selecting "$label" calls onChange with key "$expectedKey" and propertyFilterType "$expectedPropertyFilterType"',
+            async ({ label, expectedKey, expectedPropertyFilterType }) => {
+                renderFilter({
+                    taxonomicGroupTypes: [TaxonomicFilterGroupType.Replay],
+                })
+
+                await waitFor(() => {
+                    expect(screen.getAllByText(label).length).toBeGreaterThanOrEqual(1)
+                })
+
+                await userEvent.click(screen.getAllByText(label)[0])
+
+                await waitFor(() => {
+                    expect(onChangeMock).toHaveBeenCalledTimes(1)
+                })
+                const [group, value, item] = onChangeMock.mock.calls[0]
+                expect(group.type).toBe(TaxonomicFilterGroupType.Replay)
+                expect(value).toBe(expectedKey)
+                expect(item.propertyFilterType).toBe(expectedPropertyFilterType)
+            }
+        )
+    })
+
     describe('autocapture context', () => {
         it.each([
             {


### PR DESCRIPTION
## Problem

The Replay taxonomic filter group is about to be converted from a custom render component to a standard options-based group. Before making that change, we need tests that lock down the current selection behavior so we can verify nothing breaks.

## Changes

Adds parameterized RTL tests to `TaxonomicFilter.test.tsx` that verify selecting each of the 5 Replay group items calls `onChange` with:
- The correct group type (`TaxonomicFilterGroupType.Replay`)
- The correct key (`visited_page`, `snapshot_source`, `level`, `message`, `comment_text`)
- The correct `propertyFilterType` (`recording` or `log_entry`)

| Label | Key | propertyFilterType |
|---|---|---|
| Visited page | visited_page | recording |
| Platform | snapshot_source | recording |
| Console log level | level | log_entry |
| Console log message | message | log_entry |
| Comment text | comment_text | recording |

## How did you test this code?

Could not run tests locally due to worktree environment issue (`@posthog/hogvm` module resolution). CI will validate.

I'm an agent and haven't tested this manually.

## Publish to changelog?

no

## LLM context

Part of the taxonomic filter simplification stack. Tests go before the conversion PR to lock down behavior.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*