### PR TITLE
feat(mcp): Tool search mode

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3054,6 +3054,9 @@ importers:
       fflate:
         specifier: ^0.8.2
         version: 0.8.2
+      minisearch:
+        specifier: ^7.1.1
+        version: 7.2.0
       posthog-js-lite:
         specifier: 4.2.2
         version: 4.2.2
@@ -17500,6 +17503,9 @@ packages:
     resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
     engines: {node: '>=16 || 14 >=14.17'}
 
+  minisearch@7.2.0:
+    resolution: {integrity: sha512-dqT2XBYUOZOiC5t2HRnwADjhNS2cecp9u+TJRiJ1Qp/f5qjkeT5APcGPjHw+bz89Ms8Jp+cG4AlE+QZ/QnDglg==}
+
   minizlib@2.1.2:
     resolution: {integrity: sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==}
     engines: {node: '>= 8'}
@@ -21532,8 +21538,8 @@ packages:
     resolution: {integrity: sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==}
     engines: {node: '>= 10.0.0'}
 
-  unlayer-types@1.394.0:
-    resolution: {integrity: sha512-0y7+/QQ8MxCjPcpWK3rz7pQXsNGQAUGI6JlBKHQBneqOAWeCVET6Ohd5KVgD95Rm8v6ZLRn5TJvjdsRwIWHHUg==}
+  unlayer-types@1.395.0:
+    resolution: {integrity: sha512-2tb1IuEBa11ZUXueDtYCHc7PqV3WbAoBmEpNWjgE4WZclSk4sW0P41KKpa6NswdoP8UfFd18aV+oQJhz467NcA==}
 
   unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
@@ -41734,6 +41740,8 @@ snapshots:
 
   minipass@7.1.2: {}
 
+  minisearch@7.2.0: {}
+
   minizlib@2.1.2:
     dependencies:
       minipass: 3.3.6
@@ -44338,7 +44346,7 @@ snapshots:
   react-email-editor@1.7.11(react@18.3.1):
     dependencies:
       react: 18.3.1
-      unlayer-types: 1.394.0
+      unlayer-types: 1.395.0
 
   react-error-overlay@6.0.9: {}
 
@@ -46734,7 +46742,7 @@ snapshots:
 
   universalify@2.0.0: {}
 
-  unlayer-types@1.394.0: {}
+  unlayer-types@1.395.0: {}
 
   unpipe@1.0.0: {}
 

--- a/services/mcp/package.json
+++ b/services/mcp/package.json
@@ -41,6 +41,7 @@
         "agents": "^0.3.6",
         "ai": "^6.0.0",
         "fflate": "^0.8.2",
+        "minisearch": "^7.1.1",
         "posthog-js-lite": "4.2.2",
         "posthog-node": "^5.25.0",
         "uuid": "^11.1.0",

