### PR TITLE
fix(session-analytics): stop %20 from being appended to session attribution explorer URLs

### DIFF
--- a/frontend/src/scenes/web-analytics/SessionAttributionExplorer/sessionAttributionExplorerLogic.ts
+++ b/frontend/src/scenes/web-analytics/SessionAttributionExplorer/sessionAttributionExplorerLogic.ts
@@ -119,15 +119,15 @@ export const sessionAttributionExplorerLogic = kea<sessionAttributionExplorerLog
     }),
 
     actionToUrl(({ values }) => {
-        const stateToUrl = (): [string, Record<string, string>] => {
+        const stateToUrl = (): [string, Record<string, any>] => {
             const { properties, dateRange } = values
 
-            const urlParams: Record<string, string> = {}
+            const urlParams: Record<string, any> = {}
             if (properties.length > 0) {
-                urlParams['properties'] = JSON.stringify(properties)
+                urlParams['properties'] = properties
             }
             if (dateRange) {
-                urlParams['dateRange'] = JSON.stringify(dateRange)
+                urlParams['dateRange'] = dateRange
             }
 
             return [urls.sessionAttributionExplorer(), urlParams]
@@ -142,7 +142,10 @@ export const sessionAttributionExplorerLogic = kea<sessionAttributionExplorerLog
     urlToAction(({ actions }) => ({
         [urls.sessionAttributionExplorer()]: (_, { properties, dateRange }) => {
             const parsedProperties = isSessionPropertyFilters(properties) ? properties : initialProperties
-            const parsedDateRange = dateRange ?? null
+            const parsedDateRange: DateRange | null =
+                dateRange && typeof dateRange === 'object' && ('date_from' in dateRange || 'date_to' in dateRange)
+                    ? (dateRange as DateRange)
+                    : null
 
             actions.setStateFromUrl({
                 properties: parsedProperties,


### PR DESCRIPTION
Fixed problem of  `%20` being appended to session attribution explorer URLs when interacting with filters (date range, property filters), which caused a Pydantic validation error on the backend.

Root cause was manual `JSON.stringify()` calls in `actionToUrl` before passing params to kea-router, which triggered kea-router's trailing-space escape mechanism, which appended `%20` to the URL

Also added a shape guard on `dateRange` in `urlToAction` to gracefully handle malformed values from hand-edited URLs

Closes #53467

## How did you test this code?
Tested in a browser on my local.

## Publish to changelog?
no

## 🤖 LLM context
Opus 4.6, code-reviewer ran before commit.


