### PR TITLE
feat(insight-testing): hog-charts capture mock

### DIFF
--- a/frontend/jest.config.ts
+++ b/frontend/jest.config.ts
@@ -139,6 +139,8 @@ const config: Config = {
         '^.+\\.sql\\?raw$': '<rootDir>/src/test/mocks/rawFileMock.js',
         '^~/(.*)$': '<rootDir>/src/$1',
         '^@posthog/lemon-ui(|/.*)$': '<rootDir>/@posthog/lemon-ui/src/$1',
+        // Must precede the catch-all `^lib/(.*)$` so hog-charts resolves to the capture mock.
+        '^lib/hog-charts$': '<rootDir>/src/test/insight-testing/hog-charts-mock',
         '^lib/(.*)$': '<rootDir>/src/lib/$1',
         '^react-markdown$': '<rootDir>/src/test/mocks/reactMarkdownMock.js',
         '^remark-gfm$': '<rootDir>/src/test/mocks/emptyMock.js',

--- a/frontend/src/test/insight-testing/README.md
+++ b/frontend/src/test/insight-testing/README.md
@@ -145,27 +145,24 @@ shim via `jest.config.ts` → `hog-charts-mock.tsx`, so no canvas code runs.
 
 ### Tooltip testing
 
-Hog-charts tooltips are tested by imperatively driving the hover index:
+Tooltips are tested by imperatively driving the hover index. Both renderers
+render `InsightTooltip` into the DOM — `waitForTooltip` finds it regardless
+of which renderer produced it:
 
 ```tsx
 const chart = await waitForChart()
 chart.hover(2) // move hover to index 2
-const tooltip = await waitForTooltip(chart)
+const tooltip = await waitForTooltip()
 expect(within(tooltip).getByText('134')).toBeInTheDocument()
-
-chart.pin() // pin the tooltip to show the close button
-chart.unpin() // unpin
 ```
 
-`chart.hover`, `chart.pin`, `chart.unpin` are only available on hog-charts
-entries and throw on Chart.js entries. The fabricated `TooltipContext` passed
-to the bridge render prop is minimal: real position math, `ResizeObserver`,
-and `findNearestIndex` are intentionally bypassed — those concerns are
-covered by `lib/hog-charts/core/hooks/useChartInteraction.test.ts` and
-Playwright end-to-end tests.
+For Chart.js, `hover(index)` calls the real external tooltip handler from
+`LineGraph.tsx` with a fabricated `TooltipModel`, so `InsightTooltip` renders
+with real data. For hog-charts, `hover(index)` sets the shim's hover state
+which triggers the tooltip render prop with a fabricated `TooltipContext`.
 
-**What this harness validates:** the TrendsTooltip bridge mapping, series
-formatting, pin/unpin UI, and end-to-end kea data flow into the bridge.
+**What this harness validates:** tooltip content, series formatting, and
+end-to-end kea data flow into the tooltip.
 
 **What it does not validate:** mouse-coordinate-to-index resolution, canvas
-drawing, or scroll-to-dismiss pinned tooltip behavior.
+drawing, tooltip positioning, or pinnable-tooltip interactions.

--- a/frontend/src/test/insight-testing/README.md
+++ b/frontend/src/test/insight-testing/README.md
@@ -119,3 +119,53 @@ queries to the right data based on event name and breakdown property.
 | `$pageview`                        | `[45, 82, 134, 210, 95]` over Mon–Fri                |
 | `Napped`                           | `[1, 3, 5, 8, 2]` over Mon–Fri                       |
 | `Napped` + breakdown by `hedgehog` | 5 series (Spike, Bramble, Thistle, Conker, Prickles) |
+
+## Hog-charts renderer
+
+The harness captures charts from both the legacy Chart.js renderer and the
+new hog-charts renderer (`lib/hog-charts`). `chart.renderer` is either
+`'chartjs'` or `'hog-charts'`; assertions against series names, data, labels,
+and axes work identically across both.
+
+Because `scenes/trends/Trends.tsx` still routes trends visualizations through
+`ActionsLineGraph` (Chart.js), test files that want to exercise the hog-charts
+path must add a per-file module mock that swaps `ActionsLineGraph` for
+`TrendsLineChartD3`:
+
+```tsx
+jest.mock('scenes/trends/viz/ActionsLineGraph', () => {
+  const { TrendsLineChartD3 } = require('./TrendsLineChartD3')
+  return { ActionsLineGraph: (props) => <TrendsLineChartD3 {...props} /> }
+})
+```
+
+With the mock in place, `renderInsightPage` routes through the real hog-charts
+bridge. The underlying `LineChart` component is itself swapped for a capture
+shim via `jest.config.ts` → `hog-charts-mock.tsx`, so no canvas code runs.
+
+### Tooltip testing
+
+Hog-charts tooltips are tested by imperatively driving the hover index:
+
+```tsx
+const chart = await waitForChart()
+chart.hover(2) // move hover to index 2
+const tooltip = await waitForTooltip(chart)
+expect(within(tooltip).getByText('134')).toBeInTheDocument()
+
+chart.pin() // pin the tooltip to show the close button
+chart.unpin() // unpin
+```
+
+`chart.hover`, `chart.pin`, `chart.unpin` are only available on hog-charts
+entries and throw on Chart.js entries. The fabricated `TooltipContext` passed
+to the bridge render prop is minimal: real position math, `ResizeObserver`,
+and `findNearestIndex` are intentionally bypassed — those concerns are
+covered by `lib/hog-charts/core/hooks/useChartInteraction.test.ts` and
+Playwright end-to-end tests.
+
+**What this harness validates:** the TrendsTooltip bridge mapping, series
+formatting, pin/unpin UI, and end-to-end kea data flow into the bridge.
+
+**What it does not validate:** mouse-coordinate-to-index resolution, canvas
+drawing, or scroll-to-dismiss pinned tooltip behavior.

--- a/frontend/src/test/insight-testing/hog-charts-mock.tsx
+++ b/frontend/src/test/insight-testing/hog-charts-mock.tsx
@@ -91,9 +91,7 @@ function buildNormalizedFromProps(
 function CaptureShim(props: CaptureShimProps): React.ReactElement {
     const { kind, series, labels, config, tooltip, children } = props
 
-    const tooltipHostRef = useRef<HTMLDivElement | null>(null)
     const [hoverIndex, setHoverIndex] = useState<number>(-1)
-    const [isPinned, setIsPinned] = useState<boolean>(false)
 
     // Mutable normalized entry — the same reference is returned for every
     // accessor call, so late data updates (hover-driven tooltip rebuilds)
@@ -108,9 +106,6 @@ function CaptureShim(props: CaptureShimProps): React.ReactElement {
             axes: {} as NormalizedChart['axes'],
             raw: props,
             hover: (i: number) => setHoverIndex(i),
-            pin: () => setIsPinned(true),
-            unpin: () => setIsPinned(false),
-            getTooltipHost: () => tooltipHostRef.current,
         }
         entryRef.current = entry
         pushCapturedChart(entry)
@@ -142,11 +137,11 @@ function CaptureShim(props: CaptureShimProps): React.ReactElement {
                 right: 800,
                 toJSON: () => ({}),
             } as DOMRect,
-            isPinned,
-            onUnpin: isPinned ? () => setIsPinned(false) : undefined,
+            isPinned: false,
+            onUnpin: undefined,
         }
         return tooltip(ctx)
-    }, [tooltip, hoverIndex, isPinned, labels, visibleSeries])
+    }, [tooltip, hoverIndex, labels, visibleSeries])
 
     return (
         <div data-attr="hog-charts-mock" data-renderer="hog-charts" data-kind={kind}>
@@ -173,9 +168,7 @@ function CaptureShim(props: CaptureShimProps): React.ReactElement {
                     ))}
                 </div>
             </div>