--- a/services/mcp/src/index.ts
+++ b/services/mcp/src/index.ts
@@ -248,7 +248,9 @@ const handleRequest = async (
     const readOnlyRaw = request.headers.get('x-posthog-readonly') || url.searchParams.get('readonly')
     const readOnly = readOnlyRaw === 'true' || readOnlyRaw === '1' || undefined
 
-    const extraContextProps = { features, tools, region: regionParam, version, readOnly }
+    const mode = url.searchParams.get('mode') || undefined
+
+    const extraContextProps = { features, tools, region: regionParam, version, readOnly, mode }
     Object.assign(ctx.props, extraContextProps)
     log.extend(extraContextProps)
 

--- a/services/mcp/src/mcp.ts
+++ b/services/mcp/src/mcp.ts
@@ -23,6 +23,7 @@ import { sanitizeHeaderValue } from '@/lib/utils'
 import { registerPrompts } from '@/prompts'
 import { registerResources } from '@/resources'
 import { registerUiAppResources } from '@/resources/ui-apps'
+import INSTRUCTIONS_TEMPLATE_TOOL_SEARCH from '@/templates/instructions-tool-search.md'
 import INSTRUCTIONS_TEMPLATE_V1 from '@/templates/instructions-v1.md'
 import INSTRUCTIONS_TEMPLATE_V2 from '@/templates/instructions-v2.md'
 import type { CloudRegion, Context, State, Tool } from '@/tools/types'
@@ -44,6 +45,7 @@ export type RequestProperties = {
     projectId?: string
     clientUserAgent?: string
     readOnly?: boolean
+    mode?: 'tool_search'
     transport?: 'streamable-http' | 'sse'
 }
 
@@ -417,7 +419,15 @@ export class MCP extends McpAgent<Env> {
     }
 
     async init(): Promise<void> {
-        const { features, tools, version: clientVersion, organizationId, projectId, readOnly } = this.requestProperties
+        const {
+            features,
+            tools,
+            version: clientVersion,
+            organizationId,
+            projectId,
+            readOnly,
+            mode,
+        } = this.requestProperties
 
         // Pre-seed cache, fetch group types, and evaluate feature flag in parallel
         const groupTypesPromise = projectId ? this.getOrFetchGroupTypes(projectId) : Promise.resolve(undefined)
@@ -433,10 +443,6 @@ export class MCP extends McpAgent<Env> {
         const groupTypes = await groupTypesPromise
         const flagVersion = await flagPromise
         const version = flagVersion ?? clientVersion ?? 1
-        const instructions = version === 2 ? buildInstructions(groupTypes) : INSTRUCTIONS_TEMPLATE_V1
-
-        this.server = new McpServer({ name: 'PostHog', version: '1.0.0' }, { instructions })
-
         // When project ID is provided, both switch tools are removed (project implies org).
         // When only organization ID is provided, only switch-organization is removed.
         const excludeTools: string[] = []
@@ -447,6 +453,35 @@ export class MCP extends McpAgent<Env> {
         }
 
         const context = await this.getContext()
+
+        // In tool_search mode, register only 3 meta-tools (search, schema, call)
+        // instead of all ~155 tools. This reduces token usage for LLM clients.
+        // The original version-specific instructions are preserved with the
+        // tool_search preamble prepended.
+        if (mode === 'tool_search') {
+            const baseInstructions = version === 2 ? buildInstructions(groupTypes) : INSTRUCTIONS_TEMPLATE_V1
+            const instructions = INSTRUCTIONS_TEMPLATE_TOOL_SEARCH.trim() + '\n\n' + baseInstructions
+            this.server = new McpServer({ name: 'PostHog', version: '1.0.0' }, { instructions })
+
+            await registerPrompts(this.server)
+            await registerResources(this.server, context)
+            await registerUiAppResources(this.server, context)
+
+            const aiConsentGiven = await context.stateManager.getAiConsentGiven()
+            const { registerToolSearchMode } = await import('@/tools/toolSearchMode')
+            await registerToolSearchMode(this.server, context, {
+                features,
+                tools,
+                version,
+                excludeTools,
+                readOnly,
+                aiConsentGiven: aiConsentGiven ?? undefined,
+            })
+            return
+        }
+
+        const instructions = version === 2 ? buildInstructions(groupTypes) : INSTRUCTIONS_TEMPLATE_V1
+        this.server = new McpServer({ name: 'PostHog', version: '1.0.0' }, { instructions })
 
         // Register prompts and resources
         await registerPrompts(this.server)

--- a/services/mcp/src/templates/instructions-tool-search.md
+++ b/services/mcp/src/templates/instructions-tool-search.md
@@ -1,0 +1,13 @@
+This MCP server uses tool search mode. Instead of having all tools loaded at once, you discover and call them on demand using three meta-tools that MUST be called in order:
+
+1. **tool_search** (required) — Find tools by keyword. Returns names and short summaries. You must always start here — do not guess tool names.
+2. **tool_schema** (required) — Get the full input schema for a tool by its exact name. You must call this before tool_call to know the accepted parameters.
+3. **tool_call** — Execute a tool with the parameters matching the schema from step 2.
+
+IMPORTANT: Always follow the sequence tool_search → tool_schema → tool_call. Do not skip steps. Do not call tool_call without first retrieving the schema via tool_schema.
+
+### Tool naming conventions
+
+Tools use lowercase kebab-case with a domain prefix. Common domains: dashboard, insight, feature-flag, experiment, survey, cohort, error-tracking, logs, action, workflows, organization, projects, docs, llm.
+Typical action suffixes: list, get, get-all, create, update, delete, query.
+Example search queries: "feature flag", "experiment results", "dashboard create".

--- a/services/mcp/src/tools/toolSearchMode.ts
+++ b/services/mcp/src/tools/toolSearchMode.ts
@@ -1,0 +1,234 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js'
+import MiniSearch from 'minisearch'
+import { z } from 'zod'
+
+import { hasScopes } from '@/lib/api'
+import { formatResponse } from '@/lib/response'
+import { GENERATED_TOOL_MAP } from '@/tools/generated'
+import { TOOL_MAP } from '@/tools/index'
+import { type ToolFilterOptions, getToolDefinitions, getToolsForFeatures } from '@/tools/toolDefinitions'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
+
+interface ToolSearchDocument {
+    id: string
+    name: string
+    title: string
+    description: string
+    summary: string
+    category: string
+    feature: string
+}
+
+function textResult(text: string): CallToolResult {
+    return { content: [{ type: 'text', text }] }
+}
+
+function errorResult(text: string): CallToolResult {
+    return { content: [{ type: 'text', text }], isError: true }
+}
+
+/**
+ * Registers the 3 meta-tools (tool_search, tool_schema, tool_call) that let
+ * LLM clients discover and invoke PostHog tools without loading all tool
+ * schemas upfront. Respects the same filtering as normal mode (features, tools,
+ * version, readOnly, OAuth scopes, AI consent).
+ */
+export async function registerToolSearchMode(
+    server: McpServer,
+    context: Context,
+    options: ToolFilterOptions
+): Promise<void> {
+    const excludeTools = options.excludeTools ?? []
+    const filteredNames = getToolsForFeatures(options).filter((name) => !excludeTools.includes(name))
+
+    const apiKey = await context.stateManager.getApiKey()
+    const scopes = apiKey?.scopes ?? []
+    const definitions = getToolDefinitions(options.version)
+    const allowedToolNames = new Set(
+        filteredNames.filter((name) => {
+            const def = definitions[name]
+            return def && hasScopes(scopes, def.required_scopes)
+        })
+    )
+
+    const searchIndex = new MiniSearch<ToolSearchDocument>({
+        fields: ['name', 'title', 'description', 'summary', 'category', 'feature'],
+        storeFields: ['name', 'title', 'summary', 'category', 'feature'],
+        idField: 'id',
+        searchOptions: {
+            boost: { name: 3, title: 2, summary: 1.5 },
+            fuzzy: 0.2,
+            prefix: true,
+            combineWith: 'AND',
+        },
+    })
+
+    const documents: ToolSearchDocument[] = []
+    for (const name of allowedToolNames) {
+        const def = definitions[name]
+        if (def) {
+            documents.push({
+                id: name,
+                name,
+                title: def.title,
+                description: def.description,
+                summary: def.summary,
+                category: def.category,
+                feature: def.feature,
+            })
+        }
+    }
+    searchIndex.addAll(documents)
+
+    const effectiveMap = { ...TOOL_MAP, ...GENERATED_TOOL_MAP }
+
+    // Lazy cache for tool factories and JSON schemas to avoid repeated
+    // instantiation and schema conversion on every tool_schema/tool_call.
+    const toolCache = new Map<string, ToolBase<ZodObjectAny>>()
+    const schemaCache = new Map<string, object>()
+
+    function getToolBase(toolName: string): ToolBase<ZodObjectAny> | undefined {
+        let cached = toolCache.get(toolName)
+        if (!cached) {
+            const factory = effectiveMap[toolName]
+            if (!factory) {
+                return undefined
+            }
+            cached = factory()
+            toolCache.set(toolName, cached)
+        }
+        return cached
+    }
+
+    function getJsonSchema(toolName: string, toolBase: ToolBase<ZodObjectAny>): object {
+        let cached = schemaCache.get(toolName)
+        if (!cached) {
+            cached = z.toJSONSchema(toolBase.schema as z.ZodType, { io: 'input', reused: 'inline' })
+            schemaCache.set(toolName, cached)
+        }
+        return cached
+    }
+
+    function resolveTool(toolName: string): { tool: ToolBase<ZodObjectAny> } | { error: CallToolResult } {
+        if (!allowedToolNames.has(toolName)) {
+            return {
+                error: errorResult(`Error: Tool "${toolName}" not found. Use tool_search to find available tools.`),
+            }
+        }
+        const tool = getToolBase(toolName)
+        if (!tool) {
+            return { error: errorResult(`Error: Tool "${toolName}" has no implementation.`) }
+        }
+        return { tool }
+    }
+
+    server.registerTool(
+        'tool_search',
+        {
+            title: 'Search for PostHog tools',
+            description:
+                'Search for available PostHog tools by keyword. Use this to discover which tools are available before calling them. Returns matching tools with their names, summaries, and categories. Always start here when you need to interact with PostHog — search for what you need, then use tool_schema to get the full input schema, then use tool_call to execute.',
+            inputSchema: {
+                query: z
+                    .string()
+                    .describe('Search query to find PostHog tools (e.g., "feature flag", "dashboard", "experiment")'),
+                limit: z.number().optional().default(10).describe('Maximum number of results to return'),
+            },
+            annotations: {
+                readOnlyHint: true,
+                idempotentHint: true,
+                destructiveHint: false,
+                openWorldHint: false,
+            },
+        },
+        async ({ query, limit }) => {
+            const results = searchIndex.search(query).slice(0, limit)
+            const items = results.map((result) => ({
+                name: result.id,
+                title: result.title,
+                summary: result.summary,
+                category: result.category,
+                feature: result.feature,
+            }))
+            return textResult(formatResponse(items))
+        }
+    )
+
+    server.registerTool(
+        'tool_schema',
+        {
+            title: 'Get tool input schema',
+            description:
+                'Get the full input schema for a specific PostHog tool. Returns the JSON Schema describing all accepted parameters, including required fields, types, and descriptions. Use this after tool_search to understand what parameters a tool needs before calling it with tool_call. Pass the exact tool name from tool_search results.',
+            inputSchema: {
+                tool_name: z.string().describe('Exact tool name from tool_search results'),
+            },
+            annotations: {
+                readOnlyHint: true,
+                idempotentHint: true,
+                destructiveHint: false,
+                openWorldHint: false,
+            },
+        },
+        async ({ tool_name }) => {
+            const resolved = resolveTool(tool_name)
+            if ('error' in resolved) {
+                return resolved.error
+            }
+
+            const def = definitions[tool_name]!
+            return textResult(
+                formatResponse({
+                    name: tool_name,
+                    title: def.title,
+                    description: def.description,
+                    annotations: def.annotations,
+                    inputSchema: getJsonSchema(tool_name, resolved.tool),
+                })
+            )
+        }
+    )
+
+    server.registerTool(
+        'tool_call',
+        {
+            title: 'Call a PostHog tool',
+            description:
+                "Execute a PostHog tool by name with the given parameters. Use tool_search to find the right tool, then tool_schema to get its input schema, then this tool to call it. The params object must match the schema returned by tool_schema. Returns the tool's response.",
+            inputSchema: {
+                tool_name: z.string().describe('Exact tool name to call'),
+                params: z
+                    .record(z.string(), z.any())
+                    .optional()
+                    .default({})
+                    .describe("Input parameters matching the tool's schema"),
+            },
+            annotations: {
+                readOnlyHint: false,
+                idempotentHint: false,
+                destructiveHint: false,
+                openWorldHint: true,
+            },
+        },
+        async ({ tool_name, params }) => {
+            const resolved = resolveTool(tool_name)
+            if ('error' in resolved) {
+                return resolved.error
+            }
+
+            const validation = (resolved.tool.schema as z.ZodType).safeParse(params)
+            if (!validation.success) {
+                return errorResult(`Invalid parameters for "${tool_name}": ${validation.error.message}`)
+            }
+
+            try {
+                const result = await resolved.tool.handler(context, validation.data)
+                return textResult(formatResponse(result))
+            } catch (error: any) {
+                const message = error instanceof Error ? error.message : String(error)
+                return errorResult(`Error calling "${tool_name}": ${message}`)
+            }
+        }
+    )
+}

--- a/services/mcp/tests/unit/tool-search-mode.test.ts
+++ b/services/mcp/tests/unit/tool-search-mode.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, it } from 'vitest'
+
+import { SessionManager } from '@/lib/SessionManager'
+import { registerToolSearchMode } from '@/tools/toolSearchMode'
+import type { Context } from '@/tools/types'
+
+function createMockContext(scopes: string[] = ['*']): Context {
+    return {
+        api: {} as any,
+        cache: {} as any,
+        env: {
+            INKEEP_API_KEY: undefined,
+            MCP_APPS_BASE_URL: undefined,
+            POSTHOG_ANALYTICS_API_KEY: undefined,
+            POSTHOG_ANALYTICS_HOST: undefined,
+            POSTHOG_API_BASE_URL: undefined,
+            POSTHOG_MCP_APPS_ANALYTICS_BASE_URL: undefined,
+            POSTHOG_UI_APPS_TOKEN: undefined,
+        },
+        stateManager: {
+            getApiKey: async () => ({ scopes }),
+            getAiConsentGiven: async () => true,
+        } as any,
+        sessionManager: new SessionManager({} as any),
+    }
+}
+
+// Collects tools registered on a mock McpServer
+function createMockServer(): { server: any; registeredTools: Map<string, { config: any; handler: Function }> } {
+    const registeredTools = new Map<string, { config: any; handler: Function }>()
+    const server = {
+        registerTool: (name: string, config: any, handler: Function) => {
+            registeredTools.set(name, { config, handler })
+        },
+    }
+    return { server, registeredTools }
+}
+
+describe('Tool Search Mode', () => {
+    it('registers exactly 3 meta-tools', async () => {
+        const { server, registeredTools } = createMockServer()
+        const context = createMockContext()
+
+        await registerToolSearchMode(server, context, {})
+
+        expect(registeredTools.size).toBe(3)
+        expect(registeredTools.has('tool_search')).toBe(true)
+        expect(registeredTools.has('tool_schema')).toBe(true)
+        expect(registeredTools.has('tool_call')).toBe(true)
+    })
+
+    describe('tool_search', () => {
+        it('returns relevant results for a query', async () => {
+            const { server, registeredTools } = createMockServer()
+            const context = createMockContext()
+            await registerToolSearchMode(server, context, {})
+
+            const handler = registeredTools.get('tool_search')!.handler
+            const result = await handler({ query: 'experiment', limit: 10 })
+
+            const text = result.content[0].text
+            expect(text).toContain('experiment')
+        })
+
+        it('returns results matching feature flag queries', async () => {
+            const { server, registeredTools } = createMockServer()
+            const context = createMockContext()
+            await registerToolSearchMode(server, context, {})
+
+            const handler = registeredTools.get('tool_search')!.handler
+            const result = await handler({ query: 'feature flag', limit: 10 })
+
+            const text = result.content[0].text
+            expect(text).toContain('feature-flag')
+        })
+
+        it('respects limit parameter', async () => {
+            const { server, registeredTools } = createMockServer()
+            const context = createMockContext()
+            await registerToolSearchMode(server, context, {})
+
+            const handler = registeredTools.get('tool_search')!.handler
+            const result = await handler({ query: 'get', limit: 2 })
+
+            // The response is TOON-formatted, but should contain at most 2 results
+            const text = result.content[0].text
+            // Count occurrences of "name:" in the output (each result has a name field)
+            const nameMatches = text.match(/"?name"?\s*[:=]/g) || []
+            expect(nameMatches.length).toBeLessThanOrEqual(2)
+        })
+
+        it('respects feature filtering', async () => {
+            const { server, registeredTools } = createMockServer()
+            const context = createMockContext()
+            await registerToolSearchMode(server, context, { features: ['flags'] })
+
+            const handler = registeredTools.get('tool_search')!.handler
+            const result = await handler({ query: 'dashboard', limit: 10 })
+
+            // Dashboard tools should not appear when only flags feature is enabled
+            const text = result.content[0].text
+            expect(text).not.toContain('dashboard')
+        })
+    })
+
+    describe('tool_schema', () => {
+        it('returns JSON Schema for a valid tool', async () => {
+            const { server, registeredTools } = createMockServer()
+            const context = createMockContext()
+            await registerToolSearchMode(server, context, {})
+
+            const handler = registeredTools.get('tool_schema')!.handler
+            const result = await handler({ tool_name: 'dashboard-get' })
+
+            const text = result.content[0].text
+            expect(text).toContain('dashboard-get')
+            expect(text).toContain('inputSchema')
+            expect(result.isError).toBeUndefined()
+        })
+
+        it('returns error for unknown tool', async () => {
+            const { server, registeredTools } = createMockServer()
+            const context = createMockContext()
+            await registerToolSearchMode(server, context, {})
+
+            const handler = registeredTools.get('tool_schema')!.handler
+            const result = await handler({ tool_name: 'nonexistent-tool' })
+
+            expect(result.isError).toBe(true)
+            expect(result.content[0].text).toContain('not found')
+        })
+
+        it('returns error for tool outside allowed features', async () => {
+            const { server, registeredTools } = createMockServer()
+            const context = createMockContext()
+            await registerToolSearchMode(server, context, { features: ['flags'] })
+
+            const handler = registeredTools.get('tool_schema')!.handler
+            const result = await handler({ tool_name: 'dashboard-get' })
+
+            expect(result.isError).toBe(true)
+            expect(result.content[0].text).toContain('not found')
+        })
+    })
+
+    describe('tool_call', () => {
+        it('returns error for unknown tool', async () => {
+            const { server, registeredTools } = createMockServer()
+            const context = createMockContext()
+            await registerToolSearchMode(server, context, {})
+
+            const handler = registeredTools.get('tool_call')!.handler
+            const result = await handler({ tool_name: 'nonexistent-tool', params: {} })
+
+            expect(result.isError).toBe(true)
+            expect(result.content[0].text).toContain('not found')
+        })
+
+        it('returns validation error for invalid params', async () => {
+            const { server, registeredTools } = createMockServer()
+            const context = createMockContext()
+            await registerToolSearchMode(server, context, {})
+
+            const handler = registeredTools.get('tool_call')!.handler
+            // entity-search requires a query param with minLength 1
+            const result = await handler({ tool_name: 'entity-search', params: {} })
+
+            expect(result.isError).toBe(true)
+            expect(result.content[0].text).toContain('Invalid parameters')
+        })
+
+        it('returns error for tool outside allowed scopes', async () => {
+            const { server, registeredTools } = createMockServer()
+            // Only dashboard scopes — no experiment scopes
+            const context = createMockContext(['dashboard:read'])
+            await registerToolSearchMode(server, context, {})
+
+            const handler = registeredTools.get('tool_call')!.handler
+            const result = await handler({ tool_name: 'experiment-get-all', params: {} })
+
+            expect(result.isError).toBe(true)
+            expect(result.content[0].text).toContain('not found')
+        })
+    })
+})


### PR DESCRIPTION
## Problem

  Our MCP server registers ~155 tools, each with full JSON schemas. LLM clients (Claude, Cursor, etc.) must
  load all schemas into their context window upfront, consuming significant tokens before any work begins. This
   is wasteful because most sessions only use a handful of tools.

## Comparison 


### Tool Search Mode vs Direct Mode

  | Metric | Tool Search | Direct |
  |---|---|---|
  | System prompt per turn | **~500 tok** (3 meta-tools) | ~100K+ tok (130+ full schemas) |
  | System prompt over 12 turns | **~6K tok** | ~1.2M tok |
  | Schema overhead | ~25K tok (6 on-demand fetches) | **0** (pre-loaded) |
  | MCP responses | ~45K tok | ~45K tok |
  | **Total tokens** | **~76K** | ~1.25M |
  | Round trips | ~25 | **~12** |
  | Failed calls | **0** | 1 |
  | Tools used / total available | **6 / 130+** | 6 / 130+ |
  | Parallelism | Good (batched `tool_call`) | **Best** (native parallel) |
  | Discoverability | **Keyword search** | Must know tool names |


  #### Takeaway

  Tool search mode is **~16x more token-efficient** because only **6 of 130+ tools** were needed. Direct mode
  pays **~100K tokens per turn** for **124 schemas that are never used**. The tradeoff is latency: tool search
  adds **~2 extra round trips per new tool** discovered. For **narrow tasks** (few tools, many operations),
  **tool search wins decisively**. Direct mode would only break even if a single conversation regularly used
  **50+ different tools**.


  ## Changes

  Adds a **tool search mode** (`?mode=tool_search`) that replaces the 155 individual tool registrations with 3
  meta-tools:

  1. **`tool_search`** — Fuzzy keyword search over available tools using
  [MiniSearch](https://github.com/lucaong/minisearch). The search index is built at init time from all allowed
  tool definitions (after applying feature gates, OAuth scopes, read-only mode, and AI consent filters). Fields
   are boosted so name matches rank highest (3×), then title (2×), then summary (1.5×). Supports fuzzy matching
   (0.2 tolerance) and prefix search, combined with AND logic so multi-word queries like "feature flag" narrow
  results rather than broadening them. Returns names, summaries, and categories — no schemas yet, keeping the
  response small.
  2. **`tool_schema`** — Returns the full JSON Schema for a single tool by exact name. Tool factories and their
   converted JSON schemas are lazy-cached in `Map`s, so the first call for a given tool pays the instantiation
  cost but subsequent calls are instant.
  3. **`tool_call`** — Validates params against the Zod schema via `safeParse`, then delegates to the tool's
  handler with the same `Context` object used in normal mode. Returns the same `formatResponse` output as
  direct tool calls, so downstream behavior is identical.

  The mode is opt-in via query parameter and preserves all existing filtering. Instructions are composed by
  prepending a tool search preamble (explaining the search → schema → call workflow and naming conventions) to
  the existing version-specific instructions.

  **Files changed:**

  - `services/mcp/src/tools/toolSearchMode.ts` — Core implementation of the 3 meta-tools with MiniSearch index,
   lazy caching, and scope filtering
  - `services/mcp/src/mcp.ts` — `mode` parameter plumbing; early return path for tool search mode
  - `services/mcp/src/index.ts` — Extracts `mode` from query params and passes it through
  - `services/mcp/src/templates/instructions-tool-search.md` — Instructions explaining the search → schema →
  call workflow
  - `services/mcp/tests/unit/tool-search-mode.test.ts` — Unit tests for registration, search relevance, limit,
  feature filtering, schema retrieval, validation errors, and scope enforcement
  - `services/mcp/package.json` / `pnpm-lock.yaml` — Added `minisearch` dependency

  ## How did you test this code?

  - Unit tests covering all 3 meta-tools: search relevance, limit parameter, feature filtering, schema output,
  unknown tool errors, validation errors, and scope restrictions
  - Manual end-to-end testing via Claude Code MCP client: ran the alerts CRUD lifecycle (list, create with
  various threshold types, get, update, delete) through the tool search mode — all scenarios passed through the
   search → schema → call flow




## Testing scenario

```markdown
# Alerts MCP Tools — Prompt Testing Scenarios

  Natural language prompts for manually verifying the alerts CRUD lifecycle via any MCP client (Claude,
  Cursor, etc.).

  ## Prerequisites

  - MCP server running locally or connected to a PostHog instance
  - At least one saved **TrendsQuery** insight (e.g. a pageview count insight)
  - A user subscribed to the project

  ## Scenarios

  ### 1. List alerts (empty state)

  **Prompt:** "Show me all my alerts"

  **Tools invoked:** `alerts-list`

  **Key assertions:**
  - Returns `count: 0` and empty results array
  - No errors

  ### 2. Create alert — absolute threshold with upper bound

  **Prompt:** "Create a daily alert on the pageview count insight that fires when the value exceeds 500"

  **Tools invoked:** `alerts-list` or `insights-get-all` (to find the insight), then `alert-create`

  **Key assertions:**
  - `condition.type` = `absolute_value`
  - `threshold.configuration.type` = `absolute`
  - `threshold.configuration.bounds.upper` = `500`
  - `calculation_interval` = `daily`
  - `state` = `Not firing`
  - `enabled` = `true`

  ### 3. Create alert — absolute threshold with lower and upper bounds

  **Prompt:** "Create an alert on my pageview insight that fires when the daily count drops below 20 or
  exceeds 100"

  **Tools invoked:** `alert-create`

  **Key assertions:**
  - `condition.type` = `absolute_value`
  - `threshold.configuration.bounds.lower` = `20`
  - `threshold.configuration.bounds.upper` = `100`
  - `calculation_interval` = `daily`

  ### 4. Create alert — relative increase (percentage)

  **Prompt:** "Set up an alert that notifies me if pageviews increase by more than 50% compared to the
  previous period. Check it hourly."

  **Tools invoked:** `alert-create`

  **Key assertions:**
  - `condition.type` = `relative_increase`
  - `threshold.configuration.type` = `percentage`
  - `threshold.configuration.bounds.upper` = `50`
  - `calculation_interval` = `hourly`

  ### 5. Create alert — relative decrease (percentage)

  **Prompt:** "Alert me if my pageview count drops by more than 30% relative to the previous period. Check
   weekly and skip weekends."

  **Tools invoked:** `alert-create`

  **Key assertions:**
  - `condition.type` = `relative_decrease`
  - `threshold.configuration.type` = `percentage`
  - `threshold.configuration.bounds.upper` = `30`
  - `calculation_interval` = `weekly`
  - `skip_weekend` = `true`

  ### 6. List alerts (after creation)

  **Prompt:** "List all my alerts and show their current state"

  **Tools invoked:** `alerts-list`

  **Key assertions:**
  - `count` matches the number of created alerts
  - Each alert shows `name`, `state` (`Not firing`), `threshold`, and `calculation_interval`

  ### 7. Get specific alert

  **Prompt:** "Show me the details of alert [name from scenario 2]"

  **Tools invoked:** `alerts-list` (to find ID), then `alert-get`

  **Key assertions:**
  - Returns full alert config including `checks` array (empty if no checks have run)
  - `threshold`, `condition`, `config`, `subscribed_users` are all present

  ### 8. Update alert — change interval

  **Prompt:** "Change my pageview alert to check hourly instead of daily"

  **Tools invoked:** `alerts-list` (to find ID), then `alert-update`

  **Key assertions:**
  - `calculation_interval` changed from `daily` to `hourly`
  - All other fields remain unchanged

  ### 9. Update alert — change threshold

  **Prompt:** "Update my pageview alert threshold to fire when the value is below 50 or above 1000"

  **Tools invoked:** `alert-update`

  **Key assertions:**
  - `threshold.configuration.bounds.lower` = `50`
  - `threshold.configuration.bounds.upper` = `1000`

  ### 10. Update alert — disable

  **Prompt:** "Disable my pageview alert"

  **Tools invoked:** `alert-update`

  **Key assertions:**
  - `enabled` = `false`

  ### 11. Update alert — re-enable

  **Prompt:** "Re-enable my pageview alert"

  **Tools invoked:** `alert-update`

  **Key assertions:**
  - `enabled` = `true`

  ### 12. Update alert — snooze

  **Prompt:** "Snooze my pageview alert for 2 hours"

  **Tools invoked:** `alert-update`

  **Key assertions:**
  - `state` = `Snoozed`
  - `snoozed_until` is set to a datetime ~2h in the future
  - Note: the schema requires ISO 8601 datetime, so the LLM must resolve relative durations to absolute
  timestamps

  ### 13. Full lifecycle workflow

  **Prompt:** "Create an alert on my pageview insight that fires when the count exceeds 200, check it
  daily. Then show me its details. Then update it to check hourly with a lower threshold of 10. Then
  disable it. Finally, delete it."

  **Tools invoked:** `alert-create` → `alert-get` → `alert-update` (×2) → `alert-delete`

  **Key assertions:**
  - Each step completes successfully in sequence
  - Final `alerts-list` shows the alert is gone

  ### 14. Delete alert

  **Prompt:** "Delete the pageview alert"

  **Tools invoked:** `alerts-list` (to find ID), then `alert-delete`

  **Key assertions:**
  - Returns `null` (success)
  - Subsequent `alerts-list` no longer includes the deleted alert

  ### 15. Edge case — create on non-trends insight

  **Prompt:** "Create an alert on my funnel insight"

  **Tools invoked:** `alert-create` (on a FunnelsQuery insight)

  **Key assertions:**
  - Returns validation error: `"Alerts are not supported for this insight."`
  - No alert is created
```


  ## Publish to changelog?

  No

  ## Docs update

  N/A — this is an internal optimization for MCP clients.

  ## 🤖 LLM context

  Co-authored with Claude Code. The tool search mode was designed to reduce token usage for LLM clients
  interacting with PostHog's MCP server, which has grown to ~155 tools. Manual testing confirmed the 3-step
  flow works correctly for real CRUD operations (alerts lifecycle).