### PR TITLE
fix(modeling): dont fail materialization just to calculate table size

### DIFF
--- a/posthog/ducklake/client.py
+++ b/posthog/ducklake/client.py
@@ -4,7 +4,10 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 import psycopg
-from psycopg import sql as psql
+from psycopg import (
+    Cursor,
+    sql as psql,
+)
 from psycopg.conninfo import make_conninfo
 
 from posthog.ducklake.common import get_duckgres_config, sanitize_ducklake_identifier
@@ -113,6 +116,24 @@ def execute_ducklake_query(
     )
 
 
+def _calculate_table_size(cur: Cursor, safe_schema: str, safe_table: str):
+    try:
+        cur.execute(
+            """
+            SELECT t.file_size_bytes
+            FROM ducklake_table_info('ducklake') t
+            JOIN __ducklake_metadata_ducklake.ducklake_schema s
+            ON t.schema_id = s.schema_id AND s.end_snapshot IS NULL
+            WHERE s.schema_name = %s AND t.table_name = %s
+            """,
+            (safe_schema, safe_table),
+        )
+        row = cur.fetchone()
+        return int(row[0]) if row and row[0] else 0
+    except Exception:
+        return 0
+
+
 def execute_ducklake_create_table(team_id: int, sql: str, schema_name: str, table_name: str) -> DuckLakeTableResult:
     """Execute a query via duckgres and materialize the result as a DuckLake table.
 
@@ -129,23 +150,7 @@ def execute_ducklake_create_table(team_id: int, sql: str, schema_name: str, tabl
         _set_search_path(conn, extra_schemas=[safe_schema])
         with conn.cursor() as cur:
             # capture previous table size before replacing — best-effort, don't block materialization
-            prev_file_size_bytes = 0
-            try:
-                cur.execute(
-                    """
-                    SELECT t.file_size_bytes
-                    FROM ducklake_table_info('ducklake') t
-                    JOIN __ducklake_metadata_ducklake.ducklake_schema s
-                        ON t.schema_id = s.schema_id
-                        AND s.end_snapshot IS NULL
-                    WHERE s.schema_name = %s AND t.table_name = %s
-                    """,
-                    (safe_schema, safe_table),
-                )
-                prev_row = cur.fetchone()
-                prev_file_size_bytes = int(prev_row[0]) if prev_row and prev_row[0] else 0
-            except Exception:
-                pass
+            previous_file_size_bytes = _calculate_table_size(cur, safe_schema, safe_table)
             cur.execute(psql.SQL("CREATE OR REPLACE TABLE {} AS {}").format(qualified, sql))
     with psycopg.connect(conninfo) as conn:
         _set_search_path(conn, extra_schemas=[safe_schema])
@@ -153,27 +158,11 @@ def execute_ducklake_create_table(team_id: int, sql: str, schema_name: str, tabl
             cur.execute(psql.SQL("SELECT count(*) FROM {}").format(qualified))
             row = cur.fetchone()
             row_count = int(row[0]) if row else 0
-            file_size_bytes = 0
-            try:
-                cur.execute(
-                    """
-                    SELECT t.file_size_bytes
-                    FROM ducklake_table_info('ducklake') t
-                    JOIN __ducklake_metadata_ducklake.ducklake_schema s
-                        ON t.schema_id = s.schema_id
-                        AND s.end_snapshot IS NULL
-                    WHERE s.schema_name = %s AND t.table_name = %s
-                    """,
-                    (safe_schema, safe_table),
-                )
-                size_row = cur.fetchone()
-                file_size_bytes = int(size_row[0]) if size_row and size_row[0] else 0
-            except Exception:
-                pass
+            file_size_bytes = _calculate_table_size(cur, safe_schema, safe_table)
     return DuckLakeTableResult(
         schema_name=safe_schema,
         table_name=safe_table,
         row_count=row_count,
         file_size_bytes=file_size_bytes,
-        file_size_delta_bytes=file_size_bytes - prev_file_size_bytes,
+        file_size_delta_bytes=file_size_bytes - previous_file_size_bytes,
     )

--- a/posthog/ducklake/client.py
+++ b/posthog/ducklake/client.py
@@ -128,13 +128,24 @@ def execute_ducklake_create_table(team_id: int, sql: str, schema_name: str, tabl
         # duckgres SET seems to only accept a single comma-separated string value with single quotes
         _set_search_path(conn, extra_schemas=[safe_schema])
         with conn.cursor() as cur:
-            # capture previous table size before replacing
-            cur.execute(
-                "SELECT file_size_bytes FROM posthog.table_info() WHERE schema_name = %s AND table_name = %s",
-                (safe_schema, safe_table),
-            )
-            prev_row = cur.fetchone()
-            prev_file_size_bytes = int(prev_row[0]) if prev_row and prev_row[0] else 0
+            # capture previous table size before replacing — best-effort, don't block materialization
+            prev_file_size_bytes = 0
+            try:
+                cur.execute(
+                    """
+                    SELECT t.file_size_bytes
+                    FROM ducklake_table_info('ducklake') t
+                    JOIN __ducklake_metadata_ducklake.ducklake_schema s
+                        ON t.schema_id = s.schema_id
+                        AND s.end_snapshot IS NULL
+                    WHERE s.schema_name = %s AND t.table_name = %s
+                    """,
+                    (safe_schema, safe_table),
+                )
+                prev_row = cur.fetchone()
+                prev_file_size_bytes = int(prev_row[0]) if prev_row and prev_row[0] else 0
+            except Exception:
+                pass
             cur.execute(psql.SQL("CREATE OR REPLACE TABLE {} AS {}").format(qualified, sql))
     with psycopg.connect(conninfo) as conn:
         _set_search_path(conn, extra_schemas=[safe_schema])
@@ -142,12 +153,23 @@ def execute_ducklake_create_table(team_id: int, sql: str, schema_name: str, tabl
             cur.execute(psql.SQL("SELECT count(*) FROM {}").format(qualified))
             row = cur.fetchone()
             row_count = int(row[0]) if row else 0
-            cur.execute(
-                "SELECT file_size_bytes FROM posthog.table_info() WHERE schema_name = %s AND table_name = %s",
-                (safe_schema, safe_table),
-            )
-            size_row = cur.fetchone()
-            file_size_bytes = int(size_row[0]) if size_row and size_row[0] else 0
+            file_size_bytes = 0
+            try:
+                cur.execute(
+                    """
+                    SELECT t.file_size_bytes
+                    FROM ducklake_table_info('ducklake') t
+                    JOIN __ducklake_metadata_ducklake.ducklake_schema s
+                        ON t.schema_id = s.schema_id
+                        AND s.end_snapshot IS NULL
+                    WHERE s.schema_name = %s AND t.table_name = %s
+                    """,
+                    (safe_schema, safe_table),
+                )
+                size_row = cur.fetchone()
+                file_size_bytes = int(size_row[0]) if size_row and size_row[0] else 0
+            except Exception:
+                pass
     return DuckLakeTableResult(
         schema_name=safe_schema,
         table_name=safe_table,

--- a/posthog/ducklake/client.py
+++ b/posthog/ducklake/client.py
@@ -4,10 +4,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 import psycopg
-from psycopg import (
-    Cursor,
-    sql as psql,
-)
+from psycopg import sql as psql
 from psycopg.conninfo import make_conninfo
 
 from posthog.ducklake.common import get_duckgres_config, sanitize_ducklake_identifier
@@ -116,20 +113,22 @@ def execute_ducklake_query(
     )
 
 
-def _calculate_table_size(cur: Cursor, safe_schema: str, safe_table: str):
+def _calculate_table_size(conninfo: str, safe_schema: str, safe_table: str) -> int:
     try:
-        cur.execute(
-            """
-            SELECT t.file_size_bytes
-            FROM ducklake_table_info('ducklake') t
-            JOIN __ducklake_metadata_ducklake.ducklake_schema s
-            ON t.schema_id = s.schema_id AND s.end_snapshot IS NULL
-            WHERE s.schema_name = %s AND t.table_name = %s
-            """,
-            (safe_schema, safe_table),
-        )
-        row = cur.fetchone()
-        return int(row[0]) if row and row[0] else 0
+        with psycopg.connect(conninfo) as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    SELECT t.file_size_bytes
+                    FROM ducklake_table_info('ducklake') t
+                    JOIN __ducklake_metadata_ducklake.ducklake_schema s
+                    ON t.schema_id = s.schema_id AND s.end_snapshot IS NULL
+                    WHERE s.schema_name = %s AND t.table_name = %s
+                    """,
+                    (safe_schema, safe_table),
+                )
+                row = cur.fetchone()
+                return int(row[0]) if row and row[0] else 0
     except Exception:
         return 0
 
