### PR TITLE
chore(modeling): some minor tweaks for duckgres workflow

### DIFF
--- a/posthog/ducklake/client.py
+++ b/posthog/ducklake/client.py
@@ -150,7 +150,13 @@ def execute_ducklake_create_table(team_id: int, sql: str, schema_name: str, tabl
         # duckgres SET seems to only accept a single comma-separated string value with single quotes
         _set_search_path(conn, extra_schemas=[safe_schema])
         with conn.cursor() as cur:
-            cur.execute(psql.SQL("CREATE OR REPLACE TABLE {} AS ({})").format(qualified, psql.SQL(sql)))
+            cur.execute(
+                psql.SQL("""
+                    CREATE OR REPLACE TABLE {} AS (
+                        {}
+                    )
+                """).format(qualified, psql.SQL(sql))
+            )
     row_count = 0
     try:
         with psycopg.connect(conninfo) as conn:

--- a/posthog/temporal/data_modeling/workflows/materialize_view.py
+++ b/posthog/temporal/data_modeling/workflows/materialize_view.py
@@ -156,7 +156,6 @@ class MaterializeViewWorkflow(PostHogWorkflow):
                 ),
                 start_to_close_timeout=dt.timedelta(minutes=1),
             )
-
             # fire-and-forget: start duckgres shadow materialization in parallel
             duckgres_shadow_handle = temporalio.workflow.start_activity(
                 materialize_view_duckgres_activity,
@@ -169,7 +168,7 @@ class MaterializeViewWorkflow(PostHogWorkflow):
                 ),
                 start_to_close_timeout=dt.timedelta(minutes=15),
                 retry_policy=temporalio.common.RetryPolicy(
-                    maximum_attempts=1,
+                    maximum_attempts=3 if inputs.duckgres_only else 1,
                 ),
             )
 

--- a/posthog/temporal/data_modeling/workflows/materialize_view.py
+++ b/posthog/temporal/data_modeling/workflows/materialize_view.py
@@ -169,6 +169,8 @@ class MaterializeViewWorkflow(PostHogWorkflow):
                 start_to_close_timeout=dt.timedelta(minutes=15),
                 retry_policy=temporalio.common.RetryPolicy(
                     maximum_attempts=3 if inputs.duckgres_only else 1,
+                    initial_interval=dt.timedelta(seconds=10),
+                    maximum_interval=dt.timedelta(minutes=5),
                 ),
             )
 


### PR DESCRIPTION
## Problem

i need more green queries bc i'm too much of a perfectionist

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

## Changes

~50 queries failed purely bc they were skipped bc of upstream failure

1 query failed bc of shadowing a keyword and duck is more sensitive to that than nilla postgres i think?

2 queries failed bc my "compiled" versions of them didn't fully qualify some of the table names in WHERE clauses. fixed that manually just for demo's sake. not in PR

1 query failed bc of a comment at the end so it comment out one of the parents in the create or replace :facepalm-to-death: 

4 queries failed from transaction aborts? claude seems to think this is on the duck side bc the ducklake client were using should be using one  connection per statement basically with psycopg autocommit off. not sure. but adding retries might help if its something transient. so bumped retry count on `duckgres only`

1 failed from a connection error. likely transient

2 failed from silly nameing issues in compile (leading underscores got normalized out). fixed outside of PR by renaming the views

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

i didn't but i can feel the spirit moving in this PR

## Publish to changelog?

no

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->