### PR TITLE
fix(experiments): extract shared metric detail modal from shared metric modal.

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentForm/MetricsPanel/MetricsPanel.tsx
+++ b/frontend/src/scenes/experiments/ExperimentForm/MetricsPanel/MetricsPanel.tsx
@@ -107,10 +107,6 @@ export const MetricsPanel = ({
                     onSaveSharedMetrics(sharedMetrics, context)
                     closeSharedMetricModal()
                 }}
-                onDelete={(metric, context) => {
-                    onDeleteMetric(convertSharedMetricToExperimentMetric(metric), context)
-                    closeSharedMetricModal()
-                }}
             />
             <ExposureCriteriaModal onSave={onSaveExposureCriteria} />
         </div>

--- a/frontend/src/scenes/experiments/ExperimentView/ExperimentView.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/ExperimentView.tsx
@@ -39,7 +39,6 @@ import { ExperimentMetricModal } from '../Metrics/ExperimentMetricModal'
 import { experimentMetricModalLogic } from '../Metrics/experimentMetricModalLogic'
 import { MetricSourceModal } from '../Metrics/MetricSourceModal'
 import { SharedMetricDetailsModal } from '../Metrics/SharedMetricDetailsModal'
-import { sharedMetricDetailsModalLogic } from '../Metrics/sharedMetricDetailsModalLogic'
 import { SharedMetricModal } from '../Metrics/SharedMetricModal'
 import { sharedMetricModalLogic } from '../Metrics/sharedMetricModalLogic'
 import { Metrics } from '../MetricsView/new/Metrics'
@@ -268,7 +267,6 @@ export function ExperimentView({ tabId }: Pick<ExperimentSceneLogicProps, 'tabId
 
     const { closeExperimentMetricModal } = useActions(experimentMetricModalLogic)
     const { closeSharedMetricModal } = useActions(sharedMetricModalLogic)
-    const { closeSharedMetricDetailModal } = useActions(sharedMetricDetailsModalLogic)
 
     const isAiAnalysisTabEnabled = useFeatureFlag('EXPERIMENT_AI_ANALYSIS_TAB')
 
@@ -409,12 +407,7 @@ export function ExperimentView({ tabId }: Pick<ExperimentSceneLogicProps, 'tabId
                                     closeSharedMetricModal()
                                 }}
                             />
