### PR TITLE
chore(hog-charts): extract pure transform functions from trends rendering

### DIFF
--- a/frontend/src/lib/hog-charts/transforms/__tests__/trends.test.ts
+++ b/frontend/src/lib/hog-charts/transforms/__tests__/trends.test.ts
@@ -1,0 +1,200 @@
+import { ChartDisplayType, CompareLabelType, TrendResult } from '~/types'
+
+import { buildTrendsConfig, buildTrendsSeries, indexTrendResults } from '../trends'
+
+const baseTrendResult = (overrides: Partial<TrendResult> = {}): TrendResult => ({
+    action: { id: '$pageview', type: 'events', order: 0, name: '$pageview' },
+    label: '$pageview',
+    count: 100,
+    data: [10, 20, 30, 40],
+    days: ['2023-01-01', '2023-01-02', '2023-01-03', '2023-01-04'],
+    labels: ['1-Jan', '2-Jan', '3-Jan', '4-Jan'],
+    aggregated_value: 100,
+    ...overrides,
+})
+
+describe('indexTrendResults', () => {
+    it('indexes results with sequential ids and colorIndexes', () => {
+        const results = [baseTrendResult(), baseTrendResult({ label: '$autocapture', count: 50 })]
+        const indexed = indexTrendResults(results, ChartDisplayType.ActionsLineGraph)
+
+        expect(indexed).toHaveLength(2)
+        expect(indexed[0].id).toBe(0)
+        expect(indexed[1].id).toBe(1)
+        expect(indexed[0].seriesIndex).toBe(0)
+        expect(indexed[1].seriesIndex).toBe(1)
+        expect(typeof indexed[0].colorIndex).toBe('number')
+        expect(typeof indexed[1].colorIndex).toBe('number')
+    })
+
+    it('sorts bar value display by aggregated_value descending', () => {
+        const results = [
+            baseTrendResult({ label: 'low', aggregated_value: 10 }),
+            baseTrendResult({ label: 'high', aggregated_value: 100 }),
+        ]
+        const indexed = indexTrendResults(results, ChartDisplayType.ActionsBarValue)
+
+        expect(indexed[0].label).toBe('high')
+        expect(indexed[1].label).toBe('low')
+    })
+
+    it('sorts pie display by aggregated_value descending', () => {
+        const results = [
+            baseTrendResult({ label: 'small', aggregated_value: 5 }),
+            baseTrendResult({ label: 'big', aggregated_value: 50 }),
+        ]
+        const indexed = indexTrendResults(results, ChartDisplayType.ActionsPie)
+
+        expect(indexed[0].label).toBe('big')
+        expect(indexed[1].label).toBe('small')
+    })
+
+    it('sorts compare results with previous before current for unstacked bar', () => {
+        const results = [
+            baseTrendResult({ compare_label: CompareLabelType.Current, compare: true }),
+            baseTrendResult({ compare_label: CompareLabelType.Previous, compare: true }),
+        ]
+        const indexed = indexTrendResults(results, ChartDisplayType.ActionsUnstackedBar)
+
+        expect(indexed[0].compare_label).toBe(CompareLabelType.Previous)
+        expect(indexed[1].compare_label).toBe(CompareLabelType.Current)
+    })
+
+    it('filters lifecycle results by toggled lifecycles', () => {
+        const results = [
+            baseTrendResult({ status: 'new' }),
+            baseTrendResult({ status: 'dormant' }),
+            baseTrendResult({ status: 'returning' }),
+        ]
+        const indexed = indexTrendResults(results, ChartDisplayType.ActionsLineGraph, {
+            toggledLifecycles: ['new', 'returning'],
+        })
+
+        expect(indexed).toHaveLength(2)
+        expect(indexed.map((r) => r.status)).toContain('new')
+        expect(indexed.map((r) => r.status)).toContain('returning')
+        expect(indexed.map((r) => r.status)).not.toContain('dormant')
+    })
+
+    it('assigns same colorIndex to current and previous compare series with same label', () => {
+        const results = [
+            baseTrendResult({
+                label: '$pageview',
+                compare_label: CompareLabelType.Current,
+                compare: true,
+                action: { id: '$pageview', type: 'events', order: 0, name: '$pageview' },
+            }),
+            baseTrendResult({
+                label: '$pageview',
+                compare_label: CompareLabelType.Previous,
+                compare: true,
+                action: { id: '$pageview', type: 'events', order: 0, name: '$pageview' },
+            }),
+        ]
+        const indexed = indexTrendResults(results, ChartDisplayType.ActionsLineGraph)
+
+        expect(indexed[0].colorIndex).toBe(indexed[1].colorIndex)
+    })
+})
+
+describe('buildTrendsSeries', () => {
+    it('maps indexed results to Series[]', () => {
+        const results = [baseTrendResult()]
+        const indexed = indexTrendResults(results, ChartDisplayType.ActionsLineGraph)
+        const series = buildTrendsSeries(indexed, ChartDisplayType.ActionsLineGraph, () => '#ff0000')
+
+        expect(series).toHaveLength(1)
+        expect(series[0].label).toBe('$pageview')
+        expect(series[0].data).toEqual([10, 20, 30, 40])
+        expect(series[0].color).toBe('#ff0000')
+        expect(series[0].fillArea).toBe(false)
+    })
+
+    it('sets fillArea for area graph display', () => {
+        const results = [baseTrendResult()]
+        const indexed = indexTrendResults(results, ChartDisplayType.ActionsAreaGraph)
+        const series = buildTrendsSeries(indexed, ChartDisplayType.ActionsAreaGraph, () => '#ff0000')
+
+        expect(series[0].fillArea).toBe(true)
+    })
+
+    it('includes metadata from trend results', () => {
+        const results = [baseTrendResult({ breakdown_value: 'Chrome', compare_label: CompareLabelType.Current })]
+        const indexed = indexTrendResults(results, ChartDisplayType.ActionsLineGraph)
+        const series = buildTrendsSeries(indexed, ChartDisplayType.ActionsLineGraph, () => '#ff0000')
+
+        expect(series[0].meta).toMatchObject({
+            breakdown_value: 'Chrome',
+            compare_label: CompareLabelType.Current,
+        })
+    })
+
+    it('includes zero-count series', () => {
+        const results = [
+            baseTrendResult({ count: 100 }),
+            baseTrendResult({ label: 'empty', count: 0, data: [0, 0, 0, 0] }),
+        ]
+        const indexed = indexTrendResults(results, ChartDisplayType.ActionsLineGraph)
+        const series = buildTrendsSeries(indexed, ChartDisplayType.ActionsLineGraph, () => '#ff0000')
+
+        expect(series).toHaveLength(2)
+    })
+})
+
+describe('buildTrendsConfig', () => {
+    it('builds basic config with defaults', () => {
+        const config = buildTrendsConfig({
+            interval: 'day',
+            days: ['2023-01-01', '2023-01-02'],
+            timezone: 'UTC',
+            yAxisScaleType: undefined,
+            isPercentStackView: false,
+            goalLines: undefined,
+        })
+
+        expect(config.showGrid).toBe(true)
+        expect(config.showCrosshair).toBe(true)
+        expect(config.pinnableTooltip).toBe(true)
+        expect(config.yScaleType).toBe('linear')
+        expect(config.percentStackView).toBe(false)
+    })
+
+    it('sets log scale when yAxisScaleType is log10', () => {
+        const config = buildTrendsConfig({
+            interval: 'day',
+            days: [],
+            timezone: 'UTC',
+            yAxisScaleType: 'log10',
+            isPercentStackView: false,
+            goalLines: undefined,
+        })
+
+        expect(config.yScaleType).toBe('log')
+    })
+
+    it('maps goal lines', () => {
+        const config = buildTrendsConfig({
+            interval: 'day',
+            days: [],
+            timezone: 'UTC',
+            yAxisScaleType: undefined,
+            isPercentStackView: false,
+            goalLines: [{ value: 100, label: 'Target' }],
+        })
+
+        expect(config.goalLines).toEqual([{ value: 100, label: 'Target', borderColor: undefined }])
+    })
+
+    it('provides an xTickFormatter', () => {
+        const config = buildTrendsConfig({
+            interval: 'day',
+            days: ['2023-01-01', '2023-01-02'],
+            timezone: 'UTC',
+            yAxisScaleType: undefined,
+            isPercentStackView: false,
+            goalLines: undefined,
+        })
+
+        expect(typeof config.xTickFormatter).toBe('function')
+    })
+})

