### PR TITLE
fix(dashboard): center insight empty states vertically on dashboard tiles

### DIFF
--- a/frontend/src/queries/nodes/InsightViz/InsightViz.tsx
+++ b/frontend/src/queries/nodes/InsightViz/InsightViz.tsx
@@ -154,7 +154,14 @@ export function InsightViz({
                                         embedded={isEmbedded}
                                     />
                                 )}
-                                {!isEmbedded ? <div className="flex-1 h-full overflow-auto">{display}</div> : display}
+                                <div
+                                    className={clsx(
+                                        'flex flex-1 flex-col min-h-0 h-full',
+                                        !isEmbedded && 'overflow-auto'
+                                    )}
+                                >
+                                    {display}
+                                </div>
                             </div>
                         </BindLogic>
                     </BindLogic>

--- a/frontend/src/scenes/insights/EmptyStates/EmptyStates.tsx
+++ b/frontend/src/scenes/insights/EmptyStates/EmptyStates.tsx
@@ -62,7 +62,7 @@ export function InsightEmptyState({
     return (
         <div
             data-attr="insight-empty-state"
-            className="flex flex-col flex-1 rounded px-4 py-6 w-full items-center justify-center text-center text-balance"
+            className="flex flex-col flex-1 min-h-0 h-full rounded px-4 py-6 w-full items-center justify-center text-center text-balance"
         >
             {icon}
             <h2 className="text-xl leading-tight">{heading}</h2>
@@ -76,7 +76,7 @@ export function InsightRefreshDataHint({ onRetry }: { onRetry: () => void }): JS
     return (
         <div
             data-attr="insight-refresh-data-hint"
-            className="flex flex-col flex-1 rounded px-4 py-6 w-full items-center justify-center text-center text-balance gap-3"
+            className="flex flex-col flex-1 min-h-0 h-full rounded px-4 py-6 w-full items-center justify-center text-center text-balance gap-3"
         >
             <IconInfo className="text-5xl mb-2 text-tertiary" />
             <h2 className="text-xl leading-tight">Chart data didn&apos;t load</h2>


### PR DESCRIPTION
## Problem

Insight tiles on dashboards showed the “no matching events” (and similar) empty states pinned to the top of the chart area, with a large empty band below, because height was not propagated through the embedded `InsightViz` layout the same way as on the full insight page.

## Changes

- **`InsightViz`**: Always wrap `InsightVizDisplay` in a `flex flex-1 flex-col min-h-0 h-full` container (keep `overflow-auto` only when not embedded) so embedded/dashboard views get the same flex height chain as non-embedded.
- **`InsightEmptyState` / `InsightRefreshDataHint`**: Add `min-h-0 h-full` so the empty state fills the available chart region and `justify-center` actually centers vertically.

## How did you test this code?

Layout-only change; verified the flex/height chain in code. No new automated tests.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

do not publish to changelog

## Docs update

Add the `skip-inkeep-docs` label — UI layout fix only.

## 🤖 LLM context

Co-authored with Cursor. Change was driven by tracing `InsightCard` → `Query` → `InsightViz` embedded layout: embedded mode omitted the `flex-1 h-full` wrapper used for non-embedded insights, so `InsightEmptyState`’s `flex-1` + `justify-center` had no expanded height. Wrapper + `h-full min-h-0` on the empty state components align with patterns used by `InsightValidationError` / similar full-bleed states.
