### PR TITLE
fix(surveys): sanitize ai-generated survey content

### DIFF
--- a/products/surveys/backend/api/survey.py
+++ b/products/surveys/backend/api/survey.py
@@ -821,6 +821,20 @@ class SurveySerializerCreateUpdateOnly(serializers.ModelSerializer):
                 else:
                     cleaned_question["description"] = description
 
+            for field_name, error_message in [
+                ("buttonText", "Question buttonText must be a string"),
+                ("lowerBoundLabel", "Question lowerBoundLabel must be a string"),
+                ("upperBoundLabel", "Question upperBoundLabel must be a string"),
+            ]:
+                field_value = raw_question.get(field_name)
+                if field_value:
+                    if not isinstance(field_value, str):
+                        raise serializers.ValidationError(error_message)
+                    if nh3.is_html(field_value):
+                        cleaned_question[field_name] = nh3_clean_with_allow_list(field_value)
+                    else:
+                        cleaned_question[field_name] = field_value
+
             # Validate choices first before translation validation to provide clearer error messages
             choices = raw_question.get("choices")
             if choices:

--- a/products/surveys/backend/api/test/test_survey.py
+++ b/products/surveys/backend/api/test/test_survey.py
@@ -317,6 +317,42 @@ class TestSurvey(APIBaseTest):
         assert "<script>" not in q2_es["choices"][1]
         assert "Opción B" in q2_es["choices"][1]
 
+    def test_question_fields_sanitize_all_top_level_translatable_fields(self):
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/surveys/",
+            data={
+                "name": "Survey",
+                "type": "popover",
+                "questions": [
+                    {
+                        "type": "rating",
+                        "question": "<i>Rate us</i><script>xss()</script>",
+                        "description": "<b>Please rate</b><script>bad()</script>",
+                        "buttonText": "<strong>Submit</strong><script>evil()</script>",
+                        "lowerBoundLabel": "<em>Bad</em><script>x()</script>",
+                        "upperBoundLabel": "<u>Good</u><script>y()</script>",
+                    }
+                ],
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED
+        survey = Survey.objects.get(id=response.json()["id"])
+        assert survey.questions is not None
+
+        question = survey.questions[0]
+        assert "<i>Rate us</i>" in question["question"]
+        assert "<script>" not in question["question"]
+        assert "<b>Please rate</b>" in question["description"]
+        assert "<script>" not in question["description"]
+        assert "<strong>Submit</strong>" in question["buttonText"]
+        assert "<script>" not in question["buttonText"]
+        assert "<em>Bad</em>" in question["lowerBoundLabel"]
+        assert "<script>" not in question["lowerBoundLabel"]
+        assert "<u>Good</u>" in question["upperBoundLabel"]
+        assert "<script>" not in question["upperBoundLabel"]
+
     def test_translated_link_validation(self):
         # Test invalid URL scheme in translated link
         response = self.client.post(

--- a/products/surveys/backend/max_tools.py
+++ b/products/surveys/backend/max_tools.py
@@ -10,6 +10,7 @@ import django.utils.timezone
 
 from asgiref.sync import sync_to_async
 from pydantic import BaseModel, ConfigDict, Field
+from rest_framework import serializers
 
 from posthog.schema import SurveyAnalysisQuestionGroup, SurveyAnalysisResponseItem
 
@@ -17,6 +18,7 @@ from posthog.constants import DEFAULT_SURVEY_APPEARANCE
 from posthog.exceptions_capture import capture_exception
 from posthog.models import Team
 
+from products.surveys.backend.api.survey import SurveySerializerCreateUpdateOnly
 from products.surveys.backend.models import Survey
 from products.surveys.backend.summarization.fetch import fetch_responses
 
@@ -92,6 +94,11 @@ def _build_question(q: SimpleSurveyQuestion) -> dict[str, Any]:
     if q.button_text is not None:
         result["buttonText"] = q.button_text
     return result
+
+
+def _validate_and_sanitize_questions(questions: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    serializer = SurveySerializerCreateUpdateOnly()
+    return serializer.validate_questions(questions)
 
 
 def _build_appearance(team: Team) -> dict[str, Any]:
@@ -272,6 +279,7 @@ class CreateSurveyTool(MaxTool):
                 wait_period_days=wait_period_days,
                 responses_limit=responses_limit,
             )
+            survey_data["questions"] = _validate_and_sanitize_questions(survey_data["questions"])
 
             if should_launch:
                 survey_data["start_date"] = django.utils.timezone.now()
@@ -290,6 +298,12 @@ class CreateSurveyTool(MaxTool):
                 "survey_type": survey_type,
             }
 
+        except serializers.ValidationError as e:
+            error_message = str(e.detail if hasattr(e, "detail") else e)
+            return f"Survey validation failed: {error_message}", {
+                "error": "validation_failed",
+                "error_message": error_message,
+            }
         except Exception as e:
             capture_exception(e, {"team_id": self._team.id, "user_id": self._user.id})
             return f"Failed to create survey: {str(e)}", {"error": "creation_failed", "details": str(e)}
@@ -436,7 +450,7 @@ class EditSurveyTool(MaxTool):
                     if simple_q.id and simple_q.id in id_map:
                         new_q["id"] = id_map[simple_q.id]
 
-                update_data["questions"] = new_questions
+                update_data["questions"] = _validate_and_sanitize_questions(new_questions)
             if linked_flag_id is not None:
                 update_data["linked_flag_id"] = linked_flag_id
             if responses_limit is not None:
@@ -490,6 +504,12 @@ class EditSurveyTool(MaxTool):
                 "updated_fields": list(update_data.keys()),
             }
 
