### PR TITLE
fix(mcp): limit output of the cohort list

### DIFF
--- a/products/cohorts/mcp/tools.yaml
+++ b/products/cohorts/mcp/tools.yaml
@@ -28,8 +28,11 @@ tools:
         list: true
         title: List all cohorts
         description: >
-            List all cohorts in the project. Returns a summary of each cohort (name, description, count, type).
+
+            List all cohorts in the project. Returns a summary of each cohort including 
+            id, name, description, count (person count), is_static (cohort type), and created_at timestamp.
             Use 'cohorts-retrieve' with the cohort ID to get full details including filters, calculation status,
+
             and query definition.
         response:
             include:

--- a/products/cohorts/mcp/tools.yaml
+++ b/products/cohorts/mcp/tools.yaml
@@ -28,8 +28,17 @@ tools:
         list: true
         title: List all cohorts
         description: >
-            List all cohorts in the project. Returns both static cohorts (manually defined user lists) and dynamic
-            cohorts (automatically updated based on property filters).
+            List all cohorts in the project. Returns a summary of each cohort (name, description, count, type).
+            Use 'cohorts-retrieve' with the cohort ID to get full details including filters, calculation status,
+            and query definition.
+        response:
+            include:
+                - id
+                - name
+                - description
+                - count
+                - is_static
+                - created_at
         ui_app: cohort-list
     cohorts-create:
         operation: cohorts_create

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -390,7 +390,7 @@
         }
     },
     "cohorts-list": {
-        "description": "List all cohorts in the project. Returns a summary of each cohort (name, description, count, type). Use 'cohorts-retrieve' with the cohort ID to get full details including filters, calculation status, and query definition.",
+        "description": "List all cohorts in the project. Returns a summary of each cohort including  id, name, description, count (person count), is_static (cohort type), and created_at timestamp. Use 'cohorts-retrieve' with the cohort ID to get full details including filters, calculation status,\nand query definition.",
         "category": "Cohorts",
         "feature": "cohorts",
         "summary": "List all cohorts",

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -390,7 +390,7 @@
         }
     },
     "cohorts-list": {
-        "description": "List all cohorts in the project. Returns both static cohorts (manually defined user lists) and dynamic cohorts (automatically updated based on property filters).",
+        "description": "List all cohorts in the project. Returns a summary of each cohort (name, description, count, type). Use 'cohorts-retrieve' with the cohort ID to get full details including filters, calculation status, and query definition.",
         "category": "Cohorts",
         "feature": "cohorts",
         "summary": "List all cohorts",

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -1090,7 +1090,7 @@
         }
     },
     "cohorts-list": {
-        "description": "List all cohorts in the project. Returns both static cohorts (manually defined user lists) and dynamic cohorts (automatically updated based on property filters).",
+        "description": "List all cohorts in the project. Returns a summary of each cohort (name, description, count, type). Use 'cohorts-retrieve' with the cohort ID to get full details including filters, calculation status, and query definition.",
         "category": "Cohorts",
         "feature": "cohorts",
         "summary": "List all cohorts",

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -1090,7 +1090,7 @@
         }
     },
     "cohorts-list": {
-        "description": "List all cohorts in the project. Returns a summary of each cohort (name, description, count, type). Use 'cohorts-retrieve' with the cohort ID to get full details including filters, calculation status, and query definition.",
+        "description": "List all cohorts in the project. Returns a summary of each cohort including  id, name, description, count (person count), is_static (cohort type), and created_at timestamp. Use 'cohorts-retrieve' with the cohort ID to get full details including filters, calculation status,\nand query definition.",
         "category": "Cohorts",
         "feature": "cohorts",
         "summary": "List all cohorts",

--- a/services/mcp/src/tools/generated/cohorts.ts
+++ b/services/mcp/src/tools/generated/cohorts.ts
@@ -1,7 +1,7 @@
 // AUTO-GENERATED from products/cohorts/mcp/tools.yaml + OpenAPI — do not edit
-import { z } from 'zod'
+import { z } from "zod";
 
-import type { Schemas } from '@/api/generated'
+import type { Schemas } from "@/api/generated";
 import {
     CohortsAddPersonsToStaticCohortPartialUpdateBody,
     CohortsAddPersonsToStaticCohortPartialUpdateParams,
@@ -12,188 +12,270 @@ import {
     CohortsRemovePersonFromStaticCohortPartialUpdateBody,
     CohortsRemovePersonFromStaticCohortPartialUpdateParams,
     CohortsRetrieveParams,
-} from '@/generated/cohorts/api'
-import { withUiApp } from '@/resources/ui-apps'
-import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
+} from "@/generated/cohorts/api";
+import { withUiApp } from "@/resources/ui-apps";
+import {
+    withPostHogUrl,
+    pickResponseFields,
+    type WithPostHogUrl,
+} from "@/tools/tool-utils";
+import type { Context, ToolBase, ZodObjectAny } from "@/tools/types";
 
-const CohortsListSchema = CohortsListQueryParams
+const CohortsListSchema = CohortsListQueryParams;
 
-const cohortsList = (): ToolBase<typeof CohortsListSchema, WithPostHogUrl<Schemas.PaginatedCohortList>> =>
-    withUiApp('cohort-list', {
-        name: 'cohorts-list',
+const cohortsList = (): ToolBase<
+    typeof CohortsListSchema,
+    WithPostHogUrl<Schemas.PaginatedCohortList>
+> =>
+    withUiApp("cohort-list", {
+        name: "cohorts-list",
         schema: CohortsListSchema,
-        handler: async (context: Context, params: z.infer<typeof CohortsListSchema>) => {
-            const projectId = await context.stateManager.getProjectId()
-            const result = await context.api.request<Schemas.PaginatedCohortList>({
-                method: 'GET',
-                path: `/api/projects/${projectId}/cohorts/`,
-                query: {
-                    limit: params.limit,
-                    offset: params.offset,
-                },
-            })
+        handler: async (
+            context: Context,
+            params: z.infer<typeof CohortsListSchema>,
+        ) => {
+            const projectId = await context.stateManager.getProjectId();
+            const result =
+                await context.api.request<Schemas.PaginatedCohortList>({
+                    method: "GET",
+                    path: `/api/projects/${projectId}/cohorts/`,
+                    query: {
+                        limit: params.limit,
+                        offset: params.offset,
+                    },
+                });
+            const filtered = {
+                ...result,
+                results: result.results.map((item: any) =>
+                    pickResponseFields(item, [
+                        "id",
+                        "name",
+                        "description",
+                        "count",
+                        "is_static",
+                        "created_at",
+                    ]),
+                ),
+            } as typeof result;
             return await withPostHogUrl(
                 context,
                 {
-                    ...result,
+                    ...filtered,
                     results: await Promise.all(
-                        result.results.map((item) => withPostHogUrl(context, item, `/cohorts/${item.id}`))
+                        filtered.results.map((item) =>
+                            withPostHogUrl(
+                                context,
+                                item,
+                                `/cohorts/${item.id}`,
+                            ),
+                        ),
                     ),
                 },
-                '/cohorts'
-            )
+                "/cohorts",
+            );
         },
-    })
+    });
 
-const CohortsCreateSchema = CohortsCreateBody.omit({ _create_in_folder: true, _create_static_person_ids: true })
+const CohortsCreateSchema = CohortsCreateBody.omit({
+    _create_in_folder: true,
+    _create_static_person_ids: true,
+});
 
-const cohortsCreate = (): ToolBase<typeof CohortsCreateSchema, WithPostHogUrl<Schemas.Cohort>> =>
-    withUiApp('cohort', {
-        name: 'cohorts-create',
+const cohortsCreate = (): ToolBase<
+    typeof CohortsCreateSchema,
+    WithPostHogUrl<Schemas.Cohort>
+> =>
+    withUiApp("cohort", {
+        name: "cohorts-create",
         schema: CohortsCreateSchema,
-        handler: async (context: Context, params: z.infer<typeof CohortsCreateSchema>) => {
-            const projectId = await context.stateManager.getProjectId()
-            const body: Record<string, unknown> = {}
+        handler: async (
+            context: Context,
+            params: z.infer<typeof CohortsCreateSchema>,
+        ) => {
+            const projectId = await context.stateManager.getProjectId();
+            const body: Record<string, unknown> = {};
             if (params.name !== undefined) {
-                body['name'] = params.name
+                body["name"] = params.name;
             }
             if (params.description !== undefined) {
-                body['description'] = params.description
+                body["description"] = params.description;
             }
             if (params.filters !== undefined) {
-                body['filters'] = params.filters
+                body["filters"] = params.filters;
             }
             if (params.query !== undefined) {
-                body['query'] = params.query
+                body["query"] = params.query;
             }
             if (params.is_static !== undefined) {
-                body['is_static'] = params.is_static
+                body["is_static"] = params.is_static;
             }
             if (params.cohort_type !== undefined) {
-                body['cohort_type'] = params.cohort_type
+                body["cohort_type"] = params.cohort_type;
             }
             const result = await context.api.request<Schemas.Cohort>({
-                method: 'POST',
+                method: "POST",
                 path: `/api/projects/${projectId}/cohorts/`,
                 body,
-            })
-            return await withPostHogUrl(context, result, `/cohorts/${result.id}`)
+            });
+            return await withPostHogUrl(
+                context,
+                result,
+                `/cohorts/${result.id}`,
+            );
         },
-    })
+    });
 