-            <div ref={tooltipHostRef} data-attr="hog-charts-tooltip-host">
-                {tooltipNode}
-            </div>
+            <div data-attr="hog-charts-tooltip-host">{tooltipNode}</div>
             {children}
         </div>
     )

--- a/frontend/src/test/insight-testing/hog-charts-mock.tsx
+++ b/frontend/src/test/insight-testing/hog-charts-mock.tsx
@@ -1,0 +1,193 @@
+import React, { useMemo, useRef, useState } from 'react'
+
+// Re-export type-only symbols from the real module. Types erase at runtime, so
+// this costs nothing and keeps consumers typing cleanly.
+export type {
+    ChartConfig,
+    ChartDrawArgs,
+    ChartScales,
+    CreateScalesFn,
+    GoalLine,
+    LineChartConfig,
+    PointClickData,
+    ResolveValueFn,
+    Series,
+    TooltipContext,
+} from 'lib/hog-charts/core/types'
+
+import type { ChartTheme } from 'lib/charts/types'
+import type {
+    LineChartConfig as _LineChartConfig,
+    Series as _Series,
+    TooltipContext as _TooltipContext,
+} from 'lib/hog-charts/core/types'
+
+import { type NormalizedChart, pushCapturedChart } from './captured-charts'
+
+// The mock intentionally does not re-export non-component symbols (useChart,
+// DefaultTooltip, BaseChartContext). The current consumers of lib/hog-charts
+// under test (TrendsLineChartD3) only use LineChart + types, and those types
+// erase at runtime. Add re-exports here if a new consumer lands.
+
+interface CaptureShimProps {
+    kind: 'LineChart' | 'Chart'
+    series: _Series[]
+    labels: string[]
+    config?: _LineChartConfig
+    theme: ChartTheme
+    tooltip?: (ctx: _TooltipContext) => React.ReactNode
+    onPointClick?: unknown
+    className?: string
+    children?: React.ReactNode
+}
+
+function buildNormalizedFromProps(
+    kind: 'LineChart' | 'Chart',
+    series: _Series[],
+    labels: string[],
+    config: _LineChartConfig | undefined,
+    entry: NormalizedChart
+): void {
+    entry.type = kind === 'LineChart' ? 'line' : 'chart'
+    entry.labels = labels
+    entry.datasets = series.map((s) => ({
+        label: s.label,
+        data: s.data,
+        hidden: s.hidden ?? false,
+        borderColor: s.color,
+        backgroundColor: s.fillArea ? s.color : '',
+        compare: s.meta?.compare_label != null,
+        compareLabel: s.meta?.compare_label != null ? String(s.meta.compare_label) : '',
+        meta: s.meta,
+    }))
+    entry.axes = {
+        x: {
+            display: true,
+            type: 'category',
+            stacked: false,
+            position: 'bottom',
+            tickLabel: (v) => {
+                const cb = config?.xTickFormatter
+                if (typeof cb === 'function') {
+                    const out = cb(String(v), 0)
+                    return out == null ? '' : String(out)
+                }
+                return String(v)
+            },
+        },
+        y: {
+            display: true,
+            type: config?.yScaleType === 'log' ? 'log' : 'linear',
+            stacked: !!config?.percentStackView,
+            position: 'left',
+            tickLabel: (v) => {
+                const cb = config?.yTickFormatter
+                return typeof cb === 'function' && typeof v === 'number' ? String(cb(v)) : String(v)
+            },
+        },
+    }
+}
+
+function CaptureShim(props: CaptureShimProps): React.ReactElement {
+    const { kind, series, labels, config, tooltip, children } = props
+
+    const tooltipHostRef = useRef<HTMLDivElement | null>(null)
+    const [hoverIndex, setHoverIndex] = useState<number>(-1)
+    const [isPinned, setIsPinned] = useState<boolean>(false)
+
+    // Mutable normalized entry — the same reference is returned for every
+    // accessor call, so late data updates (hover-driven tooltip rebuilds)
+    // are visible without re-pushing to the store.
+    const entryRef = useRef<NormalizedChart | null>(null)
+    if (entryRef.current === null) {
+        const entry: NormalizedChart = {
+            renderer: 'hog-charts',
+            type: kind === 'LineChart' ? 'line' : 'chart',
+            labels: [],
+            datasets: [],
+            axes: {} as NormalizedChart['axes'],
+            raw: props,
+            hover: (i: number) => setHoverIndex(i),
+            pin: () => setIsPinned(true),
+            unpin: () => setIsPinned(false),
+            getTooltipHost: () => tooltipHostRef.current,
+        }
+        entryRef.current = entry
+        pushCapturedChart(entry)
+    }
+    // Keep the normalized projection current on every render so tests that
+    // read the accessor after a props change see fresh data.
+    buildNormalizedFromProps(kind, series, labels, config, entryRef.current!)
+    entryRef.current!.raw = props
+
+    const visibleSeries = useMemo(() => series.filter((s) => !s.hidden), [series])
+
+    const tooltipNode = useMemo(() => {
+        if (!tooltip || hoverIndex < 0 || hoverIndex >= labels.length) {
+            return null
+        }
+        const ctx: _TooltipContext = {
+            dataIndex: hoverIndex,
+            label: labels[hoverIndex] ?? '',
+            seriesData: visibleSeries.map((s) => ({ series: s, value: s.data[hoverIndex], color: s.color })),
+            position: { x: 0, y: 0 },
+            canvasBounds: {
+                x: 0,
+                y: 0,
+                width: 800,
+                height: 400,
+                top: 0,
+                left: 0,
+                bottom: 400,
+                right: 800,
+                toJSON: () => ({}),
+            } as DOMRect,
+            isPinned,
+            onUnpin: isPinned ? () => setIsPinned(false) : undefined,
+        }
+        return tooltip(ctx)
+    }, [tooltip, hoverIndex, isPinned, labels, visibleSeries])
+
+    return (
+        <div data-attr="hog-charts-mock" data-renderer="hog-charts" data-kind={kind}>
+            <div data-attr="chart-data" data-type={kind === 'LineChart' ? 'line' : 'chart'}>
+                <div data-attr="chart-labels">
+                    {labels.map((l, i) => (
+                        <span key={i} data-attr={`label-${i}`}>
+                            {l}
+                        </span>
+                    ))}
+                </div>
+                <div data-attr="chart-datasets">
+                    {series.map((s, i) => (
+                        <div
+                            key={i}
+                            data-attr={`dataset-${i}`}
+                            data-label={s.label}
+                            data-hidden={String(s.hidden ?? false)}
+                        >
+                            {s.data.map((v, j) => (
+                                <span key={j} data-attr={`dataset-${i}-point-${j}`} data-value={String(v)} />
+                            ))}
+                        </div>
+                    ))}
+                </div>
+            </div>
+            <div ref={tooltipHostRef} data-attr="hog-charts-tooltip-host">
+                {tooltipNode}
+            </div>
+            {children}
+        </div>
+    )
+}
+
+export function LineChart(props: Omit<CaptureShimProps, 'kind'>): React.ReactElement {
+    return <CaptureShim kind="LineChart" {...props} />
+}
+
+export function Chart(props: Omit<CaptureShimProps, 'kind'>): React.ReactElement {
+    return <CaptureShim kind="Chart" {...props} />
+}
+
+export type { LineChartProps } from 'lib/hog-charts/charts/LineChart'
+export type { ChartProps } from 'lib/hog-charts/core/Chart'


