### PR TITLE
feat(gateway): Add usage endpoint, plan resolver and billing-aware rate limits

### DIFF
--- a/services/llm-gateway/src/llm_gateway/api/routes.py
+++ b/services/llm-gateway/src/llm_gateway/api/routes.py
@@ -3,8 +3,10 @@ from fastapi import APIRouter
 from llm_gateway.api.anthropic import anthropic_router
 from llm_gateway.api.models import models_router
 from llm_gateway.api.openai import openai_router
+from llm_gateway.api.usage import usage_router
 
 router = APIRouter()
 router.include_router(anthropic_router, tags=["Anthropic"])
 router.include_router(models_router, tags=["Models"])
 router.include_router(openai_router, tags=["OpenAI"])
+router.include_router(usage_router)

--- a/services/llm-gateway/src/llm_gateway/api/usage.py
+++ b/services/llm-gateway/src/llm_gateway/api/usage.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from pydantic import BaseModel
+
+from llm_gateway.auth.models import AuthenticatedUser
+from llm_gateway.dependencies import get_authenticated_user
+from llm_gateway.rate_limiting.cost_throttles import CostThrottle, UserCostBurstThrottle, UserCostSustainedThrottle
+from llm_gateway.rate_limiting.runner import ThrottleRunner
+from llm_gateway.rate_limiting.throttles import ThrottleContext
+from llm_gateway.services.plan_resolver import PlanResolver, resolve_plan_info
+
+usage_router = APIRouter(prefix="/v1/usage", tags=["Usage"])
+
+
+class CostLimitStatus(BaseModel):
+    used_usd: float
+    limit_usd: float
+    remaining_usd: float
+    resets_in_seconds: int
+    exceeded: bool
+
+
+class UsageResponse(BaseModel):
+    product: str
+    user_id: int
+    burst: CostLimitStatus
+    sustained: CostLimitStatus
+    is_rate_limited: bool
+
+
+async def _get_cost_status(
+    throttle: CostThrottle,
+    context: ThrottleContext,
+) -> CostLimitStatus:
+    limiter = throttle._get_limiter(context)
+    key = throttle._get_cache_key(context)
+    limit, _ = throttle._get_limit_and_window(context)
+
+    current = await limiter.get_current(key)
+    ttl = await limiter.get_ttl(key)
+    remaining = max(0.0, limit - current)
+
+    return CostLimitStatus(
+        used_usd=round(current, 6),
+        limit_usd=round(limit, 2),
+        remaining_usd=round(remaining, 6),
+        resets_in_seconds=ttl,
+        exceeded=current >= limit,
+    )
+
+
+@usage_router.get("/{product}")
+async def get_usage(
+    product: str,
+    request: Request,
+    user: Annotated[AuthenticatedUser, Depends(get_authenticated_user)],
+) -> UsageResponse:
+    runner: ThrottleRunner = request.app.state.throttle_runner
+    plan_info = await resolve_plan_info(request, user.user_id, product)
+
+    context = ThrottleContext(
+        user=user,
+        product=product,
+        end_user_id=str(user.user_id),
+        plan_key=plan_info.plan_key,
+        in_trial_period=plan_info.in_trial_period,
+        seat_created_at=plan_info.seat_created_at,
+    )
+
+    burst_status: CostLimitStatus | None = None
+    sustained_status: CostLimitStatus | None = None
+
+    for throttle in runner._throttles:
+        if isinstance(throttle, UserCostBurstThrottle):
+            burst_status = await _get_cost_status(throttle, context)
+        elif isinstance(throttle, UserCostSustainedThrottle):
+            sustained_status = await _get_cost_status(throttle, context)
+
+    if burst_status is None:
+        burst_status = CostLimitStatus(
+            used_usd=0, limit_usd=0, remaining_usd=0, resets_in_seconds=0, exceeded=False
+        )
+    if sustained_status is None:
+        sustained_status = CostLimitStatus(
+            used_usd=0, limit_usd=0, remaining_usd=0, resets_in_seconds=0, exceeded=False
+        )
+
+    return UsageResponse(
+        product=product,
+        user_id=user.user_id,
+        burst=burst_status,
+        sustained=sustained_status,
+        is_rate_limited=burst_status.exceeded or sustained_status.exceeded,
+    )
+
+
+@usage_router.post("/{product}/invalidate-plan-cache")
+async def invalidate_plan_cache(
+    product: str,
+    request: Request,
+    user: Annotated[AuthenticatedUser, Depends(get_authenticated_user)],
+) -> dict[str, bool]:
+    if product != "posthog_code":
+        raise HTTPException(status_code=404, detail="Plan cache not available for this product")
+    plan_resolver: PlanResolver = request.app.state.plan_resolver
+    await plan_resolver.invalidate(user.user_id)
+    return {"ok": True}

