### PR TITLE
feat(logs): add last checked column and live polling to alert list

### DIFF
--- a/products/logs/frontend/components/LogsAlerting/LogsAlertList.tsx
+++ b/products/logs/frontend/components/LogsAlerting/LogsAlertList.tsx
@@ -2,6 +2,7 @@ import { useActions, useValues } from 'kea'
 
 import { LemonButton, LemonDialog, LemonSwitch, LemonTable, LemonTableColumns, SpinnerOverlay } from '@posthog/lemon-ui'
 
+import { TZLabel } from 'lib/components/TZLabel'
 import { More } from 'lib/lemon-ui/LemonButton/More'
 import { LemonMenuOverlay } from 'lib/lemon-ui/LemonMenu/LemonMenu'
 
@@ -37,6 +38,16 @@ export function LogsAlertList(): JSX.Element {
         {
             title: 'Threshold',
             render: (_, alert) => <span className="text-muted text-xs">{formatThreshold(alert)}</span>,
+        },
+        {
+            title: 'Last checked',
+            dataIndex: 'last_checked_at',
+            render: (_, alert) =>
+                alert.last_checked_at ? (
+                    <TZLabel time={alert.last_checked_at} />
+                ) : (
+                    <span className="text-muted text-xs">Never</span>
+                ),
         },
         {
             title: 'Enabled',
@@ -84,7 +95,7 @@ export function LogsAlertList(): JSX.Element {
         },
     ]
 
-    if (alertsLoading) {
+    if (alertsLoading && alerts.length === 0) {
         return <SpinnerOverlay />
     }
 
@@ -99,6 +110,7 @@ export function LogsAlertList(): JSX.Element {
                 columns={columns}
                 dataSource={alerts}
                 rowKey="id"
+                loading={alertsLoading}
                 emptyState="No alerts configured yet."
                 size="small"
             />

--- a/products/logs/frontend/components/LogsAlerting/logsAlertingLogic.ts
+++ b/products/logs/frontend/components/LogsAlerting/logsAlertingLogic.ts
@@ -10,6 +10,8 @@ import { LogsAlertConfigurationApi } from 'products/logs/frontend/generated/api.
 
 import type { logsAlertingLogicType } from './logsAlertingLogicType'
 
+const ALERT_POLL_INTERVAL_MS = 30_000
+
 export const logsAlertingLogic = kea<logsAlertingLogicType>([
     path(['products', 'logs', 'frontend', 'components', 'LogsAlerting', 'logsAlertingLogic']),
 
@@ -78,7 +80,15 @@ export const logsAlertingLogic = kea<logsAlertingLogicType>([
         },
     })),
 
-    afterMount(({ actions }) => {
+    afterMount(({ actions, values, cache }) => {
         actions.loadAlerts()
+        cache.disposables.add(() => {
+            const intervalId = window.setInterval(() => {
+                if (!values.isCreating && values.editingAlert === null) {
+                    actions.loadAlerts()
+                }
+            }, ALERT_POLL_INTERVAL_MS)
+            return () => clearInterval(intervalId)
+        }, 'pollAlerts')
     }),
 ])


### PR DESCRIPTION
## Problem

Users need visibility into when log alerts were last checked to understand the current status and health of their alerting system. Without this information, it's difficult to troubleshoot issues or verify that alerts are running as expected.

## Changes

- Added a "Last checked" column to the logs alert list table that displays the timestamp when each alert was last evaluated, or "Never" if it hasn't been checked yet
- Implemented automatic polling of alert data every 30 seconds to keep the "Last checked" timestamps current
- Polling is paused when users are creating new alerts or editing existing ones to avoid interfering with their workflow

## How did you test this code?

Manuallly on local dev

## Publish to changelog?

No

## Docs update

No documentation update needed for this internal UI enhancement.