### PR TITLE
feat(hogli): auto-scaffold feature flag and unreleased nav entry for new products

### DIFF
--- a/common/hogli/product/paths.py
+++ b/common/hogli/product/paths.py
@@ -12,6 +12,7 @@ TACH_TOML = REPO_ROOT / "tach.toml"
 FRONTEND_PACKAGE_JSON = REPO_ROOT / "frontend" / "package.json"
 DJANGO_SETTINGS = REPO_ROOT / "posthog" / "settings" / "web.py"
 DB_ROUTING_YAML = PRODUCTS_DIR / "db_routing.yaml"
+FEATURE_FLAGS_CONSTANTS = REPO_ROOT / "frontend" / "src" / "lib" / "constants.tsx"
 
 
 def load_structure() -> dict:

--- a/common/hogli/product/scaffold.py
+++ b/common/hogli/product/scaffold.py
@@ -9,7 +9,15 @@ from pathlib import Path
 
 import click
 
-from .paths import DB_ROUTING_YAML, DJANGO_SETTINGS, FRONTEND_PACKAGE_JSON, PRODUCTS_DIR, TACH_TOML, load_structure
+from .paths import (
+    DB_ROUTING_YAML,
+    DJANGO_SETTINGS,
+    FEATURE_FLAGS_CONSTANTS,
+    FRONTEND_PACKAGE_JSON,
+    PRODUCTS_DIR,
+    TACH_TOML,
+    load_structure,
+)
 
 
 def flatten_structure(files: dict, prefix: str = "", result: dict | None = None) -> dict[str, dict]:
@@ -29,7 +37,9 @@ def flatten_structure(files: dict, prefix: str = "", result: dict | None = None)
 
 def _render_template(template: str, product_name: str) -> str:
     pascal_name = "".join(word.capitalize() for word in product_name.split("_"))
-    return template.format(product=product_name, Product=pascal_name)
+    upper_name = product_name.upper()
+    hyphen_name = product_name.replace("_", "-")
+    return template.format(product=product_name, Product=pascal_name, PRODUCT=upper_name, product_hyphen=hyphen_name)
 
 
 def _register_in_file(
@@ -99,6 +109,53 @@ def _add_to_django_settings(product_name: str, *, dry_run: bool) -> None:
         return content[:insert_pos] + f'    "{app_config}",\n' + content[insert_pos:]
 
     _register_in_file(DJANGO_SETTINGS, "Django settings", app_config, write, dry_run=dry_run)
+
+
+def _add_to_feature_flags(product_name: str, *, dry_run: bool) -> None:
+    flag_key = product_name.upper()
+    flag_value = product_name.replace("_", "-")
+    entry = f"    {flag_key}: '{flag_value}', // owner: #team-CHANGEME\n"
+
+    def write(content: str) -> str | None:
+        lines = content.split("\n")
+
+        marker_idx = None
+        for i, line in enumerate(lines):
+            if "// PLEASE KEEP THIS ALPHABETICALLY ORDERED" in line:
+                marker_idx = i
+                break
+
+        if marker_idx is None:
+            click.echo(f"\n  Could not find FEATURE_FLAGS insertion point — add manually: {flag_key}")
+            return None
+
+        # Walk backward from marker to find the last section comment.
+        # constants.tsx has curated sub-sections (Eternal, Holidays, UX, etc.)
+        # before the general "Temporary feature flags" section — we only want
+        # to insert into that last section.
+        section_start = None
+        for i in range(marker_idx - 1, -1, -1):
+            stripped = lines[i].strip()
+            if stripped.startswith("//") and not stripped.startswith("// owner"):
+                section_start = i + 1
+                break
+
+        # Walk forward to find the alphabetical insertion point
+        insert_idx = marker_idx
+        if section_start is not None:
+            for i in range(section_start, marker_idx):
+                stripped = lines[i].strip()
+                if not stripped or stripped.startswith("//"):
+                    continue
+                existing_key = stripped.split(":")[0].strip().rstrip(",")
+                if existing_key > flag_key:
+                    insert_idx = i
+                    break
+
+        lines.insert(insert_idx, entry.rstrip("\n"))
+        return "\n".join(lines)
+
+    _register_in_file(FEATURE_FLAGS_CONSTANTS, "FEATURE_FLAGS constants", flag_key, write, dry_run=dry_run)
 
 
 def _get_existing_databases() -> list[str]:
@@ -190,6 +247,7 @@ def bootstrap_product(name: str, dry_run: bool, force: bool) -> None:
     _add_to_tach_toml(name, dry_run=dry_run)
     _add_to_frontend_package_json(name, dry_run=dry_run)
     _add_to_django_settings(name, dry_run=dry_run)
+    _add_to_feature_flags(name, dry_run=dry_run)
 
     if dry_run:
         _add_to_db_routing(name, name, dry_run=True)
@@ -218,3 +276,42 @@ def bootstrap_product(name: str, dry_run: bool, force: bool) -> None:
                 show_default=True,
             )
             _add_to_db_routing(name, db_name, dry_run=False)
