### PR TITLE
feat: add configurable outlier display for box plot insights

### DIFF
--- a/frontend/src/queries/nodes/InsightViz/InsightDisplayConfig.test.tsx
+++ b/frontend/src/queries/nodes/InsightViz/InsightDisplayConfig.test.tsx
@@ -85,7 +85,7 @@ describe('InsightDisplayConfig', () => {
             await openOptionsMenu()
 
             const items = getDisplaySectionItems()
-            expect(items).toEqual(['Show legend'])
+            expect(items).toEqual(['Show legend', 'Exclude outliers'])
         })
 
         it('shows unit picker and Y-axis scale but not statistical analysis', async () => {

--- a/frontend/src/queries/nodes/InsightViz/InsightDisplayConfig.tsx
+++ b/frontend/src/queries/nodes/InsightViz/InsightDisplayConfig.tsx
@@ -130,24 +130,23 @@ export function InsightDisplayConfig(): JSX.Element {
                                         <LemonCheckbox
                                             label={
                                                 <span className="font-normal">
-                                                    Show outliers{' '}
-                                                    <Tooltip title="When enabled, the y-axis extends to show extreme values beyond the whiskers. When disabled, whiskers are clipped to 1.5x the interquartile range, making it easier to see differences between the quartiles.">
+                                                    Exclude outliers{' '}
+                                                    <Tooltip title="When enabled, whiskers are clipped to 1.5x the interquartile range, making it easier to see differences between the quartiles. When disabled, the y-axis extends to show the full range including extreme values.">
                                                         <IconInfo className="relative top-0.5 text-lg text-secondary" />
                                                     </Tooltip>
                                                 </span>
                                             }
                                             className="p-1 px-2"
                                             size="small"
-                                            checked={!!trendsFilter?.showBoxPlotOutliers}
+                                            checked={trendsFilter?.excludeBoxPlotOutliers !== false}
                                             onChange={(checked) => {
                                                 if (isTrendsQuery(querySource)) {
-                                                    updateQuerySource({
-                                                        ...querySource,
-                                                        trendsFilter: {
-                                                            ...trendsFilter,
-                                                            showBoxPlotOutliers: checked,
-                                                        },
-                                                    })
+                                                    const newQuery = { ...querySource }
+                                                    newQuery.trendsFilter = {
+                                                        ...trendsFilter,
+                                                        excludeBoxPlotOutliers: checked,
+                                                    }
+                                                    updateQuerySource(newQuery)
                                                 }
                                             }}
                                         />

--- a/frontend/src/queries/nodes/InsightViz/InsightDisplayConfig.tsx
+++ b/frontend/src/queries/nodes/InsightViz/InsightDisplayConfig.tsx
@@ -4,8 +4,7 @@ import { ReactNode } from 'react'
 import { useDebouncedCallback } from 'use-debounce'
 
 import { IconInfo } from '@posthog/icons'
-import { LemonButton, LemonCheckbox, LemonInput, Tooltip } from '@posthog/lemon-ui'
-import { LemonSwitch } from '@posthog/lemon-ui'
+import { LemonButton, LemonCheckbox, LemonInput, LemonSwitch, Tooltip } from '@posthog/lemon-ui'
 
 import { ChartFilter } from 'lib/components/ChartFilter'
 import { CompareFilter } from 'lib/components/CompareFilter/CompareFilter'

--- a/frontend/src/queries/nodes/InsightViz/InsightDisplayConfig.tsx
+++ b/frontend/src/queries/nodes/InsightViz/InsightDisplayConfig.tsx
@@ -4,7 +4,7 @@ import { ReactNode } from 'react'
 import { useDebouncedCallback } from 'use-debounce'
 
 import { IconInfo } from '@posthog/icons'
-import { LemonButton, LemonInput, Tooltip } from '@posthog/lemon-ui'
+import { LemonButton, LemonCheckbox, LemonInput, Tooltip } from '@posthog/lemon-ui'
 import { LemonSwitch } from '@posthog/lemon-ui'
 
 import { ChartFilter } from 'lib/components/ChartFilter'
@@ -124,9 +124,37 @@ export function InsightDisplayConfig(): JSX.Element {
                           </h5>
                       ),
                       items: isBoxPlot
-                          ? hasLegend
-                              ? [{ label: () => <ShowLegendFilter /> }]
-                              : []
+                          ? [
+                                ...(hasLegend ? [{ label: () => <ShowLegendFilter /> }] : []),
+                                {
+                                    label: () => (
+                                        <LemonCheckbox
+                                            label={
+                                                <span className="font-normal">
+                                                    Show outliers{' '}
+                                                    <Tooltip title="When enabled, the y-axis extends to show extreme values beyond the whiskers. When disabled, whiskers are clipped to 1.5x the interquartile range, making it easier to see differences between the quartiles.">
+                                                        <IconInfo className="relative top-0.5 text-lg text-secondary" />
+                                                    </Tooltip>
+                                                </span>
+                                            }
+                                            className="p-1 px-2"
+                                            size="small"
+                                            checked={!!trendsFilter?.showBoxPlotOutliers}
+                                            onChange={(checked) => {
+                                                if (isTrendsQuery(querySource)) {
+                                                    updateQuerySource({
+                                                        ...querySource,
+                                                        trendsFilter: {
+                                                            ...trendsFilter,
+                                                            showBoxPlotOutliers: checked,
+                                                        },
+                                                    })
+                                                }
+                                            }}
+                                        />
+                                    ),
+                                },
+                            ]
                           : [
                                 ...(isLifecycle ? [{ label: () => <LifecycleStackingFilter /> }] : []),
                                 ...(supportsValueOnSeries ? [{ label: () => <ValueOnSeriesFilter /> }] : []),

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -3306,6 +3306,10 @@
                     "description": "Whether to show alert threshold lines on the chart.",
                     "type": "boolean"
                 },
+                "showBoxPlotOutliers": {
+                    "default": false,
+                    "type": "boolean"
+                },
                 "showLabelsOnSeries": {
                     "default": false,
                     "description": "Whether to show labels on each series.",
@@ -35818,6 +35822,10 @@
                     "description": "Customizations for the appearance of result datasets."
                 },
                 "showAlertThresholdLines": {
+                    "default": false,
+                    "type": "boolean"
+                },
+                "showBoxPlotOutliers": {
                     "default": false,
                     "type": "boolean"
                 },

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -35751,6 +35751,10 @@
                     "$ref": "#/definitions/ChartDisplayType",
                     "default": "ActionsLineGraph"
                 },
+                "excludeBoxPlotOutliers": {
+                    "default": true,
+                    "type": "boolean"
+                },
                 "formula": {
                     "deprecated": "Use formulaNodes instead.",
                     "type": "string"
@@ -35818,10 +35822,6 @@
                     "description": "Customizations for the appearance of result datasets."
                 },
                 "showAlertThresholdLines": {
-                    "default": false,
-                    "type": "boolean"
-                },
-                "showBoxPlotOutliers": {
                     "default": false,
                     "type": "boolean"
                 },

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -3306,10 +3306,6 @@
                     "description": "Whether to show alert threshold lines on the chart.",
                     "type": "boolean"
                 },
-                "showBoxPlotOutliers": {
-                    "default": false,
-                    "type": "boolean"
-                },
                 "showLabelsOnSeries": {
                     "default": false,
                     "description": "Whether to show labels on each series.",

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -1387,8 +1387,8 @@ export type TrendsFilter = {
     movingAverageIntervals?: number
     /** detailed results table */
     detailedResultsAggregationType?: 'total' | 'average' | 'median'
-    /** @default false */
-    showBoxPlotOutliers?: boolean
+    /** @default true */
+    excludeBoxPlotOutliers?: boolean
     /** @default false */
     hideWeekends?: boolean
 }
@@ -1413,7 +1413,7 @@ export const TRENDS_FILTER_PROPERTIES = new Set<keyof TrendsFilter>([
     'showPercentStackView',
     'yAxisScaleType',
     'hiddenLegendIndexes',
-    'showBoxPlotOutliers',
+    'excludeBoxPlotOutliers',
     'hideWeekends',
 ])
 

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -1388,6 +1388,8 @@ export type TrendsFilter = {
     /** detailed results table */
     detailedResultsAggregationType?: 'total' | 'average' | 'median'
     /** @default false */
+    showBoxPlotOutliers?: boolean
+    /** @default false */
     hideWeekends?: boolean
 }
 
@@ -1411,6 +1413,7 @@ export const TRENDS_FILTER_PROPERTIES = new Set<keyof TrendsFilter>([
     'showPercentStackView',
     'yAxisScaleType',
     'hiddenLegendIndexes',
+    'showBoxPlotOutliers',
     'hideWeekends',
 ])
 

--- a/frontend/src/scenes/insights/utils/queryUtils.ts
+++ b/frontend/src/scenes/insights/utils/queryUtils.ts
@@ -246,7 +246,7 @@ export const cleanInsightQuery = (query: InsightQueryNode, opts?: CompareQueryOp
             movingAverageIntervals: undefined,
             stacked: undefined,
             detailedResultsAggregationType: undefined,
-            showBoxPlotOutliers: undefined,
+            excludeBoxPlotOutliers: undefined,
             showFullUrls: undefined,
             selectedInterval: undefined,
             funnelStepReference: undefined,

--- a/frontend/src/scenes/insights/utils/queryUtils.ts
+++ b/frontend/src/scenes/insights/utils/queryUtils.ts
@@ -246,6 +246,7 @@ export const cleanInsightQuery = (query: InsightQueryNode, opts?: CompareQueryOp
             movingAverageIntervals: undefined,
             stacked: undefined,
             detailedResultsAggregationType: undefined,
+            showBoxPlotOutliers: undefined,
             showFullUrls: undefined,
             selectedInterval: undefined,
             funnelStepReference: undefined,

--- a/frontend/src/scenes/insights/views/BoxPlot/BoxPlotChart.tsx
+++ b/frontend/src/scenes/insights/views/BoxPlot/BoxPlotChart.tsx
@@ -194,7 +194,6 @@ export function BoxPlotChart({ showPersonsModal = true }: ChartParams): JSX.Elem
                 return null
             }
 
-            const showOutliers = !!trendsFilter?.showBoxPlotOutliers
             const datasets = seriesGroups.map((group) => {
                 const seriesColor = getSeriesColor(group.seriesIndex)
                 return {
@@ -209,8 +208,8 @@ export function BoxPlotChart({ showPersonsModal = true }: ChartParams): JSX.Elem
                     meanRadius: 3,
                     outlierBackgroundColor: `${seriesColor}80`,
                     outlierBorderColor: seriesColor,
-                    minStats: showOutliers ? ('min' as const) : ('whiskerMin' as const),
-                    maxStats: showOutliers ? ('max' as const) : ('whiskerMax' as const),
+                    minStats: 'whiskerMin' as const,
+                    maxStats: 'whiskerMax' as const,
                 }
             })
 

--- a/frontend/src/scenes/insights/views/BoxPlot/BoxPlotChart.tsx
+++ b/frontend/src/scenes/insights/views/BoxPlot/BoxPlotChart.tsx
@@ -194,6 +194,7 @@ export function BoxPlotChart({ showPersonsModal = true }: ChartParams): JSX.Elem
                 return null
             }
 
+            const showOutliers = !!trendsFilter?.showBoxPlotOutliers
             const datasets = seriesGroups.map((group) => {
                 const seriesColor = getSeriesColor(group.seriesIndex)
                 return {
@@ -208,6 +209,8 @@ export function BoxPlotChart({ showPersonsModal = true }: ChartParams): JSX.Elem
                     meanRadius: 3,
                     outlierBackgroundColor: `${seriesColor}80`,
                     outlierBorderColor: seriesColor,
+                    minStats: showOutliers ? ('min' as const) : ('whiskerMin' as const),
+                    maxStats: showOutliers ? ('max' as const) : ('whiskerMax' as const),
                 }
             })
 

--- a/frontend/src/scenes/insights/views/BoxPlot/boxPlotChartLogic.tsx
+++ b/frontend/src/scenes/insights/views/BoxPlot/boxPlotChartLogic.tsx
@@ -47,8 +47,9 @@ export const boxPlotChartLogic = kea<boxPlotChartLogicType>([
             },
         ],
         seriesGroups: [
-            (s) => [s.boxplotData],
-            (boxplotData: BoxPlotDatum[]): BoxPlotSeriesData[] => {
+            (s) => [s.boxplotData, s.trendsFilter],
+            (boxplotData: BoxPlotDatum[], trendsFilter): BoxPlotSeriesData[] => {
+                const showOutliers = !!trendsFilter?.showBoxPlotOutliers
                 const groupMap = new Map<number, { label: string; data: BoxPlotDatum[] }>()
 
                 for (const d of boxplotData) {
@@ -66,16 +67,19 @@ export const boxPlotChartLogic = kea<boxPlotChartLogicType>([
                         seriesIndex,
                         seriesLabel: group.label,
                         rawData: group.data,
-                        data: group.data.map((d) => ({
-                            min: d.min,
-                            q1: d.p25,
-                            median: d.median,
-                            q3: d.p75,
-                            max: d.max,
-                            mean: d.mean,
-                            whiskerMin: d.min,
-                            whiskerMax: d.max,
-                        })),
+                        data: group.data.map((d) => {
+                            const iqr = d.p75 - d.p25
+                            return {
+                                min: d.min,
+                                q1: d.p25,
+                                median: d.median,
+                                q3: d.p75,
+                                max: d.max,
+                                mean: d.mean,
+                                whiskerMin: showOutliers ? d.min : Math.max(d.min, d.p25 - 1.5 * iqr),
+                                whiskerMax: showOutliers ? d.max : Math.min(d.max, d.p75 + 1.5 * iqr),
+                            }
+                        }),
                     }))
             },
         ],

--- a/frontend/src/scenes/insights/views/BoxPlot/boxPlotChartLogic.tsx
+++ b/frontend/src/scenes/insights/views/BoxPlot/boxPlotChartLogic.tsx
@@ -49,7 +49,7 @@ export const boxPlotChartLogic = kea<boxPlotChartLogicType>([
         seriesGroups: [
             (s) => [s.boxplotData, s.trendsFilter],
             (boxplotData: BoxPlotDatum[], trendsFilter): BoxPlotSeriesData[] => {
-                const showOutliers = !!trendsFilter?.showBoxPlotOutliers
+                const excludeOutliers = trendsFilter?.excludeBoxPlotOutliers !== false
                 const groupMap = new Map<number, { label: string; data: BoxPlotDatum[] }>()
 
                 for (const d of boxplotData) {
@@ -76,8 +76,8 @@ export const boxPlotChartLogic = kea<boxPlotChartLogicType>([
                                 q3: d.p75,
                                 max: d.max,
                                 mean: d.mean,
-                                whiskerMin: showOutliers ? d.min : Math.max(d.min, d.p25 - 1.5 * iqr),
-                                whiskerMax: showOutliers ? d.max : Math.min(d.max, d.p75 + 1.5 * iqr),
+                                whiskerMin: excludeOutliers ? Math.max(d.min, d.p25 - 1.5 * iqr) : d.min,
+                                whiskerMax: excludeOutliers ? Math.min(d.max, d.p75 + 1.5 * iqr) : d.max,
                             }
                         }),
                     }))

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -7962,6 +7962,7 @@ class TrendsFilter(BaseModel):
         default=None, description="detailed results table"
     )
     display: ChartDisplayType | None = ChartDisplayType.ACTIONS_LINE_GRAPH
+    excludeBoxPlotOutliers: bool | None = True
     formula: str | None = None
     formulaNodes: list[TrendsFormulaNode] | None = Field(
         default=None,
@@ -7984,7 +7985,6 @@ class TrendsFilter(BaseModel):
         )
     )
     showAlertThresholdLines: bool | None = False
-    showBoxPlotOutliers: bool | None = False
     showConfidenceIntervals: bool | None = None
     showLabelsOnSeries: bool | None = None
     showLegend: bool | None = False

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -7984,6 +7984,7 @@ class TrendsFilter(BaseModel):
         )
     )
     showAlertThresholdLines: bool | None = False
