### PR TITLE
fix(modeling): correct search path and ducklake changes dont deploy modeling worker

### DIFF
--- a/.github/workflows/container-images-cd.yml
+++ b/.github/workflows/container-images-cd.yml
@@ -430,6 +430,18 @@ jobs:
                         - 'posthog/management/commands/start_temporal_worker.py'
                         - pyproject.toml
                         - bin/temporal-django-worker
+                      dataModeling:
+                        - 'posthog/hogql/**'
+                        - 'posthog/ducklake/**'
+                        - 'posthog/temporal/data_modeling/**'
+                        - 'posthog/temporal/data_warehouse/**'
+                        - 'posthog/temporal/common/**'
+                        - 'posthog/warehouse/**'
+                        - 'products/data_modeling/**'
+                        - 'products/data_warehouse/**'
+                        - 'posthog/management/commands/**'
+                        - pyproject.toml
+                        - bin/temporal-django-worker
 
             - name: Trigger Health Check Temporal Worker Cloud deployment
               if: steps.check_temporal_worker_changes.outputs.healthCheck == 'true'
@@ -596,13 +608,8 @@ jobs:
                         "timestamp": "${{ github.event.head_commit.timestamp }}"
                       }
 
-            - name: Check for changes that affect data modeling temporal worker
-              id: check_changes_data_modeling_temporal_worker
-              run: |
-                  echo "changed=$((git diff --name-only HEAD^ HEAD | grep -qE '^posthog/hogql|^posthog/ducklake|^posthog/temporal/data_modeling|^posthog/temporal/data_warehouse|^posthog/temporal/common|^posthog/warehouse|^products/data_modeling|^products/data_warehouse|^posthog/management/commands|^pyproject.toml$|^bin/temporal-django-worker$' && echo true) || echo false)" >> $GITHUB_OUTPUT
-
             - name: Trigger Data Warehouse Modeling Temporal Worker Cloud deployment
-              if: steps.check_changes_data_modeling_temporal_worker.outputs.changed == 'true'
+              if: steps.check_temporal_worker_changes.outputs.dataModeling == 'true'
               uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4.0.1
               with:
                   token: ${{ steps.deployer.outputs.token }}

--- a/.github/workflows/container-images-cd.yml
+++ b/.github/workflows/container-images-cd.yml
@@ -599,7 +599,7 @@ jobs:
             - name: Check for changes that affect data modeling temporal worker
               id: check_changes_data_modeling_temporal_worker
               run: |
-                  echo "changed=$((git diff --name-only HEAD^ HEAD | grep -qE '^posthog/hogql|^posthog/temporal/data_modeling|^posthog/temporal/data_warehouse|^posthog/temporal/common|^posthog/warehouse|^products/data_modeling|^products/data_warehouse|^posthog/management/commands|^pyproject.toml$|^bin/temporal-django-worker$' && echo true) || echo false)" >> $GITHUB_OUTPUT
+                  echo "changed=$((git diff --name-only HEAD^ HEAD | grep -qE '^posthog/hogql|^posthog/ducklake|^posthog/temporal/data_modeling|^posthog/temporal/data_warehouse|^posthog/temporal/common|^posthog/warehouse|^products/data_modeling|^products/data_warehouse|^posthog/management/commands|^pyproject.toml$|^bin/temporal-django-worker$' && echo true) || echo false)" >> $GITHUB_OUTPUT
 
             - name: Trigger Data Warehouse Modeling Temporal Worker Cloud deployment
               if: steps.check_changes_data_modeling_temporal_worker.outputs.changed == 'true'

--- a/posthog/ducklake/client.py
+++ b/posthog/ducklake/client.py
@@ -46,6 +46,20 @@ def _make_duckgres_conninfo(team_id: int) -> str:
     )
 
 
