### PR TITLE
chore(modeling): fix some duckgres related bugs

### DIFF
--- a/posthog/temporal/data_modeling/__init__.py
+++ b/posthog/temporal/data_modeling/__init__.py
@@ -1,4 +1,5 @@
 from posthog.temporal.data_modeling.activities import (
+    check_duckgres_shadow_enabled_activity,
     create_data_modeling_job_activity,
     fail_materialization_activity,
     get_dag_structure_activity,
@@ -23,6 +24,7 @@ from posthog.temporal.data_modeling.workflows import ExecuteDAGWorkflow, Materia
 
 WORKFLOWS = [RunWorkflow, MaterializeViewWorkflow, ExecuteDAGWorkflow]
 ACTIVITIES = [
+    check_duckgres_shadow_enabled_activity,
     create_data_modeling_job_activity,
     get_dag_structure_activity,
     fail_materialization_activity,

--- a/posthog/temporal/data_modeling/activities/__init__.py
+++ b/posthog/temporal/data_modeling/activities/__init__.py
@@ -2,7 +2,12 @@ from .create_data_modeling_job import CreateDataModelingJobInputs, create_data_m
 from .fail_materialization import FailMaterializationInputs, fail_materialization_activity
 from .get_dag_structure import GetDAGStructureInputs, get_dag_structure_activity
 from .materialize_view import MaterializeViewInputs, MaterializeViewResult, materialize_view_activity
-from .materialize_view_duckgres import DuckgresShadowInputs, DuckgresShadowResult, materialize_view_duckgres_activity
+from .materialize_view_duckgres import (
+    DuckgresShadowInputs,
+    DuckgresShadowResult,
+    check_duckgres_shadow_enabled_activity,
+    materialize_view_duckgres_activity,
+)
 from .preempt_dag_run import PreemptDAGRunInputs, preempt_dag_run_activity
 from .prepare_queryable_table import (
     PrepareQueryableTableInputs,
@@ -23,6 +28,7 @@ __all__ = [
     "PrepareQueryableTableInputs",
     "PrepareQueryableTableResult",
     "SucceedMaterializationInputs",
+    "check_duckgres_shadow_enabled_activity",
     "create_data_modeling_job_activity",
     "fail_materialization_activity",
     "materialize_view_activity",

--- a/posthog/temporal/data_modeling/activities/materialize_view_duckgres.py
+++ b/posthog/temporal/data_modeling/activities/materialize_view_duckgres.py
@@ -1,5 +1,6 @@
 import time
 import typing
+import datetime as dt
 import dataclasses
 
 import posthoganalytics
@@ -13,6 +14,7 @@ from posthog.sync import database_sync_to_async
 from posthog.temporal.common.logger import get_logger
 
 from products.data_modeling.backend.models import Node, NodeType
+from products.data_warehouse.backend.models.data_modeling_job import DataModelingJob, DataModelingJobStatus
 from products.data_warehouse.backend.models.datawarehouse_saved_query import DataWarehouseSavedQuery
 
 LOGGER = get_logger(__name__)
@@ -61,7 +63,7 @@ def _is_duckgres_shadow_enabled(team: Team) -> bool:
     try:
         return posthoganalytics.feature_enabled(
             FEATURE_FLAG,
-            str(team.uuid),
+            str(team.pk),
             groups={
                 "organization": str(team.organization_id),
                 "project": str(team.id),
@@ -102,6 +104,27 @@ def _get_shadow_input_objects(
     return (team, node, saved_query)
 
 
+@database_sync_to_async
+def _resolve_duckgres_job(job_id: str, result: "DuckgresShadowResult") -> None:
+    """Update the duckgres job to its terminal state based on the result."""
+    if result.error == "disabled":
+        # no job to resolve — the shadow was skipped entirely
+        return
+    job = DataModelingJob.objects.get(id=job_id)
+    if job.status in (DataModelingJobStatus.FAILED, DataModelingJobStatus.CANCELLED, DataModelingJobStatus.COMPLETED):
+        return
+    if result.error is None:
+        job.status = DataModelingJobStatus.COMPLETED
+        job.rows_materialized = result.row_count
+        job.error = None
+    else:
+        job.status = DataModelingJobStatus.FAILED
+        job.rows_materialized = 0
+        job.error = result.error
+    job.last_run_at = dt.datetime.now(dt.UTC)
+    job.save()
+
+
 @activity.defn
 async def materialize_view_duckgres_activity(inputs: DuckgresShadowInputs) -> DuckgresShadowResult:
     """Shadow activity: execute materialization query via duckgres and create a DuckLake table.
@@ -117,7 +140,11 @@ async def materialize_view_duckgres_activity(inputs: DuckgresShadowInputs) -> Du
 
     if not await database_sync_to_async(_is_duckgres_shadow_enabled)(team):
         await logger.ainfo("Duckgres shadow disabled for team", extra=inputs.properties_to_log)
-        return DuckgresShadowResult(row_count=0, duration_seconds=0.0, schema_name="", table_name="", error="disabled")
+        disabled_result = DuckgresShadowResult(
+            row_count=0, duration_seconds=0.0, schema_name="", table_name="", error="disabled"
+        )
+        await _resolve_duckgres_job(inputs.job_id, disabled_result)
+        return disabled_result
 
     hogql_query = typing.cast(dict, saved_query.query)["query"]
     schema_name = f"{SHADOW_SCHEMA_PREFIX}_{team.pk}_models"
@@ -150,7 +177,7 @@ async def materialize_view_duckgres_activity(inputs: DuckgresShadowInputs) -> Du
             table_name=result.table_name,
         )
 
-        return DuckgresShadowResult(
+        shadow_result = DuckgresShadowResult(
             row_count=result.row_count,
             duration_seconds=duration,
             schema_name=result.schema_name,
@@ -158,6 +185,8 @@ async def materialize_view_duckgres_activity(inputs: DuckgresShadowInputs) -> Du
             file_size_bytes=result.file_size_bytes,
             file_size_delta_bytes=result.file_size_delta_bytes,
         )
+        await _resolve_duckgres_job(inputs.job_id, shadow_result)
+        return shadow_result
     except Exception as e:
         duration = time.monotonic() - start_time
         capture_exception(e, {"sql": sql, "inputs": inputs})
@@ -167,10 +196,12 @@ async def materialize_view_duckgres_activity(inputs: DuckgresShadowInputs) -> Du
             error=str(e),
             duration_seconds=round(duration, 2),
         )
-        return DuckgresShadowResult(
+        shadow_result = DuckgresShadowResult(
             row_count=0,
             duration_seconds=duration,
             schema_name=schema_name,
             table_name=table_name,
             error=str(e),
         )
+        await _resolve_duckgres_job(inputs.job_id, shadow_result)
+        return shadow_result

--- a/posthog/temporal/data_modeling/activities/materialize_view_duckgres.py
+++ b/posthog/temporal/data_modeling/activities/materialize_view_duckgres.py
@@ -104,12 +104,16 @@ def _get_shadow_input_objects(
     return (team, node, saved_query)
 
 
+@activity.defn
+async def check_duckgres_shadow_enabled_activity(team_id: int) -> bool:
+    """Check whether the duckgres shadow flag is enabled for a team."""
+    team = await database_sync_to_async(Team.objects.get)(id=team_id)
+    return await database_sync_to_async(_is_duckgres_shadow_enabled)(team)
+
+
 @database_sync_to_async
 def _resolve_duckgres_job(job_id: str, result: "DuckgresShadowResult") -> None:
     """Update the duckgres job to its terminal state based on the result."""
-    if result.error == "disabled":
-        # no job to resolve — the shadow was skipped entirely
-        return
     job = DataModelingJob.objects.get(id=job_id)
     if job.status in (DataModelingJobStatus.FAILED, DataModelingJobStatus.CANCELLED, DataModelingJobStatus.COMPLETED):
         return
@@ -137,14 +141,6 @@ async def materialize_view_duckgres_activity(inputs: DuckgresShadowInputs) -> Du
     logger = LOGGER.bind()
 
     team, node, saved_query = await _get_shadow_input_objects(inputs)
-
-    if not await database_sync_to_async(_is_duckgres_shadow_enabled)(team):
-        await logger.ainfo("Duckgres shadow disabled for team", extra=inputs.properties_to_log)
-        disabled_result = DuckgresShadowResult(
-            row_count=0, duration_seconds=0.0, schema_name="", table_name="", error="disabled"
-        )
-        await _resolve_duckgres_job(inputs.job_id, disabled_result)
-        return disabled_result
 
     hogql_query = typing.cast(dict, saved_query.query)["query"]
     schema_name = f"{SHADOW_SCHEMA_PREFIX}_{team.pk}_models"

--- a/posthog/temporal/data_modeling/workflows/materialize_view.py
+++ b/posthog/temporal/data_modeling/workflows/materialize_view.py
@@ -253,7 +253,6 @@ class MaterializeViewWorkflow(PostHogWorkflow):
                 # after the main workflow succeeds, collect shadow stats for comparison
                 await self._collect_shadow_comparison(
                     duckgres_shadow_handle,
-                    duckgres_job_id,
                     materialize_result.row_count,
                     duration_seconds,
                     inputs,
@@ -325,95 +324,36 @@ class MaterializeViewWorkflow(PostHogWorkflow):
 
         # await the duckgres shadow activity so the parent workflow's concurrency
         # semaphore isn't released until the query finishes on duckgres
+        result = None
         try:
-            shadow_result: DuckgresShadowResult = await duckgres_shadow_handle
-            await self._resolve_duckgres_job(shadow_result, duckgres_job_id, inputs)
+            result = await duckgres_shadow_handle
         except Exception as shadow_err:
             temporalio.workflow.logger.warning(
                 f"Duckgres shadow activity failed (duckgres_only): {str(shadow_err)}",
                 extra=inputs.properties_to_log,
             )
             capture_exception(shadow_err)
-            await self._resolve_duckgres_job(
-                DuckgresShadowResult(
-                    error=str(shadow_err), row_count=0, duration_seconds=0, schema_name="", table_name=""
-                ),
-                duckgres_job_id,
-                inputs,
-            )
-        # TODO: populate with real values
         return MaterializeViewWorkflowResult(
             job_id=job_id,
             node_id=inputs.node_id,
-            rows_materialized=-1,
-            duration_seconds=-1,
+            rows_materialized=result.row_count if result else 0,
+            duration_seconds=result.duration_seconds if result else 0,
         )
-
-    async def _resolve_duckgres_job(
-        self,
-        shadow_result: DuckgresShadowResult,
-        duckgres_job_id: str,
-        inputs: MaterializeViewWorkflowInputs,
-    ) -> None:
-        """Update the duckgres job based on the shadow result.
-
-        Best-effort — failures are logged but never affect the workflow result.
-        """
-        if shadow_result.error == "disabled":
-            return
-
-        try:
-            if shadow_result.error is None:
-                await temporalio.workflow.execute_activity(
-                    succeed_materialization_activity,
-                    SucceedMaterializationInputs(
-                        team_id=inputs.team_id,
-                        node_id=inputs.node_id,
-                        dag_id=inputs.dag_id,
-                        job_id=duckgres_job_id,
-                        row_count=shadow_result.row_count,
-                        duration_seconds=shadow_result.duration_seconds,
-                        update_node=False,
-                    ),
-                    start_to_close_timeout=dt.timedelta(minutes=5),
-                    retry_policy=temporalio.common.RetryPolicy(maximum_attempts=3),
-                )
-            else:
-                await temporalio.workflow.execute_activity(
-                    fail_materialization_activity,
-                    FailMaterializationInputs(
-                        team_id=inputs.team_id,
-                        node_id=inputs.node_id,
-                        dag_id=inputs.dag_id,
-                        job_id=duckgres_job_id,
-                        error=shadow_result.error,
-                        update_node=False,
-                    ),
-                    start_to_close_timeout=dt.timedelta(minutes=5),
-                    retry_policy=temporalio.common.RetryPolicy(maximum_attempts=3),
-                )
-        except Exception as e:
-            temporalio.workflow.logger.warning(
-                f"Failed to resolve duckgres job: {str(e)}",
-                extra=inputs.properties_to_log,
-            )
-            capture_exception(e)
 
     async def _collect_shadow_comparison(
         self,
         shadow_handle: temporalio.workflow.ActivityHandle[DuckgresShadowResult],
-        duckgres_job_id: str,
         clickhouse_row_count: int,
         clickhouse_duration_seconds: float,
         inputs: MaterializeViewWorkflowInputs,
     ) -> None:
-        """Await the duckgres shadow activity, update the duckgres job, and emit comparison metrics.
+        """Await the duckgres shadow activity and emit comparison metrics.
 
+        The activity itself is responsible for updating its job to a terminal state.
         This is best-effort — any failure is swallowed so it never affects the workflow result.
         """
         try:
             shadow_result: DuckgresShadowResult = await shadow_handle
-            await self._resolve_duckgres_job(shadow_result, duckgres_job_id, inputs)
 
             if shadow_result.error == "disabled":
                 return
@@ -457,10 +397,3 @@ class MaterializeViewWorkflow(PostHogWorkflow):
                 extra=inputs.properties_to_log,
             )
             capture_exception(shadow_err)
-            await self._resolve_duckgres_job(
-                DuckgresShadowResult(
-                    error=str(shadow_err), row_count=0, duration_seconds=0, schema_name="", table_name=""
-                ),
-                duckgres_job_id,
-                inputs,
-            )

--- a/posthog/temporal/data_modeling/workflows/materialize_view.py
+++ b/posthog/temporal/data_modeling/workflows/materialize_view.py
@@ -20,6 +20,7 @@ from posthog.temporal.data_modeling.activities import (
     MaterializeViewInputs,
     PrepareQueryableTableInputs,
     SucceedMaterializationInputs,
+    check_duckgres_shadow_enabled_activity,
     create_data_modeling_job_activity,
     fail_materialization_activity,
     materialize_view_activity,
@@ -134,33 +135,41 @@ class MaterializeViewWorkflow(PostHogWorkflow):
             start_to_close_timeout=dt.timedelta(minutes=1),
         )
 
-        # create a separate job for the duckgres shadow materialization
-        duckgres_job_id = await temporalio.workflow.execute_activity(
-            create_data_modeling_job_activity,
-            CreateDataModelingJobInputs(
-                team_id=inputs.team_id,
-                node_id=inputs.node_id,
-                dag_id=inputs.dag_id,
-                engine=DataModelingJobEngine.DUCKGRES,
-                parent_workflow_id=parent_workflow_id,
-            ),
+        # check whether duckgres shadow is enabled before creating the job
+        duckgres_enabled = await temporalio.workflow.execute_activity(
+            check_duckgres_shadow_enabled_activity,
+            inputs.team_id,
             start_to_close_timeout=dt.timedelta(minutes=1),
         )
 
-        # fire-and-forget: start duckgres shadow materialization in parallel
-        duckgres_shadow_handle = temporalio.workflow.start_activity(
-            materialize_view_duckgres_activity,
-            DuckgresShadowInputs(
-                team_id=inputs.team_id,
-                node_id=inputs.node_id,
-                dag_id=inputs.dag_id,
-                job_id=duckgres_job_id,
-            ),
-            start_to_close_timeout=dt.timedelta(minutes=15),
-            retry_policy=temporalio.common.RetryPolicy(
-                maximum_attempts=1,
-            ),
-        )
+        duckgres_shadow_handle = None
+        if duckgres_enabled:
+            duckgres_job_id = await temporalio.workflow.execute_activity(
+                create_data_modeling_job_activity,
+                CreateDataModelingJobInputs(
+                    team_id=inputs.team_id,
+                    node_id=inputs.node_id,
+                    dag_id=inputs.dag_id,
+                    engine=DataModelingJobEngine.DUCKGRES,
+                    parent_workflow_id=parent_workflow_id,
+                ),
+                start_to_close_timeout=dt.timedelta(minutes=1),
+            )
+
+            # fire-and-forget: start duckgres shadow materialization in parallel
+            duckgres_shadow_handle = temporalio.workflow.start_activity(
+                materialize_view_duckgres_activity,
+                DuckgresShadowInputs(
+                    team_id=inputs.team_id,
+                    node_id=inputs.node_id,
+                    dag_id=inputs.dag_id,
+                    job_id=duckgres_job_id,
+                ),
+                start_to_close_timeout=dt.timedelta(minutes=15),
+                retry_policy=temporalio.common.RetryPolicy(
+                    maximum_attempts=1,
+                ),
+            )
 
         if not inputs.duckgres_only:
             try:
@@ -251,12 +260,13 @@ class MaterializeViewWorkflow(PostHogWorkflow):
                 )
 
                 # after the main workflow succeeds, collect shadow stats for comparison
-                await self._collect_shadow_comparison(
-                    duckgres_shadow_handle,
-                    materialize_result.row_count,
-                    duration_seconds,
-                    inputs,
-                )
+                if duckgres_shadow_handle is not None:
+                    await self._collect_shadow_comparison(
+                        duckgres_shadow_handle,
+                        materialize_result.row_count,
+                        duration_seconds,
+                        inputs,
+                    )
 
                 temporalio.workflow.logger.info(
                     "MaterializeViewWorkflow completed successfully",
@@ -325,14 +335,15 @@ class MaterializeViewWorkflow(PostHogWorkflow):
         # await the duckgres shadow activity so the parent workflow's concurrency
         # semaphore isn't released until the query finishes on duckgres
         result = None
-        try:
-            result = await duckgres_shadow_handle
-        except Exception as shadow_err:
-            temporalio.workflow.logger.warning(
-                f"Duckgres shadow activity failed (duckgres_only): {str(shadow_err)}",
-                extra=inputs.properties_to_log,
-            )
-            capture_exception(shadow_err)
+        if duckgres_shadow_handle is not None:
+            try:
+                result = await duckgres_shadow_handle
+            except Exception as shadow_err:
+                temporalio.workflow.logger.warning(
+                    f"Duckgres shadow activity failed (duckgres_only): {str(shadow_err)}",
+                    extra=inputs.properties_to_log,
+                )
+                capture_exception(shadow_err)
         return MaterializeViewWorkflowResult(
             job_id=job_id,
             node_id=inputs.node_id,
@@ -354,9 +365,6 @@ class MaterializeViewWorkflow(PostHogWorkflow):
         """
         try:
             shadow_result: DuckgresShadowResult = await shadow_handle
-
-            if shadow_result.error == "disabled":
-                return
 
             row_count_matched = clickhouse_row_count == shadow_result.row_count
             status = "completed" if shadow_result.error is None else "failed"

--- a/products/data_warehouse/backend/api/data_modeling_job.py
+++ b/products/data_warehouse/backend/api/data_modeling_job.py
@@ -1,3 +1,4 @@
+import posthoganalytics
 from django_filters.rest_framework import DjangoFilterBackend
 from drf_spectacular.utils import extend_schema
 from rest_framework import pagination, serializers, viewsets
@@ -9,7 +10,9 @@ from posthog.schema import ProductKey
 
 from posthog.api.routing import TeamAndOrgViewSetMixin
 
-from products.data_warehouse.backend.models.data_modeling_job import DataModelingJob
+from products.data_warehouse.backend.models.data_modeling_job import DataModelingJob, DataModelingJobEngine
+
+DUCKGRES_SHADOW_FLAG = "duckgres-data-modeling-shadow"
 
 
 class DataModelingJobSerializer(serializers.ModelSerializer):
@@ -52,8 +55,30 @@ class DataModelingJobViewSet(TeamAndOrgViewSetMixin, viewsets.ReadOnlyModelViewS
     ordering_fields = ["created_at"]
     ordering = "-created_at"
 
+    def _is_duckgres_shadow_enabled(self) -> bool:
+        try:
+            return posthoganalytics.feature_enabled(
+                DUCKGRES_SHADOW_FLAG,
+                str(self.team.pk),
+                groups={
+                    "organization": str(self.team.organization_id),
+                    "project": str(self.team.id),
+                },
+                group_properties={
+                    "organization": {"id": str(self.team.organization_id)},
+                    "project": {"id": str(self.team.id)},
+                },
+                only_evaluate_locally=True,
+                send_feature_flag_events=False,
+            )
+        except Exception:
+            return False
+
     def safely_get_queryset(self, queryset):
-        return queryset.filter(team_id=self.team_id)
+        qs = queryset.filter(team_id=self.team_id)
+        if self._is_duckgres_shadow_enabled():
+            return qs.filter(engine=DataModelingJobEngine.DUCKGRES)
+        return qs.exclude(engine=DataModelingJobEngine.DUCKGRES)
 
     @action(methods=["GET"], detail=False)
     def running(self, request, *args, **kwargs):

--- a/products/data_warehouse/backend/api/data_modeling_job.py
+++ b/products/data_warehouse/backend/api/data_modeling_job.py
@@ -76,9 +76,9 @@ class DataModelingJobViewSet(TeamAndOrgViewSetMixin, viewsets.ReadOnlyModelViewS
 
     def safely_get_queryset(self, queryset):
         qs = queryset.filter(team_id=self.team_id)
-        if self._is_duckgres_shadow_enabled():
-            return qs.filter(engine=DataModelingJobEngine.DUCKGRES)
-        return qs.exclude(engine=DataModelingJobEngine.DUCKGRES)
+        if not self._is_duckgres_shadow_enabled():
+            qs = qs.exclude(engine=DataModelingJobEngine.DUCKGRES)
+        return qs
 
     @action(methods=["GET"], detail=False)
     def running(self, request, *args, **kwargs):


### PR DESCRIPTION
## Problem

couple things (i know... i'm a bad influence. i should split these but the changes are still small).

1. duckgres jobs showing for users in their job logs when they shouldn't
2. duckgres jobs left in Running state until preempted by their parent
3. duckgres ff evaluated against team UUID instead of team pk (numeric auto incrementing id)

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

## Changes

fix all that

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took, and what steps reviewers must take to get to where changes are, and what is the expected behavior. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

i didn't really bc this is all v straight forward and most of this is ff related and non-prod facing. worst case result is just people seeing shadow duckgres job logs and being a little confused by it.

## Publish to changelog?

no

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->