### PR TITLE
feat(actions): warn about references when deleting from actions list

### DIFF
--- a/products/actions/frontend/components/ActionsTable.tsx
+++ b/products/actions/frontend/components/ActionsTable.tsx
@@ -3,7 +3,6 @@ import { useActions, useValues } from 'kea'
 import { IconCheckCircle, IconPin, IconPinFilled } from '@posthog/icons'
 import { LemonInput, LemonSegmentedButton } from '@posthog/lemon-ui'
 
-import api from 'lib/api'
 import { AccessControlAction } from 'lib/components/AccessControlAction'
 import { ObjectTags } from 'lib/components/ObjectTags/ObjectTags'
 import { ProductIntroduction } from 'lib/components/ProductIntroduction/ProductIntroduction'
@@ -15,9 +14,7 @@ import { LemonTable } from 'lib/lemon-ui/LemonTable'
 import { createdAtColumn, createdByColumn } from 'lib/lemon-ui/LemonTable/columnUtils'
 import { LemonTableLink } from 'lib/lemon-ui/LemonTable/LemonTableLink'
 import { LemonTableColumn, LemonTableColumns } from 'lib/lemon-ui/LemonTable/types'
-import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
 import { stripHTTP } from 'lib/utils'
-import { deleteWithUndo } from 'lib/utils/deleteWithUndo'
 import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
 import { userLogic } from 'scenes/userLogic'
@@ -33,6 +30,7 @@ import {
 } from '~/types'
 
 import { actionsLogic } from '../logics/actionsLogic'
+import { deleteActionWithWarning } from '../utils/deleteAction'
 import { SCREEN_NAME_MATCHING_LABEL, type ScreenNameMatching, isScreenNameFilter } from '../utils/screenName'
 import { NewActionButton } from './NewActionButton'
 
@@ -255,13 +253,7 @@ export function ActionsTable(): JSX.Element {
                                     <LemonButton
                                         status="danger"
                                         onClick={() => {
-                                            deleteWithUndo({
-                                                endpoint: api.actions.determineDeleteEndpoint(),
-                                                object: action,
-                                                callback: loadActions,
-                                            }).catch((e: any) => {
-                                                lemonToast.error(`Error deleting action: ${e.detail}`)
-                                            })
+                                            void deleteActionWithWarning(action, loadActions)
                                         }}
                                         fullWidth
                                     >

--- a/products/actions/frontend/logics/actionEditLogic.tsx
+++ b/products/actions/frontend/logics/actionEditLogic.tsx
@@ -6,10 +6,8 @@ import { CombinedLocation } from 'kea-router/lib/utils'
 
 import api from 'lib/api'
 import { SetupTaskId, globalSetupLogic } from 'lib/components/ProductSetup'
-import { LemonDialog } from 'lib/lemon-ui/LemonDialog'
 import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
 import { Link } from 'lib/lemon-ui/Link'
-import { deleteWithUndo } from 'lib/utils/deleteWithUndo'
 import { eventDefinitionsTableLogic } from 'scenes/data-management/events/eventDefinitionsTableLogic'
 import { urls } from 'scenes/urls'
 
@@ -19,6 +17,7 @@ import { tagsModel } from '~/models/tagsModel'
 import { ActionStepType, ActionType } from '~/types'
 
 import type { ActionReferenceApi } from '../generated/api.schemas'
+import { deleteActionWithWarning } from '../utils/deleteAction'
 import type { actionEditLogicType } from './actionEditLogicType'
 import { actionLogic } from './actionLogic'
 
@@ -231,56 +230,17 @@ export const actionEditLogic = kea<actionEditLogicType>([
                 return
             }
 
-            if (values.referencesLoading) {
-                lemonToast.info('Checking for references. Please try again in a moment.')
-                return
-            }
-
-            const performDelete = async (): Promise<void> => {
-                try {
-                    await deleteWithUndo({
-                        endpoint: api.actions.determineDeleteEndpoint(),
-                        object: values.action,
-                        callback: (undo: boolean) => {
-                            if (undo) {
-                                router.actions.push(urls.action(actionId))
-                                refreshTreeItem('action', String(actionId))
-                            } else {
-                                actions.resetAction()
-                                deleteFromTree('action', String(actionId))
-                                router.actions.push(urls.actions())
-                                actions.loadActions()
-                            }
-                        },
-                    })
-                } catch (e: any) {
-                    lemonToast.error(`Error deleting action: ${e.detail}`)
+            await deleteActionWithWarning(values.action, (undo: boolean) => {
+                if (undo) {
+                    router.actions.push(urls.action(actionId))
+                    refreshTreeItem('action', String(actionId))
+                } else {
+                    actions.resetAction()
+                    deleteFromTree('action', String(actionId))
+                    router.actions.push(urls.actions())
+                    actions.loadActions()
                 }
-            }
-
-            if (values.references.length > 0) {
-                const count = values.references.length
-
-                LemonDialog.open({
-                    title: 'This action is used by other resources',
-                    description: (
-                        <>
-                            This action is referenced by <strong>{count}</strong> resource
-                            {count === 1 ? '' : 's'}. Deleting it may break them.
-                        </>
-                    ),
-                    primaryButton: {
-                        children: 'Delete anyway',
-                        status: 'danger',
-                        onClick: performDelete,
-                    },
-                    secondaryButton: {
-                        children: 'Cancel',
-                    },
-                })
-            } else {
-                await performDelete()
-            }
+            })
         },
     })),
 

