### PR TITLE
feat(llma): add diff-based edits to prompt publish API

### DIFF
--- a/posthog/api/llm_prompt.py
+++ b/posthog/api/llm_prompt.py
@@ -30,6 +30,7 @@ from posthog.api.monitoring import monitor
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.api.services.llm_prompt import (
     LLMPromptDuplicateNameConflictError,
+    LLMPromptEditError,
     LLMPromptNotFoundError,
     LLMPromptVersionConflictError,
     LLMPromptVersionLimitError,
@@ -260,7 +261,8 @@ class LLMPromptViewSet(
                 self.team,
                 user=cast(User, request.user),
                 prompt_name=prompt_name,
-                prompt_payload=payload.validated_data["prompt"],
+                prompt_payload=payload.validated_data.get("prompt"),
+                edits=payload.validated_data.get("edits"),
                 base_version=payload.validated_data["base_version"],
             )
         except LLMPromptNotFoundError:
@@ -280,6 +282,14 @@ class LLMPromptViewSet(
                         f"Prompt has reached the maximum of {err.max_version} versions. "
                         "Archive and recreate the prompt to continue publishing."
                     ),
+                },
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        except LLMPromptEditError as err:
+            return Response(
+                {
+                    "detail": err.message,
+                    "edit_index": err.edit_index,
                 },
                 status=status.HTTP_400_BAD_REQUEST,
             )

--- a/posthog/api/llm_prompt_serializers.py
+++ b/posthog/api/llm_prompt_serializers.py
@@ -192,14 +192,14 @@ class LLMPromptSerializer(serializers.ModelSerializer):
     def validate_prompt(self, value: Any) -> Any:
         return validate_prompt_payload_size(value)
 
-    def validate(self, data: dict[str, Any]) -> dict[str, Any]:
+    def validate(self, attrs: dict[str, Any]) -> dict[str, Any]:
         team = self.context["get_team"]()
-        name = data.get("name")
+        name = attrs.get("name")
 
         if self.instance is None:
             if name and LLMPrompt.objects.filter(name=name, team=team, deleted=False).exists():
                 raise serializers.ValidationError({"name": "A prompt with this name already exists."}, code="unique")
-            return data
+            return attrs
 
         if name is not None and self.instance.name != name:
             raise serializers.ValidationError(
@@ -207,13 +207,13 @@ class LLMPromptSerializer(serializers.ModelSerializer):
                 code="immutable",
             )
 
-        if "prompt" in data:
+        if "prompt" in attrs:
             raise serializers.ValidationError(
                 {"prompt": "Prompt content is versioned and cannot be updated in place. Create a new version instead."},
                 code="immutable",
             )
 
-        return data
+        return attrs
 
     def create(self, validated_data: dict[str, Any]) -> LLMPrompt:
         request = self.context["request"]

--- a/posthog/api/llm_prompt_serializers.py
+++ b/posthog/api/llm_prompt_serializers.py
@@ -81,8 +81,29 @@ class LLMPromptResolveQuerySerializer(LLMPromptFetchQuerySerializer):
         return attrs
 
 
+class LLMPromptEditOperationSerializer(serializers.Serializer):
+    old = serializers.CharField(
+        help_text="Text to find in the current prompt. Must match exactly once.",
+    )
+    new = serializers.CharField(
+        help_text="Replacement text.",
+    )
+
+
 class LLMPromptPublishSerializer(serializers.Serializer):