-                            <SharedMetricDetailsModal
-                                onDelete={(sharedMetricId) => {
-                                    removeSharedMetricFromExperiment(sharedMetricId)
-                                    closeSharedMetricDetailModal()
-                                }}
-                            />
+                            <SharedMetricDetailsModal onDelete={removeSharedMetricFromExperiment} />
                             <ExposureCriteriaModal
                                 onSave={(exposureCriteria) => {
                                     setExposureCriteria(exposureCriteria)

--- a/frontend/src/scenes/experiments/ExperimentView/ExperimentView.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/ExperimentView.tsx
@@ -38,6 +38,8 @@ import { LegacyEditConclusionModal } from '../legacy/LegacyEditConclusionModal'
 import { ExperimentMetricModal } from '../Metrics/ExperimentMetricModal'
 import { experimentMetricModalLogic } from '../Metrics/experimentMetricModalLogic'
 import { MetricSourceModal } from '../Metrics/MetricSourceModal'
+import { SharedMetricDetailsModal } from '../Metrics/SharedMetricDetailsModal'
+import { sharedMetricDetailsModalLogic } from '../Metrics/sharedMetricDetailsModalLogic'
 import { SharedMetricModal } from '../Metrics/SharedMetricModal'
 import { sharedMetricModalLogic } from '../Metrics/sharedMetricModalLogic'
 import { Metrics } from '../MetricsView/new/Metrics'
@@ -266,6 +268,7 @@ export function ExperimentView({ tabId }: Pick<ExperimentSceneLogicProps, 'tabId
 
     const { closeExperimentMetricModal } = useActions(experimentMetricModalLogic)
     const { closeSharedMetricModal } = useActions(sharedMetricModalLogic)
+    const { closeSharedMetricDetailModal } = useActions(sharedMetricDetailsModalLogic)
 
     const isAiAnalysisTabEnabled = useFeatureFlag('EXPERIMENT_AI_ANALYSIS_TAB')
 
@@ -405,9 +408,11 @@ export function ExperimentView({ tabId }: Pick<ExperimentSceneLogicProps, 'tabId
                                     )
                                     closeSharedMetricModal()
                                 }}
-                                onDelete={(metric) => {
-                                    removeSharedMetricFromExperiment(metric.id)
-                                    closeSharedMetricModal()
+                            />
+                            <SharedMetricDetailsModal
+                                onDelete={(sharedMetricId) => {
+                                    removeSharedMetricFromExperiment(sharedMetricId)
+                                    closeSharedMetricDetailModal()
                                 }}
                             />
                             <ExposureCriteriaModal

--- a/frontend/src/scenes/experiments/Metrics/SharedMetricDetailsModal.tsx
+++ b/frontend/src/scenes/experiments/Metrics/SharedMetricDetailsModal.tsx
@@ -1,0 +1,106 @@
+import { useActions, useValues } from 'kea'
+
+import { LemonButton, LemonModal, Link } from '@posthog/lemon-ui'
+
+import { IconOpenInNew } from 'lib/lemon-ui/icons'
+import { LemonTag } from 'lib/lemon-ui/LemonTag'
+import { urls } from 'scenes/urls'
+
+import { ExperimentMetric } from '~/queries/schema/schema-general'
+
+import { MetricConversionWindow } from '../ExperimentForm/MetricsPanel/MetricConversionWindow'
+import { MetricEventDetails } from '../ExperimentForm/MetricsPanel/MetricEventDetails'
+import { MetricGoal } from '../ExperimentForm/MetricsPanel/MetricGoal'
+import { MetricOutlierHandling } from '../ExperimentForm/MetricsPanel/MetricOutlierHandling'
+import { MetricStepOrder } from '../ExperimentForm/MetricsPanel/MetricStepOrder'
+import { getDefaultMetricTitle, getMetricTag } from '../MetricsView/shared/utils'
+import { MetricContext } from './experimentMetricModalLogic'
+import { sharedMetricDetailsModalLogic } from './sharedMetricDetailsModalLogic'
+
+function MetricSummary({
+    metric,
+}: {
+    metric: ExperimentMetric & { sharedMetricId: number; name?: string }
+}): JSX.Element {
+    return (
+        <div className="border rounded bg-surface-primary p-4">
+            <div className="space-y-3">
+                <div className="flex-1 min-w-0 gap-2">
+                    <div className="flex items-center gap-2 mb-1">
+                        <span className="font-semibold text-sm break-words">
+                            {metric.name || getDefaultMetricTitle(metric)}
+                        </span>
+                        <Link
+                            target="_blank"
+                            className="font-semibold flex items-center"
+                            to={urls.experimentsSharedMetric(metric.sharedMetricId)}
+                        >
+                            <IconOpenInNew fontSize="18" />
+                        </Link>
+                    </div>
+                    <MetricEventDetails metric={metric} />
+                    <div className="flex items-center mt-2 gap-1">
+                        <LemonTag type="muted" size="small">
+                            {getMetricTag(metric)}
+                        </LemonTag>
+                        <LemonTag type="option" size="small">
+                            Shared metric
+                        </LemonTag>
+                    </div>
+                </div>
+
+                <div className="border-t border-border" />
+
+                <div className="space-y-1">
+                    <MetricGoal metric={metric} />
+                    <MetricConversionWindow metric={metric} />
+                    <MetricStepOrder metric={metric} />
+                    <MetricOutlierHandling metric={metric} />
+                </div>
+            </div>
+        </div>
+    )
+}
+
+export function SharedMetricDetailsModal({
+    onDelete,
+}: {
+    onDelete: (sharedMetricId: number, context: MetricContext) => void
+}): JSX.Element | null {
+    const { isModalOpen, sharedMetric, context } = useValues(sharedMetricDetailsModalLogic)
+    const { closeSharedMetricDetailModal } = useActions(sharedMetricDetailsModalLogic)
+
+    return (
+        <LemonModal
+            isOpen={isModalOpen}
+            onClose={closeSharedMetricDetailModal}
+            maxWidth={800}
+            title="Shared metric"
+            footer={
+                <div className="flex justify-between w-full">
+                    <div>
+                        {sharedMetric && (
+                            <LemonButton
+                                status="danger"
+                                onClick={() => {
+                                    onDelete(sharedMetric.sharedMetricId, context)
+                                    closeSharedMetricDetailModal()
+                                }}
+                                type="secondary"
+                            >
+                                Remove from experiment
+                            </LemonButton>
+                        )}
+                    </div>
+                    <div className="flex gap-2">
+                        <LemonButton onClick={closeSharedMetricDetailModal} type="secondary">
+                            Close
+                        </LemonButton>
+                    </div>
+                </div>
+            }
+        >
+            {sharedMetric && <MetricSummary metric={sharedMetric} />}
+        </LemonModal>
+    )
+}

--- a/frontend/src/scenes/experiments/Metrics/SharedMetricDetailsModal.tsx
+++ b/frontend/src/scenes/experiments/Metrics/SharedMetricDetailsModal.tsx
@@ -6,7 +6,7 @@ import { IconOpenInNew } from 'lib/lemon-ui/icons'
 import { LemonTag } from 'lib/lemon-ui/LemonTag'
 import { urls } from 'scenes/urls'
 
-import { ExperimentMetric } from '~/queries/schema/schema-general'
+import type { ExperimentMetric } from '~/queries/schema/schema-general'
 
 import { MetricConversionWindow } from '../ExperimentForm/MetricsPanel/MetricConversionWindow'
 import { MetricEventDetails } from '../ExperimentForm/MetricsPanel/MetricEventDetails'
@@ -17,11 +17,11 @@ import { getDefaultMetricTitle, getMetricTag } from '../MetricsView/shared/utils
 import { MetricContext } from './experimentMetricModalLogic'
 import { sharedMetricDetailsModalLogic } from './sharedMetricDetailsModalLogic'
 
-function MetricSummary({
-    metric,
-}: {
-    metric: ExperimentMetric & { sharedMetricId: number; name?: string }
-}): JSX.Element {
+function MetricSummary({ metric }: { metric: ExperimentMetric }): JSX.Element | null {
+    if (!metric.sharedMetricId) {
+        return null
+    }
+
     return (
         <div className="border rounded bg-surface-primary p-4">
             <div className="space-y-3">
@@ -70,6 +70,10 @@ export function SharedMetricDetailsModal({
     const { isModalOpen, sharedMetric, context } = useValues(sharedMetricDetailsModalLogic)
     const { closeSharedMetricDetailModal } = useActions(sharedMetricDetailsModalLogic)
 
+    if (!sharedMetric || !sharedMetric.sharedMetricId) {
+        return null
+    }
+
     return (
         <LemonModal
             isOpen={isModalOpen}
@@ -83,6 +87,9 @@ export function SharedMetricDetailsModal({
                             <LemonButton
                                 status="danger"
                                 onClick={() => {
+                                    if (!sharedMetric.sharedMetricId) {
+                                        return
+                                    }
                                     onDelete(sharedMetric.sharedMetricId, context)
                                     closeSharedMetricDetailModal()
                                 }}

--- a/frontend/src/scenes/experiments/Metrics/SharedMetricModal.tsx
+++ b/frontend/src/scenes/experiments/Metrics/SharedMetricModal.tsx
@@ -3,21 +3,13 @@ import { useState } from 'react'
 
 import { LemonBanner, LemonButton, LemonInput, LemonLabel, LemonModal, Link } from '@posthog/lemon-ui'
 
-import { IconOpenInNew } from 'lib/lemon-ui/icons'
 import { LemonTable } from 'lib/lemon-ui/LemonTable'
-import { LemonTag } from 'lib/lemon-ui/LemonTag'
 import { urls } from 'scenes/urls'
 
 import { tagsModel } from '~/models/tagsModel'
-import { ExperimentMetric, NodeKind } from '~/queries/schema/schema-general'
+import { NodeKind } from '~/queries/schema/schema-general'
 import { Experiment } from '~/types'
 
-import { MetricConversionWindow } from '../ExperimentForm/MetricsPanel/MetricConversionWindow'
-import { MetricEventDetails } from '../ExperimentForm/MetricsPanel/MetricEventDetails'
-import { MetricGoal } from '../ExperimentForm/MetricsPanel/MetricGoal'
-import { MetricOutlierHandling } from '../ExperimentForm/MetricsPanel/MetricOutlierHandling'
-import { MetricStepOrder } from '../ExperimentForm/MetricsPanel/MetricStepOrder'
-import { getDefaultMetricTitle, getMetricTag } from '../MetricsView/shared/utils'
 import { InlineTagEditor } from '../SharedMetrics/InlineTagEditor'
 import { SharedMetric } from '../SharedMetrics/sharedMetricLogic'
 import { sharedMetricsLogic } from '../SharedMetrics/sharedMetricsLogic'
@@ -25,61 +17,14 @@ import { matchesSharedMetricSearch } from '../utils'
 import { MetricContext } from './experimentMetricModalLogic'
 import { sharedMetricModalLogic } from './sharedMetricModalLogic'
 
-function MetricSummary({ metric }: { metric: SharedMetric }): JSX.Element {
-    const experimentMetric = metric.query as ExperimentMetric
-
-    return (
-        <div className="border rounded bg-surface-primary p-4">
-            <div className="space-y-3">
-                <div className="flex-1 min-w-0 gap-2">
-                    <div className="flex items-center gap-2 mb-1">
-                        <span className="font-semibold text-sm break-words">
-                            {metric.name || getDefaultMetricTitle(experimentMetric)}
-                        </span>
-                        <Link
-                            target="_blank"
-                            className="font-semibold flex items-center"
-                            to={urls.experimentsSharedMetric(metric.id)}
-                        >
-                            <IconOpenInNew fontSize="18" />
-                        </Link>
-                    </div>
-                    {metric.description && <p className="text-xs text-muted m-0 mb-2">{metric.description}</p>}
-                    <MetricEventDetails metric={experimentMetric} />
-                    <div className="flex items-center mt-2 gap-1">
-                        <LemonTag type="muted" size="small">
-                            {getMetricTag(experimentMetric)}
-                        </LemonTag>
-                        <LemonTag type="option" size="small">
-                            Shared metric
-                        </LemonTag>
-                    </div>
-                </div>
-
-                <div className="border-t border-border" />
-
-                <div className="space-y-1">
-                    <MetricGoal metric={experimentMetric} />
-                    <MetricConversionWindow metric={experimentMetric} />
-                    <MetricStepOrder metric={experimentMetric} />
-                    <MetricOutlierHandling metric={experimentMetric} />
-                </div>
-            </div>
-        </div>
-    )
-}
-
 export function SharedMetricModal({
     experiment,
     onSave,
-    onDelete,
 }: {
     experiment: Experiment
     onSave: (metrics: SharedMetric[], context: MetricContext) => void
-    onDelete: (metric: SharedMetric, context: MetricContext) => void
 }): JSX.Element | null {
-    const { isModalOpen, context, compatibleSharedMetrics, sharedMetricId, isCreateMode, isEditMode, searchTerm } =
-        useValues(sharedMetricModalLogic)
+    const { isModalOpen, context, compatibleSharedMetrics, searchTerm } = useValues(sharedMetricModalLogic)
     const { closeSharedMetricModal, setSearchTerm, updateSharedMetricTags } = useActions(sharedMetricModalLogic)
     const { savingTagsMetricId } = useValues(sharedMetricsLogic)
     const { tags: allTags } = useValues(tagsModel)
@@ -120,197 +65,167 @@ export function SharedMetricModal({
             isOpen={isModalOpen}
             onClose={closeModal}
             maxWidth={800}
-            title={isCreateMode ? 'Select one or more shared metrics' : 'Shared metric'}
+            title="Select one or more shared metrics"
             footer={
                 <div className="flex justify-between w-full">
-                    <div>
-                        {isEditMode && (
-                            <LemonButton
-                                status="danger"
-                                onClick={() => {
-                                    const metric = compatibleSharedMetrics.find((m) => m.id === sharedMetricId)
-                                    if (!metric) {
-                                        return
-                                    }
-
-                                    onDelete(metric, context)
-                                }}
-                                type="secondary"
-                            >
-                                Remove from experiment
-                            </LemonButton>
-                        )}
-                    </div>
                     <div className="flex gap-2">
                         <LemonButton onClick={closeModal} type="secondary">
                             Cancel
                         </LemonButton>
                         {/* Changing the existing metric is a pain because saved metrics are stored separately */}
                         {/* Only allow deletion for now */}
-                        {isCreateMode && (
-                            <LemonButton
-                                onClick={() => {
-                                    const metrics = selectedMetricIds
-                                        .map((metricId) => compatibleSharedMetrics.find((m) => m.id === metricId))
-                                        .filter((metric): metric is SharedMetric => metric !== undefined)
+                        <LemonButton
+                            onClick={() => {
+                                const metrics = selectedMetricIds
+                                    .map((metricId) => compatibleSharedMetrics.find((m) => m.id === metricId))
+                                    .filter((metric): metric is SharedMetric => metric !== undefined)
 
-                                    onSave(metrics, context)
-                                    setSelectedMetricIds([])
-                                }}
-                                type="primary"
-                                disabledReason={addSharedMetricDisabledReason()}
-                            >
-                                {selectedMetricIds.length < 2 ? 'Add metric' : 'Add metrics'}
-                            </LemonButton>
-                        )}
+                                onSave(metrics, context)
+                                setSelectedMetricIds([])
+                            }}
+                            type="primary"
+                            disabledReason={addSharedMetricDisabledReason()}
+                        >
+                            {selectedMetricIds.length < 2 ? 'Add metric' : 'Add metrics'}
+                        </LemonButton>
                     </div>
                 </div>
             }
         >
-            {isCreateMode && (
-                <div className="deprecated-space-y-2">
-                    {availableSharedMetrics.length > 0 ? (
-                        <>
-                            {experiment.saved_metrics.length > 0 && (
-                                <LemonBanner type="info">
-                                    {`Hiding ${experiment.saved_metrics.length} shared ${
-                                        experiment.saved_metrics.length > 1 ? 'metrics' : 'metric'
-                                    } already in use with this experiment.`}
-                                </LemonBanner>
-                            )}
-                            <LemonInput
-                                type="search"
-                                placeholder="Search shared metrics..."
-                                value={searchTerm}
-                                onChange={setSearchTerm}
-                                fullWidth
-                            />
-                            <div className="flex flex-wrap gap-2">
-                                <LemonLabel>Quick select:</LemonLabel>
+            <div className="deprecated-space-y-2">
+                {availableSharedMetrics.length > 0 ? (
+                    <>
+                        {experiment.saved_metrics.length > 0 && (
+                            <LemonBanner type="info">
+                                {`Hiding ${experiment.saved_metrics.length} shared ${
+                                    experiment.saved_metrics.length > 1 ? 'metrics' : 'metric'
+                                } already in use with this experiment.`}
+                            </LemonBanner>
+                        )}
+                        <LemonInput
+                            type="search"
+                            placeholder="Search shared metrics..."
+                            value={searchTerm}
+                            onChange={setSearchTerm}
+                            fullWidth
+                        />
+                        <div className="flex flex-wrap gap-2">
+                            <LemonLabel>Quick select:</LemonLabel>
+                            <LemonButton
+                                size="xsmall"
+                                type="secondary"
+                                onClick={() => {
+                                    setSelectedMetricIds(filteredMetrics.map((metric: SharedMetric) => metric.id))
+                                }}
+                            >
+                                All
+                            </LemonButton>
+                            {selectedMetricIds.length > 0 && (
                                 <LemonButton
                                     size="xsmall"
                                     type="secondary"
                                     onClick={() => {
-                                        setSelectedMetricIds(filteredMetrics.map((metric: SharedMetric) => metric.id))
+                                        setSelectedMetricIds([])
                                     }}
                                 >
-                                    All
+                                    Clear
                                 </LemonButton>
-                                {selectedMetricIds.length > 0 && (
-                                    <LemonButton
-                                        size="xsmall"
-                                        type="secondary"
-                                        onClick={() => {
-                                            setSelectedMetricIds([])
-                                        }}
-                                    >
-                                        Clear
-                                    </LemonButton>
-                                )}
-                                {availableTags.map((tag: string, index: number) => (
-                                    <LemonButton
-                                        key={index}
-                                        size="xsmall"
-                                        type="secondary"
-                                        onClick={() => {
-                                            setSelectedMetricIds(
-                                                filteredMetrics
-                                                    .filter((metric: SharedMetric) => metric.tags?.includes(tag))
-                                                    .map((metric: SharedMetric) => metric.id)
-                                            )
-                                        }}
-                                    >
-                                        {tag}
-                                    </LemonButton>
-                                ))}
-                            </div>
-                            <LemonTable
-                                dataSource={filteredMetrics}
-                                columns={[
-                                    {
-                                        title: '',
-                                        key: 'checkbox',
-                                        render: (_, metric: SharedMetric) => (
-                                            <input
-                                                type="checkbox"
-                                                checked={selectedMetricIds.includes(metric.id)}
-                                                onChange={(e) => {
-                                                    if (e.target.checked) {
-                                                        setSelectedMetricIds([...selectedMetricIds, metric.id])
-                                                    } else {
-                                                        setSelectedMetricIds(
-                                                            selectedMetricIds.filter((id) => id !== metric.id)
-                                                        )
-                                                    }
-                                                }}
-                                            />
-                                        ),
+                            )}
+                            {availableTags.map((tag: string, index: number) => (
+                                <LemonButton
+                                    key={index}
+                                    size="xsmall"
+                                    type="secondary"
+                                    onClick={() => {
+                                        setSelectedMetricIds(
+                                            filteredMetrics
+                                                .filter((metric: SharedMetric) => metric.tags?.includes(tag))
+                                                .map((metric: SharedMetric) => metric.id)
+                                        )
+                                    }}
+                                >
+                                    {tag}
+                                </LemonButton>
+                            ))}
+                        </div>
+                        <LemonTable
+                            dataSource={filteredMetrics}
+                            columns={[
+                                {
+                                    title: '',
+                                    key: 'checkbox',
+                                    render: (_, metric: SharedMetric) => (
+                                        <input
+                                            type="checkbox"
+                                            checked={selectedMetricIds.includes(metric.id)}
+                                            onChange={(e) => {
+                                                if (e.target.checked) {
+                                                    setSelectedMetricIds([...selectedMetricIds, metric.id])
+                                                } else {
+                                                    setSelectedMetricIds(
+                                                        selectedMetricIds.filter((id) => id !== metric.id)
+                                                    )
+                                                }
+                                            }}
+                                        />
+                                    ),
+                                },
+                                {
+                                    title: 'Name',
+                                    dataIndex: 'name',
+                                    key: 'name',
+                                },
+                                {
+                                    title: 'Description',
+                                    dataIndex: 'description',
+                                    key: 'description',
+                                },
+                                {
+                                    title: 'Tags',
+                                    dataIndex: 'tags' as keyof SharedMetric,
+                                    key: 'tags',
+                                    render: (_: any, metric: SharedMetric) => (
+                                        <InlineTagEditor
+                                            metric={metric}
+                                            allTags={allTags}
+                                            onSave={(newTags) => updateSharedMetricTags(metric.id, newTags)}
+                                            saving={savingTagsMetricId === metric.id}
+                                        />
+                                    ),
+                                },
+                                {
+                                    title: 'Type',
+                                    key: 'type',
+                                    render: (_, metric: SharedMetric) => {
+                                        if (metric.query.kind === NodeKind.ExperimentMetric) {
+                                            return metric.query.metric_type
+                                        }
+                                        return metric.query.kind === NodeKind.ExperimentTrendsQuery ? 'Trend' : 'Funnel'
                                     },
-                                    {
-                                        title: 'Name',
-                                        dataIndex: 'name',
-                                        key: 'name',
-                                    },
-                                    {
-                                        title: 'Description',
-                                        dataIndex: 'description',
-                                        key: 'description',
-                                    },
-                                    {
-                                        title: 'Tags',
-                                        dataIndex: 'tags' as keyof SharedMetric,
-                                        key: 'tags',
-                                        render: (_: any, metric: SharedMetric) => (
-                                            <InlineTagEditor
-                                                metric={metric}
-                                                allTags={allTags}
-                                                onSave={(newTags) => updateSharedMetricTags(metric.id, newTags)}
-                                                saving={savingTagsMetricId === metric.id}
-                                            />
-                                        ),
-                                    },
-                                    {
-                                        title: 'Type',
-                                        key: 'type',
-                                        render: (_, metric: SharedMetric) => {
-                                            if (metric.query.kind === NodeKind.ExperimentMetric) {
-                                                return metric.query.metric_type
-                                            }
-                                            return metric.query.kind === NodeKind.ExperimentTrendsQuery
-                                                ? 'Trend'
-                                                : 'Funnel'
-                                        },
-                                    },
-                                ]}
-                                footer={
-                                    <div className="flex items-center justify-center m-2">
-                                        <Link to={`${urls.experiments()}?tab=shared-metrics`} target="_blank">
-                                            See all shared metrics
-                                        </Link>
-                                    </div>
-                                }
-                            />
-                        </>
-                    ) : (
-                        <LemonBanner className="w-full" type="info">
-                            <div className="mb-2">
-                                {compatibleSharedMetrics.length > 0
-                                    ? 'All of your shared metrics are already in this experiment.'
-                                    : "You don't have any shared metrics that match the experiment type. Shared metrics let you create reusable metrics that you can quickly add to any experiment."}
-                            </div>
-                            <Link to={urls.experimentsSharedMetric('new')} target="_blank">
-                                New shared metric
-                            </Link>
-                        </LemonBanner>
-                    )}
-                </div>
-            )}
-
-            {isEditMode &&
-                (() => {
-                    const metric = compatibleSharedMetrics.find((m) => m.id === sharedMetricId)
-                    return metric ? <MetricSummary metric={metric} /> : null
-                })()}
+                                },
+                            ]}
+                            footer={
+                                <div className="flex items-center justify-center m-2">
+                                    <Link to={`${urls.experiments()}?tab=shared-metrics`} target="_blank">
+                                        See all shared metrics
+                                    </Link>
+                                </div>
+                            }
+                        />
+                    </>
+                ) : (
+                    <LemonBanner className="w-full" type="info">
+                        <div className="mb-2">
+                            {compatibleSharedMetrics.length > 0
+                                ? 'All of your shared metrics are already in this experiment.'
+                                : "You don't have any shared metrics that match the experiment type. Shared metrics let you create reusable metrics that you can quickly add to any experiment."}
+                        </div>
+                        <Link to={urls.experimentsSharedMetric('new')} target="_blank">
+                            New shared metric
+                        </Link>
+                    </LemonBanner>
+                )}
+            </div>
         </LemonModal>
     )
 }

--- a/frontend/src/scenes/experiments/Metrics/sharedMetricDetailsModalLogic.ts
+++ b/frontend/src/scenes/experiments/Metrics/sharedMetricDetailsModalLogic.ts
@@ -9,10 +9,7 @@ export const sharedMetricDetailsModalLogic = kea<sharedMetricDetailsModalLogicTy
     path(['scenes', 'experiments', 'Metrics', 'sharedMetricDetailsModalLogic']),
 
     actions({
-        openSharedMetricDetailModal: (
-            metric: ExperimentMetric & { sharedMetricId: number },
-            context: MetricContext
-        ) => ({
+        openSharedMetricDetailModal: (metric: ExperimentMetric, context: MetricContext) => ({
             metric,
             context,
         }),
@@ -28,7 +25,7 @@ export const sharedMetricDetailsModalLogic = kea<sharedMetricDetailsModalLogicTy
             },
         ],
         sharedMetric: [
-            null as (ExperimentMetric & { sharedMetricId: number }) | null,
+            null as ExperimentMetric | null,
             {
                 openSharedMetricDetailModal: (_, { metric }) => metric,
                 closeSharedMetricDetailModal: () => null,

--- a/frontend/src/scenes/experiments/Metrics/sharedMetricDetailsModalLogic.ts
+++ b/frontend/src/scenes/experiments/Metrics/sharedMetricDetailsModalLogic.ts
@@ -1,0 +1,45 @@
+import { actions, kea, path, reducers } from 'kea'
+
+import type { ExperimentMetric } from '~/queries/schema/schema-general'
+
+import { METRIC_CONTEXTS, type MetricContext } from './experimentMetricModalLogic'
+import type { sharedMetricDetailsModalLogicType } from './sharedMetricDetailsModalLogicType'
+
+export const sharedMetricDetailsModalLogic = kea<sharedMetricDetailsModalLogicType>([
+    path(['scenes', 'experiments', 'Metrics', 'sharedMetricDetailsModalLogic']),
+
+    actions({
+        openSharedMetricDetailModal: (
+            metric: ExperimentMetric & { sharedMetricId: number },
+            context: MetricContext
+        ) => ({
+            metric,
+            context,
+        }),
+        closeSharedMetricDetailModal: true,
+    }),
+
+    reducers({
+        isModalOpen: [
+            false,
+            {
+                openSharedMetricDetailModal: () => true,
+                closeSharedMetricDetailModal: () => false,
+            },
+        ],
+        sharedMetric: [
+            null as (ExperimentMetric & { sharedMetricId: number }) | null,
+            {
+                openSharedMetricDetailModal: (_, { metric }) => metric,
+                closeSharedMetricDetailModal: () => null,
+            },
+        ],
+        context: [
+            METRIC_CONTEXTS.primary as MetricContext,
+            {
+                openSharedMetricDetailModal: (_, { context }) => context,
+                closeSharedMetricDetailModal: () => METRIC_CONTEXTS.primary,
+            },
+        ],
+    }),
+])

--- a/frontend/src/scenes/experiments/MetricsView/shared/MetricHeader.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/shared/MetricHeader.tsx
@@ -7,7 +7,7 @@ import { LemonButton, LemonDialog, LemonDropdown, LemonTag } from '@posthog/lemo
 import { TaxonomicFilter } from 'lib/components/TaxonomicFilter/TaxonomicFilter'
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 import { METRIC_CONTEXTS, experimentMetricModalLogic } from 'scenes/experiments/Metrics/experimentMetricModalLogic'
-import { sharedMetricModalLogic } from 'scenes/experiments/Metrics/sharedMetricModalLogic'
+import { sharedMetricDetailsModalLogic } from 'scenes/experiments/Metrics/sharedMetricDetailsModalLogic'
 import { modalsLogic } from 'scenes/experiments/modalsLogic'
 import { isEventExposureConfig } from 'scenes/experiments/utils'
 import { urls } from 'scenes/urls'
@@ -120,7 +120,7 @@ export const MetricHeader = ({
     } = useActions(modalsLogic)
 
     const { openExperimentMetricModal } = useActions(experimentMetricModalLogic)
-    const { openSharedMetricModal } = useActions(sharedMetricModalLogic)
+    const { openSharedMetricDetailModal } = useActions(sharedMetricDetailsModalLogic)
 
     return (
         <div className="text-xs font-semibold flex flex-col justify-between h-full">
@@ -151,9 +151,9 @@ export const MetricHeader = ({
                                                 : openSecondarySharedMetricModal
                                             openSharedModal(metric.sharedMetricId)
 
-                                            openSharedMetricModal(
-                                                METRIC_CONTEXTS[isPrimaryMetric ? 'primary' : 'secondary'],
-                                                metric.sharedMetricId
+                                            openSharedMetricDetailModal(
+                                                metric,
+                                                METRIC_CONTEXTS[isPrimaryMetric ? 'primary' : 'secondary']
                                             )
                                         } else {
                                             /**

--- a/frontend/src/scenes/experiments/MetricsView/shared/MetricHeader.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/shared/MetricHeader.tsx
@@ -101,7 +101,7 @@ export const MetricHeader = ({
     readOnly,
 }: {
     displayOrder?: number
-    metric: any
+    metric: ExperimentMetric
     metricType: any
     isPrimaryMetric: boolean
     experiment: Experiment
@@ -142,7 +142,7 @@ export const MetricHeader = ({
                                     icon={<IconPencil fontSize="12" />}
                                     tooltip="Edit"
                                     onClick={() => {
-                                        if (metric.isSharedMetric) {
+                                        if (metric.isSharedMetric && metric.sharedMetricId) {
                                             /**
                                              * this is for legacy experiments support
                                              */
@@ -184,7 +184,7 @@ export const MetricHeader = ({
                                          * For shared metrics we open the duplicate form
                                          * after a confirmation.
                                          */
-                                        if (metric.isSharedMetric) {
+                                        if (metric.isSharedMetric && metric.sharedMetricId) {
                                             LemonDialog.open({
                                                 title: 'Duplicate this shared metric?',
                                                 content: (


### PR DESCRIPTION
## Problem

When we have more than 100 shared metrics, the edit metric modal won't display metric details, and deleting them won't be possible.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

The `SharedMetricModal` is used not only to add shared metrics but also to show metric details using a child `MetricSummary` component. The provided ID for the shared metric is validated against the list of available shared metrics loaded by the component on mount. This list is limited to 100 items, so if we edit a metric beyond this limit, the details won't load, and no actions can be performed.

To fix this, we are extracting the edit code into a new `SharedMetricDetailsModal`. And because we already have the metric information, we can pass it over to the modal state when opening it. Doing this, we avoid a network call to retrieve the metric details and dependencies on the list of available shared metrics.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

![cat-type](https://github.com/user-attachments/assets/5ffd85d0-45db-41ff-9961-cfca623b3851)

<!-- Briefly describe the steps you took, and what steps reviewers must take to get to where changes are, and what is the expected behavior. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

do not publish to changelog

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
