### PR TITLE
feat(logs): enrich alert notification templates with deep links, services, and severity context

### DIFF
--- a/products/logs/backend/logs_url_params.py
+++ b/products/logs/backend/logs_url_params.py
@@ -1,0 +1,70 @@
+"""Build URL query params for deep-linking to the logs scene.
+
+The logs scene (logsSceneLogic.tsx) parses URL search params to restore
+filters. This module serializes alert filters into that format so
+notification links open the logs view with the right context.
+
+URL format:
+  severityLevels  — JSON array: '["error","warn"]'
+  serviceNames    — JSON array: '["api","worker"]'
+  filterGroup     — JSON object (PropertyGroupFilter)
+  dateRange       — JSON object: '{"date_from":"2026-04-06T14:50:00+00:00","date_to":"2026-04-06T15:00:00+00:00"}'
+"""
+
+import json
+from datetime import datetime
+from urllib.parse import urlencode
+
+
+def build_logs_url_params(
+    filters: dict,
+    *,
+    date_from: datetime | None = None,
+    date_to: datetime | None = None,
+) -> str:
+    """Convert alert filters into a URL query string for the logs scene.
+
+    Args:
+        filters: Alert filter dict with optional keys: severityLevels,
+                 serviceNames, filterGroup.
+        date_from: Start of the time range (absolute).
+        date_to: End of the time range (absolute).
+
+    Returns:
+        URL-encoded query string (without leading '?'), or empty string
+        if no params to encode.
+    """
+    params: dict[str, str] = {}
+
+    severity_levels = filters.get("severityLevels", [])
+    if severity_levels:
+        params["severityLevels"] = json.dumps(severity_levels)
+
+    service_names = filters.get("serviceNames", [])
+    if service_names:
+        params["serviceNames"] = json.dumps(service_names)
+
+    filter_group = filters.get("filterGroup")
+    if filter_group and _has_filter_values(filter_group):
+        params["filterGroup"] = json.dumps(filter_group)
+
+    if date_from is not None or date_to is not None:
+        date_range: dict[str, str] = {}
+        if date_from is not None:
+            date_range["date_from"] = date_from.isoformat()
+        if date_to is not None:
+            date_range["date_to"] = date_to.isoformat()
+        params["dateRange"] = json.dumps(date_range)
+
+    if not params:
+        return ""
+
+    return urlencode(params)
+
+
+def _has_filter_values(filter_group: dict) -> bool:
+    """True if the filter group contains at least one non-empty property filter."""
+    for group in filter_group.get("values", []):
+        if group.get("values"):
+            return True
+    return False

--- a/products/logs/backend/temporal/activities.py
+++ b/products/logs/backend/temporal/activities.py
@@ -23,6 +23,7 @@ from products.logs.backend.alert_state_machine import (
     evaluate_alert_check,
 )
 from products.logs.backend.alert_utils import advance_next_check_at
+from products.logs.backend.logs_url_params import build_logs_url_params
 from products.logs.backend.models import LogsAlertCheck, LogsAlertConfiguration
 from products.logs.backend.temporal.metrics import increment_checks_total, record_check_duration, record_scheduler_lag
 
