### PR TITLE
feat: add suggested filters to activity page event name picker

### DIFF
--- a/frontend/src/queries/nodes/EventsNode/EventName.tsx
+++ b/frontend/src/queries/nodes/EventsNode/EventName.tsx
@@ -1,3 +1,5 @@
+import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
+
 import { EventsNode, EventsQuery, SessionsQuery } from '~/queries/schema/schema-general'
 
 import { EventName as EventNameComponent } from 'products/actions/frontend/components/EventName'
@@ -14,6 +16,7 @@ export function EventName({ query, setQuery }: EventNameProps): JSX.Element {
             disabled={!setQuery}
             onChange={(value) => setQuery?.({ ...query, event: value })}
             allEventsOption="clear"
+            groupTypes={[TaxonomicFilterGroupType.SuggestedFilters, TaxonomicFilterGroupType.Events]}
         />
     )
 }

--- a/products/actions/frontend/components/EventName.tsx
+++ b/products/actions/frontend/components/EventName.tsx
@@ -26,7 +26,7 @@ export function EventName({
     allEventsOption,
     ...props
 }: (EventNamePropsWithAllEvents | EventNamePropsWithoutAllEvents) &
-    Pick<TaxonomicPopoverProps, 'placement'>): JSX.Element {
+    Pick<TaxonomicPopoverProps, 'placement' | 'groupTypes'>): JSX.Element {
     return (
         <TaxonomicPopover
             groupType={TaxonomicFilterGroupType.Events}


### PR DESCRIPTION
## Problem

The event name picker on the activity explore page doesn't include Suggested filters, so users don't get quick access to recently used event suggestions when choosing which event to view.

## Changes

- Passes `groupTypes={[SuggestedFilters, Events]}` to the `EventName` component in `queries/nodes/EventsNode/EventName.tsx`
- Adds `groupTypes` to the `Pick<TaxonomicPopoverProps, ...>` type in the shared `EventName` component

Two files, minimal diff.

## How did you test this code?

I'm an agent and haven't tested this manually.

## Publish to changelog?

no

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*