-const CohortsRetrieveSchema = CohortsRetrieveParams.omit({ project_id: true })
+const CohortsRetrieveSchema = CohortsRetrieveParams.omit({ project_id: true });
 
-const cohortsRetrieve = (): ToolBase<typeof CohortsRetrieveSchema, WithPostHogUrl<Schemas.Cohort>> =>
-    withUiApp('cohort', {
-        name: 'cohorts-retrieve',
+const cohortsRetrieve = (): ToolBase<
+    typeof CohortsRetrieveSchema,
+    WithPostHogUrl<Schemas.Cohort>
+> =>
+    withUiApp("cohort", {
+        name: "cohorts-retrieve",
         schema: CohortsRetrieveSchema,
-        handler: async (context: Context, params: z.infer<typeof CohortsRetrieveSchema>) => {
-            const projectId = await context.stateManager.getProjectId()
+        handler: async (
+            context: Context,
+            params: z.infer<typeof CohortsRetrieveSchema>,
+        ) => {
+            const projectId = await context.stateManager.getProjectId();
             const result = await context.api.request<Schemas.Cohort>({
-                method: 'GET',
+                method: "GET",
                 path: `/api/projects/${projectId}/cohorts/${params.id}/`,
-            })
-            return await withPostHogUrl(context, result, `/cohorts/${result.id}`)
+            });
+            return await withPostHogUrl(
+                context,
+                result,
+                `/cohorts/${result.id}`,
+            );
         },
-    })
+    });
 
