### PR TITLE
fix(mcp): use aggregated_value for big number visualization

### DIFF
--- a/services/mcp/src/ui-apps/components/TrendsVisualizer.tsx
+++ b/services/mcp/src/ui-apps/components/TrendsVisualizer.tsx
@@ -46,6 +46,9 @@ function prepareChartData(results: TrendsResultItem[]): {
 
 function calculateTotal(results: TrendsResultItem[]): number {
     return results.reduce((sum, item) => {
+        if (typeof item.aggregated_value === 'number') {
+            return sum + item.aggregated_value
+        }
         if (typeof item.count === 'number') {
             return sum + item.count
         }

--- a/services/mcp/src/ui-apps/components/types.ts
+++ b/services/mcp/src/ui-apps/components/types.ts
@@ -59,6 +59,7 @@ export interface TrendsResultItem {
     data?: number[]
     days?: string[]
     count?: number
+    aggregated_value?: number
     action?: {
         name?: string
     }


### PR DESCRIPTION
## Problem

BoldNumber trends queries (used for big number visualizations in MCP) return \`data: []\` and \`count: 0\`, with the actual value stored in \`aggregated_value\`. The \`TrendsVisualizer\` component's \`calculateTotal\` function only checked \`count\` and \`data\`, so it always displayed 0 for these query types (DAU, sum of property, etc.).

## Changes

- Added \`aggregated_value?: number\` to the \`TrendsResultItem\` interface in \`types.ts\`
- Updated \`calculateTotal\` to check \`aggregated_value\` first (before \`count\` and before summing \`data\`)

The priority is now: \`aggregated_value\` → \`count\` → sum of \`data\` array. When \`aggregated_value\` is present, the function returns early without falling through to \`count\`. This only affects the \`BoldNumber\` display type.

## How did you test this code?

As an agent, I have not manually tested this code. Reviewers can verify by:
1. Running a BoldNumber trends query (e.g., DAU or sum of property) through the MCP TrendsVisualizer
2. Confirming the big number now displays the correct value instead of 0

## Publish to changelog?

No

## Docs update

No docs update needed.

## 🤖 LLM context

This PR was authored by a Claude Code agent. The fix is straightforward: \`aggregated_value\` represents pre-aggregated totals returned by PostHog for certain query types and must take precedence over the \`count\` field (which is 0 for these queries) and the \`data\` array (which is empty). The change correctly uses an early return to skip the \`count\` check when \`aggregated_value\` is present.