### PR TITLE
feat(logs): add recovery notification sub-templates for log alerts

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -589,6 +589,8 @@ export const INSIGHT_ALERT_FIRING_EVENT_ID = '$insight_alert_firing'
 
 export const LOGS_ALERT_FIRING_SUB_TEMPLATE_ID = 'logs-alert-firing'
 export const LOGS_ALERT_FIRING_EVENT_ID = '$logs_alert_firing'
+export const LOGS_ALERT_RESOLVED_SUB_TEMPLATE_ID = 'logs-alert-resolved'
+export const LOGS_ALERT_RESOLVED_EVENT_ID = '$logs_alert_resolved'
 
 export const COHORT_PERSONS_QUERY_LIMIT = 10000
 

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -589,7 +589,6 @@ export const INSIGHT_ALERT_FIRING_EVENT_ID = '$insight_alert_firing'
 
 export const LOGS_ALERT_FIRING_SUB_TEMPLATE_ID = 'logs-alert-firing'
 export const LOGS_ALERT_FIRING_EVENT_ID = '$logs_alert_firing'
-export const LOGS_ALERT_RESOLVED_SUB_TEMPLATE_ID = 'logs-alert-resolved'
 export const LOGS_ALERT_RESOLVED_EVENT_ID = '$logs_alert_resolved'
 
 export const COHORT_PERSONS_QUERY_LIMIT = 10000

--- a/frontend/src/scenes/hog-functions/filters/HogFunctionFiltersInternal.tsx
+++ b/frontend/src/scenes/hog-functions/filters/HogFunctionFiltersInternal.tsx
@@ -45,6 +45,10 @@ export const getProductEventFilterOptions = (contextId: HogFunctionConfiguration
                     label: 'Log alert firing',
                     value: '$logs_alert_firing',
                 },
+                {
+                    label: 'Log alert resolved',
+                    value: '$logs_alert_resolved',
+                },
             ]
         case 'discussion-mention':
             return [

--- a/frontend/src/scenes/hog-functions/sub-templates/sub-templates.ts
+++ b/frontend/src/scenes/hog-functions/sub-templates/sub-templates.ts
@@ -93,6 +93,13 @@ export const HOG_FUNCTION_SUB_TEMPLATE_COMMON_PROPERTIES: Record<
         filters: { events: [{ id: '$logs_alert_firing', type: 'events' }] },
         flag: FEATURE_FLAGS.LOGS_ALERTING,
     },
+    'logs-alert-resolved': {
+        sub_template_id: 'logs-alert-resolved',
+        type: 'internal_destination',
+        context_id: 'logs-alerting',
+        filters: { events: [{ id: '$logs_alert_resolved', type: 'events' }] },
+        flag: FEATURE_FLAGS.LOGS_ALERTING,
+    },
 }
 
 export const HOG_FUNCTION_SUB_TEMPLATES: Record<HogFunctionSubTemplateIdType, HogFunctionSubTemplateType[]> = {
@@ -777,6 +784,58 @@ export const HOG_FUNCTION_SUB_TEMPLATES: Record<HogFunctionSubTemplateIdType, Ho
             },
         },
     ],
