### PR TITLE
refactor(funnels): replace filters with queries in funnel correlation actors tests

### DIFF
--- a/posthog/hogql_queries/insights/funnels/test/test_funnel_correlation.py
+++ b/posthog/hogql_queries/insights/funnels/test/test_funnel_correlation.py
@@ -1,5 +1,3 @@
-from typing import Any, cast
-
 import unittest
 from freezegun import freeze_time
 from posthog.test.base import (
@@ -18,6 +16,7 @@ from unittest import skip
 from rest_framework.exceptions import ValidationError
 
 from posthog.schema import (
+    ActionsNode,
     DateRange,
     EventPropertyFilter,
     EventsNode,
@@ -37,7 +36,6 @@ from posthog.hogql_queries.insights.funnels.funnel_correlation_query_runner impo
     FunnelCorrelationQueryRunner,
 )
 from posthog.hogql_queries.insights.funnels.test.test_funnel_correlation_actors import get_actors
-from posthog.hogql_queries.legacy_compatibility.filter_to_query import filter_to_query
 from posthog.models.element import Element
 from posthog.models.group.util import create_group
 from posthog.models.instance_setting import override_instance_config
@@ -50,7 +48,7 @@ class TestClickhouseFunnelCorrelation(ClickhouseTestMixin, APIBaseTest):
 
     def _get_events_for_filters(
         self,
-        filters,
+        funnels_query,
         funnelCorrelationType=FunnelCorrelationResultsType.EVENTS,
         funnelCorrelationNames=None,
         funnelCorrelationExcludeNames=None,
@@ -58,7 +56,6 @@ class TestClickhouseFunnelCorrelation(ClickhouseTestMixin, APIBaseTest):
         funnelCorrelationEventNames=None,
         funnelCorrelationEventExcludePropertyNames=None,
     ):
-        funnels_query = cast(FunnelsQuery, filter_to_query(filters))
         actors_query = FunnelsActorsQuery(source=funnels_query)
         correlation_query = FunnelCorrelationQuery(
             source=actors_query,
@@ -74,9 +71,9 @@ class TestClickhouseFunnelCorrelation(ClickhouseTestMixin, APIBaseTest):
         )._calculate_internal()
         return result, skewed_totals
 
-    def _get_actors_for_event(self, filters: dict[str, Any], event_name: str, properties=None, success=True):
+    def _get_actors_for_event(self, funnels_query: FunnelsQuery, event_name: str, properties=None, success=True):
         serialized_actors = get_actors(
-            filters,
+            funnels_query,
             self.team,
             funnelCorrelationPersonConverted=success,
             funnelCorrelationPersonEntity=EventsNode(event=event_name, properties=properties),
@@ -84,7 +81,7 @@ class TestClickhouseFunnelCorrelation(ClickhouseTestMixin, APIBaseTest):
         return [str(row[0]) for row in serialized_actors]
 
     def _get_actors_for_property(
-        self, filters: dict[str, Any], property_values: list, success=True, funnelCorrelationNames=None
+        self, funnels_query: FunnelsQuery, property_values: list, success=True, funnelCorrelationNames=None
     ):
         funnelCorrelationPropertyValues = [
             (
@@ -98,7 +95,7 @@ class TestClickhouseFunnelCorrelation(ClickhouseTestMixin, APIBaseTest):
         ]
 
         serialized_actors = get_actors(
-            filters,
+            funnels_query,
             self.team,
             funnelCorrelationType=FunnelCorrelationResultsType.PROPERTIES,
             funnelCorrelationNames=funnelCorrelationNames,
@@ -108,15 +105,10 @@ class TestClickhouseFunnelCorrelation(ClickhouseTestMixin, APIBaseTest):
         return [str(row[0]) for row in serialized_actors]
 
     def test_basic_funnel_correlation_with_events(self):
-        filters = {
-            "events": [
-                {"id": "user signed up", "type": "events", "order": 0},
-                {"id": "paid", "type": "events", "order": 1},
-            ],
-            "insight": INSIGHT_FUNNELS,
-            "date_from": "2020-01-01",
-            "date_to": "2020-01-14",
-        }
+        query = FunnelsQuery(
+            series=[EventsNode(event="user signed up"), EventsNode(event="paid")],
+            dateRange=DateRange(date_from="2020-01-01", date_to="2020-01-14"),
+        )
 
         for i in range(10):
             _create_person(distinct_ids=[f"user_{i}"], team_id=self.team.pk)
@@ -156,7 +148,7 @@ class TestClickhouseFunnelCorrelation(ClickhouseTestMixin, APIBaseTest):
                     timestamp="2020-01-03T14:00:00Z",
                 )
 
-        result, _ = self._get_events_for_filters(filters, funnelCorrelationType=FunnelCorrelationResultsType.EVENTS)
+        result, _ = self._get_events_for_filters(query, funnelCorrelationType=FunnelCorrelationResultsType.EVENTS)
 
         odds_ratios = [item.pop("odds_ratio") for item in result]
         expected_odds_ratios = [11, 1 / 11]
@@ -184,20 +176,20 @@ class TestClickhouseFunnelCorrelation(ClickhouseTestMixin, APIBaseTest):
             ],
         )
 
-        self.assertEqual(len(self._get_actors_for_event(filters, "positively_related")), 5)
+        self.assertEqual(len(self._get_actors_for_event(query, "positively_related")), 5)
         self.assertEqual(
-            len(self._get_actors_for_event(filters, "positively_related", success=False)),
+            len(self._get_actors_for_event(query, "positively_related", success=False)),
             0,
         )
         self.assertEqual(
-            len(self._get_actors_for_event(filters, "negatively_related", success=False)),
+            len(self._get_actors_for_event(query, "negatively_related", success=False)),
             5,
         )
-        self.assertEqual(len(self._get_actors_for_event(filters, "negatively_related")), 0)
+        self.assertEqual(len(self._get_actors_for_event(query, "negatively_related")), 0)
 
         # Now exclude positively_related
         result, _ = self._get_events_for_filters(
-            filters,
+            query,
             funnelCorrelationType=FunnelCorrelationResultsType.EVENTS,
             funnelCorrelationExcludeEventNames=["positively_related"],
         )
@@ -220,16 +212,16 @@ class TestClickhouseFunnelCorrelation(ClickhouseTestMixin, APIBaseTest):
             ],
         )
         # Getting specific people isn't affected by exclude_events
-        self.assertEqual(len(self._get_actors_for_event(filters, "positively_related")), 5)
+        self.assertEqual(len(self._get_actors_for_event(query, "positively_related")), 5)
         self.assertEqual(
-            len(self._get_actors_for_event(filters, "positively_related", success=False)),
+            len(self._get_actors_for_event(query, "positively_related", success=False)),
             0,
         )
         self.assertEqual(
-            len(self._get_actors_for_event(filters, "negatively_related", success=False)),
+            len(self._get_actors_for_event(query, "negatively_related", success=False)),
             5,
         )
-        self.assertEqual(len(self._get_actors_for_event(filters, "negatively_related")), 0)
+        self.assertEqual(len(self._get_actors_for_event(query, "negatively_related")), 0)
 
     @snapshot_clickhouse_queries
     def test_action_events_are_excluded_from_correlations(self):
@@ -280,19 +272,12 @@ class TestClickhouseFunnelCorrelation(ClickhouseTestMixin, APIBaseTest):
             team=self.team,
             properties=[{"key": "key", "type": "event", "value": ["val"], "operator": "exact"}],
         )
-        filters = {
-            "events": [],
-            "actions": [
-                {"id": sign_up_action.id, "order": 0},
-                {"id": paid_action.id, "order": 1},
-            ],
-            "insight": INSIGHT_FUNNELS,
-            "date_from": "2020-01-01",
-            "date_to": "2020-01-14",
-            "funnel_correlation_type": "events",
-        }
+        query = FunnelsQuery(
+            series=[ActionsNode(id=sign_up_action.id), ActionsNode(id=paid_action.id)],
+            dateRange=DateRange(date_from="2020-01-01", date_to="2020-01-14"),
+        )
 
-        result, _ = self._get_events_for_filters(filters)
+        result, _ = self._get_events_for_filters(query)
 
         #  missing user signed up and paid from result set, as expected
         self.assertEqual(
@@ -406,18 +391,13 @@ class TestClickhouseFunnelCorrelation(ClickhouseTestMixin, APIBaseTest):
             properties={"$group_0": f"org:7"},
         )
 
-        filters = {
-            "events": [
-                {"id": "user signed up", "type": "events", "order": 0},
-                {"id": "paid", "type": "events", "order": 1},
-            ],
-            "insight": INSIGHT_FUNNELS,
-            "date_from": "2020-01-01",
-            "date_to": "2020-01-14",
-            "aggregation_group_type_index": 0,
-        }
+        query = FunnelsQuery(
+            series=[EventsNode(event="user signed up"), EventsNode(event="paid")],
+            dateRange=DateRange(date_from="2020-01-01", date_to="2020-01-14"),
+            aggregation_group_type_index=0,
+        )
 
