### PR TITLE
feat(replay): allow for WHERE clauses in events in remote config triggers v2

### DIFF
--- a/posthog/api/team.py
+++ b/posthog/api/team.py
@@ -330,6 +330,49 @@ class TeamCustomerAnalyticsConfigSerializer(serializers.ModelSerializer, UserAcc
         ]
 
 
+_VALID_TRIGGER_PROPERTY_OPERATORS = {
+    "exact",
+    "is_not",
+    "icontains",
+    "not_icontains",
+    "regex",
+    "not_regex",
+    "gt",
+    "lt",
+}
+
+# Property types the SDK can evaluate client-side
+_VALID_TRIGGER_PROPERTY_TYPES = {
+    "event",
+    "person",
+}
+
+
+def _validate_trigger_property_filters(properties: object, context: str) -> None:
+    """Validate property filters on trigger conditions (events, URLs)."""
+    if not isinstance(properties, list):
+        raise exceptions.ValidationError(f"{context}: 'properties' must be an array.")
+
+    for prop_idx, prop in enumerate(properties):
+        if not isinstance(prop, dict):
+            raise exceptions.ValidationError(f"{context}: property {prop_idx} must be a dictionary.")
+        if "key" not in prop or not isinstance(prop["key"], str):
+            raise exceptions.ValidationError(f"{context}: property {prop_idx} must have a string 'key' field.")
+        if "type" not in prop or prop["type"] not in _VALID_TRIGGER_PROPERTY_TYPES:
+            raise exceptions.ValidationError(
+                f"{context}: property {prop_idx} must have a 'type' field with value: "
+                f"{', '.join(sorted(_VALID_TRIGGER_PROPERTY_TYPES))}."
+            )
+        if "operator" in prop and prop["operator"] not in _VALID_TRIGGER_PROPERTY_OPERATORS:
+            raise exceptions.ValidationError(
+                f"{context}: property {prop_idx} has invalid operator '{prop['operator']}'. "
+                f"Valid operators: {', '.join(sorted(_VALID_TRIGGER_PROPERTY_OPERATORS))}."
+            )
+        # All supported operators require a value (is_set/is_not_set are not supported)
+        if "value" not in prop:
+            raise exceptions.ValidationError(f"{context}: property {prop_idx} must have a 'value' field.")
+
+
 class TeamSerializer(serializers.ModelSerializer, UserPermissionsSerializerMixin, UserAccessControlSerializerMixin):
     instance: Team | None
 
@@ -609,9 +652,22 @@ class TeamSerializer(serializers.ModelSerializer, UserPermissionsSerializerMixin
             if "events" in conditions:
                 if not isinstance(conditions["events"], list):
                     raise exceptions.ValidationError(f"Group {idx}: field 'events' must be an array.")
-                for event in conditions["events"]:
-                    if not isinstance(event, str):
-                        raise exceptions.ValidationError(f"Group {idx}: event names must be strings.")
+                for event_idx, event in enumerate(conditions["events"]):
+                    if isinstance(event, str):
+                        pass  # Simple event name is valid
+                    elif isinstance(event, dict):
+                        if "name" not in event or not isinstance(event["name"], str):
+                            raise exceptions.ValidationError(
+                                f"Group {idx}: event {event_idx} object must have a string 'name' field."
+                            )
+                        if "properties" in event:
+                            _validate_trigger_property_filters(
+                                event["properties"], f"Group {idx}, event '{event['name']}'"
+                            )
+                    else:
+                        raise exceptions.ValidationError(
+                            f"Group {idx}: event {event_idx} must be a string or object with 'name'."
+                        )
 
             # Validate URLs array if present
             if "urls" in conditions:
@@ -652,6 +708,10 @@ class TeamSerializer(serializers.ModelSerializer, UserPermissionsSerializerMixin
                     raise exceptions.ValidationError(
                         f"Group {idx}: 'flag' must be a string (flag key), object (LinkedFeatureFlag), or null."
                     )
+
+            # Validate group-level property filters (shared WHERE clause for all triggers in group)
+            if "properties" in conditions:
+                _validate_trigger_property_filters(conditions["properties"], f"Group {idx}")
 
         # Note: All matching groups are evaluated independently
         # If any group's sample rate hits, the session is recorded (union behavior)

--- a/posthog/api/test/test_remote_config.py
+++ b/posthog/api/test/test_remote_config.py
@@ -323,6 +323,11 @@ class TestRemoteConfig(APIBaseTest, QueryMatchingTest):
         assert config["sessionRecording"]["triggerGroups"][0]["id"] == "errors"
         assert config["sessionRecording"]["triggerGroups"][0]["sampleRate"] == 1.0
         assert config["sessionRecording"]["triggerGroups"][0]["minDurationMs"] == 0
+        # Events should be normalized to objects for SDK
+        assert config["sessionRecording"]["triggerGroups"][0]["conditions"]["events"] == [
+            {"name": "error"},
+            {"name": "crash"},
+        ]
         assert config["sessionRecording"]["triggerGroups"][1]["id"] == "feature-test"
         assert config["sessionRecording"]["triggerGroups"][1]["minDurationMs"] == 10000
         # V2 fields should be present

--- a/posthog/api/test/test_team.py
+++ b/posthog/api/test/test_team.py
@@ -2518,6 +2518,152 @@ def team_api_test_factory():
                     },
                     "mindurationms",
                 ),
