### PR TITLE
fix: use hyphenated URL for check-database-name endpoint

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -5051,7 +5051,7 @@ const api = {
         async checkDatabaseName(name: string): Promise<{ name: string; available: boolean }> {
             return await new ApiRequest()
                 .dataWarehouse()
-                .withAction('check_database_name')
+                .withAction('check-database-name')
                 .withQueryString({ name })
                 .get()
         },


### PR DESCRIPTION
## Summary
- The frontend was using `check_database_name` (underscores) in the API URL, but the Django endpoint is registered with `url_path="check-database-name"` (hyphens), causing 404s when checking database name availability.

## Test plan
- [ ] Verify `check-database-name` endpoint returns results in the warehouse provisioning UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)