### PR DESCRIPTION
## Problem

The insight-testing harness had no way to exercise the hog-charts render path (`lib/hog-charts`). Tests targeting `TrendsLineChartD3` or its `TrendsTooltip` bridge would either pull in real canvas/d3 (doesn't work in jsdom — `ResizeObserver`, non-zero dimensions, `findNearestIndex` coordinate math) or require a parallel test infrastructure.

Stacked on #53407 (unified normalized chart store).

## Changes

- `frontend/src/test/insight-testing/hog-charts-mock.tsx` — a React capture shim that replaces `LineChart` and `Chart` from `lib/hog-charts`. On render it pushes a `NormalizedChart` entry into the shared store, renders a marker DOM tree (same `data-attr` contract as `chartjs-mock`), and hosts an imperative tooltip API: `hover(index)`, `pin()`, `unpin()`. The tooltip render prop is invoked with a fabricated `TooltipContext` driven by the shim's hover state — no coordinate math.
- `frontend/jest.config.ts` maps `^lib/hog-charts$` to the mock. Placed before the catch-all `^lib/(.*)$` so it wins.
- `waitForTooltip(chart)` helper in `wait-for-chart.ts` polls the mock's tooltip host for a rendered child.
- README update documents the pattern, the per-file `jest.mock('scenes/trends/viz/ActionsLineGraph', ...)` swap tests use to route Trends through the hog-charts bridge, and the fidelity trade-offs (no `useChartInteraction` coverage — that stays in its own unit tests and Playwright).

This PR does not add tests — #53409 in the stack adds regression tests for `TrendsLineChartD3`. Ran the existing consumers of the harness to confirm no regressions.

## How did you test this code?

Automated only — I'm an agent and haven't exercised this by hand.

- Existing Chart.js-backed tests unaffected (the mapper is additive).
- The mock is exercised end-to-end by the tests in #53409.

## Publish to changelog?

no

## 🤖 LLM context

Authored by Claude Opus 4.6 via Claude Code.

**Deliberately simpler than the original plan:**
- No `renderHogChartsInsight` helper. Tests use the existing `renderInsightPage` plus a per-file `jest.mock` swap of `ActionsLineGraph` → `TrendsLineChartD3`. 5 lines vs a ~60-line kea bootstrap wrapper with no meaningful fidelity difference.
- No cross-renderer parity test. Hog-charts is intended to diverge from Chart.js; every divergence would require gating the parity test. Direct fixture assertions against the hog-charts path replace it.
- `TooltipContext.canvasBounds` is a plain object cast, not `new DOMRect(...)` — jsdom doesn't polyfill `DOMRect` and bridge code only reads fields.