### PR TITLE
fix(mcp): accept PostHog UUIDs in evaluation tool parameters

### DIFF
--- a/services/mcp/src/lib/utils.ts
+++ b/services/mcp/src/lib/utils.ts
@@ -1,15 +1,4 @@
 import crypto from 'node:crypto'
-import { z } from 'zod'
-
-/**
- * PostHog uses UUIDv7-style identifiers where the version nibble can be `0`,
- * which Zod's built-in `.uuid()` rejects (it requires version 1-8 per RFC 9562).
- * This schema accepts any 8-4-4-4-12 hex string so it works with PostHog UUIDs.
- */
-export const posthogUuid = () =>
-    z
-        .string()
-        .regex(/^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/, 'Invalid UUID')
 
 export function hash(data: string): string {
     // Use PBKDF2 with sufficient computational effort for security

--- a/services/mcp/src/lib/utils.ts
+++ b/services/mcp/src/lib/utils.ts
@@ -1,4 +1,15 @@
 import crypto from 'node:crypto'
+import { z } from 'zod'
+
+/**
+ * PostHog uses UUIDv7-style identifiers where the version nibble can be `0`,
+ * which Zod's built-in `.uuid()` rejects (it requires version 1-8 per RFC 9562).
+ * This schema accepts any 8-4-4-4-12 hex string so it works with PostHog UUIDs.
+ */
+export const posthogUuid = () =>
+    z
+        .string()
+        .regex(/^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/, 'Invalid UUID')
 
 export function hash(data: string): string {
     // Use PBKDF2 with sufficient computational effort for security

--- a/services/mcp/src/tools/llmAnalytics/evaluations/create.ts
+++ b/services/mcp/src/tools/llmAnalytics/evaluations/create.ts
@@ -1,12 +1,11 @@
 import { z } from 'zod'
 
-import { posthogUuid } from '@/lib/utils'
 import type { Context, ToolBase } from '@/tools/types'
 
 const ModelConfigurationSchema = z.object({
     provider: z.enum(['openai', 'anthropic', 'gemini', 'openrouter', 'fireworks']).describe('LLM provider to use.'),
     model: z.string().describe('Model identifier (e.g. "gpt-4o", "claude-sonnet-4-20250514").'),
-    provider_key_id: posthogUuid().optional().describe('UUID of a stored provider key. Omit to use trial credits.'),
+    provider_key_id: z.string().optional().describe('UUID of a stored provider key. Omit to use trial credits.'),
 })
 
 const schema = z

--- a/services/mcp/src/tools/llmAnalytics/evaluations/create.ts
+++ b/services/mcp/src/tools/llmAnalytics/evaluations/create.ts
@@ -1,11 +1,12 @@
 import { z } from 'zod'
 
+import { posthogUuid } from '@/lib/utils'
 import type { Context, ToolBase } from '@/tools/types'
 
 const ModelConfigurationSchema = z.object({
     provider: z.enum(['openai', 'anthropic', 'gemini', 'openrouter', 'fireworks']).describe('LLM provider to use.'),
     model: z.string().describe('Model identifier (e.g. "gpt-4o", "claude-sonnet-4-20250514").'),
-    provider_key_id: z.string().uuid().optional().describe('UUID of a stored provider key. Omit to use trial credits.'),
+    provider_key_id: posthogUuid().optional().describe('UUID of a stored provider key. Omit to use trial credits.'),
 })
 
 const schema = z

--- a/services/mcp/src/tools/llmAnalytics/evaluations/delete.ts
+++ b/services/mcp/src/tools/llmAnalytics/evaluations/delete.ts
@@ -1,10 +1,9 @@
 import { z } from 'zod'
 
-import { posthogUuid } from '@/lib/utils'
 import type { Context, ToolBase } from '@/tools/types'
 
 const schema = z.object({
-    evaluationId: posthogUuid().describe('The UUID of the evaluation to delete.'),
+    evaluationId: z.string().describe('The UUID of the evaluation to delete.'),
 })
 
 type Params = z.infer<typeof schema>

--- a/services/mcp/src/tools/llmAnalytics/evaluations/delete.ts
+++ b/services/mcp/src/tools/llmAnalytics/evaluations/delete.ts
@@ -1,9 +1,10 @@
 import { z } from 'zod'
 
+import { posthogUuid } from '@/lib/utils'
 import type { Context, ToolBase } from '@/tools/types'
 
 const schema = z.object({
-    evaluationId: z.string().uuid().describe('The UUID of the evaluation to delete.'),
+    evaluationId: posthogUuid().describe('The UUID of the evaluation to delete.'),
 })
 
 type Params = z.infer<typeof schema>

--- a/services/mcp/src/tools/llmAnalytics/evaluations/get.ts
+++ b/services/mcp/src/tools/llmAnalytics/evaluations/get.ts
@@ -1,10 +1,9 @@
 import { z } from 'zod'
 
-import { posthogUuid } from '@/lib/utils'
 import type { Context, ToolBase } from '@/tools/types'
 
 const schema = z.object({
-    evaluationId: posthogUuid().describe('The UUID of the evaluation to retrieve.'),
+    evaluationId: z.string().describe('The UUID of the evaluation to retrieve.'),
 })
 
 type Params = z.infer<typeof schema>

--- a/services/mcp/src/tools/llmAnalytics/evaluations/get.ts
+++ b/services/mcp/src/tools/llmAnalytics/evaluations/get.ts
@@ -1,9 +1,10 @@
 import { z } from 'zod'
 
+import { posthogUuid } from '@/lib/utils'
 import type { Context, ToolBase } from '@/tools/types'
 
 const schema = z.object({
-    evaluationId: z.string().uuid().describe('The UUID of the evaluation to retrieve.'),
+    evaluationId: posthogUuid().describe('The UUID of the evaluation to retrieve.'),
 })
 
 type Params = z.infer<typeof schema>

--- a/services/mcp/src/tools/llmAnalytics/evaluations/run.ts
+++ b/services/mcp/src/tools/llmAnalytics/evaluations/run.ts
@@ -1,11 +1,10 @@
 import { z } from 'zod'
 
-import { posthogUuid } from '@/lib/utils'
 import type { Context, ToolBase } from '@/tools/types'
 
 const schema = z.object({
-    evaluationId: posthogUuid().describe('The UUID of the evaluation to run.'),
-    target_event_id: posthogUuid().describe('The UUID of the $ai_generation event to evaluate.'),
+    evaluationId: z.string().describe('The UUID of the evaluation to run.'),
+    target_event_id: z.string().describe('The UUID of the $ai_generation event to evaluate.'),
     timestamp: z.string().describe('ISO 8601 timestamp of the target event (needed for efficient lookup).'),
     event: z.string().optional().describe('Event name. Defaults to "$ai_generation".'),
     distinct_id: z.string().optional().describe('Distinct ID of the event (optional, improves lookup performance).'),

--- a/services/mcp/src/tools/llmAnalytics/evaluations/run.ts
+++ b/services/mcp/src/tools/llmAnalytics/evaluations/run.ts
@@ -5,7 +5,7 @@ import type { Context, ToolBase } from '@/tools/types'
 
 const schema = z.object({
     evaluationId: posthogUuid().describe('The UUID of the evaluation to run.'),
-    target_event_id: z.string().describe('The UUID of the $ai_generation event to evaluate.'),
+    target_event_id: posthogUuid().describe('The UUID of the $ai_generation event to evaluate.'),
     timestamp: z.string().describe('ISO 8601 timestamp of the target event (needed for efficient lookup).'),
     event: z.string().optional().describe('Event name. Defaults to "$ai_generation".'),
     distinct_id: z.string().optional().describe('Distinct ID of the event (optional, improves lookup performance).'),

--- a/services/mcp/src/tools/llmAnalytics/evaluations/run.ts
+++ b/services/mcp/src/tools/llmAnalytics/evaluations/run.ts
@@ -1,9 +1,10 @@
 import { z } from 'zod'
 
+import { posthogUuid } from '@/lib/utils'
 import type { Context, ToolBase } from '@/tools/types'
 
 const schema = z.object({
-    evaluationId: z.string().uuid().describe('The UUID of the evaluation to run.'),
+    evaluationId: posthogUuid().describe('The UUID of the evaluation to run.'),
     target_event_id: z.string().describe('The UUID of the $ai_generation event to evaluate.'),
     timestamp: z.string().describe('ISO 8601 timestamp of the target event (needed for efficient lookup).'),
     event: z.string().optional().describe('Event name. Defaults to "$ai_generation".'),

--- a/services/mcp/src/tools/llmAnalytics/evaluations/update.ts
+++ b/services/mcp/src/tools/llmAnalytics/evaluations/update.ts
@@ -1,9 +1,10 @@
 import { z } from 'zod'
 
+import { posthogUuid } from '@/lib/utils'
 import type { Context, ToolBase } from '@/tools/types'
 
 const schema = z.object({
-    evaluationId: z.string().uuid().describe('The UUID of the evaluation to update.'),
+    evaluationId: posthogUuid().describe('The UUID of the evaluation to update.'),
     name: z.string().max(400).optional().describe('Updated name.'),
     description: z.string().optional().describe('Updated description.'),
     enabled: z.boolean().optional().describe('Enable or disable the evaluation.'),

--- a/services/mcp/src/tools/llmAnalytics/evaluations/update.ts
+++ b/services/mcp/src/tools/llmAnalytics/evaluations/update.ts
@@ -1,10 +1,9 @@
 import { z } from 'zod'
 
-import { posthogUuid } from '@/lib/utils'
 import type { Context, ToolBase } from '@/tools/types'
 
 const schema = z.object({
-    evaluationId: posthogUuid().describe('The UUID of the evaluation to update.'),
+    evaluationId: z.string().describe('The UUID of the evaluation to update.'),
     name: z.string().max(400).optional().describe('Updated name.'),
     description: z.string().optional().describe('Updated description.'),
     enabled: z.boolean().optional().describe('Enable or disable the evaluation.'),

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/evaluation-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/evaluation-create.json
@@ -42,8 +42,7 @@
                 },
                 "provider_key_id": {
                     "description": "UUID of a stored provider key. Omit to use trial credits.",
-                    "format": "uuid",
-                    "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$",
+                    "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
                     "type": "string"
                 }
             },

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/evaluation-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/evaluation-create.json
@@ -42,7 +42,6 @@
                 },
                 "provider_key_id": {
                     "description": "UUID of a stored provider key. Omit to use trial credits.",
-                    "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
                     "type": "string"
                 }
             },

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/evaluation-delete.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/evaluation-delete.json
@@ -3,7 +3,6 @@
     "properties": {
         "evaluationId": {
             "description": "The UUID of the evaluation to delete.",
-            "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
             "type": "string"
         }
     },

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/evaluation-delete.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/evaluation-delete.json
@@ -3,8 +3,7 @@
     "properties": {
         "evaluationId": {
             "description": "The UUID of the evaluation to delete.",
-            "format": "uuid",
-            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$",
+            "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
             "type": "string"
         }
     },

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/evaluation-get.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/evaluation-get.json
@@ -3,7 +3,6 @@
     "properties": {
         "evaluationId": {
             "description": "The UUID of the evaluation to retrieve.",
-            "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
             "type": "string"
         }
     },

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/evaluation-get.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/evaluation-get.json
@@ -3,8 +3,7 @@
     "properties": {
         "evaluationId": {
             "description": "The UUID of the evaluation to retrieve.",
-            "format": "uuid",
-            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$",
+            "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
             "type": "string"
         }
     },

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/evaluation-run.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/evaluation-run.json
@@ -16,6 +16,7 @@
         },
         "target_event_id": {
             "description": "The UUID of the $ai_generation event to evaluate.",
+            "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
             "type": "string"
         },
         "timestamp": {

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/evaluation-run.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/evaluation-run.json
@@ -7,8 +7,7 @@
         },
         "evaluationId": {
             "description": "The UUID of the evaluation to run.",
-            "format": "uuid",
-            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$",
+            "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
             "type": "string"
         },
         "event": {

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/evaluation-run.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/evaluation-run.json
@@ -7,7 +7,6 @@
         },
         "evaluationId": {
             "description": "The UUID of the evaluation to run.",
-            "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
             "type": "string"
         },
         "event": {
@@ -16,7 +15,6 @@
         },
         "target_event_id": {
             "description": "The UUID of the $ai_generation event to evaluate.",
-            "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
             "type": "string"
         },
         "timestamp": {

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/evaluation-update.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/evaluation-update.json
@@ -23,8 +23,7 @@
         },
         "evaluationId": {
             "description": "The UUID of the evaluation to update.",
-            "format": "uuid",
-            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$",
+            "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
             "type": "string"
         },
         "name": {

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/evaluation-update.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/evaluation-update.json
@@ -23,7 +23,6 @@
         },
         "evaluationId": {
             "description": "The UUID of the evaluation to update.",
-            "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
             "type": "string"
         },
         "name": {


### PR DESCRIPTION
## Problem

PostHog uses UUIDv7-style identifiers where the version nibble can be `0` (e.g. `019d5924-5d0e-0000-f0ff-8b13567dc212`). Zod's built-in `.uuid()` validator rejects these because it requires version 1-8 per RFC 9562. This made it impossible to update, delete, get, or run evaluations via MCP tools — any evaluation ID returned by `evaluation-create` or `evaluations-get` would fail validation when passed back to other tools.

## Changes

- Replaced `z.string().uuid()` with plain `z.string()` in all 5 evaluation tool schemas (create, get, update, delete, run)
- The API already returns 404 for invalid IDs, so client-side UUID format validation adds no value
- Updated test snapshots

## How did you test this code?

- `pnpm tsc --noEmit` passes
- `pnpm vitest run` — all 427 tests pass (1 pre-existing SSL cert failure unrelated to this change)
- Snapshot tests updated with `vitest -u`

no

## 🤖 LLM context

Agent-authored PR. Discovered the bug while trying to use the MCP `evaluation-update` and `evaluation-delete` tools — every PostHog-generated UUID was rejected by Zod's strict UUID validation. Initially added a custom regex helper, then simplified to just dropping `.uuid()` entirely since the API handles validation.