### PR TITLE
fix(dashboard): refresh tiles after saving filters or variables

### DIFF
--- a/frontend/src/scenes/dashboard/dashboardLogic.test.ts
+++ b/frontend/src/scenes/dashboard/dashboardLogic.test.ts
@@ -381,6 +381,20 @@ describe('dashboardLogic', () => {
             )
         })
 
+        it('dashboard save after changing global dates runs tile refresh to repopulate insight results missing from PATCH', async () => {
+            await expectLogic(logic).toFinishAllListeners()
+
+            await expectLogic(logic, () => {
+                logic.actions.setDates('-7d', null)
+            }).toFinishAllListeners()
+
+            await expectLogic(logic, () => {
+                logic.actions.saveEditModeChanges()
+            })
+                .toDispatchActions(['saveEditModeChanges', 'saveEditModeChangesSuccess', 'refreshDashboardItems'])
+                .toFinishAllListeners()
+        })
+
         it('saving after breakdown color change calls api', async () => {
             await expectLogic(logic).toFinishAllListeners()
 
@@ -1013,6 +1027,19 @@ describe('dashboardLogic', () => {
                 ])
             }
         )
+
+        it('dashboard save after variable-only edits runs tile refresh to repopulate insight results missing from PATCH', async () => {
+            await mountDashboardWithVariable({
+                urlValue: 'url-override',
+                dashboardOverride: { value: 'persisted', isNull: false },
+            })
+
+            await expectLogic(logic, () => {
+                logic.actions.saveEditModeChanges()
+            })
+                .toDispatchActions(['saveEditModeChanges', 'saveEditModeChangesSuccess', 'refreshDashboardItems'])
+                .toFinishAllListeners()
+        })
     })
 
     describe('external updates', () => {

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -353,7 +353,7 @@ export const dashboardLogic = kea<dashboardLogicType>([
         setAnalysisRating: (rating: 'up' | 'down' | null) => ({ rating }),
     })),
 
-    loaders(({ actions, props, values }) => ({
+    loaders(({ actions, props, values, cache }) => ({
         dashboard: [
             null as DashboardType<QueryBasedInsightModel> | null,
             {
@@ -466,6 +466,10 @@ export const dashboardLogic = kea<dashboardLogicType>([
 
                         breakpoint()
 
+                        // Dashboard filters or variables changed—each tile must reload so charts match the
+                        // settings you just saved (same flow as Apply filters).
+                        const shouldRefreshTilesAfterSave = filtersChanged || variablesChanged
+
                         const updatedDashboard: DashboardType<InsightModel> = await api.update(
                             `api/environments/${values.currentTeamId}/dashboards/${props.id}`,
                             {
@@ -478,6 +482,9 @@ export const dashboardLogic = kea<dashboardLogicType>([
                         )
                         actions.resetUrlFilters()
                         actions.resetUrlVariables()
+                        if (shouldRefreshTilesAfterSave) {
+                            cache.shouldRefreshTilesAfterSave = true
+                        }
                         return getQueryBasedDashboard(updatedDashboard)
                     } catch (e) {
                         lemonToast.error('Could not update dashboard: ' + String(e))
@@ -2262,6 +2269,13 @@ export const dashboardLogic = kea<dashboardLogicType>([
                 // Sync the saved dashboard (including any name/description changes) to
                 // dashboardsModel so the sidebar and other global views stay up to date
                 dashboardsModel.actions.updateDashboardSuccess(dashboard)
+            }
+            if (cache.shouldRefreshTilesAfterSave) {
+                cache.shouldRefreshTilesAfterSave = false
+                actions.refreshDashboardItems({
+                    action: RefreshDashboardItemsAction.Preview,
+                    forceRefresh: false,
+                })
             }
         },
         setDashboardMode: async ({ mode, source }) => {


### PR DESCRIPTION
## Problem

Saving a dashboard after changing **global filters** or **dashboard variables** (without using Apply filters first) could leave every insight tile in a broken state: **“Chart data didn’t load”** until a full page reload. The saved settings were correct, but the client replaced tile state with the dashboard save response, which does not carry full insight results for the new filter/variable context.

## Changes

- After a successful save that persists **filters** or **variables**, dispatch the same **`refreshDashboardItems` (Preview)** path as **Apply filters** so tiles fetch results for the newly saved dashboard context.
- Kea `cache` flag bridges loader success → listener so refresh runs after dashboard state updates.
- Tests: global date edit save and variable-only save both assert `refreshDashboardItems` is dispatched.


Before


https://github.com/user-attachments/assets/065605bb-2459-428a-a184-b37bd5f8604d

After


https://github.com/user-attachments/assets/319d0af3-f438-4f54-ba90-73b885460461




## How did you test this code?

Locally.

1. Clear redis cache locally `docker exec posthog-redis7-1 redis-cli FLUSHALL`
2. Load dashboard with 10+ items
3. change date time filters, dont click apply filters, and click save.
4. Observe it works correctly.

## Publish to changelog?

no

## Docs update

N/A (bugfix; no user-facing doc change required)

## 🤖 LLM context

Co-authored with Cursor agent. Changes limited to `dashboardLogic.tsx` and `dashboardLogic.test.ts` as described above.
