### PR TITLE
chore(modeling): make duckgres modeling demo-able by skipping hogql

### DIFF
--- a/posthog/ducklake/client.py
+++ b/posthog/ducklake/client.py
@@ -113,8 +113,15 @@ def execute_ducklake_create_table(team_id: int, sql: str, schema_name: str, tabl
     conninfo = _make_duckgres_conninfo(team_id)
     with psycopg.connect(conninfo) as conn:
         conn.execute("SET search_path TO 'posthog'")
+        conn.execute(psql.SQL("CREATE SCHEMA IF NOT EXISTS {}").format(psql.Identifier(safe_schema)))
+        # TODO: remove hardcoded schemas and derive the search path from the team's
+        # data warehouse sources / DAG configuration instead
+        conn.execute(
+            psql.SQL("SET search_path TO {}, 'revenue', 'stripe', 'billing_public', 'credit', 'posthog'").format(
+                psql.Identifier(safe_schema)
+            )
+        )
         with conn.cursor() as cur:
-            cur.execute(psql.SQL("CREATE SCHEMA IF NOT EXISTS {}").format(psql.Identifier(safe_schema)))
             # capture previous table size before replacing
             cur.execute(
                 "SELECT file_size_bytes FROM posthog.table_info() WHERE schema_name = %s AND table_name = %s",

--- a/posthog/temporal/data_modeling/activities/materialize_view_duckgres.py
+++ b/posthog/temporal/data_modeling/activities/materialize_view_duckgres.py
@@ -29,6 +29,7 @@ class DuckgresShadowInputs:
     dag_id: str
     node_id: str
     job_id: str
+    dangerously_execute_raw_sql: bool = False
 
     @property
     def properties_to_log(self) -> dict[str, typing.Any]:
@@ -63,7 +64,7 @@ def _is_duckgres_shadow_enabled(team: Team) -> bool:
     try:
         return posthoganalytics.feature_enabled(
             FEATURE_FLAG,
-            str(team.pk),
+            str(team.uuid),
             groups={
                 "organization": str(team.organization_id),
                 "project": str(team.id),
@@ -142,6 +143,10 @@ async def materialize_view_duckgres_activity(inputs: DuckgresShadowInputs) -> Du
 
     team, node, saved_query = await _get_shadow_input_objects(inputs)
 
+    if not inputs.dangerously_execute_raw_sql and not await database_sync_to_async(_is_duckgres_shadow_enabled)(team):
+        await logger.ainfo("Duckgres shadow disabled for team", extra=inputs.properties_to_log)
+        return DuckgresShadowResult(row_count=0, duration_seconds=0.0, schema_name="", table_name="", error="disabled")
+
     hogql_query = typing.cast(dict, saved_query.query)["query"]
     schema_name = f"{SHADOW_SCHEMA_PREFIX}_{team.pk}_models"
     table_name = saved_query.normalized_name
@@ -156,7 +161,10 @@ async def materialize_view_duckgres_activity(inputs: DuckgresShadowInputs) -> Du
     start_time = time.monotonic()
     sql: str = ""
     try:
-        sql = await database_sync_to_async(_compile_hogql_to_postgres_sql)(hogql_query, team.pk)
+        if inputs.dangerously_execute_raw_sql:
+            sql = hogql_query
+        else:
+            sql = await database_sync_to_async(_compile_hogql_to_postgres_sql)(hogql_query, team.pk)
         await logger.adebug("Duckgres shadow SQL generated", sql=sql)
 
         from posthog.ducklake.client import execute_ducklake_create_table

--- a/posthog/temporal/data_modeling/activities/materialize_view_duckgres.py
+++ b/posthog/temporal/data_modeling/activities/materialize_view_duckgres.py
@@ -142,11 +142,6 @@ async def materialize_view_duckgres_activity(inputs: DuckgresShadowInputs) -> Du
     logger = LOGGER.bind()
 
     team, node, saved_query = await _get_shadow_input_objects(inputs)
-
-    if not inputs.dangerously_execute_raw_sql and not await database_sync_to_async(_is_duckgres_shadow_enabled)(team):
-        await logger.ainfo("Duckgres shadow disabled for team", extra=inputs.properties_to_log)
-        return DuckgresShadowResult(row_count=0, duration_seconds=0.0, schema_name="", table_name="", error="disabled")
-
     hogql_query = typing.cast(dict, saved_query.query)["query"]
     schema_name = f"{SHADOW_SCHEMA_PREFIX}_{team.pk}_models"
     table_name = saved_query.normalized_name

--- a/posthog/temporal/data_modeling/activities/materialize_view_duckgres.py
+++ b/posthog/temporal/data_modeling/activities/materialize_view_duckgres.py
@@ -64,7 +64,7 @@ def _is_duckgres_shadow_enabled(team: Team) -> bool:
     try:
         return posthoganalytics.feature_enabled(
             FEATURE_FLAG,
-            str(team.uuid),
+            str(team.pk),
             groups={
                 "organization": str(team.organization_id),
                 "project": str(team.id),

--- a/posthog/temporal/data_modeling/workflows/execute_dag.py
+++ b/posthog/temporal/data_modeling/workflows/execute_dag.py
@@ -53,6 +53,7 @@ class ExecuteDAGInputs:
     dag_id: str
     node_ids: list[str] | None = None
     duckgres_only: bool = False
+    dangerously_execute_raw_sql: bool = False
 
     @property
     def properties_to_log(self) -> dict:
@@ -324,6 +325,7 @@ class ExecuteDAGWorkflow(PostHogWorkflow):
                             dag_id=inputs.dag_id,
                             node_id=node_id,
                             duckgres_only=inputs.duckgres_only,
+                            dangerously_execute_raw_sql=inputs.dangerously_execute_raw_sql,
                         ),
                         id=f"materialize-view-{inputs.dag_id}-{node_id}-{start_time.isoformat()}",
                         parent_close_policy=ParentClosePolicy.REQUEST_CANCEL,

--- a/posthog/temporal/data_modeling/workflows/materialize_view.py
+++ b/posthog/temporal/data_modeling/workflows/materialize_view.py
@@ -144,7 +144,7 @@ class MaterializeViewWorkflow(PostHogWorkflow):
         )
 
         duckgres_shadow_handle = None
-        if duckgres_enabled:
+        if duckgres_enabled or inputs.duckgres_only:
             duckgres_job_id = await temporalio.workflow.execute_activity(
                 create_data_modeling_job_activity,
                 CreateDataModelingJobInputs(
@@ -173,7 +173,7 @@ class MaterializeViewWorkflow(PostHogWorkflow):
                 ),
             )
 
-        if not inputs.duckgres_only and not inputs.dangerously_execute_raw_sql:
+        if not inputs.duckgres_only:
             try:
                 materialize_result = await temporalio.workflow.execute_activity(
                     materialize_view_activity,

--- a/posthog/temporal/data_modeling/workflows/materialize_view.py
+++ b/posthog/temporal/data_modeling/workflows/materialize_view.py
@@ -70,6 +70,7 @@ class MaterializeViewWorkflowInputs:
     dag_id: str
     node_id: str
     duckgres_only: bool = False
+    dangerously_execute_raw_sql: bool = False
 
     @property
     def properties_to_log(self) -> dict:
@@ -164,6 +165,7 @@ class MaterializeViewWorkflow(PostHogWorkflow):
                     node_id=inputs.node_id,
                     dag_id=inputs.dag_id,
                     job_id=duckgres_job_id,
+                    dangerously_execute_raw_sql=inputs.dangerously_execute_raw_sql,
                 ),
                 start_to_close_timeout=dt.timedelta(minutes=15),
                 retry_policy=temporalio.common.RetryPolicy(
@@ -171,7 +173,7 @@ class MaterializeViewWorkflow(PostHogWorkflow):
                 ),
             )
 
-        if not inputs.duckgres_only:
+        if not inputs.duckgres_only and not inputs.dangerously_execute_raw_sql:
             try:
                 materialize_result = await temporalio.workflow.execute_activity(
                     materialize_view_activity,


### PR DESCRIPTION
## Problem

duckgres compatibility with clickhouse sql. we just aren't there yet but we have a demo tuesday.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

## Changes

make it demoable by ignore hogql validation, setting the saved query sql directly to duckgres compatible sql ONLY for the demo billing models and hardcoding some ducklake search path tables to make it all work.

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

i verified many of the models myself against this PR https://github.com/PostHog/posthog_dbt/pull/72 but i also let claude rip on "rendering" the sql via jinja templates. otherwise, i've verified the schemas are all correct and that the DAG structure looks mostly correct. still not sure if its gonna work, but the blast radius is tiny. will only affect team 2's duckling and some fake saved queries that we can just delete after (or mark as test :D )

## Publish to changelog?

no

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->