### PR TITLE
chore(flags): compact Match by selector cards

### DIFF
--- a/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditionsCollapsible.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditionsCollapsible.tsx
@@ -961,7 +961,7 @@ export function FeatureFlagReleaseConditionsCollapsible({
                     <div
                         role="radiogroup"
                         aria-labelledby="match-by-label"
-                        className="flex flex-wrap gap-3"
+                        className="flex flex-wrap gap-2"
                         data-attr="feature-flag-aggregation-filter"
                         onKeyDown={(e) => {
                             // Handle arrow key navigation for radio group
@@ -993,7 +993,7 @@ export function FeatureFlagReleaseConditionsCollapsible({
                         {[
                             {
                                 value: 'user',
-                                icon: <IconPerson className="text-lg" />,
+                                icon: <IconPerson className="text-base shrink-0" />,
                                 label: 'User',
                                 description: 'Stable assignment for logged-in users based on their distinct ID.',
                             },
@@ -1001,7 +1001,7 @@ export function FeatureFlagReleaseConditionsCollapsible({
                                 ? [
                                       {
                                           value: 'device',
-                                          icon: <IconLaptop className="text-lg" />,
+                                          icon: <IconLaptop className="text-base shrink-0" />,
                                           label: 'Device',
                                           description:
                                               'Stable assignment per device. Good fit for experiments on anonymous users.',
@@ -1014,7 +1014,7 @@ export function FeatureFlagReleaseConditionsCollapsible({
                                 ? [
                                       {
                                           value: 'group',
-                                          icon: <IconPeople className="text-lg" />,
+                                          icon: <IconPeople className="text-base shrink-0" />,
                                           label: 'Group',
                                           description:
                                               'Stable assignment for everyone in an organization, company, or other custom group type.',
@@ -1025,7 +1025,7 @@ export function FeatureFlagReleaseConditionsCollapsible({
                                 ? [
                                       {
                                           value: 'mixed',
-                                          icon: <IconBalance className="text-lg" />,
+                                          icon: <IconBalance className="text-base shrink-0" />,
                                           label: 'User & Group',
                                           description:
                                               'Mix user and group targeting across condition sets. Each condition set picks its own targeting type.',
@@ -1059,16 +1059,18 @@ export function FeatureFlagReleaseConditionsCollapsible({
                                     }}
                                     data-attr={`feature-flag-aggregation-${option.value}`}
                                 >
-                                    <div className="flex flex-col gap-2">
-                                        <div className="flex items-center gap-2">
+                                    <div className="flex flex-col gap-1">
+                                        <div className="flex items-center gap-1.5">
                                             {option.icon}
-                                            <span className="font-medium flex-1">{option.label}</span>
+                                            <span className="text-sm font-medium flex-1 truncate" title={option.label}>
+                                                {option.label}
+                                            </span>
                                             {option.badge && (
                                                 <LemonTag type={option.badge.type} size="small">
                                                     {option.badge.text}
                                                 </LemonTag>
                                             )}
-                                            {isSelected && <IconCheckCircle className="text-accent text-base" />}
+                                            {isSelected && <IconCheckCircle className="text-accent text-sm shrink-0" />}
                                         </div>
                                         <div className="text-xs text-muted">
                                             {option.description}


### PR DESCRIPTION
## Problem

The "Match by" selector cards introduced in #53441 were a bit large for the space — in particular, the "User & Group" card header was wrapping awkwardly (icon, label, NEW badge, and checkmark competing for a narrow row, forcing the label onto three lines).

## Changes

Tightened the card header layout so the four options fit more comfortably side-by-side:

- Smaller icons (`text-lg` → `text-base`) with `shrink-0` so they never squeeze
- Smaller selected-state checkmark (`text-base` → `text-sm`) with `shrink-0`
- Smaller label (`text-sm font-medium`) with `truncate` + `title` attribute so long labels like "User & Group" gracefully ellipsis on tight widths while still showing the full text on hover
- Tighter header-row gap (`gap-2` → `gap-1.5`) and vertical stack gap (`gap-2` → `gap-1`)
- Tighter gap between cards (`gap-3` → `gap-2`)

Padding (`p-3`) is unchanged.

Before

<img width="1632" height="1146" alt="image" src="https://github.com/user-attachments/assets/2f78b1d5-b1e5-4360-b491-c7fdfcfb8771" />

After

<img width="1636" height="946" alt="image" src="https://github.com/user-attachments/assets/772ed37c-3dbb-4970-a846-ac406e60c3a5" />


## How did you test this code?

Manually verified in the browser that the "User & Group" card header no longer wraps and that hovering the truncated label shows the full text via native tooltip. No automated tests added — this is a presentational tweak to existing markup.

## Publish to changelog?

no

## 🤖 LLM context

Authored via Claude Code. Iterated on sizing: first pass was more aggressive (also shrank `p-3` → `p-2`), then backed off the padding change while keeping the typography/gap tweaks and adding a `title` attribute so the truncated label remains discoverable on hover.