### PR TITLE
Remove library version column from survey response table

### DIFF
--- a/frontend/src/scenes/surveys/surveyLogic.tsx
+++ b/frontend/src/scenes/surveys/surveyLogic.tsx
@@ -1736,7 +1736,6 @@ export const surveyLogic = kea<surveyLogicType>([
                     }),
                     'timestamp',
                     'person',
-                    `coalesce(JSONExtractString(properties, '$lib_version')) -- Library Version`,
                     `coalesce(JSONExtractString(properties, '$lib')) -- Library`,
                     `coalesce(JSONExtractString(properties, '$current_url')) -- URL`,
                 ]


### PR DESCRIPTION
## TL;DR
Removed the library version column from the survey response table by removing the `$lib_version` property extraction from the default columns query.

## What changed?
- Removed the `coalesce(JSONExtractString(properties, '$lib_version')) -- Library Version` column from the survey response table's default columns in `surveyLogic.tsx`
- The library column (`$lib`) is retained; only the version column was removed

## How did you test this code?
This is a code-level change to remove a column from the survey response query. Visual testing would involve navigating to a survey's response table and verifying that the "Library Version" column no longer appears in the default columns.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*