### PR TITLE
fix(logs): resolve deep link race condition when navigating to shared log URLs

### DIFF
--- a/products/logs/frontend/components/LogsViewer/logsViewerLogic.test.ts
+++ b/products/logs/frontend/components/LogsViewer/logsViewerLogic.test.ts
@@ -686,30 +686,26 @@ describe('logsViewerLogic', () => {
             ;({ logic, dataLogic } = mountWithLogs([]))
         })
 
-        it('clears linkToLogId when linked log found after logs update', async () => {
+        it('clears linkToLogId when linked log is found in results', async () => {
+            // Simulate: linkToLogId set from URL, then query results arrive containing the log
             logic.actions.setLinkToLogId('log-2')
-            await expectLogic(logic).toFinishAllListeners()
-
-            expect(logic.values.linkToLogId).toBe('log-2')
-
             dataLogic.actions.setLogs(mockRawLogs)
             await expectLogic(logic).toFinishAllListeners()
 
             expect(logic.values.linkToLogId).toBeNull()
         })
 
-        it('does not clear linkToLogId while no query has run', async () => {
+        it('clears linkToLogId when log not found in results', async () => {
             logic.actions.setLinkToLogId('log-missing')
+            dataLogic.actions.setLogs(mockRawLogs)
             await expectLogic(logic).toFinishAllListeners()
 
-            expect(logic.values.linkToLogId).toBe('log-missing')
+            expect(logic.values.linkToLogId).toBeNull()
         })
 
-        it('clears linkToLogId when log not found after query completes', async () => {
+        it('clears linkToLogId when query returns zero results', async () => {
             logic.actions.setLinkToLogId('log-missing')
-            await expectLogic(logic).toFinishAllListeners()
-
-            dataLogic.actions.setLogs(mockRawLogs)
+            dataLogic.actions.setLogs([])
             await expectLogic(logic).toFinishAllListeners()
 
             expect(logic.values.linkToLogId).toBeNull()

--- a/products/logs/frontend/components/LogsViewer/logsViewerLogic.test.ts
+++ b/products/logs/frontend/components/LogsViewer/logsViewerLogic.test.ts
@@ -679,6 +679,53 @@ describe('logsViewerLogic', () => {
         })
     })
 
+    describe('deep linking (linkToLogId)', () => {
+        let dataLogic: ReturnType<typeof logsViewerDataLogic.build>
+
+        beforeEach(() => {
+            ;({ logic, dataLogic } = mountWithLogs([]))
+        })
+
+        it('clears linkToLogId when linked log found after logs update', async () => {
+            logic.actions.setLinkToLogId('log-2')
+            await expectLogic(logic).toFinishAllListeners()
+
+            expect(logic.values.linkToLogId).toBe('log-2')
+
+            dataLogic.actions.setLogs(mockRawLogs)
+            await expectLogic(logic).toFinishAllListeners()
+
+            expect(logic.values.linkToLogId).toBeNull()
+        })
+
+        it('does not clear linkToLogId while no query has run', async () => {
+            logic.actions.setLinkToLogId('log-missing')
+            await expectLogic(logic).toFinishAllListeners()
+
+            expect(logic.values.linkToLogId).toBe('log-missing')
+        })
+
+        it('clears linkToLogId when log not found after query completes', async () => {
+            logic.actions.setLinkToLogId('log-missing')
+            await expectLogic(logic).toFinishAllListeners()
+
+            dataLogic.actions.setLogs(mockRawLogs)
+            await expectLogic(logic).toFinishAllListeners()
+
+            expect(logic.values.linkToLogId).toBeNull()
+        })
+
+        it('opens correct log when linkToLogId changes with logs already loaded', async () => {
+            dataLogic.actions.setLogs(mockRawLogs)
+            await expectLogic(logic).toFinishAllListeners()
+
+            logic.actions.setLinkToLogId('log-2')
+            await expectLogic(logic).toFinishAllListeners()
+
+            expect(logic.values.linkToLogId).toBeNull()
+        })
+    })
+
     describe('per-row prettification', () => {
         beforeEach(() => {
             ;({ logic } = mountWithLogs())

--- a/products/logs/frontend/components/LogsViewer/logsViewerLogic.ts
+++ b/products/logs/frontend/components/LogsViewer/logsViewerLogic.ts
@@ -2,9 +2,9 @@ import { actions, connect, kea, key, listeners, path, props, reducers, selectors
 import { subscriptions } from 'kea-subscriptions'
 import posthog from 'posthog-js'
 
+import { lemonToast } from '@posthog/lemon-ui'
+
 import { dayjs } from 'lib/dayjs'
-import { tabAwareActionToUrl } from 'lib/logic/scenes/tabAwareActionToUrl'
-import { tabAwareUrlToAction } from 'lib/logic/scenes/tabAwareUrlToAction'
 import { copyToClipboard } from 'lib/utils/copyToClipboard'
 
 import { logsViewerConfigLogic } from 'products/logs/frontend/components/LogsViewer/config/logsViewerConfigLogic'
@@ -33,6 +33,32 @@ export interface LogsViewerLogicProps {
     id: string
 }
 
+function tryOpenLinkedLog(
+    logs: ParsedLogMessage[],
+    linkToLogId: string | null,
+    logsLoading: boolean,
+    actions: {
+        setCursor: (index: number) => void
+        openLogDetails: (log: ParsedLogMessage) => void
+        requestScrollToCursor: () => void
+        setLinkToLogId: (id: string | null) => void
+    }
+): void {
+    if (!linkToLogId || logs.length === 0) {
+        return
+    }
+    const index = logs.findIndex((log) => log.uuid === linkToLogId)
+    if (index !== -1) {
+        actions.setCursor(index)
+        actions.openLogDetails(logs[index])
+        actions.requestScrollToCursor()
+        actions.setLinkToLogId(null)
+    } else if (!logsLoading) {
+        lemonToast.warning('Log not found')
+        actions.setLinkToLogId(null)
+    }
+}
+
 export const logsViewerLogic = kea<logsViewerLogicType>([
     path((id) => ['products', 'logs', 'frontend', 'components', 'LogsViewer', 'logsViewerLogic', id]),
     props({} as LogsViewerLogicProps),
@@ -44,7 +70,7 @@ export const logsViewerLogic = kea<logsViewerLogicType>([
             logDetailsModalLogic({ id }),
             ['isLogDetailsOpen'],
             logsViewerDataLogic({ id }),
-            ['parsedLogs as logs'],
+            ['parsedLogs as logs', 'logsLoading'],
             logsViewerConfigLogic({ id }),
             ['orderBy'],
         ],
@@ -81,7 +107,6 @@ export const logsViewerLogic = kea<logsViewerLogicType>([
 
         // Deep linking - position cursor at a specific log by ID
         setLinkToLogId: (linkToLogId: string | null) => ({ linkToLogId }),
-        setCursorToLogId: (logId: string) => ({ logId }),
 
         // Copy link to log
         copyLinkToLog: (logId: string) => ({ logId }),
@@ -442,16 +467,6 @@ export const logsViewerLogic = kea<logsViewerLogicType>([
                 }
             }
         },
-        setCursorToLogId: ({ logId }) => {
-            const index = values.logs.findIndex((log) => log.uuid === logId)
-            if (index !== -1) {
-                actions.setCursor(index)
-                // If navigating via link, also open the details modal
-                if (values.linkToLogId === logId) {
-                    actions.openLogDetails(values.logs[index])
-                }
-            }
-        },
         copyLinkToLog: ({ logId }) => {
             posthog.capture('logs link copied')
             const url = new URL(window.location.href)
@@ -500,44 +515,20 @@ export const logsViewerLogic = kea<logsViewerLogicType>([
         },
     })),
 
-    tabAwareUrlToAction(({ actions, values }) => ({
-        '*': (_, searchParams) => {
-            // Support both new (linkToLogId) and legacy (highlightedLogId) URL params
-            const linkToLogId = (searchParams.linkToLogId ?? searchParams.highlightedLogId) as string | undefined
-            if (linkToLogId && linkToLogId !== values.linkToLogId) {
-                actions.setLinkToLogId(linkToLogId)
-            }
-        },
-    })),
-
-    tabAwareActionToUrl(() => {
-        const clearLinkToLogIdFromUrl = ():
-            | [string, Record<string, any>, Record<string, any>, { replace: boolean }]
-            | void => {
-            const url = new URL(window.location.href)
-            const hasLinkParam = url.searchParams.has('linkToLogId') || url.searchParams.has('highlightedLogId')
-            if (hasLinkParam) {
-                url.searchParams.delete('linkToLogId')
-                url.searchParams.delete('highlightedLogId')
-                return [url.pathname, Object.fromEntries(url.searchParams), {}, { replace: true }]
-            }
-        }
-        return {
-            // Clear URL param when user actively navigates
-            moveCursorDown: clearLinkToLogIdFromUrl,
-            moveCursorUp: clearLinkToLogIdFromUrl,
-            userSetCursorIndex: clearLinkToLogIdFromUrl,
-        }
-    }),
-
-    subscriptions(({ actions }) => ({
+    subscriptions(({ actions, values }) => ({
         cursorIndex: (cursorIndex) => {
             if (cursorIndex !== null) {
                 actions.requestScrollToCursor()
             }
         },
-        logs: () => {
+        logs: (logs: ParsedLogMessage[]) => {
             actions.recomputeRowHeights()
+            tryOpenLinkedLog(logs, values.linkToLogId, values.logsLoading, actions)
+        },
+        linkToLogId: (linkToLogId: string | null) => {
+            if (linkToLogId) {
+                tryOpenLinkedLog(values.logs, linkToLogId, values.logsLoading, actions)
+            }
         },
     })),
 ])

--- a/products/logs/frontend/components/LogsViewer/logsViewerLogic.ts
+++ b/products/logs/frontend/components/LogsViewer/logsViewerLogic.ts
@@ -42,9 +42,10 @@ function tryOpenLinkedLog(
         openLogDetails: (log: ParsedLogMessage) => void
         requestScrollToCursor: () => void
         setLinkToLogId: (id: string | null) => void
+        clearLinkToLogId: () => void
     }
 ): void {
-    if (!linkToLogId || logs.length === 0) {
+    if (!linkToLogId || logsLoading) {
         return
     }
     const index = logs.findIndex((log) => log.uuid === linkToLogId)
@@ -53,9 +54,9 @@ function tryOpenLinkedLog(
         actions.openLogDetails(logs[index])
         actions.requestScrollToCursor()
         actions.setLinkToLogId(null)
-    } else if (!logsLoading) {
+    } else {
         lemonToast.warning('Log not found')
-        actions.setLinkToLogId(null)
+        actions.clearLinkToLogId()
     }
 }
 
@@ -107,6 +108,7 @@ export const logsViewerLogic = kea<logsViewerLogicType>([
 
         // Deep linking - position cursor at a specific log by ID
         setLinkToLogId: (linkToLogId: string | null) => ({ linkToLogId }),
+        clearLinkToLogId: true,
 
         // Copy link to log
         copyLinkToLog: (logId: string) => ({ logId }),
@@ -187,7 +189,7 @@ export const logsViewerLogic = kea<logsViewerLogicType>([
             null as string | null,
             {
                 setLinkToLogId: (_, { linkToLogId }) => linkToLogId,
-                // Clear when user actively navigates
+                clearLinkToLogId: () => null,
                 moveCursorDown: () => null,
                 moveCursorUp: () => null,
                 userSetCursorIndex: () => null,

--- a/products/logs/frontend/components/VirtualizedLogsList/VirtualizedLogsList.tsx
+++ b/products/logs/frontend/components/VirtualizedLogsList/VirtualizedLogsList.tsx
@@ -157,8 +157,6 @@ export function VirtualizedLogsList({
         attributeColumnWidths,
         selectedLogIds,
         prettifiedLogIds,
-        linkToLogId,
-        logsCount,
     } = useValues(logsViewerLogic)
     const {
         togglePinLog,
@@ -169,7 +167,6 @@ export function VirtualizedLogsList({
         selectLogRange,
         togglePrettifyLog,
         setFocused,
-        setCursorToLogId,
     } = useActions(logsViewerLogic)
     const { openLogDetails } = useActions(logDetailsModalLogic)
 
@@ -233,15 +230,6 @@ export function VirtualizedLogsList({
     )
 
     const minRowWidth = useMemo(() => getColumnsMinRowWidth(columns), [columns])
-
-    // Position cursor at linked log when deep linking (URL -> cursor)
-    useEffect(() => {
-        if (!disableCursor && linkToLogId && logsCount > 0) {
-            setCursorToLogId(linkToLogId)
-            containerRef.current?.focus()
-            containerRef.current?.scrollIntoView({ behavior: 'smooth', block: 'center' })
-        }
-    }, [disableCursor, linkToLogId, logsCount, setCursorToLogId])
 
     // Scroll to cursor when requested (subscription fires when cursorIndex changes)
     useEffect(() => {

--- a/products/logs/frontend/logsSceneLogic.tsx
+++ b/products/logs/frontend/logsSceneLogic.tsx
@@ -56,7 +56,7 @@ export const logsSceneLogic = kea<logsSceneLogicType>([
             logsViewerDataLogic({ id: props.tabId }),
             ['setInitialLogsLimit', 'fetchLogsSuccess', 'handleQueryChange'],
             logsViewerLogic({ id: props.tabId }),
-            ['setLinkToLogId'],
+            ['setLinkToLogId', 'clearLinkToLogId'],
             logDetailsModalLogic({ id: props.tabId }),
             ['closeLogDetails'],
         ],
@@ -222,6 +222,7 @@ export const logsSceneLogic = kea<logsSceneLogicType>([
             // then resets to null so subsequent queries use the default page size.
             fetchLogsSuccess: () => clearInitialLogsLimit(),
             closeLogDetails: () => clearLinkToLogId(),
+            clearLinkToLogId: () => clearLinkToLogId(),
             syncUrl: () => syncUrl(),
             setActiveTab: () => syncActiveTab(),
         }

--- a/products/logs/frontend/logsSceneLogic.tsx
+++ b/products/logs/frontend/logsSceneLogic.tsx
@@ -28,6 +28,8 @@ import {
     isValidSeverityLevel,
     logsViewerFiltersLogic,
 } from 'products/logs/frontend/components/LogsViewer/Filters/logsViewerFiltersLogic'
+import { logDetailsModalLogic } from 'products/logs/frontend/components/LogsViewer/LogDetailsModal/logDetailsModalLogic'
+import { logsViewerLogic } from 'products/logs/frontend/components/LogsViewer/logsViewerLogic'
 
 import type { logsSceneLogicType } from './logsSceneLogicType'
 
@@ -53,6 +55,10 @@ export const logsSceneLogic = kea<logsSceneLogicType>([
             ['setOrderBy'],
             logsViewerDataLogic({ id: props.tabId }),
             ['setInitialLogsLimit', 'fetchLogsSuccess', 'handleQueryChange'],
+            logsViewerLogic({ id: props.tabId }),
+            ['setLinkToLogId'],
+            logDetailsModalLogic({ id: props.tabId }),
+            ['closeLogDetails'],
         ],
         values: [
             logsViewerFiltersLogic({ id: props.tabId }),
@@ -61,6 +67,8 @@ export const logsSceneLogic = kea<logsSceneLogicType>([
             ['orderBy'],
             logsViewerDataLogic({ id: props.tabId }),
             ['initialLogsLimit'],
+            logsViewerLogic({ id: props.tabId }),
+            ['linkToLogId'],
         ],
     })),
     tabAwareUrlToAction(({ actions, values, cache }) => {
@@ -144,6 +152,11 @@ export const logsSceneLogic = kea<logsSceneLogicType>([
             if (params.initialLogsLimit != null && +params.initialLogsLimit !== values.initialLogsLimit) {
                 actions.setInitialLogsLimit(+params.initialLogsLimit)
             }
+
+            const linkToLogId = params.linkToLogId as string | undefined
+            if (linkToLogId && linkToLogId !== values.linkToLogId) {
+                actions.setLinkToLogId(linkToLogId)
+            }
         }
         return {
             '*': urlToAction,
@@ -175,6 +188,13 @@ export const logsSceneLogic = kea<logsSceneLogicType>([
             return result
         }
 
+        const clearLinkToLogId = (): ReturnType<typeof syncSearchParams> => {
+            return syncSearchParams(router, (params: Params) => {
+                delete params.linkToLogId
+                return params
+            })
+        }
+
         const clearInitialLogsLimit = (): [
             string,
             Params,
@@ -201,6 +221,7 @@ export const logsSceneLogic = kea<logsSceneLogicType>([
             // It ensures the first fetch loads enough logs to include the linked log,
             // then resets to null so subsequent queries use the default page size.
             fetchLogsSuccess: () => clearInitialLogsLimit(),
+            closeLogDetails: () => clearLinkToLogId(),
             syncUrl: () => syncUrl(),
             setActiveTab: () => syncActiveTab(),
         }


### PR DESCRIPTION
## Problem

The "copy link to log" functionality was buggy and didn't always work as expected due to race conditions in logic.

## Changes

  - Moved `linkToLogId` URL reading from `logsViewerLogic` to `logsSceneLogic` (where `tabAwareUrlToAction` works correctly) 
  - Replaced the `useEffect` in `VirtualizedLogsList` with Kea subscriptions on both `logs` and `linkToLogId` in
  `logsViewerLogic` — these retry automatically when new query results arrive                                                
  - Added "Log not found" toast when the linked log isn't in the results after loading completes
  - URL param persists until the detail modal is closed (so refreshing re-opens the log)                                     
  - Removed legacy `highlightedLogId` URL param support                                                                      
  - Removed dead `setCursorToLogId` action and listener   

## How did you test this code?

local testing & new tests

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

no