### PR TITLE
fix(personhog): its always NODELAY

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -6534,6 +6534,7 @@ dependencies = [
  "tokio",
  "tonic 0.12.3",
  "tower 0.4.13",
+ "tracing",
 ]
 
 [[package]]

--- a/rust/personhog-common/Cargo.toml
+++ b/rust/personhog-common/Cargo.toml
@@ -13,6 +13,7 @@ sqlx = { workspace = true }
 tokio = { workspace = true }
 tonic = { workspace = true }
 tower = { workspace = true }
+tracing = { workspace = true }
 
 [lints]
 workspace = true

--- a/rust/personhog-common/src/grpc.rs
+++ b/rust/personhog-common/src/grpc.rs
@@ -75,7 +75,9 @@ impl TrackedTcpStream {
     fn new(inner: TcpStream) -> Self {
         // Disable Nagle's algorithm to prevent ~40ms tail latency from the
         // Nagle + delayed-ACK interaction on gRPC request-response exchanges.
-        drop(inner.set_nodelay(true));
+        if let Err(e) = inner.set_nodelay(true) {
+            tracing::warn!("failed to set TCP_NODELAY on accepted socket: {e}");
+        }
         gauge!("grpc_server_connections").increment(1.0);
         Self {
             inner,

--- a/rust/personhog-common/src/grpc.rs
+++ b/rust/personhog-common/src/grpc.rs
@@ -73,6 +73,9 @@ pub struct TrackedTcpStream {
 
 impl TrackedTcpStream {
     fn new(inner: TcpStream) -> Self {
+        // Disable Nagle's algorithm to prevent ~40ms tail latency from the
+        // Nagle + delayed-ACK interaction on gRPC request-response exchanges.
+        drop(inner.set_nodelay(true));
         gauge!("grpc_server_connections").increment(1.0);
         Self {
             inner,

--- a/rust/personhog-router/src/backend/leader.rs
+++ b/rust/personhog-router/src/backend/leader.rs
@@ -116,6 +116,7 @@ impl LeaderBackend {
         let channel = Channel::from_shared(address.clone())
             .map_err(|e| Status::internal(format!("invalid leader address: {e}")))?
             .timeout(self.timeout)
+            .tcp_nodelay(true)
             .connect_lazy();
         let client = PersonHogLeaderClient::new(channel)
             .max_encoding_message_size(self.max_send_message_size)

--- a/rust/personhog-router/src/backend/replica.rs
+++ b/rust/personhog-router/src/backend/replica.rs
@@ -42,7 +42,9 @@ impl ReplicaBackend {
         max_send_message_size: usize,
         max_recv_message_size: usize,
     ) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
-        let mut endpoint = Channel::from_shared(url.to_string())?.timeout(timeout);
+        let mut endpoint = Channel::from_shared(url.to_string())?
+            .timeout(timeout)
+            .tcp_nodelay(true);
         if let Some(interval) = keepalive_interval {
             endpoint = endpoint
                 .http2_keep_alive_interval(interval)


### PR DESCRIPTION
## Problem

The personhog gRPC services (router and replica) show ~40-65ms of unexplained p99 tail latency on the router→replica hop. At p50, the hop adds ~0.1ms (normal), but at p99 it balloons to 40-65ms. This pattern is consistent with the interaction between Nagle's algorithm (sender buffers small writes until outstanding ACKs return) and TCP delayed ACKs (receiver waits up to 40ms before ACKing). When HTTP/2 frames a gRPC request as multiple small writes (HEADERS + DATA), Nagle holds back the second write until the delayed ACK fires — adding up to 40ms of dead wait time. Setting TCP_NODELAY disables Nagle so every write is sent immediately, which is the correct setting for request-response protocols. Neither the router nor the replica had this configured on any connection (client or server). The capture service already sets TCP_NODELAY explicitly for this reason.

## Changes

  - rust/personhog-common/src/grpc.rs — TrackedTcpStream::new() now calls set_nodelay(true) on every       
  accepted server socket. This covers both the router and replica inbound connections since both use
  tracked_tcp_incoming().                                                                         
  - rust/personhog-router/src/backend/replica.rs — Added .tcp_nodelay(true) to the tonic Endpoint for
  outbound router→replica connections.                                                                     
  - rust/personhog-router/src/backend/leader.rs — Added .tcp_nodelay(true) to the tonic Endpoint for
  outbound router→leader connections. 

## How did you test this code?

Compiles cleanly and its basically always a good idea to set nodelay: https://brooker.co.za/blog/2024/05/09/nagle.html