### PR TITLE
fix(modeling): search path is wrong for duckgres

### DIFF
--- a/posthog/ducklake/client.py
+++ b/posthog/ducklake/client.py
@@ -116,7 +116,7 @@ def execute_ducklake_create_table(team_id: int, sql: str, schema_name: str, tabl
         conn.execute(psql.SQL("CREATE SCHEMA IF NOT EXISTS {}").format(psql.Identifier(safe_schema)))
         # TODO: remove hardcoded schemas and derive the search path from the team's
         # data warehouse sources / DAG configuration instead
-        # DuckDB SET only accepts a single comma-separated string value (no spaces)
+        # duckgres SET seems to only accepts a single comma-separated string value
         conn.execute(
             psql.SQL("SET search_path TO '{},revenue,stripe,billing_public,credit,posthog'").format(
                 psql.SQL(safe_schema)

--- a/posthog/ducklake/client.py
+++ b/posthog/ducklake/client.py
@@ -116,9 +116,10 @@ def execute_ducklake_create_table(team_id: int, sql: str, schema_name: str, tabl
         conn.execute(psql.SQL("CREATE SCHEMA IF NOT EXISTS {}").format(psql.Identifier(safe_schema)))
         # TODO: remove hardcoded schemas and derive the search path from the team's
         # data warehouse sources / DAG configuration instead
+        # DuckDB SET only accepts a single comma-separated string value (no spaces)
         conn.execute(
-            psql.SQL("SET search_path TO {}, 'revenue', 'stripe', 'billing_public', 'credit', 'posthog'").format(
-                psql.Identifier(safe_schema)
+            psql.SQL("SET search_path TO '{},revenue,stripe,billing_public,credit,posthog'").format(
+                psql.SQL(safe_schema)
             )
         )
         with conn.cursor() as cur:


### PR DESCRIPTION
## Problem

postgres / duck syntax weirdness

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

## Changes

try something else

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

didn't. blast radius is 0 bc this code path is only hit by manually passing an additional flag to temporal workflows

## Publish to changelog?

no

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->