### PR TITLE
feat(llma): Add lightweight modes to prompt list API

### DIFF
--- a/posthog/api/llm_prompt.py
+++ b/posthog/api/llm_prompt.py
@@ -2,7 +2,7 @@ from typing import Any, cast
 
 from django.conf import settings
 from django.db import IntegrityError
-from django.db.models import Q, QuerySet, TextField
+from django.db.models import Func, IntegerField, Q, QuerySet, TextField
 from django.db.models.functions import Cast
 
 import posthoganalytics
@@ -19,6 +19,7 @@ from posthog.api.llm_prompt_serializers import (
     LLMPromptDuplicateSerializer,
     LLMPromptFetchQuerySerializer,
     LLMPromptListQuerySerializer,
+    LLMPromptListSerializer,
     LLMPromptPublicSerializer,
     LLMPromptPublishSerializer,
     LLMPromptResolveQuerySerializer,
@@ -76,6 +77,8 @@ ALLOWED_LIST_ORDERINGS = {
     "-version_count": "-version_count",
     "first_version_created_at": "first_version_created_at",
     "-first_version_created_at": "-first_version_created_at",
+    "prompt_size_bytes": "prompt_size_bytes",
+    "-prompt_size_bytes": "-prompt_size_bytes",
 }
 
 
@@ -199,18 +202,35 @@ class LLMPromptViewSet(
             },
         )
 
+    def _get_list_params(self, request: Request) -> dict[str, Any]:
+        serializer = LLMPromptListQuerySerializer(data=request.query_params)
+        serializer.is_valid(raise_exception=True)
+        return serializer.validated_data
+
     def _get_list_queryset(self, request: Request) -> QuerySet[LLMPrompt]:
-        queryset = get_latest_prompts_queryset(self.team)
+        queryset = get_latest_prompts_queryset(self.team).annotate(
+            prompt_text=Cast("prompt", output_field=TextField()),
+            prompt_size_bytes=Func(Cast("prompt", output_field=TextField()), function="OCTET_LENGTH", output_field=IntegerField()),
+        )
 
         search = request.query_params.get("search", "").strip()
         if search:
-            queryset = queryset.annotate(prompt_text=Cast("prompt", output_field=TextField())).filter(
-                Q(name__icontains=search) | Q(prompt_text__icontains=search)
-            )
+            queryset = queryset.filter(Q(name__icontains=search) | Q(prompt_text__icontains=search))
 
         order_by = request.query_params.get("order_by", "-created_at")
         queryset = queryset.order_by(ALLOWED_LIST_ORDERINGS.get(order_by, "-created_at"), "-id")
         return queryset
+
+    def get_serializer_class(self):
+        if self.action == "list":
+            return LLMPromptListSerializer
+        return super().get_serializer_class()
+
+    def get_serializer_context(self) -> dict[str, Any]:
+        context = super().get_serializer_context()
+        if self.action == "list":
+            context["content_mode"] = self._get_list_params(self.request).get("content", "full")
+        return context
 
     def perform_create(self, serializer: BaseSerializer[Any]) -> None:
         instance = cast(LLMPrompt, serializer.save())

--- a/posthog/api/llm_prompt.py
+++ b/posthog/api/llm_prompt.py
@@ -209,13 +209,14 @@ class LLMPromptViewSet(
 
     def _get_list_queryset(self, request: Request) -> QuerySet[LLMPrompt]:
         queryset = get_latest_prompts_queryset(self.team).annotate(
-            prompt_text=Cast("prompt", output_field=TextField()),
             prompt_size_bytes=Func(Cast("prompt", output_field=TextField()), function="OCTET_LENGTH", output_field=IntegerField()),
         )
 
         search = request.query_params.get("search", "").strip()
         if search:
-            queryset = queryset.filter(Q(name__icontains=search) | Q(prompt_text__icontains=search))
+            queryset = queryset.annotate(prompt_text=Cast("prompt", output_field=TextField())).filter(
+                Q(name__icontains=search) | Q(prompt_text__icontains=search)
+            )
 
         order_by = request.query_params.get("order_by", "-created_at")
         queryset = queryset.order_by(ALLOWED_LIST_ORDERINGS.get(order_by, "-created_at"), "-id")

--- a/posthog/api/llm_prompt.py
+++ b/posthog/api/llm_prompt.py
@@ -209,7 +209,9 @@ class LLMPromptViewSet(
 
     def _get_list_queryset(self, request: Request) -> QuerySet[LLMPrompt]:
         queryset = get_latest_prompts_queryset(self.team).annotate(
-            prompt_size_bytes=Func(Cast("prompt", output_field=TextField()), function="OCTET_LENGTH", output_field=IntegerField()),
+            prompt_size_bytes=Func(
+                Cast("prompt", output_field=TextField()), function="OCTET_LENGTH", output_field=IntegerField()
+            ),
         )
 
         search = request.query_params.get("search", "").strip()

--- a/posthog/api/llm_prompt_serializers.py
+++ b/posthog/api/llm_prompt_serializers.py
@@ -237,51 +237,13 @@ class LLMPromptSerializer(serializers.ModelSerializer):
         )
 
 
-class LLMPromptListSerializer(serializers.ModelSerializer):
-    created_by = UserBasicSerializer(read_only=True)
-    is_latest = serializers.SerializerMethodField()
-    latest_version = serializers.SerializerMethodField()
-    version_count = serializers.SerializerMethodField()
-    first_version_created_at = serializers.SerializerMethodField()
+class LLMPromptListSerializer(LLMPromptSerializer):
     prompt_size_bytes = serializers.SerializerMethodField()
     prompt_preview = serializers.SerializerMethodField()
 
-    class Meta:
-        model = LLMPrompt
-        fields = [
-            "id",
-            "name",
-            "prompt",
-            "prompt_preview",
-            "prompt_size_bytes",
-            "version",
-            "created_by",
-            "created_at",
-            "updated_at",
-            "deleted",
-            "is_latest",
-            "latest_version",
-            "version_count",
-            "first_version_created_at",
-        ]
+    class Meta(LLMPromptSerializer.Meta):
+        fields = [*LLMPromptSerializer.Meta.fields, "prompt_preview", "prompt_size_bytes"]
         read_only_fields = fields
-
-    def get_is_latest(self, instance: LLMPrompt) -> bool:
-        return bool(getattr(instance, "is_latest", False))
-
-    def get_latest_version(self, instance: LLMPrompt) -> int:
-        return int(getattr(instance, "latest_version", instance.version))
-
-    def get_version_count(self, instance: LLMPrompt) -> int:
-        return int(getattr(instance, "version_count", 1))
-
-    def get_first_version_created_at(self, instance: LLMPrompt) -> str:
-        value = getattr(instance, "first_version_created_at", instance.created_at)
-        if value is None:
-            value = instance.created_at
-        if isinstance(value, str):
-            return value
-        return value.isoformat().replace("+00:00", "Z")
 
     def get_prompt_size_bytes(self, instance: LLMPrompt) -> int:
         return int(getattr(instance, "prompt_size_bytes", 0))
@@ -332,22 +294,6 @@ class LLMPromptPublicSerializer(serializers.Serializer):
     version_count = serializers.IntegerField()
     first_version_created_at = serializers.DateTimeField()
 
-
-class LLMPromptListPublicSerializer(serializers.Serializer):
-    id = serializers.UUIDField()
-    name = serializers.CharField()
-    prompt = serializers.JSONField(required=False)
-    prompt_preview = serializers.CharField(required=False)
-    prompt_size_bytes = serializers.IntegerField()
-    version = serializers.IntegerField()
-    created_by = UserBasicSerializer(read_only=True)
-    created_at = serializers.DateTimeField()
-    updated_at = serializers.DateTimeField()
-    deleted = serializers.BooleanField()
-    is_latest = serializers.BooleanField()
-    latest_version = serializers.IntegerField()
-    version_count = serializers.IntegerField()
-    first_version_created_at = serializers.DateTimeField()
 
 
 class LLMPromptDuplicateSerializer(serializers.Serializer):

--- a/posthog/api/llm_prompt_serializers.py
+++ b/posthog/api/llm_prompt_serializers.py
@@ -50,6 +50,16 @@ class LLMPromptListQuerySerializer(serializers.Serializer):
         allow_blank=True,
         help_text="Optional substring filter applied to prompt names and prompt content.",
     )