-        result, _ = self._get_events_for_filters(filters, funnelCorrelationType=FunnelCorrelationResultsType.EVENTS)
+        result, _ = self._get_events_for_filters(query, funnelCorrelationType=FunnelCorrelationResultsType.EVENTS)
 
         odds_ratios = [item.pop("odds_ratio") for item in result]
         expected_odds_ratios = [12 / 7, 1 / 11]
@@ -445,30 +425,31 @@ class TestClickhouseFunnelCorrelation(ClickhouseTestMixin, APIBaseTest):
             ],
         )
 
-        self.assertEqual(len(self._get_actors_for_event(filters, "positively_related")), 5)
+        self.assertEqual(len(self._get_actors_for_event(query, "positively_related")), 5)
         self.assertEqual(
-            len(self._get_actors_for_event(filters, "positively_related", success=False)),
+            len(self._get_actors_for_event(query, "positively_related", success=False)),
             0,
         )
-        self.assertEqual(len(self._get_actors_for_event(filters, "negatively_related")), 1)
+        self.assertEqual(len(self._get_actors_for_event(query, "negatively_related")), 1)
         self.assertEqual(
-            len(self._get_actors_for_event(filters, "negatively_related", success=False)),
+            len(self._get_actors_for_event(query, "negatively_related", success=False)),
             1,
         )
 
         # Now exclude all groups in positive
-        excludes = {
-            "properties": [
-                {
-                    "key": "industry",
-                    "value": "finance",
-                    "type": "group",
-                    "group_type_index": 0,
-                }
-            ]
-        }
-
-        result, _ = self._get_events_for_filters({**filters, **excludes})  # TODO destructure
+        query_with_exludes = query.model_copy(
+            update={
+                "properties": [
+                    GroupPropertyFilter(
+                        operator=PropertyOperator.EXACT,
+                        key="industry",
+                        value="finance",
+                        group_type_index=0,
+                    ),
+                ],
+            }
+        )
+        result, _ = self._get_events_for_filters(query_with_exludes)
 
         odds_ratio = result[0].pop("odds_ratio")
         expected_odds_ratio = 1
@@ -489,9 +470,9 @@ class TestClickhouseFunnelCorrelation(ClickhouseTestMixin, APIBaseTest):
             ],
         )
 
-        self.assertEqual(len(self._get_actors_for_event(filters, "negatively_related")), 1)
+        self.assertEqual(len(self._get_actors_for_event(query, "negatively_related")), 1)
         self.assertEqual(
-            len(self._get_actors_for_event(filters, "negatively_related", success=False)),
+            len(self._get_actors_for_event(query, "negatively_related", success=False)),
             1,
         )
 

--- a/posthog/hogql_queries/insights/funnels/test/test_funnel_correlation.py
+++ b/posthog/hogql_queries/insights/funnels/test/test_funnel_correlation.py
@@ -438,7 +438,7 @@ class TestClickhouseFunnelCorrelation(ClickhouseTestMixin, APIBaseTest):
         )
 
         # Now exclude all groups in positive
