### PR TITLE
feat(experiments): build an actors query for experiment exposure on the funnel metric details modal.

### DIFF
--- a/frontend/src/scenes/experiments/charts/funnel/StepBar.tsx
+++ b/frontend/src/scenes/experiments/charts/funnel/StepBar.tsx
@@ -8,15 +8,18 @@ import { percentage } from 'lib/utils'
 import {
     ExperimentActorsQuery,
     ExperimentQuery,
+    InsightActorsQuery,
     isExperimentFunnelMetric,
     NodeKind,
     SessionData,
+    TrendsQuery,
 } from '~/queries/schema/schema-general'
+import { getExposureConfigEventsNode } from '~/scenes/experiments/metricQueryUtils'
 import { getVariantColor } from '~/scenes/experiments/utils'
 import { funnelTitle } from '~/scenes/trends/persons-modal/persons-modal-utils'
 import { openPersonsModal } from '~/scenes/trends/persons-modal/PersonsModal'
 import type { Experiment } from '~/types'
-import { FunnelStepWithConversionMetrics } from '~/types'
+import { ChartDisplayType, FunnelStepWithConversionMetrics, PropertyFilterType, PropertyOperator } from '~/types'
 
 import { useTooltip } from './FunnelBarVertical'
 import { useFunnelChartData } from './FunnelChart'
