### PR TITLE
fix(dashboard): Fix copied insight triggering updating on different dashboards

### DIFF
--- a/frontend/src/models/dashboardsModel.tsx
+++ b/frontend/src/models/dashboardsModel.tsx
@@ -74,15 +74,25 @@ export const dashboardsModel = kea<dashboardsModelType>([
         delayedDeleteDashboard: (id: number) => ({ id }),
         setDiveSourceId: (id: InsightShortId | null) => ({ id }),
         addDashboardSuccess: (dashboard: DashboardType<QueryBasedInsightModel>) => ({ dashboard }),
-        // this is moved out of dashboardLogic, so that you can click "undo" on an item move when already
-        // on another dashboard - both dashboards can listen to and share this event, even if one is not yet mounted
-        // can provide extra dashboard ids if not all listeners will choose to respond to this action
-        // not providing a dashboard id is a signal that only listeners in the item.dashboards array should respond
-        // specifying `number` not `Pick<DashboardType, 'id'> because kea typegen couldn't figure out the import in `savedInsightsLogic`
-        // if an update is made against an insight it will hold color in dashboard context
-        updateDashboardInsight: (insight: QueryBasedInsightModel, extraDashboardIds?: number[]) => ({
+        /**
+         * this is moved out of dashboardLogic, so that you can click "undo" on an item move when already
+         * on another dashboard - both dashboards can listen to and share this event, even if one is not yet mounted
+         * can provide extra dashboard ids if not all listeners will choose to respond to this action
+         * not providing a dashboard id is a signal that only listeners in the item.dashboards array should respond
+         * specifying `number` not `Pick<DashboardType, 'id'> because kea typegen couldn't figure out the import in `savedInsightsLogic`
+         * if an update is made against an insight it will hold color in dashboard context
+         * @param extraDashboardIds - Same meaning as before: merged with `dashboard_tiles` so listeners still match
+         *   when placement info is incomplete (copy/move/remove).
+         * @param sourceDashboardId - Set for a dashboard-scoped GET/refresh; merged `query` is only valid for that dashboard.
+         */
+        updateDashboardInsight: (
+            insight: QueryBasedInsightModel,
+            extraDashboardIds?: number[],
+            sourceDashboardId?: number
+        ) => ({
             insight,
             extraDashboardIds,
+            sourceDashboardId,
         }),
         pinDashboard: (id: number, source: DashboardEventSource) => ({ id, source }),
         unpinDashboard: (id: number, source: DashboardEventSource) => ({ id, source }),

--- a/frontend/src/scenes/dashboard/dashboardLogic.test.ts
+++ b/frontend/src/scenes/dashboard/dashboardLogic.test.ts
@@ -1054,6 +1054,41 @@ describe('dashboardLogic', () => {
             expect(logic.values.textTiles[0].text!.body).toEqual('I AM A TEXT')
         })
 
+        it('refreshing a shared insight on one dashboard does not change its date range on another dashboard', async () => {
+            const nineLogic = dashboardLogic({ id: 9 })
+            const tenLogic = dashboardLogic({ id: 10 })
+            nineLogic.mount()
+            tenLogic.mount()
+            await expectLogic(nineLogic).toFinishAllListeners()
+            await expectLogic(tenLogic).toFinishAllListeners()
+
+            const copiedInsight = insight800()
+            const insightQuery = copiedInsight.query as InsightVizNode<TrendsQuery> | undefined
+            const payload = {
+                ...copiedInsight,
+                query: {
+                    ...insightQuery,
+                    source: {
+                        ...insightQuery?.source,
+                        dateRange: { ...insightQuery?.source?.dateRange, date_from: '-1d' },
+                        interval: 'hour',
+                    },
+                } as InsightVizNode<TrendsQuery>,
+                last_refresh: '2012-04-01T00:00:00Z',
+            }
+
+            dashboardsModel.actions.updateDashboardInsight(payload, undefined, 10)
+
+            await expectLogic(nineLogic).toFinishAllListeners()
+            const nineQuery = nineLogic.values.insightTiles[0].insight?.query as InsightVizNode<TrendsQuery> | undefined
+            expect(nineQuery?.source?.dateRange?.date_from).toBeUndefined()
+            expect(nineQuery?.source?.interval).toEqual('day')
+
+            const tenQuery = tenLogic.values.insightTiles[0].insight?.query as InsightVizNode<TrendsQuery> | undefined
+            expect(tenQuery?.source?.dateRange?.date_from).toEqual('-1d')
+            expect(tenQuery?.source?.interval).toEqual('hour')
+        })
+
         it('can respond to external insight rename', async () => {
             expect(logic.values.dashboard?.tiles[0].color).toEqual(null)
 

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -772,7 +772,14 @@ export const dashboardLogic = kea<dashboardLogicType>([
                     }
                     return state
                 },
-                [dashboardsModel.actionTypes.updateDashboardInsight]: (state, { insight, extraDashboardIds }) => {
+                [dashboardsModel.actionTypes.updateDashboardInsight]: (
+                    state,
+                    { insight, extraDashboardIds, sourceDashboardId }
+                ) => {
+                    if (sourceDashboardId != null && sourceDashboardId !== props.id) {
+                        // Insight payload is from another dashboard's refresh; merged query/date range must not leak here.
+                        return state
+                    }
                     const targetDashboards = (insight.dashboard_tiles || [])
                         .map((tile) => tile.dashboard_id)
                         .concat(extraDashboardIds || [])
@@ -1889,7 +1896,11 @@ export const dashboardLogic = kea<dashboardLogicType>([
                 actions.loadDashboard({ action: DashboardLoadAction.Update })
             }
         },
-        [dashboardsModel.actionTypes.updateDashboardInsight]: ({ insight, extraDashboardIds }) => {
+        [dashboardsModel.actionTypes.updateDashboardInsight]: ({ insight, extraDashboardIds, sourceDashboardId }) => {
+            if (sourceDashboardId != null && sourceDashboardId !== props.id) {
+                // Same rationale as the reducer: ignore refresh payloads scoped to another dashboard.
+                return
+            }
             const targetDashboards = (insight.dashboard_tiles || [])
                 .map((tile) => tile.dashboard_id)
                 .concat(extraDashboardIds || [])
@@ -2048,7 +2059,7 @@ export const dashboardLogic = kea<dashboardLogicType>([
                 )
 
                 if (refreshedInsight) {
-                    dashboardsModel.actions.updateDashboardInsight(refreshedInsight)
+                    dashboardsModel.actions.updateDashboardInsight(refreshedInsight, undefined, dashboardId)
                     actions.setRefreshStatus(insight.short_id)
                 } else {
                     actions.setRefreshError(insight.short_id)
@@ -2142,7 +2153,7 @@ export const dashboardLogic = kea<dashboardLogicType>([
                         )
 
                         if (refreshedInsight) {
-                            dashboardsModel.actions.updateDashboardInsight(refreshedInsight)
+                            dashboardsModel.actions.updateDashboardInsight(refreshedInsight, undefined, dashboardId)
                             actions.setRefreshStatus(insight.short_id)
                             tilesRefreshedCount++
                             if (refreshedInsight.is_cached) {

--- a/frontend/src/scenes/insights/insightLogic.tsx
+++ b/frontend/src/scenes/insights/insightLogic.tsx
@@ -308,14 +308,25 @@ export const insightLogic: LogicWrapper<insightLogicType> = kea<insightLogicType
             },
             // Note: setInsightMetadata state updates are handled by the loader
             setInsightMetadataLocal: (state, { metadataUpdate }) => ({ ...state, ...metadataUpdate }),
-            [dashboardsModel.actionTypes.updateDashboardInsight]: (state, { item, extraDashboardIds }) => {
-                const targetDashboards = (item?.dashboards || []).concat(extraDashboardIds || [])
+            [dashboardsModel.actionTypes.updateDashboardInsight]: (
+                state,
+                { insight, extraDashboardIds, sourceDashboardId }
+            ) => {
+                // Dashboard refresh responses merge that dashboard's filters into `query`; only the embedded
+                // insight for that dashboard (`props.dashboardId`) should apply them. Other dashboards or
+                // non-dashboard views should ignore this action when `sourceDashboardId` is set.
+                if (sourceDashboardId != null) {
+                    if (props.dashboardId !== sourceDashboardId) {
+                        return state
+                    }
+                }
+                const targetDashboards = (insight?.dashboards || []).concat(extraDashboardIds || [])
                 const updateIsForThisDashboard =
-                    item?.short_id === state.short_id &&
+                    insight?.short_id === state.short_id &&
                     props.dashboardId &&
                     targetDashboards.includes(props.dashboardId)
                 if (updateIsForThisDashboard) {
-                    return { ...state, ...item }
+                    return { ...state, ...insight }
                 }
                 return state
             },

--- a/frontend/src/scenes/saved-insights/savedInsightsLogic.ts
+++ b/frontend/src/scenes/saved-insights/savedInsightsLogic.ts
@@ -356,7 +356,12 @@ export const savedInsightsLogic = kea<savedInsightsLogicType>([
         [insightsModel.actionTypes.renameInsightSuccess]: ({ item }) => {
             actions.updateInsight(item)
         },
-        [dashboardsModel.actionTypes.updateDashboardInsight]: ({ insight }) => {
+        [dashboardsModel.actionTypes.updateDashboardInsight]: ({ insight, sourceDashboardId }) => {
+            if (sourceDashboardId != null) {
+                // That payload is only valid on the dashboard that refreshed it (date range, etc. are baked into
+                // `query`). The saved list should show the saved insight definition, not the merged view.
+                return
+            }
             const matchingInsightIndex = values.insights.results.findIndex((i) => i.id === insight.id)
             if (matchingInsightIndex >= 0) {
                 actions.updateInsight(insight)


### PR DESCRIPTION
## Problem

Placing the same insight on two dashboards (e.g. via copy tile) meant a refresh on dashboard A broadcast the API response—including that dashboard's merged filters and date range in `query`—to every mounted dashboard that listed the insight. Dashboard B then showed A's filters.


From support:
```
Got a customer who is noticing some weirdness when copying an insight to another dashboard. I've been able to recreate it - not sure if it's a new bug or existing/expected behavior. When an insight has been copied to another dashboard, the filters applied in dashboard 1 update the insight on both dashboards thus causing it to render incorrectly on dashboard 2 (i.e. ignoring the filters of dashboard 2). For example, if you set the date range on dashboard 1 to 7 days it will change the insight on dashboard 2 even though that dashboard has a date range of 30 days.
```

## Changes

added new prop when we're modifying dashboard insights so we know if the update should be constrained just to one dashboard.


## How did you test this code?

<img width="1178" height="938" alt="CleanShot 2026-04-06 at 16 30 26@2x" src="https://github.com/user-attachments/assets/ae331f59-7cf1-43ea-bed3-7aadf342e9fe" />

Verified that replicating steps work

Verified that different dashboards with same copied over insight do not ovewrrite each other's filters


Locally.

## Publish to changelog?

do not publish to changelog

## Docs update

No.

## LLM context

Agent-authored: scoped `updateDashboardInsight` to fix cross-dashboard bleed when one insight is on multiple dashboards; added `sourceDashboardId`, updated Kea listeners and reducers, saved-insights guard, regression test, and small follow-ups from code review.