+                (
+                    "event_object_missing_name",
+                    {
+                        "version": 2,
+                        "groups": [
+                            {
+                                "id": "test",
+                                "sampleRate": 0.5,
+                                "conditions": {
+                                    "matchType": "any",
+                                    "events": [{"properties": []}],
+                                },
+                            }
+                        ],
+                    },
+                    "name",
+                ),
+                (
+                    "event_invalid_type",
+                    {
+                        "version": 2,
+                        "groups": [
+                            {
+                                "id": "test",
+                                "sampleRate": 0.5,
+                                "conditions": {
+                                    "matchType": "any",
+                                    "events": [123],
+                                },
+                            }
+                        ],
+                    },
+                    "string or object",
+                ),
+                (
+                    "event_property_missing_type",
+                    {
+                        "version": 2,
+                        "groups": [
+                            {
+                                "id": "test",
+                                "sampleRate": 0.5,
+                                "conditions": {
+                                    "matchType": "any",
+                                    "events": [
+                                        {
+                                            "name": "purchase",
+                                            "properties": [{"key": "amount", "operator": "gt", "value": 100}],
+                                        }
+                                    ],
+                                },
+                            }
+                        ],
+                    },
+                    "type",
+                ),
+                (
+                    "event_property_invalid_type",
+                    {
+                        "version": 2,
+                        "groups": [
+                            {
+                                "id": "test",
+                                "sampleRate": 0.5,
+                                "conditions": {
+                                    "matchType": "any",
+                                    "events": [
+                                        {
+                                            "name": "purchase",
+                                            "properties": [
+                                                {"key": "amount", "type": "hogql", "operator": "gt", "value": 100}
+                                            ],
+                                        }
+                                    ],
+                                },
+                            }
+                        ],
+                    },
+                    "type",
+                ),
+                (
+                    "event_property_missing_key",
+                    {
+                        "version": 2,
+                        "groups": [
+                            {
+                                "id": "test",
+                                "sampleRate": 0.5,
+                                "conditions": {
+                                    "matchType": "any",
+                                    "events": [
+                                        {
+                                            "name": "purchase",
+                                            "properties": [{"type": "event", "operator": "exact", "value": "foo"}],
+                                        }
+                                    ],
+                                },
+                            }
+                        ],
+                    },
+                    "key",
+                ),
+                (
+                    "event_property_invalid_operator",
+                    {
+                        "version": 2,
+                        "groups": [
+                            {
+                                "id": "test",
+                                "sampleRate": 0.5,
+                                "conditions": {
+                                    "matchType": "any",
+                                    "events": [
+                                        {
+                                            "name": "purchase",
+                                            "properties": [
+                                                {"key": "amount", "type": "event", "operator": "banana", "value": 100}
+                                            ],
+                                        }
+                                    ],
+                                },
+                            }
+                        ],
+                    },
+                    "invalid operator",
+                ),
+                (
+                    "group_level_property_invalid_operator",
+                    {
+                        "version": 2,
+                        "groups": [
+                            {
+                                "id": "test",
+                                "sampleRate": 0.5,
+                                "conditions": {
+                                    "matchType": "any",
+                                    "events": [{"name": "error"}],
+                                    "properties": [
+                                        {"key": "country", "type": "person", "operator": "banana", "value": "US"}
+                                    ],
+                                },
+                            }
+                        ],
+                    },
+                    "invalid operator",
+                ),
             ]
         )
         def test_session_recording_trigger_groups_validation_errors(
@@ -2565,6 +2711,79 @@ def team_api_test_factory():
                         "conditions": {
                             "matchType": "any",
                             "flag": "simple-feature-flag",
+                        },
+                    },
+                ],
+            }
+
+            response = self.client.patch(
+                f"/api/environments/{self.team.id}/",
+                {"session_recording_trigger_groups": trigger_groups},
+            )
+
+            assert response.status_code == status.HTTP_200_OK
+            assert response.json()["session_recording_trigger_groups"] == trigger_groups
+
+        def test_session_recording_trigger_groups_with_event_objects_and_properties(self):
+            trigger_groups = {
+                "version": 2,
+                "groups": [
+                    {
+                        "id": "rich-events",
+                        "name": "Events with WHERE clauses",
+                        "sampleRate": 1.0,
+                        "conditions": {
+                            "matchType": "all",
+                            "events": [
+                                "simple_event",
+                                {
+                                    "name": "purchase",
+                                    "properties": [
+                                        {"key": "amount", "type": "event", "operator": "gt", "value": 100},
+                                        {"key": "currency", "type": "event", "operator": "exact", "value": "USD"},
+                                    ],
+                                },
+                                {"name": "$exception"},
+                            ],
+                            "urls": [
+                                {
+                                    "url": "/checkout.*",
+                                    "matching": "regex",
+                                }
+                            ],
+                        },
+                    },
+                ],
+            }
+
+            response = self.client.patch(
+                f"/api/environments/{self.team.id}/",
+                {"session_recording_trigger_groups": trigger_groups},
+            )
+
+            assert response.status_code == status.HTTP_200_OK
+            assert response.json()["session_recording_trigger_groups"] == trigger_groups
+
+        def test_session_recording_trigger_groups_with_group_level_properties(self):
+            trigger_groups = {
+                "version": 2,
+                "groups": [
+                    {
+                        "id": "us-errors",
+                        "name": "US errors on checkout",
+                        "sampleRate": 1.0,
+                        "conditions": {
+                            "matchType": "any",
+                            "events": [{"name": "$exception"}, {"name": "purchase_error"}],
+                            "properties": [
+                                {
+                                    "key": "$current_url",
+                                    "type": "event",
+                                    "operator": "icontains",
+                                    "value": ["checkout.acme.com", "payments.acme.com"],
+                                },
+                                {"key": "country", "type": "person", "operator": "exact", "value": "US"},
+                            ],
                         },
                     },
                 ],

--- a/posthog/models/remote_config.py
+++ b/posthog/models/remote_config.py
@@ -194,10 +194,29 @@ class RemoteConfig(UUIDTModel):
         # V2: If trigger groups configured, send V2 + V1 fallback fields
         if team.session_recording_trigger_groups:
             trigger_groups_config = team.session_recording_trigger_groups
+            groups = trigger_groups_config.get("groups", [])
+
+            # Normalize events to objects for SDK: ["purchase"] -> [{"name": "purchase"}]
+            # This future-proofs the contract so WHERE clauses (property filters on events)
+            # can be added later without a breaking SDK change.
+            # Build normalized copies to avoid mutating the team's stored data.
+            normalized_groups = []
+            for group in groups:
+                conditions = group.get("conditions", {})
+                if "events" in conditions:
+                    group = {
+                        **group,
+                        "conditions": {
+                            **conditions,
+                            "events": [{"name": e} if isinstance(e, str) else e for e in conditions["events"]],
+                        },
+                    }
+                normalized_groups.append(group)
+
             return {
                 **base_config,
                 "version": 2,
-                "triggerGroups": trigger_groups_config.get("groups", []),
+                "triggerGroups": normalized_groups,
                 # Include V1 fields for backward compatibility with old SDKs
                 **v1_fields,
             }


### PR DESCRIPTION
## Problem

after discussions/live bug reports coming in from V1, realized theres real value in allowing modifiers on filters, ie "where" clauses on events, or potentially conditions on URLs, etc. 



<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

## Changes

- Extend V2 trigger group validation to accept events as either strings ("purchase") or objects with optional property filters ({"name": "pageview", "properties": [...]})
- Same for URLs — accept optional properties array on URL trigger objects
- Normalize event strings to {"name": "..."} objects in remote config before sending to SDK, so posthog-js can just accept objects from the beginning of V2

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

- Existing trigger group tests still pass
- New parameterized tests for validation errors (missing name, invalid type, invalid operator)
- New test for valid config with mixed string/object events and URL properties

<!-- Briefly describe the steps you took, and what steps reviewers must take to get to where changes are, and what is the expected behavior. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->