### PR TITLE
fix(surveys): keep guided and full editors in sync

### DIFF
--- a/frontend/src/scenes/surveys/SurveyEdit.tsx
+++ b/frontend/src/scenes/surveys/SurveyEdit.tsx
@@ -314,7 +314,7 @@ export default function SurveyEdit({ id }: { id: string }): JSX.Element {
                                     data-attr="switch-to-wizard"
                                     type="tertiary"
                                     size="small"
-                                    to={urls.surveyWizard(id)}
+                                    to={`${urls.surveyWizard(id)}#preserveLocalChanges=true`}
                                 >
                                     Guided editor
                                 </LemonButton>

--- a/frontend/src/scenes/surveys/surveyLogic.test.ts
+++ b/frontend/src/scenes/surveys/surveyLogic.test.ts
@@ -131,6 +131,7 @@ describe('editor sync', () => {
         await expectLogic(logic).toFinishAllListeners()
 
         expect(logic.values.survey.name).toBe('Unsaved guided name')
+        expect(logic.values.isEditingSurvey).toBe(true)
     })
 })
 

--- a/frontend/src/scenes/surveys/surveyLogic.test.ts
+++ b/frontend/src/scenes/surveys/surveyLogic.test.ts
@@ -1,3 +1,4 @@
+import { router } from 'kea-router'
 import { expectLogic, partial } from 'kea-test-utils'
 
 import { dayjs } from 'lib/dayjs'
@@ -9,6 +10,7 @@ import {
 } from 'scenes/surveys/surveyLogic'
 import { OpenEndedColumnMap } from 'scenes/surveys/utils'
 