+    'logs-alert-resolved': [
+        {
+            ...HOG_FUNCTION_SUB_TEMPLATE_COMMON_PROPERTIES['logs-alert-resolved'],
+            template_id: 'template-webhook',
+            name: 'HTTP Webhook on log alert resolved',
+            description: 'Send a webhook when a log alert resolves',
+        },
+        {
+            ...HOG_FUNCTION_SUB_TEMPLATE_COMMON_PROPERTIES['logs-alert-resolved'],
+            template_id: 'template-slack',
+            name: 'Post to Slack on log alert resolved',
+            description: 'Post to a Slack channel when a log alert resolves',
+            inputs: {
+                blocks: {
+                    value: [
+                        {
+                            type: 'header',
+                            text: {
+                                type: 'plain_text',
+                                text: "Log alert '{event.properties.alert_name}' has resolved",
+                            },
+                        },
+                        {
+                            type: 'section',
+                            text: {
+                                type: 'mrkdwn',
+                                text: '*Current count:* {event.properties.result_count} in {event.properties.window_minutes}m (threshold: {event.properties.threshold_operator} {event.properties.threshold_count})',
+                            },
+                        },
+                        {
+                            type: 'context',
+                            elements: [{ type: 'mrkdwn', text: 'Project: <{project.url}|{project.name}>' }],
+                        },
+                        { type: 'divider' },
+                        {
+                            type: 'actions',
+                            elements: [
+                                {
+                                    url: '{project.url}/logs?{event.properties.logs_url_params}',
+                                    text: { text: 'View logs', type: 'plain_text' },
+                                    type: 'button',
+                                },
+                            ],
+                        },
+                    ],
+                },
+                text: {
+                    value: "Log alert '{event.properties.alert_name}' has resolved",
+                },
+            },
+        },
+    ],
 }
 
 export const getSubTemplate = (
@@ -801,6 +860,7 @@ export const eventToHogFunctionContextId = (event: string | undefined): HogFunct
         case '$discussion_mention_created':
             return 'discussion-mention'
         case '$logs_alert_firing':
+        case '$logs_alert_resolved':
             return 'logs-alerting'
         default:
             return 'standard'

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -6427,6 +6427,7 @@ export type HogFunctionSubTemplateIdType =
     | 'insight-alert-firing'
     | 'experiment-significant'
     | 'logs-alert-firing'
+    | 'logs-alert-resolved'
 
 export type HogFunctionConfigurationType = Omit<
     HogFunctionType,

--- a/products/logs/frontend/components/LogsAlerting/__tests__/logsAlertUtils.test.ts
+++ b/products/logs/frontend/components/LogsAlerting/__tests__/logsAlertUtils.test.ts
@@ -1,9 +1,13 @@
+import {
+    LOGS_ALERT_FIRING_EVENT_ID,
+    LOGS_ALERT_RESOLVED_EVENT_ID,
+} from 'lib/constants'
+
 import { PropertyFilterType, PropertyOperator } from '~/types'
 
 import {
     buildLogsAlertFilterConfig,
     buildLogsAlertHogFunctionPayload,
-    buildLogsAlertResolvedWebhookBody,
     LOGS_ALERT_NOTIFICATION_TYPE_SLACK,
     LOGS_ALERT_NOTIFICATION_TYPE_WEBHOOK,
     PendingLogsAlertNotification,
@@ -24,16 +28,16 @@ describe('logsAlertUtils', () => {
             ])
         })
 
