### PR TITLE
Add 50000 limit to aggregate survey query results

### DIFF
--- a/frontend/src/scenes/surveys/utils.ts
+++ b/frontend/src/scenes/surveys/utils.ts
@@ -585,7 +585,7 @@ export function buildAggregateQuery(
         return null
     }
 
-    return `SELECT question_id, label, cnt FROM (${branches.join('\nUNION ALL\n')})`
+    return `SELECT question_id, label, cnt FROM (${branches.join('\nUNION ALL\n')}) LIMIT 50000`
 }
 
 export function buildOpenEndedQuery(


### PR DESCRIPTION
## Problem
survey aggregate query has no defined limit, causing it to be capped at 100

this fix was attempted in https://github.com/PostHog/posthog/pull/51897, but i missed this one 🙈 

## Changes
adds explicit limit to the aggregate query

## How did you test this code?
see manual testing notes in ticket: https://posthoghelp.zendesk.com/agent/tickets/52678 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/56667)

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*