@@ -30,6 +33,102 @@ export interface StepBarProps {
 interface StepBarCSSProperties extends React.CSSProperties {
     '--series-color': string
     '--conversion-rate': string
+}
+
+/**
+ * Opens the persons modal for the experiment exposure step (step 0).
+ * Queries the exposure event directly rather than using funnel actors query.
+ */
+function openExperimentPersonsModalForExposure({
+    experimentQuery,
+    variantKey,
+    featureFlagKey,
+    featureFlagVariants,
+    exposureCriteria,
+    startDate,
+    endDate,
+}: {
+    experimentQuery: ExperimentQuery
+    variantKey: string
+    featureFlagKey: string
+    featureFlagVariants: any[]
+    exposureCriteria?: any
+    startDate: string | null
+    endDate: string | null
+}): void {
+    if (!isExperimentFunnelMetric(experimentQuery.metric)) {
+        return
+    }
+
+    // Build the exposure event from experiment configuration
+    // If exposure_criteria is empty or doesn't have an event, use the default $feature_flag_called
+    const exposureConfig = exposureCriteria?.event ? exposureCriteria : { event: '$feature_flag_called' }
+    const exposureEvent = getExposureConfigEventsNode(exposureConfig, {
+        featureFlagKey,
+        featureFlagVariants,
+    })
+
+    // Determine which property key to use for variant filtering
+    const isDefaultExposure = exposureEvent.event === '$feature_flag_called'
+    const variantPropertyKey = isDefaultExposure ? '$feature_flag' : `$feature/${featureFlagKey}`
+
+    // Build a TrendsQuery with the exposure event, filtered by the specific variant
+    // Use BoldNumber display type for total value aggregation (no day required)
+    const trendsQuery: TrendsQuery = {
+        kind: NodeKind.TrendsQuery,
+        series: [
+            {
+                kind: exposureEvent.kind,
+                event: exposureEvent.event,
+                custom_name: exposureEvent.custom_name,
+                // Filter for the specific variant only
+                properties: [
+                    // Keep any existing properties that aren't variant filters
+                    ...(exposureEvent.properties?.filter(
+                        (p) => p.key !== `$feature/${featureFlagKey}` && p.key !== '$feature_flag'
+                    ) || []),
+                    // Add the variant filter
+                    {
+                        key: variantPropertyKey,
+                        type: PropertyFilterType.Event,
+                        value: isDefaultExposure ? featureFlagKey : variantKey,
+                        operator: PropertyOperator.Exact,
+                    },
+                    // For default exposure, also filter by variant value
+                    ...(isDefaultExposure
+                        ? [
+                              {
+                                  key: '$feature_flag_response',
+                                  type: PropertyFilterType.Event,
+                                  value: variantKey,
+                                  operator: PropertyOperator.Exact,
+                              },
+                          ]
+                        : []),
+                ],
+            },
+        ],
+        dateRange: {
+            date_from: startDate,
+            date_to: endDate,
+        },
+        trendsFilter: {
+            display: ChartDisplayType.BoldNumber,
+        },
+    }
+
+    // Build InsightActorsQuery for the exposure event
+    const actorsQuery: InsightActorsQuery = {
+        kind: NodeKind.InsightActorsQuery,
+        source: trendsQuery,
+        includeRecordings: true,
+    }
+
+    openPersonsModal({
+        title: `Experiment exposure • ${variantKey}`,
+        query: actorsQuery,
+        additionalSelect: { matched_recordings: 'matched_recordings' },
+    })
 }
 
 /**
@@ -162,14 +261,29 @@ export function StepBar({ step, stepIndex }: StepBarProps): JSX.Element | null {
 
     // New click handlers for actors query (with feature flag)
     const handleDropoffClick = (): void => {
-        if (hasActorsQueryFeature && experimentQuery) {
-            openExperimentPersonsModalForSeries({
-                step: step,
-                stepIndex: stepIndex,
-                converted: false, // Dropoffs
-                experimentQuery,
-                experiment,
-            })
+        if (hasActorsQueryFeature && experimentQuery && experiment) {
+            if (stepIndex === 0) {
+                // Exposure step: query exposure event directly
+                // Both dropoff and conversion show the same data (persons who were exposed)
+                openExperimentPersonsModalForExposure({
+                    experimentQuery,
+                    variantKey,
+                    featureFlagKey: experiment.feature_flag.key,
+                    featureFlagVariants: experiment.parameters.feature_flag_variants,
+                    exposureCriteria: experiment.exposure_criteria,
+                    startDate: experiment.start_date,
+                    endDate: experiment.end_date,
+                })
+            } else {
+                // Regular steps: use funnel actors query
+                openExperimentPersonsModalForSeries({
+                    step: step,
+                    stepIndex: stepIndex,
+                    converted: false, // Dropoffs
+                    experimentQuery,
+                    experiment,
+                })
+            }
         } else {
             // Fall back to legacy behavior
             handleLegacyClick()
@@ -177,14 +291,29 @@ export function StepBar({ step, stepIndex }: StepBarProps): JSX.Element | null {
     }
 
     const handleConversionClick = (): void => {
-        if (hasActorsQueryFeature && experimentQuery) {
-            openExperimentPersonsModalForSeries({
-                step: step,
-                stepIndex: stepIndex,
-                converted: true, // Conversions
-                experimentQuery,
-                experiment,
-            })
+        if (hasActorsQueryFeature && experimentQuery && experiment) {
+            if (stepIndex === 0) {
+                // Exposure step: query exposure event directly
+                // Both dropoff and conversion show the same data (persons who were exposed)
+                openExperimentPersonsModalForExposure({
+                    experimentQuery,
+                    variantKey,
+                    featureFlagKey: experiment.feature_flag.key,
+                    featureFlagVariants: experiment.parameters.feature_flag_variants,
+                    exposureCriteria: experiment.exposure_criteria,
+                    startDate: experiment.start_date,
+                    endDate: experiment.end_date,
+                })
+            } else {
+                // Regular steps: use funnel actors query
+                openExperimentPersonsModalForSeries({
+                    step: step,
+                    stepIndex: stepIndex,
+                    converted: true, // Conversions
+                    experimentQuery,
+                    experiment,
+                })
+            }
         } else {
             // Fall back to legacy behavior
             handleLegacyClick()
@@ -206,12 +335,10 @@ export function StepBar({ step, stepIndex }: StepBarProps): JSX.Element | null {
                 onMouseEnter={() => {
                     if (ref.current) {
                         const rect = ref.current.getBoundingClientRect()
-                        // Only show "Click to inspect actors" hint when clicking will actually work:
-                        // - Step 0 (exposure) with new feature enabled: can't use actors query (returns early), so don't show hint
-                        // - Step 1 (first metric) drop-offs with new feature: can't query (no exposure in backend funnel), conversions work
-                        // - Step 2+ with new feature: both conversions and drop-offs work
-                        // - Legacy mode: show hint if sessionData exists
-                        const hasClickableData = hasActorsQueryFeature ? stepIndex > 0 : !!sessionData
+                        // Show "Click to inspect actors" hint when clicking will work:
+                        // - New feature enabled: works for all steps (including exposure)
+                        // - Legacy: only show if sessionData exists
+                        const hasClickableData = hasActorsQueryFeature || !!sessionData
                         showTooltip([rect.x, rect.y, rect.width], stepIndex, step, hasClickableData)
                     }
                 }}
@@ -221,26 +348,14 @@ export function StepBar({ step, stepIndex }: StepBarProps): JSX.Element | null {
                     className="StepBar__backdrop"
                     onClick={handleDropoffClick}
                     style={{
-                        cursor: hasActorsQueryFeature
-                            ? stepIndex > 1
-                                ? 'pointer'
-                                : 'default'
-                            : sessionData
-                              ? 'pointer'
-                              : 'default',
+                        cursor: hasActorsQueryFeature || sessionData ? 'pointer' : 'default',
                     }}
                 />
                 <div
                     className="StepBar__fill"
                     onClick={handleConversionClick}
                     style={{
-                        cursor: hasActorsQueryFeature
-                            ? stepIndex > 0
-                                ? 'pointer'
-                                : 'default'
-                            : sessionData
-                              ? 'pointer'
-                              : 'default',
+                        cursor: hasActorsQueryFeature || sessionData ? 'pointer' : 'default',
                     }}
                 />
             </div>


### PR DESCRIPTION
## Problem

The results detail funnel view is not showing a `PersonsModal` for the exposure event.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

For the exposure event in the funnel, we'll use an `InsightActorsQuery` configured with the experiment exposure configuration as the only element in the series, with a filter for the corresponding variant.
We don't use a custom `ExperimentActorsQuery` because exposure is the first element of the funnel, and we expect zero drop-off.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

![cat-type](https://github.com/user-attachments/assets/0475b8f3-ec66-4647-aaa8-2a8ba041e2e2)

<!-- Briefly describe the steps you took, and what steps reviewers must take to get to where changes are, and what is the expected behavior. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
