### PR TITLE
chore: support custom producer client.id

### DIFF
--- a/nodejs/src/ingestion/common/producers.ts
+++ b/nodejs/src/ingestion/common/producers.ts
@@ -19,6 +19,7 @@ export type ProducerName = DefaultProducer | WarpstreamProducer
  */
 export const PRODUCER_CONFIG_MAP: Record<ProducerName, Partial<Record<AllowedConfigKey, string>>> = {
     [DEFAULT_PRODUCER]: {
+        'client.id': 'KAFKA_PRODUCER_CLIENT_ID',
         'metadata.broker.list': 'KAFKA_PRODUCER_METADATA_BROKER_LIST',
         'security.protocol': 'KAFKA_PRODUCER_SECURITY_PROTOCOL',
         'sasl.mechanisms': 'KAFKA_PRODUCER_SASL_MECHANISMS',
@@ -48,6 +49,7 @@ export const PRODUCER_CONFIG_MAP: Record<ProducerName, Partial<Record<AllowedCon
      * until we move to a fire-and-forget pattern.
      */
     [WARPSTREAM_PRODUCER]: {
+        'client.id': 'KAFKA_WARPSTREAM_PRODUCER_CLIENT_ID',
         'metadata.broker.list': 'KAFKA_WARPSTREAM_PRODUCER_METADATA_BROKER_LIST',
         'security.protocol': 'KAFKA_WARPSTREAM_PRODUCER_SECURITY_PROTOCOL',
         'compression.codec': 'KAFKA_WARPSTREAM_PRODUCER_COMPRESSION_CODEC',

--- a/nodejs/src/ingestion/outputs/kafka-producer-config.test.ts
+++ b/nodejs/src/ingestion/outputs/kafka-producer-config.test.ts
@@ -3,6 +3,7 @@ import { hostname } from 'os'
 import { AllowedConfigKey, getProducerConfig } from './kafka-producer-config'
 
 const TEST_CONFIG_MAP: Partial<Record<AllowedConfigKey, string>> = {
+    'client.id': 'TEST_CLIENT_ID',
     'metadata.broker.list': 'TEST_BROKER',
     'security.protocol': 'TEST_SECURITY_PROTOCOL',
     'compression.codec': 'TEST_COMPRESSION',
@@ -84,10 +85,18 @@ describe('getProducerConfig', () => {
         expect(() => getProducerConfig(TEST_CONFIG_MAP)).toThrow()
     })
 
-    it('always sets client.id to hostname', () => {
+    it('defaults client.id to hostname when env var is not set', () => {
         const config = getProducerConfig(TEST_CONFIG_MAP)
 
         expect(config['client.id']).toBe(hostname())
+    })
+
+    it('overrides client.id when env var is set', () => {
+        process.env.TEST_CLIENT_ID = 'my-custom-client-id'
+
+        const config = getProducerConfig(TEST_CONFIG_MAP)
+
+        expect(config['client.id']).toBe('my-custom-client-id')
     })
 
     it('ignores env vars not in the config map', () => {

--- a/nodejs/src/ingestion/outputs/kafka-producer-config.ts
+++ b/nodejs/src/ingestion/outputs/kafka-producer-config.ts
@@ -10,6 +10,7 @@ import { z } from 'zod'
  * corresponding env var is set. Invalid env var values cause a startup failure.
  */
 const producerConfigSchema = z.object({
+    'client.id': z.string().optional(),
     'metadata.broker.list': z.string().default('kafka:9092'),
     'security.protocol': z.enum(['plaintext', 'ssl', 'sasl_plaintext', 'sasl_ssl']).optional(),
     'sasl.mechanisms': z.string().optional(),


### PR DESCRIPTION
## Problem

While producing to WS, we want to avoid any cross AZ traffic. For that, we need to specify the client.id including info regarding where the pod is located.

## Changes

Add support for overriding the default value of client.id (hostname) through env variables.

## How did you test this code?

Unit tests

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
