### PR TITLE
fix(filters): hide weekend data with formula in series

### DIFF
--- a/posthog/hogql_queries/insights/trends/test/test_trends_query_runner.py
+++ b/posthog/hogql_queries/insights/trends/test/test_trends_query_runner.py
@@ -7151,6 +7151,35 @@ class TestTrendsQueryRunner(ClickhouseTestMixin, APIBaseTest):
                 parsed = datetime.strptime(day_str[:10], "%Y-%m-%d")
                 assert parsed.weekday() < 5, f"{day_str} is a weekend day but should be filtered out"
 
+    def test_hide_weekends_with_formula(self):
+        self._create_test_events()
+
+        response = self._run_trends_query(
+            self.default_date_from,  # 2020-01-09 (Thu)
+            self.default_date_to,  # 2020-01-19 (Sun)
+            IntervalType.DAY,
+            [EventsNode(event="$pageview"), EventsNode(event="$pageleave")],
+            trends_filters=TrendsFilter(
+                hideWeekends=True,
+                formulaNodes=[TrendsFormulaNode(formula="A+B")],
+            ),
+        )
+
+        # Formula queries return only the formula result
+        assert len(response.results) == 1
+
+        formula_result = response.results[0]
+        for day_str in formula_result["days"]:
+            parsed = datetime.strptime(day_str[:10], "%Y-%m-%d")
+            assert parsed.weekday() < 5, f"{day_str} is a weekend day but should be filtered out"
+
+        # 11 days Thu-Sun, weekend days removed leaves 7 weekdays
+        assert len(formula_result["days"]) == 7
+        # Formula result has action=None and should not crash
+        assert formula_result["action"] is None
+        assert len(formula_result["data"]) == len(formula_result["days"])
+        assert formula_result["count"] == sum(formula_result["data"])
+
     @parameterized.expand(
         [
             (

--- a/posthog/hogql_queries/insights/trends/trends_query_runner.py
+++ b/posthog/hogql_queries/insights/trends/trends_query_runner.py
@@ -712,8 +712,8 @@ class TrendsQueryRunner(AnalyticsQueryRunner[TrendsQueryResponse]):
                 else:
                     new_result["count"] = float(sum(new_result["data"]))
 
-            # Filter action.days too
-            if "action" in new_result and "days" in new_result["action"]:
+            # Filter action.days too (formula series have action=None)
+            if new_result.get("action") is not None and "days" in new_result["action"]:
                 action_days = new_result["action"]["days"]
                 new_result["action"] = {**new_result["action"]}
                 new_result["action"]["days"] = [d for d in action_days if d.weekday() < 5]


### PR DESCRIPTION
## Problem

Fix: "Hide weekends" flag and toggle was introduced in [#49165](https://github.com/PostHog/posthog/pull/49165) (issue #20860), but when enabled in an insight with a **formula**, the query would crash with a `TypeError: argument of type 'NoneType' is not iterable.`

## Changes

- L716 changed to using a get() method in  `_filter_weekend_buckets()`
- Added regression test for formula related to `hideWeekends`
<img width="250" height="500" alt="image" src="https://github.com/user-attachments/assets/553acab3-3d98-4f38-bf32-04c9fbf2246b" />


## How did you test this code?

- `generate-demo-data` in hogli/phrocs and locally tested manually by adding formulas to series e.g. `(A+B)/2`
- Added L7154 `test_hide_weekends_with_formula()` regression test that reproduces the crash
- All 167 trends query runner tests pass locally


## Publish to changelog?

No


## Docs update

N/A