--- a/services/llm-gateway/src/llm_gateway/api/usage.py
+++ b/services/llm-gateway/src/llm_gateway/api/usage.py
@@ -80,9 +80,7 @@ async def get_usage(
             sustained_status = await _get_cost_status(throttle, context)
 
     if burst_status is None:
-        burst_status = CostLimitStatus(
-            used_usd=0, limit_usd=0, remaining_usd=0, resets_in_seconds=0, exceeded=False
-        )
+        burst_status = CostLimitStatus(used_usd=0, limit_usd=0, remaining_usd=0, resets_in_seconds=0, exceeded=False)
     if sustained_status is None:
         sustained_status = CostLimitStatus(
             used_usd=0, limit_usd=0, remaining_usd=0, resets_in_seconds=0, exceeded=False

--- a/services/llm-gateway/src/llm_gateway/api/usage.py
+++ b/services/llm-gateway/src/llm_gateway/api/usage.py
@@ -7,7 +7,7 @@ from pydantic import BaseModel
 
 from llm_gateway.auth.models import AuthenticatedUser
 from llm_gateway.dependencies import get_authenticated_user
-from llm_gateway.rate_limiting.cost_throttles import CostThrottle, UserCostBurstThrottle, UserCostSustainedThrottle
+from llm_gateway.rate_limiting.cost_throttles import CostStatus, UserCostBurstThrottle, UserCostSustainedThrottle
 from llm_gateway.rate_limiting.runner import ThrottleRunner
 from llm_gateway.rate_limiting.throttles import ThrottleContext
 from llm_gateway.services.plan_resolver import PlanResolver, resolve_plan_info
@@ -31,24 +31,13 @@ class UsageResponse(BaseModel):
     is_rate_limited: bool
 
 
-async def _get_cost_status(
-    throttle: CostThrottle,
-    context: ThrottleContext,
-) -> CostLimitStatus:
-    limiter = throttle._get_limiter(context)
-    key = throttle._get_cache_key(context)
-    limit, _ = throttle._get_limit_and_window(context)
-
-    current = await limiter.get_current(key)
-    ttl = await limiter.get_ttl(key)
-    remaining = max(0.0, limit - current)
-
+def _to_cost_limit_status(status: CostStatus) -> CostLimitStatus:
     return CostLimitStatus(
-        used_usd=round(current, 6),
-        limit_usd=round(limit, 2),
-        remaining_usd=round(remaining, 6),
-        resets_in_seconds=ttl,
-        exceeded=current >= limit,
+        used_usd=round(status.used_usd, 6),
+        limit_usd=round(status.limit_usd, 2),
+        remaining_usd=round(status.remaining_usd, 6),
+        resets_in_seconds=status.resets_in_seconds,
+        exceeded=status.exceeded,
     )
 
 
@@ -73,11 +62,11 @@ async def get_usage(
     burst_status: CostLimitStatus | None = None
     sustained_status: CostLimitStatus | None = None
 
-    for throttle in runner._throttles:
+    for throttle in runner.throttles:
         if isinstance(throttle, UserCostBurstThrottle):
-            burst_status = await _get_cost_status(throttle, context)
+            burst_status = _to_cost_limit_status(await throttle.get_status(context))
         elif isinstance(throttle, UserCostSustainedThrottle):
-            sustained_status = await _get_cost_status(throttle, context)
+            sustained_status = _to_cost_limit_status(await throttle.get_status(context))
 
     if burst_status is None:
         burst_status = CostLimitStatus(used_usd=0, limit_usd=0, remaining_usd=0, resets_in_seconds=0, exceeded=False)

--- a/services/llm-gateway/src/llm_gateway/api/usage.py
+++ b/services/llm-gateway/src/llm_gateway/api/usage.py
@@ -16,9 +16,7 @@ usage_router = APIRouter(prefix="/v1/usage", tags=["Usage"])
 
 
 class CostLimitStatus(BaseModel):
-    used_usd: float
-    limit_usd: float
-    remaining_usd: float
+    used_percent: float
     resets_in_seconds: int
     exceeded: bool
 
@@ -32,10 +30,12 @@ class UsageResponse(BaseModel):
 
 
 def _to_cost_limit_status(status: CostStatus) -> CostLimitStatus:
+    if status.limit_usd > 0:
+        used_percent = min(100.0, (status.used_usd / status.limit_usd) * 100)
+    else:
+        used_percent = 100.0 if status.used_usd > 0 else 0.0
     return CostLimitStatus(
-        used_usd=round(status.used_usd, 6),
-        limit_usd=round(status.limit_usd, 2),
-        remaining_usd=round(status.remaining_usd, 6),
+        used_percent=round(used_percent, 1),
         resets_in_seconds=status.resets_in_seconds,
         exceeded=status.exceeded,
     )
@@ -69,11 +69,9 @@ async def get_usage(
             sustained_status = _to_cost_limit_status(await throttle.get_status(context))
 
     if burst_status is None:
-        burst_status = CostLimitStatus(used_usd=0, limit_usd=0, remaining_usd=0, resets_in_seconds=0, exceeded=False)
+        burst_status = CostLimitStatus(used_percent=0, resets_in_seconds=0, exceeded=False)
     if sustained_status is None:
-        sustained_status = CostLimitStatus(
-            used_usd=0, limit_usd=0, remaining_usd=0, resets_in_seconds=0, exceeded=False
-        )
+        sustained_status = CostLimitStatus(used_percent=0, resets_in_seconds=0, exceeded=False)
 
     return UsageResponse(
         product=product,

--- a/services/llm-gateway/src/llm_gateway/api/usage.py
+++ b/services/llm-gateway/src/llm_gateway/api/usage.py
@@ -10,7 +10,7 @@ from llm_gateway.dependencies import get_authenticated_user
 from llm_gateway.rate_limiting.cost_throttles import CostStatus, UserCostBurstThrottle, UserCostSustainedThrottle
 from llm_gateway.rate_limiting.runner import ThrottleRunner
 from llm_gateway.rate_limiting.throttles import ThrottleContext
-from llm_gateway.services.plan_resolver import PlanResolver, resolve_plan_info
+from llm_gateway.services.plan_resolver import POSTHOG_CODE_PRODUCT, PlanResolver, resolve_plan_info
 
 usage_router = APIRouter(prefix="/v1/usage", tags=["Usage"])
 
@@ -88,7 +88,7 @@ async def invalidate_plan_cache(
     request: Request,
     user: Annotated[AuthenticatedUser, Depends(get_authenticated_user)],
 ) -> dict[str, bool]:
-    if product != "posthog_code":
+    if product != POSTHOG_CODE_PRODUCT:
         raise HTTPException(status_code=404, detail="Plan cache not available for this product")
     plan_resolver: PlanResolver = request.app.state.plan_resolver
     await plan_resolver.invalidate(user.user_id)

--- a/services/llm-gateway/src/llm_gateway/api/usage.py
+++ b/services/llm-gateway/src/llm_gateway/api/usage.py
@@ -33,7 +33,7 @@ def _to_cost_limit_status(status: CostStatus) -> CostLimitStatus:
     if status.limit_usd > 0:
         used_percent = min(100.0, (status.used_usd / status.limit_usd) * 100)
     else:
-        used_percent = 100.0 if status.used_usd > 0 else 0.0
+        used_percent = 100.0
     return CostLimitStatus(
         used_percent=round(used_percent, 1),
         resets_in_seconds=status.resets_in_seconds,

--- a/services/llm-gateway/src/llm_gateway/config.py
+++ b/services/llm-gateway/src/llm_gateway/config.py
@@ -46,6 +46,20 @@ DEFAULT_USER_COST_LIMITS: dict[str, "UserCostLimit"] = {
     ),
 }
 
+FREE_PLAN_TRIAL_COST_LIMIT = UserCostLimit(
+    burst_limit_usd=5.0,
+    burst_window_seconds=86400,
+    sustained_limit_usd=50.0,
+    sustained_window_seconds=2592000,
+)
+
+FREE_PLAN_EXPIRED_COST_LIMIT = UserCostLimit(
+    burst_limit_usd=0.0,
+    burst_window_seconds=86400,
+    sustained_limit_usd=0.0,
+    sustained_window_seconds=2592000,
+)
+
 
 _COST_LIMIT_KEY_ALIASES: dict[str, str] = {
     "array": "posthog_code",
@@ -134,6 +148,11 @@ class Settings(BaseSettings):
     user_cost_limits_disabled: bool = False
 
     default_fallback_cost_usd: float = 0.01
+
+    posthog_api_url: str = ""
+    plan_cache_ttl: int = 300  # 5 minutes
+    plan_aware_throttling_enabled: bool = False
+    free_plan_trial_period_days: int = 30
 
     @field_validator("product_cost_limits", mode="before")
     @classmethod

--- a/services/llm-gateway/src/llm_gateway/dependencies.py
+++ b/services/llm-gateway/src/llm_gateway/dependencies.py
@@ -18,6 +18,7 @@ from llm_gateway.request_context import (
     get_request_id,
     set_throttle_context,
 )
+from llm_gateway.services.plan_resolver import resolve_plan_info
 
 logger = structlog.get_logger(__name__)
 
@@ -157,11 +158,16 @@ async def enforce_throttles(
     else:
         end_user_id = await _extract_end_user_id_from_body(request)
 
+    plan_info = await resolve_plan_info(request, user.user_id, product)
+
     context = ThrottleContext(
         user=user,
         product=product,
         request_id=get_request_id() or None,
         end_user_id=end_user_id,
+        plan_key=plan_info.plan_key,
+        in_trial_period=plan_info.in_trial_period,
+        seat_created_at=plan_info.seat_created_at,
     )
     request.state.throttle_context = context
     set_throttle_context(runner, context)

--- a/services/llm-gateway/src/llm_gateway/main.py
+++ b/services/llm-gateway/src/llm_gateway/main.py
@@ -7,6 +7,7 @@ from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 
 import asyncpg
+import httpx
 import structlog
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
@@ -30,6 +31,7 @@ from llm_gateway.rate_limiting.cost_throttles import (
 )
 from llm_gateway.rate_limiting.runner import ThrottleRunner
 from llm_gateway.request_context import RequestContext, set_request_context
+from llm_gateway.services.plan_resolver import PlanResolver
 
 
 def configure_logging(debug: bool = False) -> None:
@@ -144,6 +146,13 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     )
     logger.info("Throttle runner initialized")
 
+    app.state.http_client = httpx.AsyncClient()
+    app.state.plan_resolver = PlanResolver(
+        redis=app.state.redis,
+        http_client=app.state.http_client,
+    )
+    logger.info("Plan resolver initialized", posthog_api_url=settings.posthog_api_url or "(not configured)")
+
     logger.info(
         "rate_limits_configured",
         product_cost_limits={
@@ -169,6 +178,9 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
 
     yield
 
+    if app.state.http_client:
+        await app.state.http_client.aclose()
+        logger.info("HTTP client closed")
     if app.state.redis:
         await app.state.redis.aclose()
         logger.info("Redis closed")

--- a/services/llm-gateway/src/llm_gateway/rate_limiting/cost_throttles.py
+++ b/services/llm-gateway/src/llm_gateway/rate_limiting/cost_throttles.py
@@ -220,9 +220,7 @@ class UserCostSustainedThrottle(_UserCostThrottleBase):
             and settings.plan_aware_throttling_enabled
             and not is_pro_plan(context.plan_key)
         ):
-            period = get_billing_period_number(
-                context.seat_created_at, settings.free_plan_trial_period_days
-            )
+            period = get_billing_period_number(context.seat_created_at, settings.free_plan_trial_period_days)
             return f"{base_key}:period:{period}"
         return base_key
 

--- a/services/llm-gateway/src/llm_gateway/rate_limiting/cost_throttles.py
+++ b/services/llm-gateway/src/llm_gateway/rate_limiting/cost_throttles.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from abc import abstractmethod
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 import structlog
@@ -106,6 +107,32 @@ class CostThrottle(Throttle):
             ttl_seconds=ttl,
             remaining=limit - new_total,
         )
+
+    async def get_status(self, context: ThrottleContext) -> CostStatus:
+        limiter = self._get_limiter(context)
+        key = self._get_cache_key(context)
+        limit, _ = self._get_limit_and_window(context)
+
+        current = await limiter.get_current(key)
+        ttl = await limiter.get_ttl(key)
+        remaining = max(0.0, limit - current)
+
+        return CostStatus(
+            used_usd=current,
+            limit_usd=limit,
+            remaining_usd=remaining,
+            resets_in_seconds=ttl,
+            exceeded=current >= limit,
+        )
+
+
+@dataclass
+class CostStatus:
+    used_usd: float
+    limit_usd: float
+    remaining_usd: float
+    resets_in_seconds: int
+    exceeded: bool
 
 
 class ProductCostThrottle(CostThrottle):

--- a/services/llm-gateway/src/llm_gateway/rate_limiting/cost_throttles.py
+++ b/services/llm-gateway/src/llm_gateway/rate_limiting/cost_throttles.py
@@ -6,12 +6,18 @@ from typing import TYPE_CHECKING
 import structlog
 from redis.asyncio import Redis
 
-from llm_gateway.config import DEFAULT_USER_COST_LIMIT, get_settings
+from llm_gateway.config import (
+    DEFAULT_USER_COST_LIMIT,
+    FREE_PLAN_EXPIRED_COST_LIMIT,
+    FREE_PLAN_TRIAL_COST_LIMIT,
+    get_settings,
+)
 
 if TYPE_CHECKING:
     from llm_gateway.config import UserCostLimit
 from llm_gateway.rate_limiting.redis_limiter import CostRateLimiter
 from llm_gateway.rate_limiting.throttles import Throttle, ThrottleContext, ThrottleResult, get_team_multiplier
+from llm_gateway.services.plan_resolver import get_billing_period_number, is_pro_plan
 
 logger = structlog.get_logger(__name__)
 
@@ -149,7 +155,17 @@ class _UserCostThrottleBase(CostThrottle):
         return f"{base}:tm{team_mult}"
 
     def _get_config(self, context: ThrottleContext) -> UserCostLimit:
-        config = get_settings().user_cost_limits.get(context.product)
+        settings = get_settings()
+        if (
+            context.product == "posthog_code"
+            and settings.plan_aware_throttling_enabled
+            and not is_pro_plan(context.plan_key)
+        ):
+            if context.in_trial_period:
+                return FREE_PLAN_TRIAL_COST_LIMIT
+            return FREE_PLAN_EXPIRED_COST_LIMIT
+
+        config = settings.user_cost_limits.get(context.product)
         if not config:
             if context.end_user_id and context.product not in self._warned_products:
                 self._warned_products.add(context.product)
@@ -193,6 +209,22 @@ class UserCostSustainedThrottle(_UserCostThrottleBase):
 
     def _get_limit_exceeded_detail(self) -> str:
         return "User sustained rate limit exceeded"
+
+    def _get_cache_key(self, context: ThrottleContext) -> str:
+        base_key = super()._get_cache_key(context)
+        if not base_key:
+            return base_key
+        settings = get_settings()
+        if (
+            context.product == "posthog_code"
+            and settings.plan_aware_throttling_enabled
+            and not is_pro_plan(context.plan_key)
+        ):
+            period = get_billing_period_number(
+                context.seat_created_at, settings.free_plan_trial_period_days
+            )
+            return f"{base_key}:period:{period}"
+        return base_key
 
     def _get_limit_and_window(self, context: ThrottleContext) -> tuple[float, int]:
         config = self._get_config(context)

--- a/services/llm-gateway/src/llm_gateway/rate_limiting/cost_throttles.py
+++ b/services/llm-gateway/src/llm_gateway/rate_limiting/cost_throttles.py
@@ -72,9 +72,15 @@ class CostThrottle(Throttle):
     def _get_limit_exceeded_detail(self) -> str: ...
 
     async def allow_request(self, context: ThrottleContext) -> ThrottleResult:
+        limit, window = self._get_limit_and_window(context)
+        if limit <= 0:
+            return ThrottleResult.deny(
+                detail=self._get_limit_exceeded_detail(),
+                scope=self.scope,
+                retry_after=window,
+            )
         limiter = self._get_limiter(context)
         key = self._get_cache_key(context)
-        limit, window = self._get_limit_and_window(context)
 
         current = await limiter.get_current(key)
         ttl = await limiter.get_ttl(key)
@@ -127,9 +133,17 @@ class CostThrottle(Throttle):
         )
 
     async def get_status(self, context: ThrottleContext) -> CostStatus:
+        limit, window = self._get_limit_and_window(context)
+        if limit <= 0:
+            return CostStatus(
+                used_usd=0.0,
+                limit_usd=0.0,
+                remaining_usd=0.0,
+                resets_in_seconds=window,
+                exceeded=True,
+            )
         limiter = self._get_limiter(context)
         key = self._get_cache_key(context)
-        limit, _ = self._get_limit_and_window(context)
 
         current = await limiter.get_current(key)
         ttl = await limiter.get_ttl(key)
@@ -246,6 +260,9 @@ class UserCostSustainedThrottle(_UserCostThrottleBase):
         if not base_key:
             return base_key
         if _is_free_plan_throttled(context):
+            # Each billing period gets a fresh key so the sustained budget
+            # resets. In-flight requests near a period boundary may land on
+            # the old key and not count against the new window.
             period = get_billing_period_number(context.seat_created_at, get_settings().free_plan_trial_period_days)
             return f"{base_key}:period:{period}"
         return base_key

--- a/services/llm-gateway/src/llm_gateway/rate_limiting/cost_throttles.py
+++ b/services/llm-gateway/src/llm_gateway/rate_limiting/cost_throttles.py
@@ -23,6 +23,24 @@ from llm_gateway.services.plan_resolver import get_billing_period_number, is_pro
 logger = structlog.get_logger(__name__)
 
 
+@dataclass
+class CostStatus:
+    used_usd: float
+    limit_usd: float
+    remaining_usd: float
+    resets_in_seconds: int
+    exceeded: bool
+
+
+def _is_free_plan_throttled(context: ThrottleContext) -> bool:
+    settings = get_settings()
+    return (
+        context.product == "posthog_code"
+        and settings.plan_aware_throttling_enabled
+        and not is_pro_plan(context.plan_key)
+    )
+
+
 class CostThrottle(Throttle):
     scope: str
 
@@ -126,15 +144,6 @@ class CostThrottle(Throttle):
         )
 
 
-@dataclass
-class CostStatus:
-    used_usd: float
-    limit_usd: float
-    remaining_usd: float
-    resets_in_seconds: int
-    exceeded: bool
-
-
 class ProductCostThrottle(CostThrottle):
     scope = "product_cost"
 
@@ -182,17 +191,12 @@ class _UserCostThrottleBase(CostThrottle):
         return f"{base}:tm{team_mult}"
 
     def _get_config(self, context: ThrottleContext) -> UserCostLimit:
-        settings = get_settings()
-        if (
-            context.product == "posthog_code"
-            and settings.plan_aware_throttling_enabled
-            and not is_pro_plan(context.plan_key)
-        ):
+        if _is_free_plan_throttled(context):
             if context.in_trial_period:
                 return FREE_PLAN_TRIAL_COST_LIMIT
             return FREE_PLAN_EXPIRED_COST_LIMIT
 
-        config = settings.user_cost_limits.get(context.product)
+        config = get_settings().user_cost_limits.get(context.product)
         if not config:
             if context.end_user_id and context.product not in self._warned_products:
                 self._warned_products.add(context.product)
@@ -241,13 +245,8 @@ class UserCostSustainedThrottle(_UserCostThrottleBase):
         base_key = super()._get_cache_key(context)
         if not base_key:
             return base_key
-        settings = get_settings()
-        if (
-            context.product == "posthog_code"
-            and settings.plan_aware_throttling_enabled
-            and not is_pro_plan(context.plan_key)
-        ):
-            period = get_billing_period_number(context.seat_created_at, settings.free_plan_trial_period_days)
+        if _is_free_plan_throttled(context):
+            period = get_billing_period_number(context.seat_created_at, get_settings().free_plan_trial_period_days)
             return f"{base_key}:period:{period}"
         return base_key
 

--- a/services/llm-gateway/src/llm_gateway/rate_limiting/cost_throttles.py
+++ b/services/llm-gateway/src/llm_gateway/rate_limiting/cost_throttles.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
     from llm_gateway.config import UserCostLimit
 from llm_gateway.rate_limiting.redis_limiter import CostRateLimiter
 from llm_gateway.rate_limiting.throttles import Throttle, ThrottleContext, ThrottleResult, get_team_multiplier
-from llm_gateway.services.plan_resolver import get_billing_period_number, is_pro_plan
+from llm_gateway.services.plan_resolver import POSTHOG_CODE_PRODUCT, get_billing_period_number, is_pro_plan
 
 logger = structlog.get_logger(__name__)
 
@@ -35,7 +35,7 @@ class CostStatus:
 def _is_free_plan_throttled(context: ThrottleContext) -> bool:
     settings = get_settings()
     return (
-        context.product == "posthog_code"
+        context.product == POSTHOG_CODE_PRODUCT
         and settings.plan_aware_throttling_enabled
         and not is_pro_plan(context.plan_key)
     )
@@ -259,11 +259,9 @@ class UserCostSustainedThrottle(_UserCostThrottleBase):
         base_key = super()._get_cache_key(context)
         if not base_key:
             return base_key
-        if _is_free_plan_throttled(context):
-            # Each billing period gets a fresh key so the sustained budget
-            # resets. In-flight requests near a period boundary may land on
-            # the old key and not count against the new window.
-            period = get_billing_period_number(context.seat_created_at, get_settings().free_plan_trial_period_days)
+        settings = get_settings()
+        if context.product == POSTHOG_CODE_PRODUCT and settings.plan_aware_throttling_enabled:
+            period = get_billing_period_number(context.seat_created_at, settings.free_plan_trial_period_days)
             return f"{base_key}:period:{period}"
         return base_key
 

--- a/services/llm-gateway/src/llm_gateway/rate_limiting/runner.py
+++ b/services/llm-gateway/src/llm_gateway/rate_limiting/runner.py
@@ -14,6 +14,10 @@ class ThrottleRunner:
     def __init__(self, throttles: list[Throttle]):
         self._throttles = throttles
 
+    @property
+    def throttles(self) -> list[Throttle]:
+        return self._throttles
+
     async def check(self, context: ThrottleContext) -> ThrottleResult:
         results = await asyncio.gather(*[t.allow_request(context) for t in self._throttles])
 

--- a/services/llm-gateway/src/llm_gateway/rate_limiting/throttles.py
+++ b/services/llm-gateway/src/llm_gateway/rate_limiting/throttles.py
@@ -20,6 +20,9 @@ class ThrottleContext:
     product: str
     request_id: str | None = None
     end_user_id: str | None = None
+    plan_key: str | None = None
+    in_trial_period: bool = True
+    seat_created_at: str | None = None
 
 
 @dataclass

--- a/services/llm-gateway/src/llm_gateway/services/plan_resolver.py
+++ b/services/llm-gateway/src/llm_gateway/services/plan_resolver.py
@@ -1,0 +1,173 @@
+"""Resolves a user's PostHog Code plan via the PostHog API seats endpoint.
+
+Calls ``GET /api/seats/me/?product_key=posthog_code`` on the PostHog API,
+forwarding the user's auth token. The Django SeatViewSet handles billing
+JWT construction and proxies to the billing service.
+
+Results are cached in Redis to avoid hitting the API on every request.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from typing import TYPE_CHECKING
+
+import structlog
+
+from llm_gateway.config import get_settings
+
+if TYPE_CHECKING:
+    import httpx
+    from fastapi import Request
+    from redis.asyncio import Redis
+
+logger = structlog.get_logger(__name__)
+
+PLAN_CACHE_PREFIX = "plan:posthog_code"
+PRO_PLAN_PREFIX = "posthog-code-200"
+
+
+@dataclass
+class PlanInfo:
+    plan_key: str | None
+    in_trial_period: bool
+    seat_created_at: str | None
+
+
+def _redis_key(user_id: int) -> str:
+    return f"{PLAN_CACHE_PREFIX}:{user_id}"
+
+
+def is_pro_plan(plan_key: str | None) -> bool:
+    if not plan_key:
+        return False
+    return plan_key.startswith(PRO_PLAN_PREFIX)
+
+
+def get_billing_period_number(seat_created_at: str | None, period_days: int = 30) -> int:
+    if not seat_created_at:
+        return 0
+    try:
+        created = datetime.fromisoformat(seat_created_at)
+        elapsed = datetime.now(tz=UTC) - created
+        return max(0, elapsed.days // period_days)
+    except (ValueError, TypeError):
+        return 0
+
+
+def _is_in_trial(seat_created_at: str | None) -> bool:
+    if not seat_created_at:
+        return True
+    try:
+        created = datetime.fromisoformat(seat_created_at)
+        trial_days = get_settings().free_plan_trial_period_days
+        return datetime.now(tz=UTC) - created < timedelta(days=trial_days)
+    except (ValueError, TypeError):
+        return True
+
+
+async def resolve_plan_info(
+    request: Request,
+    user_id: int,
+    product: str,
+) -> PlanInfo:
+    """Resolve plan info, returning safe defaults if disabled or on failure."""
+    settings = get_settings()
+    if product != "posthog_code" or not settings.plan_aware_throttling_enabled:
+        return PlanInfo(plan_key=None, in_trial_period=True, seat_created_at=None)
+
+    plan_resolver: PlanResolver = request.app.state.plan_resolver
+    auth_header = request.headers.get("Authorization", "")
+    try:
+        return await plan_resolver.get_plan(
+            user_id=user_id,
+            auth_header=auth_header,
+        )
+    except Exception:
+        logger.warning("plan_resolve_failed", user_id=user_id)
+        return PlanInfo(plan_key=None, in_trial_period=True, seat_created_at=None)
+
+
+class PlanResolver:
+    def __init__(
+        self,
+        redis: Redis[bytes] | None,
+        http_client: httpx.AsyncClient,
+    ):
+        self._redis = redis
+        self._http = http_client
+
+    async def invalidate(self, user_id: int) -> None:
+        if not self._redis:
+            return
+        try:
+            await self._redis.delete(_redis_key(user_id))
+        except Exception:
+            logger.debug("plan_cache_invalidate_failed", user_id=user_id)
+
+    async def get_plan(self, user_id: int, auth_header: str) -> PlanInfo:
+        """Return the user's plan info, using cache when available."""
+        cached = await self._get_cached(user_id)
+        if cached is not None:
+            return cached
+
+        plan_key, seat_created_at = await self._fetch_plan(auth_header)
+        await self._set_cached(user_id, plan_key, seat_created_at)
+        return PlanInfo(
+            plan_key=plan_key,
+            in_trial_period=_is_in_trial(seat_created_at),
+            seat_created_at=seat_created_at,
+        )
+
+    async def _get_cached(self, user_id: int) -> PlanInfo | None:
+        if not self._redis:
+            return None
+        try:
+            val = await self._redis.get(_redis_key(user_id))
+            if val is not None:
+                data = json.loads(val.decode())
+                plan_key = data.get("plan_key") or None
+                seat_created_at = data.get("created_at")
+                return PlanInfo(
+                    plan_key=plan_key,
+                    in_trial_period=_is_in_trial(seat_created_at),
+                    seat_created_at=seat_created_at,
+                )
+        except Exception:
+            logger.debug("plan_cache_read_failed", user_id=user_id)
+        return None
+
+    async def _set_cached(self, user_id: int, plan_key: str | None, seat_created_at: str | None) -> None:
+        if not self._redis:
+            return
+        ttl = get_settings().plan_cache_ttl
+        try:
+            data = json.dumps({"plan_key": plan_key, "created_at": seat_created_at})
+            await self._redis.set(_redis_key(user_id), data, ex=ttl)
+        except Exception:
+            logger.debug("plan_cache_write_failed", user_id=user_id)
+
+    async def _fetch_plan(self, auth_header: str) -> tuple[str | None, str | None]:
+        """Call the PostHog API seats endpoint to get the user's plan."""
+        settings = get_settings()
+        if not settings.posthog_api_url:
+            return None, None
+
+        try:
+            url = f"{settings.posthog_api_url.rstrip('/')}/api/seats/me/"
+            resp = await self._http.get(
+                url,
+                params={"product_key": "posthog_code"},
+                headers={"Authorization": auth_header},
+                timeout=5.0,
+            )
+            if resp.status_code == 404:
+                return None, None
+            resp.raise_for_status()
+            data = resp.json()
+            return data.get("plan_key"), data.get("created_at")
+        except Exception:
+            logger.warning("seat_fetch_failed")
+            return None, None

--- a/services/llm-gateway/src/llm_gateway/services/plan_resolver.py
+++ b/services/llm-gateway/src/llm_gateway/services/plan_resolver.py
@@ -51,6 +51,8 @@ def get_billing_period_number(seat_created_at: str | None, period_days: int = 30
         return 0
     try:
         created = datetime.fromisoformat(seat_created_at)
+        if created.tzinfo is None:
+            created = created.replace(tzinfo=UTC)
         elapsed = datetime.now(tz=UTC) - created
         return max(0, elapsed.days // period_days)
     except (ValueError, TypeError):
@@ -62,6 +64,8 @@ def _is_in_trial(seat_created_at: str | None) -> bool:
         return True
     try:
         created = datetime.fromisoformat(seat_created_at)
+        if created.tzinfo is None:
+            created = created.replace(tzinfo=UTC)
         trial_days = get_settings().free_plan_trial_period_days
         return datetime.now(tz=UTC) - created < timedelta(days=trial_days)
     except (ValueError, TypeError):

--- a/services/llm-gateway/src/llm_gateway/services/plan_resolver.py
+++ b/services/llm-gateway/src/llm_gateway/services/plan_resolver.py
@@ -25,7 +25,8 @@ if TYPE_CHECKING:
 
 logger = structlog.get_logger(__name__)
 
-PLAN_CACHE_PREFIX = "plan:posthog_code"
+POSTHOG_CODE_PRODUCT = "posthog_code"
+PLAN_CACHE_PREFIX = f"plan:{POSTHOG_CODE_PRODUCT}"
 PRO_PLAN_PREFIX = "posthog-code-200"
 
 
@@ -79,7 +80,7 @@ async def resolve_plan_info(
 ) -> PlanInfo:
     """Resolve plan info, returning safe defaults if disabled or on failure."""
     settings = get_settings()
-    if product != "posthog_code" or not settings.plan_aware_throttling_enabled:
+    if product != POSTHOG_CODE_PRODUCT or not settings.plan_aware_throttling_enabled:
         return PlanInfo(plan_key=None, in_trial_period=True, seat_created_at=None)
 
     plan_resolver: PlanResolver = request.app.state.plan_resolver
@@ -174,7 +175,7 @@ class PlanResolver:
         url = f"{settings.posthog_api_url.rstrip('/')}/api/seats/me/"
         resp = await self._http.get(
             url,
-            params={"product_key": "posthog_code"},
+            params={"product_key": POSTHOG_CODE_PRODUCT},
             headers={"Authorization": auth_header},
             timeout=2.0,
         )

--- a/services/llm-gateway/src/llm_gateway/services/plan_resolver.py
+++ b/services/llm-gateway/src/llm_gateway/services/plan_resolver.py
@@ -113,11 +113,19 @@ class PlanResolver:
 
     async def get_plan(self, user_id: int, auth_header: str) -> PlanInfo:
         """Return the user's plan info, using cache when available."""
+        if not auth_header:
+            return PlanInfo(plan_key=None, in_trial_period=True, seat_created_at=None)
+
         cached = await self._get_cached(user_id)
         if cached is not None:
             return cached
 
-        plan_key, seat_created_at = await self._fetch_plan(auth_header)
+        try:
+            plan_key, seat_created_at = await self._fetch_plan(auth_header)
+        except Exception:
+            logger.warning("seat_fetch_failed", user_id=user_id, exc_info=True)
+            return PlanInfo(plan_key=None, in_trial_period=True, seat_created_at=None)
+
         await self._set_cached(user_id, plan_key, seat_created_at)
         return PlanInfo(
             plan_key=plan_key,
@@ -154,24 +162,24 @@ class PlanResolver:
             logger.debug("plan_cache_write_failed", user_id=user_id)
 
     async def _fetch_plan(self, auth_header: str) -> tuple[str | None, str | None]:
-        """Call the PostHog API seats endpoint to get the user's plan."""
+        """Call the PostHog API seats endpoint to get the user's plan.
+
+        Raises on transient HTTP failures so the caller can skip caching.
+        Returns (None, None) for legitimate "no plan" states (404, no API URL).
+        """
         settings = get_settings()
         if not settings.posthog_api_url:
             return None, None
 
-        try:
-            url = f"{settings.posthog_api_url.rstrip('/')}/api/seats/me/"
-            resp = await self._http.get(
-                url,
-                params={"product_key": "posthog_code"},
-                headers={"Authorization": auth_header},
-                timeout=2.0,
-            )
-            if resp.status_code == 404:
-                return None, None
-            resp.raise_for_status()
-            data = resp.json()
-            return data.get("plan_key"), data.get("created_at")
-        except Exception:
-            logger.warning("seat_fetch_failed", exc_info=True)
+        url = f"{settings.posthog_api_url.rstrip('/')}/api/seats/me/"
+        resp = await self._http.get(
+            url,
+            params={"product_key": "posthog_code"},
+            headers={"Authorization": auth_header},
+            timeout=2.0,
+        )
+        if resp.status_code == 404:
             return None, None
+        resp.raise_for_status()
+        data = resp.json()
+        return data.get("plan_key"), data.get("created_at")

--- a/services/llm-gateway/src/llm_gateway/services/plan_resolver.py
+++ b/services/llm-gateway/src/llm_gateway/services/plan_resolver.py
@@ -165,7 +165,7 @@ class PlanResolver:
                 url,
                 params={"product_key": "posthog_code"},
                 headers={"Authorization": auth_header},
-                timeout=5.0,
+                timeout=2.0,
             )
             if resp.status_code == 404:
                 return None, None
@@ -173,5 +173,5 @@ class PlanResolver:
             data = resp.json()
             return data.get("plan_key"), data.get("created_at")
         except Exception:
-            logger.warning("seat_fetch_failed")
+            logger.warning("seat_fetch_failed", exc_info=True)
             return None, None

--- a/services/llm-gateway/tests/conftest.py
+++ b/services/llm-gateway/tests/conftest.py
@@ -16,6 +16,7 @@ from llm_gateway.rate_limiting.cost_throttles import (
 )
 from llm_gateway.rate_limiting.runner import ThrottleRunner
 from llm_gateway.rate_limiting.throttles import Throttle
+from llm_gateway.services.plan_resolver import PlanInfo
 
 
 def create_test_app(
@@ -36,6 +37,9 @@ def create_test_app(
         app.state.db_pool = mock_db_pool
         app.state.redis = None
         app.state.throttle_runner = ThrottleRunner(throttles=throttles if throttles is not None else default_throttles)
+        app.state.http_client = MagicMock()
+        app.state.plan_resolver = AsyncMock()
+        app.state.plan_resolver.get_plan = AsyncMock(return_value=PlanInfo(plan_key=None, in_trial_period=True, seat_created_at=None))
         yield
 
     app = FastAPI(title="LLM Gateway Test", lifespan=test_lifespan)

--- a/services/llm-gateway/tests/conftest.py
+++ b/services/llm-gateway/tests/conftest.py
@@ -39,7 +39,9 @@ def create_test_app(
         app.state.throttle_runner = ThrottleRunner(throttles=throttles if throttles is not None else default_throttles)
         app.state.http_client = MagicMock()
         app.state.plan_resolver = AsyncMock()
-        app.state.plan_resolver.get_plan = AsyncMock(return_value=PlanInfo(plan_key=None, in_trial_period=True, seat_created_at=None))
+        app.state.plan_resolver.get_plan = AsyncMock(
+            return_value=PlanInfo(plan_key=None, in_trial_period=True, seat_created_at=None)
+        )
         yield
 
     app = FastAPI(title="LLM Gateway Test", lifespan=test_lifespan)

--- a/services/llm-gateway/tests/test_cost_throttles.py
+++ b/services/llm-gateway/tests/test_cost_throttles.py
@@ -19,6 +19,9 @@ def make_context(
     user: AuthenticatedUser | None = None,
     product: str = "posthog_code",
     end_user_id: str | None = None,
+    plan_key: str | None = None,
+    in_trial_period: bool = True,
+    seat_created_at: str | None = None,
 ) -> ThrottleContext:
     user = user or make_user()
     if end_user_id is None and user.auth_method == "oauth_access_token":
@@ -27,6 +30,9 @@ def make_context(
         user=user,
         product=product,
         end_user_id=end_user_id,
+        plan_key=plan_key,
+        in_trial_period=in_trial_period,
+        seat_created_at=seat_created_at,
     )
 
 
@@ -304,6 +310,71 @@ class TestUserCostSustainedThrottle:
 
         key = throttle._get_cache_key(context)
         assert key == "cost:user:user_cost_sustained:posthog_code:42"
+
+    @pytest.mark.asyncio
+    async def test_cache_key_includes_period_for_free_plan(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from datetime import UTC, datetime, timedelta
+
+        monkeypatch.setenv("LLM_GATEWAY_PLAN_AWARE_THROTTLING_ENABLED", "true")
+        get_settings.cache_clear()
+        from llm_gateway.rate_limiting.cost_throttles import UserCostSustainedThrottle
+
+        throttle = UserCostSustainedThrottle(redis=None)
+        created = (datetime.now(tz=UTC) - timedelta(days=5)).isoformat()
+        context = make_context(
+            product="posthog_code",
+            end_user_id="42",
+            plan_key="posthog-code-free-20260301",
+            in_trial_period=True,
+            seat_created_at=created,
+        )
+
+        key = throttle._get_cache_key(context)
+        assert key == "cost:user:user_cost_sustained:posthog_code:42:period:0"
+        get_settings.cache_clear()
+
+    @pytest.mark.asyncio
+    async def test_cache_key_period_increments_after_period_days(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from datetime import UTC, datetime, timedelta
+
+        monkeypatch.setenv("LLM_GATEWAY_PLAN_AWARE_THROTTLING_ENABLED", "true")
+        get_settings.cache_clear()
+        from llm_gateway.rate_limiting.cost_throttles import UserCostSustainedThrottle
+
+        throttle = UserCostSustainedThrottle(redis=None)
+        created = (datetime.now(tz=UTC) - timedelta(days=35)).isoformat()
+        context = make_context(
+            product="posthog_code",
+            end_user_id="42",
+            plan_key="posthog-code-free-20260301",
+            in_trial_period=False,
+            seat_created_at=created,
+        )
+
+        key = throttle._get_cache_key(context)
+        assert key == "cost:user:user_cost_sustained:posthog_code:42:period:1"
+        get_settings.cache_clear()
+
+    @pytest.mark.asyncio
+    async def test_cache_key_no_period_for_pro_plan(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from datetime import UTC, datetime, timedelta
+
+        monkeypatch.setenv("LLM_GATEWAY_PLAN_AWARE_THROTTLING_ENABLED", "true")
+        get_settings.cache_clear()
+        from llm_gateway.rate_limiting.cost_throttles import UserCostSustainedThrottle
+
+        throttle = UserCostSustainedThrottle(redis=None)
+        created = (datetime.now(tz=UTC) - timedelta(days=5)).isoformat()
+        context = make_context(
+            product="posthog_code",
+            end_user_id="42",
+            plan_key="posthog-code-200-20260301",
+            seat_created_at=created,
+        )
+
+        key = throttle._get_cache_key(context)
+        assert key == "cost:user:user_cost_sustained:posthog_code:42"
+        get_settings.cache_clear()
 
 
 class TestBurstSustainedInteraction:
@@ -959,6 +1030,103 @@ class TestRateLimitPoisoningPrevention:
         assert attacker_key != victim_key
         assert ":999" in attacker_key
         assert ":42" in victim_key
+
+
+class TestPlanAwareThrottling:
+    @pytest.fixture(autouse=True)
+    def enable_plan_throttling(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("LLM_GATEWAY_PLAN_AWARE_THROTTLING_ENABLED", "true")
+        get_settings.cache_clear()
+        yield
+        get_settings.cache_clear()
+
+    @pytest.mark.asyncio
+    async def test_trial_user_gets_burst_limit_of_5(self) -> None:
+        from llm_gateway.rate_limiting.cost_throttles import UserCostBurstThrottle
+
+        throttle = UserCostBurstThrottle(redis=None)
+        context = make_context(product="posthog_code", plan_key=None, in_trial_period=True)
+
+        await throttle.record_cost(context, 5.0)
+        result = await throttle.allow_request(context)
+        assert result.allowed is False
+
+    @pytest.mark.asyncio
+    async def test_trial_user_gets_sustained_limit_of_50(self) -> None:
+        from llm_gateway.rate_limiting.cost_throttles import UserCostSustainedThrottle
+
+        throttle = UserCostSustainedThrottle(redis=None)
+        context = make_context(product="posthog_code", plan_key=None, in_trial_period=True)
+
+        await throttle.record_cost(context, 50.0)
+        result = await throttle.allow_request(context)
+        assert result.allowed is False
+
+    @pytest.mark.asyncio
+    async def test_expired_trial_user_gets_zero_limit(self) -> None:
+        from llm_gateway.rate_limiting.cost_throttles import UserCostBurstThrottle
+
+        throttle = UserCostBurstThrottle(redis=None)
+        context = make_context(product="posthog_code", plan_key=None, in_trial_period=False)
+
+        result = await throttle.allow_request(context)
+        assert result.allowed is False
+
+    @pytest.mark.asyncio
+    async def test_expired_trial_sustained_also_zero(self) -> None:
+        from llm_gateway.rate_limiting.cost_throttles import UserCostSustainedThrottle
+
+        throttle = UserCostSustainedThrottle(redis=None)
+        context = make_context(product="posthog_code", plan_key=None, in_trial_period=False)
+
+        result = await throttle.allow_request(context)
+        assert result.allowed is False
+
+    @pytest.mark.asyncio
+    async def test_pro_plan_allows_higher_usage(self) -> None:
+        from llm_gateway.rate_limiting.cost_throttles import UserCostBurstThrottle
+
+        throttle = UserCostBurstThrottle(redis=None)
+        context = make_context(product="posthog_code", plan_key="posthog-code-200-20260301")
+
+        await throttle.record_cost(context, 50.0)
+        result = await throttle.allow_request(context)
+        assert result.allowed is True
+
+    @pytest.mark.asyncio
+    async def test_free_plan_key_gets_trial_limits(self) -> None:
+        from llm_gateway.rate_limiting.cost_throttles import UserCostBurstThrottle
+
+        throttle = UserCostBurstThrottle(redis=None)
+        context = make_context(product="posthog_code", plan_key="posthog-code-free-20260301", in_trial_period=True)
+
+        await throttle.record_cost(context, 4.0)
+        result = await throttle.allow_request(context)
+        assert result.allowed is True
+
+    @pytest.mark.asyncio
+    async def test_non_code_product_ignores_plan(self) -> None:
+        from llm_gateway.rate_limiting.cost_throttles import UserCostBurstThrottle
+
+        throttle = UserCostBurstThrottle(redis=None)
+        context = make_context(product="wizard", plan_key=None)
+
+        await throttle.record_cost(context, 50.0)
+        result = await throttle.allow_request(context)
+        assert result.allowed is True
+
+    @pytest.mark.asyncio
+    async def test_flag_off_skips_plan_limits(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("LLM_GATEWAY_PLAN_AWARE_THROTTLING_ENABLED", "false")
+        get_settings.cache_clear()
+        from llm_gateway.rate_limiting.cost_throttles import UserCostBurstThrottle
+
+        throttle = UserCostBurstThrottle(redis=None)
+        context = make_context(product="posthog_code", plan_key=None)
+
+        await throttle.record_cost(context, 50.0)
+        result = await throttle.allow_request(context)
+        assert result.allowed is True
 
 
 class TestCostAccumulatorTTL:

--- a/services/llm-gateway/tests/test_cost_throttles.py
+++ b/services/llm-gateway/tests/test_cost_throttles.py
@@ -1,3 +1,5 @@
+from collections.abc import Iterator
+
 import pytest
 
 from llm_gateway.auth.models import AuthenticatedUser
@@ -1034,7 +1036,7 @@ class TestRateLimitPoisoningPrevention:
 
 class TestPlanAwareThrottling:
     @pytest.fixture(autouse=True)
-    def enable_plan_throttling(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def enable_plan_throttling(self, monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
         monkeypatch.setenv("LLM_GATEWAY_PLAN_AWARE_THROTTLING_ENABLED", "true")
         get_settings.cache_clear()
         yield

--- a/services/llm-gateway/tests/test_cost_throttles.py
+++ b/services/llm-gateway/tests/test_cost_throttles.py
@@ -304,7 +304,9 @@ class TestUserCostSustainedThrottle:
         get_settings.cache_clear()
 
     @pytest.mark.asyncio
-    async def test_cache_key_includes_product_and_scope(self) -> None:
+    async def test_cache_key_includes_product_and_scope(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("LLM_GATEWAY_PLAN_AWARE_THROTTLING_ENABLED", "false")
+        get_settings.cache_clear()
         from llm_gateway.rate_limiting.cost_throttles import UserCostSustainedThrottle
 
         throttle = UserCostSustainedThrottle(redis=None)
@@ -312,6 +314,7 @@ class TestUserCostSustainedThrottle:
 
         key = throttle._get_cache_key(context)
         assert key == "cost:user:user_cost_sustained:posthog_code:42"
+        get_settings.cache_clear()
 
     @pytest.mark.asyncio
     async def test_cache_key_includes_period_for_free_plan(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -358,7 +361,7 @@ class TestUserCostSustainedThrottle:
         get_settings.cache_clear()
 
     @pytest.mark.asyncio
-    async def test_cache_key_no_period_for_pro_plan(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    async def test_cache_key_includes_period_for_pro_plan(self, monkeypatch: pytest.MonkeyPatch) -> None:
         from datetime import UTC, datetime, timedelta
 
         monkeypatch.setenv("LLM_GATEWAY_PLAN_AWARE_THROTTLING_ENABLED", "true")
@@ -375,7 +378,7 @@ class TestUserCostSustainedThrottle:
         )
 
         key = throttle._get_cache_key(context)
-        assert key == "cost:user:user_cost_sustained:posthog_code:42"
+        assert key == "cost:user:user_cost_sustained:posthog_code:42:period:0"
         get_settings.cache_clear()
 
 

--- a/services/llm-gateway/tests/test_cost_throttles.py
+++ b/services/llm-gateway/tests/test_cost_throttles.py
@@ -21,7 +21,7 @@ def make_context(
     user: AuthenticatedUser | None = None,
     product: str = "posthog_code",
     end_user_id: str | None = None,
-    plan_key: str | None = None,
+    plan_key: str | None = "posthog-code-200-20260301",
     in_trial_period: bool = True,
     seat_created_at: str | None = None,
 ) -> ThrottleContext:
@@ -307,13 +307,11 @@ class TestUserCostSustainedThrottle:
     async def test_cache_key_includes_product_and_scope(self) -> None:
         from llm_gateway.rate_limiting.cost_throttles import UserCostSustainedThrottle
 
-        get_settings.cache_clear()
         throttle = UserCostSustainedThrottle(redis=None)
         context = make_context(product="posthog_code", end_user_id="42")
 
         key = throttle._get_cache_key(context)
         assert key == "cost:user:user_cost_sustained:posthog_code:42"
-        get_settings.cache_clear()
 
     @pytest.mark.asyncio
     async def test_cache_key_includes_period_for_free_plan(self, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/services/llm-gateway/tests/test_cost_throttles.py
+++ b/services/llm-gateway/tests/test_cost_throttles.py
@@ -307,11 +307,13 @@ class TestUserCostSustainedThrottle:
     async def test_cache_key_includes_product_and_scope(self) -> None:
         from llm_gateway.rate_limiting.cost_throttles import UserCostSustainedThrottle
 
+        get_settings.cache_clear()
         throttle = UserCostSustainedThrottle(redis=None)
         context = make_context(product="posthog_code", end_user_id="42")
 
         key = throttle._get_cache_key(context)
         assert key == "cost:user:user_cost_sustained:posthog_code:42"
+        get_settings.cache_clear()
 
     @pytest.mark.asyncio
     async def test_cache_key_includes_period_for_free_plan(self, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/services/llm-gateway/tests/test_plan_resolver.py
+++ b/services/llm-gateway/tests/test_plan_resolver.py
@@ -109,7 +109,8 @@ class TestPlanResolver:
         import json
 
         cached = json.dumps({"plan_key": "posthog-code-200-20260301", "created_at": None})
-        resolver_with_redis._redis.get = AsyncMock(return_value=cached.encode())
+        assert resolver_with_redis._redis is not None
+        resolver_with_redis._redis.get = AsyncMock(return_value=cached.encode())  # type: ignore[method-assign]
         with patch("llm_gateway.services.plan_resolver.get_settings") as mock_settings:
             mock_settings.return_value.free_plan_trial_period_days = 30
             result = await resolver_with_redis.get_plan(user_id=1, auth_header="Bearer phx_test")
@@ -119,7 +120,8 @@ class TestPlanResolver:
         import json
 
         cached = json.dumps({"plan_key": None, "created_at": None})
-        resolver_with_redis._redis.get = AsyncMock(return_value=cached.encode())
+        assert resolver_with_redis._redis is not None
+        resolver_with_redis._redis.get = AsyncMock(return_value=cached.encode())  # type: ignore[method-assign]
         with patch("llm_gateway.services.plan_resolver.get_settings") as mock_settings:
             mock_settings.return_value.free_plan_trial_period_days = 30
             result = await resolver_with_redis.get_plan(user_id=1, auth_header="Bearer phx_test")
@@ -131,7 +133,8 @@ class TestPlanResolver:
 
         old_date = (datetime.now(tz=UTC) - timedelta(days=60)).isoformat()
         cached = json.dumps({"plan_key": "posthog-code-free-20260301", "created_at": old_date})
-        resolver_with_redis._redis.get = AsyncMock(return_value=cached.encode())
+        assert resolver_with_redis._redis is not None
+        resolver_with_redis._redis.get = AsyncMock(return_value=cached.encode())  # type: ignore[method-assign]
         with patch("llm_gateway.services.plan_resolver.get_settings") as mock_settings:
             mock_settings.return_value.free_plan_trial_period_days = 30
             result = await resolver_with_redis.get_plan(user_id=1, auth_header="Bearer phx_test")
@@ -144,7 +147,7 @@ class TestPlanResolver:
         mock_resp.status_code = 200
         mock_resp.json.return_value = {"plan_key": "posthog-code-200-20260301", "created_at": created_at}
         mock_resp.raise_for_status = MagicMock()
-        resolver_with_redis._http.get = AsyncMock(return_value=mock_resp)
+        resolver_with_redis._http.get = AsyncMock(return_value=mock_resp)  # type: ignore[method-assign]
 
         with patch("llm_gateway.services.plan_resolver.get_settings") as mock_settings:
             mock_settings.return_value.posthog_api_url = "https://app.posthog.com"
@@ -154,9 +157,10 @@ class TestPlanResolver:
 
         assert result.plan_key == "posthog-code-200-20260301"
         assert result.in_trial_period is True
-        resolver_with_redis._redis.set.assert_called_once()
+        assert resolver_with_redis._redis is not None
+        resolver_with_redis._redis.set.assert_called_once()  # type: ignore[union-attr]
 
-        resolver_with_redis._http.get.assert_called_once_with(
+        resolver_with_redis._http.get.assert_called_once_with(  # type: ignore[union-attr]
             "https://app.posthog.com/api/seats/me/",
             params={"product_key": "posthog_code"},
             headers={"Authorization": "Bearer phx_test"},
@@ -168,7 +172,7 @@ class TestPlanResolver:
         mock_resp.status_code = 200
         mock_resp.json.return_value = {"plan_key": None, "created_at": None}
         mock_resp.raise_for_status = MagicMock()
-        resolver._http.get = AsyncMock(return_value=mock_resp)
+        resolver._http.get = AsyncMock(return_value=mock_resp)  # type: ignore[method-assign]
 
         with patch("llm_gateway.services.plan_resolver.get_settings") as mock_settings:
             mock_settings.return_value.posthog_api_url = "https://app.posthog.com"
@@ -176,14 +180,14 @@ class TestPlanResolver:
             mock_settings.return_value.free_plan_trial_period_days = 30
             await resolver.get_plan(user_id=1, auth_header="Bearer phx_mysecretkey")
 
-        resolver._http.get.assert_called_once()
-        call_kwargs = resolver._http.get.call_args
+        resolver._http.get.assert_called_once()  # type: ignore[union-attr]
+        call_kwargs = resolver._http.get.call_args  # type: ignore[union-attr]
         assert call_kwargs.kwargs["headers"]["Authorization"] == "Bearer phx_mysecretkey"
 
     async def test_404_returns_none_plan(self, resolver: PlanResolver) -> None:
         mock_resp = MagicMock()
         mock_resp.status_code = 404
-        resolver._http.get = AsyncMock(return_value=mock_resp)
+        resolver._http.get = AsyncMock(return_value=mock_resp)  # type: ignore[method-assign]
 
         with patch("llm_gateway.services.plan_resolver.get_settings") as mock_settings:
             mock_settings.return_value.posthog_api_url = "https://app.posthog.com"
@@ -195,7 +199,7 @@ class TestPlanResolver:
         assert result.in_trial_period is True
 
     async def test_api_error_returns_none_plan(self, resolver: PlanResolver) -> None:
-        resolver._http.get = AsyncMock(side_effect=Exception("connection refused"))
+        resolver._http.get = AsyncMock(side_effect=Exception("connection refused"))  # type: ignore[method-assign]
 
         with patch("llm_gateway.services.plan_resolver.get_settings") as mock_settings:
             mock_settings.return_value.posthog_api_url = "https://app.posthog.com"

--- a/services/llm-gateway/tests/test_plan_resolver.py
+++ b/services/llm-gateway/tests/test_plan_resolver.py
@@ -158,9 +158,9 @@ class TestPlanResolver:
         assert result.plan_key == "posthog-code-200-20260301"
         assert result.in_trial_period is True
         assert resolver_with_redis._redis is not None
-        resolver_with_redis._redis.set.assert_called_once()  # type: ignore[union-attr]
+        resolver_with_redis._redis.set.assert_called_once()  # type: ignore[attr-defined]
 
-        resolver_with_redis._http.get.assert_called_once_with(  # type: ignore[union-attr]
+        resolver_with_redis._http.get.assert_called_once_with(
             "https://app.posthog.com/api/seats/me/",
             params={"product_key": "posthog_code"},
             headers={"Authorization": "Bearer phx_test"},
@@ -180,8 +180,8 @@ class TestPlanResolver:
             mock_settings.return_value.free_plan_trial_period_days = 30
             await resolver.get_plan(user_id=1, auth_header="Bearer phx_mysecretkey")
 
-        resolver._http.get.assert_called_once()  # type: ignore[union-attr]
-        call_kwargs = resolver._http.get.call_args  # type: ignore[union-attr]
+        resolver._http.get.assert_called_once()
+        call_kwargs = resolver._http.get.call_args
         assert call_kwargs.kwargs["headers"]["Authorization"] == "Bearer phx_mysecretkey"
 
     async def test_404_returns_none_plan(self, resolver: PlanResolver) -> None:

--- a/services/llm-gateway/tests/test_plan_resolver.py
+++ b/services/llm-gateway/tests/test_plan_resolver.py
@@ -1,0 +1,207 @@
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from llm_gateway.services.plan_resolver import (
+    PlanResolver,
+    _is_in_trial,
+    get_billing_period_number,
+    is_pro_plan,
+)
+
+
+class TestIsProPlan:
+    @pytest.mark.parametrize(
+        "plan_key,expected",
+        [
+            ("posthog-code-200-20260301", True),
+            ("posthog-code-200-20260501", True),
+            ("posthog-code-free-20260301", False),
+            ("posthog-code-free-20260501", False),
+            ("some-other-plan", False),
+            (None, False),
+            ("", False),
+        ],
+    )
+    def test_is_pro_plan(self, plan_key: str | None, expected: bool) -> None:
+        assert is_pro_plan(plan_key) is expected
+
+
+class TestIsInTrial:
+    def test_none_created_at_is_trial(self) -> None:
+        assert _is_in_trial(None) is True
+
+    def test_recent_date_is_trial(self) -> None:
+        recent = (datetime.now(tz=UTC) - timedelta(days=5)).isoformat()
+        assert _is_in_trial(recent) is True
+
+    def test_old_date_is_not_trial(self) -> None:
+        old = (datetime.now(tz=UTC) - timedelta(days=60)).isoformat()
+        assert _is_in_trial(old) is False
+
+    def test_exactly_30_days_is_not_trial(self) -> None:
+        boundary = (datetime.now(tz=UTC) - timedelta(days=30, seconds=1)).isoformat()
+        assert _is_in_trial(boundary) is False
+
+    def test_just_under_30_days_is_trial(self) -> None:
+        boundary = (datetime.now(tz=UTC) - timedelta(days=29, hours=23)).isoformat()
+        assert _is_in_trial(boundary) is True
+
+    def test_invalid_date_string_is_trial(self) -> None:
+        assert _is_in_trial("not-a-date") is True
+
+
+class TestGetBillingPeriodNumber:
+    def test_none_returns_zero(self) -> None:
+        assert get_billing_period_number(None) == 0
+
+    def test_invalid_date_returns_zero(self) -> None:
+        assert get_billing_period_number("not-a-date") == 0
+
+    def test_today_returns_zero(self) -> None:
+        now = datetime.now(tz=UTC).isoformat()
+        assert get_billing_period_number(now) == 0
+
+    def test_five_days_ago_returns_zero(self) -> None:
+        created = (datetime.now(tz=UTC) - timedelta(days=5)).isoformat()
+        assert get_billing_period_number(created) == 0
+
+    def test_thirty_days_returns_one(self) -> None:
+        created = (datetime.now(tz=UTC) - timedelta(days=30)).isoformat()
+        assert get_billing_period_number(created) == 1
+
+    def test_sixty_days_returns_two(self) -> None:
+        created = (datetime.now(tz=UTC) - timedelta(days=60)).isoformat()
+        assert get_billing_period_number(created) == 2
+
+    def test_custom_period_days(self) -> None:
+        created = (datetime.now(tz=UTC) - timedelta(days=15)).isoformat()
+        assert get_billing_period_number(created, period_days=7) == 2
+
+    def test_just_under_boundary(self) -> None:
+        created = (datetime.now(tz=UTC) - timedelta(days=29, hours=23)).isoformat()
+        assert get_billing_period_number(created) == 0
+
+
+class TestPlanResolver:
+    @pytest.fixture
+    def resolver(self) -> PlanResolver:
+        return PlanResolver(redis=None, http_client=AsyncMock())
+
+    @pytest.fixture
+    def resolver_with_redis(self) -> PlanResolver:
+        redis = AsyncMock()
+        redis.get = AsyncMock(return_value=None)
+        redis.set = AsyncMock()
+        return PlanResolver(redis=redis, http_client=AsyncMock())
+
+    async def test_returns_none_plan_when_no_api_url(self, resolver: PlanResolver) -> None:
+        with patch("llm_gateway.services.plan_resolver.get_settings") as mock_settings:
+            mock_settings.return_value.posthog_api_url = ""
+            mock_settings.return_value.plan_cache_ttl = 300
+            mock_settings.return_value.free_plan_trial_period_days = 30
+            result = await resolver.get_plan(user_id=1, auth_header="Bearer phx_test")
+        assert result.plan_key is None
+        assert result.in_trial_period is True
+
+    async def test_returns_cached_plan(self, resolver_with_redis: PlanResolver) -> None:
+        import json
+
+        cached = json.dumps({"plan_key": "posthog-code-200-20260301", "created_at": None})
+        resolver_with_redis._redis.get = AsyncMock(return_value=cached.encode())
+        with patch("llm_gateway.services.plan_resolver.get_settings") as mock_settings:
+            mock_settings.return_value.free_plan_trial_period_days = 30
+            result = await resolver_with_redis.get_plan(user_id=1, auth_header="Bearer phx_test")
+        assert result.plan_key == "posthog-code-200-20260301"
+
+    async def test_cached_null_plan_returns_none_plan_key(self, resolver_with_redis: PlanResolver) -> None:
+        import json
+
+        cached = json.dumps({"plan_key": None, "created_at": None})
+        resolver_with_redis._redis.get = AsyncMock(return_value=cached.encode())
+        with patch("llm_gateway.services.plan_resolver.get_settings") as mock_settings:
+            mock_settings.return_value.free_plan_trial_period_days = 30
+            result = await resolver_with_redis.get_plan(user_id=1, auth_header="Bearer phx_test")
+        assert result.plan_key is None
+        assert result.in_trial_period is True
+
+    async def test_cached_old_seat_is_not_trial(self, resolver_with_redis: PlanResolver) -> None:
+        import json
+
+        old_date = (datetime.now(tz=UTC) - timedelta(days=60)).isoformat()
+        cached = json.dumps({"plan_key": "posthog-code-free-20260301", "created_at": old_date})
+        resolver_with_redis._redis.get = AsyncMock(return_value=cached.encode())
+        with patch("llm_gateway.services.plan_resolver.get_settings") as mock_settings:
+            mock_settings.return_value.free_plan_trial_period_days = 30
+            result = await resolver_with_redis.get_plan(user_id=1, auth_header="Bearer phx_test")
+        assert result.plan_key == "posthog-code-free-20260301"
+        assert result.in_trial_period is False
+
+    async def test_fetches_from_api_and_caches(self, resolver_with_redis: PlanResolver) -> None:
+        created_at = datetime.now(tz=UTC).isoformat()
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {"plan_key": "posthog-code-200-20260301", "created_at": created_at}
+        mock_resp.raise_for_status = MagicMock()
+        resolver_with_redis._http.get = AsyncMock(return_value=mock_resp)
+
+        with patch("llm_gateway.services.plan_resolver.get_settings") as mock_settings:
+            mock_settings.return_value.posthog_api_url = "https://app.posthog.com"
+            mock_settings.return_value.plan_cache_ttl = 300
+            mock_settings.return_value.free_plan_trial_period_days = 30
+            result = await resolver_with_redis.get_plan(user_id=1, auth_header="Bearer phx_test")
+
+        assert result.plan_key == "posthog-code-200-20260301"
+        assert result.in_trial_period is True
+        resolver_with_redis._redis.set.assert_called_once()
+
+        resolver_with_redis._http.get.assert_called_once_with(
+            "https://app.posthog.com/api/seats/me/",
+            params={"product_key": "posthog_code"},
+            headers={"Authorization": "Bearer phx_test"},
+            timeout=5.0,
+        )
+
+    async def test_forwards_auth_header(self, resolver: PlanResolver) -> None:
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {"plan_key": None, "created_at": None}
+        mock_resp.raise_for_status = MagicMock()
+        resolver._http.get = AsyncMock(return_value=mock_resp)
+
+        with patch("llm_gateway.services.plan_resolver.get_settings") as mock_settings:
+            mock_settings.return_value.posthog_api_url = "https://app.posthog.com"
+            mock_settings.return_value.plan_cache_ttl = 300
+            mock_settings.return_value.free_plan_trial_period_days = 30
+            await resolver.get_plan(user_id=1, auth_header="Bearer phx_mysecretkey")
+
+        resolver._http.get.assert_called_once()
+        call_kwargs = resolver._http.get.call_args
+        assert call_kwargs.kwargs["headers"]["Authorization"] == "Bearer phx_mysecretkey"
+
+    async def test_404_returns_none_plan(self, resolver: PlanResolver) -> None:
+        mock_resp = MagicMock()
+        mock_resp.status_code = 404
+        resolver._http.get = AsyncMock(return_value=mock_resp)
+
+        with patch("llm_gateway.services.plan_resolver.get_settings") as mock_settings:
+            mock_settings.return_value.posthog_api_url = "https://app.posthog.com"
+            mock_settings.return_value.plan_cache_ttl = 300
+            mock_settings.return_value.free_plan_trial_period_days = 30
+            result = await resolver.get_plan(user_id=1, auth_header="Bearer phx_test")
+
+        assert result.plan_key is None
+        assert result.in_trial_period is True
+
+    async def test_api_error_returns_none_plan(self, resolver: PlanResolver) -> None:
+        resolver._http.get = AsyncMock(side_effect=Exception("connection refused"))
+
+        with patch("llm_gateway.services.plan_resolver.get_settings") as mock_settings:
+            mock_settings.return_value.posthog_api_url = "https://app.posthog.com"
+            mock_settings.return_value.plan_cache_ttl = 300
+            mock_settings.return_value.free_plan_trial_period_days = 30
+            result = await resolver.get_plan(user_id=1, auth_header="Bearer phx_test")
+
+        assert result.plan_key is None
+        assert result.in_trial_period is True

--- a/services/llm-gateway/tests/test_plan_resolver.py
+++ b/services/llm-gateway/tests/test_plan_resolver.py
@@ -209,3 +209,23 @@ class TestPlanResolver:
 
         assert result.plan_key is None
         assert result.in_trial_period is True
+
+    async def test_empty_auth_header_skips_fetch(self, resolver: PlanResolver) -> None:
+        result = await resolver.get_plan(user_id=1, auth_header="")
+        assert result.plan_key is None
+        assert result.in_trial_period is True
+        resolver._http.get.assert_not_called()
+
+    async def test_api_error_not_cached(self, resolver_with_redis: PlanResolver) -> None:
+        resolver_with_redis._http.get = AsyncMock(side_effect=Exception("connection refused"))  # type: ignore[method-assign]
+
+        with patch("llm_gateway.services.plan_resolver.get_settings") as mock_settings:
+            mock_settings.return_value.posthog_api_url = "https://app.posthog.com"
+            mock_settings.return_value.plan_cache_ttl = 300
+            mock_settings.return_value.free_plan_trial_period_days = 30
+            result = await resolver_with_redis.get_plan(user_id=1, auth_header="Bearer phx_test")
+
+        assert result.plan_key is None
+        assert result.in_trial_period is True
+        assert resolver_with_redis._redis is not None
+        resolver_with_redis._redis.set.assert_not_called()  # type: ignore[attr-defined]

--- a/services/llm-gateway/tests/test_plan_resolver.py
+++ b/services/llm-gateway/tests/test_plan_resolver.py
@@ -214,7 +214,7 @@ class TestPlanResolver:
         result = await resolver.get_plan(user_id=1, auth_header="")
         assert result.plan_key is None
         assert result.in_trial_period is True
-        resolver._http.get.assert_not_called()
+        resolver._http.get.assert_not_called()  # type: ignore[attr-defined]
 
     async def test_api_error_not_cached(self, resolver_with_redis: PlanResolver) -> None:
         resolver_with_redis._http.get = AsyncMock(side_effect=Exception("connection refused"))  # type: ignore[method-assign]

--- a/services/llm-gateway/tests/test_plan_resolver.py
+++ b/services/llm-gateway/tests/test_plan_resolver.py
@@ -164,7 +164,7 @@ class TestPlanResolver:
             "https://app.posthog.com/api/seats/me/",
             params={"product_key": "posthog_code"},
             headers={"Authorization": "Bearer phx_test"},
-            timeout=5.0,
+            timeout=2.0,
         )
 
     async def test_forwards_auth_header(self, resolver: PlanResolver) -> None:

--- a/services/llm-gateway/tests/test_usage.py
+++ b/services/llm-gateway/tests/test_usage.py
@@ -129,8 +129,8 @@ class TestUsageEndpoint:
             end_user_id="42",
         )
 
-        burst_throttle = next(t for t in runner._throttles if isinstance(t, UserCostBurstThrottle))
-        sustained_throttle = next(t for t in runner._throttles if isinstance(t, UserCostSustainedThrottle))
+        burst_throttle = next(t for t in runner.throttles if isinstance(t, UserCostBurstThrottle))
+        sustained_throttle = next(t for t in runner.throttles if isinstance(t, UserCostSustainedThrottle))
 
         import asyncio
 
@@ -162,7 +162,7 @@ class TestUsageEndpoint:
             end_user_id="42",
         )
 
-        burst_throttle = next(t for t in runner._throttles if isinstance(t, UserCostBurstThrottle))
+        burst_throttle = next(t for t in runner.throttles if isinstance(t, UserCostBurstThrottle))
 
         import asyncio
 

--- a/services/llm-gateway/tests/test_usage.py
+++ b/services/llm-gateway/tests/test_usage.py
@@ -1,0 +1,187 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+from llm_gateway.config import get_settings
+from llm_gateway.rate_limiting.cost_throttles import (
+    UserCostBurstThrottle,
+    UserCostSustainedThrottle,
+)
+from llm_gateway.rate_limiting.throttles import ThrottleContext
+from llm_gateway.services.plan_resolver import PlanInfo
+from tests.conftest import create_test_app
+
+
+class TestUsageEndpoint:
+    @pytest.fixture
+    def authenticated_usage_client(self, mock_db_pool: MagicMock) -> TestClient:
+        app = create_test_app(mock_db_pool)
+
+        conn = AsyncMock()
+        conn.fetchrow = AsyncMock(
+            return_value={
+                "id": "key_id",
+                "user_id": 42,
+                "scopes": ["llm_gateway:read"],
+                "current_team_id": 1,
+                "distinct_id": "test-distinct-id",
+            }
+        )
+        mock_db_pool.acquire = AsyncMock(return_value=conn)
+        mock_db_pool.release = AsyncMock()
+
+        with TestClient(app) as c:
+            yield c
+
+    def test_returns_pro_limits_when_flag_off(self, authenticated_usage_client: TestClient) -> None:
+        response = authenticated_usage_client.get(
+            "/v1/usage/posthog_code",
+            headers={"Authorization": "Bearer phx_test"},
+        )
+        assert response.status_code == 200
+        data = response.json()
+
+        assert data["product"] == "posthog_code"
+        assert data["user_id"] == 42
+        assert data["burst"]["limit_usd"] == 100.0
+        assert data["sustained"]["limit_usd"] == 1000.0
+        assert data["is_rate_limited"] is False
+
+    def test_returns_trial_limits_when_flag_on(
+        self, authenticated_usage_client: TestClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("LLM_GATEWAY_PLAN_AWARE_THROTTLING_ENABLED", "true")
+        get_settings.cache_clear()
+
+        app = authenticated_usage_client.app
+        app.state.plan_resolver.get_plan = AsyncMock(
+            return_value=PlanInfo(plan_key=None, in_trial_period=True, seat_created_at=None)
+        )
+
+        response = authenticated_usage_client.get(
+            "/v1/usage/posthog_code",
+            headers={"Authorization": "Bearer phx_test"},
+        )
+        assert response.status_code == 200
+        data = response.json()
+
+        assert data["burst"]["limit_usd"] == 5.0
+        assert data["sustained"]["limit_usd"] == 50.0
+        get_settings.cache_clear()
+
+    def test_returns_zero_limits_when_trial_expired(
+        self, authenticated_usage_client: TestClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("LLM_GATEWAY_PLAN_AWARE_THROTTLING_ENABLED", "true")
+        get_settings.cache_clear()
+
+        app = authenticated_usage_client.app
+        app.state.plan_resolver.get_plan = AsyncMock(
+            return_value=PlanInfo(plan_key="posthog-code-free-20260301", in_trial_period=False, seat_created_at=None)
+        )
+
+        response = authenticated_usage_client.get(
+            "/v1/usage/posthog_code",
+            headers={"Authorization": "Bearer phx_test"},
+        )
+        assert response.status_code == 200
+        data = response.json()
+
+        assert data["burst"]["limit_usd"] == 0.0
+        assert data["sustained"]["limit_usd"] == 0.0
+        assert data["is_rate_limited"] is True
+        get_settings.cache_clear()
+
+    def test_returns_pro_limits_with_pro_plan(
+        self, authenticated_usage_client: TestClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("LLM_GATEWAY_PLAN_AWARE_THROTTLING_ENABLED", "true")
+        get_settings.cache_clear()
+
+        app = authenticated_usage_client.app
+        app.state.plan_resolver.get_plan = AsyncMock(
+            return_value=PlanInfo(plan_key="posthog-code-200-20260301", in_trial_period=False, seat_created_at=None)
+        )
+
+        response = authenticated_usage_client.get(
+            "/v1/usage/posthog_code",
+            headers={"Authorization": "Bearer phx_test"},
+        )
+        assert response.status_code == 200
+        data = response.json()
+
+        assert data["burst"]["limit_usd"] == 100.0
+        assert data["sustained"]["limit_usd"] == 1000.0
+        get_settings.cache_clear()
+
+    def test_returns_401_without_auth(self, client: TestClient) -> None:
+        response = client.get("/v1/usage/posthog_code")
+        assert response.status_code == 401
+
+    def test_reflects_accumulated_cost(self, authenticated_usage_client: TestClient) -> None:
+        app = authenticated_usage_client.app
+        runner = app.state.throttle_runner
+
+        context = ThrottleContext(
+            user=MagicMock(user_id=42, team_id=1),
+            product="posthog_code",
+            end_user_id="42",
+        )
+
+        burst_throttle = next(t for t in runner._throttles if isinstance(t, UserCostBurstThrottle))
+        sustained_throttle = next(t for t in runner._throttles if isinstance(t, UserCostSustainedThrottle))
+
+        import asyncio
+
+        asyncio.get_event_loop().run_until_complete(burst_throttle.record_cost(context, 25.50))
+        asyncio.get_event_loop().run_until_complete(sustained_throttle.record_cost(context, 25.50))
+
+        response = authenticated_usage_client.get(
+            "/v1/usage/posthog_code",
+            headers={"Authorization": "Bearer phx_test"},
+        )
+        assert response.status_code == 200
+        data = response.json()
+
+        assert data["burst"]["used_usd"] == 25.5
+        assert data["burst"]["remaining_usd"] == 74.5
+        assert data["burst"]["exceeded"] is False
+
+        assert data["sustained"]["used_usd"] == 25.5
+        assert data["sustained"]["remaining_usd"] == 974.5
+        assert data["sustained"]["exceeded"] is False
+
+    def test_shows_rate_limited_when_burst_exceeded(self, authenticated_usage_client: TestClient) -> None:
+        app = authenticated_usage_client.app
+        runner = app.state.throttle_runner
+
+        context = ThrottleContext(
+            user=MagicMock(user_id=42, team_id=1),
+            product="posthog_code",
+            end_user_id="42",
+        )
+
+        burst_throttle = next(t for t in runner._throttles if isinstance(t, UserCostBurstThrottle))
+
+        import asyncio
+
+        asyncio.get_event_loop().run_until_complete(burst_throttle.record_cost(context, 100.0))
+
+        response = authenticated_usage_client.get(
+            "/v1/usage/posthog_code",
+            headers={"Authorization": "Bearer phx_test"},
+        )
+        assert response.status_code == 200
+        data = response.json()
+
+        assert data["burst"]["exceeded"] is True
+        assert data["is_rate_limited"] is True
+
+    def test_ignores_user_id_query_param(self, authenticated_usage_client: TestClient) -> None:
+        response = authenticated_usage_client.get(
+            "/v1/usage/posthog_code?user_id=99",
+            headers={"Authorization": "Bearer phx_test"},
+        )
+        assert response.status_code == 200
+        assert response.json()["user_id"] == 42

--- a/services/llm-gateway/tests/test_usage.py
+++ b/services/llm-gateway/tests/test_usage.py
@@ -130,10 +130,14 @@ class TestUsageEndpoint:
         sustained_throttle = next(t for t in runner.throttles if isinstance(t, UserCostSustainedThrottle))
 
         burst_throttle.get_status = AsyncMock(
-            return_value=CostStatus(used_usd=25.5, limit_usd=100.0, remaining_usd=74.5, resets_in_seconds=3600, exceeded=False)
+            return_value=CostStatus(
+                used_usd=25.5, limit_usd=100.0, remaining_usd=74.5, resets_in_seconds=3600, exceeded=False
+            )
         )
         sustained_throttle.get_status = AsyncMock(
-            return_value=CostStatus(used_usd=25.5, limit_usd=1000.0, remaining_usd=974.5, resets_in_seconds=86400, exceeded=False)
+            return_value=CostStatus(
+                used_usd=25.5, limit_usd=1000.0, remaining_usd=974.5, resets_in_seconds=86400, exceeded=False
+            )
         )
 
         response = authenticated_usage_client.get(
@@ -157,10 +161,14 @@ class TestUsageEndpoint:
         sustained_throttle = next(t for t in runner.throttles if isinstance(t, UserCostSustainedThrottle))
 
         burst_throttle.get_status = AsyncMock(
-            return_value=CostStatus(used_usd=100.0, limit_usd=100.0, remaining_usd=0, resets_in_seconds=3600, exceeded=True)
+            return_value=CostStatus(
+                used_usd=100.0, limit_usd=100.0, remaining_usd=0, resets_in_seconds=3600, exceeded=True
+            )
         )
         sustained_throttle.get_status = AsyncMock(
-            return_value=CostStatus(used_usd=100.0, limit_usd=1000.0, remaining_usd=900.0, resets_in_seconds=86400, exceeded=False)
+            return_value=CostStatus(
+                used_usd=100.0, limit_usd=1000.0, remaining_usd=900.0, resets_in_seconds=86400, exceeded=False
+            )
         )
 
         response = authenticated_usage_client.get(

--- a/services/llm-gateway/tests/test_usage.py
+++ b/services/llm-gateway/tests/test_usage.py
@@ -5,10 +5,10 @@ from fastapi.testclient import TestClient
 
 from llm_gateway.config import get_settings
 from llm_gateway.rate_limiting.cost_throttles import (
+    CostStatus,
     UserCostBurstThrottle,
     UserCostSustainedThrottle,
 )
-from llm_gateway.rate_limiting.throttles import ThrottleContext
 from llm_gateway.services.plan_resolver import PlanInfo
 from tests.conftest import create_test_app
 
@@ -44,8 +44,8 @@ class TestUsageEndpoint:
 
         assert data["product"] == "posthog_code"
         assert data["user_id"] == 42
-        assert data["burst"]["limit_usd"] == 100.0
-        assert data["sustained"]["limit_usd"] == 1000.0
+        assert data["burst"]["used_percent"] == 0
+        assert data["sustained"]["used_percent"] == 0
         assert data["is_rate_limited"] is False
 
     def test_returns_trial_limits_when_flag_on(
@@ -66,8 +66,8 @@ class TestUsageEndpoint:
         assert response.status_code == 200
         data = response.json()
 
-        assert data["burst"]["limit_usd"] == 5.0
-        assert data["sustained"]["limit_usd"] == 50.0
+        assert data["burst"]["used_percent"] == 0
+        assert data["sustained"]["used_percent"] == 0
         get_settings.cache_clear()
 
     def test_returns_zero_limits_when_trial_expired(
@@ -88,8 +88,10 @@ class TestUsageEndpoint:
         assert response.status_code == 200
         data = response.json()
 
-        assert data["burst"]["limit_usd"] == 0.0
-        assert data["sustained"]["limit_usd"] == 0.0
+        assert data["burst"]["used_percent"] == 0
+        assert data["burst"]["exceeded"] is True
+        assert data["sustained"]["used_percent"] == 0
+        assert data["sustained"]["exceeded"] is True
         assert data["is_rate_limited"] is True
         get_settings.cache_clear()
 
@@ -111,8 +113,9 @@ class TestUsageEndpoint:
         assert response.status_code == 200
         data = response.json()
 
-        assert data["burst"]["limit_usd"] == 100.0
-        assert data["sustained"]["limit_usd"] == 1000.0
+        assert data["burst"]["used_percent"] == 0
+        assert data["sustained"]["used_percent"] == 0
+        assert data["is_rate_limited"] is False
         get_settings.cache_clear()
 
     def test_returns_401_without_auth(self, client: TestClient) -> None:
@@ -123,19 +126,15 @@ class TestUsageEndpoint:
         app = authenticated_usage_client.app
         runner = app.state.throttle_runner
 
-        context = ThrottleContext(
-            user=MagicMock(user_id=42, team_id=1),
-            product="posthog_code",
-            end_user_id="42",
-        )
-
         burst_throttle = next(t for t in runner.throttles if isinstance(t, UserCostBurstThrottle))
         sustained_throttle = next(t for t in runner.throttles if isinstance(t, UserCostSustainedThrottle))
 
-        import asyncio
-
-        asyncio.get_event_loop().run_until_complete(burst_throttle.record_cost(context, 25.50))
-        asyncio.get_event_loop().run_until_complete(sustained_throttle.record_cost(context, 25.50))
+        burst_throttle.get_status = AsyncMock(
+            return_value=CostStatus(used_usd=25.5, limit_usd=100.0, remaining_usd=74.5, resets_in_seconds=3600, exceeded=False)
+        )
+        sustained_throttle.get_status = AsyncMock(
+            return_value=CostStatus(used_usd=25.5, limit_usd=1000.0, remaining_usd=974.5, resets_in_seconds=86400, exceeded=False)
+        )
 
         response = authenticated_usage_client.get(
             "/v1/usage/posthog_code",
@@ -144,29 +143,25 @@ class TestUsageEndpoint:
         assert response.status_code == 200
         data = response.json()
 
-        assert data["burst"]["used_usd"] == 25.5
-        assert data["burst"]["remaining_usd"] == 74.5
+        assert data["burst"]["used_percent"] == 25.5
         assert data["burst"]["exceeded"] is False
 
-        assert data["sustained"]["used_usd"] == 25.5
-        assert data["sustained"]["remaining_usd"] == 974.5
+        assert data["sustained"]["used_percent"] == 2.5
         assert data["sustained"]["exceeded"] is False
 
     def test_shows_rate_limited_when_burst_exceeded(self, authenticated_usage_client: TestClient) -> None:
         app = authenticated_usage_client.app
         runner = app.state.throttle_runner
 
-        context = ThrottleContext(
-            user=MagicMock(user_id=42, team_id=1),
-            product="posthog_code",
-            end_user_id="42",
-        )
-
         burst_throttle = next(t for t in runner.throttles if isinstance(t, UserCostBurstThrottle))
+        sustained_throttle = next(t for t in runner.throttles if isinstance(t, UserCostSustainedThrottle))
 
-        import asyncio
-
-        asyncio.get_event_loop().run_until_complete(burst_throttle.record_cost(context, 100.0))
+        burst_throttle.get_status = AsyncMock(
+            return_value=CostStatus(used_usd=100.0, limit_usd=100.0, remaining_usd=0, resets_in_seconds=3600, exceeded=True)
+        )
+        sustained_throttle.get_status = AsyncMock(
+            return_value=CostStatus(used_usd=100.0, limit_usd=1000.0, remaining_usd=900.0, resets_in_seconds=86400, exceeded=False)
+        )
 
         response = authenticated_usage_client.get(
             "/v1/usage/posthog_code",

--- a/services/llm-gateway/tests/test_usage.py
+++ b/services/llm-gateway/tests/test_usage.py
@@ -88,9 +88,9 @@ class TestUsageEndpoint:
         assert response.status_code == 200
         data = response.json()
 
-        assert data["burst"]["used_percent"] == 0
+        assert data["burst"]["used_percent"] == 100.0
         assert data["burst"]["exceeded"] is True
-        assert data["sustained"]["used_percent"] == 0
+        assert data["sustained"]["used_percent"] == 100.0
         assert data["sustained"]["exceeded"] is True
         assert data["is_rate_limited"] is True
         get_settings.cache_clear()

--- a/services/llm-gateway/tests/test_usage.py
+++ b/services/llm-gateway/tests/test_usage.py
@@ -122,22 +122,32 @@ class TestUsageEndpoint:
         response = client.get("/v1/usage/posthog_code")
         assert response.status_code == 401
 
-    def test_reflects_accumulated_cost(self, authenticated_usage_client: TestClient) -> None:
+    def test_reflects_accumulated_cost(
+        self, authenticated_usage_client: TestClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         app = authenticated_usage_client.app
         runner = app.state.throttle_runner
 
         burst_throttle = next(t for t in runner.throttles if isinstance(t, UserCostBurstThrottle))
         sustained_throttle = next(t for t in runner.throttles if isinstance(t, UserCostSustainedThrottle))
 
-        burst_throttle.get_status = AsyncMock(
-            return_value=CostStatus(
-                used_usd=25.5, limit_usd=100.0, remaining_usd=74.5, resets_in_seconds=3600, exceeded=False
-            )
+        monkeypatch.setattr(
+            burst_throttle,
+            "get_status",
+            AsyncMock(
+                return_value=CostStatus(
+                    used_usd=25.5, limit_usd=100.0, remaining_usd=74.5, resets_in_seconds=3600, exceeded=False
+                )
+            ),
         )
-        sustained_throttle.get_status = AsyncMock(
-            return_value=CostStatus(
-                used_usd=25.5, limit_usd=1000.0, remaining_usd=974.5, resets_in_seconds=86400, exceeded=False
-            )
+        monkeypatch.setattr(
+            sustained_throttle,
+            "get_status",
+            AsyncMock(
+                return_value=CostStatus(
+                    used_usd=25.5, limit_usd=1000.0, remaining_usd=974.5, resets_in_seconds=86400, exceeded=False
+                )
+            ),
         )
 
         response = authenticated_usage_client.get(
@@ -153,22 +163,32 @@ class TestUsageEndpoint:
         assert data["sustained"]["used_percent"] == 2.5
         assert data["sustained"]["exceeded"] is False
 
-    def test_shows_rate_limited_when_burst_exceeded(self, authenticated_usage_client: TestClient) -> None:
+    def test_shows_rate_limited_when_burst_exceeded(
+        self, authenticated_usage_client: TestClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         app = authenticated_usage_client.app
         runner = app.state.throttle_runner
 
         burst_throttle = next(t for t in runner.throttles if isinstance(t, UserCostBurstThrottle))
         sustained_throttle = next(t for t in runner.throttles if isinstance(t, UserCostSustainedThrottle))
 
-        burst_throttle.get_status = AsyncMock(
-            return_value=CostStatus(
-                used_usd=100.0, limit_usd=100.0, remaining_usd=0, resets_in_seconds=3600, exceeded=True
-            )
+        monkeypatch.setattr(
+            burst_throttle,
+            "get_status",
+            AsyncMock(
+                return_value=CostStatus(
+                    used_usd=100.0, limit_usd=100.0, remaining_usd=0, resets_in_seconds=3600, exceeded=True
+                )
+            ),
         )
-        sustained_throttle.get_status = AsyncMock(
-            return_value=CostStatus(
-                used_usd=100.0, limit_usd=1000.0, remaining_usd=900.0, resets_in_seconds=86400, exceeded=False
-            )
+        monkeypatch.setattr(
+            sustained_throttle,
+            "get_status",
+            AsyncMock(
+                return_value=CostStatus(
+                    used_usd=100.0, limit_usd=1000.0, remaining_usd=900.0, resets_in_seconds=86400, exceeded=False
+                )
+            ),
         )
 
         response = authenticated_usage_client.get(

--- a/services/llm-gateway/tests/test_usage.py
+++ b/services/llm-gateway/tests/test_usage.py
@@ -3,6 +3,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from fastapi.testclient import TestClient
 
+from llm_gateway.api.usage import _to_cost_limit_status
 from llm_gateway.config import get_settings
 from llm_gateway.rate_limiting.cost_throttles import (
     CostStatus,
@@ -11,6 +12,32 @@ from llm_gateway.rate_limiting.cost_throttles import (
 )
 from llm_gateway.services.plan_resolver import PlanInfo
 from tests.conftest import create_test_app
+
+
+class TestToCostLimitStatus:
+    @pytest.mark.parametrize(
+        "used_usd,limit_usd,expected_percent",
+        [
+            (0.0, 100.0, 0.0),
+            (25.5, 100.0, 25.5),
+            (100.0, 100.0, 100.0),
+            (150.0, 100.0, 100.0),
+            (0.0, 0.0, 100.0),
+            (5.0, 0.0, 100.0),
+        ],
+    )
+    def test_used_percent(self, used_usd: float, limit_usd: float, expected_percent: float) -> None:
+        status = CostStatus(
+            used_usd=used_usd, limit_usd=limit_usd, remaining_usd=0.0, resets_in_seconds=60, exceeded=False
+        )
+        result = _to_cost_limit_status(status)
+        assert result.used_percent == expected_percent
+
+    def test_passes_through_exceeded_and_resets(self) -> None:
+        status = CostStatus(used_usd=100.0, limit_usd=100.0, remaining_usd=0.0, resets_in_seconds=3600, exceeded=True)
+        result = _to_cost_limit_status(status)
+        assert result.exceeded is True
+        assert result.resets_in_seconds == 3600
 
 
 class TestUsageEndpoint:
@@ -208,3 +235,26 @@ class TestUsageEndpoint:
         )
         assert response.status_code == 200
         assert response.json()["user_id"] == 42
+
+    def test_invalidate_plan_cache_calls_resolver(self, authenticated_usage_client: TestClient) -> None:
+        app = authenticated_usage_client.app
+        app.state.plan_resolver.invalidate = AsyncMock()
+
+        response = authenticated_usage_client.post(
+            "/v1/usage/posthog_code/invalidate-plan-cache",
+            headers={"Authorization": "Bearer phx_test"},
+        )
+        assert response.status_code == 200
+        assert response.json() == {"ok": True}
+        app.state.plan_resolver.invalidate.assert_called_once_with(42)
+
+    def test_invalidate_plan_cache_404_for_other_product(self, authenticated_usage_client: TestClient) -> None:
+        response = authenticated_usage_client.post(
+            "/v1/usage/wizard/invalidate-plan-cache",
+            headers={"Authorization": "Bearer phx_test"},
+        )
+        assert response.status_code == 404
+
+    def test_invalidate_plan_cache_401_without_auth(self, client: TestClient) -> None:
+        response = client.post("/v1/usage/posthog_code/invalidate-plan-cache")
+        assert response.status_code == 401


### PR DESCRIPTION
## Problem

**IMPORTANT:** Create the feature flag `posthog-code-billing` and roll it out to enable PHC billing across the stack.

**IMPORTANT:** Add this to your .env for your local posthog isntance.
```# Gateway
LLM_GATEWAY_PLAN_AWARE_THROTTLING_ENABLED=true
LLM_GATEWAY_POSTHOG_API_URL=http://localhost:8000
```

Free plan users on PostHog Code have no billing-aware rate limits in the gateway, so everyone gets the same high pro-tier limits regardless of plan.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

## Changes

1. Add /v1/usage/{product} endpoint returning burst/sustained cost limit status per user
2. Add PlanResolver service that fetches plan info from PostHog API seats endpoint with Redis caching
3. Apply tiered rate limits based on plan: free trial ($5 burst / $50 sustained), expired trial ($0/$0), pro (existing limits)
4. Namespace sustained throttle cache keys by billing period for free plan users so limits reset monthly
5. Add POST /v1/usage/{product}/invalidate-plan-cache endpoint for cache busting on plan changes
6. Gate all plan-aware logic behind plan_aware_throttling_enabled flag

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took, and what steps reviewers must take to get to where changes are, and what is the expected behavior. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

Manually

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->