### PR TITLE
fix(logs): use immediate resolution instead of symmetric N-of-M in alert state machine

### DIFF
--- a/products/logs/backend/alert_state_machine.py
+++ b/products/logs/backend/alert_state_machine.py
@@ -54,8 +54,8 @@ def evaluate_alert_check(
     now: datetime,
 ) -> AlertCheckOutcome:
     """Implements the RFC state table: N-of-M sliding-window trigger
-    (CloudWatch-style), PENDING_RESOLVE for symmetric resolution, and
-    cooldown suppression.
+    (CloudWatch-style) for firing, immediate resolution on the first OK
+    check, and cooldown suppression.
     """
     if snapshot.state == AlertState.SNOOZED:
         if snapshot.snooze_until is not None and snapshot.snooze_until > now:
@@ -87,7 +87,6 @@ def evaluate_alert_check(
 
     breach_count = sum(1 for b in window if b)
     n = snapshot.datapoints_to_alarm
-    is_simple = n == 1 and m == 1
 
     if effective_state == AlertState.ERRORED:
         effective_state = AlertState.NOT_FIRING
@@ -102,23 +101,15 @@ def evaluate_alert_check(
         else:
             new_state = AlertState.NOT_FIRING
 
-    elif effective_state == AlertState.FIRING:
+    # PENDING_RESOLVE is currently unused — resolution is immediate on the first
+    # OK check. Kept in the enum for future symmetric N-of-M resolution support.
+    elif effective_state in (AlertState.FIRING, AlertState.PENDING_RESOLVE):
         if check.threshold_breached:
             new_state = AlertState.FIRING
-        elif is_simple:
+        else:
+            # Always resolve after a single OK check — N-of-M only governs firing
             new_state = AlertState.NOT_FIRING
             notification = NotificationAction.RESOLVE
-        else:
-            new_state = AlertState.PENDING_RESOLVE
-
-    elif effective_state == AlertState.PENDING_RESOLVE:
-        if check.threshold_breached:
-            new_state = AlertState.FIRING
-        elif len(window) - breach_count >= n:
-            new_state = AlertState.NOT_FIRING
-            notification = NotificationAction.RESOLVE
-        else:
-            new_state = AlertState.PENDING_RESOLVE
 
     else:
         new_state = AlertState.NOT_FIRING

--- a/products/logs/backend/test/test_alert_state_machine.py
+++ b/products/logs/backend/test/test_alert_state_machine.py
@@ -93,7 +93,8 @@ class TestFiringTransitions(TestCase):
             ("still_breaching_1_of_1", 1, 1, (), True, FIRING, NotificationAction.NONE),
             ("still_breaching_2_of_3", 2, 3, (True, True), True, FIRING, NotificationAction.NONE),
             ("clears_1_of_1", 1, 1, (), False, NOT_FIRING, NotificationAction.RESOLVE),
-            ("clears_enters_pending_2_of_3", 2, 3, (True, True), False, PENDING_RESOLVE, NotificationAction.NONE),
+            # N-of-M only governs firing — resolution is always immediate on first OK check
+            ("clears_immediately_2_of_3", 2, 3, (True, True), False, NOT_FIRING, NotificationAction.RESOLVE),
         ]
     )
     def test_firing_transitions(
@@ -120,12 +121,12 @@ class TestFiringTransitions(TestCase):
 class TestPendingResolveTransitions(TestCase):
     @parameterized.expand(
         [
-            # 2-of-3: window [False, False, True] -> 2 clears >= 2 -> resolve
+            # Any non-breaching check from PENDING_RESOLVE resolves immediately
             ("clears_fully", 2, 3, (False, True), False, NOT_FIRING, NotificationAction.RESOLVE),
-            # 2-of-3: window [True, False, True] -> 2 breaches >= 2 -> back to FIRING
+            # Re-breach goes back to FIRING
             ("re_breaches", 2, 3, (False, True), True, FIRING, NotificationAction.NONE),
-            # 2-of-3: window [False, True, True] -> 1 clear < 2, 2 breach >= 2 -> FIRING
-            ("mixed_still_breaching", 2, 3, (True, True), False, PENDING_RESOLVE, NotificationAction.NONE),
+            # Non-breaching resolves immediately regardless of recent history
+            ("mixed_resolves_immediately", 2, 3, (True, True), False, NOT_FIRING, NotificationAction.RESOLVE),
         ]
     )
     def test_pending_resolve_transitions(
@@ -275,7 +276,7 @@ class TestSnooze(TestCase):
 
 
 class TestEdgeCases(TestCase):
-    def test_1_of_1_skips_pending_resolve(self) -> None:
+    def test_non_breaching_check_resolves_immediately(self) -> None:
         snapshot = _snapshot(state=FIRING, datapoints_to_alarm=1, evaluation_periods=1)
         outcome = evaluate_alert_check(snapshot, _check(breached=False), NOW)
         assert outcome.new_state == NOT_FIRING


### PR DESCRIPTION
## Problem

Alert resolution behavior was inconsistent between simple (1-of-1) and complex (N-of-M) alert configurations. Complex alerts would enter a `PENDING_RESOLVE` state and require multiple consecutive OK checks before resolving, while simple alerts resolved immediately on the first OK check. This created confusing user experience where identical alert conditions behaved differently based on their N-of-M configuration.

## Changes

- Simplified alert state machine logic to resolve all alerts immediately upon first non-breaching check
- Removed the `PENDING_RESOLVE` state transition logic that required multiple OK checks for N-of-M alerts
- Consolidated `FIRING` and `PENDING_RESOLVE` state handling since they now behave identically
- Updated test cases to reflect immediate resolution behavior for all alert types
- Added clarifying comment that N-of-M logic only governs firing, not resolution

## How did you test this code?

Updated unit tests verify the new behavior:

- `TestFiringTransitions` confirms that 2-of-3 alerts now resolve immediately on first OK check instead of entering pending state
- `TestPendingResolveTransitions` validates that any non-breaching check from `PENDING_RESOLVE` resolves immediately regardless of recent breach history
- All existing test cases for firing behavior remain unchanged

## Publish to changelog?

No

## Docs update

This change may require documentation updates to clarify that N-of-M configuration only affects alert firing behavior, not resolution timing.