-const CohortsPartialUpdateSchema = CohortsPartialUpdateParams.omit({ project_id: true }).extend(
-    CohortsPartialUpdateBody.omit({ _create_in_folder: true, _create_static_person_ids: true }).shape
-)
+const CohortsPartialUpdateSchema = CohortsPartialUpdateParams.omit({
+    project_id: true,
+}).extend(
+    CohortsPartialUpdateBody.omit({
+        _create_in_folder: true,
+        _create_static_person_ids: true,
+    }).shape,
+);
 
-const cohortsPartialUpdate = (): ToolBase<typeof CohortsPartialUpdateSchema, WithPostHogUrl<Schemas.Cohort>> =>
-    withUiApp('cohort', {
-        name: 'cohorts-partial-update',
+const cohortsPartialUpdate = (): ToolBase<
+    typeof CohortsPartialUpdateSchema,
+    WithPostHogUrl<Schemas.Cohort>
+> =>
+    withUiApp("cohort", {
+        name: "cohorts-partial-update",
         schema: CohortsPartialUpdateSchema,
-        handler: async (context: Context, params: z.infer<typeof CohortsPartialUpdateSchema>) => {
-            const projectId = await context.stateManager.getProjectId()
-            const body: Record<string, unknown> = {}
+        handler: async (
+            context: Context,
+            params: z.infer<typeof CohortsPartialUpdateSchema>,
+        ) => {
+            const projectId = await context.stateManager.getProjectId();
+            const body: Record<string, unknown> = {};
             if (params.name !== undefined) {
-                body['name'] = params.name
+                body["name"] = params.name;
             }
             if (params.description !== undefined) {
-                body['description'] = params.description
+                body["description"] = params.description;
             }
             if (params.deleted !== undefined) {
-                body['deleted'] = params.deleted
+                body["deleted"] = params.deleted;
             }
             if (params.filters !== undefined) {
-                body['filters'] = params.filters
+                body["filters"] = params.filters;
             }
             if (params.query !== undefined) {
-                body['query'] = params.query
+                body["query"] = params.query;
             }
             if (params.is_static !== undefined) {
-                body['is_static'] = params.is_static
+                body["is_static"] = params.is_static;
             }
             if (params.cohort_type !== undefined) {
-                body['cohort_type'] = params.cohort_type
+                body["cohort_type"] = params.cohort_type;
             }
             const result = await context.api.request<Schemas.Cohort>({
-                method: 'PATCH',
+                method: "PATCH",
                 path: `/api/projects/${projectId}/cohorts/${params.id}/`,
                 body,
-            })
-            return await withPostHogUrl(context, result, `/cohorts/${result.id}`)
+            });
+            return await withPostHogUrl(
+                context,
+                result,
+                `/cohorts/${result.id}`,
+            );
         },
-    })
+    });
 
