### PR TITLE
chore(experiments): remove dead code from duplicated shared components.

### DIFF
--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -38643,6 +38643,29 @@
             },
             "type": "object"
         },
+        "isExperimentFunnelsQuery": {
+            "$comment": "(\n    query: ExperimentTrendsQuery | ExperimentFunnelsQuery) => query is ExperimentFunnelsQuery",
+            "properties": {
+                "namedArgs": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "query": {
+                            "anyOf": [
+                                {
+                                    "$ref": "#/definitions/ExperimentTrendsQuery"
+                                },
+                                {
+                                    "$ref": "#/definitions/ExperimentFunnelsQuery"
+                                }
+                            ]
+                        }
+                    },
+                    "required": ["query"],
+                    "type": "object"
+                }
+            },
+            "type": "object"
+        },
         "isExperimentMeanMetric": {
             "$comment": "(metric: ExperimentMetric) => metric is ExperimentMeanMetric",
             "properties": {
@@ -38686,6 +38709,29 @@
                         }
                     },
                     "required": ["metric"],
+                    "type": "object"
+                }
+            },
+            "type": "object"
+        },
+        "isExperimentTrendsQuery": {
+            "$comment": "(\n    query: ExperimentTrendsQuery | ExperimentFunnelsQuery) => query is ExperimentTrendsQuery",
+            "properties": {
+                "namedArgs": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "query": {
+                            "anyOf": [
+                                {
+                                    "$ref": "#/definitions/ExperimentTrendsQuery"
+                                },
+                                {
+                                    "$ref": "#/definitions/ExperimentFunnelsQuery"
+                                }
+                            ]
+                        }
+                    },
+                    "required": ["query"],
                     "type": "object"
                 }
             },

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -3369,6 +3369,15 @@ export type ExperimentRetentionMetric = ExperimentMetricBaseProperties & {
 export const isExperimentRetentionMetric = (metric: ExperimentMetric): metric is ExperimentRetentionMetric =>
     metric.metric_type === ExperimentMetricType.RETENTION
 
+// Legacy experiment query type guards
+export const isExperimentTrendsQuery = (
+    query: ExperimentTrendsQuery | ExperimentFunnelsQuery
+): query is ExperimentTrendsQuery => query.kind === NodeKind.ExperimentTrendsQuery
+
+export const isExperimentFunnelsQuery = (
+    query: ExperimentTrendsQuery | ExperimentFunnelsQuery
+): query is ExperimentFunnelsQuery => query.kind === NodeKind.ExperimentFunnelsQuery
+
 export type ExperimentMeanMetricTypeProps = Omit<ExperimentMeanMetric, keyof ExperimentMetricBaseProperties>
 export type ExperimentFunnelMetricTypeProps = Omit<ExperimentFunnelMetric, keyof ExperimentMetricBaseProperties>
 export type ExperimentRatioMetricTypeProps = Omit<ExperimentRatioMetric, keyof ExperimentMetricBaseProperties>

--- a/frontend/src/scenes/experiments/legacy/components/LegacySummaryTable.tsx
+++ b/frontend/src/scenes/experiments/legacy/components/LegacySummaryTable.tsx
@@ -9,22 +9,8 @@ import ViewRecordingsPlaylistButton from 'lib/components/ViewRecordingButton/Vie
 import { LemonProgress } from 'lib/lemon-ui/LemonProgress'
 import { humanFriendlyNumber } from 'lib/utils'
 
-import {
-    ExperimentFunnelsQuery,
-    ExperimentMetric,
-    ExperimentTrendsQuery,
-    NodeKind,
-} from '~/queries/schema/schema-general'
-import {
-    FilterLogicalOperator,
-    FunnelExperimentVariant,
-    InsightType,
-    RecordingUniversalFilters,
-    TrendExperimentVariant,
-} from '~/types'
-
-import { experimentLogic } from '../../experimentLogic'
-import { getViewRecordingFilters, getViewRecordingFiltersLegacy, isLegacyExperimentQuery } from '../../utils'
+import { ExperimentFunnelsQuery, ExperimentTrendsQuery, isExperimentTrendsQuery } from '~/queries/schema/schema-general'
+import { experimentLogic } from '~/scenes/experiments/experimentLogic'
 import {
     legacyCalculateDelta,
     legacyConversionRateForVariant,
@@ -32,8 +18,10 @@ import {
     legacyCredibleIntervalForVariant,
     legacyExposureCountDataForVariant,
     legacyGetHighestProbabilityVariant,
-} from '../calculations/legacyExperimentCalculations'
-import { LegacyVariantTag } from './LegacyVariantTag'
+} from '~/scenes/experiments/legacy/calculations/legacyExperimentCalculations'
+import { LegacyVariantTag } from '~/scenes/experiments/legacy/components/LegacyVariantTag'
+import { getViewRecordingFiltersLegacy } from '~/scenes/experiments/utils'
+import { FilterLogicalOperator, InsightType, RecordingUniversalFilters, TrendExperimentVariant } from '~/types'
 
 /**
  * @deprecated
@@ -45,7 +33,7 @@ export function LegacySummaryTable({
     displayOrder = 0,
     isSecondary = false,
 }: {
-    metric: ExperimentMetric | ExperimentTrendsQuery | ExperimentFunnelsQuery
+    metric: ExperimentTrendsQuery | ExperimentFunnelsQuery
     displayOrder?: number
     isSecondary?: boolean
 }): JSX.Element {
@@ -205,37 +193,6 @@ export function LegacySummaryTable({
     }
 
     if (insightType === InsightType.FUNNELS) {
-        // NOTE: For funnel metrics on the new engine, we show exposures and converted counts in the table,
-        // as we don't yet have the detailed view as we do for the legacy funnel metrics.
-        if (metric.kind === NodeKind.ExperimentMetric) {
-            columns.push({
-                key: 'exposures',
-                title: 'Exposures',
-                render: function Key(_, item): JSX.Element {
-                    const variant = item as FunnelExperimentVariant
-                    const exposures = variant.success_count + variant.failure_count
-                    if (!exposures) {
-                        return <>—</>
-                    }
-
-                    return <div className="font-semibold">{humanFriendlyNumber(exposures)}</div>
-                },
-            })
-            columns.push({
-                key: 'converted',
-                title: 'Converted',
-                render: function Key(_, item): JSX.Element {
-                    const variant = item as FunnelExperimentVariant
-                    const converted = variant.success_count
-                    if (!converted) {
-                        return <>—</>
-                    }
-
-                    return <div className="font-semibold">{humanFriendlyNumber(converted)}</div>
-                },
-            })
-        }
-
         columns.push({
             key: 'conversionRate',
             title: 'Conversion rate',
@@ -352,9 +309,7 @@ export function LegacySummaryTable({
         render: function Key(_, item): JSX.Element {
             const variantKey = item.key
 
-            const filters = isLegacyExperimentQuery(metric)
-                ? getViewRecordingFiltersLegacy(metric, experiment.feature_flag_key, variantKey)
-                : getViewRecordingFilters(experiment, metric, variantKey)
+            const filters = getViewRecordingFiltersLegacy(metric, experiment.feature_flag_key, variantKey)
 
             const filterGroup: Partial<RecordingUniversalFilters> = {
                 filter_group: {
@@ -368,12 +323,9 @@ export function LegacySummaryTable({
                 },
                 date_from: experiment?.start_date,
                 date_to: experiment?.end_date,
-                filter_test_accounts:
-                    metric.kind === NodeKind.ExperimentMetric
-                        ? (experiment.exposure_criteria?.filterTestAccounts ?? false)
-                        : metric.kind === NodeKind.ExperimentTrendsQuery
-                          ? metric.count_query.filterTestAccounts
-                          : metric.funnels_query.filterTestAccounts,
+                filter_test_accounts: isExperimentTrendsQuery(metric)
+                    ? metric.count_query.filterTestAccounts
+                    : metric.funnels_query.filterTestAccounts,
             }
 
             return (

--- a/frontend/src/scenes/experiments/legacy/components/LegacyVariantTag.tsx
+++ b/frontend/src/scenes/experiments/legacy/components/LegacyVariantTag.tsx
@@ -21,7 +21,7 @@ export function LegacyVariantTag({
     fontSize?: number
     className?: string
 }): JSX.Element {
-    const { experiment, legacyPrimaryMetricsResults, usesNewQueryRunner } = useValues(experimentLogic)
+    const { experiment, legacyPrimaryMetricsResults } = useValues(experimentLogic)
 
     if (variantKey === EXPERIMENT_VARIANT_MULTIPLE) {
         return (
@@ -58,14 +58,6 @@ export function LegacyVariantTag({
 
     return (
         <span className={clsx('flex items-center min-w-0', className)}>
-            {/* Only show color if using new query runner - legacy experiments are using the old funnel component */}
-            {usesNewQueryRunner && (
-                <div
-                    className="w-2 h-2 rounded-full shrink-0"
-                    // eslint-disable-next-line react/forbid-dom-props
-                    style={{ backgroundColor: variantColor }}
-                />
-            )}
             <span
                 className="ml-2 text-xs font-semibold truncate text-secondary"
                 // eslint-disable-next-line react/forbid-dom-props