--- a/frontend/src/lib/hog-charts/transforms/trends.ts
+++ b/frontend/src/lib/hog-charts/transforms/trends.ts
@@ -1,0 +1,151 @@
+import { createXAxisTickCallback } from 'lib/charts/utils/dates'
+
+import { GoalLine as SchemaGoalLine } from '~/queries/schema/schema-general'
+import { ChartDisplayType, IntervalType, LifecycleToggle, TrendResult } from '~/types'
+
+import type { LineChartConfig, Series } from '../core/types'
+
+// Breakdown sentinel values — duplicated from scenes/insights/utils to avoid
+// coupling the transform layer to scene-level code.
+const BREAKDOWN_OTHER_STRING_LABEL = '$$_posthog_breakdown_other_$$'
+const BREAKDOWN_OTHER_NUMERIC_LABEL = 9007199254740991
+const BREAKDOWN_NULL_STRING_LABEL = '$$_posthog_breakdown_null_$$'
+const BREAKDOWN_NULL_NUMERIC_LABEL = 9007199254740990
+
+export interface IndexedTrendResult extends TrendResult {
+    id: number
+    seriesIndex: number
+    colorIndex: number
+}
+
+/** Sort and index raw trend results for visualization. */
+export function indexTrendResults(
+    results: TrendResult[],
+    display: ChartDisplayType | undefined | null,
+    lifecycleFilter?: { toggledLifecycles?: LifecycleToggle[] } | null
+): IndexedTrendResult[] {
+    const defaultLifecyclesOrder = ['new', 'resurrecting', 'returning', 'dormant']
+    let indexed = results.map((result, index) => ({ ...result, seriesIndex: index }))
+
+    // want the previous bars to show before current bars
+    if (display === ChartDisplayType.ActionsUnstackedBar && indexed.some((x) => x.compare)) {
+        indexed.sort((a, b) => {
+            if (a.compare_label === b.compare_label) {
+                return 0
+            }
+            if (a.compare_label === 'previous') {
+                return -1
+            }
+            if (b.compare_label === 'previous') {
+                return 1
+            }
+            return 0
+        })
+    } else if (display && (display === ChartDisplayType.ActionsBarValue || display === ChartDisplayType.ActionsPie)) {
+        indexed.sort((a, b) => {
+            const aValue =
+                a.breakdown_value === BREAKDOWN_OTHER_STRING_LABEL
+                    ? -BREAKDOWN_OTHER_NUMERIC_LABEL
+                    : a.breakdown_value === BREAKDOWN_NULL_STRING_LABEL
+                      ? -BREAKDOWN_NULL_NUMERIC_LABEL
+                      : a.aggregated_value
+            const bValue =
+                b.breakdown_value === BREAKDOWN_OTHER_STRING_LABEL
+                    ? -BREAKDOWN_OTHER_NUMERIC_LABEL
+                    : b.breakdown_value === BREAKDOWN_NULL_STRING_LABEL
+                      ? -BREAKDOWN_NULL_NUMERIC_LABEL
+                      : b.aggregated_value
+            return bValue - aValue
+        })
+    } else if (lifecycleFilter) {
+        if (lifecycleFilter.toggledLifecycles) {
+            indexed = indexed.filter((result) =>
+                lifecycleFilter.toggledLifecycles!.includes(String(result.status) as LifecycleToggle)
+            )
+        }
+
+        indexed = indexed.sort(
+            (a, b) =>
+                defaultLifecyclesOrder.indexOf(String(b.status)) - defaultLifecyclesOrder.indexOf(String(a.status))
+        )
+    }
+
+    const colorIndexMap = new Map<string, number>()
+    indexed
+        .slice()
+        .sort((a, b) => (a.action?.order ?? 0) - (b.action?.order ?? 0))
+        .forEach((item) => {
+            const key = `${item.label}_${item.action?.order}_${item?.breakdown_value}`
+            if (!colorIndexMap.has(key)) {
+                colorIndexMap.set(key, colorIndexMap.size)
+            }
+        })
+
+    return indexed.map((item, index) => {
+        const key = `${item.label}_${item.action?.order}_${item?.breakdown_value}`
+        const colorIndex = colorIndexMap.get(key) ?? 0
+        return { ...item, colorIndex, id: index }
+    })
+}
+
+/** Map indexed trend results to hog-charts Series[]. */
+export function buildTrendsSeries(
+    indexedResults: IndexedTrendResult[],
+    display: ChartDisplayType | undefined | null,
+    getColor: (result: IndexedTrendResult) => string
+): Series[] {
+    return indexedResults.map((r) => ({
+        key: `${r.id}`,
+        label: r.label ?? '',
+        data: r.data,
+        color: getColor(r),
+        fillArea: display === ChartDisplayType.ActionsAreaGraph,
+        meta: {
+            action: r.action,
+            breakdown_value: r.breakdown_value,
+            compare_label: r.compare_label,
+            days: r.days,
+            // Fall back to the pre-filter index (r.id) so ordering is stable when earlier series are dropped.
+            order: r.action?.order ?? r.id,
+            filter: r.filter,
+        },
+    }))
+}
+
+export interface BuildTrendsConfigOptions {
+    interval: IntervalType | undefined | null
+    days: (string | number)[]
+    timezone: string
+    yAxisScaleType: string | null | undefined
+    isPercentStackView: boolean
+    goalLines: SchemaGoalLine[] | undefined | null
+}
+
+/** Build a LineChartConfig from trends query options. */
+export function buildTrendsConfig({
+    interval,
+    days,
+    timezone,
+    yAxisScaleType,
+    isPercentStackView,
+    goalLines,
+}: BuildTrendsConfigOptions): LineChartConfig {
+    const xTickFormatter = createXAxisTickCallback({
+        interval: interval ?? 'day',
+        allDays: days,
+        timezone,
+    })
+    return {
+        showGrid: true,
+        showCrosshair: true,
+        pinnableTooltip: true,
+        yScaleType: yAxisScaleType === 'log10' ? 'log' : 'linear',
+        percentStackView: isPercentStackView,
+        xTickFormatter,
+        goalLines: goalLines?.map((g) => ({
+            value: g.value,
+            label: g.label ?? undefined,
+            borderColor: g.borderColor ?? undefined,
+        })),
+    }
+}