-const CohortsAddPersonsToStaticCohortPartialUpdateSchema = CohortsAddPersonsToStaticCohortPartialUpdateParams.omit({
-    project_id: true,
-}).extend(CohortsAddPersonsToStaticCohortPartialUpdateBody.shape)
+const CohortsAddPersonsToStaticCohortPartialUpdateSchema =
+    CohortsAddPersonsToStaticCohortPartialUpdateParams.omit({
+        project_id: true,
+    }).extend(CohortsAddPersonsToStaticCohortPartialUpdateBody.shape);
 
 const cohortsAddPersonsToStaticCohortPartialUpdate = (): ToolBase<
     typeof CohortsAddPersonsToStaticCohortPartialUpdateSchema,
     unknown
 > => ({
-    name: 'cohorts-add-persons-to-static-cohort-partial-update',
+    name: "cohorts-add-persons-to-static-cohort-partial-update",
     schema: CohortsAddPersonsToStaticCohortPartialUpdateSchema,
-    handler: async (context: Context, params: z.infer<typeof CohortsAddPersonsToStaticCohortPartialUpdateSchema>) => {
-        const projectId = await context.stateManager.getProjectId()
-        const body: Record<string, unknown> = {}
+    handler: async (
+        context: Context,
+        params: z.infer<
+            typeof CohortsAddPersonsToStaticCohortPartialUpdateSchema
+        >,
+    ) => {
+        const projectId = await context.stateManager.getProjectId();
+        const body: Record<string, unknown> = {};
         if (params.person_ids !== undefined) {
-            body['person_ids'] = params.person_ids
+            body["person_ids"] = params.person_ids;
         }
         const result = await context.api.request<unknown>({
-            method: 'PATCH',
+            method: "PATCH",
             path: `/api/projects/${projectId}/cohorts/${params.id}/add_persons_to_static_cohort/`,
             body,
-        })
-        return result
+        });
+        return result;
     },
-})
+});
 