--- a/frontend/src/scenes/experiments/legacy/metricsView/LegacyChartModal.tsx
+++ b/frontend/src/scenes/experiments/legacy/metricsView/LegacyChartModal.tsx
@@ -1,18 +1,6 @@
 import { LemonBanner, LemonButton, LemonModal } from '@posthog/lemon-ui'
 
-import {
-    ExperimentFunnelsQuery,
-    ExperimentMetric,
-    ExperimentTrendsQuery,
-    NodeKind,
-} from '~/queries/schema/schema-general'
-import {
-    ExploreAsInsightButton,
-    ResultsBreakdown,
-    ResultsBreakdownSkeleton,
-    ResultsInsightInfoBanner,
-    ResultsQuery,
-} from '~/scenes/experiments/components/ResultsBreakdown'
+import { ExperimentFunnelsQuery, ExperimentTrendsQuery } from '~/queries/schema/schema-general'
 import type { Experiment } from '~/types'
 
 import { LegacyExploreButton } from '../components/LegacyExploreButton'
@@ -23,7 +11,7 @@ import { LegacyWinningVariantText, LegacySignificanceText } from './LegacyOvervi
 interface LegacyChartModalProps {
     isOpen: boolean
     onClose: () => void
-    metric: ExperimentMetric | ExperimentTrendsQuery | ExperimentFunnelsQuery
+    metric: ExperimentTrendsQuery | ExperimentFunnelsQuery
     displayOrder: number
     isSecondary: boolean
     result: any
@@ -44,77 +32,33 @@ export function LegacyChartModal({
     result,
     experiment,
 }: LegacyChartModalProps): JSX.Element {
-    const isLegacyResult =
-        result && (result.kind === NodeKind.ExperimentTrendsQuery || result.kind === NodeKind.ExperimentFunnelsQuery)
+    // Get metric uuid from experiment metrics array using displayOrder
+    const metricsList = isSecondary ? experiment.metrics_secondary : experiment.metrics
+    const metricUuid = metricsList[displayOrder]?.uuid || ''
 
     return (
         <LemonModal
             isOpen={isOpen}
             onClose={onClose}
             width={1200}
-            title={`Metric results: ${metric.name || 'Untitled metric'}`}
+            title="Metric results"
             footer={
                 <LemonButton type="secondary" onClick={onClose}>
                     Close
                 </LemonButton>
             }
         >
-            {isLegacyResult ? (
-                <>
-                    <div className="flex justify-end">
-                        <LegacyExploreButton result={result} />
-                    </div>
-                    <LemonBanner type={result?.significant ? 'success' : 'info'} className="mb-4">
-                        <div className="items-center inline-flex flex-wrap">
-                            <LegacyWinningVariantText result={result} />
-                            <LegacySignificanceText metricUuid={metric.uuid || ''} isSecondary={isSecondary} />
-                        </div>
-                    </LemonBanner>
-                    <LegacySummaryTable metric={metric} displayOrder={displayOrder} isSecondary={isSecondary} />
-                    <LegacyResultsQuery result={result} showTable={true} />
-                </>
-            ) : (
-                <ResultsBreakdown
-                    result={result}
-                    experiment={experiment}
-                    metricUuid={metric.uuid || ''}
-                    isPrimary={!isSecondary}
-                >
-                    {({
-                        query,
-                        breakdownResults,
-                        breakdownResultsLoading,
-                        exposureDifference,
-                        breakdownLastRefresh,
-                    }) => (
-                        <>
-                            {query && (
-                                <div className="flex justify-end">
-                                    <ExploreAsInsightButton query={query} />
-                                </div>
-                            )}
-                            <LemonBanner type={result?.significant ? 'success' : 'info'} className="mb-4">
-                                <div className="items-center inline-flex flex-wrap">
-                                    <LegacyWinningVariantText result={result} />
-                                    <LegacySignificanceText metricUuid={metric.uuid || ''} isSecondary={isSecondary} />
-                                </div>
-                            </LemonBanner>
-                            <LegacySummaryTable metric={metric} displayOrder={displayOrder} isSecondary={isSecondary} />
-                            {breakdownResultsLoading && <ResultsBreakdownSkeleton />}
-                            {query && breakdownResults && (
-                                <>
-                                    <ResultsInsightInfoBanner exposureDifference={exposureDifference} />
-                                    <ResultsQuery
-                                        query={query}
-                                        breakdownResults={breakdownResults}
-                                        breakdownLastRefresh={breakdownLastRefresh}
-                                    />
-                                </>
-                            )}
-                        </>
-                    )}
-                </ResultsBreakdown>
-            )}
+            <div className="flex justify-end">
+                <LegacyExploreButton result={result} />
+            </div>
+            <LemonBanner type={result?.significant ? 'success' : 'info'} className="mb-4">
+                <div className="items-center inline-flex flex-wrap">
+                    <LegacyWinningVariantText result={result} />
+                    <LegacySignificanceText metricUuid={metricUuid} isSecondary={isSecondary} />
+                </div>
+            </LemonBanner>
+            <LegacySummaryTable metric={metric} displayOrder={displayOrder} isSecondary={isSecondary} />
+            <LegacyResultsQuery result={result} showTable={true} />
         </LemonModal>
     )
 }

--- a/frontend/src/scenes/experiments/legacy/metricsView/LegacyDeltaChart.tsx
+++ b/frontend/src/scenes/experiments/legacy/metricsView/LegacyDeltaChart.tsx
@@ -7,11 +7,14 @@ import { LemonButton } from '@posthog/lemon-ui'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { modalsLogic } from 'scenes/experiments/modalsLogic'
 
+import {
+    EXPERIMENT_MIN_EXPOSURES_FOR_RESULTS,
+    EXPERIMENT_MIN_METRIC_VALUE_FOR_RESULTS,
+} from '~/scenes/experiments/constants'
 import { experimentLogic } from '~/scenes/experiments/experimentLogic'
 import { isLaunched } from '~/scenes/experiments/experimentsLogic'
 import { Experiment, FunnelExperimentVariant, InsightType, TrendExperimentVariant } from '~/types'
 
-import { EXPERIMENT_MIN_EXPOSURES_FOR_RESULTS, EXPERIMENT_MIN_METRIC_VALUE_FOR_RESULTS } from '../../constants'
 import {
     legacyCalculateDelta,
     legacyConversionRateForVariant,

--- a/frontend/src/scenes/experiments/legacy/metricsView/LegacyErrorChecklist.tsx
+++ b/frontend/src/scenes/experiments/legacy/metricsView/LegacyErrorChecklist.tsx
@@ -8,9 +8,8 @@ import { IconOpenInNew } from 'lib/lemon-ui/icons'
 import { urls } from 'scenes/urls'
 
 import { NodeKind } from '~/queries/schema/schema-general'
+import { experimentLogic } from '~/scenes/experiments/experimentLogic'
 import { ActivityTab, InsightType } from '~/types'
-
-import { experimentLogic } from '../../experimentLogic'
 
 export enum ResultErrorCode {
     NO_CONTROL_VARIANT = 'no-control-variant',

--- a/frontend/src/scenes/experiments/legacy/sharedMetrics/LegacySharedFunnelsMetricForm.tsx
+++ b/frontend/src/scenes/experiments/legacy/sharedMetrics/LegacySharedFunnelsMetricForm.tsx
@@ -14,15 +14,14 @@ import { actionsAndEventsToSeries } from '~/queries/nodes/InsightQuery/utils/fil
 import { queryNodeToFilter } from '~/queries/nodes/InsightQuery/utils/queryNodeToFilter'
 import { Query } from '~/queries/Query/Query'
 import { ExperimentFunnelsQuery, NodeKind } from '~/queries/schema/schema-general'
-import { BreakdownAttributionType, FilterType } from '~/types'
-
 import {
     FunnelAggregationSelect,
     FunnelAttributionSelect,
     FunnelConversionWindowFilter,
     commonActionFilterProps,
-} from '../../Metrics/Selectors'
-import { sharedMetricLogic } from '../../SharedMetrics/sharedMetricLogic'
+} from '~/scenes/experiments/Metrics/Selectors'
+import { sharedMetricLogic } from '~/scenes/experiments/SharedMetrics/sharedMetricLogic'
+import { BreakdownAttributionType, FilterType } from '~/types'
 
 export function LegacySharedFunnelsMetricForm(): JSX.Element {
     const { sharedMetric } = useValues(sharedMetricLogic)

--- a/frontend/src/scenes/experiments/legacy/sharedMetrics/LegacySharedTrendsMetricForm.tsx
+++ b/frontend/src/scenes/experiments/legacy/sharedMetrics/LegacySharedTrendsMetricForm.tsx
@@ -15,11 +15,10 @@ import { actionsAndEventsToSeries } from '~/queries/nodes/InsightQuery/utils/fil
 import { queryNodeToFilter } from '~/queries/nodes/InsightQuery/utils/queryNodeToFilter'
 import { Query } from '~/queries/Query/Query'
 import { ExperimentTrendsQuery, InsightQueryNode, NodeKind } from '~/queries/schema/schema-general'
+import { LEGACY_EXPERIMENT_ALLOWED_MATH_TYPES } from '~/scenes/experiments/constants'
+import { commonActionFilterProps } from '~/scenes/experiments/Metrics/Selectors'
+import { sharedMetricLogic } from '~/scenes/experiments/SharedMetrics/sharedMetricLogic'
 import { BaseMathType, ChartDisplayType, FilterType } from '~/types'
-
-import { LEGACY_EXPERIMENT_ALLOWED_MATH_TYPES } from '../../constants'
-import { commonActionFilterProps } from '../../Metrics/Selectors'
-import { sharedMetricLogic } from '../../SharedMetrics/sharedMetricLogic'
 
 export function LegacySharedTrendsMetricForm(): JSX.Element {
     const { sharedMetric } = useValues(sharedMetricLogic)

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -20984,6 +20984,21 @@ class WebVitalsQuery(BaseModel):
     version: float | None = Field(default=None, description="version of the node, used for schema migrations")
 
 
+class NamedArgs1(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    query: ExperimentTrendsQuery | ExperimentFunnelsQuery
+
+
+class IsExperimentFunnelsQuery(BaseModel):
+    namedArgs: NamedArgs1 | None = None
+
+
+class IsExperimentTrendsQuery(BaseModel):
+    namedArgs: NamedArgs1 | None = None
+
+
 class EndpointRequest(BaseModel):
     model_config = ConfigDict(
         extra="forbid",


### PR DESCRIPTION
## Problem

The duplicated shared components have codepaths associated with the `ExperimentMetric` type. We need to remove this unused code from the legacy components.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

We are removing unused code from the duplicated shared components that handle the `ExperimentMetric` case. Eventually, we'll do the same with the original components, but by removing the legacy code path.
We add a new type guard for `ExperimentTrendsQuery` and `ExperimentFunnelsQuery`, so we can simplify some of the code when selecting between query types in a type-safe fashion. This will be used in future PRs.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

![cat-type](https://github.com/user-attachments/assets/0fb11daf-9889-450c-87e1-37f824e1a6fb)

<!-- Briefly describe the steps you took, and what steps reviewers must take to get to where changes are, and what is the expected behavior. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

do not publish to changelog

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
