### PR TITLE
feat(batch-exports): add us-central1 region to S3 destination

### DIFF
--- a/frontend/src/scenes/data-pipelines/batch-exports/BatchExportEditForm.tsx
+++ b/frontend/src/scenes/data-pipelines/batch-exports/BatchExportEditForm.tsx
@@ -139,6 +139,8 @@ export function BatchExportsEditFields({
                                     { value: 'me-south-1', label: 'Middle East (Bahrain)' },
                                     { value: 'me-central-1', label: 'Middle East (Riyadh)' },
                                     { value: 'sa-east-1', label: 'South America (São Paulo)' },
+                                    // GCP
+                                    { value: 'us-central1', label: 'US Central (Iowa)' },
                                     // Cloudflare R2
                                     { value: 'auto', label: 'Automatic (AUTO)' },
                                     { value: 'apac', label: 'Asia Pacific (APAC)' },


### PR DESCRIPTION
Adds GCP us-central1 (Iowa) region option to the S3 batch export region dropdown, for users exporting to GCP Cloud Storage via the S3-compatible API.

This is a similar change to https://github.com/PostHog/posthog/pull/32970 by @tomasfarias

## Problem

The us-central1 region is not supported in the UI.

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
Closes #53458

## Changes

- adds a new region, us-central1

## How did you test this code?

I have not tested this code. It's a one line region addition only. However I _was_ able to set the option via the API, and my exports do work.

```bash
curl -X POST 'https://us.posthog.com/api/projects/135344/batch_exports/' \
    -H 'Authorization: Bearer <POSTHOG_API_KEY>' \
    -H 'Content-Type: application/json' \
    -d '{
      "name": "events",
      "destination": {
        "type": "S3",
        "config": {
          "bucket_name": "dev-ws-analytics",
          "region": "us-central1",
          "prefix": "events/",
          "aws_access_key_id": "<ANALYTICS_WRITER_HMAC_KEY>",
          "aws_secret_access_key": "<ANALYTICS_WRITER_HMAC_SECRET>",
          "endpoint_url": "https://storage.googleapis.com",
          "file_format": "Parquet",
          "compression": "zstd"
        }
      },
      "interval": "day",
      "model": "events"
    }'
```