+        except serializers.ValidationError as e:
+            error_message = str(e.detail if hasattr(e, "detail") else e)
+            return f"Survey validation failed: {error_message}", {
+                "error": "validation_failed",
+                "error_message": error_message,
+            }
         except Exception as e:
             capture_exception(e, {"team_id": self._team.id, "user_id": self._user.id})
             return f"Failed to edit survey: {str(e)}", {"error": "edit_failed", "details": str(e)}

--- a/products/surveys/backend/test_max_tools.py
+++ b/products/surveys/backend/test_max_tools.py
@@ -328,6 +328,57 @@ class TestSurveyCreatorTool(BaseTest):
         assert survey.conditions["url"] == "/pricing"
         assert survey.conditions["urlMatchType"] == "icontains"
 
+    @pytest.mark.django_db
+    @pytest.mark.asyncio
+    async def test_create_survey_sanitizes_question_html(self):
+        tool = self._setup_tool()
+
+        content, artifact = await tool._arun_impl(
+            name="Sanitized Survey",
+            questions=[
+                SimpleSurveyQuestion(
+                    type="link",
+                    question="<b>Click here</b><script>alert('xss')</script>",
+                    description="<i>Learn more</i><script>evil()</script>",
+                    button_text="<strong>Open</strong><script>bad()</script>",
+                    link="https://example.com",
+                )
+            ],
+        )
+
+        assert "successfully" in content
+        survey = await sync_to_async(Survey.objects.get)(id=artifact["survey_id"])
+        assert survey.questions is not None
+
+        question = survey.questions[0]
+        assert "<b>Click here</b>" in question["question"]
+        assert "<script>" not in question["question"]
+        assert "<i>Learn more</i>" in question["description"]
+        assert "<script>" not in question["description"]
+        assert "<strong>Open</strong>" in question["buttonText"]
+        assert "<script>" not in question["buttonText"]
+
+    @pytest.mark.django_db
+    @pytest.mark.asyncio
+    async def test_create_survey_rejects_javascript_link(self):
+        tool = self._setup_tool()
+
+        content, artifact = await tool._arun_impl(
+            name="Unsafe Survey",
+            questions=[
+                SimpleSurveyQuestion(
+                    type="link",
+                    question="Open this link",
+                    link="javascript:alert('xss')",
+                )
+            ],
+        )
+
+        assert "validation failed" in content.lower()
+        assert artifact["error"] == "validation_failed"
+        assert "schemes" in artifact["error_message"]
+        assert not await sync_to_async(Survey.objects.filter(name="Unsafe Survey").exists)()
+
 
 class TestSurveyAnalysisTool(BaseTest):
     def setUp(self):