+    content = serializers.ChoiceField(
+        choices=["full", "preview", "none"],
+        required=False,
+        default="full",
+        help_text=(
+            "Controls how much prompt content is included in list results. "
+            "'full' includes the full prompt, 'preview' includes a short prompt_preview, "
+            "and 'none' omits prompt content entirely."
+        ),
+    )
 
 
 class LLMPromptResolveQuerySerializer(LLMPromptFetchQuerySerializer):
@@ -227,6 +237,73 @@ class LLMPromptSerializer(serializers.ModelSerializer):
         )
 
 
+class LLMPromptListSerializer(serializers.ModelSerializer):
+    created_by = UserBasicSerializer(read_only=True)
+    is_latest = serializers.SerializerMethodField()
+    latest_version = serializers.SerializerMethodField()
+    version_count = serializers.SerializerMethodField()
+    first_version_created_at = serializers.SerializerMethodField()
+    prompt_size_bytes = serializers.SerializerMethodField()
+    prompt_preview = serializers.SerializerMethodField()
+
+    class Meta:
+        model = LLMPrompt
+        fields = [
+            "id",
+            "name",
+            "prompt",
+            "prompt_preview",
+            "prompt_size_bytes",
+            "version",
+            "created_by",
+            "created_at",
+            "updated_at",
+            "deleted",
+            "is_latest",
+            "latest_version",
+            "version_count",
+            "first_version_created_at",
+        ]
+        read_only_fields = fields
+
+    def get_is_latest(self, instance: LLMPrompt) -> bool:
+        return bool(getattr(instance, "is_latest", False))
+
+    def get_latest_version(self, instance: LLMPrompt) -> int:
+        return int(getattr(instance, "latest_version", instance.version))
+
+    def get_version_count(self, instance: LLMPrompt) -> int:
+        return int(getattr(instance, "version_count", 1))
+
+    def get_first_version_created_at(self, instance: LLMPrompt) -> str:
+        value = getattr(instance, "first_version_created_at", instance.created_at)
+        if value is None:
+            value = instance.created_at
+        if isinstance(value, str):
+            return value
+        return value.isoformat().replace("+00:00", "Z")
+
+    def get_prompt_size_bytes(self, instance: LLMPrompt) -> int:
+        return int(getattr(instance, "prompt_size_bytes", 0))
+
+    def get_prompt_preview(self, instance: LLMPrompt) -> str:
+        prompt = instance.prompt
+        display_value = prompt if isinstance(prompt, str) else json.dumps(prompt, ensure_ascii=False)
+        return display_value[:160] + ("..." if len(display_value) > 160 else "")
+
+    def to_representation(self, instance: LLMPrompt) -> dict[str, Any]:
+        data = super().to_representation(instance)
+        content_mode = self.context.get("content_mode", "full")
+        if content_mode == "none":
+            data.pop("prompt", None)
+            data.pop("prompt_preview", None)
+        elif content_mode == "preview":
+            data.pop("prompt", None)
+        else:
+            data.pop("prompt_preview", None)
+        return data
+
+
 class LLMPromptVersionSummarySerializer(serializers.ModelSerializer):
     created_by = UserBasicSerializer(read_only=True)
 
@@ -247,6 +324,23 @@ class LLMPromptPublicSerializer(serializers.Serializer):
     name = serializers.CharField()
     prompt = serializers.JSONField()
     version = serializers.IntegerField()
+    created_at = serializers.DateTimeField()
+    updated_at = serializers.DateTimeField()
+    deleted = serializers.BooleanField()
+    is_latest = serializers.BooleanField()
+    latest_version = serializers.IntegerField()
+    version_count = serializers.IntegerField()
+    first_version_created_at = serializers.DateTimeField()
+
+
+class LLMPromptListPublicSerializer(serializers.Serializer):
+    id = serializers.UUIDField()
+    name = serializers.CharField()
+    prompt = serializers.JSONField(required=False)
+    prompt_preview = serializers.CharField(required=False)
+    prompt_size_bytes = serializers.IntegerField()
+    version = serializers.IntegerField()
+    created_by = UserBasicSerializer(read_only=True)
     created_at = serializers.DateTimeField()
     updated_at = serializers.DateTimeField()
     deleted = serializers.BooleanField()

--- a/posthog/api/llm_prompt_serializers.py
+++ b/posthog/api/llm_prompt_serializers.py
@@ -295,7 +295,6 @@ class LLMPromptPublicSerializer(serializers.Serializer):
     first_version_created_at = serializers.DateTimeField()
 
 