+
+    if not dry_run:
+        click.echo("")
+        click.secho("  📦 Installing dependencies", bold=True)
+        import subprocess
+
+        click.echo("  Running pnpm install...")
+        result = subprocess.run(["pnpm", "install"], capture_output=True, text=True)
+        if result.returncode == 0:
+            click.secho("  ✓ pnpm install", fg="green")
+        else:
+            click.secho("  ✗ pnpm install failed — run it manually", fg="red")
+            output = (result.stderr or result.stdout or "").strip()
+            if output:
+                click.echo(f"    {output.splitlines()[-1]}")
+
+        click.echo("  Running pnpm build:products...")
+        result = subprocess.run(
+            ["pnpm", "--filter=@posthog/frontend", "build:products"], capture_output=True, text=True
+        )
+        if result.returncode == 0:
+            click.secho("  ✓ build:products", fg="green")
+        else:
+            click.secho("  ✗ build:products failed — run it manually", fg="red")
+            output = (result.stderr or result.stdout or "").strip()
+            if output:
+                click.echo(f"    {output.splitlines()[-1]}")
+
+    flag_value = name.replace("_", "-")
+    click.echo("")
+    click.secho("  🚩 Feature flag", bold=True)
+    click.echo(f"  Your product is gated behind '{flag_value}' (category: Unreleased, tags: alpha).")
+    click.secho(
+        "  Enable the flag in PostHog to see it in the nav!",
+        fg="green",
+    )
+    click.echo("")
+    click.secho("  📋 Next steps", bold=True)
+    click.echo(f"  See TODO.md in products/{name}/ for the full setup checklist.")

--- a/common/hogli/product_structure.yaml
+++ b/common/hogli/product_structure.yaml
@@ -18,6 +18,33 @@ root_files:
         required_lenient: true
         template: ''
 
+    TODO.md:
+        required: false
+        required_lenient: false
+        template: |
+            # {Product} — setup checklist
+
+            > Delete this file once all items are done.
+
+            ## Feature flag
+
+            - [ ] Update `// owner: #team-CHANGEME` on `{PRODUCT}` in `frontend/src/lib/constants.tsx`
+            - [ ] Enable the `{product_hyphen}` flag in PostHog to see the product in the nav
+
+            ## Manifest
+
+            - [ ] Replace placeholder icon (`default_icon_type`) in `manifest.tsx`
+            - [ ] Define CSS color variable (`--color-product-{product_hyphen}-light`) or update `iconColor`
+            - [ ] Add a `ProductKey` entry and fill in `intents: []`
+            - [ ] Wire up scenes and routes
+
+            ## Release lifecycle
+
+            Your product starts in **alpha** (category: Unreleased, tags: alpha).
+
+            See the full release guide for moving through alpha → beta → GA:
+            https://posthog.com/handbook/product/releasing-new-products-and-features
+
     manifest.tsx:
         required: true
         required_lenient: false
@@ -27,7 +54,9 @@ root_files:
              *
              * Defines scenes, routes, URLs, and navigation for this product.
              */
