### PR TITLE
chore(cli): bump posthog-cli to 0.7.5

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -2,11 +2,9 @@
 
 # 0.7.5
 
-- fix(cymbal): prefer arm64 slice when building symcache from fat dSYM
-- fix(cli): stable source bundle for dSYM uploads — CU-anchored prefix filter
-- fix(cli): thin fat dSYM binaries per arch before zipping
-- fix(cymbal): basename fallback for cross-file inlined frames (Swift WMO)
-- fix(api): allow re-upload of symbol sets with no existing content hash
+- fix: stable source bundle for dSYM uploads — CU-anchored prefix filter prevents framework sources from changing the content hash
+- fix: thin fat dSYM binaries per arch before zipping so sibling arch rebuilds don't cause content_hash_mismatch
+- fix: add `--force` flag to allow overwriting symbol sets whose content has changed
 
 # 0.7.4
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,5 +1,13 @@
 # posthog-cli
 
+# 0.7.5
+
+- fix(cymbal): prefer arm64 slice when building symcache from fat dSYM
+- fix(cli): stable source bundle for dSYM uploads — CU-anchored prefix filter
+- fix(cli): thin fat dSYM binaries per arch before zipping
+- fix(cymbal): basename fallback for cross-file inlined frames (Swift WMO)
+- fix(api): allow re-upload of symbol sets with no existing content hash
+
 # 0.7.4
 
 - fix: create per-UUID ZIP for dSYM uploads

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -1851,7 +1851,7 @@ dependencies = [
 
 [[package]]
 name = "posthog-cli"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "anyhow",
  "chrono",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "posthog-cli"
-version = "0.7.4"
+version = "0.7.5"
 authors = [
     "David <david@posthog.com>",
     "Olly <oliver@posthog.com>",


### PR DESCRIPTION
## What
Bumps `posthog-cli` to version 0.7.5 and updates the CHANGELOG.

## Changes in this release
- **Stable source bundles**: CU-anchored prefix filter prevents framework sources from affecting the dSYM content hash, fixing spurious `content_hash_mismatch` errors on incremental builds.
- **Fat binary thinning**: dSYM DWARF binaries are now thinned per-arch before zipping, so rebuilding a sibling architecture slice no longer changes the content hash for an unrelated UUID.
- **`--force` flag**: new flag to allow overwriting symbol sets whose content has changed server-side.