+import { useMocks } from '~/mocks/jest'
 import { initKeaTests } from '~/test/init'
 import {
     AccessControlLevel,
@@ -81,6 +83,56 @@ const MULTIPLE_CHOICE_SURVEY: Survey = {
     schedule: SurveySchedule.Once,
     user_access_level: AccessControlLevel.Editor,
 }
+
+const createPersistedSurvey = (): Survey => ({
+    ...MULTIPLE_CHOICE_SURVEY,
+    id: 'test-survey',
+    name: 'Saved survey',
+    questions: [
+        {
+            type: SurveyQuestionType.Open,
+            question: 'What do you think?',
+            description: '',
+            buttonText: 'Submit',
+        },
+    ],
+})
+
+describe('editor sync', () => {
+    beforeEach(() => {
+        initKeaTests()
+
+        useMocks({
+            get: {
+                '/api/projects/:team/surveys/': () => [200, { count: 0, results: [], next: null, previous: null }],
+                '/api/projects/:team/surveys/test-survey/': () => [200, createPersistedSurvey()],
+                '/api/projects/:team/surveys/test-survey/archived-response-uuids/': () => [200, []],
+            },
+        })
+    })
+
+    it('preserves unsaved changes when switching from guided to the full editor', async () => {
+        const logic = surveyLogic({ id: 'test-survey' })
+        logic.mount()
+
+        await expectLogic(logic).toFinishAllListeners()
+
+        await expectLogic(logic, () => {
+            logic.actions.setSurveyValue('name', 'Unsaved guided name')
+        }).toMatchValues({
+            survey: partial({
+                name: 'Unsaved guided name',
+            }),
+            surveyChanged: true,
+        })
+
+        router.actions.push('/surveys/test-survey?edit=true#preserveLocalChanges=true')
+
+        await expectLogic(logic).toFinishAllListeners()
+
+        expect(logic.values.survey.name).toBe('Unsaved guided name')
+    })
+})
 
 describe('set response-based survey branching', () => {
     let logic: ReturnType<typeof surveyLogic.build>

--- a/frontend/src/scenes/surveys/surveyLogic.tsx
+++ b/frontend/src/scenes/surveys/surveyLogic.tsx
@@ -2291,7 +2291,10 @@ export const surveyLogic = kea<surveyLogicType>([
         },
     })),
     urlToAction(({ actions, props, values }) => ({
-        [urls.survey(props.id ?? 'new')]: (_, searchParams, { fromTemplate }, { method }) => {
+        [urls.survey(props.id ?? 'new')]: (_, searchParams, { fromTemplate, preserveLocalChanges }, { method }) => {
+            const shouldPreserveLocalChanges =
+                preserveLocalChanges && values.surveyChanged && values.survey.id === (props.id ?? NEW_SURVEY.id)
+
             // Parse filters from URL params
             if (searchParams.propertyFilters) {
                 try {
@@ -2341,6 +2344,9 @@ export const surveyLogic = kea<surveyLogicType>([
             // If the URL was pushed (user clicked on a link), reset the scene's data.
             // This avoids resetting form fields if you click back/forward.
             if (method === 'PUSH') {
+                if (shouldPreserveLocalChanges) {
+                    return
+                }
                 // When pushing to `/new` and the id matches the new survey's id, do not load the survey again
                 if (props.id === 'new' && values.survey.id === NEW_SURVEY.id && !fromTemplate) {
                     return
@@ -2387,12 +2393,15 @@ export const surveyLogic = kea<surveyLogicType>([
             { replace: true },
         ],
     })),
-    afterMount(({ props, actions }) => {
-        if (props.id !== 'new') {
+    afterMount(({ props, actions, values }) => {
+        const shouldPreserveLocalChanges =
+            router.values.hashParams.preserveLocalChanges && values.surveyChanged && values.survey.id === props.id
+
+        if (props.id !== 'new' && !shouldPreserveLocalChanges) {
             actions.loadSurvey()
             actions.loadSurveyNotifications()
         }
-        if (props.id === 'new') {
+        if (props.id === 'new' && !shouldPreserveLocalChanges) {
             actions.resetSurvey()
         }
     }),

--- a/frontend/src/scenes/surveys/surveyLogic.tsx
+++ b/frontend/src/scenes/surveys/surveyLogic.tsx
@@ -2345,6 +2345,9 @@ export const surveyLogic = kea<surveyLogicType>([
             // This avoids resetting form fields if you click back/forward.
             if (method === 'PUSH') {
                 if (shouldPreserveLocalChanges) {
+                    if (searchParams.edit) {
+                        actions.editingSurvey(true)
+                    }
                     return
                 }
                 // When pushing to `/new` and the id matches the new survey's id, do not load the survey again

--- a/frontend/src/scenes/surveys/wizard/SurveyWizard.tsx
+++ b/frontend/src/scenes/surveys/wizard/SurveyWizard.tsx
@@ -90,7 +90,10 @@ function SurveyWizard({ id }: SurveyWizardLogicProps): JSX.Element {
     }, [maxPreviewIndex])
 
     const handleCustomizeMore = (): void => {
-        router.actions.push(urls.survey(id) + (isEditing ? '?edit=true' : '#fromTemplate=true'))
+        const target = isEditing
+            ? `${urls.survey(id)}?edit=true#preserveLocalChanges=true`
+            : `${urls.survey(id)}#fromTemplate=true&preserveLocalChanges=true`
+        router.actions.push(target)
     }
 
     // Show loading state while loading existing survey

--- a/frontend/src/scenes/surveys/wizard/surveyWizardLogic.test.ts
+++ b/frontend/src/scenes/surveys/wizard/surveyWizardLogic.test.ts
@@ -1,3 +1,4 @@
+import { router } from 'kea-router'
 import { expectLogic } from 'kea-test-utils'
 
 import { useMocks } from '~/mocks/jest'
@@ -13,6 +14,7 @@ import {
 } from '~/types'
 
 import { SURVEY_CREATED_SOURCE, SURVEY_RATING_SCALE, SurveyTemplate, SurveyTemplateType } from '../constants'
+import { surveyLogic } from '../surveyLogic'
 import { surveyWizardLogic } from './surveyWizardLogic'
 
 const createMockTemplate = (): SurveyTemplate => ({
@@ -227,6 +229,25 @@ describe('surveyWizardLogic', () => {
             }).toMatchValues({
                 currentStep: 'when',
             })
+        })
+
+        it('preserves unsaved full editor changes when switching to the guided editor', async () => {
+            const surveyFormLogic = surveyLogic({ id: 'new' })
+            surveyFormLogic.mount()
+
+            await expectLogic(surveyFormLogic, () => {
+                surveyFormLogic.actions.setSurveyValue('description', 'Edited in the full editor')
+            }).toMatchValues({
+                surveyChanged: true,
+            })
+
+            router.actions.push('/surveys/guided/new#preserveLocalChanges=true')
+
+            const logic = surveyWizardLogic({ id: 'new' })
+            logic.mount()
+
+            expect(logic.values.currentStep).toBe('questions')
+            expect(logic.values.survey.description).toBe('Edited in the full editor')
         })
     })
 

--- a/frontend/src/scenes/surveys/wizard/surveyWizardLogic.ts
+++ b/frontend/src/scenes/surveys/wizard/surveyWizardLogic.ts
@@ -58,7 +58,12 @@ export const surveyWizardLogic = kea<surveyWizardLogicType>([
             teamLogic,
             ['addProductIntent'],
         ],
-        values: [surveyLogic({ id: props.id }), ['survey', 'surveyLoading'], teamLogic, ['currentTeam']],
+        values: [
+            surveyLogic({ id: props.id }),
+            ['survey', 'surveyChanged', 'surveyLoading'],
+            teamLogic,
+            ['currentTeam'],
+        ],
     })),
 
     actions({
@@ -360,7 +365,15 @@ export const surveyWizardLogic = kea<surveyWizardLogicType>([
     })),
 
     afterMount(({ actions, props, values }) => {
+        const shouldPreserveLocalChanges =
+            router.values.hashParams.preserveLocalChanges && values.surveyChanged && values.survey.id === props.id
+
         if (props.id === 'new') {
+            if (shouldPreserveLocalChanges) {
+                actions.setStep('questions')
+                return
+            }
+
             // Templates set both name AND questions, while default NEW_SURVEY has empty name
             const hasTemplateSelected = values.survey?.name && values.survey?.questions?.length > 0
             if (hasTemplateSelected) {
@@ -369,7 +382,7 @@ export const surveyWizardLogic = kea<surveyWizardLogicType>([
                 actions.resetWizard()
                 actions.resetSurvey()
             }
-        } else {
+        } else if (!shouldPreserveLocalChanges) {
             actions.loadSurvey()
         }
 


### PR DESCRIPTION
## Problem

Switching between the guided survey editor and the full editor could drop unsaved local edits.
Both editors already use the same survey logic, but route transitions could still reload or reset the survey state and replace in-memory changes with the last saved backend copy.

## Changes

Preserve dirty local survey state when switching between the guided and full editors for the same survey.
Only skip reload/reset during explicit editor-to-editor handoffs, so normal direct opens still refresh from the backend.
Add regression tests covering guided-to-full and full-to-guided transitions.

## How did you test this code?

Ran:
- `pnpm --filter=@posthog/frontend exec jest --watchman=false frontend/src/scenes/surveys/surveyLogic.test.ts`
- `pnpm --filter=@posthog/frontend exec jest --watchman=false frontend/src/scenes/surveys/wizard/surveyWizardLogic.test.ts`

Both test files passed.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

no

## Docs update

No docs update needed.

## 🤖 LLM context

Authored with Codex.
Focused on the survey editor route handoff between the guided editor and the full editor.
Added targeted regression tests for both transition directions.