@@ -155,7 +156,14 @@ def _evaluate_single_alert(
     notified = False
     notification_failed = False
     if outcome.notification == NotificationAction.FIRE:
-        notified = _emit_alert_event(alert, "$logs_alert_firing", check_result, now)
+        notified = _emit_alert_event(
+            alert,
+            "$logs_alert_firing",
+            check_result,
+            now,
+            date_from=date_from,
+            date_to=date_to,
+        )
         notification_failed = not notified
         if notified:
             stats["fired"] += 1
@@ -168,7 +176,14 @@ def _evaluate_single_alert(
             notified=notified,
         )
     elif outcome.notification == NotificationAction.RESOLVE:
-        notified = _emit_alert_event(alert, "$logs_alert_resolved", check_result, now)
+        notified = _emit_alert_event(
+            alert,
+            "$logs_alert_resolved",
+            check_result,
+            now,
+            date_from=date_from,
+            date_to=date_to,
+        )
         notification_failed = not notified
         if notified:
             stats["resolved"] += 1
@@ -241,6 +256,9 @@ def _emit_alert_event(
     event_name: str,
     check_result: CheckResult,
     now: datetime,
+    *,
+    date_from: datetime,
+    date_to: datetime,
 ) -> bool:
     """Produce an internal event to Kafka for CDP processing. Returns True on success."""
     properties: dict = {
@@ -252,6 +270,10 @@ def _emit_alert_event(
         "window_minutes": alert.window_minutes,
         "result_count": check_result.result_count,
         "filters": alert.filters,
+        "service_names": alert.filters.get("serviceNames", []),
+        "severity_levels": alert.filters.get("severityLevels", []),
+        "logs_url_params": build_logs_url_params(alert.filters, date_from=date_from, date_to=date_to),
+        "triggered_at": now.isoformat(),
     }
 
     try:

--- a/products/logs/backend/test/test_logs_alerting_activities.py
+++ b/products/logs/backend/test/test_logs_alerting_activities.py
@@ -337,6 +337,46 @@ class TestEvaluateSingleAlert(APIBaseTest):
     @freeze_time("2025-01-01T00:01:00Z")
     @patch("products.logs.backend.temporal.activities.AlertCheckQuery")
     @patch("products.logs.backend.temporal.activities.produce_internal_event")
+    def test_event_properties_include_logs_url_params(self, mock_produce, mock_query_cls):
+        alert = self._make_alert(
+            threshold_count=5,
+            filters={"severityLevels": ["error"], "serviceNames": ["api-server"]},
+        )
+        mock_query_cls.return_value.execute.return_value = AlertCheckCountResult(count=10, query_duration_ms=50)
+
+        _evaluate_single_alert(alert, datetime(2025, 1, 1, 0, 1, 0, tzinfo=UTC), _make_stats())
+
+        assert mock_produce.called
+        props = mock_produce.call_args.kwargs["event"].properties
+        assert "logs_url_params" in props
+        assert "severityLevels" in props["logs_url_params"]
+        assert "api-server" in props["logs_url_params"]
+        assert props["service_names"] == ["api-server"]
+        assert props["severity_levels"] == ["error"]
+        assert props["triggered_at"] == "2025-01-01T00:01:00+00:00"
+
+    @freeze_time("2025-01-01T00:01:00Z")
+    @patch("products.logs.backend.temporal.activities.AlertCheckQuery")
+    @patch("products.logs.backend.temporal.activities.produce_internal_event")
+    def test_logs_url_params_includes_absolute_date_range(self, mock_produce, mock_query_cls):
+        alert = self._make_alert(
+            threshold_count=5,
+            window_minutes=10,
+            filters={"severityLevels": ["error"]},
+        )
+        mock_query_cls.return_value.execute.return_value = AlertCheckCountResult(count=10, query_duration_ms=50)
+
+        _evaluate_single_alert(alert, datetime(2025, 1, 1, 0, 1, 0, tzinfo=UTC), _make_stats())
+
+        props = mock_produce.call_args.kwargs["event"].properties
+        assert "dateRange" in props["logs_url_params"]
+        # Window is 10m, check time is 00:01 — so date_from should be 23:51 (previous day)
+        assert "2024-12-31T23%3A51%3A00" in props["logs_url_params"] or "23:51:00" in props["logs_url_params"]
+        assert "2025-01-01T00%3A01%3A00" in props["logs_url_params"] or "00:01:00" in props["logs_url_params"]
+
+    @freeze_time("2025-01-01T00:01:00Z")
+    @patch("products.logs.backend.temporal.activities.AlertCheckQuery")
+    @patch("products.logs.backend.temporal.activities.produce_internal_event")
     def test_resolution_within_cooldown_suppresses_resolved_event(self, mock_produce, mock_query_cls):
         mock_query_cls.return_value.execute.return_value = AlertCheckCountResult(count=0, query_duration_ms=100)
         alert = self._make_alert(

--- a/products/logs/backend/test/test_logs_url_params.py
+++ b/products/logs/backend/test/test_logs_url_params.py
@@ -1,0 +1,96 @@
+import json
+from datetime import UTC, datetime
+from urllib.parse import parse_qs
+
+from posthog.test.base import BaseTest
+
+from parameterized import parameterized
+
+from products.logs.backend.logs_url_params import build_logs_url_params
+
+
+class TestBuildLogsUrlParams(BaseTest):
+    @parameterized.expand(
+        [
+            ("empty_filters", {}, None, None, ""),
+            ("empty_lists", {"severityLevels": [], "serviceNames": []}, None, None, ""),
+        ]
+    )
+    def test_returns_empty_string(self, _name, filters, date_from, date_to, expected):
+        assert build_logs_url_params(filters, date_from=date_from, date_to=date_to) == expected
+
+    @parameterized.expand(
+        [
+            ("severity_levels", {"severityLevels": ["error", "warn"]}, "severityLevels", '["error", "warn"]'),
+            ("service_names", {"serviceNames": ["api", "worker"]}, "serviceNames", '["api", "worker"]'),
+        ]
+    )
+    def test_filter_encoded_as_json_array(self, _name, filters, param_key, expected_json):
+        result = build_logs_url_params(filters)
+        params = parse_qs(result)
+        assert params[param_key] == [expected_json]
+
+    @parameterized.expand(
+        [
+            ("combined", {"severityLevels": ["error"], "serviceNames": ["api"]}, ["severityLevels", "serviceNames"]),
+            (
+                "with_filter_group",
+                {
+                    "filterGroup": {
+                        "type": "AND",
+                        "values": [{"type": "AND", "values": [{"key": "body", "value": "error"}]}],
+                    },
+                },
+                ["filterGroup"],
+            ),
+        ]
+    )
+    def test_expected_params_present(self, _name, filters, expected_keys):
+        result = build_logs_url_params(filters)
+        params = parse_qs(result)
+        for key in expected_keys:
+            assert key in params
+
+    @parameterized.expand(
+        [
+            ("no_filter_group_key", {"severityLevels": ["error"]}),
+            ("empty_filter_group_values", {"filterGroup": {"type": "AND", "values": [{"type": "AND", "values": []}]}}),
+        ]
+    )
+    def test_empty_filter_group_omitted(self, _name, filters):
+        result = build_logs_url_params(filters)
+        params = parse_qs(result)
+        assert "filterGroup" not in params
+
+    @parameterized.expand(
+        [
+            (
+                "both_timestamps",
+                datetime(2026, 4, 6, 14, 50, 0, tzinfo=UTC),
+                datetime(2026, 4, 6, 15, 0, 0, tzinfo=UTC),
+                {"date_from": "2026-04-06T14:50:00+00:00", "date_to": "2026-04-06T15:00:00+00:00"},
+            ),
+            (
+                "only_date_from",
+                datetime(2026, 4, 6, 14, 50, 0, tzinfo=UTC),
+                None,
+                {"date_from": "2026-04-06T14:50:00+00:00"},
+            ),
+            (
+                "only_date_to",
+                None,
+                datetime(2026, 4, 6, 15, 0, 0, tzinfo=UTC),
+                {"date_to": "2026-04-06T15:00:00+00:00"},
+            ),
+        ]
+    )
+    def test_date_range(self, _name, date_from, date_to, expected_range):
+        result = build_logs_url_params({}, date_from=date_from, date_to=date_to)
+        params = parse_qs(result)
+        date_range = json.loads(params["dateRange"][0])
+        assert date_range == expected_range
+
+    def test_no_date_range_when_no_timestamps(self):
+        result = build_logs_url_params({"severityLevels": ["error"]})
+        params = parse_qs(result)
+        assert "dateRange" not in params

--- a/products/logs/frontend/components/LogsAlerting/__tests__/logsAlertUtils.test.ts
+++ b/products/logs/frontend/components/LogsAlerting/__tests__/logsAlertUtils.test.ts
@@ -70,6 +70,14 @@ describe('logsAlertUtils', () => {
             expect(headerText).toContain("if(event.event == '$logs_alert_resolved'")
             expect(headerText).toContain('has resolved')
             expect(headerText).toContain('is firing')
+
+            // Context block includes services/severities element
+            const contextBlock = payload.inputs?.blocks?.value?.[2]
+            expect(contextBlock?.type).toBe('context')
+            expect(contextBlock?.elements).toHaveLength(2)
+            const filterContext = contextBlock?.elements?.[0]?.text
+            expect(filterContext).toContain('severity_levels')
+            expect(filterContext).toContain('service_names')
         })
 
         it('uses fallback name when alertName is undefined for slack', () => {
@@ -115,12 +123,16 @@ describe('logsAlertUtils', () => {
             expect(payload.inputs?.url).toEqual({ value: 'https://example.com/hook' })
             expect(payload.inputs?.body?.value).toMatchObject({
                 event: "{if(event.event == '$logs_alert_resolved', 'resolved', 'firing')}",
+                alert_id: '{event.properties.alert_id}',
                 alert_name: '{event.properties.alert_name}',
                 result_count: '{event.properties.result_count}',
                 threshold_count: '{event.properties.threshold_count}',
                 threshold_operator: '{event.properties.threshold_operator}',
                 window_minutes: '{event.properties.window_minutes}',
+                service_names: '{event.properties.service_names}',
+                severity_levels: '{event.properties.severity_levels}',
                 logs_url: '{project.url}/logs?{event.properties.logs_url_params}',
+                triggered_at: '{event.properties.triggered_at}',
             })
             expect(payload.filters?.events).toHaveLength(2)
         })

--- a/products/logs/frontend/components/LogsAlerting/logsAlertUtils.ts
+++ b/products/logs/frontend/components/LogsAlerting/logsAlertUtils.ts
@@ -66,7 +66,19 @@ const LOGS_ALERT_SLACK_BLOCKS = [
     },
     {
         type: 'context',
-        elements: [{ type: 'mrkdwn', text: 'Project: <{project.url}|{project.name}>' }],
+        elements: [
+            {
+                type: 'mrkdwn',
+                text: [
+                    '{if(length(event.properties.severity_levels) > 0 or length(event.properties.service_names) > 0, concat(',
+                    "if(length(event.properties.severity_levels) > 0, concat('Severity: ', arrayStringConcat(event.properties.severity_levels, ', ')), ''),",
+                    "if(length(event.properties.severity_levels) > 0 and length(event.properties.service_names) > 0, ' | ', ''),",
+                    "if(length(event.properties.service_names) > 0, concat('Services: ', arrayStringConcat(event.properties.service_names, ', ')), '')",
+                    "), 'All log levels and services')}",
+                ].join(''),
+            },
+            { type: 'mrkdwn', text: 'Project: <{project.url}|{project.name}>' },
+        ],
     },
     { type: 'divider' },
     {
@@ -95,12 +107,16 @@ const LOGS_ALERT_SLACK_INPUTS = {
 
 const LOGS_ALERT_WEBHOOK_BODY: Record<string, string> = {
     event: "{if(event.event == '$logs_alert_resolved', 'resolved', 'firing')}",
+    alert_id: '{event.properties.alert_id}',
     alert_name: '{event.properties.alert_name}',
     result_count: '{event.properties.result_count}',
     threshold_count: '{event.properties.threshold_count}',
     threshold_operator: '{event.properties.threshold_operator}',
     window_minutes: '{event.properties.window_minutes}',
+    service_names: '{event.properties.service_names}',
+    severity_levels: '{event.properties.severity_levels}',
     logs_url: '{project.url}/logs?{event.properties.logs_url_params}',
+    triggered_at: '{event.properties.triggered_at}',
 }
 
 export function buildLogsAlertHogFunctionPayload(


### PR DESCRIPTION
## Problem

Logs alert notifications need to include contextual information and deep-linking capabilities to help users quickly navigate to the relevant logs when an alert fires or resolves. Currently, alert events lack sufficient context about the filters and time ranges that triggered the alert.

## Changes

- **Added URL parameter builder**: Created `logs_url_params.py` module to serialize alert filters into URL query parameters that can be used for deep-linking to the logs scene with the correct context
- **Enhanced alert event properties**: Alert events now include additional properties:
  - `logs_url_params`: URL-encoded query string for deep-linking to logs with filters applied
  - `service_names` and `severity_levels`: Extracted filter values for easier template access
  - `triggered_at`: ISO timestamp of when the alert was triggered
- **Improved notification templates**: 
  - Slack notifications now display severity levels and service names in the context section
  - Webhook payloads include all new properties for richer integrations
- **Date range support**: URL parameters include absolute date ranges based on the alert's time window

## How did you test this code?

Added comprehensive unit tests covering:
- URL parameter encoding for various filter combinations
- Date range serialization with absolute timestamps
- Alert event property inclusion in notification payloads
- Template rendering with new context fields

The tests verify that empty filters are handled gracefully, JSON serialization works correctly, and the generated URLs contain the expected parameters for deep-linking to the logs scene.

## Publish to changelog?

No - this is an internal enhancement to alert notifications and doesn't introduce user-facing features.

## Docs update

No docs update needed as this enhances existing alert functionality without changing the user interface.