### PR TITLE
feat(trends): render InsightTooltip on the hog-charts line chart

### DIFF
--- a/frontend/src/lib/hog-charts/core/hooks/useChartInteraction.test.ts
+++ b/frontend/src/lib/hog-charts/core/hooks/useChartInteraction.test.ts
@@ -147,13 +147,13 @@ describe('useChartInteraction — tooltip pinning', () => {
 
     it.each<[string, () => void]>([
         ['Escape key', () => document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }))],
-        ['window scroll', () => window.dispatchEvent(new Event('scroll'))],
         [
-            'nested element scroll (capture phase)',
+            'scroll outside the chart wrapper',
             () => {
-                const scrollContainer = document.createElement('div')
-                refs.wrapperRef.current!.appendChild(scrollContainer)
-                scrollContainer.dispatchEvent(new Event('scroll'))
+                const outside = document.createElement('div')
+                document.body.appendChild(outside)
+                outside.dispatchEvent(new Event('scroll', { bubbles: true }))
+                document.body.removeChild(outside)
             },
         ],
         [
@@ -172,6 +172,20 @@ describe('useChartInteraction — tooltip pinning', () => {
         })
 
         expect(result.current.tooltipCtx).toBeNull()
+    })
+
+    it('does not clear pinned tooltip on scroll inside the chart wrapper', () => {
+        const { result } = renderInteraction()
+        hoverAndPin(result)
+
+        const scrollContainer = document.createElement('div')
+        refs.wrapperRef.current!.appendChild(scrollContainer)
+
+        act(() => {
+            scrollContainer.dispatchEvent(new Event('scroll', { bubbles: true }))
+        })
+
+        expect(result.current.tooltipCtx?.isPinned).toBe(true)
     })
 
     it('does not clear on non-Escape keys', () => {

--- a/frontend/src/lib/hog-charts/core/hooks/useChartInteraction.ts
+++ b/frontend/src/lib/hog-charts/core/hooks/useChartInteraction.ts
@@ -76,11 +76,17 @@ export function useChartInteraction({
         }
 
         const handleScroll = (e: Event): void => {
-            // Ignore scrolls that originate inside the tooltip itself — users
-            // should be able to scroll long pinned content without dismissing it.
-            const target = e.target as Element | null
-            if (target && typeof target.closest === 'function' && target.closest('[data-hog-charts-tooltip]')) {
-                return
+            // Ignore scrolls that originate inside the tooltip itself or inside
+            // the chart wrapper — users should be able to scroll long pinned
+            // content (or a nested legend) without dismissing the tooltip.
+            const target = e.target
+            if (target instanceof Element) {
+                if (target.closest('[data-hog-charts-tooltip]')) {
+                    return
+                }
+                if (wrapperRef.current?.contains(target)) {
+                    return
+                }
             }
             clearTooltip()
         }
@@ -120,10 +126,10 @@ export function useChartInteraction({
 
             if (index >= 0 && showTooltip) {
                 const canvasBounds = canvasRef.current?.getBoundingClientRect() ?? new DOMRect()
-                const ctx = buildTooltipContext(index, series, labels, scales.x, scales.y, canvasBounds, resolveValue)
-                if (ctx) {
-                    setTooltipCtx(ctx)
-                }
+                // Always propagate the result (including null) so tooltipCtx stays in sync with hoverIndex.
+                setTooltipCtx(
+                    buildTooltipContext(index, series, labels, scales.x, scales.y, canvasBounds, resolveValue)
+                )
             }
         },
         [scales, dimensions, labels, series, showTooltip, resolveValue, canvasRef, isPinned, clearTooltip]

--- a/frontend/src/lib/hog-charts/core/types.ts
+++ b/frontend/src/lib/hog-charts/core/types.ts
@@ -20,6 +20,10 @@ export interface Series {
     hidden?: boolean
     /** Radius in px for data point dots. Set to 0 or omit to hide dots. */
     pointRadius?: number
+    /** Arbitrary consumer data attached to this series. Flows through to TooltipContext
+     *  so custom tooltip components can access domain-specific information (e.g. breakdown
+     *  values, comparison labels, anomaly scores) without the library needing to know about them. */
+    meta?: Record<string, unknown>
 }
 
 /** A horizontal reference line drawn across the chart at a fixed y-value. */

--- a/frontend/src/scenes/trends/viz/TrendsLineChartD3.tsx
+++ b/frontend/src/scenes/trends/viz/TrendsLineChartD3.tsx
@@ -1,10 +1,11 @@
 import { useValues } from 'kea'
-import { useMemo } from 'react'
+import { useCallback, useMemo } from 'react'
 
 import { createXAxisTickCallback } from 'lib/charts/utils/dates'
 import { buildTheme } from 'lib/charts/utils/theme'
 import { LineChart } from 'lib/hog-charts'
 import type { LineChartConfig, Series } from 'lib/hog-charts'
+import type { TooltipContext } from 'lib/hog-charts/core/types'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { teamLogic } from 'scenes/teamLogic'
 
@@ -59,77 +60,91 @@ export function TrendsLineChartD3({ context }: TrendsLineChartD3Props): JSX.Elem
 
     const labels = currentPeriodResult?.labels ?? []
 
-    if (
-        !(
-            indexedResults &&
-            indexedResults[0]?.data &&
-            indexedResults.filter((result: IndexedTrendResult) => result.count !== 0).length > 0
-        )
-    ) {
+    const hasData =
+        indexedResults &&
+        indexedResults[0]?.data &&
+        indexedResults.filter((result: IndexedTrendResult) => result.count !== 0).length > 0
+
+    const hogSeries: Series[] = useMemo(
+        () =>
+            (indexedResults ?? [])
+                .filter((r: IndexedTrendResult) => r.count !== 0)
+                .map((r: IndexedTrendResult) => ({
+                    key: `${r.id}`,
+                    label: r.label ?? '',
+                    data: r.data,
+                    color: getTrendsColor(r),
+                    fillArea: display === ChartDisplayType.ActionsAreaGraph,
+                    meta: {
+                        action: r.action,
+                        breakdown_value: r.breakdown_value,
+                        compare_label: r.compare_label,
+                        days: r.days,
+                        // Fall back to the pre-filter index (r.id) so ordering is stable when earlier series are dropped.
+                        order: r.action?.order ?? r.id,
+                        filter: r.filter,
+                    },
+                })),
+        [indexedResults, display, getTrendsColor]
+    )
+
+    const chartConfig: LineChartConfig = useMemo(() => {
+        const xTickFormatter = createXAxisTickCallback({
+            interval: interval ?? 'day',
+            allDays: currentPeriodResult?.days ?? [],
+            timezone,
+        })
+        return {
+            showGrid: true,
+            showCrosshair: true,
+            pinnableTooltip: true,
+            yScaleType: yAxisScaleType === 'log10' ? 'log' : 'linear',
+            percentStackView: isPercentStackView,
+            xTickFormatter,
+            goalLines: goalLines?.map((g: SchemaGoalLine) => ({
+                value: g.value,
+                label: g.label ?? undefined,
+                borderColor: g.borderColor ?? undefined,
+            })),
+        }
+    }, [interval, currentPeriodResult?.days, timezone, yAxisScaleType, isPercentStackView, goalLines])
+
+    const formatCompareLabel = context?.formatCompareLabel
+    const renderTooltip = useCallback(
+        (ctx: TooltipContext) => (
+            <TrendsTooltip
+                context={ctx}
+                timezone={timezone}
+                interval={interval ?? undefined}
+                breakdownFilter={breakdownFilter ?? undefined}
+                dateRange={insightData?.resolved_date_range ?? undefined}
+                trendsFilter={trendsFilter}
+                formula={formula}
+                showPercentView={isStickiness}
+                isPercentStackView={isPercentStackView}
+                baseCurrency={baseCurrency}
+                groupTypeLabel={resolvedGroupTypeLabel}
+                formatCompareLabel={formatCompareLabel}
+            />
+        ),
+        [
+            timezone,
+            interval,
+            breakdownFilter,
+            insightData?.resolved_date_range,
+            trendsFilter,
+            formula,
+            isStickiness,
+            isPercentStackView,
+            baseCurrency,
+            resolvedGroupTypeLabel,
+            formatCompareLabel,
+        ]
+    )
+
+    if (!hasData) {
         return <InsightEmptyState heading={context?.emptyStateHeading} detail={context?.emptyStateDetail} />
     }
 
-    const hogSeries: Series[] = indexedResults
-        .filter((r: IndexedTrendResult) => r.count !== 0)
-        .map((r: IndexedTrendResult) => ({
-            key: `${r.id}`,
-            label: r.label ?? '',
-            data: r.data,
-            color: getTrendsColor(r),
-            fillArea: display === ChartDisplayType.ActionsAreaGraph,
-            meta: {
-                action: r.action,
-                breakdown_value: r.breakdown_value,
-                compare_label: r.compare_label,
-                days: r.days,
-                // Fall back to the pre-filter index (r.id) so ordering is stable when earlier series are dropped.
-                order: r.action?.order ?? r.id,
-                filter: r.filter,
-            },
-        }))
-
-    const xTickFormatter = createXAxisTickCallback({
-        interval: interval ?? 'day',
-        allDays: currentPeriodResult?.days ?? [],
-        timezone,
-    })
-
-    const chartConfig: LineChartConfig = {
-        showGrid: true,
-        showCrosshair: true,
-        pinnableTooltip: true,
-        yScaleType: yAxisScaleType === 'log10' ? 'log' : 'linear',
-        percentStackView: isPercentStackView,
-        xTickFormatter: xTickFormatter,
-        goalLines: goalLines?.map((g: SchemaGoalLine) => ({
-            value: g.value,
-            label: g.label ?? undefined,
-            borderColor: g.borderColor ?? undefined,
-        })),
-    }
-
-    return (
-        <LineChart
-            series={hogSeries}
-            labels={labels}
-            config={chartConfig}
-            theme={theme}
-            tooltip={(ctx) => (
-                <TrendsTooltip
-                    context={ctx}
-                    timezone={timezone}
-                    interval={interval ?? undefined}
-                    breakdownFilter={breakdownFilter ?? undefined}
-                    dateRange={insightData?.resolved_date_range ?? undefined}
-                    trendsFilter={trendsFilter}
-                    formula={formula}
-                    showPercentView={isStickiness}
-                    isPercentStackView={isPercentStackView}
-                    baseCurrency={baseCurrency}
-                    groupTypeLabel={resolvedGroupTypeLabel}
-                    formatCompareLabel={context?.formatCompareLabel}
-                />
-            )}
-        />
-    )
+    return <LineChart series={hogSeries} labels={labels} config={chartConfig} theme={theme} tooltip={renderTooltip} />
 }

--- a/frontend/src/scenes/trends/viz/TrendsLineChartD3.tsx
+++ b/frontend/src/scenes/trends/viz/TrendsLineChartD3.tsx
@@ -9,6 +9,7 @@ import { insightLogic } from 'scenes/insights/insightLogic'
 import { teamLogic } from 'scenes/teamLogic'
 
 import { themeLogic } from '~/layout/navigation-3000/themeLogic'
+import { groupsModel } from '~/models/groupsModel'
 import { GoalLine as SchemaGoalLine, InsightVizNode } from '~/queries/schema/schema-general'
 import { QueryContext } from '~/queries/types'
 import { ChartDisplayType } from '~/types'
@@ -39,8 +40,22 @@ export function TrendsLineChartD3({ context }: TrendsLineChartD3Props): JSX.Elem
         currentPeriodResult,
         breakdownFilter,
         insightData,
+        trendsFilter,
+        formula,
+        isStickiness,
+        labelGroupType,
     } = useValues(trendsDataLogic(insightProps))
-    const { timezone } = useValues(teamLogic)
+    const { timezone, baseCurrency } = useValues(teamLogic)
+    const { aggregationLabel } = useValues(groupsModel)
+
+    const isPercentStackView = !!showPercentStackView && !!supportsPercentStackView
+    const resolvedGroupTypeLabel =
+        context?.groupTypeLabel ??
+        (labelGroupType === 'people'
+            ? 'people'
+            : labelGroupType === 'none'
+              ? ''
+              : aggregationLabel(labelGroupType).plural)
 
     const labels = currentPeriodResult?.labels ?? []
 
@@ -84,7 +99,7 @@ export function TrendsLineChartD3({ context }: TrendsLineChartD3Props): JSX.Elem
         showCrosshair: true,
         pinnableTooltip: true,
         yScaleType: yAxisScaleType === 'log10' ? 'log' : 'linear',
-        percentStackView: !!showPercentStackView && !!supportsPercentStackView,
+        percentStackView: isPercentStackView,
         xTickFormatter: xTickFormatter,
         goalLines: goalLines?.map((g: SchemaGoalLine) => ({
             value: g.value,
@@ -106,6 +121,13 @@ export function TrendsLineChartD3({ context }: TrendsLineChartD3Props): JSX.Elem
                     interval={interval ?? undefined}
                     breakdownFilter={breakdownFilter ?? undefined}
                     dateRange={insightData?.resolved_date_range ?? undefined}
+                    trendsFilter={trendsFilter}
+                    formula={formula}
+                    showPercentView={isStickiness}
+                    isPercentStackView={isPercentStackView}
+                    baseCurrency={baseCurrency}
+                    groupTypeLabel={resolvedGroupTypeLabel}
+                    formatCompareLabel={context?.formatCompareLabel}
                 />
             )}
         />

--- a/frontend/src/scenes/trends/viz/TrendsLineChartD3.tsx
+++ b/frontend/src/scenes/trends/viz/TrendsLineChartD3.tsx
@@ -56,7 +56,7 @@ export function TrendsLineChartD3({ context }: TrendsLineChartD3Props): JSX.Elem
 
     const hogSeries: Series[] = indexedResults
         .filter((r: IndexedTrendResult) => r.count !== 0)
-        .map((r: IndexedTrendResult, idx: number) => ({
+        .map((r: IndexedTrendResult) => ({
             key: `${r.id}`,
             label: r.label ?? '',
             data: r.data,
@@ -67,7 +67,8 @@ export function TrendsLineChartD3({ context }: TrendsLineChartD3Props): JSX.Elem
                 breakdown_value: r.breakdown_value,
                 compare_label: r.compare_label,
                 days: r.days,
-                order: r.action?.order ?? idx,
+                // Fall back to the pre-filter index (r.id) so ordering is stable when earlier series are dropped.
+                order: r.action?.order ?? r.id,
                 filter: r.filter,
             },
         }))

--- a/frontend/src/scenes/trends/viz/TrendsLineChartD3.tsx
+++ b/frontend/src/scenes/trends/viz/TrendsLineChartD3.tsx
@@ -16,6 +16,7 @@ import { ChartDisplayType } from '~/types'
 import { InsightEmptyState } from '../../insights/EmptyStates'
 import { trendsDataLogic } from '../trendsDataLogic'
 import type { IndexedTrendResult } from '../types'
+import { TrendsTooltip } from './TrendsTooltip'
 
 interface TrendsLineChartD3Props {
     context?: QueryContext<InsightVizNode>
@@ -36,6 +37,8 @@ export function TrendsLineChartD3({ context }: TrendsLineChartD3Props): JSX.Elem
         goalLines,
         getTrendsColor,
         currentPeriodResult,
+        breakdownFilter,
+        insightData,
     } = useValues(trendsDataLogic(insightProps))
     const { timezone } = useValues(teamLogic)
 
@@ -53,12 +56,20 @@ export function TrendsLineChartD3({ context }: TrendsLineChartD3Props): JSX.Elem
 
     const hogSeries: Series[] = indexedResults
         .filter((r: IndexedTrendResult) => r.count !== 0)
-        .map((r: IndexedTrendResult) => ({
+        .map((r: IndexedTrendResult, idx: number) => ({
             key: `${r.id}`,
             label: r.label ?? '',
             data: r.data,
             color: getTrendsColor(r),
             fillArea: display === ChartDisplayType.ActionsAreaGraph,
+            meta: {
+                action: r.action,
+                breakdown_value: r.breakdown_value,
+                compare_label: r.compare_label,
+                days: r.days,
+                order: r.action?.order ?? idx,
+                filter: r.filter,
+            },
         }))
 
     const xTickFormatter = createXAxisTickCallback({
@@ -70,6 +81,7 @@ export function TrendsLineChartD3({ context }: TrendsLineChartD3Props): JSX.Elem
     const chartConfig: LineChartConfig = {
         showGrid: true,
         showCrosshair: true,
+        pinnableTooltip: true,
         yScaleType: yAxisScaleType === 'log10' ? 'log' : 'linear',
         percentStackView: !!showPercentStackView && !!supportsPercentStackView,
         xTickFormatter: xTickFormatter,
@@ -80,5 +92,21 @@ export function TrendsLineChartD3({ context }: TrendsLineChartD3Props): JSX.Elem
         })),
     }
 
-    return <LineChart series={hogSeries} labels={labels} config={chartConfig} theme={theme} />
+    return (
+        <LineChart
+            series={hogSeries}
+            labels={labels}
+            config={chartConfig}
+            theme={theme}
+            tooltip={(ctx) => (
+                <TrendsTooltip
+                    context={ctx}
+                    timezone={timezone}
+                    interval={interval ?? undefined}
+                    breakdownFilter={breakdownFilter ?? undefined}
+                    dateRange={insightData?.resolved_date_range ?? undefined}
+                />
+            )}
+        />
+    )
 }

--- a/frontend/src/scenes/trends/viz/TrendsTooltip.tsx
+++ b/frontend/src/scenes/trends/viz/TrendsTooltip.tsx
@@ -2,12 +2,12 @@ import { IconX } from '@posthog/icons'
 
 import { SeriesLetter } from 'lib/components/SeriesGlyph'
 import type { TooltipContext } from 'lib/hog-charts/core/types'
-import { formatAggregationAxisValue } from 'scenes/insights/aggregationAxisFormat'
+import { formatAggregationAxisValue, formatPercentStackAxisValue } from 'scenes/insights/aggregationAxisFormat'
 import { InsightTooltip } from 'scenes/insights/InsightTooltip/InsightTooltip'
-import { SeriesDatum } from 'scenes/insights/InsightTooltip/insightTooltipUtils'
+import { getDatumTitle, SeriesDatum } from 'scenes/insights/InsightTooltip/insightTooltipUtils'
 
-import { BreakdownFilter, DateRange } from '~/queries/schema/schema-general'
-import { ActionFilter, IntervalType } from '~/types'
+import { BreakdownFilter, DateRange, TrendsFilter } from '~/queries/schema/schema-general'
+import { ActionFilter, CurrencyCode, IntervalType } from '~/types'
 
 interface TrendsTooltipProps {
     context: TooltipContext
@@ -15,6 +15,13 @@ interface TrendsTooltipProps {
     interval?: IntervalType
     breakdownFilter?: BreakdownFilter
     dateRange?: DateRange
+    trendsFilter?: TrendsFilter | null
+    formula?: string | null
+    showPercentView?: boolean
+    isPercentStackView?: boolean
+    baseCurrency?: CurrencyCode
+    groupTypeLabel?: string
+    formatCompareLabel?: (label: string, dateLabel?: string) => string
 }
 
 /** Bridges hog-charts TooltipContext to the legacy InsightTooltip.
@@ -26,30 +33,55 @@ export function TrendsTooltip({
     interval,
     breakdownFilter,
     dateRange,
+    trendsFilter,
+    formula,
+    showPercentView,
+    isPercentStackView,
+    baseCurrency,
+    groupTypeLabel,
+    formatCompareLabel,
 }: TrendsTooltipProps): React.ReactElement {
-    const seriesData: SeriesDatum[] = context.seriesData.map((entry, idx) => {
-        const meta = entry.series.meta ?? {}
-        const days = meta.days as string[] | undefined
+    const seriesData: SeriesDatum[] = context.seriesData
+        .map((entry, idx) => {
+            const meta = entry.series.meta ?? {}
+            const days = meta.days as string[] | undefined
 
-        return {
-            id: idx,
-            dataIndex: context.dataIndex,
-            datasetIndex: idx,
-            order: typeof meta.order === 'number' ? meta.order : idx,
-            label: entry.series.label,
-            color: entry.color,
-            count: entry.value,
-            action: meta.action as ActionFilter | undefined,
-            breakdown_value: meta.breakdown_value as string | number | string[] | undefined,
-            compare_label: meta.compare_label as SeriesDatum['compare_label'],
-            date_label: days?.[context.dataIndex],
-            filter: meta.filter as SeriesDatum['filter'],
-        }
-    })
+            return {
+                id: idx,
+                dataIndex: context.dataIndex,
+                datasetIndex: idx,
+                order: typeof meta.order === 'number' ? meta.order : idx,
+                label: entry.series.label,
+                color: entry.color,
+                count: entry.value,
+                action: meta.action as ActionFilter | undefined,
+                breakdown_value: meta.breakdown_value as string | number | string[] | undefined,
+                compare_label: meta.compare_label as SeriesDatum['compare_label'],
+                date_label: days?.[context.dataIndex],
+                filter: meta.filter as SeriesDatum['filter'],
+                hideTooltip: meta.hideTooltip === true,
+            }
+        })
+        .filter((s) => !s.hideTooltip)
 
     const meta = context.seriesData[0]?.series.meta ?? {}
     const days = meta.days as string[] | undefined
     const date = days?.[context.dataIndex]
+
+    const renderCount = (value: number): string => {
+        if (showPercentView) {
+            // Stickiness percent view: value is already a percentage; show with raw alongside.
+            const series = seriesData.find((s) => s.count === value)
+            if (series) {
+                // Raw value isn't on SeriesDatum here, so just show percent.
+                return `${value.toFixed(1)}%`
+            }
+        }
+        if (!isPercentStackView) {
+            return formatAggregationAxisValue(trendsFilter, value, baseCurrency)
+        }
+        return formatPercentStackAxisValue(trendsFilter, value, isPercentStackView, baseCurrency)
+    }
 
     return (
         <div className="relative">
@@ -69,18 +101,32 @@ export function TrendsTooltip({
                 breakdownFilter={breakdownFilter}
                 interval={interval}
                 dateRange={dateRange}
-                renderSeries={(value, datum) => (
-                    <div className="datum-label-column">
-                        <SeriesLetter
-                            className="mr-2"
-                            hasBreakdown={datum.breakdown_value !== undefined && !!datum.breakdown_value}
-                            seriesIndex={datum.action?.order ?? datum.id}
-                            seriesColor={datum.color}
-                        />
-                        {value}
-                    </div>
-                )}
-                renderCount={(value: number): string => formatAggregationAxisValue(null, value)}
+                formatCompareLabel={formatCompareLabel}
+                groupTypeLabel={groupTypeLabel}
+                renderSeries={(value, datum) => {
+                    const hasBreakdown = datum.breakdown_value !== undefined && !!datum.breakdown_value
+                    const hasMultipleSeries = seriesData.length > 1
+
+                    if (hasBreakdown && !hasMultipleSeries) {
+                        const title = getDatumTitle(datum, breakdownFilter, formatCompareLabel)
+                        return <div className="datum-label-column">{title}</div>
+                    }
+
+                    return (
+                        <div className="datum-label-column">
+                            {!formula && (
+                                <SeriesLetter
+                                    className="mr-2"
+                                    hasBreakdown={hasBreakdown}
+                                    seriesIndex={datum.action?.order ?? datum.id}
+                                    seriesColor={datum.color}
+                                />
+                            )}
+                            {value}
+                        </div>
+                    )
+                }}
+                renderCount={renderCount}
                 hideInspectActorsSection
             />
         </div>

--- a/frontend/src/scenes/trends/viz/TrendsTooltip.tsx
+++ b/frontend/src/scenes/trends/viz/TrendsTooltip.tsx
@@ -4,8 +4,8 @@ import { formatAggregationAxisValue, formatPercentStackAxisValue } from 'scenes/
 import { InsightTooltip } from 'scenes/insights/InsightTooltip/InsightTooltip'
 import { getDatumTitle, SeriesDatum } from 'scenes/insights/InsightTooltip/insightTooltipUtils'
 
-import { BreakdownFilter, DateRange, TrendsFilter } from '~/queries/schema/schema-general'
-import { ActionFilter, CurrencyCode, IntervalType } from '~/types'
+import { BreakdownFilter, CurrencyCode, DateRange, TrendsFilter } from '~/queries/schema/schema-general'
+import { ActionFilter, IntervalType } from '~/types'
 
 interface TrendsSeriesMeta {
     action?: ActionFilter

--- a/frontend/src/scenes/trends/viz/TrendsTooltip.tsx
+++ b/frontend/src/scenes/trends/viz/TrendsTooltip.tsx
@@ -70,12 +70,8 @@ export function TrendsTooltip({
 
     const renderCount = (value: number): string => {
         if (showPercentView) {
-            // Stickiness percent view: value is already a percentage; show with raw alongside.
-            const series = seriesData.find((s) => s.count === value)
-            if (series) {
-                // Raw value isn't on SeriesDatum here, so just show percent.
-                return `${value.toFixed(1)}%`
-            }
+            // Stickiness percent view: value is already a percentage.
+            return `${value.toFixed(1)}%`
         }
         if (!isPercentStackView) {
             return formatAggregationAxisValue(trendsFilter, value, baseCurrency)

--- a/frontend/src/scenes/trends/viz/TrendsTooltip.tsx
+++ b/frontend/src/scenes/trends/viz/TrendsTooltip.tsx
@@ -35,7 +35,7 @@ export function TrendsTooltip({
             id: idx,
             dataIndex: context.dataIndex,
             datasetIndex: idx,
-            order: (meta.order as number) ?? idx,
+            order: typeof meta.order === 'number' ? meta.order : idx,
             label: entry.series.label,
             color: entry.color,
             count: entry.value,

--- a/frontend/src/scenes/trends/viz/TrendsTooltip.tsx
+++ b/frontend/src/scenes/trends/viz/TrendsTooltip.tsx
@@ -1,5 +1,3 @@
-import { IconX } from '@posthog/icons'
-
 import { SeriesLetter } from 'lib/components/SeriesGlyph'
 import type { TooltipContext } from 'lib/hog-charts/core/types'
 import { formatAggregationAxisValue, formatPercentStackAxisValue } from 'scenes/insights/aggregationAxisFormat'
@@ -8,6 +6,35 @@ import { getDatumTitle, SeriesDatum } from 'scenes/insights/InsightTooltip/insig
 
 import { BreakdownFilter, DateRange, TrendsFilter } from '~/queries/schema/schema-general'
 import { ActionFilter, CurrencyCode, IntervalType } from '~/types'
+
+interface TrendsSeriesMeta {
+    action?: ActionFilter
+    breakdown_value?: string | number | string[]
+    compare_label?: SeriesDatum['compare_label']
+    days?: string[]
+    order?: number
+    filter?: SeriesDatum['filter']
+}
+
+function extractMeta(raw: Record<string, unknown> | undefined): TrendsSeriesMeta {
+    if (!raw) {
+        return {}
+    }
+    const action = typeof raw.action === 'object' && raw.action !== null ? (raw.action as ActionFilter) : undefined
+    const breakdown_value =
+        typeof raw.breakdown_value === 'string' ||
+        typeof raw.breakdown_value === 'number' ||
+        Array.isArray(raw.breakdown_value)
+            ? (raw.breakdown_value as string | number | string[])
+            : undefined
+    const compare_label =
+        typeof raw.compare_label === 'string' ? (raw.compare_label as SeriesDatum['compare_label']) : undefined
+    const days = Array.isArray(raw.days) ? (raw.days as string[]) : undefined
+    const order = typeof raw.order === 'number' ? raw.order : undefined
+    const filter =
+        typeof raw.filter === 'object' && raw.filter !== null ? (raw.filter as SeriesDatum['filter']) : undefined
+    return { action, breakdown_value, compare_label, days, order, filter }
+}
 
 interface TrendsTooltipProps {
     context: TooltipContext
@@ -41,32 +68,29 @@ export function TrendsTooltip({
     groupTypeLabel,
     formatCompareLabel,
 }: TrendsTooltipProps): React.ReactElement {
-    const seriesData: SeriesDatum[] = context.seriesData
-        .map((entry, idx) => {
-            const meta = entry.series.meta ?? {}
-            const days = meta.days as string[] | undefined
+    // TODO: CI bands and moving-average datasets aren't yet built in the hog-charts path. When they
+    // are, the bridge (or TrendsLineChartD3) will need to mark them as non-tooltip rows — legacy
+    // Chart.js path used a `hideTooltip: true` flag on the dataset for this.
+    const seriesData: SeriesDatum[] = context.seriesData.map((entry, idx) => {
+        const meta = extractMeta(entry.series.meta)
+        return {
+            id: idx,
+            dataIndex: context.dataIndex,
+            datasetIndex: idx,
+            order: meta.order ?? idx,
+            label: entry.series.label,
+            color: entry.color,
+            count: entry.value,
+            action: meta.action,
+            breakdown_value: meta.breakdown_value,
+            compare_label: meta.compare_label,
+            date_label: meta.days?.[context.dataIndex],
+            filter: meta.filter,
+        }
+    })
 
-            return {
-                id: idx,
-                dataIndex: context.dataIndex,
-                datasetIndex: idx,
-                order: typeof meta.order === 'number' ? meta.order : idx,
-                label: entry.series.label,
-                color: entry.color,
-                count: entry.value,
-                action: meta.action as ActionFilter | undefined,
-                breakdown_value: meta.breakdown_value as string | number | string[] | undefined,
-                compare_label: meta.compare_label as SeriesDatum['compare_label'],
-                date_label: days?.[context.dataIndex],
-                filter: meta.filter as SeriesDatum['filter'],
-                hideTooltip: meta.hideTooltip === true,
-            }
-        })
-        .filter((s) => !s.hideTooltip)
-
-    const meta = context.seriesData[0]?.series.meta ?? {}
-    const days = meta.days as string[] | undefined
-    const date = days?.[context.dataIndex]
+    const firstMeta = extractMeta(context.seriesData[0]?.series.meta)
+    const date = firstMeta.days?.[context.dataIndex]
 
     const renderCount = (value: number): string => {
         if (showPercentView) {
@@ -80,51 +104,41 @@ export function TrendsTooltip({
     }
 
     return (
-        <div className="relative">
-            {context.isPinned && context.onUnpin && (
-                <button
-                    type="button"
-                    className="absolute top-2 right-2 z-10 p-0.5 leading-none rounded cursor-pointer hover:bg-fill-button-tertiary-hover"
-                    onClick={context.onUnpin}
-                >
-                    <IconX className="!w-3 !h-3" />
-                </button>
-            )}
-            <InsightTooltip
-                date={date}
-                timezone={timezone}
-                seriesData={seriesData}
-                breakdownFilter={breakdownFilter}
-                interval={interval}
-                dateRange={dateRange}
-                formatCompareLabel={formatCompareLabel}
-                groupTypeLabel={groupTypeLabel}
-                renderSeries={(value, datum) => {
-                    const hasBreakdown = datum.breakdown_value !== undefined && !!datum.breakdown_value
-                    const hasMultipleSeries = seriesData.length > 1
+        <InsightTooltip
+            date={date}
+            timezone={timezone}
+            seriesData={seriesData}
+            breakdownFilter={breakdownFilter}
+            interval={interval}
+            dateRange={dateRange}
+            formatCompareLabel={formatCompareLabel}
+            groupTypeLabel={groupTypeLabel}
+            onClose={context.isPinned ? context.onUnpin : undefined}
+            renderSeries={(value, datum) => {
+                const hasBreakdown = datum.breakdown_value !== undefined && !!datum.breakdown_value
+                const hasMultipleSeries = seriesData.length > 1
 
-                    if (hasBreakdown && !hasMultipleSeries) {
-                        const title = getDatumTitle(datum, breakdownFilter, formatCompareLabel)
-                        return <div className="datum-label-column">{title}</div>
-                    }
+                if (hasBreakdown && !hasMultipleSeries) {
+                    const title = getDatumTitle(datum, breakdownFilter, formatCompareLabel)
+                    return <div className="datum-label-column">{title}</div>
+                }
 
-                    return (
-                        <div className="datum-label-column">
-                            {!formula && (
-                                <SeriesLetter
-                                    className="mr-2"
-                                    hasBreakdown={hasBreakdown}
-                                    seriesIndex={datum.action?.order ?? datum.id}
-                                    seriesColor={datum.color}
-                                />
-                            )}
-                            {value}
-                        </div>
-                    )
-                }}
-                renderCount={renderCount}
-                hideInspectActorsSection
-            />
-        </div>
+                return (
+                    <div className="datum-label-column">
+                        {!formula && (
+                            <SeriesLetter
+                                className="mr-2"
+                                hasBreakdown={hasBreakdown}
+                                seriesIndex={datum.action?.order ?? datum.id}
+                                seriesColor={datum.color}
+                            />
+                        )}
+                        {value}
+                    </div>
+                )
+            }}
+            renderCount={renderCount}
+            hideInspectActorsSection
+        />
     )
 }

--- a/frontend/src/scenes/trends/viz/TrendsTooltip.tsx
+++ b/frontend/src/scenes/trends/viz/TrendsTooltip.tsx
@@ -1,0 +1,88 @@
+import { IconX } from '@posthog/icons'
+
+import { SeriesLetter } from 'lib/components/SeriesGlyph'
+import type { TooltipContext } from 'lib/hog-charts/core/types'
+import { formatAggregationAxisValue } from 'scenes/insights/aggregationAxisFormat'
+import { InsightTooltip } from 'scenes/insights/InsightTooltip/InsightTooltip'
+import { SeriesDatum } from 'scenes/insights/InsightTooltip/insightTooltipUtils'
+
+import { BreakdownFilter, DateRange } from '~/queries/schema/schema-general'
+import { ActionFilter, IntervalType } from '~/types'
+
+interface TrendsTooltipProps {
+    context: TooltipContext
+    timezone?: string
+    interval?: IntervalType
+    breakdownFilter?: BreakdownFilter
+    dateRange?: DateRange
+}
+
+/** Bridges hog-charts TooltipContext to the legacy InsightTooltip.
+ *  Once hog-charts fully replaces Chart.js, we can refactor InsightTooltip
+ *  to consume TooltipContext directly and remove this adapter. */
+export function TrendsTooltip({
+    context,
+    timezone,
+    interval,
+    breakdownFilter,
+    dateRange,
+}: TrendsTooltipProps): React.ReactElement {
+    const seriesData: SeriesDatum[] = context.seriesData.map((entry, idx) => {
+        const meta = entry.series.meta ?? {}
+        const days = meta.days as string[] | undefined
+
+        return {
+            id: idx,
+            dataIndex: context.dataIndex,
+            datasetIndex: idx,
+            order: (meta.order as number) ?? idx,
+            label: entry.series.label,
+            color: entry.color,
+            count: entry.value,
+            action: meta.action as ActionFilter | undefined,
+            breakdown_value: meta.breakdown_value as string | number | string[] | undefined,
+            compare_label: meta.compare_label as SeriesDatum['compare_label'],
+            date_label: days?.[context.dataIndex],
+            filter: meta.filter as SeriesDatum['filter'],
+        }
+    })
+
+    const meta = context.seriesData[0]?.series.meta ?? {}
+    const days = meta.days as string[] | undefined
+    const date = days?.[context.dataIndex]
+
+    return (
+        <div className="relative">
+            {context.isPinned && context.onUnpin && (
+                <button
+                    type="button"
+                    className="absolute top-2 right-2 z-10 p-0.5 leading-none rounded cursor-pointer hover:bg-fill-button-tertiary-hover"
+                    onClick={context.onUnpin}
+                >
+                    <IconX className="!w-3 !h-3" />
+                </button>
+            )}
+            <InsightTooltip
+                date={date}
+                timezone={timezone}
+                seriesData={seriesData}
+                breakdownFilter={breakdownFilter}
+                interval={interval}
+                dateRange={dateRange}
+                renderSeries={(value, datum) => (
+                    <div className="datum-label-column">
+                        <SeriesLetter
+                            className="mr-2"
+                            hasBreakdown={datum.breakdown_value !== undefined && !!datum.breakdown_value}
+                            seriesIndex={datum.action?.order ?? datum.id}
+                            seriesColor={datum.color}
+                        />
+                        {value}
+                    </div>
+                )}
+                renderCount={(value: number): string => formatAggregationAxisValue(null, value)}
+                hideInspectActorsSection
+            />
+        </div>
+    )
+}


### PR DESCRIPTION
## Problem

`TrendsLineChartD3` (the hog-charts path) was using the default hog-charts tooltip, which shows only raw series labels and values. The Chart.js `LineGraph` it's replacing uses `InsightTooltip`, which renders breakdown values, formatted dates, group type labels, series letters, and formatted counts. We need the same tooltip experience in the hog-charts path while keeping `lib/hog-charts` product-agnostic — hog-charts itself should stay unaware of insight-specific concepts like breakdowns, actions, or compare labels.

While wiring this up, two small edge cases in the pinnable tooltip from #53389 also surfaced and are fixed here.

## Changes

**Product-agnostic API addition in `lib/hog-charts`:**
- Adds a `meta?: Record<string, unknown>` field on `Series` so consumers can attach arbitrary data that flows through to `TooltipContext.seriesData[i].series.meta`. The library never reads specific keys — it's an opaque pass-through slot.

**Trends-side bridge (`scenes/trends/viz/`):**
- New `TrendsTooltip` component: reads `Series.meta` off the `TooltipContext` via a guarded `extractMeta` helper (no unchecked casts on `meta.action`, `meta.compare_label`, etc.) and maps it to `InsightTooltip` props (`SeriesDatum`). Handles breakdown-single-series via `getDatumTitle`, stickiness percent view (`value.toFixed(1)%`), formula mode, and the percent-stack formatter.
- Uses `InsightTooltip`'s native `onClose` for unpin (wired from `TooltipContext.onUnpin` when pinned) instead of a custom overlay button — removes an absolutely-positioned button that would have collided with `InsightTooltip`'s `closeColumn`.
- `TrendsLineChartD3` populates `Series.meta` from `indexedResults` (`action`, `breakdown_value`, `compare_label`, `days`, `filter`, and a stable `order` that falls back to the pre-filter index `r.id`) and passes `TrendsTooltip` as the `tooltip` render prop.
- `hogSeries`, `chartConfig`, and the `tooltip` render prop are memoized — without this, every kea `useValues` update (theme toggles, unrelated insight state) would invalidate `coloredSeries` → `scales` → force a full canvas repaint.
- Hook ordering fixed: `useMemo`/`useCallback` calls moved above the early `InsightEmptyState` return.

**Pinnable tooltip edge-case fixes (`lib/hog-charts/core/hooks/useChartInteraction.ts`):**
- Always propagate the `buildTooltipContext` result (including `null`) so `tooltipCtx` stays in sync with `hoverIndex` — previously a stale tooltip could persist with an out-of-sync `dataIndex` if `buildTooltipContext` returned null mid-hover.
- In the scroll-dismiss handler, additionally exempt any scroll whose target is inside `wrapperRef.current` (e.g. a nested legend), and guard `Node.contains()` behind `target instanceof Element` so window-dispatched scroll events don't throw. Updated tests accordingly.

## How did you test this code?

- `useChartInteraction.test.ts` (13 passing) covers the hog-charts side: hover, pin, dismiss triggers (Escape, click-outside, scroll outside wrapper), scroll exemptions (inside tooltip, inside wrapper), and the `onUnpin` invariant.
- I'm an agent — no manual testing of the `TrendsTooltip` bridge itself beyond `eslint` and type-checks. Follow-up work to wire the existing `insight-testing` harness through to hog-charts would let us assert tooltip DOM against the legacy `ActionsLineGraph` path.

## Publish to changelog?

no

## 🤖 LLM context

Does NOT switch `Trends.tsx` to use `TrendsLineChartD3` — the renderer swap is still a local testing toggle per user instruction.