+# TODO: remove hardcoded schemas and derive the search path from the team's
+# data warehouse sources / DAG configuration instead
+# duckgres SET seems to only accept a single comma-separated string value
+_SEARCH_PATH_SCHEMAS = ["revenue", "stripe", "billing_public", "credit", "posthog"]
+
+
+def _set_search_path(conn: psycopg.Connection[Any], extra_schemas: list[str] | None = None) -> None:
+    schemas = (extra_schemas or []) + _SEARCH_PATH_SCHEMAS
+    literal = psql.Literal(",".join(schemas))
+    sql = psql.SQL("SET search_path TO {}").format(literal)
+    return sql
+    # conn.execute(sql)
+
+
 def compile_hogql_to_ducklake_sql(team_id: int, query: HogQLQuery) -> tuple[str, str]:
     """Compile a HogQLQuery to Postgres-dialect SQL for DuckLake.
 
@@ -86,7 +100,7 @@ def execute_ducklake_query(
 
     conninfo = _make_duckgres_conninfo(team_id)
     with psycopg.connect(conninfo) as conn:
-        conn.execute("SET search_path TO 'posthog'")
+        _set_search_path(conn)
         with conn.cursor() as cur:
             cur.execute(sql)
             columns = [desc.name for desc in cur.description] if cur.description else []
@@ -112,16 +126,11 @@ def execute_ducklake_create_table(team_id: int, sql: str, schema_name: str, tabl
     qualified = psql.Identifier(safe_schema, safe_table)
     conninfo = _make_duckgres_conninfo(team_id)
     with psycopg.connect(conninfo) as conn:
-        conn.execute("SET search_path TO 'posthog'")
         conn.execute(psql.SQL("CREATE SCHEMA IF NOT EXISTS {}").format(psql.Identifier(safe_schema)))
         # TODO: remove hardcoded schemas and derive the search path from the team's
         # data warehouse sources / DAG configuration instead
         # duckgres SET seems to only accepts a single comma-separated string value
-        conn.execute(
-            psql.SQL("SET search_path TO '{},revenue,stripe,billing_public,credit,posthog'").format(
-                psql.SQL(safe_schema)
-            )
-        )
+        _set_search_path(conn, extra_schemas=[safe_schema])
         with conn.cursor() as cur:
             # capture previous table size before replacing
             cur.execute(
@@ -132,7 +141,7 @@ def execute_ducklake_create_table(team_id: int, sql: str, schema_name: str, tabl
             prev_file_size_bytes = int(prev_row[0]) if prev_row and prev_row[0] else 0
             cur.execute(psql.SQL("CREATE OR REPLACE TABLE {} AS {}").format(qualified, sql))
     with psycopg.connect(conninfo) as conn:
-        conn.execute("SET search_path TO 'posthog'")
+        _set_search_path(conn, extra_schemas=[safe_schema])
         with conn.cursor() as cur:
             cur.execute(psql.SQL("SELECT count(*) FROM {}").format(qualified))
             row = cur.fetchone()

--- a/posthog/ducklake/client.py
+++ b/posthog/ducklake/client.py
@@ -48,7 +48,6 @@ def _make_duckgres_conninfo(team_id: int) -> str:
 
 # TODO: remove hardcoded schemas and derive the search path from the team's
 # data warehouse sources / DAG configuration instead
-# duckgres SET seems to only accept a single comma-separated string value
 _SEARCH_PATH_SCHEMAS = ["revenue", "stripe", "billing_public", "credit", "posthog"]
 
 
@@ -126,9 +125,7 @@ def execute_ducklake_create_table(team_id: int, sql: str, schema_name: str, tabl
     conninfo = _make_duckgres_conninfo(team_id)
     with psycopg.connect(conninfo) as conn:
         conn.execute(psql.SQL("CREATE SCHEMA IF NOT EXISTS {}").format(psql.Identifier(safe_schema)))
-        # TODO: remove hardcoded schemas and derive the search path from the team's
-        # data warehouse sources / DAG configuration instead
-        # duckgres SET seems to only accepts a single comma-separated string value
+        # duckgres SET seems to only accept a single comma-separated string value with single quotes
         _set_search_path(conn, extra_schemas=[safe_schema])
         with conn.cursor() as cur:
             # capture previous table size before replacing

--- a/posthog/ducklake/client.py
+++ b/posthog/ducklake/client.py
@@ -56,8 +56,7 @@ def _set_search_path(conn: psycopg.Connection[Any], extra_schemas: list[str] | N
     schemas = (extra_schemas or []) + _SEARCH_PATH_SCHEMAS
     literal = psql.Literal(",".join(schemas))
     sql = psql.SQL("SET search_path TO {}").format(literal)
-    return sql
-    # conn.execute(sql)
+    conn.execute(sql)
 
 
 def compile_hogql_to_ducklake_sql(team_id: int, query: HogQLQuery) -> tuple[str, str]:

--- a/posthog/ducklake/test_client.py
+++ b/posthog/ducklake/test_client.py
@@ -1,9 +1,11 @@
 import pytest
 from unittest import mock
 
+from psycopg import sql as psql
+
 from posthog.schema import HogQLQuery
 
-from posthog.ducklake.client import execute_ducklake_query
+from posthog.ducklake.client import _SEARCH_PATH_SCHEMAS, execute_ducklake_query
 
 pytestmark = [pytest.mark.django_db]
 
@@ -99,4 +101,5 @@ class TestExecuteDuckLakeQuery:
 
         execute_ducklake_query(1, sql="SELECT 1")
 
-        mock_conn.execute.assert_called_once_with("SET search_path TO 'posthog'")
+        expected_sql = psql.SQL("SET search_path TO {}").format(psql.Literal(",".join(_SEARCH_PATH_SCHEMAS)))
+        mock_conn.execute.assert_called_once_with(expected_sql)


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

two things. the search path was outputing with double quotes and the changes from ducklake client don't trigger deploys on modeling worker. 

## Changes

fix both (hopefully)

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took, and what steps reviewers must take to get to where changes are, and what is the expected behavior. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

verified that the exact output from the set search path function is 
`SET search_path TO 'shadow_2_models,revenue,stripe,billing_public,credit,posthog'`

## Publish to changelog?

no

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->