### PR TITLE
fix(llma): normalize prompt field to string on save

### DIFF
--- a/posthog/api/llm_prompt_serializers.py
+++ b/posthog/api/llm_prompt_serializers.py
@@ -109,8 +109,11 @@ class LLMPromptPublishSerializer(serializers.Serializer):
         help_text="Latest version you are editing from. Used for optimistic concurrency checks.",
     )
 
-    def validate_prompt(self, value: Any) -> Any:
-        return validate_prompt_payload_size(value)
+    def validate_prompt(self, value: Any) -> str:
+        validate_prompt_payload_size(value)
+        if not isinstance(value, str):
+            return json.dumps(value, ensure_ascii=False)
+        return value
 
     def validate_edits(self, value: list[dict[str, str]]) -> list[dict[str, str]]:
         if len(value) == 0:
@@ -189,8 +192,11 @@ class LLMPromptSerializer(serializers.ModelSerializer):
     def validate_name(self, value: str) -> str:
         return validate_prompt_name_value(value)
 
-    def validate_prompt(self, value: Any) -> Any:
-        return validate_prompt_payload_size(value)
+    def validate_prompt(self, value: Any) -> str:
+        validate_prompt_payload_size(value)
+        if not isinstance(value, str):
+            return json.dumps(value, ensure_ascii=False)
+        return value
 
     def validate(self, attrs: dict[str, Any]) -> dict[str, Any]:
         team = self.context["get_team"]()

--- a/posthog/api/llm_prompt_serializers.py
+++ b/posthog/api/llm_prompt_serializers.py
@@ -26,6 +26,13 @@ def validate_prompt_name_value(value: str) -> str:
     return value
 
 
+def normalize_prompt_to_string(value: Any) -> str:
+    validate_prompt_payload_size(value)
+    if not isinstance(value, str):
+        return json.dumps(value, ensure_ascii=False)
+    return value
+
+
 def validate_prompt_payload_size(prompt_payload: Any) -> Any:
     prompt_payload_bytes = len(json.dumps(prompt_payload, separators=(",", ":"), ensure_ascii=False).encode("utf-8"))
     if prompt_payload_bytes > MAX_PROMPT_PAYLOAD_BYTES:
@@ -110,10 +117,7 @@ class LLMPromptPublishSerializer(serializers.Serializer):
     )
 
     def validate_prompt(self, value: Any) -> str:
-        validate_prompt_payload_size(value)
-        if not isinstance(value, str):
-            return json.dumps(value, ensure_ascii=False)
-        return value
+        return normalize_prompt_to_string(value)
 
     def validate_edits(self, value: list[dict[str, str]]) -> list[dict[str, str]]:
         if len(value) == 0:
@@ -193,10 +197,7 @@ class LLMPromptSerializer(serializers.ModelSerializer):
         return validate_prompt_name_value(value)
 
     def validate_prompt(self, value: Any) -> str:
-        validate_prompt_payload_size(value)
-        if not isinstance(value, str):
-            return json.dumps(value, ensure_ascii=False)
-        return value
+        return normalize_prompt_to_string(value)
 
     def validate(self, attrs: dict[str, Any]) -> dict[str, Any]:
         team = self.context["get_team"]()

--- a/posthog/api/test/test_llm_prompt.py
+++ b/posthog/api/test/test_llm_prompt.py
@@ -881,6 +881,8 @@ class TestLLMPromptAPI(APIBaseTest):
             ("json_object", {"role": "system", "content": "v2"}, '{"role": "system", "content": "v2"}'),
             ("json_array", [{"role": "system", "content": "v2"}], '[{"role": "system", "content": "v2"}]'),
             ("string", "v2 plain string", "v2 plain string"),
+            ("number", 42, "42"),
+            ("boolean", True, "true"),
         ]
     )
     def test_publish_prompt_normalizes_prompt_to_string(

--- a/posthog/api/test/test_llm_prompt.py
+++ b/posthog/api/test/test_llm_prompt.py
@@ -844,3 +844,57 @@ class TestLLMPromptAPI(APIBaseTest):
         assert response.status_code == status.HTTP_201_CREATED
         assert response.json()["name"] == "archived-name"
         assert response.json()["version"] == 1
+
+    @parameterized.expand(
+        [
+            (
+                "json_object",
+                {"role": "system", "content": "You are helpful"},
+                '{"role": "system", "content": "You are helpful"}',
+            ),
+            (
+                "json_array",
+                [{"role": "system", "content": "You are helpful"}],
+                '[{"role": "system", "content": "You are helpful"}]',
+            ),
+            ("string", "You are a helpful assistant.", "You are a helpful assistant."),
+            ("number", 42, "42"),
+            ("boolean", True, "true"),
+        ]
+    )
+    def test_create_prompt_normalizes_prompt_to_string(
+        self, mock_feature_enabled, _label, input_prompt, expected_stored
+    ):
+        response = self.client.post(
+            f"/api/environments/{self.team.id}/llm_prompts/",
+            data={"name": f"normalize-{_label}", "prompt": input_prompt},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED
+        assert response.json()["prompt"] == expected_stored
+        db_prompt = LLMPrompt.objects.get(id=response.json()["id"])
+        assert db_prompt.prompt == expected_stored
+
+    @parameterized.expand(
+        [
+            ("json_object", {"role": "system", "content": "v2"}, '{"role": "system", "content": "v2"}'),
+            ("json_array", [{"role": "system", "content": "v2"}], '[{"role": "system", "content": "v2"}]'),
+            ("string", "v2 plain string", "v2 plain string"),
+        ]
+    )
+    def test_publish_prompt_normalizes_prompt_to_string(
+        self, mock_feature_enabled, _label, input_prompt, expected_stored
+    ):
+        self.create_prompt_version(name="publish-normalize", version=1, is_latest=True, prompt="v1")
+
+        response = self.client.patch(
+            f"/api/environments/{self.team.id}/llm_prompts/name/publish-normalize/",
+            data={"prompt": input_prompt, "base_version": 1},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["prompt"] == expected_stored
+        latest = LLMPrompt.objects.get(team=self.team, name="publish-normalize", version=2, deleted=False)
+        assert latest.prompt == expected_stored


### PR DESCRIPTION


## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->


The prompt JSONField accepts any JSON type (string, object, array), causing inconsistent API responses and frontend crashes.

UI error caused by prompt returned as JSON from server.

[Video recording of the bug and the fix on UI](https://drive.google.com/file/d/1Y7kNo5WWkzMjWeanXJlhlzXZBUeqILWQ/view?usp=sharing)

Original Bug report ticket: https://posthoghelp.zendesk.com/hc/en-us/requests/55017?brand_id=5586869146267 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/56382)


<img width="1056" height="552" alt="image" src="https://github.com/user-attachments/assets/92fade68-61c5-43e5-8661-7a6f28d2959c" />


## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

Normalize non-string values to their JSON string representation in both LLMPromptSerializer and LLMPromptPublishSerializer validate_prompt methods.

Related UI fix PR: https://github.com/PostHog/posthog/pull/53330

## How did you test this code?

<!-- Briefly describe the steps you took, and what steps reviewers must take to get to where changes are, and what is the expected behavior. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

- Unit tests




👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