-const CohortsRmPersonFromStaticCohortPartialUpdateSchema = CohortsRemovePersonFromStaticCohortPartialUpdateParams.omit({
-    project_id: true,
-}).extend(CohortsRemovePersonFromStaticCohortPartialUpdateBody.shape)
+const CohortsRmPersonFromStaticCohortPartialUpdateSchema =
+    CohortsRemovePersonFromStaticCohortPartialUpdateParams.omit({
+        project_id: true,
+    }).extend(CohortsRemovePersonFromStaticCohortPartialUpdateBody.shape);
 
 const cohortsRmPersonFromStaticCohortPartialUpdate = (): ToolBase<
     typeof CohortsRmPersonFromStaticCohortPartialUpdateSchema,
     unknown
 > => ({
-    name: 'cohorts-rm-person-from-static-cohort-partial-update',
+    name: "cohorts-rm-person-from-static-cohort-partial-update",
     schema: CohortsRmPersonFromStaticCohortPartialUpdateSchema,
-    handler: async (context: Context, params: z.infer<typeof CohortsRmPersonFromStaticCohortPartialUpdateSchema>) => {
-        const projectId = await context.stateManager.getProjectId()
-        const body: Record<string, unknown> = {}
+    handler: async (
+        context: Context,
+        params: z.infer<
+            typeof CohortsRmPersonFromStaticCohortPartialUpdateSchema
+        >,
+    ) => {
+        const projectId = await context.stateManager.getProjectId();
+        const body: Record<string, unknown> = {};
         if (params.person_id !== undefined) {
-            body['person_id'] = params.person_id
+            body["person_id"] = params.person_id;
         }
         const result = await context.api.request<unknown>({
-            method: 'PATCH',
+            method: "PATCH",
             path: `/api/projects/${projectId}/cohorts/${params.id}/remove_person_from_static_cohort/`,
             body,
-        })
-        return result
+        });
+        return result;
     },
-})
+});
 
 export const GENERATED_TOOLS: Record<string, () => ToolBase<ZodObjectAny>> = {
-    'cohorts-list': cohortsList,
-    'cohorts-create': cohortsCreate,
-    'cohorts-retrieve': cohortsRetrieve,
-    'cohorts-partial-update': cohortsPartialUpdate,
-    'cohorts-add-persons-to-static-cohort-partial-update': cohortsAddPersonsToStaticCohortPartialUpdate,
-    'cohorts-rm-person-from-static-cohort-partial-update': cohortsRmPersonFromStaticCohortPartialUpdate,
-}
+    "cohorts-list": cohortsList,
+    "cohorts-create": cohortsCreate,
+    "cohorts-retrieve": cohortsRetrieve,
+    "cohorts-partial-update": cohortsPartialUpdate,
+    "cohorts-add-persons-to-static-cohort-partial-update":
+        cohortsAddPersonsToStaticCohortPartialUpdate,
+    "cohorts-rm-person-from-static-cohort-partial-update":
+        cohortsRmPersonFromStaticCohortPartialUpdate,
+};

--- a/services/mcp/src/tools/generated/cohorts.ts
+++ b/services/mcp/src/tools/generated/cohorts.ts
@@ -1,7 +1,7 @@
 // AUTO-GENERATED from products/cohorts/mcp/tools.yaml + OpenAPI — do not edit
-import { z } from "zod";
+import { z } from 'zod'
 
-import type { Schemas } from "@/api/generated";
+import type { Schemas } from '@/api/generated'
 import {
     CohortsAddPersonsToStaticCohortPartialUpdateBody,
     CohortsAddPersonsToStaticCohortPartialUpdateParams,
@@ -12,270 +12,194 @@ import {
     CohortsRemovePersonFromStaticCohortPartialUpdateBody,
     CohortsRemovePersonFromStaticCohortPartialUpdateParams,
     CohortsRetrieveParams,
-} from "@/generated/cohorts/api";
-import { withUiApp } from "@/resources/ui-apps";
-import {
-    withPostHogUrl,
-    pickResponseFields,
-    type WithPostHogUrl,
-} from "@/tools/tool-utils";
-import type { Context, ToolBase, ZodObjectAny } from "@/tools/types";
+} from '@/generated/cohorts/api'
+import { withUiApp } from '@/resources/ui-apps'
+import { withPostHogUrl, pickResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
-const CohortsListSchema = CohortsListQueryParams;
+const CohortsListSchema = CohortsListQueryParams
 
-const cohortsList = (): ToolBase<
-    typeof CohortsListSchema,
-    WithPostHogUrl<Schemas.PaginatedCohortList>
-> =>
-    withUiApp("cohort-list", {
-        name: "cohorts-list",
+const cohortsList = (): ToolBase<typeof CohortsListSchema, WithPostHogUrl<Schemas.PaginatedCohortList>> =>
+    withUiApp('cohort-list', {
+        name: 'cohorts-list',
         schema: CohortsListSchema,
-        handler: async (
-            context: Context,
-            params: z.infer<typeof CohortsListSchema>,
-        ) => {
-            const projectId = await context.stateManager.getProjectId();
-            const result =
-                await context.api.request<Schemas.PaginatedCohortList>({
-                    method: "GET",
-                    path: `/api/projects/${projectId}/cohorts/`,
-                    query: {
-                        limit: params.limit,
-                        offset: params.offset,
-                    },
-                });
+        handler: async (context: Context, params: z.infer<typeof CohortsListSchema>) => {
+            const projectId = await context.stateManager.getProjectId()
+            const result = await context.api.request<Schemas.PaginatedCohortList>({
+                method: 'GET',
+                path: `/api/projects/${projectId}/cohorts/`,
+                query: {
+                    limit: params.limit,
+                    offset: params.offset,
+                },
+            })
             const filtered = {
                 ...result,
                 results: result.results.map((item: any) =>
-                    pickResponseFields(item, [
-                        "id",
-                        "name",
-                        "description",
-                        "count",
-                        "is_static",
-                        "created_at",
-                    ]),
+                    pickResponseFields(item, ['id', 'name', 'description', 'count', 'is_static', 'created_at'])
                 ),
-            } as typeof result;
+            } as typeof result
             return await withPostHogUrl(
                 context,
                 {
                     ...filtered,
                     results: await Promise.all(
-                        filtered.results.map((item) =>
-                            withPostHogUrl(
-                                context,
-                                item,
-                                `/cohorts/${item.id}`,
-                            ),
-                        ),
+                        filtered.results.map((item) => withPostHogUrl(context, item, `/cohorts/${item.id}`))
                     ),
                 },
-                "/cohorts",
-            );
+                '/cohorts'
+            )
         },
-    });
+    })
 
