### PR TITLE
chore(mcp): track initialization metrics and duration

### DIFF
--- a/services/mcp/src/index.ts
+++ b/services/mcp/src/index.ts
@@ -227,6 +227,7 @@ const handleRequest = async (
         organizationId,
         projectId,
         clientUserAgent,
+        requestStartTime: performance.now(),
     })
 
     // Search params are used to build up the list of available tools. If no features are provided, all tools are available.

--- a/services/mcp/src/index.ts
+++ b/services/mcp/src/index.ts
@@ -227,7 +227,7 @@ const handleRequest = async (
         organizationId,
         projectId,
         clientUserAgent,
-        requestStartTime: performance.now(),
+        requestStartTime: Date.now(),
     })
 
     // Search params are used to build up the list of available tools. If no features are provided, all tools are available.

--- a/services/mcp/src/lib/analytics.ts
+++ b/services/mcp/src/lib/analytics.ts
@@ -10,6 +10,7 @@ const DEV_POSTHOG_HOST: string | undefined = env.POSTHOG_ANALYTICS_HOST ?? POSTH
 let _client: PostHog | undefined
 
 export enum AnalyticsEvent {
+    MCP_INIT = 'mcp init',
     MCP_TOOL_CALL = 'mcp tool call',
     MCP_TOOL_RESPONSE = 'mcp tool response',
     AI_TRACE = '$ai_trace',

--- a/services/mcp/src/mcp.ts
+++ b/services/mcp/src/mcp.ts
@@ -477,7 +477,7 @@ export class MCP extends McpAgent<Env> {
         }
 
         const initDurationMs = this.requestProperties.requestStartTime
-            ? performance.now() - this.requestProperties.requestStartTime
+            ? Date.now() - this.requestProperties.requestStartTime
             : undefined
 
         this.ctx.waitUntil(

--- a/services/mcp/src/mcp.ts
+++ b/services/mcp/src/mcp.ts
@@ -45,6 +45,7 @@ export type RequestProperties = {
     clientUserAgent?: string
     readOnly?: boolean
     transport?: 'streamable-http' | 'sse'
+    requestStartTime?: number
 }
 
 export class MCP extends McpAgent<Env> {
@@ -474,6 +475,21 @@ export class MCP extends McpAgent<Env> {
             const typedTool = tool as Tool<z.ZodObject>
             this.registerTool(typedTool, async (params) => typedTool.handler(context, params))
         }
+
+        const initDurationMs = this.requestProperties.requestStartTime
+            ? performance.now() - this.requestProperties.requestStartTime
+            : undefined
+
+        this.ctx.waitUntil(
+            this.trackEvent(AnalyticsEvent.MCP_INIT, {
+                tool_count: allTools.length,
+                mcp_version: version,
+                has_organization_id: !!organizationId,
+                has_project_id: !!projectId,
+                read_only: !!readOnly,
+                ...(initDurationMs !== undefined ? { init_duration_ms: initDurationMs } : {}),
+            })
+        )
     }
 
     private async resolveVersionFlag(): Promise<number | undefined> {


### PR DESCRIPTION
## Problem

We need visibility into MCP initialization performance and configuration to understand initialization patterns and identify potential bottlenecks.

## Changes

- Added `requestStartTime` to `RequestProperties` to capture when request handling begins
- Record request start time in `handleRequest` using `performance.now()`
- Calculate initialization duration and track it along with other initialization metrics via a new `MCP_INIT` analytics event
- Added `MCP_INIT` event to the `AnalyticsEvent` enum
- Tracked metrics include: tool count, MCP version, organization/project presence, read-only mode, and initialization duration

## How did you test this code?

The changes are straightforward instrumentation additions:
- `requestStartTime` is captured at request entry point and used to calculate duration
- Analytics event tracking uses existing `trackEvent` infrastructure with `ctx.waitUntil` to ensure non-blocking execution
- No breaking changes to existing functionality

## Publish to changelog?

No

https://claude.ai/code/session_01Ftskvk73bBFr2UACJmrEiu