-            import {{ ProductManifest }} from '../../frontend/src/types'
+            import {{ FEATURE_FLAGS }} from 'lib/constants'
+
+            import {{ FileSystemIconColor, ProductManifest }} from '~/types'
 
             export const manifest: ProductManifest = {{
                 name: '{Product}',
@@ -43,7 +72,20 @@ root_files:
                 }},
                 fileSystemTypes: {{}},
                 treeItemsNew: [],
-                treeItemsProducts: [],
+                treeItemsProducts: [
+                    {{
+                        path: '{Product}',
+                        type: '{product}',
+                        intents: [], // Add your ProductKey after running schema:build
+                        category: 'Unreleased',
+                        iconType: 'default_icon_type',
+                        iconColor: ['var(--color-product-{product_hyphen}-light)'] as FileSystemIconColor,
+                        href: '/{product}',
+                        sceneKey: '{Product}',
+                        flag: FEATURE_FLAGS.{PRODUCT},
+                        tags: ['alpha'],
+                    }},
+                ],
             }}
 
     package.json:
@@ -51,7 +93,7 @@ root_files:
         required_lenient: true
         template: |
             {{
-                "name": "@posthog/products-{product}",
+                "name": "@posthog/products-{product_hyphen}",
                 "scripts": {{
                     "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/tests -v --tb=short",
                     "backend:contract-check": "echo 'Contract files unchanged'"

--- a/common/hogli/tests/test_scaffold.py
+++ b/common/hogli/tests/test_scaffold.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+from pathlib import Path
+from textwrap import dedent
+
+import pytest
+from unittest.mock import patch
+
+from hogli.product.scaffold import _add_to_feature_flags, _render_template
+from parameterized import parameterized
+
+
+class TestRenderTemplate:
+    @parameterized.expand(
+        [
+            ("simple", "my_product", "MyProduct", "MY_PRODUCT", "my-product"),
+            ("single_word", "analytics", "Analytics", "ANALYTICS", "analytics"),
+            (
+                "multi_word",
+                "opportunity_solution_trees",
+                "OpportunitySolutionTrees",
+                "OPPORTUNITY_SOLUTION_TREES",
+                "opportunity-solution-trees",
+            ),
+        ]
+    )
+    def test_substitutes_all_placeholders(self, _name: str, product: str, pascal: str, upper: str, hyphen: str) -> None:
+        template = "name: {product}, class: {Product}, flag: {PRODUCT}, css: {product_hyphen}"
+        result = _render_template(template, product)
+        assert result == f"name: {product}, class: {pascal}, flag: {upper}, css: {hyphen}"
+
+
+class TestAddToFeatureFlags:
+    CONSTANTS_TEMPLATE = dedent("""\
+        export const FEATURE_FLAGS = {
+            // Eternal feature flags
+            ETERNAL: 'eternal', // owner: #team-a
+
+            // Temporary feature flags
+            ALPHA: 'alpha', // owner: #team-a
+            ZETA: 'zeta', // owner: #team-z
+            // PLEASE KEEP THIS ALPHABETICALLY ORDERED
+        } as const
+    """)
+
+    def _run(self, tmp_path: Path, product_name: str, content: str | None = None) -> str:
+        constants = tmp_path / "constants.tsx"
+        constants.write_text(content or self.CONSTANTS_TEMPLATE)
+        with patch("hogli.product.scaffold.FEATURE_FLAGS_CONSTANTS", constants):
+            _add_to_feature_flags(product_name, dry_run=False)
+        return constants.read_text()
+
+    @pytest.mark.parametrize(
+        "product, expected_order",
+        [
+            ("my_product", ["ETERNAL", "ALPHA", "MY_PRODUCT", "ZETA"]),
+            ("zzz_product", ["ETERNAL", "ALPHA", "ZETA", "ZZZ_PRODUCT"]),
+            ("aaa_product", ["ETERNAL", "AAA_PRODUCT", "ALPHA", "ZETA"]),
+        ],
+        ids=["middle", "last", "first"],
+    )
+    def test_inserts_in_alphabetical_order(self, product: str, expected_order: list[str], tmp_path: Path) -> None:
+        content = self._run(tmp_path, product)
+        lines = content.split("\n")
+        key_lines = [
+            line.strip().split(":")[0].strip()
+            for line in lines
+            if line.strip() and not line.strip().startswith("//") and ":" in line and "'" in line
+        ]
+        assert key_lines == expected_order
+
+    @pytest.mark.parametrize(
+        "product, expected_key, expected_value",
+        [
+            ("my_product", "MY_PRODUCT", "my-product"),
+            ("my_cool_product", "MY_COOL_PRODUCT", "my-cool-product"),
+            ("analytics", "ANALYTICS", "analytics"),
+        ],
+        ids=["simple", "multi_word", "single_word"],
+    )
+    def test_flag_entry_format(self, product: str, expected_key: str, expected_value: str, tmp_path: Path) -> None:
+        content = self._run(tmp_path, product)
+        assert f"    {expected_key}: '{expected_value}', // owner: #team-CHANGEME" in content
+
+    def test_skips_when_already_present(self, tmp_path: Path) -> None:
+        content = self._run(tmp_path, "alpha")
+        assert content == self.CONSTANTS_TEMPLATE
+
+    def test_no_op_when_marker_missing(self, tmp_path: Path) -> None:
+        original = "export const FEATURE_FLAGS = {} as const\n"
+        content = self._run(tmp_path, "my_product", content=original)
+        assert content == original
+
+    def test_no_op_when_file_missing(self, tmp_path: Path) -> None:
+        constants = tmp_path / "constants.tsx"
+        with patch("hogli.product.scaffold.FEATURE_FLAGS_CONSTANTS", constants):
+            _add_to_feature_flags("my_product", dry_run=False)
+        assert not constants.exists()


### PR DESCRIPTION
## Problem

The `hogli product:bootstrap` command is awesome for creating new products, but there's still a bit of manual wiring needed to go from new product to merged product. You had to manually add a feature flag, populate the nav entry, hide it behind a flag, fix the package name, and run build commands — without this, pushing a bootstrapped product risked exposing it in the sidebar.

## Changes

- **`product_structure.yaml`** — Updated the `manifest.tsx` template to include a fully populated `treeItemsProducts` entry (`category: 'Unreleased'`, `flag`, `tags: ['alpha']`, `iconColor`, `sceneKey`, `type`). Updated import path to `'~/types'`. Added a `TODO.md` template with a setup checklist (feature flag, manifest, release lifecycle link). Fixed `package.json` template to use hyphens in the package name (was using underscores, causing pnpm workspace resolution to fail).
- **`scaffold.py`** — Added `_add_to_feature_flags()` which auto-inserts a `FEATURE_FLAGS` entry into `constants.tsx` in the correct alphabetical position within the "Temporary feature flags" section. Added `{PRODUCT}` and `{product_hyphen}` template placeholders. Runs `pnpm install` and `pnpm build:products` automatically after scaffolding. Added CLI output with feature flag info and pointer to `TODO.md`.
- **`paths.py`** — Added `FEATURE_FLAGS_CONSTANTS` path constant.
- **`test_scaffold.py`** — New test file covering template rendering (3 parameterized cases) and feature flag insertion (alphabetical ordering across sections, format, duplicates, missing marker, missing file).

After bootstrapping, developers still need to:
- Update the `#team-CHANGEME` comment on the feature flag
- Add an icon, CSS color variable, and `ProductKey`

All documented in the generated `TODO.md` and shown in the CLI.

## How did you test this code?

- Ran `hogli product:bootstrap opportunity_solution_trees` and verified the generated `manifest.tsx`, `TODO.md`, and `constants.tsx` entry
- Verified the feature flag lands in the "Temporary feature flags" section (not the Eternal section)
- Verified `pnpm install` and `build:products` run automatically after scaffolding
- 12 unit tests covering `_render_template` and `_add_to_feature_flags`
- Full hogli test suite passes (213+ tests)

## Publish to changelog?

No

## 🤖 LLM context

Co-authored with Claude Code. QA review caught two bugs: (1) alphabetical insertion placed flags in the "Eternal feature flags" section instead of the general "Temporary" section — fixed by narrowing the scan range, (2) `package.json` template used underscores in the package name but workspace registration used hyphens, causing pnpm install to fail — fixed by using `{product_hyphen}` placeholder.