### PR TITLE
fix: rename homepage configure event property from 'value' to 'homepage choice'

### DIFF
--- a/frontend/src/layout/scenes/ConfigurePinnedTabsModal.tsx
+++ b/frontend/src/layout/scenes/ConfigurePinnedTabsModal.tsx
@@ -178,7 +178,7 @@ export function ConfigurePinnedTabsModal({ isOpen, onClose }: ConfigurePinnedTab
                                             type="secondary"
                                             onClick={() => {
                                                 posthog.capture('homepage configure set homepage', {
-                                                    value: 'launchpad',
+                                                    'homepage choice': 'launchpad',
                                                 })
                                                 setHomepage(null)
                                             }}
@@ -194,7 +194,9 @@ export function ConfigurePinnedTabsModal({ isOpen, onClose }: ConfigurePinnedTab
                                             size="small"
                                             type="secondary"
                                             onClick={() => {
-                                                posthog.capture('homepage configure set homepage', { value: 'search' })
+                                                posthog.capture('homepage configure set homepage', {
+                                                    'homepage choice': 'search',
+                                                })
                                                 setHomepage(newTabHomepage)
                                             }}
                                             data-attr="configure-homepage-modal-set-search"
@@ -207,7 +209,7 @@ export function ConfigurePinnedTabsModal({ isOpen, onClose }: ConfigurePinnedTab
                                             type="secondary"
                                             onClick={() => {
                                                 posthog.capture('homepage configure set homepage', {
-                                                    value: 'default_dashboard',
+                                                    'homepage choice': 'default_dashboard',
                                                 })
                                                 const dashboardId = currentTeam?.primary_dashboard
                                                 if (dashboardId) {


### PR DESCRIPTION
## Problem

The `homepage configure set homepage` event uses a property called `value` which is too generic and clashes with other properties. This makes it harder to filter/query in analytics.

## Changes

Renamed the property from `value` to `homepage choice` across all 3 capture calls in `ConfigurePinnedTabsModal.tsx`.

## How did you test this code?

This is a simple property rename on analytics events — no behavioral change. Verified via grep that all occurrences were updated.

## Publish to changelog?

no

## Docs update

n/a

## LLM context

Agent-authored PR. Simple find-and-replace of a PostHog capture event property name.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*