### PR TITLE
fix(onboarding): close manual modal before opening SDK instructions in wizard-only variant

### DIFF
--- a/frontend/src/scenes/onboarding/sdks/OnboardingInstallStep.tsx
+++ b/frontend/src/scenes/onboarding/sdks/OnboardingInstallStep.tsx
@@ -486,6 +486,7 @@ function WizardOnlyVariant({
 
     const handleWizardOnlySDKClick = (sdk: SDK): void => {
         sdkGridProps.onSDKClick(sdk)
+        setManualModalOpen(false)
         setSdkInstructionsOpen(true)
     }
 


### PR DESCRIPTION
## Problem

In the wizard-only variant of the onboarding installation step, clicking a framework in the "Manual SDK setup" modal does nothing. Reported by Fernando [in Slack](https://posthog.slack.com/archives/C043VJ93L3B/p1775481926389919) with a [session replay](https://us.posthog.com/project/2/replay/019d62db-b21c-7411-ad16-2881f65b9f05?t=522).

## Changes

One-line fix: close the manual modal before opening the SDK instructions modal in `handleWizardOnlySDKClick`.

The `SDKInstructionsModal` has `isOpen={sdkInstructionsOpen && !manualModalOpen}`, so while the manual modal stays open, the instructions modal can never appear. Adding `setManualModalOpen(false)` fixes the condition.

## How did you test this code?

Reproduced locally with the `onboarding-wizard-prominence` flag set to `wizard-only`:
1. Navigate to onboarding install step
2. Click "Need to set up manually?" to open the modal
3. Click a framework (e.g. Next.js)
4. **Before fix:** Nothing happens
5. **After fix:** SDK instructions modal opens with framework-specific setup guide
6. Clicking "All SDKs" back button returns to the manual SDK grid

## Publish to changelog?

no

## 🤖 LLM context

Co-authored by Claude Code. Bug reproduced and fix verified using Chrome browser automation.