-const CohortsCreateSchema = CohortsCreateBody.omit({
-    _create_in_folder: true,
-    _create_static_person_ids: true,
-});
+const CohortsCreateSchema = CohortsCreateBody.omit({ _create_in_folder: true, _create_static_person_ids: true })
 
-const cohortsCreate = (): ToolBase<
-    typeof CohortsCreateSchema,
-    WithPostHogUrl<Schemas.Cohort>
-> =>
-    withUiApp("cohort", {
-        name: "cohorts-create",
+const cohortsCreate = (): ToolBase<typeof CohortsCreateSchema, WithPostHogUrl<Schemas.Cohort>> =>
+    withUiApp('cohort', {
+        name: 'cohorts-create',
         schema: CohortsCreateSchema,
-        handler: async (
-            context: Context,
-            params: z.infer<typeof CohortsCreateSchema>,
-        ) => {
-            const projectId = await context.stateManager.getProjectId();
-            const body: Record<string, unknown> = {};
+        handler: async (context: Context, params: z.infer<typeof CohortsCreateSchema>) => {
+            const projectId = await context.stateManager.getProjectId()
+            const body: Record<string, unknown> = {}
             if (params.name !== undefined) {
-                body["name"] = params.name;
+                body['name'] = params.name
             }
             if (params.description !== undefined) {
-                body["description"] = params.description;
+                body['description'] = params.description
             }
             if (params.filters !== undefined) {
-                body["filters"] = params.filters;
+                body['filters'] = params.filters
             }
             if (params.query !== undefined) {
-                body["query"] = params.query;
+                body['query'] = params.query
             }
             if (params.is_static !== undefined) {
-                body["is_static"] = params.is_static;
+                body['is_static'] = params.is_static
             }
             if (params.cohort_type !== undefined) {
-                body["cohort_type"] = params.cohort_type;
+                body['cohort_type'] = params.cohort_type
             }
             const result = await context.api.request<Schemas.Cohort>({
-                method: "POST",
+                method: 'POST',
                 path: `/api/projects/${projectId}/cohorts/`,
                 body,
-            });
-            return await withPostHogUrl(
-                context,
-                result,
-                `/cohorts/${result.id}`,
-            );
+            })
+            return await withPostHogUrl(context, result, `/cohorts/${result.id}`)
         },
-    });
+    })
 
-const CohortsRetrieveSchema = CohortsRetrieveParams.omit({ project_id: true });
+const CohortsRetrieveSchema = CohortsRetrieveParams.omit({ project_id: true })
 
-const cohortsRetrieve = (): ToolBase<
-    typeof CohortsRetrieveSchema,
-    WithPostHogUrl<Schemas.Cohort>
-> =>
-    withUiApp("cohort", {
-        name: "cohorts-retrieve",
+const cohortsRetrieve = (): ToolBase<typeof CohortsRetrieveSchema, WithPostHogUrl<Schemas.Cohort>> =>
+    withUiApp('cohort', {
+        name: 'cohorts-retrieve',
         schema: CohortsRetrieveSchema,
-        handler: async (
-            context: Context,
-            params: z.infer<typeof CohortsRetrieveSchema>,
-        ) => {
-            const projectId = await context.stateManager.getProjectId();
+        handler: async (context: Context, params: z.infer<typeof CohortsRetrieveSchema>) => {
+            const projectId = await context.stateManager.getProjectId()
             const result = await context.api.request<Schemas.Cohort>({
-                method: "GET",
+                method: 'GET',
                 path: `/api/projects/${projectId}/cohorts/${params.id}/`,
-            });
-            return await withPostHogUrl(
-                context,
-                result,
-                `/cohorts/${result.id}`,
-            );
+            })
+            return await withPostHogUrl(context, result, `/cohorts/${result.id}`)
         },
-    });
+    })
 
