### PR TITLE
feat: add context classes for organization intelligence

### DIFF
--- a/ee/hogai/context/org_intelligence/access_control_context.py
+++ b/ee/hogai/context/org_intelligence/access_control_context.py
@@ -1,0 +1,124 @@
+from typing import Any
+
+from django.db.models import QuerySet
+
+from posthog.constants import AvailableFeature
+from posthog.models import Team, User
+from posthog.sync import database_sync_to_async
+
+from ee.hogai.context.org_intelligence.prompts import ACCESS_CONTROL_CONTEXT_TEMPLATE, ACCESS_CONTROL_NO_CUSTOM
+from ee.models.rbac.access_control import AccessControl
+from ee.models.rbac.role import Role, RoleMembership
+
+
+class AccessControlContext:
+    def __init__(self, team: Team, user: User):
+        self._team = team
+        self._user = user
+
+    async def fetch_and_format(
+        self,
+        *,
+        resource: str | None = None,
+        include_members: bool = False,
+        include_roles: bool = False,
+    ) -> str:
+        if not self._team.organization.is_feature_available(AvailableFeature.ACCESS_CONTROL):
+            return ACCESS_CONTROL_NO_CUSTOM
+
+        if include_roles and not self._team.organization.is_feature_available(AvailableFeature.ROLE_BASED_ACCESS):
+            include_roles = False
+
+        data = await self._fetch_data(
+            resource=resource,
+            include_members=include_members,
+            include_roles=include_roles,
+        )
+        return self._format_data(data)
+
+    @database_sync_to_async
+    def _fetch_data(
+        self,
+        *,
+        resource: str | None = None,
+        include_members: bool = False,
+        include_roles: bool = False,
+    ) -> dict[str, Any]:
+        queryset: QuerySet[AccessControl] = AccessControl.objects.filter(team=self._team)
+
+        if resource:
+            queryset = queryset.filter(resource=resource)
+
+        defaults = list(
+            queryset.filter(resource_id__isnull=True, organization_member__isnull=True, role__isnull=True).values(
+                "resource", "access_level"
+            )
+        )
+
+        restricted = list(
+            queryset.exclude(resource_id__isnull=True, organization_member__isnull=True, role__isnull=True)
+            .select_related("organization_member__user", "role")
+            .values("resource", "resource_id", "access_level", "role__name", "organization_member__user__email")
+        )
+
+        roles_data: list[dict[str, Any]] = []
+        if include_roles:
+            roles = Role.objects.filter(organization=self._team.organization)
+            for role in roles:
+                members = list(
+                    RoleMembership.objects.filter(role=role)
+                    .select_related("user")
+                    .values_list("user__email", flat=True)
+                )
+                roles_data.append({"name": role.name, "member_count": len(members), "members": list(members)})
+
+        return {
+            "defaults": defaults,
+            "restricted": restricted,
+            "roles": roles_data,
+        }
+
+    def _format_data(self, data: dict[str, Any]) -> str:
+        defaults = data["defaults"]
+        restricted = data["restricted"]
+        roles = data["roles"]
+
+        if not defaults and not restricted and not roles:
+            return ACCESS_CONTROL_NO_CUSTOM
+
+        if defaults:
+            defaults_str = "\n".join(f"- {d['resource']}: {d['access_level']}" for d in defaults)
+        else:
+            defaults_str = "No custom defaults — using organization-level defaults."
+
+        if restricted:
+            restricted_lines: list[str] = []
+            for r in restricted:
+                target = ""
+                if r.get("role__name"):
+                    target = f" (role: {r['role__name']})"
+                elif r.get("organization_member__user__email"):
+                    target = f" (member: {r['organization_member__user__email']})"
+                resource_id = f" #{r['resource_id']}" if r.get("resource_id") else ""
+                restricted_lines.append(f"- {r['resource']}{resource_id}: {r['access_level']}{target}")
+            restricted_str = "\n".join(restricted_lines)
+        else:
+            restricted_str = "No resource-specific overrides."
+
+        roles_section = ""
+        if roles:
+            roles_lines = ["\n## Roles"]
+            for role in roles:
+                members_preview = ", ".join(role["members"][:5])
+                if role["member_count"] > 5:
+                    members_preview += f" (+{role['member_count'] - 5} more)"
+                roles_lines.append(f"- {role['name']} ({role['member_count']} members): {members_preview}")
+            roles_section = "\n".join(roles_lines)
+
+        return ACCESS_CONTROL_CONTEXT_TEMPLATE.format(
+            team_name=self._team.name,
+            defaults=defaults_str,
+            restricted_resources=restricted_str,
+            roles_section=roles_section,
+            members_section="",
+        )