-    prompt = serializers.JSONField(help_text="Prompt payload to publish as a new version.")
+    prompt = serializers.JSONField(
+        required=False,
+        help_text="Full prompt payload to publish as a new version. Mutually exclusive with edits.",
+    )
+    edits = LLMPromptEditOperationSerializer(
+        many=True,
+        required=False,
+        help_text=(
+            "List of find/replace operations to apply to the current prompt version. "
+            "Each edit's 'old' text must match exactly once. Edits are applied sequentially. "
+            "Mutually exclusive with prompt."
+        ),
+    )
     base_version = serializers.IntegerField(
         min_value=1,
         help_text="Latest version you are editing from. Used for optimistic concurrency checks.",
@@ -90,6 +111,22 @@ class LLMPromptPublishSerializer(serializers.Serializer):
 
     def validate_prompt(self, value: Any) -> Any:
         return validate_prompt_payload_size(value)
+
+    def validate_edits(self, value: list[dict[str, str]]) -> list[dict[str, str]]:
+        if len(value) == 0:
+            raise serializers.ValidationError("At least one edit operation is required.")
+        return value
+
+    def validate(self, attrs: dict[str, Any]) -> dict[str, Any]:
+        has_prompt = "prompt" in attrs
+        has_edits = "edits" in attrs
+
+        if has_prompt and has_edits:
+            raise serializers.ValidationError("Provide either 'prompt' or 'edits', not both.")
+        if not has_prompt and not has_edits:
+            raise serializers.ValidationError("Either 'prompt' or 'edits' is required.")
+
+        return attrs
 
 
 class LLMPromptSerializer(serializers.ModelSerializer):

--- a/posthog/api/services/llm_prompt.py
+++ b/posthog/api/services/llm_prompt.py
@@ -1,3 +1,4 @@
+import json
 from dataclasses import dataclass
 from typing import Any
 
@@ -26,6 +27,50 @@ class LLMPromptVersionConflictError(Exception):
 @dataclass
 class LLMPromptVersionLimitError(Exception):
     max_version: int
+
+
+@dataclass
+class LLMPromptEditError(Exception):
+    message: str
+    edit_index: int
+
+
+def apply_prompt_edits(prompt_content: Any, edits: list[dict[str, str]]) -> Any:
+    """Apply sequential find/replace edits to a prompt.
+
+    If the prompt is a string, edits operate on it directly.
+    If it's a JSON structure, it's serialized to a string for editing then parsed back.
+    Each edit's 'old' text must match exactly once.
+    """
+    is_string = isinstance(prompt_content, str)
+    text = prompt_content if is_string else json.dumps(prompt_content, indent=2, ensure_ascii=False)
+
+    for i, edit in enumerate(edits):
+        old = edit["old"]
+        new = edit["new"]
+        count = text.count(old)
+        if count == 0:
+            raise LLMPromptEditError(
+                message=f"Text to replace was not found in the prompt.",
+                edit_index=i,
+            )
+        if count > 1:
+            raise LLMPromptEditError(
+                message=f"Text to replace matches {count} times — provide more context to make it unique.",
+                edit_index=i,
+            )
+        text = text.replace(old, new, 1)
+
+    if is_string:
+        return text
+
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError as err:
+        raise LLMPromptEditError(
+            message=f"Edits produced invalid JSON: {err}",
+            edit_index=len(edits) - 1,
+        ) from err
 
 
 def get_active_prompt_queryset(team: Team) -> QuerySet[LLMPrompt]:
@@ -89,7 +134,8 @@ def publish_prompt_version(
     *,
     user: User,
     prompt_name: str,
-    prompt_payload: Any,
+    prompt_payload: Any | None = None,
+    edits: list[dict[str, str]] | None = None,
     base_version: int,
 ) -> LLMPrompt:
     with transaction.atomic():
@@ -107,11 +153,16 @@ def publish_prompt_version(
         if current_latest.version >= MAX_PROMPT_VERSION:
             raise LLMPromptVersionLimitError(max_version=MAX_PROMPT_VERSION)
 
+        if edits is not None:
+            resolved_payload = apply_prompt_edits(current_latest.prompt, edits)
+        else:
+            resolved_payload = prompt_payload
+
         LLMPrompt.objects.filter(pk=current_latest.pk).update(is_latest=False)
         published_prompt = LLMPrompt.objects.create(
             team=team,
             name=current_latest.name,
-            prompt=prompt_payload,
+            prompt=resolved_payload,
             version=current_latest.version + 1,
             is_latest=True,
             created_by=user,

--- a/posthog/api/services/llm_prompt.py
+++ b/posthog/api/services/llm_prompt.py
@@ -6,6 +6,7 @@ from django.conf import settings
 from django.db import IntegrityError, transaction
 from django.db.models import QuerySet
 
+from posthog.api.llm_prompt_serializers import MAX_PROMPT_PAYLOAD_BYTES
 from posthog.exceptions_capture import capture_exception
 from posthog.models import Team, User
 from posthog.models.llm_prompt import LLMPrompt, annotate_llm_prompt_version_history_metadata
@@ -61,16 +62,24 @@ def apply_prompt_edits(prompt_content: Any, edits: list[dict[str, str]]) -> Any:
             )
         text = text.replace(old, new, 1)
 
-    if is_string:
-        return text
+    result = text if is_string else None
+    if result is None:
+        try:
+            result = json.loads(text)
+        except json.JSONDecodeError as err:
+            raise LLMPromptEditError(
+                message=f"Edits produced invalid JSON: {err}",
+                edit_index=len(edits) - 1,
+            ) from err
 
-    try:
-        return json.loads(text)
-    except json.JSONDecodeError as err:
+    result_bytes = len(json.dumps(result, separators=(",", ":"), ensure_ascii=False).encode("utf-8"))
+    if result_bytes > MAX_PROMPT_PAYLOAD_BYTES:
         raise LLMPromptEditError(
-            message=f"Edits produced invalid JSON: {err}",
+            message=f"Resulting prompt exceeds the {MAX_PROMPT_PAYLOAD_BYTES} byte size limit.",
             edit_index=len(edits) - 1,
-        ) from err
+        )
+
+    return result
 
 
 def get_active_prompt_queryset(team: Team) -> QuerySet[LLMPrompt]:

--- a/posthog/api/services/llm_prompt.py
+++ b/posthog/api/services/llm_prompt.py
@@ -51,7 +51,7 @@ def apply_prompt_edits(prompt_content: Any, edits: list[dict[str, str]]) -> Any:
         count = text.count(old)
         if count == 0:
             raise LLMPromptEditError(
-                message=f"Text to replace was not found in the prompt.",
+                message="Text to replace was not found in the prompt.",
                 edit_index=i,
             )
         if count > 1:

--- a/posthog/api/test/test_llm_prompt.py
+++ b/posthog/api/test/test_llm_prompt.py
@@ -344,63 +344,76 @@ class TestLLMPromptAPI(APIBaseTest):
         latest = LLMPrompt.objects.get(team=self.team, name="multi-edit", version=2, deleted=False)
         assert latest.prompt == "Hi there. See you later."
 
-    def test_update_prompt_by_name_with_edits_rejects_when_old_not_found(self, mock_feature_enabled):
-        self.create_prompt_version(name="missing-edit", version=1, is_latest=True, prompt="Hello world.")
+    @parameterized.expand(
+        [
+            (
+                "old_not_found",
+                "Hello world.",
+                [{"old": "nonexistent text", "new": "replacement"}],
+                "not found",
+                0,
+            ),
+            (
+                "ambiguous_match",
+                "foo bar foo",
+                [{"old": "foo", "new": "baz"}],
+                "matches 2 times",
+                0,
+            ),
+        ]
+    )
+    def test_update_prompt_by_name_with_edits_rejects_bad_edit(
+        self, mock_feature_enabled, _name, prompt, edits, expected_detail, expected_index
+    ):
+        self.create_prompt_version(name="edit-error", version=1, is_latest=True, prompt=prompt)
 
         response = self.client.patch(
-            f"/api/environments/{self.team.id}/llm_prompts/name/missing-edit/",
+            f"/api/environments/{self.team.id}/llm_prompts/name/edit-error/",
+            data={"edits": edits, "base_version": 1},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert expected_detail in response.json()["detail"]
+        assert response.json()["edit_index"] == expected_index
+
+    @parameterized.expand(
+        [
+            (
+                "both_provided",
+                {"prompt": "v2", "edits": [{"old": "v1", "new": "v2"}], "base_version": 1},
+            ),
+            (
+                "neither_provided",
+                {"base_version": 1},
+            ),
+        ]
+    )
+    def test_update_prompt_by_name_rejects_invalid_prompt_edits_combo(self, mock_feature_enabled, _name, data):
+        self.create_prompt_version(name="combo-edit", version=1, is_latest=True, prompt="v1")
+
+        response = self.client.patch(
+            f"/api/environments/{self.team.id}/llm_prompts/name/combo-edit/",
+            data=data,
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_update_prompt_by_name_with_edits_rejects_oversized_result(self, mock_feature_enabled):
+        self.create_prompt_version(name="size-edit", version=1, is_latest=True, prompt="small")
+
+        response = self.client.patch(
+            f"/api/environments/{self.team.id}/llm_prompts/name/size-edit/",
             data={
-                "edits": [{"old": "nonexistent text", "new": "replacement"}],
+                "edits": [{"old": "small", "new": "x" * (MAX_PROMPT_PAYLOAD_BYTES + 1)}],
                 "base_version": 1,
             },
             format="json",
         )
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
-        assert "not found" in response.json()["detail"]
-        assert response.json()["edit_index"] == 0
-
-    def test_update_prompt_by_name_with_edits_rejects_ambiguous_match(self, mock_feature_enabled):
-        self.create_prompt_version(name="ambig-edit", version=1, is_latest=True, prompt="foo bar foo")
-
-        response = self.client.patch(
-            f"/api/environments/{self.team.id}/llm_prompts/name/ambig-edit/",
-            data={
-                "edits": [{"old": "foo", "new": "baz"}],
-                "base_version": 1,
-            },
-            format="json",
-        )
-
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
-        assert "matches 2 times" in response.json()["detail"]
-        assert response.json()["edit_index"] == 0
-
-    def test_update_prompt_by_name_rejects_both_prompt_and_edits(self, mock_feature_enabled):
-        self.create_prompt_version(name="both-edit", version=1, is_latest=True, prompt="v1")
-
-        response = self.client.patch(
-            f"/api/environments/{self.team.id}/llm_prompts/name/both-edit/",
-            data={
-                "prompt": "v2",
-                "edits": [{"old": "v1", "new": "v2"}],
-                "base_version": 1,
-            },
-            format="json",
-        )
-
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
-
-    def test_update_prompt_by_name_rejects_neither_prompt_nor_edits(self, mock_feature_enabled):
-        self.create_prompt_version(name="neither-edit", version=1, is_latest=True, prompt="v1")
-
-        response = self.client.patch(
-            f"/api/environments/{self.team.id}/llm_prompts/name/neither-edit/",
-            data={"base_version": 1},
-            format="json",
-        )
-
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "size limit" in response.json()["detail"]
 
     def test_update_prompt_by_name_with_edits_on_json_prompt(self, mock_feature_enabled):
         self.create_prompt_version(

--- a/posthog/api/test/test_llm_prompt.py
+++ b/posthog/api/test/test_llm_prompt.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from posthog.test.base import APIBaseTest
 from unittest.mock import patch
 
@@ -48,7 +50,7 @@ class TestLLMPromptAPI(APIBaseTest):
         self,
         *,
         name: str = "my-prompt",
-        prompt: str = "Prompt content",
+        prompt: Any = "Prompt content",
         version: int = 1,
         is_latest: bool = True,
         deleted: bool = False,

--- a/posthog/api/test/test_llm_prompt.py
+++ b/posthog/api/test/test_llm_prompt.py
@@ -309,9 +309,7 @@ class TestLLMPromptAPI(APIBaseTest):
         assert LLMPrompt.objects.filter(team=self.team, name="publish-prompt", deleted=False).count() == 1
 
     def test_update_prompt_by_name_with_edits_applies_find_replace(self, mock_feature_enabled):
-        self.create_prompt_version(
-            name="edit-prompt", version=1, is_latest=True, prompt="You are a helpful assistant."
-        )
+        self.create_prompt_version(name="edit-prompt", version=1, is_latest=True, prompt="You are a helpful assistant.")
 
         response = self.client.patch(
             f"/api/environments/{self.team.id}/llm_prompts/name/edit-prompt/",
@@ -328,9 +326,7 @@ class TestLLMPromptAPI(APIBaseTest):
         assert latest.prompt == "You are a expert coding assistant."
 
     def test_update_prompt_by_name_with_multiple_edits_applies_sequentially(self, mock_feature_enabled):
-        self.create_prompt_version(
-            name="multi-edit", version=1, is_latest=True, prompt="Hello world. Goodbye world."
-        )
+        self.create_prompt_version(name="multi-edit", version=1, is_latest=True, prompt="Hello world. Goodbye world.")
 
         response = self.client.patch(
             f"/api/environments/{self.team.id}/llm_prompts/name/multi-edit/",

--- a/posthog/api/test/test_llm_prompt.py
+++ b/posthog/api/test/test_llm_prompt.py
@@ -308,6 +308,125 @@ class TestLLMPromptAPI(APIBaseTest):
         assert str(MAX_PROMPT_VERSION) in response.json()["detail"]
         assert LLMPrompt.objects.filter(team=self.team, name="publish-prompt", deleted=False).count() == 1
 
+    def test_update_prompt_by_name_with_edits_applies_find_replace(self, mock_feature_enabled):
+        self.create_prompt_version(
+            name="edit-prompt", version=1, is_latest=True, prompt="You are a helpful assistant."
+        )
+
+        response = self.client.patch(
+            f"/api/environments/{self.team.id}/llm_prompts/name/edit-prompt/",
+            data={
+                "edits": [{"old": "helpful assistant", "new": "expert coding assistant"}],
+                "base_version": 1,
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["version"] == 2
+        latest = LLMPrompt.objects.get(team=self.team, name="edit-prompt", version=2, deleted=False)
+        assert latest.prompt == "You are a expert coding assistant."
+
+    def test_update_prompt_by_name_with_multiple_edits_applies_sequentially(self, mock_feature_enabled):
+        self.create_prompt_version(
+            name="multi-edit", version=1, is_latest=True, prompt="Hello world. Goodbye world."
+        )
+
+        response = self.client.patch(
+            f"/api/environments/{self.team.id}/llm_prompts/name/multi-edit/",
+            data={
+                "edits": [
+                    {"old": "Hello world", "new": "Hi there"},
+                    {"old": "Goodbye world", "new": "See you later"},
+                ],
+                "base_version": 1,
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        latest = LLMPrompt.objects.get(team=self.team, name="multi-edit", version=2, deleted=False)
+        assert latest.prompt == "Hi there. See you later."
+
+    def test_update_prompt_by_name_with_edits_rejects_when_old_not_found(self, mock_feature_enabled):
+        self.create_prompt_version(name="missing-edit", version=1, is_latest=True, prompt="Hello world.")
+
+        response = self.client.patch(
+            f"/api/environments/{self.team.id}/llm_prompts/name/missing-edit/",
+            data={
+                "edits": [{"old": "nonexistent text", "new": "replacement"}],
+                "base_version": 1,
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "not found" in response.json()["detail"]
+        assert response.json()["edit_index"] == 0
+
+    def test_update_prompt_by_name_with_edits_rejects_ambiguous_match(self, mock_feature_enabled):
+        self.create_prompt_version(name="ambig-edit", version=1, is_latest=True, prompt="foo bar foo")
+
+        response = self.client.patch(
+            f"/api/environments/{self.team.id}/llm_prompts/name/ambig-edit/",
+            data={
+                "edits": [{"old": "foo", "new": "baz"}],
+                "base_version": 1,
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "matches 2 times" in response.json()["detail"]
+        assert response.json()["edit_index"] == 0
+
+    def test_update_prompt_by_name_rejects_both_prompt_and_edits(self, mock_feature_enabled):
+        self.create_prompt_version(name="both-edit", version=1, is_latest=True, prompt="v1")
+
+        response = self.client.patch(
+            f"/api/environments/{self.team.id}/llm_prompts/name/both-edit/",
+            data={
+                "prompt": "v2",
+                "edits": [{"old": "v1", "new": "v2"}],
+                "base_version": 1,
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_update_prompt_by_name_rejects_neither_prompt_nor_edits(self, mock_feature_enabled):
+        self.create_prompt_version(name="neither-edit", version=1, is_latest=True, prompt="v1")
+
+        response = self.client.patch(
+            f"/api/environments/{self.team.id}/llm_prompts/name/neither-edit/",
+            data={"base_version": 1},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_update_prompt_by_name_with_edits_on_json_prompt(self, mock_feature_enabled):
+        self.create_prompt_version(
+            name="json-edit",
+            version=1,
+            is_latest=True,
+            prompt={"system": "You are helpful.", "temperature": 0.7},
+        )
+
+        response = self.client.patch(
+            f"/api/environments/{self.team.id}/llm_prompts/name/json-edit/",
+            data={
+                "edits": [{"old": "You are helpful.", "new": "You are an expert."}],
+                "base_version": 1,
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        latest = LLMPrompt.objects.get(team=self.team, name="json-edit", version=2, deleted=False)
+        assert latest.prompt == {"system": "You are an expert.", "temperature": 0.7}
+
     def test_update_prompt_by_name_forbidden_for_personal_api_key_auth(self, mock_feature_enabled):
         self.create_prompt_version(name="publish-prompt", version=1, is_latest=True, prompt="v1")
         api_key = self.create_personal_api_key_with_scopes(["llm_prompt:read"])

--- a/products/llm_analytics/frontend/generated/api.schemas.ts
+++ b/products/llm_analytics/frontend/generated/api.schemas.ts
@@ -1072,9 +1072,18 @@ export interface LLMPromptPublicApi {
     first_version_created_at: string
 }
 
+export interface LLMPromptEditOperationApi {
+    /** Text to find in the current prompt. Must match exactly once. */
+    old: string
+    /** Replacement text. */
+    new: string
+}
+
 export interface PatchedLLMPromptPublishApi {
-    /** Prompt payload to publish as a new version. */
+    /** Full prompt payload to publish as a new version. Mutually exclusive with edits. */
     prompt?: unknown
+    /** List of find/replace operations to apply to the current prompt version. Each edit's 'old' text must match exactly once. Edits are applied sequentially. Mutually exclusive with prompt. */
+    edits?: LLMPromptEditOperationApi[]
     /**
      * Latest version you are editing from. Used for optimistic concurrency checks.
      * @minimum 1

--- a/products/llm_analytics/mcp/prompts.yaml
+++ b/products/llm_analytics/mcp/prompts.yaml
@@ -64,6 +64,14 @@ tools:
         title: Update prompt
         description: |
             Publish a new version of an existing LLM prompt by name. Name is immutable after creation.
+            You can either provide the full prompt content via 'prompt', or use 'edits' for incremental
+            find/replace updates. Each edit must have 'old' (text to find, must match exactly once) and
+            'new' (replacement text). Edits are applied sequentially. Only one of 'prompt' or 'edits'
+            may be provided.
+        include_params:
+            - prompt
+            - edits
+            - base_version
     prompt-duplicate:
         operation: llm_prompts_name_duplicate_create
         enabled: true

--- a/products/llm_analytics/skills/skills-store/SKILL.md
+++ b/products/llm_analytics/skills/skills-store/SKILL.md
@@ -72,7 +72,10 @@ posthog:prompt-get
 { "prompt_name": "my-new-skill" }
 ```
 
-Then update using the version from the response:
+Then update using the version from the response.
+You can either send the full prompt, or use `edits` for incremental find/replace changes:
+
+### Full replacement
 
 ```json
 posthog:prompt-update
@@ -82,6 +85,24 @@ posthog:prompt-update
   "base_version": 1
 }
 ```
+
+### Incremental edits
+
+For small changes, use `edits` instead of resending the entire prompt.
+Each edit's `old` text must match exactly once in the current version:
+
+```json
+posthog:prompt-update
+{
+  "prompt_name": "my-new-skill",
+  "edits": [
+    { "old": "old text to find", "new": "replacement text" }
+  ],
+  "base_version": 1
+}
+```
+
+Only one of `prompt` or `edits` may be provided, not both.
 
 ## Porting a local skill
 

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -1365,7 +1365,7 @@
         }
     },
     "prompt-update": {
-        "description": "Publish a new version of an existing LLM prompt by name. Name is immutable after creation.",
+        "description": "Publish a new version of an existing LLM prompt by name. Name is immutable after creation.\nYou can either provide the full prompt content via 'prompt', or use 'edits' for incremental\nfind/replace updates. Each edit must have 'old' (text to find, must match exactly once) and\n'new' (replacement text). Edits are applied sequentially. Only one of 'prompt' or 'edits'\nmay be provided.",
         "category": "Prompts",
         "feature": "prompts",
         "summary": "Update prompt",

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -2065,7 +2065,7 @@
         }
     },
     "prompt-update": {
-        "description": "Publish a new version of an existing LLM prompt by name. Name is immutable after creation.",
+        "description": "Publish a new version of an existing LLM prompt by name. Name is immutable after creation.\nYou can either provide the full prompt content via 'prompt', or use 'edits' for incremental\nfind/replace updates. Each edit must have 'old' (text to find, must match exactly once) and\n'new' (replacement text). Edits are applied sequentially. Only one of 'prompt' or 'edits'\nmay be provided.",
         "category": "Prompts",
         "feature": "prompts",
         "summary": "Update prompt",

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -18300,6 +18300,13 @@ export namespace Schemas {
       new_name: string;
     }
 
+    export interface LLMPromptEditOperation {
+      /** Text to find in the current prompt. Must match exactly once. */
+      old: string;
+      /** Replacement text. */
+      new: string;
+    }
+
     export interface LLMPromptPublic {
       id: string;
       name: string;
@@ -23690,8 +23697,10 @@ export namespace Schemas {
     }
 
     export interface PatchedLLMPromptPublish {
-      /** Prompt payload to publish as a new version. */
+      /** Full prompt payload to publish as a new version. Mutually exclusive with edits. */
       prompt?: unknown;
+      /** List of find/replace operations to apply to the current prompt version. Each edit's 'old' text must match exactly once. Edits are applied sequentially. Mutually exclusive with prompt. */
+      edits?: LLMPromptEditOperation[];
       /**
        * Latest version you are editing from. Used for optimistic concurrency checks.
        * @minimum 1

--- a/services/mcp/src/generated/prompts/api.ts
+++ b/services/mcp/src/generated/prompts/api.ts
@@ -71,7 +71,21 @@ export const LlmPromptsNamePartialUpdateParams = /* @__PURE__ */ zod.object({
 })
 
 export const LlmPromptsNamePartialUpdateBody = /* @__PURE__ */ zod.object({
-    prompt: zod.unknown().optional().describe('Prompt payload to publish as a new version.'),
+    prompt: zod
+        .unknown()
+        .optional()
+        .describe('Full prompt payload to publish as a new version. Mutually exclusive with edits.'),
+    edits: zod
+        .array(
+            zod.object({
+                old: zod.string().describe('Text to find in the current prompt. Must match exactly once.'),
+                new: zod.string().describe('Replacement text.'),
+            })
+        )
+        .optional()
+        .describe(
+            "List of find/replace operations to apply to the current prompt version. Each edit's 'old' text must match exactly once. Edits are applied sequentially. Mutually exclusive with prompt."
+        ),
     base_version: zod
         .number()
         .min(1)

--- a/services/mcp/src/tools/generated/prompts.ts
+++ b/services/mcp/src/tools/generated/prompts.ts
@@ -88,6 +88,9 @@ const promptUpdate = (): ToolBase<typeof PromptUpdateSchema, Schemas.LLMPrompt> 
         if (params.prompt !== undefined) {
             body['prompt'] = params.prompt
         }
+        if (params.edits !== undefined) {
+            body['edits'] = params.edits
+        }
         if (params.base_version !== undefined) {
             body['base_version'] = params.base_version
         }

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/prompt-update.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/prompt-update.json
@@ -6,8 +6,26 @@
             "minimum": 1,
             "type": "number"
         },
+        "edits": {
+            "description": "List of find/replace operations to apply to the current prompt version. Each edit's 'old' text must match exactly once. Edits are applied sequentially. Mutually exclusive with prompt.",
+            "items": {
+                "properties": {
+                    "new": {
+                        "description": "Replacement text.",
+                        "type": "string"
+                    },
+                    "old": {
+                        "description": "Text to find in the current prompt. Must match exactly once.",
+                        "type": "string"
+                    }
+                },
+                "required": ["old", "new"],
+                "type": "object"
+            },
+            "type": "array"
+        },
         "prompt": {
-            "description": "Prompt payload to publish as a new version."
+            "description": "Full prompt payload to publish as a new version. Mutually exclusive with edits."
         },
         "prompt_name": {
             "pattern": "^[^/]+$",


### PR DESCRIPTION
## Problem

Agents using the prompt management MCP tools must send the entire prompt payload on every update, even for small changes. For large prompts this is inefficient and wastes tokens.

## Changes

Adds an optional `edits` field to the prompt publish endpoint (`PATCH /llm-analytics/prompts/name/<name>/`) as an alternative to the existing `prompt` field. Each edit is a find/replace pair (`old`/`new`) applied sequentially to the current version's content.

- `LLMPromptPublishSerializer`: `prompt` is now optional, new `edits` field added, cross-validated as mutually exclusive
- `apply_prompt_edits()` in the service layer resolves edits against the current version (works for both string and JSON prompts)
- Each `old` text must match exactly once — 0 matches or 2+ matches return a 400 with the failing edit index
- Existing callers sending `prompt` are unaffected — fully backwards-compatible
- MCP tool definition updated with `edits` parameter and description

## How did you test this code?

7 new test cases covering: single edit, multiple sequential edits, old-not-found error, ambiguous match error, both-fields rejection, neither-field rejection, and JSON prompt editing. All 60 tests in `test_llm_prompt.py` pass.

## Publish to changelog?

No

## Docs update

No docs update needed — this is an API addition for MCP tool consumers.