-const CohortsPartialUpdateSchema = CohortsPartialUpdateParams.omit({
-    project_id: true,
-}).extend(
-    CohortsPartialUpdateBody.omit({
-        _create_in_folder: true,
-        _create_static_person_ids: true,
-    }).shape,
-);
+const CohortsPartialUpdateSchema = CohortsPartialUpdateParams.omit({ project_id: true }).extend(
+    CohortsPartialUpdateBody.omit({ _create_in_folder: true, _create_static_person_ids: true }).shape
+)
 
-const cohortsPartialUpdate = (): ToolBase<
-    typeof CohortsPartialUpdateSchema,
-    WithPostHogUrl<Schemas.Cohort>
-> =>
-    withUiApp("cohort", {
-        name: "cohorts-partial-update",
+const cohortsPartialUpdate = (): ToolBase<typeof CohortsPartialUpdateSchema, WithPostHogUrl<Schemas.Cohort>> =>
+    withUiApp('cohort', {
+        name: 'cohorts-partial-update',
         schema: CohortsPartialUpdateSchema,
-        handler: async (
-            context: Context,
-            params: z.infer<typeof CohortsPartialUpdateSchema>,
-        ) => {
-            const projectId = await context.stateManager.getProjectId();
-            const body: Record<string, unknown> = {};
+        handler: async (context: Context, params: z.infer<typeof CohortsPartialUpdateSchema>) => {
+            const projectId = await context.stateManager.getProjectId()
+            const body: Record<string, unknown> = {}
             if (params.name !== undefined) {
-                body["name"] = params.name;
+                body['name'] = params.name
             }
             if (params.description !== undefined) {
-                body["description"] = params.description;
+                body['description'] = params.description
             }
             if (params.deleted !== undefined) {
-                body["deleted"] = params.deleted;
+                body['deleted'] = params.deleted
             }
             if (params.filters !== undefined) {
-                body["filters"] = params.filters;
+                body['filters'] = params.filters
             }
             if (params.query !== undefined) {
-                body["query"] = params.query;
+                body['query'] = params.query
             }
             if (params.is_static !== undefined) {
-                body["is_static"] = params.is_static;
+                body['is_static'] = params.is_static
             }
             if (params.cohort_type !== undefined) {
-                body["cohort_type"] = params.cohort_type;
+                body['cohort_type'] = params.cohort_type
             }
             const result = await context.api.request<Schemas.Cohort>({
-                method: "PATCH",
+                method: 'PATCH',
                 path: `/api/projects/${projectId}/cohorts/${params.id}/`,
                 body,
-            });
-            return await withPostHogUrl(
-                context,
-                result,
-                `/cohorts/${result.id}`,
-            );
+            })
+            return await withPostHogUrl(context, result, `/cohorts/${result.id}`)
         },
-    });
+    })
 
-const CohortsAddPersonsToStaticCohortPartialUpdateSchema =
-    CohortsAddPersonsToStaticCohortPartialUpdateParams.omit({
-        project_id: true,
-    }).extend(CohortsAddPersonsToStaticCohortPartialUpdateBody.shape);
+const CohortsAddPersonsToStaticCohortPartialUpdateSchema = CohortsAddPersonsToStaticCohortPartialUpdateParams.omit({
+    project_id: true,
+}).extend(CohortsAddPersonsToStaticCohortPartialUpdateBody.shape)
 
 const cohortsAddPersonsToStaticCohortPartialUpdate = (): ToolBase<
     typeof CohortsAddPersonsToStaticCohortPartialUpdateSchema,
     unknown
 > => ({
-    name: "cohorts-add-persons-to-static-cohort-partial-update",
+    name: 'cohorts-add-persons-to-static-cohort-partial-update',
     schema: CohortsAddPersonsToStaticCohortPartialUpdateSchema,
-    handler: async (
-        context: Context,
-        params: z.infer<
-            typeof CohortsAddPersonsToStaticCohortPartialUpdateSchema
-        >,
-    ) => {
-        const projectId = await context.stateManager.getProjectId();
-        const body: Record<string, unknown> = {};
+    handler: async (context: Context, params: z.infer<typeof CohortsAddPersonsToStaticCohortPartialUpdateSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const body: Record<string, unknown> = {}
         if (params.person_ids !== undefined) {
-            body["person_ids"] = params.person_ids;
+            body['person_ids'] = params.person_ids
         }
         const result = await context.api.request<unknown>({
-            method: "PATCH",
+            method: 'PATCH',
             path: `/api/projects/${projectId}/cohorts/${params.id}/add_persons_to_static_cohort/`,
             body,
-        });
-        return result;
+        })
+        return result
     },
-});
+})
 
