### PR TITLE
fix: prevent 404 on log_entry property values and fix visited_page URL

### DIFF
--- a/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
@@ -1180,7 +1180,6 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>([
                             if (key === 'visited_page') {
                                 return (
                                     `api/environments/${teamId}/events/values/?key=` +
-                                    'api/event/values/?key=' +
                                     encodeURIComponent('$current_url') +
                                     '&event_name=' +
                                     encodeURIComponent('$pageview')

--- a/frontend/src/models/propertyDefinitionsModel.test.ts
+++ b/frontend/src/models/propertyDefinitionsModel.test.ts
@@ -466,6 +466,61 @@ describe('the property definitions model', () => {
         })
     })
 
+    describe('log_entry property values', () => {
+        it('returns local options for log_entry/level without a network request', async () => {
+            let networkCalled = false
+
+            useMocks({
+                get: {
+                    '/api/log_entry/values': () => {
+                        networkCalled = true
+                        return [200, { results: [], refreshing: false }]
+                    },
+                },
+            })
+
+            await expectLogic(logic, () => {
+                logic.actions.loadPropertyValues({
+                    endpoint: undefined,
+                    type: PropertyDefinitionType.LogEntry,
+                    propertyKey: 'level',
+                    newInput: undefined,
+                })
+            }).toFinishAllListeners()
+
+            expect(networkCalled).toBe(false)
+            expect(logic.values.options['level'].values).toEqual([
+                { id: 0, name: 'info' },
+                { id: 1, name: 'warn' },
+                { id: 2, name: 'error' },
+            ])
+        })
+
+        it('does not fetch from a nonexistent endpoint for log_entry properties without local options', async () => {
+            let networkCalled = false
+
+            useMocks({
+                get: {
+                    '/api/log_entry/values': () => {
+                        networkCalled = true
+                        return [200, { results: [], refreshing: false }]
+                    },
+                },
+            })
+
+            await expectLogic(logic, () => {
+                logic.actions.loadPropertyValues({
+                    endpoint: undefined,
+                    type: PropertyDefinitionType.LogEntry,
+                    propertyKey: 'message',
+                    newInput: undefined,
+                })
+            }).toFinishAllListeners()
+
+            expect(networkCalled).toBe(false)
+        })
+    })
+
     describe('loadPropertyValues', () => {
         it('includes refresh=force_cache in the URL when polling', async () => {
             let capturedUrl: string | undefined

--- a/frontend/src/models/propertyDefinitionsModel.ts
+++ b/frontend/src/models/propertyDefinitionsModel.ts
@@ -425,6 +425,10 @@ export const propertyDefinitionsModel = kea<propertyDefinitionsModelType>([
                 return
             }
 
+            if (!endpoint && type === 'log_entry') {
+                return
+            }
+
             const start = performance.now()
 
             await breakpoint(300)


### PR DESCRIPTION
## Problem

Two pre-existing bugs in the Replay taxonomic filter, surfaced by the conversion to a standard options group:

1. **404 on log_entry values**: Selecting a log entry property (e.g. "Console log message") triggers a fetch to `api/log_entry/values?key=message` which doesn't exist as a backend endpoint. The old custom component never attempted this fetch.

2. **Garbled visited_page URL**: The `valuesEndpoint` for `visited_page` concatenated two URL path segments (`api/environments/{id}/events/values/?key=` + `api/event/values/?key=`), producing a broken URL.

## Changes

- Add `'log_entry'` to the bail-out list in `propertyDefinitionsModel.loadPropertyValues` so it skips the fetch, matching the old behavior (no value autocomplete for log entry properties)
- Remove the duplicate path segment from the `visited_page` valuesEndpoint

## How did you test this code?

Verified the URL construction logic by reading the code path. The log_entry bail-out matches the existing pattern for `cohort` and `log` types that also lack backend values endpoints.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*