### PR TITLE
fix(hobby): add docker log rotation to prevent disk exhaustion

### DIFF
--- a/docker-compose.hobby.yml
+++ b/docker-compose.hobby.yml
@@ -8,12 +8,19 @@
 # See: https://posthog.com/blog/sunsetting-helm-support-posthog
 #
 
+x-logging: &default-logging
+    driver: json-file
+    options:
+        max-size: '50m'
+        max-file: '3'
+
 services:
     db:
         extends:
             file: docker-compose.base.yml
             service: db
         image: ${DOCKER_REGISTRY_PREFIX:-}postgres:15.12-alpine
+        logging: *default-logging
         volumes:
             - postgres-data:/var/lib/postgresql/data
 
@@ -21,6 +28,7 @@ services:
         extends:
             file: docker-compose.base.yml
             service: redis7
+        logging: *default-logging
         volumes:
             - redis7-data:/data
 
@@ -33,6 +41,7 @@ services:
             file: docker-compose.base.yml
             service: clickhouse
         restart: on-failure
+        logging: *default-logging
         depends_on:
             - kafka
             - zookeeper
@@ -50,6 +59,7 @@ services:
         extends:
             file: docker-compose.base.yml
             service: zookeeper
+        logging: *default-logging
         volumes:
             - zookeeper-datalog:/datalog
             - zookeeper-data:/data
@@ -58,6 +68,7 @@ services:
         extends:
             file: docker-compose.base.yml
             service: kafka
+        logging: *default-logging
         depends_on:
             - zookeeper
         environment:
@@ -71,6 +82,7 @@ services:
         extends:
             file: docker-compose.base.yml
             service: worker
+        logging: *default-logging
         environment:
             SITE_URL: https://$DOMAIN
             SECRET_KEY: $POSTHOG_SECRET
@@ -102,6 +114,7 @@ services:
             file: docker-compose.base.yml
             service: web
         command: /compose/start
+        logging: *default-logging
         volumes:
             - ./compose:/compose
         image: $REGISTRY_URL:$POSTHOG_APP_TAG
@@ -139,6 +152,7 @@ services:
             file: docker-compose.base.yml
             service: plugins
         image: ${REGISTRY_URL}-node:${POSTHOG_NODE_TAG:-latest}
+        logging: *default-logging
         environment:
             SITE_URL: https://$DOMAIN
             SECRET_KEY: $POSTHOG_SECRET
@@ -169,6 +183,7 @@ services:
             file: docker-compose.base.yml
             service: ingestion-general
         image: ${REGISTRY_URL}-node:${POSTHOG_NODE_TAG:-latest}
+        logging: *default-logging
         environment:
             PERSONS_DATABASE_URL: 'postgres://posthog:posthog@db:5432/posthog'
             BEHAVIORAL_COHORTS_DATABASE_URL: 'postgres://posthog:posthog@db:5432/posthog'
@@ -184,6 +199,7 @@ services:
             file: docker-compose.base.yml
             service: ingestion-sessionreplay
         image: ${REGISTRY_URL}-node:${POSTHOG_NODE_TAG:-latest}
+        logging: *default-logging
         environment:
             SESSION_RECORDING_V2_S3_ACCESS_KEY_ID: 'any'
             SESSION_RECORDING_V2_S3_SECRET_ACCESS_KEY: 'any'
@@ -201,6 +217,7 @@ services:
             file: docker-compose.base.yml
             service: recording-api
         image: ${REGISTRY_URL}-node:${POSTHOG_NODE_TAG:-latest}
+        logging: *default-logging
         environment:
             ENCRYPTION_SALT_KEYS: $ENCRYPTION_SALT_KEYS
         depends_on:
@@ -213,6 +230,7 @@ services:
             file: docker-compose.base.yml
             service: ingestion-error-tracking
         image: ${REGISTRY_URL}-node:${POSTHOG_NODE_TAG:-latest}
+        logging: *default-logging
         environment:
             ENCRYPTION_SALT_KEYS: $ENCRYPTION_SALT_KEYS
         depends_on:
@@ -225,6 +243,7 @@ services:
             file: docker-compose.base.yml
             service: ingestion-logs
         image: ${REGISTRY_URL}-node:${POSTHOG_NODE_TAG:-latest}
+        logging: *default-logging
         depends_on:
             - db
             - redis7
@@ -235,6 +254,7 @@ services:
             file: docker-compose.base.yml
             service: ingestion-traces
         image: ${REGISTRY_URL}-node:${POSTHOG_NODE_TAG:-latest}
+        logging: *default-logging
         depends_on:
             - db
             - redis7
@@ -244,6 +264,7 @@ services:
         extends:
             file: docker-compose.base.yml
             service: proxy