-const CohortsRmPersonFromStaticCohortPartialUpdateSchema =
-    CohortsRemovePersonFromStaticCohortPartialUpdateParams.omit({
-        project_id: true,
-    }).extend(CohortsRemovePersonFromStaticCohortPartialUpdateBody.shape);
+const CohortsRmPersonFromStaticCohortPartialUpdateSchema = CohortsRemovePersonFromStaticCohortPartialUpdateParams.omit({
+    project_id: true,
+}).extend(CohortsRemovePersonFromStaticCohortPartialUpdateBody.shape)
 
 const cohortsRmPersonFromStaticCohortPartialUpdate = (): ToolBase<
     typeof CohortsRmPersonFromStaticCohortPartialUpdateSchema,
     unknown
 > => ({
-    name: "cohorts-rm-person-from-static-cohort-partial-update",
+    name: 'cohorts-rm-person-from-static-cohort-partial-update',
     schema: CohortsRmPersonFromStaticCohortPartialUpdateSchema,
-    handler: async (
-        context: Context,
-        params: z.infer<
-            typeof CohortsRmPersonFromStaticCohortPartialUpdateSchema
-        >,
-    ) => {
-        const projectId = await context.stateManager.getProjectId();
-        const body: Record<string, unknown> = {};
+    handler: async (context: Context, params: z.infer<typeof CohortsRmPersonFromStaticCohortPartialUpdateSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const body: Record<string, unknown> = {}
         if (params.person_id !== undefined) {
-            body["person_id"] = params.person_id;
+            body['person_id'] = params.person_id
         }
         const result = await context.api.request<unknown>({
-            method: "PATCH",
+            method: 'PATCH',
             path: `/api/projects/${projectId}/cohorts/${params.id}/remove_person_from_static_cohort/`,
             body,
-        });
-        return result;
+        })
+        return result
     },
-});
+})
 
 export const GENERATED_TOOLS: Record<string, () => ToolBase<ZodObjectAny>> = {
-    "cohorts-list": cohortsList,
-    "cohorts-create": cohortsCreate,
-    "cohorts-retrieve": cohortsRetrieve,
-    "cohorts-partial-update": cohortsPartialUpdate,
-    "cohorts-add-persons-to-static-cohort-partial-update":
-        cohortsAddPersonsToStaticCohortPartialUpdate,
-    "cohorts-rm-person-from-static-cohort-partial-update":
-        cohortsRmPersonFromStaticCohortPartialUpdate,
-};
+    'cohorts-list': cohortsList,
+    'cohorts-create': cohortsCreate,
+    'cohorts-retrieve': cohortsRetrieve,
+    'cohorts-partial-update': cohortsPartialUpdate,
+    'cohorts-add-persons-to-static-cohort-partial-update': cohortsAddPersonsToStaticCohortPartialUpdate,
+    'cohorts-rm-person-from-static-cohort-partial-update': cohortsRmPersonFromStaticCohortPartialUpdate,
+}


### PR DESCRIPTION
## Problem

The cohorts list endpoint returns excessive data that isn't needed for the summary view.

https://posthog.slack.com/archives/C06NZEZ7V3Q/p1775289660007189

## Changes

Output the id, name, description, type, person count, and created at fields.

## How did you test this code?

The changes are auto-generated code formatting and a straightforward utility function application. The `pickResponseFields` function is an existing utility already used elsewhere in the codebase. The schema definitions in the YAML and JSON files are automatically generated from the source code changes.

## Publish to changelog?

No