### PR TITLE
fix(cohorts): improve backfill error isolation and evaluation determinism

### DIFF
--- a/posthog/hogql_queries/hogql_cohort_query.py
+++ b/posthog/hogql_queries/hogql_cohort_query.py
@@ -1057,7 +1057,7 @@ class HogQLRealtimeCohortQuery(HogQLCohortQuery):
                 SELECT
                     person_id,
                     condition,
-                    argMax(matches, _timestamp) as latest_matches
+                    argMax(matches, (_timestamp, _offset)) as latest_matches
                 FROM precalculated_person_properties
                 WHERE
                     team_id = {team_id}
@@ -1100,7 +1100,7 @@ class HogQLRealtimeCohortQuery(HogQLCohortQuery):
                 SELECT
                     person_id,
                     condition,
-                    argMax(matches, _timestamp) as latest_matches
+                    argMax(matches, (_timestamp, _offset)) as latest_matches
                 FROM precalculated_person_properties
                 WHERE
                     team_id = {team_id}
@@ -1167,7 +1167,7 @@ class HogQLRealtimeCohortQuery(HogQLCohortQuery):
                     team_id = {team_id}
                     AND condition = {condition_hash}
                 GROUP BY person_id
-                HAVING argMax(matches, _offset) = 1
+                HAVING argMax(matches, (_timestamp, _offset)) = 1
             """
 
             return cast(

--- a/posthog/temporal/messaging/backfill_precalculated_person_properties_workflow.py
+++ b/posthog/temporal/messaging/backfill_precalculated_person_properties_workflow.py
@@ -294,8 +294,6 @@ def evaluate_individual_filters_sync(
                 cohort_ids=filter_obj.cohort_ids,
                 error=str(e),
             )
-            # Continue processing other filters instead of failing all
-            continue
 
     return results
 
@@ -329,7 +327,19 @@ def evaluate_combined_filters_with_fallback_sync(
             )
 
         if isinstance(result, dict):
-            return result
+            invalid_result_entries = {
+                condition_hash: value for condition_hash, value in result.items() if not isinstance(value, bool)
+            }
+            if not invalid_result_entries:
+                return result
+            LOGGER.warning(
+                "Combined filter evaluation returned non-boolean values, falling back to individual execution",
+                person_id=person_id,
+                invalid_condition_hashes=list(invalid_result_entries.keys()),
+                invalid_result_types={
+                    condition_hash: type(value).__name__ for condition_hash, value in invalid_result_entries.items()
+                },
+            )
 
         if detailed_logging:
             LOGGER.warning(

--- a/posthog/temporal/messaging/backfill_precalculated_person_properties_workflow.py
+++ b/posthog/temporal/messaging/backfill_precalculated_person_properties_workflow.py
@@ -246,6 +246,110 @@ def evaluate_combined_filters_sync(
         return {}
 
 
+def evaluate_individual_filters_sync(
+    filters: list[PersonPropertyFilter],
+    hog_globals: dict[str, Any],
+    person_id: str,
+    detailed_logging: bool = False,
+) -> dict[str, Any]:
+    """Execute each filter's bytecode individually, returning {condition_hash: result}.
+
+    Isolates failures to individual cohorts rather than failing all cohorts for a person.
+    Returns results for successful filters only; failed filters are omitted from results.
+    """
+    results = {}
+
+    for filter_obj in filters:
+        try:
+            bytecode_result: BytecodeResult = execute_bytecode(filter_obj.bytecode, hog_globals)
+            result = bytecode_result.result
+
+            if detailed_logging:
+                LOGGER.info(
+                    "Individual filter evaluation completed",
+                    person_id=person_id,
+                    condition_hash=filter_obj.condition_hash,
+                    result=result,
+                    result_type=type(result).__name__,
+                    execution_successful=True,
+                    execution_stdout=bytecode_result.stdout,
+                )
+
+            # Store the result for this specific condition
+            if isinstance(result, bool):
+                results[filter_obj.condition_hash] = result
+            elif detailed_logging:
+                LOGGER.warning(
+                    "Individual filter evaluation returned non-bool result",
+                    person_id=person_id,
+                    condition_hash=filter_obj.condition_hash,
+                    result=result,
+                    result_type=type(result).__name__,
+                )
+        except Exception as e:
+            LOGGER.warning(
+                "Failed to execute filter bytecode for person",
+                person_id=person_id,
+                condition_hash=filter_obj.condition_hash,
+                cohort_ids=filter_obj.cohort_ids,
+                error=str(e),
+            )
+            # Continue processing other filters instead of failing all
+            continue
+
+    return results
+
+
+def evaluate_combined_filters_with_fallback_sync(
+    combined_bytecode: list[Any],
+    filters: list[PersonPropertyFilter],
+    hog_globals: dict[str, Any],
+    person_id: str,
+    detailed_logging: bool = False,
+) -> dict[str, Any]:
+    """Execute combined bytecode with fallback to individual filter execution.
+
+    First attempts to execute all filters in a single combined bytecode for performance.
+    If that fails, falls back to executing each filter individually to isolate failures.
+    """
+    # First, try the fast path with combined bytecode
+    try:
+        bytecode_result: BytecodeResult = execute_bytecode(combined_bytecode, hog_globals)
+        result = bytecode_result.result
+
+        if detailed_logging:
+            LOGGER.info(
+                "Combined filter evaluation completed successfully",
+                person_id=person_id,
+                result=result,
+                result_type=type(result).__name__,
+                person_properties=hog_globals.get("person", {}).get("properties", {}),
+                execution_successful=True,
+                execution_stdout=bytecode_result.stdout,
+            )
+
+        if isinstance(result, dict):
+            return result
+
+        if detailed_logging:
+            LOGGER.warning(
+                "Combined filter evaluation returned non-dict result, falling back to individual execution",
+                person_id=person_id,
+                result=result,
+                result_type=type(result).__name__,
+            )
+    except Exception as e:
+        LOGGER.info(
+            "Combined filter execution failed, falling back to individual filter evaluation",
+            person_id=person_id,
+            error=str(e),
+            fallback_reason="combined_execution_failed",
+        )
+
+    # Fallback to individual filter execution for error isolation
+    return evaluate_individual_filters_sync(filters, hog_globals, person_id, detailed_logging)
+
+
 @temporalio.activity.defn
 async def backfill_precalculated_person_properties_activity(
     inputs: BackfillPrecalculatedPersonPropertiesInputs,
@@ -448,8 +552,9 @@ async def backfill_precalculated_person_properties_activity(
                     hog_globals = {"person": {"properties": parsed_properties}}
 
                     filter_results = await asyncio.to_thread(
-                        evaluate_combined_filters_sync,
+                        evaluate_combined_filters_with_fallback_sync,
                         combined_bytecode,
+                        filters,
                         hog_globals,
                         person_id,
                         detailed_logging=detailed_logging_enabled,

--- a/posthog/temporal/messaging/test/test_backfill_precalculated_person_properties_workflow.py
+++ b/posthog/temporal/messaging/test/test_backfill_precalculated_person_properties_workflow.py
@@ -282,77 +282,47 @@ class TestCombineFilterBytecodes:
         result = execute_bytecode(combined, globals_input)
         assert result.result == expected_result
 
-    def test_failing_filter_returns_false_for_that_condition(self):
-        """A failing filter should return false for its condition, not crash the entire execution."""
+    @parameterized.expand(
+        [
+            (
+                "single_failing",
+                ["failing_condition"],
+                ["working_condition"],
+                {"working_condition": True},
+            ),
+            (
+                "multiple_failing",
+                ["fail1", "fail2"],
+                ["work"],
+                {"work": True},
+            ),
+        ]
+    )
+    def test_failing_filters_are_omitted_from_results(self, _, failing_hashes, working_hashes, expected):
+        """Failing filters should be omitted from results, not crash the entire execution."""
         from posthog.temporal.messaging.backfill_precalculated_person_properties_workflow import (
             evaluate_combined_filters_with_fallback_sync,
         )
 
-        # Create a filter that will fail with a comparison error
-        failing_bytecode = [
-            "_H",
-            1,
-            31,
-            32,
-            "nonexistent_prop",
-            32,
-            "properties",
-            32,
-            "person",
-            1,
-            3,
-            32,
-            "test",
-            13,
-        ]  # > comparison with null
+        failing_bytecode = ["_H", 1, 31, 32, "nonexistent", 32, "properties", 32, "person", 1, 3, 32, "test", 13]
         working_bytecode = ["_H", 1, 29]  # Always true
 
         filters = [
+            PersonPropertyFilter(condition_hash=h, bytecode=failing_bytecode, cohort_ids=[i], property_key=None)
+            for i, h in enumerate(failing_hashes)
+        ] + [
             PersonPropertyFilter(
-                condition_hash="failing_condition", bytecode=failing_bytecode, cohort_ids=[1], property_key=None
-            ),
-            PersonPropertyFilter(
-                condition_hash="working_condition", bytecode=working_bytecode, cohort_ids=[2], property_key=None
-            ),
+                condition_hash=h, bytecode=working_bytecode, cohort_ids=[len(failing_hashes) + i], property_key=None
+            )
+            for i, h in enumerate(working_hashes)
         ]
 
         combined = combine_filter_bytecodes(filters)
         result = evaluate_combined_filters_with_fallback_sync(
-            combined, filters, {"person": {"properties": {}}}, "test-person-123"
+            combined, filters, {"person": {"properties": {}}}, "test-person"
         )
 
-        # The failing filter should not be in results (failed filters are omitted)
-        # The working one should return true
-        assert result == {"working_condition": True}
-
-    def test_multiple_failing_filters_isolated(self):
-        """Multiple failing filters should not interfere with each other or working filters."""
-        from posthog.temporal.messaging.backfill_precalculated_person_properties_workflow import (
-            evaluate_combined_filters_with_fallback_sync,
-        )
-
-        failing_bytecode_1 = ["_H", 1, 31, 32, "prop1", 32, "properties", 32, "person", 1, 3, 32, "test", 13]
-        failing_bytecode_2 = ["_H", 1, 31, 32, "prop2", 32, "properties", 32, "person", 1, 3, 32, "test", 13]
-        working_bytecode = ["_H", 1, 29]  # Always true
-
-        filters = [
-            PersonPropertyFilter(
-                condition_hash="fail1", bytecode=failing_bytecode_1, cohort_ids=[1], property_key=None
-            ),
-            PersonPropertyFilter(
-                condition_hash="fail2", bytecode=failing_bytecode_2, cohort_ids=[2], property_key=None
-            ),
-            PersonPropertyFilter(condition_hash="work", bytecode=working_bytecode, cohort_ids=[3], property_key=None),
-        ]
-
-        combined = combine_filter_bytecodes(filters)
-        result = evaluate_combined_filters_with_fallback_sync(
-            combined, filters, {"person": {"properties": {}}}, "test-person-456"
-        )
-
-        # Failing filters should not be in results (failed filters are omitted)
-        # Working filter should return true
-        assert result == {"work": True}
+        assert result == expected
 
 
 class TestEvaluateCombinedFiltersSync:

--- a/posthog/temporal/messaging/test/test_backfill_precalculated_person_properties_workflow.py
+++ b/posthog/temporal/messaging/test/test_backfill_precalculated_person_properties_workflow.py
@@ -282,6 +282,78 @@ class TestCombineFilterBytecodes:
         result = execute_bytecode(combined, globals_input)
         assert result.result == expected_result
 
+    def test_failing_filter_returns_false_for_that_condition(self):
+        """A failing filter should return false for its condition, not crash the entire execution."""
+        from posthog.temporal.messaging.backfill_precalculated_person_properties_workflow import (
+            evaluate_combined_filters_with_fallback_sync,
+        )
+
+        # Create a filter that will fail with a comparison error
+        failing_bytecode = [
+            "_H",
+            1,
+            31,
+            32,
+            "nonexistent_prop",
+            32,
+            "properties",
+            32,
+            "person",
+            1,
+            3,
+            32,
+            "test",
+            13,
+        ]  # > comparison with null
+        working_bytecode = ["_H", 1, 29]  # Always true
+
+        filters = [
+            PersonPropertyFilter(
+                condition_hash="failing_condition", bytecode=failing_bytecode, cohort_ids=[1], property_key=None
+            ),
+            PersonPropertyFilter(
+                condition_hash="working_condition", bytecode=working_bytecode, cohort_ids=[2], property_key=None
+            ),
+        ]
+
+        combined = combine_filter_bytecodes(filters)
+        result = evaluate_combined_filters_with_fallback_sync(
+            combined, filters, {"person": {"properties": {}}}, "test-person-123"
+        )
+
+        # The failing filter should not be in results (failed filters are omitted)
+        # The working one should return true
+        assert result == {"working_condition": True}
+
+    def test_multiple_failing_filters_isolated(self):
+        """Multiple failing filters should not interfere with each other or working filters."""
+        from posthog.temporal.messaging.backfill_precalculated_person_properties_workflow import (
+            evaluate_combined_filters_with_fallback_sync,
+        )
+
+        failing_bytecode_1 = ["_H", 1, 31, 32, "prop1", 32, "properties", 32, "person", 1, 3, 32, "test", 13]
+        failing_bytecode_2 = ["_H", 1, 31, 32, "prop2", 32, "properties", 32, "person", 1, 3, 32, "test", 13]
+        working_bytecode = ["_H", 1, 29]  # Always true
+
+        filters = [
+            PersonPropertyFilter(
+                condition_hash="fail1", bytecode=failing_bytecode_1, cohort_ids=[1], property_key=None
+            ),
+            PersonPropertyFilter(
+                condition_hash="fail2", bytecode=failing_bytecode_2, cohort_ids=[2], property_key=None
+            ),
+            PersonPropertyFilter(condition_hash="work", bytecode=working_bytecode, cohort_ids=[3], property_key=None),
+        ]
+
+        combined = combine_filter_bytecodes(filters)
+        result = evaluate_combined_filters_with_fallback_sync(
+            combined, filters, {"person": {"properties": {}}}, "test-person-456"
+        )
+
+        # Failing filters should not be in results (failed filters are omitted)
+        # Working filter should return true
+        assert result == {"work": True}
+
 
 class TestEvaluateCombinedFiltersSync:
     """Tests for evaluate_combined_filters_sync."""


### PR DESCRIPTION
## Problem

Two cohort evaluation issues:

1. **Backfill cascade failures**: Single failing cohort evaluations (e.g., `TypeError: '>' not supported between instances of 'NoneType' and 'str'`) would crash entire person property backfills, causing all cohorts to fail for affected persons
2. **Non-deterministic realtime evaluation**: When multiple person property records had identical timestamps, `argMax(_offset, ...)` could return different records across evaluations, leading to inconsistent cohort membership

## Changes

**Backfill error isolation**:
- Added fallback strategy: try combined bytecode execution first, fall back to individual filter evaluation on failure
- Failed filters are now logged and omitted from results instead of crashing the entire evaluation
- Maintains performance for successful cases while providing resilience for edge cases

**Deterministic evaluation**:
- Updated `argMax` functions to use `(_timestamp, _offset)` tuple instead of just `_offset` for consistent tie-breaking
- Ensures reproducible cohort evaluation results when timestamps are identical

## How did you test this code?

✅ Added comprehensive tests for error isolation scenarios  
✅ All existing tests pass  
✅ Verified original error cases are handled gracefully

## Publish to changelog?

No - internal infrastructure improvements.