@@ -144,13 +143,13 @@ def execute_ducklake_create_table(team_id: int, sql: str, schema_name: str, tabl
     safe_table = sanitize_ducklake_identifier(table_name, default_prefix="model")
     qualified = psql.Identifier(safe_schema, safe_table)
     conninfo = _make_duckgres_conninfo(team_id)
+    # capture previous table size before replacing — best-effort, don't block materialization
+    previous_file_size_bytes = _calculate_table_size(conninfo, safe_schema, safe_table)
     with psycopg.connect(conninfo) as conn:
         conn.execute(psql.SQL("CREATE SCHEMA IF NOT EXISTS {}").format(psql.Identifier(safe_schema)))
         # duckgres SET seems to only accept a single comma-separated string value with single quotes
         _set_search_path(conn, extra_schemas=[safe_schema])
         with conn.cursor() as cur:
-            # capture previous table size before replacing — best-effort, don't block materialization
-            previous_file_size_bytes = _calculate_table_size(cur, safe_schema, safe_table)
             cur.execute(psql.SQL("CREATE OR REPLACE TABLE {} AS {}").format(qualified, sql))
     with psycopg.connect(conninfo) as conn:
         _set_search_path(conn, extra_schemas=[safe_schema])
@@ -158,7 +157,8 @@ def execute_ducklake_create_table(team_id: int, sql: str, schema_name: str, tabl
             cur.execute(psql.SQL("SELECT count(*) FROM {}").format(qualified))
             row = cur.fetchone()
             row_count = int(row[0]) if row else 0
-            file_size_bytes = _calculate_table_size(cur, safe_schema, safe_table)
+    # capture new table size — best-effort, don't block materialization
+    file_size_bytes = _calculate_table_size(conninfo, safe_schema, safe_table)
     return DuckLakeTableResult(
         schema_name=safe_schema,
         table_name=safe_table,


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

table size calculations were causing job failures.

## Changes

wrap em

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

verified the queries to calculate file size work against the ducklake catalog. wrapped em in try's anyway just to be safe

## Publish to changelog?

no

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->