### PR TITLE
feat: add DUCKGRES_PG_URL setting for public-facing warehouse host

### DIFF
--- a/posthog/settings/base_variables.py
+++ b/posthog/settings/base_variables.py
@@ -50,9 +50,11 @@ SERVER_GATEWAY_INTERFACE = get_from_env("SERVER_GATEWAY_INTERFACE", "WSGI", type
 # GitHub secret alert relay URL - set in US deployment to forward alerts to EU
 GITHUB_SECRET_ALERT_RELAY_URL: str | None = get_from_env("GITHUB_SECRET_ALERT_RELAY_URL", optional=True)
 
-# Duckgres API - URL and internal secret for the managed warehouse service
+# Duckgres - URL, internal secret, and PG endpoint for the managed warehouse service
 DUCKGRES_API_URL: str | None = get_from_env("DUCKGRES_API_URL", optional=True)
 DUCKGRES_INTERNAL_SECRET: str | None = get_from_env("DUCKGRES_INTERNAL_SECRET", optional=True)
+DUCKGRES_PG_URL: str | None = get_from_env("DUCKGRES_PG_URL", optional=True)
+DUCKGRES_PG_PORT: int = int(get_from_env("DUCKGRES_PG_PORT", "5432"))
 
 # Bulk deletion operations can be disabled during database migrations
 DISABLE_BULK_DELETES: bool = get_from_env("DISABLE_BULK_DELETES", False, type_cast=str_to_bool)

--- a/posthog/settings/base_variables.py
+++ b/posthog/settings/base_variables.py
@@ -54,7 +54,7 @@ GITHUB_SECRET_ALERT_RELAY_URL: str | None = get_from_env("GITHUB_SECRET_ALERT_RE
 DUCKGRES_API_URL: str | None = get_from_env("DUCKGRES_API_URL", optional=True)
 DUCKGRES_INTERNAL_SECRET: str | None = get_from_env("DUCKGRES_INTERNAL_SECRET", optional=True)
 DUCKGRES_PG_URL: str | None = get_from_env("DUCKGRES_PG_URL", optional=True)
-DUCKGRES_PG_PORT: int = int(get_from_env("DUCKGRES_PG_PORT", "5432"))
+DUCKGRES_PG_PORT: int = get_from_env("DUCKGRES_PG_PORT", 5432, type_cast=int)
 
 # Bulk deletion operations can be disabled during database migrations
 DISABLE_BULK_DELETES: bool = get_from_env("DISABLE_BULK_DELETES", False, type_cast=str_to_bool)

--- a/products/data_warehouse/backend/api/data_warehouse.py
+++ b/products/data_warehouse/backend/api/data_warehouse.py
@@ -906,7 +906,15 @@ class DataWarehouseViewSet(TeamAndOrgViewSetMixin, viewsets.ViewSet):
     @action(methods=["GET"], detail=False)
     def warehouse_status(self, request: Request, **kwargs) -> Response:
         """Get the current provisioning status of the managed warehouse."""
-        return self._provisioning_request("GET", "/warehouse/status")
+        resp = self._provisioning_request("GET", "/warehouse/status")
+        # Override connection host/port with the public-facing duckgres PG endpoint
+        if resp.status_code == 200 and isinstance(resp.data, dict) and resp.data.get("connection"):
+            pg_url = getattr(django_settings, "DUCKGRES_PG_URL", None)
+            pg_port = getattr(django_settings, "DUCKGRES_PG_PORT", 5432)
+            if pg_url:
+                resp.data["connection"]["host"] = pg_url
+                resp.data["connection"]["port"] = pg_port
+        return resp
 
     @extend_schema(
         responses={


### PR DESCRIPTION
## Problem

The managed warehouse status endpoint returns connection details from the duckgres internal config, but the host/port shown to users should be the public-facing PG load balancer, not the internal endpoint.

## Changes

- Add `DUCKGRES_PG_URL` and `DUCKGRES_PG_PORT` (default 5432) settings
- `warehouse_status` endpoint overrides `connection.host` and `connection.port` with these values before returning to the client
- Companion charts PR: PostHog/charts#TBD

## How did you test this code?

Code review only — straightforward config plumbing.

## Publish to changelog?

no

## 🤖 LLM context

Co-authored with Claude Code.