### PR TITLE
feat(hog-charts): add pinnable tooltip

### DIFF
--- a/frontend/src/lib/hog-charts/core/Chart.tsx
+++ b/frontend/src/lib/hog-charts/core/Chart.tsx
@@ -73,6 +73,7 @@ export function Chart({
         hideXAxis = false,
         hideYAxis = false,
         showTooltip = true,
+        pinnableTooltip = false,
         showCrosshair = false,
         goalLines,
     } = config ?? {}
@@ -121,7 +122,9 @@ export function Chart({
         labels,
         series: coloredSeries,
         canvasRef,
+        wrapperRef,
         showTooltip,
+        pinnable: pinnableTooltip,
         onPointClick,
         resolveValue,
     })

--- a/frontend/src/lib/hog-charts/core/hooks/useChartInteraction.test.ts
+++ b/frontend/src/lib/hog-charts/core/hooks/useChartInteraction.test.ts
@@ -185,6 +185,27 @@ describe('useChartInteraction — tooltip pinning', () => {
         expect(result.current.tooltipCtx?.isPinned).toBe(true)
     })
 
+    it('does not clear pinned tooltip on scroll inside the tooltip element', () => {
+        const { result } = renderInteraction()
+        hoverAndPin(result)
+
+        // Simulate a scrollable element rendered inside the tooltip (it carries
+        // the data-hog-charts-tooltip marker applied by the Tooltip overlay).
+        const tooltipEl = document.createElement('div')
+        tooltipEl.setAttribute('data-hog-charts-tooltip', '')
+        const scrollableChild = document.createElement('div')
+        tooltipEl.appendChild(scrollableChild)
+        document.body.appendChild(tooltipEl)
+
+        act(() => {
+            scrollableChild.dispatchEvent(new Event('scroll', { bubbles: true }))
+        })
+
+        expect(result.current.tooltipCtx?.isPinned).toBe(true)
+
+        document.body.removeChild(tooltipEl)
+    })
+
     it('keeps tooltip on click inside wrapper', () => {
         const { result } = renderInteraction()
         hoverAndPin(result)

--- a/frontend/src/lib/hog-charts/core/hooks/useChartInteraction.test.ts
+++ b/frontend/src/lib/hog-charts/core/hooks/useChartInteraction.test.ts
@@ -145,12 +145,30 @@ describe('useChartInteraction — tooltip pinning', () => {
         hoverAndPin(result)
     })
 
-    it('clears tooltip on Escape when pinned', () => {
+    it.each<[string, () => void]>([
+        ['Escape key', () => document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }))],
+        ['window scroll', () => window.dispatchEvent(new Event('scroll'))],
+        [
+            'nested element scroll (capture phase)',
+            () => {
+                const scrollContainer = document.createElement('div')
+                refs.wrapperRef.current!.appendChild(scrollContainer)
+                scrollContainer.dispatchEvent(new Event('scroll'))
+            },
+        ],
+        [
+            'click outside',
+            () => {
+                jest.runAllTimers()
+                document.body.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+            },
+        ],
+    ])('clears pinned tooltip on %s', (_name, trigger) => {
         const { result } = renderInteraction()
         hoverAndPin(result)
 
         act(() => {
-            document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }))
+            trigger()
         })
 
         expect(result.current.tooltipCtx).toBeNull()
@@ -167,21 +185,6 @@ describe('useChartInteraction — tooltip pinning', () => {
         expect(result.current.tooltipCtx?.isPinned).toBe(true)
     })
 
-    it('clears tooltip on click outside', () => {
-        const { result } = renderInteraction()
-        hoverAndPin(result)
-
-        act(() => {
-            jest.runAllTimers()
-        })
-
-        act(() => {
-            document.body.dispatchEvent(new MouseEvent('click', { bubbles: true }))
-        })
-
-        expect(result.current.tooltipCtx).toBeNull()
-    })
-
     it('keeps tooltip on click inside wrapper', () => {
         const { result } = renderInteraction()
         hoverAndPin(result)
@@ -195,31 +198,6 @@ describe('useChartInteraction — tooltip pinning', () => {
         })
 
         expect(result.current.tooltipCtx?.isPinned).toBe(true)
-    })
-
-    it('clears tooltip on scroll', () => {
-        const { result } = renderInteraction()
-        hoverAndPin(result)
-
-        act(() => {
-            window.dispatchEvent(new Event('scroll'))
-        })
-
-        expect(result.current.tooltipCtx).toBeNull()
-    })
-
-    it('clears tooltip on nested element scroll (capture phase)', () => {
-        const scrollContainer = document.createElement('div')
-        refs.wrapperRef.current!.appendChild(scrollContainer)
-
-        const { result } = renderInteraction()
-        hoverAndPin(result)
-
-        act(() => {
-            scrollContainer.dispatchEvent(new Event('scroll'))
-        })
-
-        expect(result.current.tooltipCtx).toBeNull()
     })
 
     it('unpins on second click on chart', () => {

--- a/frontend/src/lib/hog-charts/core/hooks/useChartInteraction.test.ts
+++ b/frontend/src/lib/hog-charts/core/hooks/useChartInteraction.test.ts
@@ -1,0 +1,254 @@
+import { renderHook } from '@testing-library/react'
+import { act } from 'react'
+
+import type { ChartDimensions, ChartScales } from '../types'
+import { useChartInteraction } from './useChartInteraction'
+
+const dimensions: ChartDimensions = {
+    width: 800,
+    height: 400,
+    plotLeft: 48,
+    plotTop: 16,
+    plotWidth: 736,
+    plotHeight: 352,
+}
+
+const scales: ChartScales = {
+    x: (label: string) => ({ Mon: 100, Tue: 200, Wed: 300 })[label],
+    y: (value: number) => 200 - value,
+    yTicks: () => [0, 50, 100],
+}
+
+const series = [
+    { key: 'a', label: 'A', data: [10, 20, 30], color: '#f00' },
+    { key: 'b', label: 'B', data: [5, 15, 25], color: '#0f0' },
+]
+
+const labels = ['Mon', 'Tue', 'Wed']
+
+function makeRefs(): { canvasRef: React.RefObject<HTMLCanvasElement>; wrapperRef: React.RefObject<HTMLDivElement> } {
+    const wrapper = document.createElement('div')
+    document.body.appendChild(wrapper)
+    const canvas = document.createElement('canvas')
+    wrapper.appendChild(canvas)
+    // Mock getBoundingClientRect for canvas
+    canvas.getBoundingClientRect = () =>
+        ({
+            x: 0,
+            y: 0,
+            width: 800,
+            height: 400,
+            top: 0,
+            right: 800,
+            bottom: 400,
+            left: 0,
+            toJSON: () => ({}),
+        }) as DOMRect
+
+    return {
+        canvasRef: { current: canvas },
+        wrapperRef: { current: wrapper },
+    }
+}
+
+function simulateMouseMove(
+    handlers: { onMouseMove: (e: React.MouseEvent<HTMLDivElement>) => void },
+    refs: ReturnType<typeof makeRefs>,
+    clientX: number,
+    clientY: number
+): void {
+    const mockEvent = {
+        clientX,
+        clientY,
+        currentTarget: refs.wrapperRef.current!,
+    } as unknown as React.MouseEvent<HTMLDivElement>
+    // Mock getBoundingClientRect on wrapper for the mouse move calculation
+    refs.wrapperRef.current!.getBoundingClientRect = () =>
+        ({
+            x: 0,
+            y: 0,
+            width: 800,
+            height: 400,
+            top: 0,
+            right: 800,
+            bottom: 400,
+            left: 0,
+            toJSON: () => ({}),
+        }) as DOMRect
+    handlers.onMouseMove(mockEvent)
+}
+
+describe('useChartInteraction — tooltip pinning', () => {
+    let refs: ReturnType<typeof makeRefs>
+
+    beforeEach(() => {
+        jest.useFakeTimers()
+        refs = makeRefs()
+    })
+
+    afterEach(() => {
+        jest.useRealTimers()
+        if (refs.wrapperRef.current) {
+            document.body.removeChild(refs.wrapperRef.current)
+        }
+    })
+
+    function renderInteraction(pinnable = true): ReturnType<typeof renderHook<ReturnType<typeof useChartInteraction>>> {
+        return renderHook(() =>
+            useChartInteraction({
+                scales,
+                dimensions,
+                labels,
+                series,
+                canvasRef: refs.canvasRef,
+                wrapperRef: refs.wrapperRef,
+                showTooltip: true,
+                pinnable,
+                resolveValue: (s, i) => s.data[i],
+            })
+        )
+    }
+
+    function hoverAndPin(result: { current: ReturnType<typeof useChartInteraction> }): void {
+        // Hover to create a tooltip context
+        act(() => {
+            simulateMouseMove(result.current.handlers, refs, 200, 100)
+        })
+        expect(result.current.tooltipCtx).not.toBeNull()
+
+        // Click to pin
+        act(() => {
+            result.current.handlers.onClick()
+        })
+        expect(result.current.tooltipCtx?.isPinned).toBe(true)
+    }
+
+    it('starts with no tooltip', () => {
+        const { result } = renderInteraction()
+        expect(result.current.tooltipCtx).toBeNull()
+        expect(result.current.hoverIndex).toBe(-1)
+    })
+
+    it('shows tooltip on hover', () => {
+        const { result } = renderInteraction()
+
+        act(() => {
+            simulateMouseMove(result.current.handlers, refs, 200, 100)
+        })
+
+        expect(result.current.tooltipCtx).not.toBeNull()
+        expect(result.current.hoverIndex).toBeGreaterThanOrEqual(0)
+    })
+
+    it('pins tooltip on click when pinnable and multiple series', () => {
+        const { result } = renderInteraction()
+        hoverAndPin(result)
+    })
+
+    it('clears tooltip on Escape when pinned', () => {
+        const { result } = renderInteraction()
+        hoverAndPin(result)
+
+        act(() => {
+            document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }))
+        })
+
+        expect(result.current.tooltipCtx).toBeNull()
+    })
+
+    it('does not clear on non-Escape keys', () => {
+        const { result } = renderInteraction()
+        hoverAndPin(result)
+
+        act(() => {
+            document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }))
+        })
+
+        expect(result.current.tooltipCtx?.isPinned).toBe(true)
+    })
+
+    it('clears tooltip on click outside', () => {
+        const { result } = renderInteraction()
+        hoverAndPin(result)
+
+        act(() => {
+            jest.runAllTimers()
+        })
+
+        act(() => {
+            document.body.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+        })
+
+        expect(result.current.tooltipCtx).toBeNull()
+    })
+
+    it('keeps tooltip on click inside wrapper', () => {
+        const { result } = renderInteraction()
+        hoverAndPin(result)
+
+        act(() => {
+            jest.runAllTimers()
+        })
+
+        act(() => {
+            refs.wrapperRef.current!.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+        })
+
+        expect(result.current.tooltipCtx?.isPinned).toBe(true)
+    })
+
+    it('clears tooltip on scroll', () => {
+        const { result } = renderInteraction()
+        hoverAndPin(result)
+
+        act(() => {
+            window.dispatchEvent(new Event('scroll'))
+        })
+
+        expect(result.current.tooltipCtx).toBeNull()
+    })
+
+    it('clears tooltip on nested element scroll (capture phase)', () => {
+        const scrollContainer = document.createElement('div')
+        refs.wrapperRef.current!.appendChild(scrollContainer)
+
+        const { result } = renderInteraction()
+        hoverAndPin(result)
+
+        act(() => {
+            scrollContainer.dispatchEvent(new Event('scroll'))
+        })
+
+        expect(result.current.tooltipCtx).toBeNull()
+    })
+
+    it('unpins on second click on chart', () => {
+        const { result } = renderInteraction()
+        hoverAndPin(result)
+
+        act(() => {
+            result.current.handlers.onClick()
+        })
+
+        expect(result.current.tooltipCtx).toBeNull()
+    })
+
+    it('hover context does not have onUnpin', () => {
+        const { result } = renderInteraction(true)
+
+        act(() => {
+            simulateMouseMove(result.current.handlers, refs, 200, 100)
+        })
+
+        expect(result.current.tooltipCtx?.isPinned).toBe(false)
+        expect(result.current.tooltipCtx?.onUnpin).toBeUndefined()
+    })
+
+    it('pinned context has onUnpin', () => {
+        const { result } = renderInteraction(true)
+        hoverAndPin(result)
+
+        expect(result.current.tooltipCtx?.isPinned).toBe(true)
+        expect(result.current.tooltipCtx?.onUnpin).toBeInstanceOf(Function)
+    })
+})

