### PR TITLE
feat(cdp): Allow configurable max fetch retries

### DIFF
--- a/nodejs/src/cdp/services/batch-export-hog-function.service.ts
+++ b/nodejs/src/cdp/services/batch-export-hog-function.service.ts
@@ -88,7 +88,7 @@ export class BatchExportHogFunctionService {
         const invocation = createInvocation(globalsWithInputs, hogFunction)
         invocation.id = invocationId.toString()
 
-        const result = await this.hogExecutor.executeWithAsyncFunctions(invocation)
+        const result = await this.hogExecutor.executeWithAsyncFunctions(invocation, { maxFetchRetries: 0 })
 
         // TODO: Follow up - we might want to more accuratelt link an execution to the fact it came from a batch export
         // We have the parent_id but that overrides the function id which is not always what we want

--- a/nodejs/src/cdp/services/batch-export-hog-function.service.ts
+++ b/nodejs/src/cdp/services/batch-export-hog-function.service.ts
@@ -88,7 +88,7 @@ export class BatchExportHogFunctionService {
         const invocation = createInvocation(globalsWithInputs, hogFunction)
         invocation.id = invocationId.toString()
 
-        const result = await this.hogExecutor.executeWithAsyncFunctions(invocation, { maxFetchRetries: 0 })
+        const result = await this.hogExecutor.executeWithAsyncFunctions(invocation, { maxFetchRetries: 0 }) // Retries are handled by the batch export service
 
         // TODO: Follow up - we might want to more accuratelt link an execution to the fact it came from a batch export
         // We have the parent_id but that overrides the function id which is not always what we want

--- a/nodejs/src/cdp/services/hog-executor.service.test.ts
+++ b/nodejs/src/cdp/services/hog-executor.service.test.ts
@@ -1130,6 +1130,24 @@ describe('Hog Executor', () => {
             expect(result.invocation.queueScheduledAt).toBeUndefined()
         })
 
+        it('respects maxFetchRetries option to disable retries', async () => {
+            mockRequest.mockImplementation((req: any, res: any) => {
+                res.writeHead(500, { 'Content-Type': 'text/plain' })
+                res.end('server error')
+            })
+
+            const invocation = await createFetchInvocation({
+                url: `${baseUrl}/test`,
+                method: 'GET',
+            })
+
+            const result = await executor.executeFetch(invocation, { maxFetchRetries: 0 })
+
+            expect(result.error).toBeInstanceOf(Error)
+            expect(result.error!.message).toContain('HTTP fetch failed on attempt 1')
+            expect(result.invocation.queueScheduledAt).toBeUndefined()
+        })
+
         it('handles request errors', async () => {
             const invocation = await createFetchInvocation({
                 url: 'http://non-existent-host-name',

--- a/nodejs/src/cdp/services/hog-executor.service.test.ts
+++ b/nodejs/src/cdp/services/hog-executor.service.test.ts
@@ -1141,10 +1141,9 @@ describe('Hog Executor', () => {
                 method: 'GET',
             })
 
-            const result = await executor.executeFetch(invocation, { maxFetchRetries: 0 })
+            const result = await executor.executeWithAsyncFunctions(invocation, { maxFetchRetries: 0 })
 
-            // The executeFetch part considers this not finished from an overall hog function perspective
-            expect(result.finished).toBe(false)
+            expect(result.finished).toBe(true)
             expect(result.error).toBeInstanceOf(Error)
             expect(result.error!.message).toContain('HTTP fetch failed on attempt 1')
             expect(result.invocation.queueScheduledAt).toBeUndefined()

--- a/nodejs/src/cdp/services/hog-executor.service.test.ts
+++ b/nodejs/src/cdp/services/hog-executor.service.test.ts
@@ -1143,7 +1143,8 @@ describe('Hog Executor', () => {
 
             const result = await executor.executeFetch(invocation, { maxFetchRetries: 0 })
 
-            expect(result.finished).toBe(true)
+            // The executeFetch part considers this not finished from an overall hog function perspective
+            expect(result.finished).toBe(false)
             expect(result.error).toBeInstanceOf(Error)
             expect(result.error!.message).toContain('HTTP fetch failed on attempt 1')
             expect(result.invocation.queueScheduledAt).toBeUndefined()

--- a/nodejs/src/cdp/services/hog-executor.service.test.ts
+++ b/nodejs/src/cdp/services/hog-executor.service.test.ts
@@ -1143,6 +1143,7 @@ describe('Hog Executor', () => {
 
             const result = await executor.executeFetch(invocation, { maxFetchRetries: 0 })
 
+            expect(result.finished).toBe(true)
             expect(result.error).toBeInstanceOf(Error)
             expect(result.error!.message).toContain('HTTP fetch failed on attempt 1')
             expect(result.invocation.queueScheduledAt).toBeUndefined()

--- a/nodejs/src/cdp/services/hog-executor.service.ts
+++ b/nodejs/src/cdp/services/hog-executor.service.ts
@@ -175,6 +175,7 @@ export type HogExecutorExecuteOptions = {
 
 export type HogExecutorExecuteAsyncOptions = HogExecutorExecuteOptions & {
     maxAsyncFunctions?: number
+    maxFetchRetries?: number
 }
 
 export class HogExecutorService {
@@ -338,7 +339,7 @@ export class HogExecutorService {
                 }
 
                 if (queueParamsType === 'fetch') {
-                    result = await this.executeFetch(nextInvocation)
+                    result = await this.executeFetch(nextInvocation, options)
                 } else if (queueParamsType === 'email') {
                     result = await this.emailService.executeSendEmail(nextInvocation)
                 } else {
@@ -603,7 +604,8 @@ export class HogExecutorService {
 
     @instrumented('hog-executor.executeFetch')
     async executeFetch(
-        invocation: CyclotronJobInvocationHogFunction
+        invocation: CyclotronJobInvocationHogFunction,
+        options?: Pick<HogExecutorExecuteAsyncOptions, 'maxFetchRetries'>
     ): Promise<CyclotronJobInvocationResult<CyclotronJobInvocationHogFunction>> {
         const templateId = invocation.hogFunction.template_id ?? 'unknown'
         if (invocation.queueParameters?.type !== 'fetch') {
@@ -693,7 +695,8 @@ export class HogExecutorService {
 
             addLog('error', message)
 
-            if (canRetry && result.invocation.state.attempts < this.config.fetchRetries) {
+            const maxRetries = options?.maxFetchRetries ?? this.config.fetchRetries
+            if (canRetry && result.invocation.state.attempts < maxRetries) {
                 await fetchResponse?.dump()
                 result.invocation.queue = 'hog'
                 result.invocation.queueParameters = params


### PR DESCRIPTION
## Problem

The fetch retries is configurable via an env var but for certain services this is strongly deterministic (like batch exports where we want it to control retries - not the service itself.

## Changes

* Adds a config option for changing the max fetch retries

## How did you test this code?

Added some tests

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

no 

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