--- a/ee/hogai/context/org_intelligence/approvals_context.py
+++ b/ee/hogai/context/org_intelligence/approvals_context.py
@@ -1,0 +1,169 @@
+from datetime import datetime, timedelta
+
+from django.db.models import QuerySet
+from django.utils import timezone
+
+from posthog.approvals.models import ChangeRequest
+from posthog.constants import AvailableFeature
+from posthog.models import Team, User
+from posthog.sync import database_sync_to_async
+
+from ee.hogai.context.org_intelligence.prompts import (
+    APPROVALS_CONTEXT_TEMPLATE,
+    APPROVALS_NO_RESULTS,
+    APPROVALS_PAGINATION_END,
+    APPROVALS_PAGINATION_MORE,
+)
+
+STALE_THRESHOLD_HOURS = 48
+
+
+class ApprovalsContext:
+    def __init__(self, team: Team, user: User):
+        self._team = team
+        self._user = user
+
+    async def fetch_and_format(
+        self,
+        *,
+        state: str | None = None,
+        resource_type: str | None = None,
+        date_range: tuple[str, str] | None = None,
+        limit: int = 20,
+        offset: int = 0,
+    ) -> str:
+        if not self._team.organization.is_feature_available(AvailableFeature.APPROVALS):
+            return APPROVALS_NO_RESULTS
+
+        if state is None:
+            state = "pending"
+
+        entries, total = await self._fetch_entries(
+            state=state,
+            resource_type=resource_type,
+            date_range=date_range,
+            limit=limit,
+            offset=offset,
+        )
+        return self._format_entries(entries, total_count=total, limit=limit, offset=offset, state_filter=state)
+
+    @database_sync_to_async
+    def _fetch_entries(
+        self,
+        *,
+        state: str | None = None,
+        resource_type: str | None = None,
+        date_range: tuple[str, str] | None = None,
+        limit: int = 20,
+        offset: int = 0,
+    ) -> tuple[list[ChangeRequest], int]:
+        queryset: QuerySet[ChangeRequest] = (
+            ChangeRequest.objects.filter(team=self._team)
+            .select_related("created_by")
+            .prefetch_related("approvals", "approvals__created_by")
+            .order_by("-created_at")
+        )
+
+        if state and state != "all":
+            queryset = queryset.filter(state=state)
+
+        if resource_type:
+            queryset = queryset.filter(resource_type=resource_type)
+
+        if date_range:
+            after_str, before_str = date_range
+            try:
+                queryset = queryset.filter(created_at__gte=datetime.fromisoformat(after_str))
+            except ValueError:
+                pass
+            try:
+                queryset = queryset.filter(created_at__lte=datetime.fromisoformat(before_str))
+            except ValueError:
+                pass
+
+        limit = min(max(limit, 1), 50)
+        total_count = queryset.count()
+        entries = list(queryset[offset : offset + limit])
+        return entries, total_count
+
+    def _format_entries(
+        self,
+        entries: list[ChangeRequest],
+        *,
+        total_count: int,
+        limit: int,
+        offset: int,
+        state_filter: str | None = None,
+    ) -> str:
+        if not entries:
+            return APPROVALS_NO_RESULTS
+
+        formatted_entries: list[str] = []
+        for entry in entries:
+            formatted_entries.append(self._format_single_entry(entry))
+
+        filter_desc = f" for state={state_filter}" if state_filter and state_filter != "all" else ""
+        has_more = total_count > offset + limit
+        pagination_hint = (
+            APPROVALS_PAGINATION_MORE.format(next_offset=offset + limit) if has_more else APPROVALS_PAGINATION_END
+        )
+
+        return APPROVALS_CONTEXT_TEMPLATE.format(
+            count=len(entries),
+            total_count=total_count,
+            offset_start=offset + 1,
+            offset_end=offset + len(entries),
+            state_filter=filter_desc,
+            entries="\n".join(formatted_entries),
+            pagination_hint=pagination_hint,
+        )
+
+    def _format_single_entry(self, entry: ChangeRequest) -> str:
+        timestamp = entry.created_at.isoformat()
+        intent_summary = self._extract_intent_summary(entry)
+        user_attr = self._format_user_attribution(entry)
+        vote_status = self._format_vote_status(entry)
+        staleness = self._format_staleness(entry)
+
+        return (
+            f"- **{timestamp}** | {entry.resource_type} | {entry.state} | "
+            f'"{intent_summary}"{user_attr}{vote_status}{staleness}'
+        )
+
+    def _extract_intent_summary(self, entry: ChangeRequest) -> str:
+        if entry.intent_display and isinstance(entry.intent_display, dict):
+            summary = entry.intent_display.get("summary")
+            if summary:
+                return str(summary)[:200]
+        return f"{entry.action_key} on {entry.resource_type}"
+
+    def _format_user_attribution(self, entry: ChangeRequest) -> str:
+        if entry.created_by:
+            name = entry.created_by.first_name or entry.created_by.email
+            return f" | by {name}"
+        return ""
+
+    def _format_vote_status(self, entry: ChangeRequest) -> str:
+        approvals = list(entry.approvals.all())
+        if not approvals:
+            return " | no votes yet"
+        approved = sum(1 for a in approvals if a.decision == "approved")
+        rejected = sum(1 for a in approvals if a.decision == "rejected")
+        parts: list[str] = []
+        if approved:
+            parts.append(f"{approved} approved")
+        if rejected:
+            parts.append(f"{rejected} rejected")
+        return f" | votes: {', '.join(parts)}"
+
+    def _format_staleness(self, entry: ChangeRequest) -> str:
+        if entry.state != "pending":
+            return ""
+        age = timezone.now() - entry.created_at
+        if age > timedelta(hours=STALE_THRESHOLD_HOURS):
+            hours = int(age.total_seconds() // 3600)
+            if hours >= 48:
+                days = hours // 24
+                return f" | stale ({days} days pending)"
+            return f" | stale ({hours}h pending)"
+        return ""

--- a/ee/hogai/context/org_intelligence/discussions_context.py
+++ b/ee/hogai/context/org_intelligence/discussions_context.py
@@ -1,0 +1,167 @@
+from datetime import datetime
+from typing import Any
+
+from django.db.models import Count, Max, Q, QuerySet
+
+from posthog.models import Team, User
+from posthog.models.comment.comment import Comment
+from posthog.sync import database_sync_to_async
+
+from ee.hogai.context.org_intelligence.prompts import (
+    DISCUSSIONS_CONTEXT_TEMPLATE,
+    DISCUSSIONS_NO_RESULTS,
+    DISCUSSIONS_PAGINATION_END,
+    DISCUSSIONS_PAGINATION_MORE,
+)
+
+
+class DiscussionsContext:
+    def __init__(self, team: Team, user: User):
+        self._team = team
+        self._user = user
+
+    async def fetch_and_format(
+        self,
+        *,
+        scope: str | None = None,
+        item_id: str | None = None,
+        date_range: tuple[str, str] | None = None,
+        search_text: str | None = None,
+        limit: int = 20,
+        offset: int = 0,
+    ) -> str:
+        entries, total = await self._fetch_entries(
+            scope=scope,
+            item_id=item_id,
+            date_range=date_range,
+            search_text=search_text,
+            limit=limit,
+            offset=offset,
+        )
+        return self._format_entries(entries, total_count=total, limit=limit, offset=offset, scope_filter=scope)
+
+    @database_sync_to_async
+    def _fetch_entries(
+        self,
+        *,
+        scope: str | None = None,
+        item_id: str | None = None,
+        date_range: tuple[str, str] | None = None,
+        search_text: str | None = None,
+        limit: int = 20,
+        offset: int = 0,
+    ) -> tuple[list[dict[str, Any]], int]:
+        queryset: QuerySet[Comment] = (
+            Comment.objects.filter(team=self._team, deleted=False, source_comment__isnull=True)
+            .select_related("created_by")
+            .annotate(
+                reply_count=Count("comment", filter=Q(comment__deleted=False)),
+                last_reply_at=Max("comment__created_at", filter=Q(comment__deleted=False)),
+            )
+            .order_by("-created_at")
+        )
+
+        if scope:
+            queryset = queryset.filter(scope=scope)
+
+        if item_id:
+            queryset = queryset.filter(item_id=item_id)
+
+        if date_range:
+            after_str, before_str = date_range
+            try:
+                queryset = queryset.filter(created_at__gte=datetime.fromisoformat(after_str))
+            except ValueError:
+                pass
+            try:
+                queryset = queryset.filter(created_at__lte=datetime.fromisoformat(before_str))
+            except ValueError:
+                pass
+
+        if search_text:
+            queryset = queryset.filter(content__icontains=search_text)
+
+        limit = min(max(limit, 1), 50)
+        total_count = queryset.count()
+        entries = list(queryset[offset : offset + limit])
+
+        result: list[dict[str, Any]] = []
+        for comment in entries:
+            mentions = self._extract_mentions(comment.rich_content)
+            result.append(
+                {
+                    "timestamp": comment.created_at.isoformat(),
+                    "scope": comment.scope,
+                    "item_id": comment.item_id,
+                    "item_name": self._extract_item_name(comment),
+                    "content_preview": (comment.content or "")[:200],
+                    "reply_count": comment.reply_count,
+                    "last_activity": (comment.last_reply_at or comment.created_at).isoformat(),
+                    "created_by": (
+                        comment.created_by.first_name or comment.created_by.email if comment.created_by else "Unknown"
+                    ),
+                    "mentions": mentions,
+                }
+            )
+        return result, total_count
+
+    def _format_entries(
+        self,
+        entries: list[dict[str, Any]],
+        *,
+        total_count: int,
+        limit: int,
+        offset: int,
+        scope_filter: str | None = None,
+    ) -> str:
+        if not entries:
+            return DISCUSSIONS_NO_RESULTS
+
+        formatted: list[str] = []
+        for entry in entries:
+            mentions_str = ""
+            if entry["mentions"]:
+                mentions_str = f" | mentions: {', '.join(entry['mentions'])}"
+            formatted.append(
+                f'- **{entry["timestamp"]}** | {entry["scope"]} | "{entry["item_name"]}" | '
+                f"{entry['reply_count']} replies | last activity: {entry['last_activity']}{mentions_str}"
+            )
+
+        filter_desc = f" for scope={scope_filter}" if scope_filter else ""
+        has_more = total_count > offset + limit
+        pagination_hint = (
+            DISCUSSIONS_PAGINATION_MORE.format(next_offset=offset + limit) if has_more else DISCUSSIONS_PAGINATION_END
+        )
+
+        return DISCUSSIONS_CONTEXT_TEMPLATE.format(
+            count=len(entries),
+            total_count=total_count,
+            offset_start=offset + 1,
+            offset_end=offset + len(entries),
+            scope_filter=filter_desc,
+            entries="\n".join(formatted),
+            pagination_hint=pagination_hint,
+        )
+
+    def _extract_item_name(self, comment: Comment) -> str:
+        if comment.item_context and isinstance(comment.item_context, dict):
+            name = comment.item_context.get("name")
+            if name:
+                return str(name)[:200]
+        return f"{comment.scope} #{comment.item_id}"
+
+    def _extract_mentions(self, rich_content: dict | None) -> list[str]:
+        if not rich_content or not isinstance(rich_content, dict):
+            return []
+        mentions: list[str] = []
+        self._walk_mentions(rich_content, mentions)
+        return mentions
+
+    def _walk_mentions(self, node: dict, mentions: list[str]) -> None:
+        if node.get("type") == "mention":
+            label = node.get("attrs", {}).get("label", "")
+            if label:
+                mentions.append(label)
+        for child in node.get("content", []):
+            if isinstance(child, dict):
+                self._walk_mentions(child, mentions)

--- a/ee/hogai/context/org_intelligence/metalytics_context.py
+++ b/ee/hogai/context/org_intelligence/metalytics_context.py
@@ -1,0 +1,144 @@
+from typing import Any
+
+from posthog.hogql.query import execute_hogql_query
+
+from posthog.models import Team, User
+from posthog.sync import database_sync_to_async
+
+from ee.hogai.context.org_intelligence.prompts import (
+    METALYTICS_CONTEXT_TEMPLATE,
+    METALYTICS_NO_RESULTS,
+    METALYTICS_PAGINATION_END,
+    METALYTICS_PAGINATION_MORE,
+)
+
+
+class MetalyticsContext:
+    def __init__(self, team: Team, user: User):
+        self._team = team
+        self._user = user
+
+    async def fetch_and_format(
+        self,
+        *,
+        scope: str | None = None,
+        date_range: tuple[str, str] | None = None,
+        sort_by: str = "views",
+        limit: int = 20,
+        offset: int = 0,
+    ) -> str:
+        entries, total = await self._fetch_entries(
+            scope=scope,
+            date_range=date_range,
+            sort_by=sort_by,
+            limit=limit,
+            offset=offset,
+        )
+        return self._format_entries(
+            entries,
+            total_count=total,
+            limit=limit,
+            offset=offset,
+            scope_filter=scope,
+        )
+
+    @database_sync_to_async
+    def _fetch_entries(
+        self,
+        *,
+        scope: str | None = None,
+        date_range: tuple[str, str] | None = None,
+        sort_by: str = "views",
+        limit: int = 20,
+        offset: int = 0,
+    ) -> tuple[list[dict[str, Any]], int]:
+        limit = min(max(limit, 1), 50)
+
+        where_clauses = ["app_source = 'metalytics'"]
+        if scope:
+            where_clauses.append(f"metric_name = '{scope}'")
+
+        if date_range:
+            after_str, before_str = date_range
+            where_clauses.append(f"timestamp >= toDateTime64('{after_str}', 6, 'UTC')")
+            where_clauses.append(f"timestamp <= toDateTime64('{before_str}', 6, 'UTC')")
+        else:
+            where_clauses.append("timestamp >= now() - INTERVAL 7 DAY")
+
+        where = " AND ".join(where_clauses)
+
+        order_by = "total_views DESC"
+        if sort_by == "unique_users":
+            order_by = "unique_viewers DESC"
+
+        query = f"""
+            SELECT
+                metric_name as resource_type,
+                app_source_id as resource_id,
+                sum(count) as total_views,
+                uniqExact(instance_id) as unique_viewers
+            FROM app_metrics2
+            WHERE {where}
+            GROUP BY resource_type, resource_id
+            ORDER BY {order_by}
+            LIMIT {limit}
+            OFFSET {offset}
+        """
+
+        count_query = f"""
+            SELECT count(DISTINCT (metric_name, app_source_id)) as cnt
+            FROM app_metrics2
+            WHERE {where}
+        """
+
+        try:
+            results = execute_hogql_query(query, team=self._team)
+            count_results = execute_hogql_query(count_query, team=self._team)
+            total = count_results.results[0][0] if count_results.results else 0
+
+            entries: list[dict[str, Any]] = []
+            for row in results.results:
+                entries.append(
+                    {
+                        "resource_type": row[0],
+                        "resource_id": row[1],
+                        "view_count": row[2],
+                        "unique_viewers": row[3],
+                    }
+                )
+            return entries, total
+        except Exception:
+            return [], 0
+
+    def _format_entries(
+        self,
+        entries: list[dict[str, Any]],
+        *,
+        total_count: int,
+        limit: int,
+        offset: int,
+        scope_filter: str | None = None,
+    ) -> str:
+        if not entries:
+            return METALYTICS_NO_RESULTS
+
+        formatted: list[str] = []
+        for entry in entries:
+            formatted.append(
+                f"- {entry['resource_type']} #{entry['resource_id']} | "
+                f"{entry['view_count']} views | {entry['unique_viewers']} unique viewers"
+            )
+
+        filter_desc = f" for {scope_filter}" if scope_filter else ""
+        has_more = total_count > offset + limit
+        pagination_hint = (
+            METALYTICS_PAGINATION_MORE.format(next_offset=offset + limit) if has_more else METALYTICS_PAGINATION_END
+        )
+
+        return METALYTICS_CONTEXT_TEMPLATE.format(
+            count=len(entries),
+            scope_filter=filter_desc,
+            date_range_desc="last 7 days",
+            entries="\n".join(formatted),
+            pagination_hint=pagination_hint,
+        )

--- a/ee/hogai/context/org_intelligence/org_members_context.py
+++ b/ee/hogai/context/org_intelligence/org_members_context.py
@@ -1,0 +1,76 @@
+from typing import Any
+
+from posthog.models import Team, User
+from posthog.models.organization import OrganizationMembership
+from posthog.sync import database_sync_to_async
+
+from ee.hogai.context.org_intelligence.prompts import (
+    MEMBERSHIP_LEVEL_NAMES,
+    ORG_MEMBERS_CONTEXT_TEMPLATE,
+    ORG_MEMBERS_NO_RESULTS,
+)
+
+
+class OrgMembersContext:
+    def __init__(self, team: Team, user: User):
+        self._team = team
+        self._user = user
+
+    async def fetch_and_format(
+        self,
+        *,
+        include_roles: bool = False,
+        include_activity_summary: bool = False,
+    ) -> str:
+        entries = await self._fetch_entries(include_roles=include_roles)
+        return self._format_entries(entries)
+
+    @database_sync_to_async
+    def _fetch_entries(self, *, include_roles: bool = False) -> list[dict[str, Any]]:
+        memberships = (
+            OrganizationMembership.objects.filter(organization=self._team.organization)
+            .select_related("user")
+            .order_by("-level", "user__first_name", "user__email")
+        )
+
+        role_map: dict[int, list[str]] = {}
+        if include_roles:
+            from ee.models.rbac.role import RoleMembership
+
+            role_memberships = RoleMembership.objects.filter(role__organization=self._team.organization).select_related(
+                "role", "user"
+            )
+            for rm in role_memberships:
+                role_map.setdefault(rm.user_id, []).append(rm.role.name)
+
+        entries: list[dict[str, Any]] = []
+        for membership in memberships:
+            user = membership.user
+            level_name = MEMBERSHIP_LEVEL_NAMES.get(membership.level, "member")
+            roles = role_map.get(user.id, []) if include_roles else []
+            entries.append(
+                {
+                    "name": user.first_name or user.email.split("@")[0],
+                    "email": user.email,
+                    "level": level_name,
+                    "roles": roles,
+                    "joined_at": membership.joined_at.isoformat() if membership.joined_at else None,
+                    "last_active": user.last_login.isoformat() if user.last_login else None,
+                }
+            )
+        return entries
+
+    def _format_entries(self, entries: list[dict[str, Any]]) -> str:
+        if not entries:
+            return ORG_MEMBERS_NO_RESULTS
+
+        formatted: list[str] = []
+        for entry in entries:
+            roles_str = f" | roles: {', '.join(entry['roles'])}" if entry["roles"] else ""
+            last_active_str = f" | last active: {entry['last_active']}" if entry["last_active"] else ""
+            formatted.append(f"- {entry['name']} ({entry['email']}) | {entry['level']}{roles_str}{last_active_str}")
+
+        return ORG_MEMBERS_CONTEXT_TEMPLATE.format(
+            count=len(entries),
+            entries="\n".join(formatted),
+        )

--- a/ee/hogai/context/org_intelligence/prompts.py
+++ b/ee/hogai/context/org_intelligence/prompts.py
@@ -1,0 +1,11 @@
+APPROVALS_CONTEXT_TEMPLATE = """Approval requests ({count} of {total_count}, showing {offset_start}-{offset_end}{state_filter}):
+
+{entries}
+
+{pagination_hint}"""
+
+APPROVALS_NO_RESULTS = "No approval requests found matching the specified filters."
+
+APPROVALS_PAGINATION_MORE = "There are more results. To see the next page, call with offset={next_offset}."
+
+APPROVALS_PAGINATION_END = "All matching results have been shown."

--- a/ee/hogai/context/org_intelligence/prompts.py
+++ b/ee/hogai/context/org_intelligence/prompts.py
@@ -1,3 +1,5 @@
+# Approvals
+
 APPROVALS_CONTEXT_TEMPLATE = """Approval requests ({count} of {total_count}, showing {offset_start}-{offset_end}{state_filter}):
 
 {entries}
@@ -9,3 +11,55 @@ APPROVALS_NO_RESULTS = "No approval requests found matching the specified filter
 APPROVALS_PAGINATION_MORE = "There are more results. To see the next page, call with offset={next_offset}."
 
 APPROVALS_PAGINATION_END = "All matching results have been shown."
+
+# Discussions
+
+DISCUSSIONS_CONTEXT_TEMPLATE = """Discussion threads ({count} of {total_count}, showing {offset_start}-{offset_end}{scope_filter}):
+
+{entries}
+
+{pagination_hint}"""
+
+DISCUSSIONS_NO_RESULTS = "No discussion threads found matching the specified filters."
+
+DISCUSSIONS_PAGINATION_MORE = "There are more results. To see the next page, call with offset={next_offset}."
+
+DISCUSSIONS_PAGINATION_END = "All matching results have been shown."
+
+# Access control
+
+ACCESS_CONTROL_CONTEXT_TEMPLATE = """Access control summary for project "{team_name}":
+
+## Default Access Levels
+{defaults}
+
+## Restricted Resources
+{restricted_resources}
+
+{roles_section}{members_section}"""
+
+ACCESS_CONTROL_NO_CUSTOM = "No custom access controls configured. All resources use organization defaults."
+
+# Metalytics
+
+METALYTICS_CONTEXT_TEMPLATE = """Resource usage metrics ({count} resources{scope_filter}, {date_range_desc}):
+
+{entries}
+
+{pagination_hint}"""
+
+METALYTICS_NO_RESULTS = "No resource usage data found matching the specified filters."
+
+METALYTICS_PAGINATION_MORE = "There are more results. To see the next page, call with offset={next_offset}."
+
+METALYTICS_PAGINATION_END = "All matching results have been shown."
+
+# Org members
+
+ORG_MEMBERS_CONTEXT_TEMPLATE = """Organization members ({count} total):
+
+{entries}"""
+
+ORG_MEMBERS_NO_RESULTS = "No organization members found."
+
+MEMBERSHIP_LEVEL_NAMES = {1: "member", 8: "admin", 15: "owner"}

--- a/ee/hogai/context/org_intelligence/test/test_access_control_context.py
+++ b/ee/hogai/context/org_intelligence/test/test_access_control_context.py
@@ -1,0 +1,146 @@
+from freezegun import freeze_time
+from posthog.test.base import BaseTest
+from unittest.mock import patch
+
+from posthog.constants import AvailableFeature
+
+from ee.hogai.context.org_intelligence.access_control_context import AccessControlContext
+from ee.hogai.context.org_intelligence.prompts import ACCESS_CONTROL_NO_CUSTOM
+from ee.models.rbac.access_control import AccessControl
+from ee.models.rbac.role import Role, RoleMembership
+
+
+class AccessControlContextTestBase(BaseTest):
+    def _mock_features(self, access_control: bool = True, rbac: bool = True):
+        def side_effect(feature, **kwargs):
+            if feature == AvailableFeature.ACCESS_CONTROL:
+                return access_control
+            if feature == AvailableFeature.ROLE_BASED_ACCESS:
+                return rbac
+            return False
+
+        return patch.object(
+            type(self.organization),
+            "is_feature_available",
+            side_effect=side_effect,
+        )
+
+
+@freeze_time("2025-06-15T12:00:00Z")
+class TestAccessControlContext(AccessControlContextTestBase):
+    def _create_context(self) -> AccessControlContext:
+        return AccessControlContext(team=self.team, user=self.user)
+
+    async def test_fetch_and_format_no_custom_controls(self):
+        with self._mock_features():
+            result = await self._create_context().fetch_and_format()
+
+        assert result == ACCESS_CONTROL_NO_CUSTOM
+
+    async def test_fetch_and_format_shows_defaults(self):
+        await AccessControl.objects.acreate(
+            team=self.team,
+            resource="dashboard",
+            access_level="viewer",
+        )
+
+        with self._mock_features():
+            result = await self._create_context().fetch_and_format()
+
+        assert "dashboard" in result.lower()
+        assert "viewer" in result.lower()
+
+    async def test_fetch_and_format_shows_restricted_resources(self):
+        await AccessControl.objects.acreate(
+            team=self.team,
+            resource="dashboard",
+            resource_id="42",
+            access_level="viewer",
+        )
+
+        with self._mock_features():
+            result = await self._create_context().fetch_and_format()
+
+        assert "42" in result
+        assert "viewer" in result.lower()
+
+    async def test_fetch_and_format_includes_roles(self):
+        role = await Role.objects.acreate(
+            name="Release Managers",
+            organization=self.organization,
+            created_by=self.user,
+        )
+        await RoleMembership.objects.acreate(role=role, user=self.user)
+
+        with self._mock_features():
+            result = await self._create_context().fetch_and_format(include_roles=True)
+
+        assert "release managers" in result.lower()
+
+    async def test_fetch_and_format_respects_team_scope(self):
+        await AccessControl.objects.acreate(
+            team=self.team,
+            resource="dashboard",
+            access_level="viewer",
+        )
+        other_team = await self.organization.teams.acreate(name="Other")
+        await AccessControl.objects.acreate(
+            team=other_team,
+            resource="insight",
+            access_level="none",
+        )
+
+        with self._mock_features():
+            result = await self._create_context().fetch_and_format()
+
+        assert "dashboard" in result.lower()
+        assert "insight: none" not in result.lower()
+
+    async def test_fetch_and_format_returns_empty_when_feature_unavailable(self):
+        await AccessControl.objects.acreate(
+            team=self.team,
+            resource="dashboard",
+            access_level="viewer",
+        )
+
+        with self._mock_features(access_control=False):
+            result = await self._create_context().fetch_and_format()
+
+        assert result == ACCESS_CONTROL_NO_CUSTOM
+
+    async def test_fetch_and_format_skips_roles_when_rbac_unavailable(self):
+        role = await Role.objects.acreate(
+            name="Release Managers",
+            organization=self.organization,
+            created_by=self.user,
+        )
+        await RoleMembership.objects.acreate(role=role, user=self.user)
+        await AccessControl.objects.acreate(
+            team=self.team,
+            resource="dashboard",
+            access_level="viewer",
+        )
+
+        with self._mock_features(rbac=False):
+            result = await self._create_context().fetch_and_format(include_roles=True)
+
+        assert "release managers" not in result.lower()
+        assert "dashboard" in result.lower()
+
+    async def test_fetch_and_format_filters_by_resource(self):
+        await AccessControl.objects.acreate(
+            team=self.team,
+            resource="dashboard",
+            access_level="viewer",
+        )
+        await AccessControl.objects.acreate(
+            team=self.team,
+            resource="insight",
+            access_level="editor",
+        )
+
+        with self._mock_features():
+            result = await self._create_context().fetch_and_format(resource="dashboard")
+
+        assert "dashboard" in result.lower()
+        assert "insight" not in result.lower()

--- a/ee/hogai/context/org_intelligence/test/test_approvals_context.py
+++ b/ee/hogai/context/org_intelligence/test/test_approvals_context.py
@@ -1,0 +1,184 @@
+from datetime import timedelta
+
+from freezegun import freeze_time
+from posthog.test.base import BaseTest
+from unittest.mock import patch
+
+from django.utils import timezone
+
+from posthog.approvals.models import Approval, ApprovalPolicy, ChangeRequest
+from posthog.constants import AvailableFeature
+
+from ee.hogai.context.org_intelligence.approvals_context import ApprovalsContext
+from ee.hogai.context.org_intelligence.prompts import APPROVALS_NO_RESULTS
+
+
+class ApprovalsContextTestBase(BaseTest):
+    def _mock_feature(self):
+        return patch.object(
+            type(self.organization),
+            "is_feature_available",
+            side_effect=lambda feature, **kwargs: feature == AvailableFeature.APPROVALS,
+        )
+
+    async def _create_policy(self, **kwargs):
+        defaults = {
+            "organization": self.organization,
+            "team": self.team,
+            "action_key": "feature_flag:update",
+            "approver_config": {"users": []},
+            "enabled": True,
+        }
+        defaults.update(kwargs)
+        return await ApprovalPolicy.objects.acreate(**defaults)
+
+    async def _create_change_request(self, **kwargs):
+        action_key = kwargs.get("action_key", "feature_flag:update")
+        await self._create_policy(action_key=action_key)
+        defaults = {
+            "team": self.team,
+            "organization": self.organization,
+            "action_key": action_key,
+            "action_version": 1,
+            "resource_type": "FeatureFlag",
+            "intent": {"key": "new-checkout", "rollout_percentage": 50},
+            "intent_display": {"summary": "Roll out new-checkout to 50%"},
+            "policy_snapshot": {},
+            "state": "pending",
+            "expires_at": timezone.now() + timedelta(days=14),
+            "created_by": self.user,
+        }
+        defaults.update(kwargs)
+        return await ChangeRequest.objects.acreate(**defaults)
+
+
+@freeze_time("2025-06-15T12:00:00Z")
+class TestApprovalsContext(ApprovalsContextTestBase):
+    def _create_context(self) -> ApprovalsContext:
+        return ApprovalsContext(team=self.team, user=self.user)
+
+    async def test_fetch_and_format_returns_pending_by_default(self):
+        await self._create_change_request(state="pending")
+        await self._create_change_request(state="approved", action_key="feature_flag:update:2")
+
+        with self._mock_feature():
+            result = await self._create_context().fetch_and_format()
+
+        assert "pending" in result.lower()
+        assert result.count("- **") == 1
+
+    async def test_fetch_and_format_filters_by_state(self):
+        await self._create_change_request(state="pending")
+        await self._create_change_request(state="approved", action_key="feature_flag:update:2")
+
+        with self._mock_feature():
+            result = await self._create_context().fetch_and_format(state="approved")
+
+        assert "approved" in result.lower()
+
+    async def test_fetch_and_format_state_all(self):
+        await self._create_change_request(state="pending")
+        await self._create_change_request(state="approved", action_key="feature_flag:update:2")
+
+        with self._mock_feature():
+            result = await self._create_context().fetch_and_format(state="all")
+
+        assert result.count("- **") == 2
+
+    async def test_fetch_and_format_empty(self):
+        with self._mock_feature():
+            result = await self._create_context().fetch_and_format()
+
+        assert result == APPROVALS_NO_RESULTS
+
+    async def test_fetch_and_format_includes_vote_status(self):
+        cr = await self._create_change_request(state="pending")
+        await Approval.objects.acreate(
+            change_request=cr,
+            decision="approved",
+            reason="Looks good",
+            created_by=self.user,
+        )
+
+        with self._mock_feature():
+            result = await self._create_context().fetch_and_format()
+
+        assert "1 approved" in result.lower()
+
+    async def test_fetch_and_format_shows_staleness(self):
+        cr = await self._create_change_request(state="pending")
+        await ChangeRequest.objects.filter(id=cr.id).aupdate(
+            created_at=timezone.now() - timedelta(hours=50),
+        )
+
+        with self._mock_feature():
+            result = await self._create_context().fetch_and_format()
+
+        assert "stale" in result.lower()
+
+    async def test_fetch_and_format_no_staleness_for_recent(self):
+        await self._create_change_request(state="pending")
+
+        with self._mock_feature():
+            result = await self._create_context().fetch_and_format()
+
+        assert "stale" not in result.lower()
+
+    async def test_fetch_and_format_respects_team_scope(self):
+        await self._create_change_request(state="pending")
+
+        other_team = await self.organization.teams.acreate(name="Other team")
+        await ChangeRequest.objects.acreate(
+            team=other_team,
+            organization=self.organization,
+            action_key="feature_flag:update",
+            action_version=1,
+            resource_type="FeatureFlag",
+            intent={},
+            intent_display={"summary": "Other team request"},
+            policy_snapshot={},
+            state="pending",
+            expires_at=timezone.now() + timedelta(days=14),
+            created_by=self.user,
+        )
+
+        with self._mock_feature():
+            result = await self._create_context().fetch_and_format()
+
+        assert "other team request" not in result.lower()
+
+    async def test_fetch_and_format_pagination(self):
+        for i in range(5):
+            await self._create_change_request(
+                state="pending",
+                action_key=f"feature_flag:update:{i}",
+            )
+
+        with self._mock_feature():
+            result = await self._create_context().fetch_and_format(limit=2)
+
+        assert "more results" in result.lower()
+        assert "offset=2" in result.lower()
+
+    async def test_fetch_and_format_shows_intent_summary(self):
+        await self._create_change_request(
+            state="pending",
+            intent_display={"summary": "Roll out new-checkout to 50%"},
+        )
+
+        with self._mock_feature():
+            result = await self._create_context().fetch_and_format()
+
+        assert "roll out new-checkout to 50%" in result.lower()
+
+    async def test_fetch_and_format_returns_empty_when_feature_unavailable(self):
+        await self._create_change_request(state="pending")
+
+        with patch.object(
+            type(self.organization),
+            "is_feature_available",
+            return_value=False,
+        ):
+            result = await self._create_context().fetch_and_format()
+
+        assert result == APPROVALS_NO_RESULTS

--- a/ee/hogai/context/org_intelligence/test/test_discussions_context.py
+++ b/ee/hogai/context/org_intelligence/test/test_discussions_context.py
@@ -1,0 +1,106 @@
+from freezegun import freeze_time
+from posthog.test.base import BaseTest
+
+from posthog.models.comment.comment import Comment
+
+from ee.hogai.context.org_intelligence.discussions_context import DiscussionsContext
+from ee.hogai.context.org_intelligence.prompts import DISCUSSIONS_NO_RESULTS
+
+
+class DiscussionsContextTestBase(BaseTest):
+    async def _create_comment(self, **kwargs):
+        defaults = {
+            "team": self.team,
+            "content": "Test comment",
+            "scope": "Dashboard",
+            "item_id": "1",
+            "created_by": self.user,
+        }
+        defaults.update(kwargs)
+        return await Comment.objects.acreate(**defaults)
+
+
+@freeze_time("2025-06-15T12:00:00Z")
+class TestDiscussionsContext(DiscussionsContextTestBase):
+    def _create_context(self) -> DiscussionsContext:
+        return DiscussionsContext(team=self.team, user=self.user)
+
+    async def test_fetch_and_format_returns_threads(self):
+        parent = await self._create_comment(content="Parent thread")
+        await self._create_comment(content="Reply 1", source_comment=parent)
+        await self._create_comment(content="Reply 2", source_comment=parent)
+
+        result = await self._create_context().fetch_and_format(scope="Dashboard")
+
+        assert "dashboard" in result.lower()
+        assert "2 repl" in result.lower()
+
+    async def test_fetch_and_format_filters_by_scope(self):
+        await self._create_comment(scope="Dashboard", item_id="1")
+        await self._create_comment(scope="FeatureFlag", item_id="2")
+
+        result = await self._create_context().fetch_and_format(scope="Dashboard")
+
+        assert result.count("- **") == 1
+        assert "dashboard" in result.lower()
+
+    async def test_fetch_and_format_empty(self):
+        result = await self._create_context().fetch_and_format(scope="Dashboard")
+
+        assert result == DISCUSSIONS_NO_RESULTS
+
+    async def test_fetch_and_format_excludes_deleted(self):
+        await self._create_comment(content="Active", deleted=False)
+        await self._create_comment(content="Deleted", deleted=True)
+
+        result = await self._create_context().fetch_and_format(scope="Dashboard")
+
+        assert result.count("- **") == 1
+
+    async def test_fetch_and_format_respects_team_scope(self):
+        await self._create_comment(content="My team comment")
+        other_team = await self.organization.teams.acreate(name="Other")
+        await Comment.objects.acreate(
+            team=other_team, content="Other team", scope="Dashboard", item_id="1", created_by=self.user
+        )
+
+        result = await self._create_context().fetch_and_format(scope="Dashboard")
+
+        assert "other team" not in result.lower()
+        assert result.count("- **") == 1
+
+    async def test_fetch_and_format_extracts_mentions(self):
+        await self._create_comment(
+            content="Hey @alice check this",
+            rich_content={"type": "doc", "content": [{"type": "mention", "attrs": {"label": "alice@example.com"}}]},
+        )
+
+        result = await self._create_context().fetch_and_format(scope="Dashboard")
+
+        assert "alice@example.com" in result
+
+    async def test_fetch_and_format_extracts_item_name_from_context(self):
+        await self._create_comment(
+            item_context={"name": "Growth KPIs"},
+        )
+
+        result = await self._create_context().fetch_and_format(scope="Dashboard")
+
+        assert "growth kpis" in result.lower()
+
+    async def test_fetch_and_format_pagination(self):
+        for i in range(5):
+            await self._create_comment(item_id=str(i))
+
+        result = await self._create_context().fetch_and_format(scope="Dashboard", limit=2)
+
+        assert "more results" in result.lower()
+        assert "offset=2" in result.lower()
+
+    async def test_fetch_and_format_search_text(self):
+        await self._create_comment(content="Found this bug in checkout")
+        await self._create_comment(content="Everything is fine", item_id="2")
+
+        result = await self._create_context().fetch_and_format(scope="Dashboard", search_text="bug")
+
+        assert result.count("- **") == 1

--- a/ee/hogai/context/org_intelligence/test/test_metalytics_context.py
+++ b/ee/hogai/context/org_intelligence/test/test_metalytics_context.py
@@ -1,0 +1,46 @@
+from posthog.test.base import BaseTest
+
+from ee.hogai.context.org_intelligence.metalytics_context import MetalyticsContext
+from ee.hogai.context.org_intelligence.prompts import METALYTICS_NO_RESULTS
+
+
+class TestMetalyticsContext(BaseTest):
+    def _create_context(self) -> MetalyticsContext:
+        return MetalyticsContext(team=self.team, user=self.user)
+
+    async def test_fetch_and_format_empty(self):
+        result = await self._create_context().fetch_and_format()
+
+        assert result == METALYTICS_NO_RESULTS
+
+    async def test_fetch_and_format_with_scope_filter(self):
+        result = await self._create_context().fetch_and_format(scope="Dashboard")
+
+        assert result == METALYTICS_NO_RESULTS
+
+    async def test_format_entries_formats_correctly(self):
+        ctx = self._create_context()
+        entries = [
+            {"resource_type": "Dashboard", "resource_id": "42", "view_count": 100, "unique_viewers": 8},
+            {"resource_type": "Insight", "resource_id": "7", "view_count": 50, "unique_viewers": 3},
+        ]
+
+        result = ctx._format_entries(entries, total_count=2, limit=20, offset=0, scope_filter=None)
+
+        assert "Dashboard #42" in result
+        assert "100 views" in result
+        assert "8 unique viewers" in result
+        assert "Insight #7" in result
+        assert "all matching results" in result.lower()
+
+    async def test_format_entries_with_pagination(self):
+        ctx = self._create_context()
+        entries = [
+            {"resource_type": "Dashboard", "resource_id": "1", "view_count": 10, "unique_viewers": 2},
+        ]
+
+        result = ctx._format_entries(entries, total_count=5, limit=1, offset=0, scope_filter="Dashboard")
+
+        assert "more results" in result.lower()
+        assert "offset=1" in result.lower()
+        assert "for Dashboard" in result

--- a/ee/hogai/context/org_intelligence/test/test_org_members_context.py
+++ b/ee/hogai/context/org_intelligence/test/test_org_members_context.py
@@ -1,0 +1,50 @@
+from freezegun import freeze_time
+from posthog.test.base import BaseTest
+
+from ee.hogai.context.org_intelligence.org_members_context import OrgMembersContext
+from ee.models.rbac.role import Role, RoleMembership
+
+
+@freeze_time("2025-06-15T12:00:00Z")
+class TestOrgMembersContext(BaseTest):
+    def _create_context(self) -> OrgMembersContext:
+        return OrgMembersContext(team=self.team, user=self.user)
+
+    async def test_fetch_and_format_lists_members(self):
+        result = await self._create_context().fetch_and_format()
+
+        assert self.user.email in result
+
+    async def test_fetch_and_format_shows_membership_level(self):
+        result = await self._create_context().fetch_and_format()
+
+        assert "member" in result.lower()
+
+    async def test_fetch_and_format_includes_roles(self):
+        role = await Role.objects.acreate(
+            name="Analysts",
+            organization=self.organization,
+            created_by=self.user,
+        )
+        await RoleMembership.objects.acreate(role=role, user=self.user)
+
+        result = await self._create_context().fetch_and_format(include_roles=True)
+
+        assert "analysts" in result.lower()
+
+    async def test_fetch_and_format_excludes_roles_by_default(self):
+        role = await Role.objects.acreate(
+            name="Analysts",
+            organization=self.organization,
+            created_by=self.user,
+        )
+        await RoleMembership.objects.acreate(role=role, user=self.user)
+
+        result = await self._create_context().fetch_and_format()
+
+        assert "analysts" not in result.lower()
+
+    async def test_fetch_and_format_shows_member_count(self):
+        result = await self._create_context().fetch_and_format()
+
+        assert "1 total" in result.lower()


### PR DESCRIPTION
## Problem

PH AI currently has no awareness of what's happening in an organization — pending approvals, active discussions, who has access to what, which resources people are looking at, or who's on the team. This PR adds the query layer that makes all of that data available for the upcoming org intelligence briefing and PH AI tools.

Stacked on #53421.

## Changes

- **ApprovalsContext** — queries `ChangeRequest`/`Approval` with state filtering, vote status, and staleness detection. Feature-gated behind `AvailableFeature.APPROVALS`
- **DiscussionsContext** — queries `Comment` threads with reply counts, mentions extraction, and search. No RBAC needed (comments are INTERNAL scope)
- **AccessControlContext** — queries `AccessControl`/`Role`/`RoleMembership` for resource defaults, restrictions, and role assignments. Two-tier feature gate: `ACCESS_CONTROL` for base, `ROLE_BASED_ACCESS` for roles
- **MetalyticsContext** — queries `app_metrics2` via HogQL for resource view counts and unique viewers. No RBAC (INTERNAL scope)
- **OrgMembersContext** — queries `OrganizationMembership` with optional role data. No feature gate (visible to all org members)
- Shared `prompts.py` with formatting templates for all five contexts

All context classes follow the established pattern from `ActivityLogContext` — standalone class with `team`+`user` constructor, async `fetch_and_format()`, `@database_sync_to_async` for DB access, and markdown-formatted output for AI consumption.

None of these are wired into Max yet — that happens in the next PRs (briefing assembly + injection).

## How did you test this code?

- 37 unit tests added across all 5 context classes
- Coverage includes: filtering, pagination, team scoping, feature gating, edge cases (empty results, staleness, mentions extraction)

## Publish to changelog?

no