-        query_with_exludes = query.model_copy(
+        query_with_excludes = query.model_copy(
             update={
                 "properties": [
                     GroupPropertyFilter(
@@ -450,7 +450,7 @@ class TestClickhouseFunnelCorrelation(ClickhouseTestMixin, APIBaseTest):
                 ],
             }
         )
-        result, _ = self._get_events_for_query(query_with_exludes)
+        result, _ = self._get_events_for_query(query_with_excludes)
 
         odds_ratio = result[0].pop("odds_ratio")
         expected_odds_ratio = 1

--- a/posthog/hogql_queries/insights/funnels/test/test_funnel_correlation.py
+++ b/posthog/hogql_queries/insights/funnels/test/test_funnel_correlation.py
@@ -46,7 +46,7 @@ from posthog.test.test_utils import create_group_type_mapping_without_created_at
 class TestClickhouseFunnelCorrelation(ClickhouseTestMixin, APIBaseTest):
     maxDiff = None
 
-    def _get_events_for_filters(
+    def _get_events_for_query(
         self,
         funnels_query,
         funnelCorrelationType=FunnelCorrelationResultsType.EVENTS,
@@ -148,7 +148,7 @@ class TestClickhouseFunnelCorrelation(ClickhouseTestMixin, APIBaseTest):
                     timestamp="2020-01-03T14:00:00Z",
                 )
 
-        result, _ = self._get_events_for_filters(query, funnelCorrelationType=FunnelCorrelationResultsType.EVENTS)
+        result, _ = self._get_events_for_query(query, funnelCorrelationType=FunnelCorrelationResultsType.EVENTS)
 
         odds_ratios = [item.pop("odds_ratio") for item in result]
         expected_odds_ratios = [11, 1 / 11]
@@ -188,7 +188,7 @@ class TestClickhouseFunnelCorrelation(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(len(self._get_actors_for_event(query, "negatively_related")), 0)
 
         # Now exclude positively_related
-        result, _ = self._get_events_for_filters(
+        result, _ = self._get_events_for_query(
             query,
             funnelCorrelationType=FunnelCorrelationResultsType.EVENTS,
             funnelCorrelationExcludeEventNames=["positively_related"],
@@ -277,7 +277,7 @@ class TestClickhouseFunnelCorrelation(ClickhouseTestMixin, APIBaseTest):
             dateRange=DateRange(date_from="2020-01-01", date_to="2020-01-14"),
         )
 
-        result, _ = self._get_events_for_filters(query)
+        result, _ = self._get_events_for_query(query)
 
         #  missing user signed up and paid from result set, as expected
         self.assertEqual(
@@ -397,7 +397,7 @@ class TestClickhouseFunnelCorrelation(ClickhouseTestMixin, APIBaseTest):
             aggregation_group_type_index=0,
         )
 
-        result, _ = self._get_events_for_filters(query, funnelCorrelationType=FunnelCorrelationResultsType.EVENTS)
+        result, _ = self._get_events_for_query(query, funnelCorrelationType=FunnelCorrelationResultsType.EVENTS)
 
         odds_ratios = [item.pop("odds_ratio") for item in result]
         expected_odds_ratios = [12 / 7, 1 / 11]
@@ -449,7 +449,7 @@ class TestClickhouseFunnelCorrelation(ClickhouseTestMixin, APIBaseTest):
                 ],
             }
         )
-        result, _ = self._get_events_for_filters(query_with_exludes)
+        result, _ = self._get_events_for_query(query_with_exludes)
 
         odds_ratio = result[0].pop("odds_ratio")
         expected_odds_ratio = 1
@@ -565,7 +565,7 @@ class TestClickhouseFunnelCorrelation(ClickhouseTestMixin, APIBaseTest):
             timestamp="2020-01-04T14:00:00Z",
         )
 
-        result, _ = self._get_events_for_filters(
+        result, _ = self._get_events_for_query(
             filters, funnelCorrelationType=FunnelCorrelationResultsType.PROPERTIES, funnelCorrelationNames=["$browser"]
         )
 
@@ -766,7 +766,7 @@ class TestClickhouseFunnelCorrelation(ClickhouseTestMixin, APIBaseTest):
             "aggregation_group_type_index": 0,
         }
 
-        result, _ = self._get_events_for_filters(
+        result, _ = self._get_events_for_query(
             filters, funnelCorrelationType=FunnelCorrelationResultsType.PROPERTIES, funnelCorrelationNames=["industry"]
         )
 
@@ -834,7 +834,7 @@ class TestClickhouseFunnelCorrelation(ClickhouseTestMixin, APIBaseTest):
 
         # test with `$all` as property
         # _run property correlation with filter on all properties
-        new_result, _ = self._get_events_for_filters(
+        new_result, _ = self._get_events_for_query(
             filters, funnelCorrelationType=FunnelCorrelationResultsType.PROPERTIES, funnelCorrelationNames=["$all"]
         )
 
@@ -971,7 +971,7 @@ class TestClickhouseFunnelCorrelation(ClickhouseTestMixin, APIBaseTest):
         }
 
         with override_instance_config("PERSON_ON_EVENTS_ENABLED", True):
-            result, _ = self._get_events_for_filters(
+            result, _ = self._get_events_for_query(
                 filters,
                 funnelCorrelationType=FunnelCorrelationResultsType.PROPERTIES,
                 funnelCorrelationNames=["industry"],
@@ -1037,7 +1037,7 @@ class TestClickhouseFunnelCorrelation(ClickhouseTestMixin, APIBaseTest):
 
             # test with `$all` as property
             # _run property correlation with filter on all properties
-            new_result, _ = self._get_events_for_filters(
+            new_result, _ = self._get_events_for_query(
                 filters,
                 funnelCorrelationType=FunnelCorrelationResultsType.PROPERTIES,
                 funnelCorrelationNames=["$all"],
@@ -1108,7 +1108,7 @@ class TestClickhouseFunnelCorrelation(ClickhouseTestMixin, APIBaseTest):
                     timestamp="2020-01-03T14:00:00Z",
                 )
 
-        result, skewed_totals = self._get_events_for_filters(filters)
+        result, skewed_totals = self._get_events_for_query(filters)
 
         self.assertFalse(skewed_totals)
 
@@ -1175,14 +1175,14 @@ class TestClickhouseFunnelCorrelation(ClickhouseTestMixin, APIBaseTest):
         flush_persons_and_events()
 
         with self.assertRaises(ValidationError):
-            self._get_events_for_filters(
+            self._get_events_for_query(
                 filters,
                 funnelCorrelationType=FunnelCorrelationResultsType.PROPERTIES,
                 # funnelCorrelationNames=["$browser"] -- missing
             )
 
         with self.assertRaises(ValidationError):
-            self._get_events_for_filters(
+            self._get_events_for_query(
                 filters,
                 funnelCorrelationType=FunnelCorrelationResultsType.EVENT_WITH_PROPERTIES,
                 # "funnelCorrelationEventNames": ["rick"] -- missing
@@ -1289,7 +1289,7 @@ class TestClickhouseFunnelCorrelation(ClickhouseTestMixin, APIBaseTest):
             timestamp="2020-01-04T14:00:00Z",
         )
 
-        result, _ = self._get_events_for_filters(
+        result, _ = self._get_events_for_query(
             filters,
             funnelCorrelationType=FunnelCorrelationResultsType.PROPERTIES,
             funnelCorrelationNames=["$browser", "$nice"],
@@ -1361,7 +1361,7 @@ class TestClickhouseFunnelCorrelation(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(result, expected_result)
 
         # _run property correlation with filter on all properties
-        new_result, _ = self._get_events_for_filters(
+        new_result, _ = self._get_events_for_query(
             filters, funnelCorrelationType=FunnelCorrelationResultsType.PROPERTIES, funnelCorrelationNames=["$all"]
         )
 
@@ -1379,7 +1379,7 @@ class TestClickhouseFunnelCorrelation(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(new_result, new_expected_result)
 
         # search for $all but exclude $browser
-        new_result, _ = self._get_events_for_filters(
+        new_result, _ = self._get_events_for_query(
             filters,
             funnelCorrelationType=FunnelCorrelationResultsType.PROPERTIES,
             funnelCorrelationNames=["$all"],
@@ -1491,7 +1491,7 @@ class TestClickhouseFunnelCorrelation(ClickhouseTestMixin, APIBaseTest):
         # Discard both due to %
         FunnelCorrelationQueryRunner.MIN_PERSON_PERCENTAGE = 0.11
         FunnelCorrelationQueryRunner.MIN_PERSON_COUNT = 25
-        result, _ = self._get_events_for_filters(filters, funnelCorrelationType=FunnelCorrelationResultsType.EVENTS)
+        result, _ = self._get_events_for_query(filters, funnelCorrelationType=FunnelCorrelationResultsType.EVENTS)
 
         self.assertEqual(len(result), 2)
 
@@ -1542,7 +1542,7 @@ class TestClickhouseFunnelCorrelation(ClickhouseTestMixin, APIBaseTest):
             timestamp="2020-01-02T14:15:00Z",  # event happened outside conversion window
         )
 
-        result, _ = self._get_events_for_filters(filters, funnelCorrelationType=FunnelCorrelationResultsType.EVENTS)
+        result, _ = self._get_events_for_query(filters, funnelCorrelationType=FunnelCorrelationResultsType.EVENTS)
 
         odds_ratios = [item.pop("odds_ratio") for item in result]
         expected_odds_ratios = [4]
@@ -1620,7 +1620,7 @@ class TestClickhouseFunnelCorrelation(ClickhouseTestMixin, APIBaseTest):
                 )
                 # source: shazam occurs only once, so would be discarded from result set
 
-        result, _ = self._get_events_for_filters(
+        result, _ = self._get_events_for_query(
             filters,
             funnelCorrelationType=FunnelCorrelationResultsType.EVENT_WITH_PROPERTIES,
             funnelCorrelationEventNames=[
@@ -1788,7 +1788,7 @@ class TestClickhouseFunnelCorrelation(ClickhouseTestMixin, APIBaseTest):
             "aggregation_group_type_index": 1,
         }
 
-        result, _ = self._get_events_for_filters(
+        result, _ = self._get_events_for_query(
             filters,
             funnelCorrelationType=FunnelCorrelationResultsType.EVENT_WITH_PROPERTIES,
             funnelCorrelationEventNames=[
@@ -1873,7 +1873,7 @@ class TestClickhouseFunnelCorrelation(ClickhouseTestMixin, APIBaseTest):
             timestamp="2020-01-02T14:00:00Z",
         )
 
-        result, _ = self._get_events_for_filters(
+        result, _ = self._get_events_for_query(
             filters,
             funnelCorrelationType=FunnelCorrelationResultsType.EVENT_WITH_PROPERTIES,
             funnelCorrelationEventNames=["positively_related"],
@@ -1981,7 +1981,7 @@ class TestClickhouseFunnelCorrelation(ClickhouseTestMixin, APIBaseTest):
             timestamp="2020-01-02T14:00:00Z",
         )
 
-        result, _ = self._get_events_for_filters(
+        result, _ = self._get_events_for_query(
             filters,
             funnelCorrelationType=FunnelCorrelationResultsType.EVENT_WITH_PROPERTIES,
             funnelCorrelationEventNames=["$autocapture"],

--- a/posthog/hogql_queries/insights/funnels/test/test_funnel_correlation.py
+++ b/posthog/hogql_queries/insights/funnels/test/test_funnel_correlation.py
@@ -18,6 +18,7 @@ from unittest import skip
 from rest_framework.exceptions import ValidationError
 
 from posthog.schema import (
+    DateRange,
     EventPropertyFilter,
     EventsNode,
     FunnelCorrelationQuery,
@@ -2179,22 +2180,22 @@ class TestFunnelCorrelationSQLInjection(ClickhouseTestMixin, APIBaseTest):
     and related parameters are safely escaped.
     """
 
-    def _setup_basic_funnel(self):
+    def _setup_basic_funnel(self) -> FunnelsQuery:
         """Create minimal funnel data for testing."""
         _create_person(distinct_ids=["person1"], team_id=self.team.pk, properties={"email": "test@example.com"})
         _create_event(team=self.team, event="$pageview", distinct_id="person1")
         _create_event(team=self.team, event="$pageleave", distinct_id="person1")
         flush_persons_and_events()
-        return {
-            "insight": INSIGHT_FUNNELS,
-            "date_from": "2020-01-01",
-            "date_to": "2020-01-14",
-            "events": [{"id": "$pageview", "order": 0}, {"id": "$pageleave", "order": 1}],
-        }
+        return FunnelsQuery(
+            series=[EventsNode(event="$pageview"), EventsNode(event="$pageleave")],
+            dateRange=DateRange(
+                date_from="2020-01-01",
+                date_to="2020-01-14",
+            ),
+        )
 
-    def _run_correlation_with_names(self, filters, correlation_names):
+    def _run_correlation_with_names(self, funnels_query: FunnelsQuery, correlation_names: list[str]):
         """Helper to run correlation query with given names."""
-        funnels_query = cast(FunnelsQuery, filter_to_query(filters))
         actors_query = FunnelsActorsQuery(source=funnels_query)
         correlation_query = FunnelCorrelationQuery(
             source=actors_query,
@@ -2203,9 +2204,8 @@ class TestFunnelCorrelationSQLInjection(ClickhouseTestMixin, APIBaseTest):
         )
         return FunnelCorrelationQueryRunner(query=correlation_query, team=self.team)._calculate_internal()
 
-    def _run_event_correlation_with_exclude(self, filters, exclude_names):
+    def _run_event_correlation_with_exclude(self, funnels_query: FunnelsQuery, exclude_names: list[str]):
         """Helper to run event correlation with exclude names."""
-        funnels_query = cast(FunnelsQuery, filter_to_query(filters))
         actors_query = FunnelsActorsQuery(source=funnels_query)
         correlation_query = FunnelCorrelationQuery(
             source=actors_query,
@@ -2217,7 +2217,7 @@ class TestFunnelCorrelationSQLInjection(ClickhouseTestMixin, APIBaseTest):
     @freeze_time("2020-01-14")
     def test_sql_injection_quote_breakout_in_correlation_names(self):
         """Verify SQL injection via quote breakout in funnelCorrelationNames is escaped."""
-        filters = self._setup_basic_funnel()
+        query = self._setup_basic_funnel()
 
         malicious_inputs = [
             "x') as a, version() as b --",
@@ -2231,7 +2231,7 @@ class TestFunnelCorrelationSQLInjection(ClickhouseTestMixin, APIBaseTest):
             # Should not raise a SQL syntax error from injection
             # (may raise other errors like empty results, but NOT from injected SQL executing)
             try:
-                result, _, _, _ = self._run_correlation_with_names(filters, [payload])
+                result, _, _, _ = self._run_correlation_with_names(query, [payload])
                 # If we get here, the query executed safely (payload was escaped)
             except Exception as e:
                 # Acceptable errors: validation errors, empty results
@@ -2243,7 +2243,7 @@ class TestFunnelCorrelationSQLInjection(ClickhouseTestMixin, APIBaseTest):
     @freeze_time("2020-01-14")
     def test_sql_injection_in_exclude_event_names(self):
         """Verify SQL injection via funnelCorrelationExcludeEventNames is escaped."""
-        filters = self._setup_basic_funnel()
+        query = self._setup_basic_funnel()
 
         malicious_inputs = [
             "'; DROP TABLE events; --",
@@ -2252,7 +2252,7 @@ class TestFunnelCorrelationSQLInjection(ClickhouseTestMixin, APIBaseTest):
 
         for payload in malicious_inputs:
             try:
-                result, _, _, _ = self._run_event_correlation_with_exclude(filters, [payload])
+                result, _, _, _ = self._run_event_correlation_with_exclude(query, [payload])
             except Exception as e:
                 error_msg = str(e).lower()
                 self.assertNotIn("syntax error", error_msg, f"SQL injection may have worked with payload: {payload}")
@@ -2260,7 +2260,7 @@ class TestFunnelCorrelationSQLInjection(ClickhouseTestMixin, APIBaseTest):
     @freeze_time("2020-01-14")
     def test_special_characters_in_property_names_are_handled(self):
         """Verify special characters in property names don't cause SQL errors."""
-        filters = self._setup_basic_funnel()
+        query = self._setup_basic_funnel()
 
         special_chars = [
             "property with spaces",
@@ -2275,7 +2275,7 @@ class TestFunnelCorrelationSQLInjection(ClickhouseTestMixin, APIBaseTest):
 
         for prop_name in special_chars:
             try:
-                result, _, _, _ = self._run_correlation_with_names(filters, [prop_name])
+                result, _, _, _ = self._run_correlation_with_names(query, [prop_name])
                 # Query should execute without SQL errors
             except Exception as e:
                 error_msg = str(e).lower()

--- a/posthog/hogql_queries/insights/funnels/test/test_funnel_correlation.py
+++ b/posthog/hogql_queries/insights/funnels/test/test_funnel_correlation.py
@@ -20,16 +20,17 @@ from posthog.schema import (
     DateRange,
     EventPropertyFilter,
     EventsNode,
+    FunnelConversionWindowTimeUnit,
     FunnelCorrelationQuery,
     FunnelCorrelationResultsType,
     FunnelsActorsQuery,
+    FunnelsFilter,
     FunnelsQuery,
     GroupPropertyFilter,
     PersonPropertyFilter,
     PropertyOperator,
 )
 
-from posthog.constants import INSIGHT_FUNNELS
 from posthog.hogql_queries.insights.funnels.funnel_correlation_query_runner import (
     EventContingencyTable,
     EventStats,
@@ -48,7 +49,7 @@ class TestClickhouseFunnelCorrelation(ClickhouseTestMixin, APIBaseTest):
 
     def _get_events_for_query(
         self,
-        funnels_query,
+        funnels_query: FunnelsQuery,
         funnelCorrelationType=FunnelCorrelationResultsType.EVENTS,
         funnelCorrelationNames=None,
         funnelCorrelationExcludeNames=None,
@@ -482,17 +483,13 @@ class TestClickhouseFunnelCorrelation(ClickhouseTestMixin, APIBaseTest):
     @freeze_time("2019-12-31")
     @snapshot_clickhouse_queries
     def test_basic_funnel_correlation_with_properties(self):
-        filters = {
-            "events": [
-                {"id": "user signed up", "type": "events", "order": 0},
-                {"id": "paid", "type": "events", "order": 1},
+        query = FunnelsQuery(
+            series=[
+                EventsNode(event="user signed up"),
+                EventsNode(event="paid"),
             ],
-            "insight": INSIGHT_FUNNELS,
-            "date_from": "2020-01-01",
-            "date_to": "2020-01-14",
-            "funnel_correlation_type": "properties",
-            "funnel_correlation_names": ["$browser"],
-        }
+            dateRange=DateRange(date_from="2020-01-01", date_to="2020-01-14"),
+        )
 
         for i in range(10):
             _create_person(
@@ -566,7 +563,7 @@ class TestClickhouseFunnelCorrelation(ClickhouseTestMixin, APIBaseTest):
         )
 
         result, _ = self._get_events_for_query(
-            filters, funnelCorrelationType=FunnelCorrelationResultsType.PROPERTIES, funnelCorrelationNames=["$browser"]
+            query, funnelCorrelationType=FunnelCorrelationResultsType.PROPERTIES, funnelCorrelationNames=["$browser"]
         )
 
         odds_ratios = [item.pop("odds_ratio") for item in result]
@@ -613,7 +610,7 @@ class TestClickhouseFunnelCorrelation(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(
             len(
                 self._get_actors_for_property(
-                    filters, [("$browser", "Positive", "person", None)], funnelCorrelationNames=["$browser"]
+                    query, [("$browser", "Positive", "person", None)], funnelCorrelationNames=["$browser"]
                 )
             ),
             10,
@@ -621,7 +618,7 @@ class TestClickhouseFunnelCorrelation(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(
             len(
                 self._get_actors_for_property(
-                    filters, [("$browser", "Positive", "person", None)], False, funnelCorrelationNames=["$browser"]
+                    query, [("$browser", "Positive", "person", None)], False, funnelCorrelationNames=["$browser"]
                 )
             ),
             1,
@@ -629,7 +626,7 @@ class TestClickhouseFunnelCorrelation(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(
             len(
                 self._get_actors_for_property(
-                    filters, [("$browser", "Negative", "person", None)], funnelCorrelationNames=["$browser"]
+                    query, [("$browser", "Negative", "person", None)], funnelCorrelationNames=["$browser"]
                 )
             ),
             1,
@@ -637,7 +634,7 @@ class TestClickhouseFunnelCorrelation(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(
             len(
                 self._get_actors_for_property(
-                    filters, [("$browser", "Negative", "person", None)], False, funnelCorrelationNames=["$browser"]
+                    query, [("$browser", "Negative", "person", None)], False, funnelCorrelationNames=["$browser"]
                 )
             ),
             10,
@@ -755,19 +752,17 @@ class TestClickhouseFunnelCorrelation(ClickhouseTestMixin, APIBaseTest):
             properties={"$group_0": f"org:succ"},
         )
 
-        filters = {
-            "events": [
-                {"id": "user signed up", "type": "events", "order": 0},
-                {"id": "paid", "type": "events", "order": 1},
+        query = FunnelsQuery(
+            series=[
+                EventsNode(event="user signed up"),
+                EventsNode(event="paid"),
             ],
-            "insight": INSIGHT_FUNNELS,
-            "date_from": "2020-01-01",
-            "date_to": "2020-01-14",
-            "aggregation_group_type_index": 0,
-        }
+            dateRange=DateRange(date_from="2020-01-01", date_to="2020-01-14"),
+            aggregation_group_type_index=0,
+        )
 
         result, _ = self._get_events_for_query(
-            filters, funnelCorrelationType=FunnelCorrelationResultsType.PROPERTIES, funnelCorrelationNames=["industry"]
+            query, funnelCorrelationType=FunnelCorrelationResultsType.PROPERTIES, funnelCorrelationNames=["industry"]
         )
 
         odds_ratios = [item.pop("odds_ratio") for item in result]
@@ -814,28 +809,28 @@ class TestClickhouseFunnelCorrelation(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(
             len(
                 self._get_actors_for_property(
-                    filters, [("industry", "positive", "group", 0)], funnelCorrelationNames=["industry"]
+                    query, [("industry", "positive", "group", 0)], funnelCorrelationNames=["industry"]
                 )
             ),
             10,
         )
         self.assertEqual(
-            len(self._get_actors_for_property(filters, [("industry", "positive", "group", 0)], False)),
+            len(self._get_actors_for_property(query, [("industry", "positive", "group", 0)], False)),
             1,
         )
         self.assertEqual(
-            len(self._get_actors_for_property(filters, [("industry", "negative", "group", 0)])),
+            len(self._get_actors_for_property(query, [("industry", "negative", "group", 0)])),
             1,
         )
         self.assertEqual(
-            len(self._get_actors_for_property(filters, [("industry", "negative", "group", 0)], False)),
+            len(self._get_actors_for_property(query, [("industry", "negative", "group", 0)], False)),
             10,
         )
 
         # test with `$all` as property
         # _run property correlation with filter on all properties
         new_result, _ = self._get_events_for_query(
-            filters, funnelCorrelationType=FunnelCorrelationResultsType.PROPERTIES, funnelCorrelationNames=["$all"]
+            query, funnelCorrelationType=FunnelCorrelationResultsType.PROPERTIES, funnelCorrelationNames=["$all"]
         )
 
         odds_ratios = [item.pop("odds_ratio") for item in new_result]
@@ -959,20 +954,18 @@ class TestClickhouseFunnelCorrelation(ClickhouseTestMixin, APIBaseTest):
             properties={"$group_0": f"org:succ"},
         )
 
-        filters = {
-            "events": [
-                {"id": "user signed up", "type": "events", "order": 0},
-                {"id": "paid", "type": "events", "order": 1},
+        query = FunnelsQuery(
+            series=[
+                EventsNode(event="user signed up"),
+                EventsNode(event="paid"),
             ],
-            "insight": INSIGHT_FUNNELS,
-            "date_from": "2020-01-01",
-            "date_to": "2020-01-14",
-            "aggregation_group_type_index": 0,
-        }
+            dateRange=DateRange(date_from="2020-01-01", date_to="2020-01-14"),
+            aggregation_group_type_index=0,
+        )
 
         with override_instance_config("PERSON_ON_EVENTS_ENABLED", True):
             result, _ = self._get_events_for_query(
-                filters,
+                query,
                 funnelCorrelationType=FunnelCorrelationResultsType.PROPERTIES,
                 funnelCorrelationNames=["industry"],
             )
@@ -1019,26 +1012,26 @@ class TestClickhouseFunnelCorrelation(ClickhouseTestMixin, APIBaseTest):
             )
 
             self.assertEqual(
-                len(self._get_actors_for_property(filters, [("industry", "positive", "group", 0)])),
+                len(self._get_actors_for_property(query, [("industry", "positive", "group", 0)])),
                 10,
             )
             self.assertEqual(
-                len(self._get_actors_for_property(filters, [("industry", "positive", "group", 0)], False)),
+                len(self._get_actors_for_property(query, [("industry", "positive", "group", 0)], False)),
                 1,
             )
             self.assertEqual(
-                len(self._get_actors_for_property(filters, [("industry", "negative", "group", 0)])),
+                len(self._get_actors_for_property(query, [("industry", "negative", "group", 0)])),
                 1,
             )
             self.assertEqual(
-                len(self._get_actors_for_property(filters, [("industry", "negative", "group", 0)], False)),
+                len(self._get_actors_for_property(query, [("industry", "negative", "group", 0)], False)),
                 10,
             )
 
             # test with `$all` as property
             # _run property correlation with filter on all properties
             new_result, _ = self._get_events_for_query(
-                filters,
+                query,
                 funnelCorrelationType=FunnelCorrelationResultsType.PROPERTIES,
                 funnelCorrelationNames=["$all"],
             )
@@ -1051,15 +1044,13 @@ class TestClickhouseFunnelCorrelation(ClickhouseTestMixin, APIBaseTest):
             self.assertEqual(new_result, result)
 
     def test_no_divide_by_zero_errors(self):
-        filters = {
-            "events": [
-                {"id": "user signed up", "type": "events", "order": 0},
-                {"id": "paid", "type": "events", "order": 1},
+        query = FunnelsQuery(
+            series=[
+                EventsNode(event="user signed up"),
+                EventsNode(event="paid"),
             ],
-            "insight": INSIGHT_FUNNELS,
-            "date_from": "2020-01-01",
-            "date_to": "2020-01-14",
-        }
+            dateRange=DateRange(date_from="2020-01-01", date_to="2020-01-14"),
+        )
 
         for i in range(2):
             _create_person(
@@ -1108,7 +1099,7 @@ class TestClickhouseFunnelCorrelation(ClickhouseTestMixin, APIBaseTest):
                     timestamp="2020-01-03T14:00:00Z",
                 )
 
-        result, skewed_totals = self._get_events_for_query(filters)
+        result, skewed_totals = self._get_events_for_query(query)
 
         self.assertFalse(skewed_totals)
 
@@ -1139,15 +1130,13 @@ class TestClickhouseFunnelCorrelation(ClickhouseTestMixin, APIBaseTest):
         )
 
     def test_correlation_with_properties_raises_validation_error(self):
-        filters = {
-            "events": [
-                {"id": "user signed up", "type": "events", "order": 0},
-                {"id": "paid", "type": "events", "order": 1},
+        query = FunnelsQuery(
+            series=[
+                EventsNode(event="user signed up"),
+                EventsNode(event="paid"),
             ],
-            "insight": INSIGHT_FUNNELS,
-            "date_from": "2020-01-01",
-            "date_to": "2020-01-14",
-        }
+            dateRange=DateRange(date_from="2020-01-01", date_to="2020-01-14"),
+        )
 
         _create_person(
             distinct_ids=[f"user_1"],
@@ -1176,14 +1165,14 @@ class TestClickhouseFunnelCorrelation(ClickhouseTestMixin, APIBaseTest):
 
         with self.assertRaises(ValidationError):
             self._get_events_for_query(
-                filters,
+                query,
                 funnelCorrelationType=FunnelCorrelationResultsType.PROPERTIES,
                 # funnelCorrelationNames=["$browser"] -- missing
             )
 
         with self.assertRaises(ValidationError):
             self._get_events_for_query(
-                filters,
+                query,
                 funnelCorrelationType=FunnelCorrelationResultsType.EVENT_WITH_PROPERTIES,
                 # "funnelCorrelationEventNames": ["rick"] -- missing
             )
@@ -1193,15 +1182,13 @@ class TestClickhouseFunnelCorrelation(ClickhouseTestMixin, APIBaseTest):
     )
     @skip("Works locally and works after you tmate onto github actions and run it, but fails in CI")
     def test_correlation_with_multiple_properties(self):
-        filters = {
-            "events": [
-                {"id": "user signed up", "type": "events", "order": 0},
-                {"id": "paid", "type": "events", "order": 1},
+        query = FunnelsQuery(
+            series=[
+                EventsNode(event="user signed up"),
+                EventsNode(event="paid"),
             ],
-            "insight": INSIGHT_FUNNELS,
-            "date_from": "2020-01-01",
-            "date_to": "2020-01-14",
-        }
+            dateRange=DateRange(date_from="2020-01-01", date_to="2020-01-14"),
+        )
 
         # 5 successful people with both properties
         for i in range(5):
@@ -1290,7 +1277,7 @@ class TestClickhouseFunnelCorrelation(ClickhouseTestMixin, APIBaseTest):
         )
 
         result, _ = self._get_events_for_query(
-            filters,
+            query,
             funnelCorrelationType=FunnelCorrelationResultsType.PROPERTIES,
             funnelCorrelationNames=["$browser", "$nice"],
         )
@@ -1362,7 +1349,7 @@ class TestClickhouseFunnelCorrelation(ClickhouseTestMixin, APIBaseTest):
 
         # _run property correlation with filter on all properties
         new_result, _ = self._get_events_for_query(
-            filters, funnelCorrelationType=FunnelCorrelationResultsType.PROPERTIES, funnelCorrelationNames=["$all"]
+            query, funnelCorrelationType=FunnelCorrelationResultsType.PROPERTIES, funnelCorrelationNames=["$all"]
         )
 
         odds_ratios = [item.pop("odds_ratio") for item in new_result]
@@ -1380,7 +1367,7 @@ class TestClickhouseFunnelCorrelation(ClickhouseTestMixin, APIBaseTest):
 
         # search for $all but exclude $browser
         new_result, _ = self._get_events_for_query(
-            filters,
+            query,
             funnelCorrelationType=FunnelCorrelationResultsType.PROPERTIES,
             funnelCorrelationNames=["$all"],
             funnelCorrelationExcludeNames=["$browser"],
@@ -1399,7 +1386,7 @@ class TestClickhouseFunnelCorrelation(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(
             len(
                 self._get_actors_for_property(
-                    filters, [("$nice", "not", "person", None)], funnelCorrelationNames=["$browser", "$nice"]
+                    query, [("$nice", "not", "person", None)], funnelCorrelationNames=["$browser", "$nice"]
                 )
             ),
             10,
@@ -1407,7 +1394,7 @@ class TestClickhouseFunnelCorrelation(ClickhouseTestMixin, APIBaseTest):
         # self.assertEqual(
         #     len(
         #         self._get_actors_for_property(
-        #             filters, [("$nice", "", "person", None)], False, funnelCorrelationNames=["$browser", "$nice"]
+        #             query, [("$nice", "", "person", None)], False, funnelCorrelationNames=["$browser", "$nice"]
         #         )
         #     ),
         #     1,
@@ -1415,22 +1402,20 @@ class TestClickhouseFunnelCorrelation(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(
             len(
                 self._get_actors_for_property(
-                    filters, [("$nice", "very", "person", None)], funnelCorrelationNames=["$browser", "$nice"]
+                    query, [("$nice", "very", "person", None)], funnelCorrelationNames=["$browser", "$nice"]
                 )
             ),
             5,
         )
 
     def test_discarding_insignificant_events(self):
-        filters = {
-            "events": [
-                {"id": "user signed up", "type": "events", "order": 0},
-                {"id": "paid", "type": "events", "order": 1},
+        query = FunnelsQuery(
+            series=[
+                EventsNode(event="user signed up"),
+                EventsNode(event="paid"),
             ],
-            "insight": INSIGHT_FUNNELS,
-            "date_from": "2020-01-01",
-            "date_to": "2020-01-14",
-        }
+            dateRange=DateRange(date_from="2020-01-01", date_to="2020-01-14"),
+        )
 
         for i in range(10):
             _create_person(distinct_ids=[f"user_{i}"], team_id=self.team.pk)
@@ -1491,22 +1476,22 @@ class TestClickhouseFunnelCorrelation(ClickhouseTestMixin, APIBaseTest):
         # Discard both due to %
         FunnelCorrelationQueryRunner.MIN_PERSON_PERCENTAGE = 0.11
         FunnelCorrelationQueryRunner.MIN_PERSON_COUNT = 25
-        result, _ = self._get_events_for_query(filters, funnelCorrelationType=FunnelCorrelationResultsType.EVENTS)
+        result, _ = self._get_events_for_query(query, funnelCorrelationType=FunnelCorrelationResultsType.EVENTS)
 
         self.assertEqual(len(result), 2)
 
     def test_events_within_conversion_window_for_correlation(self):
-        filters = {
-            "events": [
-                {"id": "user signed up", "type": "events", "order": 0},
-                {"id": "paid", "type": "events", "order": 1},
+        query = FunnelsQuery(
+            series=[
+                EventsNode(event="user signed up"),
+                EventsNode(event="paid"),
             ],
-            "insight": INSIGHT_FUNNELS,
-            "funnel_window_interval": "10",
-            "funnel_window_interval_unit": "minute",
-            "date_from": "2020-01-01",
-            "date_to": "2020-01-14",
-        }
+            dateRange=DateRange(date_from="2020-01-01", date_to="2020-01-14"),
+            funnelsFilter=FunnelsFilter(
+                funnelWindowInterval=10,
+                funnelWindowIntervalUnit=FunnelConversionWindowTimeUnit.MINUTE,
+            ),
+        )
 
         _create_person(distinct_ids=["user_successful"], team_id=self.team.pk)
         _create_event(
@@ -1542,7 +1527,7 @@ class TestClickhouseFunnelCorrelation(ClickhouseTestMixin, APIBaseTest):
             timestamp="2020-01-02T14:15:00Z",  # event happened outside conversion window
         )
 
-        result, _ = self._get_events_for_query(filters, funnelCorrelationType=FunnelCorrelationResultsType.EVENTS)
+        result, _ = self._get_events_for_query(query, funnelCorrelationType=FunnelCorrelationResultsType.EVENTS)
 
         odds_ratios = [item.pop("odds_ratio") for item in result]
         expected_odds_ratios = [4]
@@ -1565,15 +1550,13 @@ class TestClickhouseFunnelCorrelation(ClickhouseTestMixin, APIBaseTest):
 
     @also_test_with_materialized_columns(["blah", "signup_source"], verify_no_jsonextract=False)
     def test_funnel_correlation_with_event_properties(self):
-        filters = {
-            "events": [
-                {"id": "user signed up", "type": "events", "order": 0},
-                {"id": "paid", "type": "events", "order": 1},
+        query = FunnelsQuery(
+            series=[
+                EventsNode(event="user signed up"),
+                EventsNode(event="paid"),
             ],
-            "insight": INSIGHT_FUNNELS,
-            "date_from": "2020-01-01",
-            "date_to": "2020-01-14",
-        }
+            dateRange=DateRange(date_from="2020-01-01", date_to="2020-01-14"),
+        )
 
         for i in range(10):
             _create_person(distinct_ids=[f"user_{i}"], team_id=self.team.pk)
@@ -1621,7 +1604,7 @@ class TestClickhouseFunnelCorrelation(ClickhouseTestMixin, APIBaseTest):
                 # source: shazam occurs only once, so would be discarded from result set
 
         result, _ = self._get_events_for_query(
-            filters,
+            query,
             funnelCorrelationType=FunnelCorrelationResultsType.EVENT_WITH_PROPERTIES,
             funnelCorrelationEventNames=[
                 "positively_related",
@@ -1665,7 +1648,7 @@ class TestClickhouseFunnelCorrelation(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(
             len(
                 self._get_actors_for_event(
-                    filters,
+                    query,
                     "positively_related",
                     [EventPropertyFilter(operator=PropertyOperator.EXACT, key="blah", value="value_bleh")],
                 )
@@ -1675,7 +1658,7 @@ class TestClickhouseFunnelCorrelation(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(
             len(
                 self._get_actors_for_event(
-                    filters,
+                    query,
                     "positively_related",
                     [EventPropertyFilter(operator=PropertyOperator.EXACT, key="signup_source", value="facebook")],
                 )
@@ -1685,7 +1668,7 @@ class TestClickhouseFunnelCorrelation(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(
             len(
                 self._get_actors_for_event(
-                    filters,
+                    query,
                     "positively_related",
                     [EventPropertyFilter(operator=PropertyOperator.EXACT, key="signup_source", value="facebook")],
                     False,
@@ -1696,7 +1679,7 @@ class TestClickhouseFunnelCorrelation(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(
             len(
                 self._get_actors_for_event(
-                    filters,
+                    query,
                     "negatively_related",
                     [EventPropertyFilter(operator=PropertyOperator.EXACT, key="signup_source", value="email")],
                     False,
@@ -1777,19 +1760,17 @@ class TestClickhouseFunnelCorrelation(ClickhouseTestMixin, APIBaseTest):
                 )
                 # source: shazam occurs only once, so would be discarded from result set
 
-        filters = {
-            "events": [
-                {"id": "user signed up", "type": "events", "order": 0},
-                {"id": "paid", "type": "events", "order": 1},
+        query = FunnelsQuery(
+            series=[
+                EventsNode(event="user signed up"),
+                EventsNode(event="paid"),
             ],
-            "insight": INSIGHT_FUNNELS,
-            "date_from": "2020-01-01",
-            "date_to": "2020-01-14",
-            "aggregation_group_type_index": 1,
-        }
+            dateRange=DateRange(date_from="2020-01-01", date_to="2020-01-14"),
+            aggregation_group_type_index=1,
+        )
 
         result, _ = self._get_events_for_query(
-            filters,
+            query,
             funnelCorrelationType=FunnelCorrelationResultsType.EVENT_WITH_PROPERTIES,
             funnelCorrelationEventNames=[
                 "positively_related",
@@ -1831,15 +1812,13 @@ class TestClickhouseFunnelCorrelation(ClickhouseTestMixin, APIBaseTest):
         )
 
     def test_funnel_correlation_with_event_properties_exclusions(self):
-        filters = {
-            "events": [
-                {"id": "user signed up", "type": "events", "order": 0},
-                {"id": "paid", "type": "events", "order": 1},
+        query = FunnelsQuery(
+            series=[
+                EventsNode(event="user signed up"),
+                EventsNode(event="paid"),
             ],
-            "insight": INSIGHT_FUNNELS,
-            "date_from": "2020-01-01",
-            "date_to": "2020-01-14",
-        }
+            dateRange=DateRange(date_from="2020-01-01", date_to="2020-01-14"),
+        )
 
         # Need more than 2 events to get a correlation
         for i in range(3):
@@ -1874,7 +1853,7 @@ class TestClickhouseFunnelCorrelation(ClickhouseTestMixin, APIBaseTest):
         )
 
         result, _ = self._get_events_for_query(
-            filters,
+            query,
             funnelCorrelationType=FunnelCorrelationResultsType.EVENT_WITH_PROPERTIES,
             funnelCorrelationEventNames=["positively_related"],
             funnelCorrelationEventExcludePropertyNames=["signup_source"],
@@ -1897,7 +1876,7 @@ class TestClickhouseFunnelCorrelation(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(
             len(
                 self._get_actors_for_event(
-                    filters,
+                    query,
                     "positively_related",
                     [EventPropertyFilter(operator=PropertyOperator.EXACT, key="blah", value="value_bleh")],
                 )
@@ -1909,7 +1888,7 @@ class TestClickhouseFunnelCorrelation(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(
             len(
                 self._get_actors_for_event(
-                    filters,
+                    query,
                     "positively_related",
                     [EventPropertyFilter(operator=PropertyOperator.EXACT, key="signup_source", value="facebook")],
                 )
@@ -1920,15 +1899,13 @@ class TestClickhouseFunnelCorrelation(ClickhouseTestMixin, APIBaseTest):
     # :FIXME: This should also work with materialized columns
     # @also_test_with_materialized_columns(["$event_type", "signup_source"])
     def test_funnel_correlation_with_event_properties_autocapture(self):
-        filters = {
-            "events": [
-                {"id": "user signed up", "type": "events", "order": 0},
-                {"id": "paid", "type": "events", "order": 1},
+        query = FunnelsQuery(
+            series=[
+                EventsNode(event="user signed up"),
+                EventsNode(event="paid"),
             ],
-            "insight": INSIGHT_FUNNELS,
-            "date_from": "2020-01-01",
-            "date_to": "2020-01-14",
-        }
+            dateRange=DateRange(date_from="2020-01-01", date_to="2020-01-14"),
+        )
 
         # Need a minimum of 3 hits to get a correlation result
         for i in range(6):
@@ -1982,7 +1959,7 @@ class TestClickhouseFunnelCorrelation(ClickhouseTestMixin, APIBaseTest):
         )
 
         result, _ = self._get_events_for_query(
-            filters,
+            query,
             funnelCorrelationType=FunnelCorrelationResultsType.EVENT_WITH_PROPERTIES,
             funnelCorrelationEventNames=["$autocapture"],
         )
@@ -2169,15 +2146,12 @@ class TestFunnelCorrelationSQLInjection(ClickhouseTestMixin, APIBaseTest):
         flush_persons_and_events()
         return FunnelsQuery(
             series=[EventsNode(event="$pageview"), EventsNode(event="$pageleave")],
-            dateRange=DateRange(
-                date_from="2020-01-01",
-                date_to="2020-01-14",
-            ),
+            dateRange=DateRange(date_from="2020-01-01", date_to="2020-01-14"),
         )
 
-    def _run_correlation_with_names(self, funnels_query: FunnelsQuery, correlation_names: list[str]):
+    def _run_correlation_with_names(self, query: FunnelsQuery, correlation_names):
         """Helper to run correlation query with given names."""
-        actors_query = FunnelsActorsQuery(source=funnels_query)
+        actors_query = FunnelsActorsQuery(source=query)
         correlation_query = FunnelCorrelationQuery(
             source=actors_query,
             funnelCorrelationType=FunnelCorrelationResultsType.PROPERTIES,
@@ -2185,9 +2159,9 @@ class TestFunnelCorrelationSQLInjection(ClickhouseTestMixin, APIBaseTest):
         )
         return FunnelCorrelationQueryRunner(query=correlation_query, team=self.team)._calculate_internal()
 
-    def _run_event_correlation_with_exclude(self, funnels_query: FunnelsQuery, exclude_names: list[str]):
+    def _run_event_correlation_with_exclude(self, query: FunnelsQuery, exclude_names):
         """Helper to run event correlation with exclude names."""
-        actors_query = FunnelsActorsQuery(source=funnels_query)
+        actors_query = FunnelsActorsQuery(source=query)
         correlation_query = FunnelCorrelationQuery(
             source=actors_query,
             funnelCorrelationType=FunnelCorrelationResultsType.EVENTS,

--- a/posthog/hogql_queries/insights/funnels/test/test_funnel_correlation_actors.py
+++ b/posthog/hogql_queries/insights/funnels/test/test_funnel_correlation_actors.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timedelta
-from typing import Any, Optional, cast
+from typing import Optional
 from uuid import UUID
 
 from freezegun import freeze_time
@@ -16,26 +16,25 @@ from django.utils import timezone
 
 from posthog.schema import (
     ActorsQuery,
+    DateRange,
     EventsNode,
     FunnelCorrelationActorsQuery,
     FunnelCorrelationQuery,
     FunnelCorrelationResultsType,
     FunnelsActorsQuery,
+    FunnelsFilter,
     FunnelsQuery,
+    StepOrderValue,
 )
 
-from posthog.constants import INSIGHT_FUNNELS
 from posthog.hogql_queries.actors_query_runner import ActorsQueryRunner
-from posthog.hogql_queries.legacy_compatibility.filter_to_query import filter_to_query
 from posthog.models.team.team import Team
 from posthog.session_recordings.queries.test.session_replay_sql import produce_replay_summary
 from posthog.test.test_journeys import journeys_for
 
-FORMAT_TIME = "%Y-%m-%d 00:00:00"
-
 
 def get_actors(
-    filters: dict[str, Any],
+    funnels_query: FunnelsQuery,
     team: Team,
     funnelCorrelationType: Optional[FunnelCorrelationResultsType] = FunnelCorrelationResultsType.EVENTS,
     funnelCorrelationNames=None,
@@ -44,7 +43,6 @@ def get_actors(
     funnelCorrelationPropertyValues=None,
     includeRecordings: Optional[bool] = True,
 ):
-    funnels_query = cast(FunnelsQuery, filter_to_query(filters))
     funnel_actors_query = FunnelsActorsQuery(source=funnels_query, includeRecordings=includeRecordings)
     correlation_query = FunnelCorrelationQuery(
         source=funnel_actors_query,
@@ -75,15 +73,16 @@ class TestFunnelCorrelationActors(ClickhouseTestMixin, APIBaseTest):
     maxDiff = None
 
     def _setup_basic_test(self):
-        filters = {
-            "events": [
-                {"id": "user signed up", "type": "events", "order": 0},
-                {"id": "paid", "type": "events", "order": 1},
+        query = FunnelsQuery(
+            series=[
+                EventsNode(event="user signed up"),
+                EventsNode(event="paid"),
             ],
-            "insight": INSIGHT_FUNNELS,
-            "date_from": "2020-01-01",
-            "date_to": "2020-01-14",
-        }
+            dateRange=DateRange(
+                date_from="2020-01-01",
+                date_to="2020-01-14",
+            ),
+        )
 
         success_target_persons = []
         failure_target_persons = []
@@ -137,7 +136,7 @@ class TestFunnelCorrelationActors(ClickhouseTestMixin, APIBaseTest):
         journeys_for(events_by_person, self.team, create_people=False)
 
         return (
-            filters,
+            query,
             success_target_persons,
             failure_target_persons,
             person_fail,
@@ -146,7 +145,7 @@ class TestFunnelCorrelationActors(ClickhouseTestMixin, APIBaseTest):
 
     def test_basic_funnel_correlation_with_events(self):
         (
-            filters,
+            query,
             success_target_persons,
             failure_target_persons,
             person_fail,
@@ -155,7 +154,7 @@ class TestFunnelCorrelationActors(ClickhouseTestMixin, APIBaseTest):
 
         # test positively_related successes
         serialized_actors = get_actors(
-            filters,
+            query,
             self.team,
             funnelCorrelationPersonConverted=True,
             funnelCorrelationPersonEntity=EventsNode(event="positively_related"),
@@ -165,7 +164,7 @@ class TestFunnelCorrelationActors(ClickhouseTestMixin, APIBaseTest):
 
         # test negatively_related failures
         serialized_actors = get_actors(
-            filters,
+            query,
             self.team,
             funnelCorrelationPersonConverted=False,
             funnelCorrelationPersonEntity=EventsNode(event="negatively_related"),
@@ -175,7 +174,7 @@ class TestFunnelCorrelationActors(ClickhouseTestMixin, APIBaseTest):
 
         # test positively_related failures
         serialized_actors = get_actors(
-            filters,
+            query,
             self.team,
             funnelCorrelationPersonConverted=False,
             funnelCorrelationPersonEntity=EventsNode(event="positively_related"),
@@ -185,7 +184,7 @@ class TestFunnelCorrelationActors(ClickhouseTestMixin, APIBaseTest):
 
         # test negatively_related successes
         serialized_actors = get_actors(
-            filters,
+            query,
             self.team,
             funnelCorrelationPersonConverted=True,
             funnelCorrelationPersonEntity=EventsNode(event="negatively_related"),
@@ -195,7 +194,7 @@ class TestFunnelCorrelationActors(ClickhouseTestMixin, APIBaseTest):
 
         # test all positively_related
         serialized_actors = get_actors(
-            filters,
+            query,
             self.team,
             funnelCorrelationPersonConverted=None,
             funnelCorrelationPersonEntity=EventsNode(event="positively_related"),
@@ -208,7 +207,7 @@ class TestFunnelCorrelationActors(ClickhouseTestMixin, APIBaseTest):
 
         # test all negatively_related
         serialized_actors = get_actors(
-            filters,
+            query,
             self.team,
             funnelCorrelationPersonConverted=None,
             funnelCorrelationPersonEntity=EventsNode(event="negatively_related"),
@@ -239,18 +238,19 @@ class TestFunnelCorrelationActors(ClickhouseTestMixin, APIBaseTest):
             self.team,
         )
 
-        filters = {
-            "events": [
-                {"id": "user signed up", "type": "events", "order": 0},
-                {"id": "paid", "type": "events", "order": 1},
+        query = FunnelsQuery(
+            series=[
+                EventsNode(event="user signed up"),
+                EventsNode(event="paid"),
             ],
-            "insight": INSIGHT_FUNNELS,
-            "date_from": "2020-01-01",
-            "date_to": "2020-01-14",
-        }
+            dateRange=DateRange(
+                date_from="2020-01-01",
+                date_to="2020-01-14",
+            ),
+        )
 
         serialized_actors = get_actors(
-            filters,
+            query,
             self.team,
             funnelCorrelationPersonConverted=True,
             funnelCorrelationPersonEntity=EventsNode(event="positively_related"),
@@ -297,18 +297,19 @@ class TestFunnelCorrelationActors(ClickhouseTestMixin, APIBaseTest):
         )
 
         # Success filter
-        filters = {
-            "insight": INSIGHT_FUNNELS,
-            "date_from": "2021-01-01",
-            "date_to": "2021-01-08",
-            "events": [
-                {"id": "$pageview", "order": 0},
-                {"id": "insight analyzed", "order": 1},
+        query = FunnelsQuery(
+            series=[
+                EventsNode(event="$pageview"),
+                EventsNode(event="insight analyzed"),
             ],
-        }
+            dateRange=DateRange(
+                date_from="2021-01-01",
+                date_to="2021-01-08",
+            ),
+        )
 
         results = get_actors(
-            filters,
+            query,
             self.team,
             funnelCorrelationPersonConverted=True,
             funnelCorrelationPersonEntity=EventsNode(event="insight loaded"),
@@ -332,19 +333,19 @@ class TestFunnelCorrelationActors(ClickhouseTestMixin, APIBaseTest):
         )
 
         # Drop off filter
-        filters = {
-            "insight": INSIGHT_FUNNELS,
-            "date_from": "2021-01-01",
-            "date_to": "2021-01-08",
-            "funnel_correlation_type": "events",
-            "events": [
-                {"id": "$pageview", "order": 0},
-                {"id": "insight analyzed", "order": 1},
-                {"id": "insight updated", "order": 2},
+        query = FunnelsQuery(
+            series=[
+                EventsNode(event="$pageview"),
+                EventsNode(event="insight analyzed"),
+                EventsNode(event="insight updated"),
             ],
-        }
+            dateRange=DateRange(
+                date_from="2021-01-01",
+                date_to="2021-01-08",
+            ),
+        )
         results = get_actors(
-            filters,
+            query,
             self.team,
             funnelCorrelationPersonConverted=False,
             funnelCorrelationPersonEntity=EventsNode(event="insight loaded"),
@@ -398,17 +399,18 @@ class TestFunnelCorrelationActors(ClickhouseTestMixin, APIBaseTest):
         )
 
         # Success filter
-        filters = {
-            "insight": INSIGHT_FUNNELS,
-            "date_from": "2021-01-01",
-            "date_to": "2021-01-08",
-            "events": [
-                {"id": "$pageview", "order": 0},
-                {"id": "insight analyzed", "order": 1},
+        query = FunnelsQuery(
+            series=[
+                EventsNode(event="$pageview"),
+                EventsNode(event="insight analyzed"),
             ],
-        }
+            dateRange=DateRange(
+                date_from="2021-01-01",
+                date_to="2021-01-08",
+            ),
+        )
         results = get_actors(
-            filters,
+            query,
             self.team,
             funnelCorrelationType=FunnelCorrelationResultsType.PROPERTIES,
             funnelCorrelationPersonConverted=True,
@@ -510,19 +512,20 @@ class TestFunnelCorrelationActors(ClickhouseTestMixin, APIBaseTest):
         )
 
         # Success filter
-        filters = {
-            "insight": INSIGHT_FUNNELS,
-            "date_from": "2021-01-01",
-            "date_to": "2021-01-08",
-            "funnel_order_type": "strict",
-            "events": [
-                {"id": "$pageview", "order": 0},
-                {"id": "insight analyzed", "order": 1},
+        query = FunnelsQuery(
+            series=[
+                EventsNode(event="$pageview"),
+                EventsNode(event="insight analyzed"),
             ],
-        }
+            dateRange=DateRange(
+                date_from="2021-01-01",
+                date_to="2021-01-08",
+            ),
+            funnelsFilter=FunnelsFilter(funnelOrderType=StepOrderValue.STRICT),
+        )
 
         results = get_actors(
-            filters,
+            query,
             self.team,
             funnelCorrelationType=FunnelCorrelationResultsType.PROPERTIES,
             funnelCorrelationPersonConverted=True,
@@ -556,7 +559,7 @@ class TestFunnelCorrelationActors(ClickhouseTestMixin, APIBaseTest):
 
         # Drop off filter
         results = get_actors(
-            filters,
+            query,
             self.team,
             funnelCorrelationType=FunnelCorrelationResultsType.PROPERTIES,
             funnelCorrelationPersonConverted=False,

--- a/posthog/hogql_queries/insights/funnels/test/test_funnel_correlation_actors.py
+++ b/posthog/hogql_queries/insights/funnels/test/test_funnel_correlation_actors.py
@@ -43,7 +43,11 @@ def get_actors(
     funnelCorrelationPropertyValues=None,
     includeRecordings: Optional[bool] = True,
 ):
-    funnel_actors_query = FunnelsActorsQuery(source=funnels_query, includeRecordings=includeRecordings)
+    # FunnelCorrelationQueryRunner mutates query.properties for property actor lookups,
+    # so use a fresh query model per call to avoid leaking filters between assertions.
+    funnel_actors_query = FunnelsActorsQuery(
+        source=funnels_query.model_copy(deep=True), includeRecordings=includeRecordings
+    )
     correlation_query = FunnelCorrelationQuery(
         source=funnel_actors_query,
         funnelCorrelationType=(funnelCorrelationType or FunnelCorrelationResultsType.EVENTS),

--- a/posthog/hogql_queries/insights/funnels/test/test_funnel_correlation_actors.py
+++ b/posthog/hogql_queries/insights/funnels/test/test_funnel_correlation_actors.py
@@ -48,10 +48,6 @@ def get_actors(
         source=funnel_actors_query,
         funnelCorrelationType=(funnelCorrelationType or FunnelCorrelationResultsType.EVENTS),
         funnelCorrelationNames=funnelCorrelationNames,
-        # funnelCorrelationExcludeNames=funnelCorrelationExcludeNames,
-        # funnelCorrelationExcludeEventNames=funnelCorrelationExcludeEventNames,
-        # funnelCorrelationEventNames=funnelCorrelationEventNames,
-        # funnelCorrelationEventExcludePropertyNames=funnelCorrelationEventExcludePropertyNames,
     )
     correlation_actors_query = FunnelCorrelationActorsQuery(
         source=correlation_query,
@@ -118,7 +114,7 @@ class TestFunnelCorrelationActors(ClickhouseTestMixin, APIBaseTest):
                 failure_target_persons.append(str(person.uuid))
 
         # One positively_related as failure
-        person_fail_id = f"user_fail"
+        person_fail_id = "user_fail"
         person_fail = _create_person(distinct_ids=[person_fail_id], team_id=self.team.pk)
         events_by_person[person_fail_id] = [
             {"event": "user signed up", "timestamp": datetime(2020, 1, 2, 14)},
@@ -126,7 +122,7 @@ class TestFunnelCorrelationActors(ClickhouseTestMixin, APIBaseTest):
         ]
 
         # One negatively_related as success
-        person_success_id = f"user_succ"
+        person_success_id = "user_succ"
         person_succ = _create_person(distinct_ids=[person_success_id], team_id=self.team.pk)
         events_by_person[person_success_id] = [
             {"event": "user signed up", "timestamp": datetime(2020, 1, 2, 14)},


### PR DESCRIPTION
## Problem

We want to get rid of legacy "filters".

## Changes

Replaces them in `posthog/hogql_queries/insights/funnels/test/test_funnel_correlation_actors.py` and `posthog/hogql_queries/insights/funnels/test/test_funnel_correlation.py`.

## How did you test this code?

Tests still run