### PR TITLE
fix(phai): remove count<=3 filter blocking well-known events in taxonomy

### DIFF
--- a/ee/hogai/utils/helpers.py
+++ b/ee/hogai/utils/helpers.py
@@ -178,11 +178,9 @@ def _process_events_data(
         "All events",
     ]
     for item in response.results:
-        if len(response.results) > 25 and item.count <= 3:
+        event_def = CORE_FILTER_DEFINITIONS_BY_GROUP.get("events", {}).get(item.event)
+        if event_def and (event_def.get("system") or event_def.get("ignored_in_assistant")):
             continue
-        if event_core_definition := CORE_FILTER_DEFINITIONS_BY_GROUP["events"].get(item.event):
-            if event_core_definition.get("system") or event_core_definition.get("ignored_in_assistant"):
-                continue  # Skip system or ignored events (safety net, already filtered in SQL)
         events.append(item.event)
 
     event_to_description: dict[str, str] = {}
@@ -204,7 +202,7 @@ def _process_events_data(
             if event_name not in context_event_names and (
                 event_core_definition.get("system") or event_core_definition.get("ignored_in_assistant")
             ):
-                continue  # Skip irrelevant events but keep events the user has added to the context
+                continue
             if description := event_core_definition.get("description"):
                 if label := event_core_definition.get("label_llm") or event_core_definition.get("label"):
                     event_data["description"] = f"{label}. {description}"

--- a/ee/hogai/utils/helpers.py
+++ b/ee/hogai/utils/helpers.py
@@ -180,7 +180,7 @@ def _process_events_data(
     for item in response.results:
         event_def = CORE_FILTER_DEFINITIONS_BY_GROUP.get("events", {}).get(item.event)
         if event_def and (event_def.get("system") or event_def.get("ignored_in_assistant")):
-            continue
+            continue  # Skip system or ignored events (safety net, already filtered in SQL)
         events.append(item.event)
 
     event_to_description: dict[str, str] = {}
@@ -202,7 +202,7 @@ def _process_events_data(
             if event_name not in context_event_names and (
                 event_core_definition.get("system") or event_core_definition.get("ignored_in_assistant")
             ):
-                continue
+                continue  # Skip irrelevant events but keep events the user has added to the context
             if description := event_core_definition.get("description"):
                 if label := event_core_definition.get("label_llm") or event_core_definition.get("label"):
                     event_data["description"] = f"{label}. {description}"

--- a/ee/hogai/utils/test/test_format_events_prompt.py
+++ b/ee/hogai/utils/test/test_format_events_prompt.py
@@ -139,37 +139,13 @@ class TestFormatEventsPrompt(BaseTest):
         self.assertGreater(len(descriptions), 0)
 
     @patch("ee.hogai.utils.helpers.TeamTaxonomyQueryRunner")
-    def test_format_events_xml_filters_low_count_events(self, mock_runner_class):
-        """Test that events with count <= 3 are filtered out when there are more than 25 results."""
-        # Create 30 results with some low count events
+    def test_format_events_xml_includes_all_taxonomy_results(self, mock_runner_class):
+        """Test that all events from the taxonomy runner are included regardless of count."""
         taxonomy_items = self._create_taxonomy_items(
             [
                 ("high_count_event", 100),
-                ("low_count_event", 2),  # Should be filtered out
-                ("medium_count_event", 10),
-            ]
-            * 10
-        )  # Create 30 results total
-        self._setup_mock_runner(mock_runner_class, taxonomy_items)
-
-        events_in_context: list[MaxEventContext] = []
-        result = format_events_xml(events_in_context, self.team)
-
-        event_names = self._get_event_names_from_xml(result)
-
-        # Should not contain the low count event
-        self.assertNotIn("low_count_event", event_names)
-        self.assertIn("high_count_event", event_names)
-        self.assertIn("medium_count_event", event_names)
-
-    @patch("ee.hogai.utils.helpers.TeamTaxonomyQueryRunner")
-    def test_format_events_xml_keeps_low_count_events_when_few_results(self, mock_runner_class):
-        """Test that low count events are kept when there are 25 or fewer results."""
-        taxonomy_items = self._create_taxonomy_items(
-            [
-                ("high_count_event", 100),
-                ("low_count_event", 2),  # Should be kept
-                ("medium_count_event", 10),
+                ("low_count_event", 2),
+                ("zero_count_event", 0),
             ]
         )
         self._setup_mock_runner(mock_runner_class, taxonomy_items)
@@ -179,15 +155,15 @@ class TestFormatEventsPrompt(BaseTest):
 
         event_names = self._get_event_names_from_xml(result)
 
-        # Should contain the low count event when there are few results
+        self.assertIn("high_count_event", event_names)
         self.assertIn("low_count_event", event_names)
+        self.assertIn("zero_count_event", event_names)
 
     @patch("ee.hogai.utils.helpers.TeamTaxonomyQueryRunner")
     def test_format_events_xml_skips_ignored_events(self, mock_runner_class):
-        """Test that events marked as ignored_in_assistant are skipped."""
         taxonomy_items = self._create_taxonomy_items(
             [
-                ("$autocapture", 50),  # This is ignored_in_assistant
+                ("$autocapture", 50),
             ]
         )
         self._setup_mock_runner(mock_runner_class, taxonomy_items)
@@ -196,13 +172,10 @@ class TestFormatEventsPrompt(BaseTest):
         result = format_events_xml(events_in_context, self.team)
 
         event_names = self._get_event_names_from_xml(result)
-
-        # Should not contain ignored events that are not in the context
         self.assertNotIn("$autocapture", event_names)
 
     @patch("ee.hogai.utils.helpers.TeamTaxonomyQueryRunner")
     def test_format_events_xml_keeps_ignored_events_in_context(self, mock_runner_class):
-        """Test that ignored events are kept if they're in the context."""
         taxonomy_items = self._create_taxonomy_items(
             [
                 ("$pageview", 100),
@@ -211,7 +184,6 @@ class TestFormatEventsPrompt(BaseTest):
         )
         self._setup_mock_runner(mock_runner_class, taxonomy_items)
 
-        # Add ignored event to context
         events_in_context = self._create_context_events(
             [
                 ("$autocapture", "User interactions"),
@@ -221,8 +193,6 @@ class TestFormatEventsPrompt(BaseTest):
         result = format_events_xml(events_in_context, self.team)
 
         event_names = self._get_event_names_from_xml(result)
-
-        # Should contain the ignored event because it's in context
         self.assertIn("$autocapture", event_names)
 
     @patch("ee.hogai.utils.helpers.TeamTaxonomyQueryRunner")

--- a/ee/hogai/utils/test/test_format_events_prompt.py
+++ b/ee/hogai/utils/test/test_format_events_prompt.py
@@ -163,7 +163,7 @@ class TestFormatEventsPrompt(BaseTest):
     def test_format_events_xml_skips_ignored_events(self, mock_runner_class):
         taxonomy_items = self._create_taxonomy_items(
             [
-                ("$autocapture", 50),
+                ("$autocapture", 50),  # This is ignored_in_assistant
             ]
         )
         self._setup_mock_runner(mock_runner_class, taxonomy_items)
@@ -172,6 +172,8 @@ class TestFormatEventsPrompt(BaseTest):
         result = format_events_xml(events_in_context, self.team)
 
         event_names = self._get_event_names_from_xml(result)
+
+        # Should not contain ignored events that are not in the context
         self.assertNotIn("$autocapture", event_names)
 
     @patch("ee.hogai.utils.helpers.TeamTaxonomyQueryRunner")
@@ -184,6 +186,7 @@ class TestFormatEventsPrompt(BaseTest):
         )
         self._setup_mock_runner(mock_runner_class, taxonomy_items)
 
+        # Add ignored event to context
         events_in_context = self._create_context_events(
             [
                 ("$autocapture", "User interactions"),
@@ -193,6 +196,8 @@ class TestFormatEventsPrompt(BaseTest):
         result = format_events_xml(events_in_context, self.team)
 
         event_names = self._get_event_names_from_xml(result)
+
+        # Should contain the ignored event because it's in context
         self.assertIn("$autocapture", event_names)
 
     @patch("ee.hogai.utils.helpers.TeamTaxonomyQueryRunner")


### PR DESCRIPTION
## Problem

The `_process_events_data` function in `helpers.py` filtered out events with `count <= 3` when there were more than 25 results. This blocked well-known events appended by `TeamTaxonomyQueryRunner` with `count=0`, defeating the purpose of always including them in the AI taxonomy (added in #53445).

## Changes

- Remove the `count <= 3` filter from `_process_events_data` — the query runner already handles relevance via sorting and pagination
- Keep the `ignored_in_assistant` / `system` safety-net filter in both loops
- Update tests to reflect the new behavior

## How did you test this code?

- Ran `pytest ee/hogai/utils/test/test_format_events_prompt.py` — 14 tests pass
- Ran `pytest ee/hogai/tools/read_taxonomy/test/test_tool.py posthog/hogql_queries/ai/test/test_team_taxonomy_query_runner.py posthog/hogql_queries/ai/test/test_event_taxonomy_query_runner.py` — 33 tests pass
- Verified via MCP `read-data-schema` tool that well-known events now appear in the taxonomy output

## 🤖 LLM context

Agent-authored fix for a regression where well-known events were being filtered out by the presentation layer after being correctly appended by the query runner.