+        logging: *default-logging
         ports:
             - '80:80'
             - '443:443'
@@ -262,6 +283,7 @@ services:
             service: objectstorage
 
         restart: on-failure
+        logging: *default-logging
         volumes:
             - objectstorage:/data
         ports:
@@ -274,6 +296,7 @@ services:
             service: seaweedfs
         container_name: '${SEAWEEDFS_DOCKER_NAME:-seaweedfs-main}'
         restart: on-failure
+        logging: *default-logging
         ports:
             - '127.0.0.1:8333:8333' # S3 API
             - '127.0.0.1:9333:9333' # Master server
@@ -297,6 +320,7 @@ services:
             file: docker-compose.base.yml
             service: asyncmigrationscheck
         image: $REGISTRY_URL:$POSTHOG_APP_TAG
+        logging: *default-logging
         environment:
             SITE_URL: https://$DOMAIN
             SECRET_KEY: $POSTHOG_SECRET
@@ -307,6 +331,7 @@ services:
         extends:
             file: docker-compose.base.yml
             service: temporal
+        logging: *default-logging
         environment:
             - ENABLE_ES=false
         ports:
@@ -317,16 +342,19 @@ services:
         extends:
             file: docker-compose.base.yml
             service: elasticsearch
+        logging: *default-logging
     temporal-admin-tools:
         extends:
             file: docker-compose.base.yml
             service: temporal-admin-tools
+        logging: *default-logging
         depends_on:
             - temporal
     temporal-ui:
         extends:
             file: docker-compose.base.yml
             service: temporal-ui
+        logging: *default-logging
         ports:
             - 8081:8080
         depends_on:
@@ -339,6 +367,7 @@ services:
         extends:
             file: docker-compose.base.yml
             service: temporal-django-worker
+        logging: *default-logging
         volumes:
             - ./compose:/compose
         image: $REGISTRY_URL:$POSTHOG_APP_TAG
@@ -360,6 +389,7 @@ services:
             service: cyclotron-janitor
         build:
             context: ./posthog/rust
+        logging: *default-logging
         environment:
             DATABASE_URL: 'postgres://posthog:posthog@db:5432/posthog'
             KAFKA_HOSTS: 'kafka:9092'
@@ -375,6 +405,7 @@ services:
         extends:
             file: docker-compose.base.yml
             service: capture
+        logging: *default-logging
 
     replay-capture:
         build:
@@ -382,6 +413,7 @@ services:
         extends:
             file: docker-compose.base.yml
             service: replay-capture
+        logging: *default-logging
 
     property-defs-rs:
         build:
@@ -389,6 +421,7 @@ services:
         extends:
             file: docker-compose.base.yml
             service: property-defs-rs
+        logging: *default-logging
         depends_on:
             kafka-init:
                 condition: service_completed_successfully
@@ -399,6 +432,7 @@ services:
         extends:
             file: docker-compose.base.yml
             service: livestream
+        logging: *default-logging
         environment:
             - LIVESTREAM_JWT_SECRET=${POSTHOG_SECRET}
         volumes:
@@ -410,6 +444,7 @@ services:
         extends:
             file: docker-compose.base.yml
             service: feature-flags
+        logging: *default-logging
         depends_on:
             - db
             - redis7
@@ -417,6 +452,7 @@ services:
     kafka-init:
         image: docker.redpanda.com/redpandadata/redpanda:v25.1.9
         entrypoint: /bin/sh
+        logging: *default-logging
         command:
             - -c
             - |
@@ -466,6 +502,7 @@ services:
             args:
                 BIN: cymbal
         restart: on-failure
+        logging: *default-logging
         volumes:
             - ./share:/share
         environment:


### PR DESCRIPTION
## Problem

Docker's default `json-file` logging driver has no size limit. On hobby deployments with small disks (e.g. 80GB), container logs — especially ClickHouse — can grow to tens of GB and exhaust disk space entirely.

**I had 29GB of space used on an 80GB disk - just from clickhouse server logs**

## Changes

Add an `x-logging` YAML extension to `docker-compose.hobby.yml` with `max-size: 50m` and `max-file: 3`, applied to all 31 services via a YAML anchor. This caps each container at 150MB of logs, for a worst-case total of ~4.5GB across all services.

## How did you test this code?

This PR was authored by an agent. Testing performed:
- Validated the YAML parses correctly with `yaml.safe_load()`
- Verified all 31 services have the `logging` key with correct `driver`, `max-size`, and `max-file` values
- No automated tests exist for compose files; manual verification on a hobby instance by running `docker inspect <container> --format '{{.HostConfig.LogConfig}}'` is recommended

## Publish to changelog?

no

## Docs update

N/A

## 🤖 LLM context

Authored by PostHog Code agent. Single-file change to docker-compose config — no application code modified.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*