### PR TITLE
fix: centralise signals-related hogql queries

### DIFF
--- a/products/signals/backend/temporal/__init__.py
+++ b/products/signals/backend/temporal/__init__.py
@@ -18,13 +18,10 @@ from products.signals.backend.temporal.grouping import (
     TeamSignalGroupingWorkflow,
     assign_and_emit_signal_activity,
     fetch_report_contexts_activity,
-    fetch_signal_type_examples_activity,
     generate_search_queries_activity,
     get_embedding_activity,
     match_signal_to_report_activity,
-    run_signal_semantic_search_activity,
     verify_match_specificity_activity,
-    wait_for_signal_in_clickhouse_activity,
 )
 from products.signals.backend.temporal.grouping_v2 import TeamSignalGroupingV2Workflow, read_signals_from_s3_activity
 from products.signals.backend.temporal.reingestion import (
@@ -35,9 +32,14 @@ from products.signals.backend.temporal.reingestion import (
 )
 from products.signals.backend.temporal.report_safety_judge import report_safety_judge_activity
 from products.signals.backend.temporal.safety_filter import safety_filter_activity
+from products.signals.backend.temporal.signal_queries import (
+    fetch_signal_type_examples_activity,
+    fetch_signals_for_report_activity,
+    run_signal_semantic_search_activity,
+    wait_for_signal_in_clickhouse_activity,
+)
 from products.signals.backend.temporal.summary import (
     SignalReportSummaryWorkflow,
-    fetch_signals_for_report_activity,
     mark_report_failed_activity,
     mark_report_in_progress_activity,
     mark_report_pending_input_activity,

--- a/products/signals/backend/temporal/deletion.py
+++ b/products/signals/backend/temporal/deletion.py
@@ -5,21 +5,19 @@ import temporalio
 from temporalio import workflow
 from temporalio.common import RetryPolicy
 
-from products.signals.backend.temporal.grouping import (
-    WaitForClickHouseInput,
-    WaitForClickHouseSignal,
-    wait_for_signal_in_clickhouse_activity,
-)
 from products.signals.backend.temporal.reingestion import (
     DeleteReportInput,
     SoftDeleteReportSignalsInput,
     delete_report_activity,
     soft_delete_report_signals_activity,
 )
-from products.signals.backend.temporal.summary import (
+from products.signals.backend.temporal.signal_queries import (
     FetchSignalsForReportInput,
     FetchSignalsForReportOutput,
+    WaitForClickHouseInput,
+    WaitForClickHouseSignal,
     fetch_signals_for_report_activity,
+    wait_for_signal_in_clickhouse_activity,
 )
 from products.signals.backend.temporal.types import SignalReportDeletionWorkflowInputs
 

--- a/products/signals/backend/temporal/grouping.py
+++ b/products/signals/backend/temporal/grouping.py
@@ -21,21 +21,29 @@ from temporalio.workflow import ParentClosePolicy
 
 from posthog.schema import EmbeddingModelName
 
-from posthog.hogql import ast
-
 from posthog.api.embedding_worker import async_generate_embedding, emit_embedding_request
 from posthog.models import Team
 from posthog.sync import database_sync_to_async
 
 from products.signals.backend.models import SignalReport
-from products.signals.backend.temporal.clickhouse import execute_hogql_query_with_retry
 from products.signals.backend.temporal.llm import MAX_QUERY_TOKENS, call_llm, truncate_query_to_token_limit
-from products.signals.backend.temporal.summary import (
+from products.signals.backend.temporal.signal_queries import (
+    EMBEDDING_MODEL,
     FetchSignalsForReportInput,
     FetchSignalsForReportOutput,
-    SignalReportSummaryWorkflow,
+    FetchSignalTypeExamplesInput,
+    FetchSignalTypeExamplesOutput,
+    RunSignalSemanticSearchInput,
+    RunSignalSemanticSearchOutput,
+    WaitForClickHouseInput,
+    WaitForClickHouseSignal,
+    fetch_signal_type_examples_activity,
     fetch_signals_for_report_activity,
+    run_signal_semantic_search_activity,
+    soft_delete_report_signals,
+    wait_for_signal_in_clickhouse_activity,
 )
+from products.signals.backend.temporal.summary import SignalReportSummaryWorkflow
 from products.signals.backend.temporal.types import (
     EmitSignalInputs,
     ExistingReportMatch,
@@ -51,7 +59,6 @@ from products.signals.backend.temporal.types import (
     SpecificityMetadata,
     TeamSignalGroupingInput,
 )
-from products.signals.backend.utils import EMBEDDING_MODEL, soft_delete_report_signals
 
 logger = structlog.get_logger(__name__)
 
@@ -85,92 +92,6 @@ async def get_embedding_activity(input: GenerateEmbeddingInput) -> GenerateEmbed
     except Exception as e:
         logger.exception(
             f"Failed to generate embedding for team {input.team_id}: {e}",
-            team_id=input.team_id,
-        )
-        raise
-
-
-@dataclass
-class FetchSignalTypeExamplesInput:
-    team_id: int
-
-
-@dataclass
-class FetchSignalTypeExamplesOutput:
-    examples: list[SignalTypeExample]
-
-
-@temporalio.activity.defn
-async def fetch_signal_type_examples_activity(input: FetchSignalTypeExamplesInput) -> FetchSignalTypeExamplesOutput:
-    """Fetch one example signal per unique (source_product, source_type) pair from ClickHouse."""
-    try:
-        team = await Team.objects.aget(pk=input.team_id)
-
-        query = """
-            SELECT -- Grab the latest unique example of each signal type
-                source_product,
-                source_type,
-                argMax(content, timestamp) as example_content,
-                argMax(metadata, timestamp) as example_metadata,
-                toString(max(timestamp)) as latest_timestamp
-            FROM ( -- From the set of most recent versions where the signal appeared at most a month ago
-                SELECT
-                    JSONExtractString(metadata, 'source_product') as source_product,
-                    JSONExtractString(metadata, 'source_type') as source_type,
-                    content,
-                    metadata,
-                    timestamp
-                FROM ( -- From the most recent versions of all signals
-                    SELECT
-                        document_id,
-                        argMax(content, inserted_at) as content,
-                        argMax(metadata, inserted_at) as metadata,
-                        argMax(timestamp, inserted_at) as timestamp
-                    FROM document_embeddings
-                    WHERE model_name = {model_name}
-                      AND product = 'signals'
-                      AND document_type = 'signal'
-                    GROUP BY document_id
-                )
-                WHERE content != ''
-                  AND timestamp >= now() - INTERVAL 1 MONTH
-                  AND NOT JSONExtractBool(metadata, 'deleted')
-            )
-            GROUP BY source_product, source_type
-        """
-
-        result = await execute_hogql_query_with_retry(
-            query_type="SignalsFetchTypeExamples",
-            query=query,
-            team=team,
-            placeholders={
-                "model_name": ast.Constant(value=EMBEDDING_MODEL.value),
-            },
-        )
-
-        examples = []
-        for row in result.results or []:
-            source_product, source_type, content, metadata_str, timestamp = row
-            metadata = json.loads(metadata_str)
-            examples.append(
-                SignalTypeExample(
-                    source_product=source_product,
-                    source_type=source_type,
-                    content=content,
-                    timestamp=timestamp,
-                    extra=metadata.get("extra", {}),
-                )
-            )
-
-        logger.debug(
-            f"Fetched {len(examples)} signal type examples for team {input.team_id}",
-            team_id=input.team_id,
-            example_count=len(examples),
-        )
-        return FetchSignalTypeExamplesOutput(examples=examples)
-    except Exception as e:
-        logger.exception(
-            f"Failed to fetch signal type examples for team {input.team_id}: {e}",
             team_id=input.team_id,
         )
         raise
@@ -283,91 +204,6 @@ async def generate_search_queries_activity(input: GenerateSearchQueriesInput) ->
             f"Failed to generate search queries: {e}",
             source_product=input.source_product,
             source_type=input.source_type,
-        )
-        raise
-
-
-@dataclass
-class RunSignalSemanticSearchInput:
-    team_id: int
-    embedding: list[float]
-    limit: int = 10
-
-
-@dataclass
-class RunSignalSemanticSearchOutput:
-    candidates: list[SignalCandidate]
-
-
-@temporalio.activity.defn
-async def run_signal_semantic_search_activity(input: RunSignalSemanticSearchInput) -> RunSignalSemanticSearchOutput:
-    """Run a nearest neighbor query against the signal embeddings in ClickHouse."""
-    try:
-        team = await Team.objects.aget(pk=input.team_id)
-
-        query = """
-            SELECT
-                document_id,
-                content,
-                JSONExtractString(metadata, 'report_id') as report_id,
-                JSONExtractString(metadata, 'source_product') as source_product,
-                JSONExtractString(metadata, 'source_type') as source_type,
-                cosineDistance(embedding, {embedding}) as distance
-            FROM (
-                SELECT
-                    document_id,
-                    argMax(content, inserted_at) as content,
-                    argMax(metadata, inserted_at) as metadata,
-                    argMax(embedding, inserted_at) as embedding,
-                    argMax(timestamp, inserted_at) as timestamp
-                FROM document_embeddings
-                WHERE model_name = {model_name}
-                  AND product = 'signals'
-                  AND document_type = 'signal'
-                GROUP BY document_id
-            )
-            WHERE JSONExtractString(metadata, 'report_id') != ''
-              AND timestamp >= now() - INTERVAL 1 MONTH
-              AND NOT JSONExtractBool(metadata, 'deleted')
-            ORDER BY distance ASC
-            LIMIT {limit}
-        """
-
-        result = await execute_hogql_query_with_retry(
-            query_type="SignalsRunEmbeddingQuery",
-            query=query,
-            team=team,
-            placeholders={
-                "embedding": ast.Constant(value=input.embedding),
-                "model_name": ast.Constant(value=EMBEDDING_MODEL.value),
-                "limit": ast.Constant(value=input.limit),
-            },
-        )
-
-        candidates = []
-        for row in result.results or []:
-            document_id, content, report_id, source_product, source_type, distance = row
-            candidates.append(
-                SignalCandidate(
-                    signal_id=document_id,
-                    report_id=report_id,
-                    content=content,
-                    source_product=source_product,
-                    source_type=source_type,
-                    distance=distance,
-                )
-            )
-
-        logger.debug(
-            f"Found {len(candidates)} candidate signals for team {input.team_id}",
-            team_id=input.team_id,
-            candidate_count=len(candidates),
-        )
-        return RunSignalSemanticSearchOutput(candidates=candidates)
-    except Exception as e:
-        logger.exception(
-            f"Failed to run embedding query for team {input.team_id}: {e}",
-            team_id=input.team_id,
         )
         raise
 
@@ -947,106 +783,6 @@ async def assign_and_emit_signal_activity(input: AssignAndEmitSignalInput) -> As
             signal_id=input.signal_id,
         )
         raise
-
-
-@dataclass
-class WaitForClickHouseSignal:
-    signal_id: str
-    timestamp: datetime
-
-
-@dataclass
-class WaitForClickHouseInput:
-    team_id: int
-    signals: list[WaitForClickHouseSignal]
-    max_wait_time_seconds: int = 3600
-
-
-WAIT_POLL_INTERVAL_SECONDS = 10
-
-
-@temporalio.activity.defn
-async def wait_for_signal_in_clickhouse_activity(input: WaitForClickHouseInput) -> None:
-    """Poll ClickHouse until all emitted signals appear, or give up after max_wait_time_seconds.
-
-    Filters on inserted_at >= (now - 30 minutes) to avoid matching stale rows from a
-    previous emission of the same document_id (e.g. deleted then reingested). The window
-    is generous because signals are emitted during the sequential phase before this
-    activity starts, so early signals may already be minutes old.
-    """
-    if not input.signals:
-        return
-
-    team = await Team.objects.aget(pk=input.team_id)
-    inserted_at_threshold = timezone.now() - timedelta(minutes=30)
-    max_attempts = max(1, input.max_wait_time_seconds // WAIT_POLL_INTERVAL_SECONDS)
-
-    signal_ids = [s.signal_id for s in input.signals]
-    timestamps = [s.timestamp for s in input.signals]
-    # Widen the timestamp range to account for precision loss (Python microseconds vs ClickHouse DateTime64(3) milliseconds)
-    min_timestamp = min(timestamps) - timedelta(minutes=2)
-    max_timestamp = max(timestamps) + timedelta(minutes=2)
-
-    query = """
-        SELECT count(DISTINCT document_id)
-        FROM document_embeddings
-        WHERE timestamp >= {min_timestamp}
-          AND timestamp <= {max_timestamp}
-          AND product = 'signals'
-          AND document_type = 'signal'
-          AND model_name = {model_name}
-          AND rendering = 'plain'
-          AND document_id IN {signal_ids}
-          AND inserted_at >= {inserted_at_threshold}
-    """
-
-    placeholders = {
-        "min_timestamp": ast.Constant(value=min_timestamp),
-        "max_timestamp": ast.Constant(value=max_timestamp),
-        "model_name": ast.Constant(value=EMBEDDING_MODEL.value),
-        "signal_ids": ast.Constant(value=signal_ids),
-        "inserted_at_threshold": ast.Constant(value=inserted_at_threshold),
-    }
-
-    expected_count = len(signal_ids)
-
-    for attempt in range(max_attempts):
-        temporalio.activity.heartbeat(attempt)
-
-        result = await execute_hogql_query_with_retry(
-            query_type="SignalsWaitForClickHouse",
-            query=query,
-            team=team,
-            placeholders=placeholders,
-            heartbeat_fn=temporalio.activity.heartbeat,
-        )
-
-        # Heartbeat immediately after the query completes — the query itself runs in
-        # sync_to_async and can't heartbeat during execution, so this ensures we don't
-        # hit the heartbeat timeout when queries are slow.
-        temporalio.activity.heartbeat(attempt)
-
-        if result.results and result.results[0][0] >= expected_count:
-            logger.debug(
-                f"All {expected_count} signal(s) found in ClickHouse after {attempt + 1} attempt(s)",
-                signal_ids=signal_ids,
-                team_id=input.team_id,
-            )
-            return
-
-        # Sleep in chunks so we keep heartbeating during the poll interval
-        remaining = WAIT_POLL_INTERVAL_SECONDS
-        while remaining > 0:
-            chunk = min(remaining, 5)
-            await asyncio.sleep(chunk)
-            remaining -= chunk
-            temporalio.activity.heartbeat(attempt)
-
-    logger.warning(
-        f"Not all signals found in ClickHouse after {input.max_wait_time_seconds}s, proceeding anyway",
-        signal_ids=signal_ids,
-        team_id=input.team_id,
-    )
 
 
 CONTINUE_AS_NEW_THRESHOLD = 20

--- a/products/signals/backend/temporal/reingestion.py
+++ b/products/signals/backend/temporal/reingestion.py
@@ -13,18 +13,16 @@ from posthog.sync import database_sync_to_async
 
 from products.signals.backend.api import emit_signal
 from products.signals.backend.models import SignalReport
-from products.signals.backend.temporal.grouping import (
-    WaitForClickHouseInput,
-    WaitForClickHouseSignal,
-    wait_for_signal_in_clickhouse_activity,
-)
-from products.signals.backend.temporal.summary import (
+from products.signals.backend.temporal.signal_queries import (
     FetchSignalsForReportInput,
     FetchSignalsForReportOutput,
+    WaitForClickHouseInput,
+    WaitForClickHouseSignal,
     fetch_signals_for_report_activity,
+    soft_delete_report_signals,
+    wait_for_signal_in_clickhouse_activity,
 )
 from products.signals.backend.temporal.types import SignalData, SignalReportReingestionWorkflowInputs
-from products.signals.backend.utils import soft_delete_report_signals
 
 logger = structlog.get_logger(__name__)
 

--- a/products/signals/backend/temporal/signal_queries.py
+++ b/products/signals/backend/temporal/signal_queries.py
@@ -1,0 +1,538 @@
+import json
+import asyncio
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from typing import Union
+
+import structlog
+import temporalio
+
+from posthog.schema import EmbeddingModelName
+
+from posthog.hogql import ast
+from posthog.hogql.query import execute_hogql_query
+
+from posthog.api.embedding_worker import emit_embedding_request
+from posthog.clickhouse.query_tagging import Feature, Product, tag_queries
+from posthog.models import Team
+
+from products.signals.backend.temporal.clickhouse import execute_hogql_query_with_retry
+from products.signals.backend.temporal.types import SignalCandidate, SignalData, SignalTypeExample
+
+logger = structlog.get_logger(__name__)
+
+EMBEDDING_MODEL = EmbeddingModelName.TEXT_EMBEDDING_3_SMALL_1536
+
+WAIT_POLL_INTERVAL_SECONDS = 10
+
+
+def _ensure_tz_aware(value: Union[datetime, str]) -> datetime:
+    """Coerce a ClickHouse timestamp (usually a datetime, occasionally a string) to a tz-aware datetime."""
+    if isinstance(value, str):
+        value = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=UTC)
+    return value
+
+
+# ---------------------------------------------------------------------------
+# Shared query builders
+# ---------------------------------------------------------------------------
+
+# The innermost dedup subquery, shared by every query that reads signal rows.
+# Uses argMax(…, inserted_at) GROUP BY document_id to collapse ReplacingMergeTree
+# duplicates deterministically, regardless of background merge state.
+_DEDUPED_SIGNALS_SUBQUERY = """
+    SELECT
+        document_id,
+        argMax(content, inserted_at) as content,
+        argMax(metadata, inserted_at) as metadata,
+        argMax(timestamp, inserted_at) as timestamp
+    FROM document_embeddings
+    WHERE model_name = {model_name}
+      AND product = 'signals'
+      AND document_type = 'signal'
+    GROUP BY document_id
+"""
+
+# Same as above but also deduplicates the embedding column (needed for vector search).
+_DEDUPED_SIGNALS_WITH_EMBEDDING_SUBQUERY = """
+    SELECT
+        document_id,
+        argMax(content, inserted_at) as content,
+        argMax(metadata, inserted_at) as metadata,
+        argMax(embedding, inserted_at) as embedding,
+        argMax(timestamp, inserted_at) as timestamp
+    FROM document_embeddings
+    WHERE model_name = {model_name}
+      AND product = 'signals'
+      AND document_type = 'signal'
+    GROUP BY document_id
+"""
+
+
+def _signals_for_report_query(*, include_deleted: bool = False, limit: int | None = None) -> str:
+    """Build a HogQL query that fetches signal rows for a single report.
+
+    Args:
+        include_deleted: When True the ``NOT deleted`` filter is omitted.
+            Used by soft-delete which intentionally re-processes already-deleted rows.
+        limit: Optional row cap appended as a LIMIT clause.
+    """
+    deleted_filter = "" if include_deleted else "\n          AND NOT JSONExtractBool(metadata, 'deleted')"
+    limit_clause = "" if limit is None else f"\n        LIMIT {limit}"
+
+    return f"""
+        SELECT
+            document_id,
+            content,
+            metadata,
+            timestamp
+        FROM ({_DEDUPED_SIGNALS_SUBQUERY})
+        WHERE JSONExtractString(metadata, 'report_id') = {{report_id}}{deleted_filter}
+        ORDER BY timestamp ASC{limit_clause}
+    """
+
+
+def _report_placeholders(report_id: str) -> dict:
+    return {
+        "model_name": ast.Constant(value=EMBEDDING_MODEL.value),
+        "report_id": ast.Constant(value=report_id),
+    }
+
+
+def _parse_signal_row(row: tuple) -> SignalData:
+    """Turn a (document_id, content, metadata_str, timestamp) row into a SignalData."""
+    document_id, content, metadata_str, timestamp_raw = row
+    timestamp_raw = _ensure_tz_aware(timestamp_raw)
+    # Purposefully throw here if we fail - we rely on metadata being correct, and it's not llm generated, so
+    # no defensive parsing, we want to fail loudly.
+    metadata = json.loads(metadata_str)
+    return SignalData(
+        signal_id=document_id,
+        content=content,
+        source_product=metadata.get("source_product", ""),
+        source_type=metadata.get("source_type", ""),
+        source_id=metadata.get("source_id", ""),
+        weight=metadata.get("weight", 0.0),
+        timestamp=timestamp_raw,
+        extra=metadata.get("extra", {}),
+    )
+
+
+# ---------------------------------------------------------------------------
+# soft_delete_report_signals — synchronous, called from reingestion activity
+# ---------------------------------------------------------------------------
+
+
+def soft_delete_report_signals(report_id: str, team_id: int, team: Team) -> None:
+    """
+    Soft-delete all ClickHouse signals for a report by re-emitting them with metadata.deleted=True.
+
+    Preserves the original timestamp so each row lands in the same ReplacingMergeTree partition
+    and replaces the original. Intentionally fetches ALL signals (including already-deleted ones)
+    so no signals are missed on repeated calls.
+    """
+    result = execute_hogql_query(
+        query_type="SignalsSoftDeleteForReport",
+        query=_signals_for_report_query(include_deleted=True, limit=5000),
+        team=team,
+        placeholders=_report_placeholders(report_id),
+    )
+
+    for row in result.results or []:
+        document_id, content, metadata_str, timestamp_raw = row
+        metadata = json.loads(metadata_str)
+        metadata["deleted"] = True
+
+        emit_embedding_request(
+            content=content,
+            team_id=team_id,
+            product="signals",
+            document_type="signal",
+            rendering="plain",
+            document_id=document_id,
+            models=[m.value for m in EmbeddingModelName],
+            timestamp=_ensure_tz_aware(timestamp_raw),
+            metadata=metadata,
+        )
+
+
+# ---------------------------------------------------------------------------
+# fetch_signal_type_examples_activity
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class FetchSignalTypeExamplesInput:
+    team_id: int
+
+
+@dataclass
+class FetchSignalTypeExamplesOutput:
+    examples: list[SignalTypeExample]
+
+
+@temporalio.activity.defn
+async def fetch_signal_type_examples_activity(input: FetchSignalTypeExamplesInput) -> FetchSignalTypeExamplesOutput:
+    """Fetch one example signal per unique (source_product, source_type) pair from ClickHouse."""
+    try:
+        team = await Team.objects.aget(pk=input.team_id)
+
+        query = f"""
+            SELECT -- Grab the latest unique example of each signal type
+                source_product,
+                source_type,
+                argMax(content, timestamp) as example_content,
+                argMax(metadata, timestamp) as example_metadata,
+                toString(max(timestamp)) as latest_timestamp
+            FROM ( -- From the set of most recent versions where the signal appeared at most a month ago
+                SELECT
+                    JSONExtractString(metadata, 'source_product') as source_product,
+                    JSONExtractString(metadata, 'source_type') as source_type,
+                    content,
+                    metadata,
+                    timestamp
+                FROM ({_DEDUPED_SIGNALS_SUBQUERY})
+                WHERE content != ''
+                  AND timestamp >= now() - INTERVAL 1 MONTH
+                  AND NOT JSONExtractBool(metadata, 'deleted')
+            )
+            GROUP BY source_product, source_type
+        """
+
+        result = await execute_hogql_query_with_retry(
+            query_type="SignalsFetchTypeExamples",
+            query=query,
+            team=team,
+            placeholders={
+                "model_name": ast.Constant(value=EMBEDDING_MODEL.value),
+            },
+        )
+
+        examples = []
+        for row in result.results or []:
+            source_product, source_type, content, metadata_str, timestamp = row
+            metadata = json.loads(metadata_str)
+            examples.append(
+                SignalTypeExample(
+                    source_product=source_product,
+                    source_type=source_type,
+                    content=content,
+                    timestamp=timestamp,
+                    extra=metadata.get("extra", {}),
+                )
+            )
+
+        logger.debug(
+            f"Fetched {len(examples)} signal type examples for team {input.team_id}",
+            team_id=input.team_id,
+            example_count=len(examples),
+        )
+        return FetchSignalTypeExamplesOutput(examples=examples)
+    except Exception as e:
+        logger.exception(
+            f"Failed to fetch signal type examples for team {input.team_id}: {e}",
+            team_id=input.team_id,
+        )
+        raise
+
+
+# ---------------------------------------------------------------------------
+# run_signal_semantic_search_activity
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class RunSignalSemanticSearchInput:
+    team_id: int
+    embedding: list[float]
+    limit: int = 10
+
+
+@dataclass
+class RunSignalSemanticSearchOutput:
+    candidates: list[SignalCandidate]
+
+
+@temporalio.activity.defn
+async def run_signal_semantic_search_activity(input: RunSignalSemanticSearchInput) -> RunSignalSemanticSearchOutput:
+    """Run a nearest neighbor query against the signal embeddings in ClickHouse."""
+    try:
+        team = await Team.objects.aget(pk=input.team_id)
+
+        query = f"""
+            SELECT
+                document_id,
+                content,
+                JSONExtractString(metadata, 'report_id') as report_id,
+                JSONExtractString(metadata, 'source_product') as source_product,
+                JSONExtractString(metadata, 'source_type') as source_type,
+                cosineDistance(embedding, {{embedding}}) as distance
+            FROM ({_DEDUPED_SIGNALS_WITH_EMBEDDING_SUBQUERY})
+            WHERE JSONExtractString(metadata, 'report_id') != ''
+              AND timestamp >= now() - INTERVAL 1 MONTH
+              AND NOT JSONExtractBool(metadata, 'deleted')
+            ORDER BY distance ASC
+            LIMIT {{limit}}
+        """
+
+        result = await execute_hogql_query_with_retry(
+            query_type="SignalsRunEmbeddingQuery",
+            query=query,
+            team=team,
+            placeholders={
+                "embedding": ast.Constant(value=input.embedding),
+                "model_name": ast.Constant(value=EMBEDDING_MODEL.value),
+                "limit": ast.Constant(value=input.limit),
+            },
+        )
+
+        candidates = []
+        for row in result.results or []:
+            document_id, content, report_id, source_product, source_type, distance = row
+            candidates.append(
+                SignalCandidate(
+                    signal_id=document_id,
+                    report_id=report_id,
+                    content=content,
+                    source_product=source_product,
+                    source_type=source_type,
+                    distance=distance,
+                )
+            )
+
+        logger.debug(
+            f"Found {len(candidates)} candidate signals for team {input.team_id}",
+            team_id=input.team_id,
+            candidate_count=len(candidates),
+        )
+        return RunSignalSemanticSearchOutput(candidates=candidates)
+    except Exception as e:
+        logger.exception(
+            f"Failed to run embedding query for team {input.team_id}: {e}",
+            team_id=input.team_id,
+        )
+        raise
+
+
+# ---------------------------------------------------------------------------
+# wait_for_signal_in_clickhouse_activity
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class WaitForClickHouseSignal:
+    signal_id: str
+    timestamp: datetime
+
+
+@dataclass
+class WaitForClickHouseInput:
+    team_id: int
+    signals: list[WaitForClickHouseSignal]
+    max_wait_time_seconds: int = 3600
+
+
+@temporalio.activity.defn
+async def wait_for_signal_in_clickhouse_activity(input: WaitForClickHouseInput) -> None:
+    """Poll ClickHouse until all emitted signals appear, or give up after max_wait_time_seconds.
+
+    Filters on inserted_at >= (now - 30 minutes) to avoid matching stale rows from a
+    previous emission of the same document_id (e.g. deleted then reingested). The window
+    is generous because signals are emitted during the sequential phase before this
+    activity starts, so early signals may already be minutes old.
+    """
+    if not input.signals:
+        return
+
+    from django.utils import timezone
+
+    team = await Team.objects.aget(pk=input.team_id)
+    inserted_at_threshold = timezone.now() - timedelta(minutes=30)
+    max_attempts = max(1, input.max_wait_time_seconds // WAIT_POLL_INTERVAL_SECONDS)
+
+    signal_ids = [s.signal_id for s in input.signals]
+    timestamps = [s.timestamp for s in input.signals]
+    # Widen the timestamp range to account for precision loss (Python microseconds vs ClickHouse DateTime64(3) milliseconds)
+    min_timestamp = min(timestamps) - timedelta(minutes=2)
+    max_timestamp = max(timestamps) + timedelta(minutes=2)
+
+    query = """
+        SELECT count(DISTINCT document_id)
+        FROM document_embeddings
+        WHERE timestamp >= {min_timestamp}
+          AND timestamp <= {max_timestamp}
+          AND product = 'signals'
+          AND document_type = 'signal'
+          AND model_name = {model_name}
+          AND rendering = 'plain'
+          AND document_id IN {signal_ids}
+          AND inserted_at >= {inserted_at_threshold}
+    """
+
+    placeholders = {
+        "min_timestamp": ast.Constant(value=min_timestamp),
+        "max_timestamp": ast.Constant(value=max_timestamp),
+        "model_name": ast.Constant(value=EMBEDDING_MODEL.value),
+        "signal_ids": ast.Constant(value=signal_ids),
+        "inserted_at_threshold": ast.Constant(value=inserted_at_threshold),
+    }
+
+    expected_count = len(signal_ids)
+
+    for attempt in range(max_attempts):
+        temporalio.activity.heartbeat(attempt)
+
+        result = await execute_hogql_query_with_retry(
+            query_type="SignalsWaitForClickHouse",
+            query=query,
+            team=team,
+            placeholders=placeholders,
+            heartbeat_fn=temporalio.activity.heartbeat,
+        )
+
+        # Heartbeat immediately after the query completes — the query itself runs in
+        # sync_to_async and can't heartbeat during execution, so this ensures we don't
+        # hit the heartbeat timeout when queries are slow.
+        temporalio.activity.heartbeat(attempt)
+
+        if result.results and result.results[0][0] >= expected_count:
+            logger.debug(
+                f"All {expected_count} signal(s) found in ClickHouse after {attempt + 1} attempt(s)",
+                signal_ids=signal_ids,
+                team_id=input.team_id,
+            )
+            return
+
+        # Sleep in chunks so we keep heartbeating during the poll interval
+        remaining = WAIT_POLL_INTERVAL_SECONDS
+        while remaining > 0:
+            chunk = min(remaining, 5)
+            await asyncio.sleep(chunk)
+            remaining -= chunk
+            temporalio.activity.heartbeat(attempt)
+
+    logger.warning(
+        f"Not all signals found in ClickHouse after {input.max_wait_time_seconds}s, proceeding anyway",
+        signal_ids=signal_ids,
+        team_id=input.team_id,
+    )
+
+
+# ---------------------------------------------------------------------------
+# fetch_signals_for_report — async activity + sync helper for views
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class FetchSignalsForReportInput:
+    team_id: int
+    report_id: str
+
+
+@dataclass
+class FetchSignalsForReportOutput:
+    signals: list[SignalData]
+
+
+@temporalio.activity.defn
+async def fetch_signals_for_report_activity(input: FetchSignalsForReportInput) -> FetchSignalsForReportOutput:
+    try:
+        team = await Team.objects.aget(pk=input.team_id)
+
+        result = await execute_hogql_query_with_retry(
+            query_type="SignalsFetchForReport",
+            query=_signals_for_report_query(),
+            team=team,
+            placeholders=_report_placeholders(input.report_id),
+        )
+
+        signals = [_parse_signal_row(row) for row in (result.results or [])]
+
+        logger.debug(
+            f"Fetched {len(signals)} signals for report {input.report_id}",
+            team_id=input.team_id,
+            report_id=input.report_id,
+            signal_count=len(signals),
+        )
+        return FetchSignalsForReportOutput(signals=signals)
+    except Exception as e:
+        logger.exception(
+            f"Failed to fetch signals for report {input.report_id}: {e}",
+            team_id=input.team_id,
+            report_id=input.report_id,
+        )
+        raise
+
+
+def fetch_signals_for_report_sync(team: Team, report_id: str) -> list[dict]:
+    """Fetch all signals for a report from ClickHouse, including full metadata. Synchronous."""
+    tag_queries(product=Product.SIGNALS, feature=Feature.USAGE_REPORT)
+    result = execute_hogql_query(
+        query_type="SignalsDebugFetchForReport",
+        query=_signals_for_report_query(),
+        team=team,
+        placeholders=_report_placeholders(report_id),
+    )
+
+    signals_list = []
+    for row in result.results or []:
+        document_id, content, metadata_str, timestamp = row
+        metadata = json.loads(metadata_str)
+        signals_list.append(
+            {
+                "signal_id": document_id,
+                "content": content,
+                "source_product": metadata.get("source_product", ""),
+                "source_type": metadata.get("source_type", ""),
+                "source_id": metadata.get("source_id", ""),
+                "weight": metadata.get("weight", 0.0),
+                "timestamp": timestamp,
+                "extra": metadata.get("extra", {}),
+                "match_metadata": metadata.get("match_metadata"),
+            }
+        )
+
+    return signals_list
+
+
+# ---------------------------------------------------------------------------
+# fetch_report_ids_for_source_products — synchronous, for the viewset list filter
+# ---------------------------------------------------------------------------
+
+
+def fetch_report_ids_for_source_products(team: Team, source_products: list[str]) -> set[str]:
+    """Return the set of report IDs that have at least one non-deleted signal from the given source products.
+
+    Uses argMax deduplication to give stable results regardless of ReplacingMergeTree merge state.
+    """
+    ch_query = f"""
+        SELECT DISTINCT report_id
+        FROM (
+            SELECT
+                JSONExtractString(metadata, 'report_id') as report_id,
+                JSONExtractBool(metadata, 'deleted') as is_deleted,
+                JSONExtractString(metadata, 'source_product') as source_product,
+                timestamp
+            FROM ({_DEDUPED_SIGNALS_SUBQUERY})
+            ORDER BY timestamp DESC
+        )
+        WHERE NOT is_deleted
+          AND report_id != ''
+          AND source_product IN ({{source_products}})
+        LIMIT 300
+    """
+
+    tag_queries(product=Product.SIGNALS, feature=Feature.USAGE_REPORT)
+    result = execute_hogql_query(
+        query_type="SignalsFilterBySourceProduct",
+        query=ch_query,
+        team=team,
+        placeholders={
+            "model_name": ast.Constant(value=EMBEDDING_MODEL.value),
+            "source_products": ast.Tuple(exprs=[ast.Constant(value=sp) for sp in source_products]),
+        },
+    )
+
+    return {row[0] for row in (result.results or []) if row[0]}

--- a/products/signals/backend/temporal/summary.py
+++ b/products/signals/backend/temporal/summary.py
@@ -1,7 +1,7 @@
 import json
 import asyncio
 from dataclasses import dataclass
-from datetime import UTC, datetime, timedelta
+from datetime import timedelta
 
 from django.db import transaction
 
@@ -10,11 +10,8 @@ import temporalio
 from temporalio import workflow
 from temporalio.common import RetryPolicy
 
-from posthog.hogql import ast
-
 from posthog.kafka_client.client import KafkaProducer
 from posthog.kafka_client.topics import KAFKA_SIGNALS_REPORT_COMPLETED
-from posthog.models import Team
 from posthog.sync import database_sync_to_async
 
 from products.signals.backend.models import SignalReport
@@ -29,10 +26,13 @@ from products.signals.backend.temporal.agentic.select_repository import (
     SelectRepositoryInput,
     select_repository_activity,
 )
-from products.signals.backend.temporal.clickhouse import execute_hogql_query_with_retry
 from products.signals.backend.temporal.report_safety_judge import SafetyJudgeInput, report_safety_judge_activity
+from products.signals.backend.temporal.signal_queries import (
+    FetchSignalsForReportInput,
+    FetchSignalsForReportOutput,
+    fetch_signals_for_report_activity,
+)
 from products.signals.backend.temporal.types import SignalData, SignalReportSummaryWorkflowInputs
-from products.signals.backend.utils import EMBEDDING_MODEL
 
 logger = structlog.get_logger(__name__)
 
@@ -239,95 +239,6 @@ class SignalReportSummaryWorkflow:
                 retry_policy=RetryPolicy(maximum_attempts=3),
             )
             raise
-
-
-@dataclass
-class FetchSignalsForReportInput:
-    team_id: int
-    report_id: str
-
-
-@dataclass
-class FetchSignalsForReportOutput:
-    signals: list[SignalData]
-
-
-@temporalio.activity.defn
-async def fetch_signals_for_report_activity(input: FetchSignalsForReportInput) -> FetchSignalsForReportOutput:
-    try:
-        team = await Team.objects.aget(pk=input.team_id)
-
-        query = """
-            SELECT
-                document_id,
-                content,
-                metadata,
-                timestamp
-            FROM (
-                SELECT
-                    document_id,
-                    argMax(content, inserted_at) as content,
-                    argMax(metadata, inserted_at) as metadata,
-                    argMax(timestamp, inserted_at) as timestamp
-                FROM document_embeddings
-                WHERE model_name = {model_name}
-                  AND product = 'signals'
-                  AND document_type = 'signal'
-                GROUP BY document_id
-            )
-            WHERE JSONExtractString(metadata, 'report_id') = {report_id}
-              AND NOT JSONExtractBool(metadata, 'deleted')
-            ORDER BY timestamp ASC
-        """
-
-        result = await execute_hogql_query_with_retry(
-            query_type="SignalsFetchForReport",
-            query=query,
-            team=team,
-            placeholders={
-                "model_name": ast.Constant(value=EMBEDDING_MODEL.value),
-                "report_id": ast.Constant(value=input.report_id),
-            },
-        )
-
-        signals = []
-        for row in result.results or []:
-            document_id, content, metadata_str, timestamp_raw = row
-            # HogQL returns datetime objects, but defend against strings too
-            if isinstance(timestamp_raw, str):
-                timestamp_raw = datetime.fromisoformat(timestamp_raw.replace("Z", "+00:00"))
-            if timestamp_raw.tzinfo is None:
-                timestamp_raw = timestamp_raw.replace(tzinfo=UTC)
-            # Purposefully throw here if we fail - we rely on metadata being correct, and it's not llm generated, so
-            # no defensive parsing, we want to fail loudly.
-            metadata = json.loads(metadata_str)
-            signals.append(
-                SignalData(
-                    signal_id=document_id,
-                    content=content,
-                    source_product=metadata.get("source_product", ""),
-                    source_type=metadata.get("source_type", ""),
-                    source_id=metadata.get("source_id", ""),
-                    weight=metadata.get("weight", 0.0),
-                    timestamp=timestamp_raw,
-                    extra=metadata.get("extra", {}),
-                )
-            )
-
-        logger.debug(
-            f"Fetched {len(signals)} signals for report {input.report_id}",
-            team_id=input.team_id,
-            report_id=input.report_id,
-            signal_count=len(signals),
-        )
-        return FetchSignalsForReportOutput(signals=signals)
-    except Exception as e:
-        logger.exception(
-            f"Failed to fetch signals for report {input.report_id}: {e}",
-            team_id=input.team_id,
-            report_id=input.report_id,
-        )
-        raise
 
 
 @dataclass

--- a/products/signals/backend/utils.py
+++ b/products/signals/backend/utils.py
@@ -1,81 +1,12 @@
-import json
-from datetime import UTC, datetime
-from typing import Union
+# Re-export from the canonical location for backward compatibility
+from products.signals.backend.temporal.signal_queries import (
+    EMBEDDING_MODEL,
+    _ensure_tz_aware,
+    soft_delete_report_signals,
+)
 
-from posthog.schema import EmbeddingModelName
-
-from posthog.hogql import ast
-from posthog.hogql.query import execute_hogql_query
-
-from posthog.api.embedding_worker import emit_embedding_request
-from posthog.models import Team
-
-EMBEDDING_MODEL = EmbeddingModelName.TEXT_EMBEDDING_3_SMALL_1536
-
-
-def soft_delete_report_signals(report_id: str, team_id: int, team: Team) -> None:
-    """
-    Soft-delete all ClickHouse signals for a report by re-emitting them with metadata.deleted=True.
-
-    Preserves the original timestamp so each row lands in the same ReplacingMergeTree partition
-    and replaces the original. Intentionally fetches ALL signals (including already-deleted ones)
-    so no signals are missed on repeated calls.
-    """
-    query = """
-        SELECT
-            document_id,
-            content,
-            metadata,
-            timestamp
-        FROM (
-            SELECT
-                document_id,
-                argMax(content, inserted_at) as content,
-                argMax(metadata, inserted_at) as metadata,
-                argMax(timestamp, inserted_at) as timestamp
-            FROM document_embeddings
-            WHERE model_name = {model_name}
-              AND product = 'signals'
-              AND document_type = 'signal'
-            GROUP BY document_id
-        )
-        WHERE JSONExtractString(metadata, 'report_id') = {report_id}
-        ORDER BY timestamp ASC
-        LIMIT 5000
-    """
-
-    result = execute_hogql_query(
-        query_type="SignalsSoftDeleteForReport",
-        query=query,
-        team=team,
-        placeholders={
-            "model_name": ast.Constant(value=EMBEDDING_MODEL.value),
-            "report_id": ast.Constant(value=report_id),
-        },
-    )
-
-    for row in result.results or []:
-        document_id, content, metadata_str, timestamp_raw = row
-        metadata = json.loads(metadata_str)
-        metadata["deleted"] = True
-
-        emit_embedding_request(
-            content=content,
-            team_id=team_id,
-            product="signals",
-            document_type="signal",
-            rendering="plain",
-            document_id=document_id,
-            models=[m.value for m in EmbeddingModelName],
-            timestamp=_ensure_tz_aware(timestamp_raw),
-            metadata=metadata,
-        )
-
-
-def _ensure_tz_aware(value: Union[datetime, str]) -> datetime:
-    """Coerce a ClickHouse timestamp (usually a datetime, occasionally a string) to a tz-aware datetime."""
-    if isinstance(value, str):
-        value = datetime.fromisoformat(value.replace("Z", "+00:00"))
-    if value.tzinfo is None:
-        value = value.replace(tzinfo=UTC)
-    return value
+__all__ = [
+    "EMBEDDING_MODEL",
+    "_ensure_tz_aware",
+    "soft_delete_report_signals",
+]

--- a/products/signals/backend/views.py
+++ b/products/signals/backend/views.py
@@ -37,12 +37,8 @@ from temporalio.common import RetryPolicy, WorkflowIDConflictPolicy, WorkflowIDR
 from temporalio.exceptions import WorkflowAlreadyStartedError
 from temporalio.service import RPCError, RPCStatusCode
 
-from posthog.hogql import ast
-from posthog.hogql.query import execute_hogql_query
-
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.auth import InternalAPIAuthentication, OAuthAccessTokenAuthentication, PersonalAPIKeyAuthentication
-from posthog.clickhouse.query_tagging import Feature, Product, tag_queries
 from posthog.models import Team
 from posthog.permissions import APIScopePermission
 from posthog.temporal.ai.video_segment_clustering.constants import clustering_workflow_id
@@ -70,11 +66,14 @@ from products.signals.backend.temporal.backfill_error_tracking import (
 from products.signals.backend.temporal.deletion import SignalReportDeletionWorkflow
 from products.signals.backend.temporal.grouping_v2 import TeamSignalGroupingV2Workflow
 from products.signals.backend.temporal.reingestion import SignalReportReingestionWorkflow
+from products.signals.backend.temporal.signal_queries import (
+    fetch_report_ids_for_source_products,
+    fetch_signals_for_report_sync,
+)
 from products.signals.backend.temporal.types import (
     SignalReportDeletionWorkflowInputs,
     SignalReportReingestionWorkflowInputs,
 )
-from products.signals.backend.utils import EMBEDDING_MODEL
 
 logger = structlog.get_logger(__name__)
 
@@ -327,29 +326,7 @@ class SignalReportViewSet(
         if source_product_filter:
             source_products = [s.strip() for s in source_product_filter.split(",") if s.strip()]
             if source_products:
-                # Find report IDs that have at least one signal from the requested source products.
-                # We start from signals (narrowed by source_product) and get their report IDs,
-                # then intersect with the PG queryset that already has status/search filters.
-                ch_query = """
-                    SELECT DISTINCT
-                        JSONExtractString(metadata, 'report_id') as report_id
-                    FROM document_embeddings
-                    WHERE model_name = {model_name}
-                      AND product = 'signals'
-                      AND JSONExtractString(metadata, 'source_product') IN ({source_products})
-                      AND NOT JSONExtractBool(metadata, 'deleted')
-                """
-                tag_queries(product=Product.SIGNALS, feature=Feature.USAGE_REPORT)
-                result = execute_hogql_query(
-                    query_type="SignalsFilterBySourceProduct",
-                    query=ch_query,
-                    team=self.team,
-                    placeholders={
-                        "model_name": ast.Constant(value=EMBEDDING_MODEL.value),
-                        "source_products": ast.Tuple(exprs=[ast.Constant(value=sp) for sp in source_products]),
-                    },
-                )
-                report_ids_with_source = {row[0] for row in (result.results or []) if row[0]}
+                report_ids_with_source = fetch_report_ids_for_source_products(self.team, source_products)
                 qs = qs.filter(id__in=report_ids_with_source)
         # `ordering=status` uses semantic stage rank (annotation), not lexicographic `status` column order.
         qs = qs.annotate(
@@ -523,60 +500,7 @@ class SignalReportViewSet(
         """Fetch all signals for a report from ClickHouse, including full metadata."""
         report = self.get_object()
         report_data = SignalReportSerializer(report).data
-
-        # Fetch signals from ClickHouse
-        query = """
-            SELECT
-                document_id,
-                content,
-                metadata,
-                timestamp
-            FROM (
-                SELECT
-                    document_id,
-                    argMax(content, inserted_at) as content,
-                    argMax(metadata, inserted_at) as metadata,
-                    argMax(timestamp, inserted_at) as timestamp
-                FROM document_embeddings
-                WHERE model_name = {model_name}
-                  AND product = 'signals'
-                  AND document_type = 'signal'
-                GROUP BY document_id
-            )
-            WHERE JSONExtractString(metadata, 'report_id') = {report_id}
-              AND NOT JSONExtractBool(metadata, 'deleted')
-            ORDER BY timestamp ASC
-        """
-
-        tag_queries(product=Product.SIGNALS, feature=Feature.USAGE_REPORT)
-        result = execute_hogql_query(
-            query_type="SignalsDebugFetchForReport",
-            query=query,
-            team=self.team,
-            placeholders={
-                "model_name": ast.Constant(value=EMBEDDING_MODEL.value),
-                "report_id": ast.Constant(value=str(report.id)),
-            },
-        )
-
-        signals_list = []
-        for row in result.results or []:
-            document_id, content, metadata_str, timestamp = row
-            metadata = json.loads(metadata_str)
-            signals_list.append(
-                {
-                    "signal_id": document_id,
-                    "content": content,
-                    "source_product": metadata.get("source_product", ""),
-                    "source_type": metadata.get("source_type", ""),
-                    "source_id": metadata.get("source_id", ""),
-                    "weight": metadata.get("weight", 0.0),
-                    "timestamp": timestamp,
-                    "extra": metadata.get("extra", {}),
-                    "match_metadata": metadata.get("match_metadata"),
-                }
-            )
-
+        signals_list = fetch_signals_for_report_sync(self.team, str(report.id))
         return Response({"report": report_data, "signals": signals_list})
 
     @extend_schema(exclude=True)


### PR DESCRIPTION
Started out fixing the "[filtering the inbox for error tracking signals makes it jump around all the time](https://posthog.slack.com/archives/C09SK2PAGKF/p1775461286564439)" thing, but figured I could do a bit of cleanup while I was there.



The attempted fix for the jumpy UI (contained herein) is to use `argMax` in the signal select, I _think_, but don't know for sure. I suspect that's at least one source of the nondeterminism in the response from prod that was causing the jumping, but there may be others. I've also added a sort by timestamp to the inner select in that report ID grabbing query, to try and improve the stability a bit more.



The larger problem is that we're effectively doing a cross-DB join, though, and fixing that problem requires de-normalising the list of signals attached to a report and storing them in postgres. We only really store signals themselves in CH for convenience with hogql querying, and for semantic search, so tracking assignment in PG as well is probably fine, although having two sources of truth is nasty.