-        it('includes both $logs_alert_firing and $logs_alert_resolved event filters', () => {
+        it('includes both firing and resolved event filters', () => {
             const config = buildLogsAlertFilterConfig('alert-123')
 
             expect(config.events).toEqual([
                 {
-                    id: '$logs_alert_firing',
+                    id: LOGS_ALERT_FIRING_EVENT_ID,
                     type: 'events',
                 },
                 {
-                    id: '$logs_alert_resolved',
+                    id: LOGS_ALERT_RESOLVED_EVENT_ID,
                     type: 'events',
                 },
             ])
@@ -41,7 +45,7 @@ describe('logsAlertUtils', () => {
     })
 
     describe('buildLogsAlertHogFunctionPayload', () => {
-        it('builds slack notification payload with channel and workspace', () => {
+        it('builds slack payload with conditional blocks and both-event filter', () => {
             const notification: PendingLogsAlertNotification = {
                 type: LOGS_ALERT_NOTIFICATION_TYPE_SLACK,
                 slackWorkspaceId: 42,
@@ -60,8 +64,15 @@ describe('logsAlertUtils', () => {
             })
             expect(payload.inputs?.slack_workspace).toEqual({ value: 42 })
             expect(payload.inputs?.channel).toEqual({ value: 'C123' })
-            expect(payload.filters?.events?.[0].id).toBe('$logs_alert_firing')
-            expect(payload.filters?.properties?.[0].value).toBe('alert-1')
+            expect(payload.filters?.events).toHaveLength(2)
+            expect(payload.filters?.events?.[0].id).toBe(LOGS_ALERT_FIRING_EVENT_ID)
+            expect(payload.filters?.events?.[1].id).toBe(LOGS_ALERT_RESOLVED_EVENT_ID)
+
+            // Slack blocks use if() conditionals for firing vs resolved copy
+            const headerText = payload.inputs?.blocks?.value?.[0]?.text?.text
+            expect(headerText).toContain("if(event.event == '$logs_alert_resolved'")
+            expect(headerText).toContain('has resolved')
+            expect(headerText).toContain('is firing')
         })
 
         it('uses fallback name when alertName is undefined for slack', () => {
@@ -89,7 +100,7 @@ describe('logsAlertUtils', () => {
             expect(payload.name).toBe('My Alert: Slack #channel')
         })
 
-        it('builds webhook notification payload with URL', () => {
+        it('builds webhook payload with conditional event discriminator', () => {
             const notification: PendingLogsAlertNotification = {
                 type: LOGS_ALERT_NOTIFICATION_TYPE_WEBHOOK,
                 webhookUrl: 'https://example.com/hook',
@@ -106,12 +117,15 @@ describe('logsAlertUtils', () => {
             })
             expect(payload.inputs?.url).toEqual({ value: 'https://example.com/hook' })
             expect(payload.inputs?.body?.value).toMatchObject({
-                event: 'firing',
+                event: "{if(event.event == '$logs_alert_resolved', 'resolved', 'firing')}",
                 alert_name: '{event.properties.alert_name}',
+                result_count: '{event.properties.result_count}',
                 threshold_count: '{event.properties.threshold_count}',
+                threshold_operator: '{event.properties.threshold_operator}',
                 window_minutes: '{event.properties.window_minutes}',
                 logs_url: '{project.url}/logs?{event.properties.logs_url_params}',
             })
+            expect(payload.filters?.events).toHaveLength(2)
         })
 
         it('uses fallback name when alertName is undefined for webhook', () => {
@@ -123,21 +137,6 @@ describe('logsAlertUtils', () => {
             const payload = buildLogsAlertHogFunctionPayload('alert-5', undefined, notification)
 
             expect(payload.name).toBe('Alert: Webhook https://example.com/hook')
-        })
-    })
-
-    describe('buildLogsAlertResolvedWebhookBody', () => {
-        it('returns resolved webhook body with all expected fields', () => {
-            const body = buildLogsAlertResolvedWebhookBody()
-
-            expect(body).toEqual({
-                event: 'resolved',
-                alert_name: '{event.properties.alert_name}',
-                result_count: '{event.properties.result_count}',
-                threshold_count: '{event.properties.threshold_count}',
-                window_minutes: '{event.properties.window_minutes}',
-                logs_url: '{project.url}/logs?{event.properties.logs_url_params}',
-            })
         })
     })
 })

--- a/products/logs/frontend/components/LogsAlerting/__tests__/logsAlertUtils.test.ts
+++ b/products/logs/frontend/components/LogsAlerting/__tests__/logsAlertUtils.test.ts
@@ -3,6 +3,7 @@ import { PropertyFilterType, PropertyOperator } from '~/types'
 import {
     buildLogsAlertFilterConfig,
     buildLogsAlertHogFunctionPayload,
+    buildLogsAlertResolvedWebhookBody,
     LOGS_ALERT_NOTIFICATION_TYPE_SLACK,
     LOGS_ALERT_NOTIFICATION_TYPE_WEBHOOK,
     PendingLogsAlertNotification,
@@ -23,12 +24,16 @@ describe('logsAlertUtils', () => {
             ])
         })
 
-        it('includes $logs_alert_firing event filter', () => {
+        it('includes both $logs_alert_firing and $logs_alert_resolved event filters', () => {
             const config = buildLogsAlertFilterConfig('alert-123')
 
             expect(config.events).toEqual([
                 {
                     id: '$logs_alert_firing',
+                    type: 'events',
+                },
+                {
+                    id: '$logs_alert_resolved',
                     type: 'events',
                 },
             ])
@@ -101,6 +106,7 @@ describe('logsAlertUtils', () => {
             })
             expect(payload.inputs?.url).toEqual({ value: 'https://example.com/hook' })
             expect(payload.inputs?.body?.value).toMatchObject({
+                event: 'firing',
                 alert_name: '{event.properties.alert_name}',
                 threshold_count: '{event.properties.threshold_count}',
                 window_minutes: '{event.properties.window_minutes}',
@@ -117,6 +123,21 @@ describe('logsAlertUtils', () => {
             const payload = buildLogsAlertHogFunctionPayload('alert-5', undefined, notification)
 
             expect(payload.name).toBe('Alert: Webhook https://example.com/hook')
+        })
+    })
+
+    describe('buildLogsAlertResolvedWebhookBody', () => {
+        it('returns resolved webhook body with all expected fields', () => {
+            const body = buildLogsAlertResolvedWebhookBody()
+
+            expect(body).toEqual({
+                event: 'resolved',
+                alert_name: '{event.properties.alert_name}',
+                result_count: '{event.properties.result_count}',
+                threshold_count: '{event.properties.threshold_count}',
+                window_minutes: '{event.properties.window_minutes}',
+                logs_url: '{project.url}/logs?{event.properties.logs_url_params}',
+            })
         })
     })
 })

--- a/products/logs/frontend/components/LogsAlerting/__tests__/logsAlertUtils.test.ts
+++ b/products/logs/frontend/components/LogsAlerting/__tests__/logsAlertUtils.test.ts
@@ -1,7 +1,4 @@
-import {
-    LOGS_ALERT_FIRING_EVENT_ID,
-    LOGS_ALERT_RESOLVED_EVENT_ID,
-} from 'lib/constants'
+import { LOGS_ALERT_FIRING_EVENT_ID, LOGS_ALERT_RESOLVED_EVENT_ID } from 'lib/constants'
 
 import { PropertyFilterType, PropertyOperator } from '~/types'
 

--- a/products/logs/frontend/components/LogsAlerting/logsAlertUtils.ts
+++ b/products/logs/frontend/components/LogsAlerting/logsAlertUtils.ts
@@ -1,4 +1,8 @@
-import { LOGS_ALERT_FIRING_EVENT_ID, LOGS_ALERT_FIRING_SUB_TEMPLATE_ID } from 'lib/constants'
+import {
+    LOGS_ALERT_FIRING_EVENT_ID,
+    LOGS_ALERT_FIRING_SUB_TEMPLATE_ID,
+    LOGS_ALERT_RESOLVED_EVENT_ID,
+} from 'lib/constants'
 import {
     HOG_FUNCTION_SUB_TEMPLATES,
     HOG_FUNCTION_SUB_TEMPLATE_COMMON_PROPERTIES,
@@ -36,6 +40,10 @@ export const buildLogsAlertFilterConfig = (alertId: string): CyclotronJobFilters
     events: [
         {
             id: LOGS_ALERT_FIRING_EVENT_ID,
+            type: 'events',
+        },
+        {
+            id: LOGS_ALERT_RESOLVED_EVENT_ID,
             type: 'events',
         },
     ],
@@ -79,6 +87,7 @@ export function buildLogsAlertHogFunctionPayload(
             url: { value: notification.webhookUrl },
             body: {
                 value: {
+                    event: 'firing',
                     alert_name: '{event.properties.alert_name}',
                     threshold_count: '{event.properties.threshold_count}',
                     window_minutes: '{event.properties.window_minutes}',
@@ -86,5 +95,16 @@ export function buildLogsAlertHogFunctionPayload(
                 },
             },
         },
+    }
+}
+
+export function buildLogsAlertResolvedWebhookBody(): Record<string, string> {
+    return {
+        event: 'resolved',
+        alert_name: '{event.properties.alert_name}',
+        result_count: '{event.properties.result_count}',
+        threshold_count: '{event.properties.threshold_count}',
+        window_minutes: '{event.properties.window_minutes}',
+        logs_url: '{project.url}/logs?{event.properties.logs_url_params}',
     }
 }

--- a/products/logs/frontend/components/LogsAlerting/logsAlertUtils.ts
+++ b/products/logs/frontend/components/LogsAlerting/logsAlertUtils.ts
@@ -49,9 +49,59 @@ export const buildLogsAlertFilterConfig = (alertId: string): CyclotronJobFilters
     ],
 })
 
-const LOGS_ALERT_SLACK_INPUTS =
+const LOGS_ALERT_SLACK_BLOCKS = [
+    {
+        type: 'header',
+        text: {
+            type: 'plain_text',
+            text: "Log alert '{event.properties.alert_name}' {if(event.event == '$logs_alert_resolved', 'has resolved', 'is firing')}",
+        },
+    },
+    {
+        type: 'section',
+        text: {
+            type: 'mrkdwn',
+            text: "*{if(event.event == '$logs_alert_resolved', 'Current count', 'Threshold breached')}:* {event.properties.result_count} logs in {event.properties.window_minutes}m (threshold: {event.properties.threshold_operator} {event.properties.threshold_count})",
+        },
+    },
+    {
+        type: 'context',
+        elements: [{ type: 'mrkdwn', text: 'Project: <{project.url}|{project.name}>' }],
+    },
+    { type: 'divider' },
+    {
+        type: 'actions',
+        elements: [
+            {
+                url: '{project.url}/logs?{event.properties.logs_url_params}',
+                text: { text: 'View logs', type: 'plain_text' },
+                type: 'button',
+            },
+        ],
+    },
+]
+
+const BASE_SLACK_INPUTS =
     HOG_FUNCTION_SUB_TEMPLATES[LOGS_ALERT_FIRING_SUB_TEMPLATE_ID].find((t) => t.template_id === 'template-slack')
         ?.inputs ?? {}
+
+const LOGS_ALERT_SLACK_INPUTS = {
+    ...BASE_SLACK_INPUTS,
+    blocks: { value: LOGS_ALERT_SLACK_BLOCKS },
+    text: {
+        value: "Log alert '{event.properties.alert_name}' {if(event.event == '$logs_alert_resolved', 'has resolved', 'is firing')}",
+    },
+}
+
+const LOGS_ALERT_WEBHOOK_BODY: Record<string, string> = {
+    event: "{if(event.event == '$logs_alert_resolved', 'resolved', 'firing')}",
+    alert_name: '{event.properties.alert_name}',
+    result_count: '{event.properties.result_count}',
+    threshold_count: '{event.properties.threshold_count}',
+    threshold_operator: '{event.properties.threshold_operator}',
+    window_minutes: '{event.properties.window_minutes}',
+    logs_url: '{project.url}/logs?{event.properties.logs_url_params}',
+}
 
 export function buildLogsAlertHogFunctionPayload(
     alertId: string,
@@ -85,26 +135,7 @@ export function buildLogsAlertHogFunctionPayload(
         template_id: 'template-webhook',
         inputs: {
             url: { value: notification.webhookUrl },
-            body: {
-                value: {
-                    event: 'firing',
-                    alert_name: '{event.properties.alert_name}',
-                    threshold_count: '{event.properties.threshold_count}',
-                    window_minutes: '{event.properties.window_minutes}',
-                    logs_url: '{project.url}/logs?{event.properties.logs_url_params}',
-                },
-            },
+            body: { value: LOGS_ALERT_WEBHOOK_BODY },
         },
-    }
-}
-
-export function buildLogsAlertResolvedWebhookBody(): Record<string, string> {
-    return {
-        event: 'resolved',
-        alert_name: '{event.properties.alert_name}',
-        result_count: '{event.properties.result_count}',
-        threshold_count: '{event.properties.threshold_count}',
-        window_minutes: '{event.properties.window_minutes}',
-        logs_url: '{project.url}/logs?{event.properties.logs_url_params}',
     }
 }


### PR DESCRIPTION
## Problem

When a logs alert fires (threshold breached), users get notified via Slack/Webhook. But when the alert resolves (count drops back below threshold), they hear nothing — they don't know the incident is over without manually checking.

## Changes

Adds frontend support for `$logs_alert_resolved` recovery notifications. The backend already emits this event (Spike 3.3b);
   this PR registers the frontend sub-templates and updates the HogFunction filter config so notification destinations fire
  on both events.                                                                                                            
                                                            
  - Add `logs-alert-resolved` constants and type to `HogFunctionSubTemplateIdType`                                           
  - Register resolved sub-template with Slack and Webhook variants (resolved-specific copy: "has resolved" header, current
  count vs threshold)                                                                                                        
  - Update `buildLogsAlertFilterConfig` to include both `$logs_alert_firing` and `$logs_alert_resolved` events — newly
  created notification HogFunctions match both                                                                               
  - Add `event: 'firing'`/`'resolved'` discriminator to webhook bodies
  - Add resolved event to `eventToHogFunctionContextId` mapping and filter dropdown  

## How did you test this code?

Tested locally via temporal with webhooks

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

no