--- a/frontend/src/lib/hog-charts/core/hooks/useChartInteraction.test.ts
+++ b/frontend/src/lib/hog-charts/core/hooks/useChartInteraction.test.ts
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react'
+import { renderHook, type RenderHookResult } from '@testing-library/react'
 import { act } from 'react'
 
 import type { ChartDimensions, ChartScales } from '../types'
@@ -93,7 +93,7 @@ describe('useChartInteraction — tooltip pinning', () => {
         }
     })
 
-    function renderInteraction(pinnable = true): ReturnType<typeof renderHook<ReturnType<typeof useChartInteraction>>> {
+    function renderInteraction(pinnable = true): RenderHookResult<ReturnType<typeof useChartInteraction>, unknown> {
         return renderHook(() =>
             useChartInteraction({
                 scales,

--- a/frontend/src/lib/hog-charts/core/hooks/useChartInteraction.ts
+++ b/frontend/src/lib/hog-charts/core/hooks/useChartInteraction.ts
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useRef, useState } from 'react'
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import { buildPointClickData, buildTooltipContext, findNearestIndex, isInPlotArea } from '../interaction'
 import type { ChartDimensions, ChartScales, PointClickData, ResolveValueFn, Series, TooltipContext } from '../types'
@@ -11,7 +11,9 @@ interface UseChartInteractionOptions {
     labels: string[]
     series: Series[]
     canvasRef: React.RefObject<HTMLCanvasElement>
+    wrapperRef: React.RefObject<HTMLDivElement>
     showTooltip: boolean
+    pinnable: boolean
     onPointClick?: (data: PointClickData) => void
     resolveValue?: ResolveValueFn
 }
@@ -32,18 +34,69 @@ export function useChartInteraction({
     labels,
     series,
     canvasRef,
+    wrapperRef,
     showTooltip,
+    pinnable,
     onPointClick,
     resolveValue = defaultResolveValue,
 }: UseChartInteractionOptions): UseChartInteractionResult {
     const [hoverIndex, setHoverIndex] = useState<number>(-1)
     const [tooltipCtx, setTooltipCtx] = useState<TooltipContext | null>(null)
-    const hoverIndexRef = useRef(hoverIndex)
+    const hoverIndexRef = useRef<number>(hoverIndex)
     hoverIndexRef.current = hoverIndex
+
+    const clearTooltip = useCallback(() => {
+        setHoverIndex(-1)
+        setTooltipCtx(null)
+    }, [])
+
+    const unpin = useCallback(() => {
+        setTooltipCtx((prev) => (prev?.isPinned ? null : prev))
+    }, [])
+
+    const isPinned = tooltipCtx?.isPinned ?? false
+
+    // Dismiss listeners for pinned tooltip
+    useEffect(() => {
+        if (!isPinned) {
+            return
+        }
+
+        const handleClickOutside = (e: MouseEvent): void => {
+            const wrapper = wrapperRef.current
+            if (wrapper && !wrapper.contains(e.target as Node)) {
+                clearTooltip()
+            }
+        }
+
+        const handleKeyDown = (e: KeyboardEvent): void => {
+            if (e.key === 'Escape') {
+                clearTooltip()
+            }
+        }
+
+        const handleScroll = (): void => {
+            clearTooltip()
+        }
+
+        // Delay click listener so the pinning click doesn't immediately unpin
+        const timer = setTimeout(() => {
+            document.addEventListener('click', handleClickOutside, { passive: true })
+        }, 0)
+        document.addEventListener('keydown', handleKeyDown, { passive: true })
+        window.addEventListener('scroll', handleScroll, { passive: true, capture: true })
+
+        return () => {
+            clearTimeout(timer)
+            document.removeEventListener('click', handleClickOutside)
+            document.removeEventListener('keydown', handleKeyDown)
+            window.removeEventListener('scroll', handleScroll, true)
+        }
+    }, [isPinned, wrapperRef, clearTooltip])
 
     const onMouseMove = useCallback(
         (e: React.MouseEvent<HTMLDivElement>) => {
-            if (!scales || !dimensions) {
+            if (!scales || !dimensions || isPinned) {
                 return
             }
 
@@ -52,8 +105,7 @@ export function useChartInteraction({
             const mouseY = e.clientY - rect.top
 
             if (!isInPlotArea(mouseX, mouseY, dimensions)) {
-                setHoverIndex(-1)
-                setTooltipCtx(null)
+                clearTooltip()
                 return
             }
 
@@ -62,34 +114,46 @@ export function useChartInteraction({
 
             if (index >= 0 && showTooltip) {
                 const canvasBounds = canvasRef.current?.getBoundingClientRect() ?? new DOMRect()
-                const newTooltipCtx = buildTooltipContext(
-                    index,
-                    series,
-                    labels,
-                    scales.x,
-                    scales.y,
-                    canvasBounds,
-                    resolveValue
-                )
-                setTooltipCtx(newTooltipCtx)
+                const ctx = buildTooltipContext(index, series, labels, scales.x, scales.y, canvasBounds, resolveValue)
+                if (ctx) {
+                    setTooltipCtx(ctx)
+                }
             }
         },
-        [scales, dimensions, labels, series, showTooltip, resolveValue, canvasRef]
+        [scales, dimensions, labels, series, showTooltip, resolveValue, canvasRef, isPinned, clearTooltip]
     )
 
     const onMouseLeave = useCallback(() => {
-        setHoverIndex(-1)
-        setTooltipCtx(null)
-    }, [])
+        if (isPinned) {
+            return
+        }
+        clearTooltip()
+    }, [isPinned, clearTooltip])
 
     const onClick = useCallback(() => {
-        if (onPointClick && hoverIndexRef.current >= 0) {
-            const clickData = buildPointClickData(hoverIndexRef.current, series, labels, resolveValue)
+        const currentIndex = hoverIndexRef.current
+        if (currentIndex == null || currentIndex < 0) {
+            return
+        }
+
+        if (isPinned) {
+            clearTooltip()
+            return
+        }
+
+        // Pin the tooltip if pinnable and there are multiple series
+        if (pinnable && tooltipCtx && tooltipCtx.seriesData.length > 1) {
+            setTooltipCtx({ ...tooltipCtx, isPinned: true, onUnpin: unpin })
+            return
+        }
+
+        if (onPointClick) {
+            const clickData = buildPointClickData(currentIndex, series, labels, resolveValue)
             if (clickData) {
                 onPointClick(clickData)
             }
         }
-    }, [onPointClick, series, labels, resolveValue])
+    }, [onPointClick, series, labels, resolveValue, pinnable, tooltipCtx, isPinned, clearTooltip, unpin, hoverIndexRef])
 
     const handlers = useMemo(() => ({ onMouseMove, onMouseLeave, onClick }), [onMouseMove, onMouseLeave, onClick])
 

--- a/frontend/src/lib/hog-charts/core/hooks/useChartInteraction.ts
+++ b/frontend/src/lib/hog-charts/core/hooks/useChartInteraction.ts
@@ -131,7 +131,8 @@ export function useChartInteraction({
     }, [isPinned, clearTooltip])
 
     const onClick = useCallback(() => {
-        if (hoverIndexRef.current < 0) {
+        const currentIndex = hoverIndexRef.current
+        if (currentIndex < 0) {
             return
         }
 

--- a/frontend/src/lib/hog-charts/core/hooks/useChartInteraction.ts
+++ b/frontend/src/lib/hog-charts/core/hooks/useChartInteraction.ts
@@ -131,8 +131,7 @@ export function useChartInteraction({
     }, [isPinned, clearTooltip])
 
     const onClick = useCallback(() => {
-        const currentIndex = hoverIndexRef.current
-        if (currentIndex == null || currentIndex < 0) {
+        if (hoverIndexRef.current < 0) {
             return
         }
 

--- a/frontend/src/lib/hog-charts/core/hooks/useChartInteraction.ts
+++ b/frontend/src/lib/hog-charts/core/hooks/useChartInteraction.ts
@@ -75,7 +75,13 @@ export function useChartInteraction({
             }
         }
 
-        const handleScroll = (): void => {
+        const handleScroll = (e: Event): void => {
+            // Ignore scrolls that originate inside the tooltip itself — users
+            // should be able to scroll long pinned content without dismissing it.
+            const target = e.target as Element | null
+            if (target && typeof target.closest === 'function' && target.closest('[data-hog-charts-tooltip]')) {
+                return
+            }
             clearTooltip()
         }
 

--- a/frontend/src/lib/hog-charts/core/interaction.ts
+++ b/frontend/src/lib/hog-charts/core/interaction.ts
@@ -78,6 +78,7 @@ export function buildTooltipContext(
         seriesData,
         position: { x, y },
         canvasBounds,
+        isPinned: false,
     }
 }
 

--- a/frontend/src/lib/hog-charts/core/types.ts
+++ b/frontend/src/lib/hog-charts/core/types.ts
@@ -62,6 +62,11 @@ export interface TooltipContext {
     position: { x: number; y: number }
     /** Bounding rect of the canvas element, useful for portal-based tooltip positioning. */
     canvasBounds: DOMRect
+    /** Whether the tooltip is pinned (clicked). When pinned, the tooltip stays visible
+     *  and becomes interactive (pointer-events enabled). */
+    isPinned: boolean
+    /** Callback to unpin (close) a pinned tooltip. Only present when the tooltip is pinned. */
+    onUnpin?: () => void
 }
 
 /** Computed layout dimensions of the chart, derived from container size and margins. */
@@ -111,6 +116,8 @@ export interface ChartConfig {
     showGrid?: boolean
     /** Show a tooltip on hover. Defaults to true. Use the `tooltip` prop to customize content. */
     showTooltip?: boolean
+    /** When true, clicking a data point with multiple series pins the tooltip in place. */
+    pinnableTooltip?: boolean
     /** Show a vertical crosshair line that follows the cursor. */
     showCrosshair?: boolean
     /** Horizontal goal/reference lines to draw across the chart. */

--- a/frontend/src/lib/hog-charts/overlays/Tooltip.tsx
+++ b/frontend/src/lib/hog-charts/overlays/Tooltip.tsx
@@ -46,7 +46,7 @@ export function Tooltip({ context, renderTooltip }: TooltipProps): React.ReactEl
             ref={refs.setFloating}
             style={{
                 ...floatingStyles,
-                pointerEvents: 'none',
+                pointerEvents: context.isPinned ? 'auto' : 'none',
                 width: 'max-content',
                 zIndex: 10,
             }}

--- a/frontend/src/lib/hog-charts/overlays/Tooltip.tsx
+++ b/frontend/src/lib/hog-charts/overlays/Tooltip.tsx
@@ -44,6 +44,10 @@ export function Tooltip({ context, renderTooltip }: TooltipProps): React.ReactEl
     return (
         <div
             ref={refs.setFloating}
+            // Marker so the interaction hook can distinguish scroll events that originate
+            // inside the tooltip (e.g. scrollable long content) from chart/page scrolls,
+            // which should dismiss a pinned tooltip.
+            data-hog-charts-tooltip=""
             style={{
                 ...floatingStyles,
                 pointerEvents: context.isPinned ? 'auto' : 'none',


### PR DESCRIPTION
## Problem

When a chart has multiple series, users often want to read the tooltip more carefully, copy a value, or inspect it alongside other context. A hover-only tooltip makes that awkward — the moment the mouse leaves the plot, the tooltip disappears.

## Changes

- Adds a `pinnableTooltip` flag to `ChartConfig`. When true, clicking a data point on a chart with multiple series pins the tooltip in place
- While pinned: hover updates are suppressed, `pointer-events: auto` is set on the tooltip (so its contents are interactive), and the tooltip dismisses on outside click, Escape key, or scroll
- Adds `isPinned` and `onUnpin` to `TooltipContext` so custom tooltip renderers can show a close button
- New `useChartInteraction` test file covering hover, click-to-pin, pinned click-to-unpin, and the three dismiss triggers

Stacked on top of #53369 (floating-ui positioning + render-fn API).

## How did you test this code?

I'm an AI agent. Behavior is covered by the new `useChartInteraction.test.ts`. I verified zero TypeScript diagnostics across all changed files via IDE diagnostics.

## Publish to changelog?

no

## 🤖 LLM context

Split out of the original #53369. PR 2 of 3 in the stack:
- PR 1 (#53369): floating-ui positioning + render-fn API
- PR 2 (this): pinnable tooltip
- PR 3 (#53390): Trends InsightTooltip bridge

Co-authored with Claude Code.