+    showBoxPlotOutliers: bool | None = False
     showConfidenceIntervals: bool | None = None
     showLabelsOnSeries: bool | None = None
     showLegend: bool | None = False

--- a/posthog/schema_helpers.py
+++ b/posthog/schema_helpers.py
@@ -109,7 +109,7 @@ def to_dict(query: BaseModel) -> dict:
                         "movingAverageIntervals",
                         "stacked",
                         "detailedResultsAggregationType",
-                        "showBoxPlotOutliers",
+                        "excludeBoxPlotOutliers",
                         "showFullUrls",
                         "selectedInterval",
                         "funnelStepReference",

--- a/posthog/schema_helpers.py
+++ b/posthog/schema_helpers.py
@@ -109,6 +109,7 @@ def to_dict(query: BaseModel) -> dict:
                         "movingAverageIntervals",
                         "stacked",
                         "detailedResultsAggregationType",
+                        "showBoxPlotOutliers",
                         "showFullUrls",
                         "selectedInterval",
                         "funnelStepReference",

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -2412,6 +2412,8 @@ export namespace Schemas {
       /** @nullable */
       showAlertThresholdLines?: boolean | null;
       /** @nullable */
+      excludeBoxPlotOutliers?: boolean | null;
+      /** @nullable */
       showConfidenceIntervals?: boolean | null;
       /** @nullable */
       showLabelsOnSeries?: boolean | null;

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -2384,6 +2384,8 @@ export namespace Schemas {
       detailedResultsAggregationType?: DetailedResultsAggregationType | null;
       display?: ChartDisplayType | null;
       /** @nullable */
+      excludeBoxPlotOutliers?: boolean | null;
+      /** @nullable */
       formula?: string | null;
       /**
        * List of formulas with optional custom names. Takes precedence over formula/formulas if set.
@@ -2411,8 +2413,6 @@ export namespace Schemas {
       resultCustomizations?: TrendsFilterResultCustomizations;
       /** @nullable */
       showAlertThresholdLines?: boolean | null;
-      /** @nullable */
-      excludeBoxPlotOutliers?: boolean | null;
       /** @nullable */
       showConfidenceIntervals?: boolean | null;
       /** @nullable */


### PR DESCRIPTION
## Problem

Box plot insights with extreme outliers make it difficult to see differences between the quartiles, as the y-axis scales to accommodate min/max values that may be far from the IQR.

## Changes

(gif captured before shifting from a toggle)
![CleanShot 2026-04-04 at 22 09 31](https://github.com/user-attachments/assets/55146864-58b5-4717-98da-d56003499bbb)


- Add `showBoxPlotOutliers` toggle to `TrendsFilter` schema (Python + TypeScript + JSON schema)
- Calculate whisker bounds using the standard 1.5x IQR rule when outliers are hidden
- Use `minStats`/`maxStats` from `@sgratzl/chartjs-chart-boxplot` to clip whiskers accordingly
- Add checkbox toggle in the box plot Options menu (matching the style of other display options)
- Default to hiding outliers for better readability out of the box

## How did you test this code?

Manual testing with box plot insights containing outlier data — toggling the checkbox clips whiskers to 1.5x IQR and rescales the y-axis.

## 🤖 LLM context

Agent-assisted: converted the "Show outliers" toggle from a `LemonSwitch` to a `LemonCheckbox` to match the style of other options menu items. Also removed a leftover `console.log` debug statement.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*