--- a/products/actions/frontend/utils/deleteAction.tsx
+++ b/products/actions/frontend/utils/deleteAction.tsx
@@ -1,6 +1,5 @@
 import api from 'lib/api'
 import { LemonDialog } from 'lib/lemon-ui/LemonDialog'
-import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
 import { deleteWithUndo } from 'lib/utils/deleteWithUndo'
 
 import { ActionType } from '~/types'
@@ -20,15 +19,11 @@ export async function deleteActionWithWarning(action: ActionType, callback: (und
     }
 
     const performDelete = async (): Promise<void> => {
-        try {
-            await deleteWithUndo({
-                endpoint: api.actions.determineDeleteEndpoint(),
-                object: action,
-                callback,
-            })
-        } catch (e: any) {
-            lemonToast.error(`Error deleting action: ${e.detail}`)
-        }
+        await deleteWithUndo({
+            endpoint: api.actions.determineDeleteEndpoint(),
+            object: action,
+            callback,
+        })
     }
 
     if (references.length > 0) {

--- a/products/actions/frontend/utils/deleteAction.tsx
+++ b/products/actions/frontend/utils/deleteAction.tsx
@@ -1,0 +1,55 @@
+import api from 'lib/api'
+import { LemonDialog } from 'lib/lemon-ui/LemonDialog'
+import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
+import { deleteWithUndo } from 'lib/utils/deleteWithUndo'
+
+import { ActionType } from '~/types'
+
+import type { ActionReferenceApi } from '../generated/api.schemas'
+
+/**
+ * Delete an action, warning first if it has references.
+ * Fetches references on the fly so it works from both the list and detail pages.
+ */
+export async function deleteActionWithWarning(action: ActionType, callback: (undo: boolean) => void): Promise<void> {
+    let references: ActionReferenceApi[] = []
+    try {
+        references = await api.get(`api/projects/@current/actions/${action.id}/references`)
+    } catch {
+        // If we can't fetch references, proceed with delete anyway
+    }
+
+    const performDelete = async (): Promise<void> => {
+        try {
+            await deleteWithUndo({
+                endpoint: api.actions.determineDeleteEndpoint(),
+                object: action,
+                callback,
+            })
+        } catch (e: any) {
+            lemonToast.error(`Error deleting action: ${e.detail}`)
+        }
+    }
+
+    if (references.length > 0) {
+        LemonDialog.open({
+            title: 'This action is used by other resources',
+            description: (
+                <>
+                    This action is referenced by <strong>{references.length}</strong> resource
+                    {references.length === 1 ? '' : 's'}. Deleting it may break them.
+                </>
+            ),
+            primaryButton: {
+                children: 'Delete anyway',
+                status: 'danger',
+                onClick: performDelete,
+            },
+            secondaryButton: {
+                children: 'Cancel',
+            },
+        })
+    } else {
+        await performDelete()
+    }
+}


### PR DESCRIPTION
## Problem

When deleting an action from the actions list page, there was no warning about resources that depend on it (insights, experiments, cohorts, destinations). The action detail page already had this warning via the references endpoint, but the list page's delete button bypassed it entirely.

## Changes

- Extract `deleteActionWithWarning` utility that fetches references on the fly and shows a confirmation dialog before deleting
- Use it in both the actions list table (`ActionsTable`) and the action detail page (`actionEditLogic`)

## How did you test this code?

- Verified locally warning is shown before deleting

<img width="1728" height="611" alt="Screenshot 2026-04-06 at 2 05 27 PM" src="https://github.com/user-attachments/assets/1dfc1c15-94e8-49d1-8925-3d0e4adff7e9" />

## Publish to changelog?

No

## Docs update

N/A

## LLM context

Co-authored with Claude Code. Builds on the action references endpoint from #52973.