--- a/frontend/src/lib/hog-charts/transforms/trends.ts
+++ b/frontend/src/lib/hog-charts/transforms/trends.ts
@@ -13,8 +13,11 @@ const BREAKDOWN_NULL_STRING_LABEL = '$$_posthog_breakdown_null_$$'
 const BREAKDOWN_NULL_NUMERIC_LABEL = 9007199254740990
 
 export interface IndexedTrendResult extends TrendResult {
+    /** Index after applying visualization-specific sorting and filtering. */
     id: number
+    /** Original index before re-sorting — used to get series color correctly. */
     seriesIndex: number
+    /** Color index shared between current/previous compare series with the same label. */
     colorIndex: number
 }
 

--- a/frontend/src/scenes/trends/trendsDataLogic.ts
+++ b/frontend/src/scenes/trends/trendsDataLogic.ts
@@ -2,16 +2,14 @@ import { actions, connect, kea, key, listeners, path, props, reducers, selectors
 
 import { DataColorTheme, DataColorToken } from 'lib/colors'
 import { dayjs } from 'lib/dayjs'
+import { indexTrendResults } from 'lib/hog-charts/transforms/trends'
+import type { IndexedTrendResult } from 'lib/hog-charts/transforms/trends'
 import { isMultiSeriesFormula } from 'lib/utils'
 import { dashboardLogic } from 'scenes/dashboard/dashboardLogic'
 import { getColorFromToken } from 'scenes/dataThemeLogic'
 import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
 import { keyForInsightLogicProps } from 'scenes/insights/sharedUtils'
 import {
-    BREAKDOWN_NULL_NUMERIC_LABEL,
-    BREAKDOWN_NULL_STRING_LABEL,
-    BREAKDOWN_OTHER_NUMERIC_LABEL,
-    BREAKDOWN_OTHER_STRING_LABEL,
     getTrendDatasetKey,
     getTrendResultCustomization,
     getTrendResultCustomizationColorToken,
@@ -36,14 +34,12 @@ import {
     HogQLMathType,
     InsightLogicProps,
     IntervalType,
-    LifecycleToggle,
     PropertyMathType,
     TrendAPIResponse,
     TrendResult,
 } from '~/types'
 
 import type { trendsDataLogicType } from './trendsDataLogicType'
-import { IndexedTrendResult } from './types'
 
 export const RESULT_CUSTOMIZATION_DEFAULT = ResultCustomizationBy.Value
 
@@ -193,74 +189,8 @@ export const trendsDataLogic = kea<trendsDataLogicType>([
 
         indexedResults: [
             (s) => [s.results, s.display, s.lifecycleFilter],
-            (results, display, lifecycleFilter): IndexedTrendResult[] => {
-                const defaultLifecyclesOrder = ['new', 'resurrecting', 'returning', 'dormant']
-                let indexedResults = results.map((result, index) => ({ ...result, seriesIndex: index }))
-
-                // want the previous bars to show before current bars
-                if (display === ChartDisplayType.ActionsUnstackedBar && indexedResults.some((x) => x.compare)) {
-                    indexedResults.sort((a, b) => {
-                        if (a.compare_label === b.compare_label) {
-                            return 0
-                        }
-                        if (a.compare_label === 'previous') {
-                            return -1
-                        }
-                        if (b.compare_label === 'previous') {
-                            return 1
-                        }
-                        return 0
-                    })
-                } else if (
-                    display &&
-                    (display === ChartDisplayType.ActionsBarValue || display === ChartDisplayType.ActionsPie)
-                ) {
-                    indexedResults.sort((a, b) => {
-                        const aValue =
-                            a.breakdown_value === BREAKDOWN_OTHER_STRING_LABEL
-                                ? -BREAKDOWN_OTHER_NUMERIC_LABEL
-                                : a.breakdown_value === BREAKDOWN_NULL_STRING_LABEL
-                                  ? -BREAKDOWN_NULL_NUMERIC_LABEL
-                                  : a.aggregated_value
-                        const bValue =
-                            b.breakdown_value === BREAKDOWN_OTHER_STRING_LABEL
-                                ? -BREAKDOWN_OTHER_NUMERIC_LABEL
-                                : b.breakdown_value === BREAKDOWN_NULL_STRING_LABEL
-                                  ? -BREAKDOWN_NULL_NUMERIC_LABEL
-                                  : b.aggregated_value
-                        return bValue - aValue
-                    })
-                } else if (lifecycleFilter) {
-                    if (lifecycleFilter.toggledLifecycles) {
-                        indexedResults = indexedResults.filter((result) =>
-                            lifecycleFilter.toggledLifecycles!.includes(String(result.status) as LifecycleToggle)
-                        )
-                    }
-
-                    indexedResults = indexedResults.sort(
-                        (a, b) =>
-                            defaultLifecyclesOrder.indexOf(String(b.status)) -
-                            defaultLifecyclesOrder.indexOf(String(a.status))
-                    )
-                }
-
-                const colorIndexMap = new Map<string, number>()
-                indexedResults
-                    .slice()
-                    .sort((a, b) => (a.action?.order ?? 0) - (b.action?.order ?? 0))
-                    .forEach((item) => {
-                        const key = `${item.label}_${item.action?.order}_${item?.breakdown_value}`
-                        if (!colorIndexMap.has(key)) {
-                            colorIndexMap.set(key, colorIndexMap.size)
-                        }
-                    })
-
-                return indexedResults.map((item, index) => {
-                    const key = `${item.label}_${item.action?.order}_${item?.breakdown_value}`
-                    const colorIndex = colorIndexMap.get(key) ?? 0
-                    return { ...item, colorIndex, id: index }
-                })
-            },
+            (results, display, lifecycleFilter): IndexedTrendResult[] =>
+                indexTrendResults(results, display, lifecycleFilter),
         ],
 
         currentPeriodResult: [

--- a/frontend/src/scenes/trends/types.ts
+++ b/frontend/src/scenes/trends/types.ts
@@ -6,21 +6,7 @@ export interface TrendResponse {
     next?: string
 }
 
-export interface IndexedTrendResult extends TrendResult {
-    /**
-     * The index after applying visualization-specific sorting (e.g. for pie
-     * chart) and filtering (e.g. for lifecycle toggles).
-     */
-    id: number
-    /** The original index of the series, before re-sorting into visualization
-     * specific order (e.g. for pie chart). The series index is used e.g. to
-     * get series color correctly. */
-    seriesIndex: number
-    /** An index computed in trendsDataLogic that is used to generate colors. This index is the same for current and previous
-     * series with the same label. The previous series is given a slightly lighter version of the same color.
-     * */
-    colorIndex: number
-}
+export type { IndexedTrendResult } from 'lib/hog-charts/transforms/trends'
 
 export interface TrendActors {
     seriesId?: number // The series identifier for this particular point (i.e. index of series)

--- a/frontend/src/scenes/trends/viz/TrendsLineChartD3.tsx
+++ b/frontend/src/scenes/trends/viz/TrendsLineChartD3.tsx
@@ -1,23 +1,20 @@
 import { useValues } from 'kea'
 import { useCallback, useMemo } from 'react'
 
-import { createXAxisTickCallback } from 'lib/charts/utils/dates'
 import { buildTheme } from 'lib/charts/utils/theme'
 import { LineChart } from 'lib/hog-charts'
-import type { LineChartConfig, Series } from 'lib/hog-charts'
 import type { TooltipContext } from 'lib/hog-charts/core/types'
+import { buildTrendsConfig, buildTrendsSeries } from 'lib/hog-charts/transforms/trends'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { teamLogic } from 'scenes/teamLogic'
 
 import { themeLogic } from '~/layout/navigation-3000/themeLogic'
 import { groupsModel } from '~/models/groupsModel'
-import { GoalLine as SchemaGoalLine, InsightVizNode } from '~/queries/schema/schema-general'
+import { InsightVizNode } from '~/queries/schema/schema-general'
 import { QueryContext } from '~/queries/types'
-import { ChartDisplayType } from '~/types'
 
 import { InsightEmptyState } from '../../insights/EmptyStates'
 import { trendsDataLogic } from '../trendsDataLogic'
-import type { IndexedTrendResult } from '../types'
 import { TrendsTooltip } from './TrendsTooltip'
 
 interface TrendsLineChartD3Props {
@@ -60,54 +57,21 @@ export function TrendsLineChartD3({ context }: TrendsLineChartD3Props): JSX.Elem
 
     const labels = currentPeriodResult?.labels ?? []
 
-    const hasData =
-        indexedResults &&
-        indexedResults[0]?.data &&
-        indexedResults.filter((result: IndexedTrendResult) => result.count !== 0).length > 0
-
-    const hogSeries: Series[] = useMemo(
-        () =>
-            (indexedResults ?? [])
-                .filter((r: IndexedTrendResult) => r.count !== 0)
-                .map((r: IndexedTrendResult) => ({
-                    key: `${r.id}`,
-                    label: r.label ?? '',
-                    data: r.data,
-                    color: getTrendsColor(r),
-                    fillArea: display === ChartDisplayType.ActionsAreaGraph,
-                    meta: {
-                        action: r.action,
-                        breakdown_value: r.breakdown_value,
-                        compare_label: r.compare_label,
-                        days: r.days,
-                        // Fall back to the pre-filter index (r.id) so ordering is stable when earlier series are dropped.
-                        order: r.action?.order ?? r.id,
-                        filter: r.filter,
-                    },
-                })),
+    const hogSeries = useMemo(
+        () => buildTrendsSeries(indexedResults ?? [], display, getTrendsColor),
         [indexedResults, display, getTrendsColor]
     )
 
-    const chartConfig: LineChartConfig = useMemo(() => {
-        const xTickFormatter = createXAxisTickCallback({
-            interval: interval ?? 'day',
-            allDays: currentPeriodResult?.days ?? [],
-            timezone,
-        })
-        return {
-            showGrid: true,
-            showCrosshair: true,
-            pinnableTooltip: true,
-            yScaleType: yAxisScaleType === 'log10' ? 'log' : 'linear',
-            percentStackView: isPercentStackView,
-            xTickFormatter,
-            goalLines: goalLines?.map((g: SchemaGoalLine) => ({
-                value: g.value,
-                label: g.label ?? undefined,
-                borderColor: g.borderColor ?? undefined,
-            })),
-        }
-    }, [interval, currentPeriodResult?.days, timezone, yAxisScaleType, isPercentStackView, goalLines])
+    const hasData = indexedResults && indexedResults[0]?.data && indexedResults.some((r) => r.count !== 0)
+
+    const chartConfig = buildTrendsConfig({
+        interval,
+        days: currentPeriodResult?.days ?? [],
+        timezone,
+        yAxisScaleType,
+        isPercentStackView,
+        goalLines,
+    })
 
     const formatCompareLabel = context?.formatCompareLabel
     const renderTooltip = useCallback(

--- a/frontend/src/scenes/trends/viz/TrendsLineChartD3.tsx
+++ b/frontend/src/scenes/trends/viz/TrendsLineChartD3.tsx
@@ -64,14 +64,18 @@ export function TrendsLineChartD3({ context }: TrendsLineChartD3Props): JSX.Elem
 
     const hasData = indexedResults && indexedResults[0]?.data && indexedResults.some((r) => r.count !== 0)
 
-    const chartConfig = buildTrendsConfig({
-        interval,
-        days: currentPeriodResult?.days ?? [],
-        timezone,
-        yAxisScaleType,
-        isPercentStackView,
-        goalLines,
-    })
+    const chartConfig = useMemo(
+        () =>
+            buildTrendsConfig({
+                interval,
+                days: currentPeriodResult?.days ?? [],
+                timezone,
+                yAxisScaleType,
+                isPercentStackView,
+                goalLines,
+            }),
+        [interval, currentPeriodResult?.days, timezone, yAxisScaleType, isPercentStackView, goalLines]
+    )
 
     const formatCompareLabel = context?.formatCompareLabel
     const renderTooltip = useCallback(


### PR DESCRIPTION
## Problem

I want to re-use some code from these logics.

## Changes

- Extract `indexTrendResults`, `buildTrendsSeries`, `buildTrendsConfig` as pure functions in `lib/hog-charts/transforms/trends.ts`
- `trendsDataLogic` and `TrendsLineChartD3` now call these instead of inlining the logic
- `IndexedTrendResult` type moved to transforms, re-exported from `scenes/trends/types.ts`
- 14 new tests for the transform functions

## How did you test this code?

AI agent — ran `trendsDataLogic.test.ts` (23 tests) and `hog-charts` suite (97 tests) plus 14 new transform tests. All pass.

## LLM context

Foundation for a lightweight `<Insight />` embedding component. The pure transforms are the shared contract both paths will use.