@@ -802,6 +853,67 @@ class TestEditSurveyTool(BaseTest):
         updated_survey = await sync_to_async(Survey.objects.get)(id=survey.id)
         assert updated_survey.end_date is not None
         assert updated_survey.archived is True
+
+    @pytest.mark.django_db
+    @pytest.mark.asyncio
+    async def test_edit_survey_sanitizes_question_html(self):
+        tool = self._setup_tool()
+        survey = await self._create_test_survey()
+
+        content, artifact = await tool._arun_impl(
+            survey_id=str(survey.id),
+            questions=[
+                SimpleSurveyQuestion(
+                    id="1",
+                    type="open",
+                    question="<b>Updated question</b><script>alert('xss')</script>",
+                    description="<i>Details</i><script>bad()</script>",
+                    button_text="<strong>Send</strong><script>evil()</script>",
+                )
+            ],
+        )
+
+        assert "updated successfully" in content
+        assert "questions" in artifact["updated_fields"]
+
+        updated_survey = await sync_to_async(Survey.objects.get)(id=survey.id)
+        assert updated_survey.questions is not None
+        question = updated_survey.questions[0]
+        assert "<b>Updated question</b>" in question["question"]
+        assert "<script>" not in question["question"]
+        assert "<i>Details</i>" in question["description"]
+        assert "<script>" not in question["description"]
+        assert "<strong>Send</strong>" in question["buttonText"]
+        assert "<script>" not in question["buttonText"]
+
+    @pytest.mark.django_db
+    @pytest.mark.asyncio
+    async def test_edit_survey_rejects_javascript_link(self):
+        tool = self._setup_tool()
+        survey = await self._create_test_survey(
+            questions=[{"type": "link", "question": "Safe question?", "link": "https://example.com", "id": "q1"}]
+        )
+
+        content, artifact = await tool._arun_impl(
+            survey_id=str(survey.id),
+            questions=[
+                SimpleSurveyQuestion(
+                    id="1",
+                    type="link",
+                    question="Unsafe question?",
+                    link="javascript:alert('xss')",
+                )
+            ],
+        )
+
+        assert "validation failed" in content.lower()
+        assert artifact["error"] == "validation_failed"
+        assert "schemes" in artifact["error_message"]
+
+        updated_survey = await sync_to_async(Survey.objects.get)(id=survey.id)
+        assert updated_survey.questions is not None
+        assert updated_survey.questions[0]["question"] == "Safe question?"
+        assert updated_survey.questions[0]["link"] == "https://example.com"
 
     @pytest.mark.django_db
     @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

Security report VERIA-266 found that the Max survey creation/edit flow bypassed the existing survey serializer sanitization. Users with survey editor access could generate surveys through Max that persisted unsafe HTML or unsupported link schemes into survey questions and CTA links.

## Changes

- Route Max survey question payloads through the existing `SurveySerializerCreateUpdateOnly.validate_questions(...)` sanitization and validation path before persistence
- Return a `validation_failed` result from Max when AI-generated survey content contains invalid links or other rejected question data
- Add regression coverage for create and edit flows covering sanitized HTML content and rejected `javascript:` links

## How did you test this code?

- `ruff check products/surveys/backend/max_tools.py products/surveys/backend/test_max_tools.py`
- `python -m py_compile products/surveys/backend/max_tools.py products/surveys/backend/test_max_tools.py`
- Attempted `pytest products/surveys/backend/test_max_tools.py -k 'sanitizes_question_html or rejects_javascript_link'`, but Django test DB setup failed in this environment because the configured Postgres host `db` was not reachable

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

no

## Docs update

No docs update needed.

## 🤖 LLM context

Authored by Codex in the local workspace.
Reused the existing survey serializer sanitization logic instead of introducing a separate Max-only sanitizer.