-
 class LLMPromptDuplicateSerializer(serializers.Serializer):
     new_name = serializers.CharField(
         max_length=255,

--- a/posthog/api/test/test_api_docs.py
+++ b/posthog/api/test/test_api_docs.py
@@ -43,6 +43,7 @@ class TestAPIDocsSchema(APIBaseTest):
         list_operation = paths["/api/environments/{project_id}/llm_prompts/"]["get"]
         list_params = list_operation.get("parameters", [])
         assert any(param.get("in") == "query" and param.get("name") == "search" for param in list_params)
+        assert any(param.get("in") == "query" and param.get("name") == "content" for param in list_params)
 
         by_name_path = "/api/environments/{project_id}/llm_prompts/name/{prompt_name}/"
         assert by_name_path in paths

--- a/posthog/api/test/test_llm_prompt.py
+++ b/posthog/api/test/test_llm_prompt.py
@@ -170,28 +170,25 @@ class TestLLMPromptAPI(APIBaseTest):
         assert prompt_a["prompt"] == "v2"
         assert prompt_a["prompt_size_bytes"] > 0
 
-    def test_list_with_preview_content_mode_returns_preview_without_full_prompt(self, mock_feature_enabled):
-        self.create_prompt_version(name="preview-prompt", prompt="x" * 200)
+    @parameterized.expand(
+        [
+            ("full", True, False),
+            ("preview", False, True),
+            ("none", False, False),
+        ]
+    )
+    def test_list_content_mode(self, mock_feature_enabled, mode, has_prompt, has_preview):
+        self.create_prompt_version(name="content-prompt", prompt="x" * 200)
 
-        response = self.client.get(f"/api/environments/{self.team.id}/llm_prompts/?content=preview")
-
-        assert response.status_code == status.HTTP_200_OK
-        prompt = response.json()["results"][0]
-        assert "prompt" not in prompt
-        assert "prompt_preview" in prompt
-        assert len(prompt["prompt_preview"]) <= 163
-        assert prompt["prompt_size_bytes"] > 200
-
-    def test_list_with_none_content_mode_omits_prompt_fields(self, mock_feature_enabled):
-        self.create_prompt_version(name="metadata-prompt", prompt={"text": "hello"})
-
-        response = self.client.get(f"/api/environments/{self.team.id}/llm_prompts/?content=none")
+        response = self.client.get(f"/api/environments/{self.team.id}/llm_prompts/?content={mode}")
 
         assert response.status_code == status.HTTP_200_OK
         prompt = response.json()["results"][0]
-        assert "prompt" not in prompt
-        assert "prompt_preview" not in prompt
+        assert ("prompt" in prompt) is has_prompt
+        assert ("prompt_preview" in prompt) is has_preview
         assert prompt["prompt_size_bytes"] > 0
+        if has_preview:
+            assert len(prompt["prompt_preview"]) <= 163
 
     def test_list_can_order_by_prompt_size_bytes(self, mock_feature_enabled):
         self.create_prompt_version(name="small", prompt="abc")

--- a/posthog/api/test/test_llm_prompt.py
+++ b/posthog/api/test/test_llm_prompt.py
@@ -167,6 +167,41 @@ class TestLLMPromptAPI(APIBaseTest):
         assert prompt_a["version"] == 2
         assert prompt_a["latest_version"] == 2
         assert prompt_a["version_count"] == 2
+        assert prompt_a["prompt"] == "v2"
+        assert prompt_a["prompt_size_bytes"] > 0
+
+    def test_list_with_preview_content_mode_returns_preview_without_full_prompt(self, mock_feature_enabled):
+        self.create_prompt_version(name="preview-prompt", prompt="x" * 200)
+
+        response = self.client.get(f"/api/environments/{self.team.id}/llm_prompts/?content=preview")
+
+        assert response.status_code == status.HTTP_200_OK
+        prompt = response.json()["results"][0]
+        assert "prompt" not in prompt
+        assert "prompt_preview" in prompt
+        assert len(prompt["prompt_preview"]) <= 163
+        assert prompt["prompt_size_bytes"] > 200
+
+    def test_list_with_none_content_mode_omits_prompt_fields(self, mock_feature_enabled):
+        self.create_prompt_version(name="metadata-prompt", prompt={"text": "hello"})
+
+        response = self.client.get(f"/api/environments/{self.team.id}/llm_prompts/?content=none")
+
+        assert response.status_code == status.HTTP_200_OK
+        prompt = response.json()["results"][0]
+        assert "prompt" not in prompt
+        assert "prompt_preview" not in prompt
+        assert prompt["prompt_size_bytes"] > 0
+
+    def test_list_can_order_by_prompt_size_bytes(self, mock_feature_enabled):
+        self.create_prompt_version(name="small", prompt="abc")
+        self.create_prompt_version(name="large", prompt="x" * 50)
+
+        response = self.client.get(f"/api/environments/{self.team.id}/llm_prompts/?order_by=-prompt_size_bytes")
+
+        assert response.status_code == status.HTTP_200_OK
+        names = [prompt["name"] for prompt in response.json()["results"]]
+        assert names == ["large", "small"]
 
     def test_fetch_prompt_by_name_returns_latest_by_default(self, mock_feature_enabled):
         first_version = self.create_prompt_version(name="test-prompt", version=1, is_latest=False, prompt="v1")

--- a/products/llm_analytics/frontend/generated/api.schemas.ts
+++ b/products/llm_analytics/frontend/generated/api.schemas.ts
@@ -1029,6 +1029,34 @@ export interface PatchedTraceReviewUpdateApi {
     queue_id?: string | null
 }
 
+export interface LLMPromptListApi {
+    readonly id: string
+    /** Unique prompt name using letters, numbers, hyphens, and underscores only. */
+    readonly name: string
+    /** Prompt payload as JSON or string data. */
+    readonly prompt: unknown
+    readonly version: number
+    readonly created_by: UserBasicApi
+    readonly created_at: string
+    readonly updated_at: string
+    readonly deleted: boolean
+    readonly is_latest: boolean
+    readonly latest_version: number
+    readonly version_count: number
+    readonly first_version_created_at: string
+    readonly prompt_preview: string
+    readonly prompt_size_bytes: number
+}
+
+export interface PaginatedLLMPromptListListApi {
+    count: number
+    /** @nullable */
+    next?: string | null
+    /** @nullable */
+    previous?: string | null
+    results: LLMPromptListApi[]
+}
+
 export interface LLMPromptApi {
     readonly id: string
     /**
@@ -1047,15 +1075,6 @@ export interface LLMPromptApi {
     readonly latest_version: number
     readonly version_count: number
     readonly first_version_created_at: string
-}
-
-export interface PaginatedLLMPromptListApi {
-    count: number
-    /** @nullable */
-    next?: string | null
-    /** @nullable */
-    previous?: string | null
-    results: LLMPromptApi[]
 }
 
 export interface LLMPromptPublicApi {
@@ -1416,6 +1435,15 @@ export type LlmAnalyticsTraceReviewsListParams = {
 
 export type LlmPromptsListParams = {
     /**
+ * Controls how much prompt content is included in list results. 'full' includes the full prompt, 'preview' includes a short prompt_preview, and 'none' omits prompt content entirely.
+
+* `full` - full
+* `preview` - preview
+* `none` - none
+ * @minLength 1
+ */
+    content?: LlmPromptsListContent
+    /**
      * Number of results to return per page.
      */
     limit?: number
@@ -1428,6 +1456,14 @@ export type LlmPromptsListParams = {
      */
     search?: string
 }
+
+export type LlmPromptsListContent = (typeof LlmPromptsListContent)[keyof typeof LlmPromptsListContent]
+
+export const LlmPromptsListContent = {
+    Full: 'full',
+    Preview: 'preview',
+    None: 'none',
+} as const
 
 export type LlmPromptsNameRetrieveParams = {
     /**

--- a/products/llm_analytics/frontend/generated/api.ts
+++ b/products/llm_analytics/frontend/generated/api.ts
@@ -39,7 +39,7 @@ import type {
     PaginatedDatasetItemListApi,
     PaginatedDatasetListApi,
     PaginatedEvaluationListApi,
-    PaginatedLLMPromptListApi,
+    PaginatedLLMPromptListListApi,
     PaginatedLLMProviderKeyListApi,
     PaginatedReviewQueueItemListApi,
     PaginatedReviewQueueListApi,
@@ -1186,8 +1186,8 @@ export const llmPromptsList = async (
     projectId: string,
     params?: LlmPromptsListParams,
     options?: RequestInit
-): Promise<PaginatedLLMPromptListApi> => {
-    return apiMutator<PaginatedLLMPromptListApi>(getLlmPromptsListUrl(projectId, params), {
+): Promise<PaginatedLLMPromptListListApi> => {
+    return apiMutator<PaginatedLLMPromptListListApi>(getLlmPromptsListUrl(projectId, params), {
         ...options,
         method: 'GET',
     })

--- a/products/llm_analytics/mcp/prompts.yaml
+++ b/products/llm_analytics/mcp/prompts.yaml
@@ -22,9 +22,11 @@ tools:
         description: >
             List all LLM prompts stored for the current team. Optionally filter by name. Returns paginated prompt
             summaries. By default, only prompt metadata is returned, not full prompt content.
-        include_params:
-            - search
-            - content
+        input_schema: PromptListInputSchema
+        response_type: >-
+            Omit<Schemas.PaginatedLLMPromptListList, 'results'> & {
+              results: (Omit<Schemas.LLMPromptList, 'prompt'> & { prompt?: unknown })[]
+            }
     prompt-get:
         operation: llm_prompts_name_retrieve
         enabled: true

--- a/products/llm_analytics/mcp/prompts.yaml
+++ b/products/llm_analytics/mcp/prompts.yaml
@@ -21,9 +21,10 @@ tools:
         title: List prompts
         description: >
             List all LLM prompts stored for the current team. Optionally filter by name. Returns paginated prompt
-            summaries.
+            summaries. By default, only prompt metadata is returned, not full prompt content.
         include_params:
             - search
+            - content
     prompt-get:
         operation: llm_prompts_name_retrieve
         enabled: true

--- a/services/mcp/definitions/README.md
+++ b/services/mcp/definitions/README.md
@@ -106,6 +106,7 @@ tools:
     title: Short title
     description: Detailed description for the LLM
     input_schema: ActionCreateSchema # named export from src/schema/tool-inputs.ts
+    response_type: Schemas.Action[] # optional TypeScript return type override for generated handlers
     list: true # marks as a list endpoint
     enrich_url: '{id}' # appended to url_prefix for result URLs
     exclude_params: [field] # hide params from tool input
@@ -153,6 +154,7 @@ When `input_schema` is set:
 - Path parameters are extracted from the URL pattern and interpolated from the input
 - Remaining parameters are forwarded as body (POST/PATCH/PUT) or query (GET/DELETE)
 - `enrich_url` and `list` enrichment still apply as normal
+- You can optionally set `response_type` to override the generated TypeScript return type when MCP intentionally differs from the raw OpenAPI response shape
 
 ### Per-param schema overrides
 

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -1485,7 +1485,7 @@
         }
     },
     "prompt-list": {
-        "description": "List all LLM prompts stored for the current team. Optionally filter by name. Returns paginated prompt summaries.",
+        "description": "List all LLM prompts stored for the current team. Optionally filter by name. Returns paginated prompt summaries. By default, only prompt metadata is returned, not full prompt content.",
         "category": "Prompts",
         "feature": "prompts",
         "summary": "List prompts",

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -2185,7 +2185,7 @@
         }
     },
     "prompt-list": {
-        "description": "List all LLM prompts stored for the current team. Optionally filter by name. Returns paginated prompt summaries.",
+        "description": "List all LLM prompts stored for the current team. Optionally filter by name. Returns paginated prompt summaries. By default, only prompt metadata is returned, not full prompt content.",
         "category": "Prompts",
         "feature": "prompts",
         "summary": "List prompts",

--- a/services/mcp/schema/tool-inputs.json
+++ b/services/mcp/schema/tool-inputs.json
@@ -1248,6 +1248,21 @@
             },
             "required": ["projectId"]
         },
+        "PromptListInputSchema": {
+            "type": "object",
+            "properties": {
+                "search": {
+                    "description": "Optional substring filter applied to prompt names and prompt content.",
+                    "type": "string"
+                },
+                "content": {
+                    "default": "none",
+                    "description": "Controls how much prompt content is included in list results. 'full' includes the full prompt, 'preview' includes a short prompt_preview, and 'none' omits prompt content entirely.",
+                    "type": "string",
+                    "enum": ["full", "preview", "none"]
+                }
+            }
+        },
         "QueryRunInputSchema": {
             "type": "object",
             "properties": {

--- a/services/mcp/scripts/generate-tools.ts
+++ b/services/mcp/scripts/generate-tools.ts
@@ -559,7 +559,7 @@ function generateToolCode(
     }
 
     const composition = composeToolSchema(config, resolved, spec)
-    let responseType = resolveResponseType(resolved.operation, knownTypes)
+    let responseType = config.response_type ?? resolveResponseType(resolved.operation, knownTypes)
 
     // Soft-delete overrides the HTTP method: use PATCH instead of DELETE.
     // `true` sends { deleted: true }, a string value specifies the field name (e.g. "archived").
@@ -715,7 +715,7 @@ function generateCustomSchemaToolCode(
     const pathExpr = buildPathExpr(resolved.path, pathParamNames)
 
     const useBody = ['POST', 'PATCH', 'PUT'].includes(resolved.method)
-    const responseType = resolveResponseType(resolved.operation, knownTypes)
+    const responseType = config.response_type ?? resolveResponseType(resolved.operation, knownTypes)
 
     const needsProjectId = resolved.path.includes('{project_id}')
     const needsOrgId = resolved.path.includes('{organization_id}')
@@ -728,16 +728,18 @@ function generateCustomSchemaToolCode(
         handlerBody += `        const projectId = await context.stateManager.getProjectId()\n`
     }
 
+    handlerBody += `        const parsedParams = ${schemaName}.parse(params)\n`
+
     if (pathParamNames.length > 0) {
         const destructured = pathParamNames.map((p) => `${p}, `).join('')
         if (useBody) {
-            handlerBody += `        const { ${destructured}...body } = params\n`
+            handlerBody += `        const { ${destructured}...body } = parsedParams\n`
         } else {
-            handlerBody += `        const { ${destructured}...query } = params\n`
+            handlerBody += `        const { ${destructured}...query } = parsedParams\n`
         }
     }
 
-    handlerBody += `        const result = await context.api.request({\n`
+    handlerBody += `        const result = await context.api.request<${responseType ?? 'unknown'}>({\n`
     handlerBody += `            method: '${resolved.method}',\n`
     handlerBody += `            path: ${pathExpr},\n`
     if (pathParamNames.length > 0) {
@@ -747,9 +749,9 @@ function generateCustomSchemaToolCode(
             handlerBody += `            query,\n`
         }
     } else if (useBody) {
-        handlerBody += `            body: params,\n`
+        handlerBody += `            body: parsedParams,\n`
     } else {
-        handlerBody += `            query: params,\n`
+        handlerBody += `            query: parsedParams,\n`
     }
     handlerBody += `        })\n`
 
@@ -763,7 +765,7 @@ function generateCustomSchemaToolCode(
     const code = `
 const ${schemaName} = ${config.input_schema}
 
-const ${factoryName} = (): ToolBase<typeof ${schemaName}> => ({
+const ${factoryName} = (): ToolBase<typeof ${schemaName}, ${responseType ?? 'unknown'}> => ({
     name: '${toolName}',
     schema: ${schemaName},
     handler: async (context: Context, params: z.infer<typeof ${schemaName}>) => {

--- a/services/mcp/scripts/yaml-config-schema.ts
+++ b/services/mcp/scripts/yaml-config-schema.ts
@@ -21,6 +21,8 @@ export const ToolConfigSchema = z
             .strict()
             .optional(),
         input_schema: z.string().optional(),
+        /** Optional TypeScript type expression used for the generated handler return type and request generic. */
+        response_type: z.string().optional(),
         enrich_url: z.string().optional(),
         list: z.boolean().optional(),
         title: z.string().optional(),

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -18473,6 +18473,25 @@ export namespace Schemas {
       new: string;
     }
 
+    export interface LLMPromptList {
+      readonly id: string;
+      /** Unique prompt name using letters, numbers, hyphens, and underscores only. */
+      readonly name: string;
+      /** Prompt payload as JSON or string data. */
+      readonly prompt: unknown;
+      readonly version: number;
+      readonly created_by: UserBasic;
+      readonly created_at: string;
+      readonly updated_at: string;
+      readonly deleted: boolean;
+      readonly is_latest: boolean;
+      readonly latest_version: number;
+      readonly version_count: number;
+      readonly first_version_created_at: string;
+      readonly prompt_preview: string;
+      readonly prompt_size_bytes: number;
+    }
+
     export interface LLMPromptPublic {
       id: string;
       name: string;
@@ -20194,13 +20213,13 @@ export namespace Schemas {
       results: Integration[];
     }
 
-    export interface PaginatedLLMPromptList {
+    export interface PaginatedLLMPromptListList {
       count: number;
       /** @nullable */
       next?: string | null;
       /** @nullable */
       previous?: string | null;
-      results: LLMPrompt[];
+      results: LLMPromptList[];
     }
 
     export interface PaginatedLLMProviderKeyList {
@@ -32826,6 +32845,15 @@ export namespace Schemas {
 
     export type LlmPromptsListParams = {
     /**
+     * Controls how much prompt content is included in list results. 'full' includes the full prompt, 'preview' includes a short prompt_preview, and 'none' omits prompt content entirely.
+
+    * `full` - full
+    * `preview` - preview
+    * `none` - none
+     * @minLength 1
+     */
+    content?: LlmPromptsListContent;
+    /**
      * Number of results to return per page.
      */
     limit?: number;
@@ -32838,6 +32866,15 @@ export namespace Schemas {
      */
     search?: string;
     };
+
+    export type LlmPromptsListContent = typeof LlmPromptsListContent[keyof typeof LlmPromptsListContent];
+
+
+    export const LlmPromptsListContent = {
+      Full: 'full',
+      Preview: 'preview',
+      None: 'none',
+    } as const;
 
     export type LlmPromptsNameRetrieveParams = {
     /**

--- a/services/mcp/src/generated/prompts/api.ts
+++ b/services/mcp/src/generated/prompts/api.ts
@@ -20,6 +20,12 @@ export const LlmPromptsListQueryParams = /* @__PURE__ */ zod.object({
     limit: zod.number().optional().describe('Number of results to return per page.'),
     offset: zod.number().optional().describe('The initial index from which to return the results.'),
     search: zod.string().optional().describe('Optional substring filter applied to prompt names and prompt content.'),
+    content: zod
+        .enum(['full', 'preview', 'none'])
+        .optional()
+        .describe(
+            "Controls how much prompt content is included in list results. 'full' includes the full prompt, 'preview' includes a short prompt_preview, and 'none' omits prompt content entirely."
+        ),
 })
 
 export const LlmPromptsCreateParams = /* @__PURE__ */ zod.object({

--- a/services/mcp/src/generated/prompts/api.ts
+++ b/services/mcp/src/generated/prompts/api.ts
@@ -16,16 +16,18 @@ export const LlmPromptsListParams = /* @__PURE__ */ zod.object({
         ),
 })
 
+export const llmPromptsListQueryContentDefault = `full`
+
 export const LlmPromptsListQueryParams = /* @__PURE__ */ zod.object({
+    content: zod
+        .enum(['full', 'preview', 'none'])
+        .default(llmPromptsListQueryContentDefault)
+        .describe(
+            "Controls how much prompt content is included in list results. 'full' includes the full prompt, 'preview' includes a short prompt_preview, and 'none' omits prompt content entirely.\n\n* `full` - full\n* `preview` - preview\n* `none` - none"
+        ),
     limit: zod.number().optional().describe('Number of results to return per page.'),
     offset: zod.number().optional().describe('The initial index from which to return the results.'),
     search: zod.string().optional().describe('Optional substring filter applied to prompt names and prompt content.'),
-    content: zod
-        .enum(['full', 'preview', 'none'])
-        .optional()
-        .describe(
-            "Controls how much prompt content is included in list results. 'full' includes the full prompt, 'preview' includes a short prompt_preview, and 'none' omits prompt content entirely."
-        ),
 })
 
 export const LlmPromptsCreateParams = /* @__PURE__ */ zod.object({

--- a/services/mcp/src/schema/tool-inputs.ts
+++ b/services/mcp/src/schema/tool-inputs.ts
@@ -4,6 +4,16 @@ import { CreateInsightInputSchema, ListInsightsSchema, UpdateInsightInputSchema 
 import { LogsListAttributeValuesInputSchema, LogsListAttributesInputSchema, LogsQueryInputSchema } from './logs'
 import { InsightQuerySchema, PropertyFilter } from './query'
 
+export const PromptListInputSchema = z.object({
+    search: z.string().optional().describe('Optional substring filter applied to prompt names and prompt content.'),
+    content: z
+        .enum(['full', 'preview', 'none'])
+        .default('none')
+        .describe(
+            "Controls how much prompt content is included in list results. 'full' includes the full prompt, 'preview' includes a short prompt_preview, and 'none' omits prompt content entirely."
+        ),
+})
+
 export const DocumentationSearchSchema = z.object({
     query: z.string(),
 })

--- a/services/mcp/src/tools/generated/prompts.ts
+++ b/services/mcp/src/tools/generated/prompts.ts
@@ -16,12 +16,22 @@ import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const PromptListSchema = LlmPromptsListQueryParams.omit({ limit: true, offset: true })
 
-const promptList = (): ToolBase<typeof PromptListSchema, Schemas.PaginatedLLMPromptList> => ({
+type PromptListResultItem = Omit<Schemas.LLMPrompt, 'prompt'> & {
+    prompt?: unknown
+    prompt_preview?: string
+    prompt_size_bytes: number
+}
+
+type PaginatedPromptListResult = Omit<Schemas.PaginatedLLMPromptList, 'results'> & {
+    results: PromptListResultItem[]
+}
+
+const promptList = (): ToolBase<typeof PromptListSchema, PaginatedPromptListResult> => ({
     name: 'prompt-list',
     schema: PromptListSchema,
     handler: async (context: Context, params: z.infer<typeof PromptListSchema>) => {
         const projectId = await context.stateManager.getProjectId()
-        const result = await context.api.request<Schemas.PaginatedLLMPromptList>({
+        const result = await context.api.request<PaginatedPromptListResult>({
             method: 'GET',
             path: `/api/environments/${projectId}/llm_prompts/`,
             query: {

--- a/services/mcp/src/tools/generated/prompts.ts
+++ b/services/mcp/src/tools/generated/prompts.ts
@@ -16,27 +16,17 @@ import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const PromptListSchema = LlmPromptsListQueryParams.omit({ limit: true, offset: true })
 
-type PromptListResultItem = Omit<Schemas.LLMPrompt, 'prompt'> & {
-    prompt?: unknown
-    prompt_preview?: string
-    prompt_size_bytes: number
-}
-
-type PaginatedPromptListResult = Omit<Schemas.PaginatedLLMPromptList, 'results'> & {
-    results: PromptListResultItem[]
-}
-
-const promptList = (): ToolBase<typeof PromptListSchema, PaginatedPromptListResult> => ({
+const promptList = (): ToolBase<typeof PromptListSchema, Schemas.PaginatedLLMPromptListList> => ({
     name: 'prompt-list',
     schema: PromptListSchema,
     handler: async (context: Context, params: z.infer<typeof PromptListSchema>) => {
         const projectId = await context.stateManager.getProjectId()
-        const result = await context.api.request<PaginatedPromptListResult>({
+        const result = await context.api.request<Schemas.PaginatedLLMPromptListList>({
             method: 'GET',
             path: `/api/environments/${projectId}/llm_prompts/`,
             query: {
+                content: params.content,
                 search: params.search,
-                content: params.content ?? 'none',
             },
         })
         return result

--- a/services/mcp/src/tools/generated/prompts.ts
+++ b/services/mcp/src/tools/generated/prompts.ts
@@ -26,6 +26,7 @@ const promptList = (): ToolBase<typeof PromptListSchema, Schemas.PaginatedLLMPro
             path: `/api/environments/${projectId}/llm_prompts/`,
             query: {
                 search: params.search,
+                content: params.content ?? 'none',
             },
         })
         return result

--- a/services/mcp/src/tools/generated/prompts.ts
+++ b/services/mcp/src/tools/generated/prompts.ts
@@ -14,18 +14,28 @@ import {
 } from '@/generated/prompts/api'
 import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
-const PromptListSchema = LlmPromptsListQueryParams.omit({ limit: true, offset: true })
+const PromptListSchema = LlmPromptsListQueryParams.omit({ limit: true, offset: true }).extend({
+    content: LlmPromptsListQueryParams.shape.content.default('none'),
+})
 
-const promptList = (): ToolBase<typeof PromptListSchema, Schemas.PaginatedLLMPromptListList> => ({
+type PromptListResultItem = Omit<Schemas.LLMPromptList, 'prompt'> & {
+    prompt?: unknown
+}
+
+type PaginatedPromptListResult = Omit<Schemas.PaginatedLLMPromptListList, 'results'> & {
+    results: PromptListResultItem[]
+}
+
+const promptList = (): ToolBase<typeof PromptListSchema, PaginatedPromptListResult> => ({
     name: 'prompt-list',
     schema: PromptListSchema,
     handler: async (context: Context, params: z.infer<typeof PromptListSchema>) => {
         const projectId = await context.stateManager.getProjectId()
-        const result = await context.api.request<Schemas.PaginatedLLMPromptListList>({
+        const result = await context.api.request<PaginatedPromptListResult>({
             method: 'GET',
             path: `/api/environments/${projectId}/llm_prompts/`,
             query: {
-                content: params.content,
+                content: params.content ?? 'none',
                 search: params.search,
             },
         })

--- a/services/mcp/src/tools/generated/prompts.ts
+++ b/services/mcp/src/tools/generated/prompts.ts
@@ -4,7 +4,6 @@ import { z } from 'zod'
 import type { Schemas } from '@/api/generated'
 import {
     LlmPromptsCreateBody,
-    LlmPromptsListQueryParams,
     LlmPromptsNameDuplicateCreateBody,
     LlmPromptsNameDuplicateCreateParams,
     LlmPromptsNamePartialUpdateBody,
@@ -12,32 +11,30 @@ import {
     LlmPromptsNameRetrieveParams,
     LlmPromptsNameRetrieveQueryParams,
 } from '@/generated/prompts/api'
+import { PromptListInputSchema } from '@/schema/tool-inputs'
 import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
-const PromptListSchema = LlmPromptsListQueryParams.omit({ limit: true, offset: true }).extend({
-    content: LlmPromptsListQueryParams.shape.content.default('none'),
-})
+const PromptListSchema = PromptListInputSchema
 
-type PromptListResultItem = Omit<Schemas.LLMPromptList, 'prompt'> & {
-    prompt?: unknown
-}
-
-type PaginatedPromptListResult = Omit<Schemas.PaginatedLLMPromptListList, 'results'> & {
-    results: PromptListResultItem[]
-}
-
-const promptList = (): ToolBase<typeof PromptListSchema, PaginatedPromptListResult> => ({
+const promptList = (): ToolBase<
+    typeof PromptListSchema,
+    Omit<Schemas.PaginatedLLMPromptListList, 'results'> & {
+        results: (Omit<Schemas.LLMPromptList, 'prompt'> & { prompt?: unknown })[]
+    }
+> => ({
     name: 'prompt-list',
     schema: PromptListSchema,
     handler: async (context: Context, params: z.infer<typeof PromptListSchema>) => {
         const projectId = await context.stateManager.getProjectId()
-        const result = await context.api.request<PaginatedPromptListResult>({
+        const parsedParams = PromptListSchema.parse(params)
+        const result = await context.api.request<
+            Omit<Schemas.PaginatedLLMPromptListList, 'results'> & {
+                results: (Omit<Schemas.LLMPromptList, 'prompt'> & { prompt?: unknown })[]
+            }
+        >({
             method: 'GET',
             path: `/api/environments/${projectId}/llm_prompts/`,
-            query: {
-                content: params.content ?? 'none',
-                search: params.search,
-            },
+            query: parsedParams,
         })
         return result
     },
@@ -98,9 +95,6 @@ const promptUpdate = (): ToolBase<typeof PromptUpdateSchema, Schemas.LLMPrompt> 
         const body: Record<string, unknown> = {}
         if (params.prompt !== undefined) {
             body['prompt'] = params.prompt
-        }
-        if (params.edits !== undefined) {
-            body['edits'] = params.edits
         }
         if (params.base_version !== undefined) {
             body['base_version'] = params.base_version

--- a/services/mcp/src/tools/generated/prompts.ts
+++ b/services/mcp/src/tools/generated/prompts.ts
@@ -96,6 +96,9 @@ const promptUpdate = (): ToolBase<typeof PromptUpdateSchema, Schemas.LLMPrompt> 
         if (params.prompt !== undefined) {
             body['prompt'] = params.prompt
         }
+        if (params.edits !== undefined) {
+            body['edits'] = params.edits
+        }
         if (params.base_version !== undefined) {
             body['base_version'] = params.base_version
         }

--- a/services/mcp/tests/unit/__snapshots__/generate-tools.test.ts.snap
+++ b/services/mcp/tests/unit/__snapshots__/generate-tools.test.ts.snap
@@ -4,15 +4,16 @@ exports[`generateToolCode with input_schema > applies enrich_url with input_sche
 "
 const ThingsCreateSchema = ThingCreateSchema
 
-const thingsCreate = (): ToolBase<typeof ThingsCreateSchema> => ({
+const thingsCreate = (): ToolBase<typeof ThingsCreateSchema, unknown> => ({
     name: 'things-create',
     schema: ThingsCreateSchema,
     handler: async (context: Context, params: z.infer<typeof ThingsCreateSchema>) => {
         const projectId = await context.stateManager.getProjectId()
-        const result = await context.api.request({
+        const parsedParams = ThingsCreateSchema.parse(params)
+        const result = await context.api.request<unknown>({
             method: 'POST',
             path: \`/api/projects/\${projectId}/things/\`,
-            body: params,
+            body: parsedParams,
         })
         return await withPostHogUrl(context, result, \`/things/\${result.id}\`)
     },
@@ -24,15 +25,16 @@ exports[`generateToolCode with input_schema > applies list enrichment with input
 "
 const ThingsListSchema = ThingListSchema
 
-const thingsList = (): ToolBase<typeof ThingsListSchema> => ({
+const thingsList = (): ToolBase<typeof ThingsListSchema, unknown> => ({
     name: 'things-list',
     schema: ThingsListSchema,
     handler: async (context: Context, params: z.infer<typeof ThingsListSchema>) => {
         const projectId = await context.stateManager.getProjectId()
-        const result = await context.api.request({
+        const parsedParams = ThingsListSchema.parse(params)
+        const result = await context.api.request<unknown>({
             method: 'GET',
             path: \`/api/projects/\${projectId}/things/\`,
-            query: params,
+            query: parsedParams,
         })
         return await withPostHogUrl(context, {
             ...result,
@@ -47,15 +49,16 @@ exports[`generateToolCode with input_schema > uses custom schema import when inp
 "
 const ThingsCreateSchema = ThingCreateSchema
 
-const thingsCreate = (): ToolBase<typeof ThingsCreateSchema> => ({
+const thingsCreate = (): ToolBase<typeof ThingsCreateSchema, unknown> => ({
     name: 'things-create',
     schema: ThingsCreateSchema,
     handler: async (context: Context, params: z.infer<typeof ThingsCreateSchema>) => {
         const projectId = await context.stateManager.getProjectId()
-        const result = await context.api.request({
+        const parsedParams = ThingsCreateSchema.parse(params)
+        const result = await context.api.request<unknown>({
             method: 'POST',
             path: \`/api/projects/\${projectId}/things/\`,
-            body: params,
+            body: parsedParams,
         })
         return result
     },

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/prompt-list.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/prompt-list.json
@@ -3,7 +3,7 @@
     "properties": {
         "content": {
             "default": "none",
-            "description": "Controls how much prompt content is included in list results. 'full' includes the full prompt, 'preview' includes a short prompt_preview, and 'none' omits prompt content entirely.\n\n* `full` - full\n* `preview` - preview\n* `none` - none",
+            "description": "Controls how much prompt content is included in list results. 'full' includes the full prompt, 'preview' includes a short prompt_preview, and 'none' omits prompt content entirely.",
             "enum": ["full", "preview", "none"],
             "type": "string"
         },

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/prompt-list.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/prompt-list.json
@@ -2,7 +2,8 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "properties": {
         "content": {
-            "description": "Controls how much prompt content is included in list results. 'full' includes the full prompt, 'preview' includes a short prompt_preview, and 'none' omits prompt content entirely.",
+            "default": "none",
+            "description": "Controls how much prompt content is included in list results. 'full' includes the full prompt, 'preview' includes a short prompt_preview, and 'none' omits prompt content entirely.\n\n* `full` - full\n* `preview` - preview\n* `none` - none",
             "enum": ["full", "preview", "none"],
             "type": "string"
         },

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/prompt-list.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/prompt-list.json
@@ -1,6 +1,11 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "properties": {
+        "content": {
+            "description": "Controls how much prompt content is included in list results. 'full' includes the full prompt, 'preview' includes a short prompt_preview, and 'none' omits prompt content entirely.",
+            "enum": ["full", "preview", "none"],
+            "type": "string"
+        },
         "search": {
             "description": "Optional substring filter applied to prompt names and prompt content.",
             "type": "string"

--- a/services/mcp/tests/unit/generate-tools.test.ts
+++ b/services/mcp/tests/unit/generate-tools.test.ts
@@ -207,7 +207,8 @@ describe('generateToolCode with input_schema', () => {
             new Set<string>()
         )
 
-        expect(result.code).toContain('body: params')
+        expect(result.code).toContain('const parsedParams = ThingsCreateSchema.parse(params)')
+        expect(result.code).toContain('body: parsedParams')
     })
 
     it('generates query forwarding for GET with input_schema', () => {
@@ -220,7 +221,27 @@ describe('generateToolCode with input_schema', () => {
 
         const result = generateToolCode('things-list', config, resolved, defaultCategory, makeSpec(), new Set<string>())
 
-        expect(result.code).toContain('query: params')
+        expect(result.code).toContain('const parsedParams = ThingsListSchema.parse(params)')
+        expect(result.code).toContain('query: parsedParams')
+    })
+
+    it('uses response_type override for custom input schema tools', () => {
+        const config: ToolConfig = {
+            operation: 'things_list',
+            enabled: true,
+            input_schema: 'ThingListSchema',
+            response_type: "Omit<Schemas.ThingList, 'results'> & { results: unknown[] }",
+        }
+        const resolved = makeResolved({ method: 'GET' })
+
+        const result = generateToolCode('things-list', config, resolved, defaultCategory, makeSpec(), new Set<string>())
+
+        expect(result.code).toContain(
+            "const thingsList = (): ToolBase<typeof ThingsListSchema, Omit<Schemas.ThingList, 'results'> & { results: unknown[] }>"
+        )
+        expect(result.code).toContain(
+            "const result = await context.api.request<Omit<Schemas.ThingList, 'results'> & { results: unknown[] }>({"
+        )
     })
 
     it('destructures path params for input_schema with path params', () => {
@@ -556,6 +577,15 @@ describe('ToolConfigSchema validation', () => {
 
     it('allows input_schema without include_params, exclude_params, or param_overrides', () => {
         const result = ToolConfigSchema.safeParse(validBase)
+        expect(result.success).toBe(true)
+    })
+
+    it('accepts response_type override', () => {
+        const result = ToolConfigSchema.safeParse({
+            operation: 'things_list',
+            enabled: true,
+            response_type: "Omit<Schemas.ThingList, 'results'>",
+        })
         expect(result.success).toBe(true)
     })
 

--- a/services/mcp/tests/unit/prompts-generated.test.ts
+++ b/services/mcp/tests/unit/prompts-generated.test.ts
@@ -46,6 +46,7 @@ describe('Generated prompt tools', () => {
                     id: '2f53a52a-06f5-4025-9ea7-f763f74f17f5',
                     name: 'checkout_prompt',
                     version: 3,
+                    prompt_size_bytes: 123,
                 },
             ],
         }
@@ -57,9 +58,22 @@ describe('Generated prompt tools', () => {
         expect(requestMock).toHaveBeenCalledWith({
             method: 'GET',
             path: '/api/environments/17/llm_prompts/',
-            query: { search: 'checkout' },
+            query: { search: 'checkout', content: 'none' },
         })
         expect(result).toEqual(paginated)
+    })
+
+    it('allows overriding prompt-list content mode', async () => {
+        const { context, requestMock } = createContext({ count: 0, next: null, previous: null, results: [] })
+        const tool = getToolByName(GENERATED_TOOLS, 'prompt-list')
+
+        await tool.handler(context, { search: 'checkout', content: 'preview' })
+
+        expect(requestMock).toHaveBeenCalledWith({
+            method: 'GET',
+            path: '/api/environments/17/llm_prompts/',
+            query: { search: 'checkout', content: 'preview' },
+        })
     })
 
     it('wires prompt-get to GET /name/{prompt_name}/ with version query', async () => {


### PR DESCRIPTION
## Problem

`prompt-list` returns full prompt content for every prompt. That makes MCP responses much larger than necessary and makes it hard to efficiently list prompts by metadata only.

## Changes

- add `content=full|preview|none` to the prompt list API
- add `prompt_size_bytes` to prompt list results
- add sorting by `prompt_size_bytes`
- keep the existing prompt management UI behavior unchanged by defaulting list responses to `content=full`
- update MCP `prompt-list` to request `content=none` by default
- add backend and MCP tests for the new list modes

## How did you test this code?

- `flox activate -c 'pytest posthog/api/test/test_llm_prompt.py posthog/api/test/test_api_docs.py::TestAPIDocsSchema::test_llm_prompt_schema_includes_search_and_prompt_name_path_param -q'`
- `flox activate -c 'pnpm --filter=@posthog/mcp exec vitest run tests/unit/prompts-generated.test.ts'`
- `flox activate -c 'ruff check posthog/api/llm_prompt.py posthog/api/llm_prompt_serializers.py posthog/api/test/test_llm_prompt.py posthog/api/test/test_api_docs.py'`

## Publish to changelog?

no

## Docs update

No docs update needed.
