### PR TITLE
feat: add Rust ingestion consumer for sidecar architecture

### DIFF
--- a/.github/rust-images.yml
+++ b/.github/rust-images.yml
@@ -43,6 +43,10 @@
   dockerfile: ./rust/Dockerfile
   project: c1bwj4j4qg
 
+- image: ingestion-consumer
+  dockerfile: ./rust/Dockerfile
+  project: mtvzx98zjn
+
 - image: kafka-deduplicator
   dockerfile: ./rust/Dockerfile
   project: vznmbshh6q

--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -87,6 +87,7 @@ jobs:
                       "embedding-worker": 98,
                       "feature-flags": 241,
                       "health": 8,
+                      "ingestion-consumer": 5,
                       "hogvm": 5,
                       "k8s-awareness": 60,
                       "kafka-assigner": 30,

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -4677,8 +4677,6 @@ dependencies = [
  "rdkafka",
  "reqwest 0.12.28",
  "serde",
- "serde_json",
- "serve-metrics",
  "thiserror 2.0.18",
  "tokio",
  "tracing",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -4662,6 +4662,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "ingestion-consumer"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "axum 0.7.9",
+ "common-alloc",
+ "envconfig",
+ "futures",
+ "lifecycle",
+ "metrics",
+ "metrics-exporter-prometheus",
+ "rand 0.8.5",
+ "rdkafka",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "serve-metrics",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "inout"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -38,6 +38,7 @@ members = [
     "common/hogvm",
     "kafka-assigner",
     "kafka-assigner-proto",
+    "ingestion-consumer",
     "kafka-deduplicator",
     "personhog-common",
     "personhog-coordination",

--- a/rust/ingestion-consumer/Cargo.toml
+++ b/rust/ingestion-consumer/Cargo.toml
@@ -16,8 +16,6 @@ rand = { workspace = true }
 rdkafka = { workspace = true }
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 serde = { workspace = true }
-serde_json = { workspace = true }
-serve-metrics = { path = "../common/serve_metrics" }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }

--- a/rust/ingestion-consumer/Cargo.toml
+++ b/rust/ingestion-consumer/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "ingestion-consumer"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+anyhow = { workspace = true }
+axum = { workspace = true }
+common-alloc = { path = "../common/alloc" }
+envconfig = { workspace = true }
+futures = { workspace = true }
+lifecycle = { path = "../common/lifecycle" }
+metrics = { workspace = true }
+metrics-exporter-prometheus = { workspace = true }
+rand = { workspace = true }
+rdkafka = { workspace = true }
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+serde = { workspace = true }
+serde_json = { workspace = true }
+serve-metrics = { path = "../common/serve_metrics" }
+thiserror = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true, features = ["env-filter", "json"] }

--- a/rust/ingestion-consumer/src/config.rs
+++ b/rust/ingestion-consumer/src/config.rs
@@ -1,0 +1,128 @@
+use envconfig::Envconfig;
+use rdkafka::ClientConfig;
+
+use crate::kafka_config::ConsumerConfigBuilder;
+
+#[derive(Envconfig, Clone, Debug)]
+pub struct Config {
+    // ---- Kafka connection ----
+    #[envconfig(default = "localhost:9092")]
+    pub kafka_hosts: String,
+
+    #[envconfig(default = "false")]
+    pub kafka_tls: bool,
+
+    // ---- Kafka consumer ----
+    #[envconfig(default = "ingestion-consumer")]
+    pub kafka_consumer_group: String,
+
+    #[envconfig(default = "events_plugin_ingestion")]
+    pub kafka_consumer_topic: String,
+
+    #[envconfig(default = "latest")]
+    pub kafka_consumer_offset_reset: String,
+
+    #[envconfig(default = "10485760")] // 10MB
+    pub kafka_consumer_max_partition_fetch_bytes: u32,
+
+    #[envconfig(default = "10000")] // 10 seconds
+    pub kafka_topic_metadata_refresh_interval_ms: u32,
+
+    #[envconfig(default = "30000")] // 30 seconds
+    pub kafka_metadata_max_age_ms: u32,
+
+    #[envconfig(default = "60000")] // 60 seconds
+    pub kafka_session_timeout_ms: u32,
+
+    #[envconfig(default = "5000")] // 5 seconds
+    pub kafka_heartbeat_interval_ms: u32,
+
+    #[envconfig(default = "300000")] // 5 minutes
+    pub kafka_max_poll_interval_ms: u32,
+
+    // Fetch tuning
+    #[envconfig(default = "1")]
+    pub kafka_consumer_fetch_min_bytes: u32,
+
+    #[envconfig(default = "52428800")] // 50MB
+    pub kafka_consumer_fetch_max_bytes: u32,
+
+    #[envconfig(default = "500")]
+    pub kafka_consumer_fetch_wait_max_ms: u32,
+
+    #[envconfig(default = "100000")]
+    pub kafka_consumer_queued_min_messages: u32,
+
+    #[envconfig(default = "65536")] // 64MB
+    pub kafka_consumer_queued_max_messages_kbytes: u32,
+
+    /// Pod hostname from K8s, used for sticky partition assignment
+    #[envconfig(from = "HOSTNAME")]
+    pub pod_hostname: Option<String>,
+
+    // ---- Batching ----
+    /// Maximum number of messages to collect before dispatching a batch
+    #[envconfig(default = "500")]
+    pub batch_size: usize,
+
+    /// Maximum time to wait while collecting a batch (milliseconds)
+    #[envconfig(default = "100")]
+    pub batch_timeout_ms: u64,
+
+    // ---- Worker transport ----
+    /// Comma-separated list of worker HTTP URLs
+    #[envconfig(default = "http://localhost:9001")]
+    pub worker_addresses: String,
+
+    /// HTTP request timeout for worker calls (milliseconds)
+    #[envconfig(default = "30000")]
+    pub http_timeout_ms: u64,
+
+    /// Maximum number of retries for a failed worker call
+    #[envconfig(default = "3")]
+    pub max_retries: u32,
+
+    // ---- Health/metrics server ----
+    #[envconfig(default = "0.0.0.0")]
+    pub bind_host: String,
+
+    #[envconfig(default = "3301")]
+    pub bind_port: u16,
+
+    #[envconfig(default = "true")]
+    pub export_prometheus: bool,
+}
+
+impl Config {
+    pub fn bind_address(&self) -> String {
+        format!("{}:{}", self.bind_host, self.bind_port)
+    }
+
+    pub fn worker_urls(&self) -> Vec<String> {
+        self.worker_addresses
+            .split(',')
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+            .collect()
+    }
+
+    /// Build a fully-configured rdkafka ClientConfig using the ConsumerConfigBuilder.
+    pub fn build_consumer_config(&self) -> ClientConfig {
+        ConsumerConfigBuilder::for_batch_consumer(&self.kafka_hosts, &self.kafka_consumer_group)
+            .with_tls(self.kafka_tls)
+            .with_max_partition_fetch_bytes(self.kafka_consumer_max_partition_fetch_bytes)
+            .with_topic_metadata_refresh_interval_ms(self.kafka_topic_metadata_refresh_interval_ms)
+            .with_metadata_max_age_ms(self.kafka_metadata_max_age_ms)
+            .with_sticky_partition_assignment(self.pod_hostname.as_deref())
+            .with_offset_reset(&self.kafka_consumer_offset_reset)
+            .with_fetch_min_bytes(self.kafka_consumer_fetch_min_bytes)
+            .with_fetch_max_bytes(self.kafka_consumer_fetch_max_bytes)
+            .with_fetch_wait_max_ms(self.kafka_consumer_fetch_wait_max_ms)
+            .with_queued_min_messages(self.kafka_consumer_queued_min_messages)
+            .with_queued_max_messages_kbytes(self.kafka_consumer_queued_max_messages_kbytes)
+            .with_max_poll_interval_ms(self.kafka_max_poll_interval_ms)
+            .with_session_timeout_ms(self.kafka_session_timeout_ms)
+            .with_heartbeat_interval_ms(self.kafka_heartbeat_interval_ms)
+            .build()
+    }
+}

--- a/rust/ingestion-consumer/src/config.rs
+++ b/rust/ingestion-consumer/src/config.rs
@@ -1,73 +1,112 @@
 use envconfig::Envconfig;
 use rdkafka::ClientConfig;
+use tracing::info;
 
 use crate::kafka_config::ConsumerConfigBuilder;
 
+/// Configuration for the ingestion consumer.
+///
+/// Kafka env vars match the Node.js ingestion consumer so this can be a
+/// drop-in replacement using the same Kubernetes ConfigMap/env config.
+/// The Node.js consumer reads `KAFKA_CONSUMER_*` env vars and maps them to
+/// rdkafka config keys. We use the same env var names and defaults here.
+///
+/// Any `KAFKA_CONSUMER_*` env var is also read and applied as an rdkafka
+/// config override — e.g. `KAFKA_CONSUMER_METADATA_BROKER_LIST=kafka:9092`
+/// becomes `metadata.broker.list=kafka:9092`. This matches the Node.js
+/// `getKafkaConfigFromEnv('CONSUMER')` behavior.
 #[derive(Envconfig, Clone, Debug)]
 pub struct Config {
-    // ---- Kafka connection ----
-    #[envconfig(default = "localhost:9092")]
+    // ---- Kafka connection (matches Node.js KafkaConsumer defaults) ----
+    /// Kafka broker list. Overridable via KAFKA_CONSUMER_METADATA_BROKER_LIST
+    /// (same as Node.js). This is used as the base default.
+    #[envconfig(default = "kafka:9092")]
     pub kafka_hosts: String,
 
     #[envconfig(default = "false")]
     pub kafka_tls: bool,
 
-    // ---- Kafka consumer ----
-    #[envconfig(default = "ingestion-consumer")]
-    pub kafka_consumer_group: String,
+    /// Security protocol (plaintext, ssl, sasl_plaintext, sasl_ssl)
+    #[envconfig(default = "plaintext")]
+    pub kafka_security_protocol: String,
 
+    /// Client rack for cross-AZ traffic awareness (shared with Node.js via KAFKA_CLIENT_RACK)
+    #[envconfig(default = "")]
+    pub kafka_client_rack: String,
+
+    // ---- Kafka consumer group (matches Node.js IngestionConsumerConfig) ----
+    /// Consumer group ID. Same env var as Node.js IngestionConsumerConfig.
+    #[envconfig(default = "events-ingestion-consumer")]
+    pub ingestion_consumer_group_id: String,
+
+    /// Topic to consume from. Same env var as Node.js IngestionConsumerConfig.
     #[envconfig(default = "events_plugin_ingestion")]
-    pub kafka_consumer_topic: String,
+    pub ingestion_consumer_consume_topic: String,
 
     #[envconfig(default = "latest")]
     pub kafka_consumer_offset_reset: String,
 
-    #[envconfig(default = "10485760")] // 10MB
-    pub kafka_consumer_max_partition_fetch_bytes: u32,
+    // ---- Kafka consumer tuning (defaults match Node.js KafkaConsumer) ----
+    #[envconfig(default = "30000")]
+    pub kafka_consumer_session_timeout_ms: u32,
 
-    #[envconfig(default = "10000")] // 10 seconds
-    pub kafka_topic_metadata_refresh_interval_ms: u32,
-
-    #[envconfig(default = "30000")] // 30 seconds
-    pub kafka_metadata_max_age_ms: u32,
-
-    #[envconfig(default = "60000")] // 60 seconds
-    pub kafka_session_timeout_ms: u32,
-
-    #[envconfig(default = "5000")] // 5 seconds
+    #[envconfig(default = "5000")]
     pub kafka_heartbeat_interval_ms: u32,
 
-    #[envconfig(default = "300000")] // 5 minutes
-    pub kafka_max_poll_interval_ms: u32,
+    #[envconfig(default = "300000")]
+    pub kafka_consumer_max_poll_interval_ms: u32,
 
-    // Fetch tuning
+    /// 1MB — matches Node.js default
+    #[envconfig(default = "1048576")]
+    pub kafka_consumer_max_partition_fetch_bytes: u32,
+
+    #[envconfig(default = "10000")]
+    pub kafka_topic_metadata_refresh_interval_ms: u32,
+
+    #[envconfig(default = "30000")]
+    pub kafka_consumer_metadata_max_age_ms: u32,
+
+    #[envconfig(default = "30000")]
+    pub kafka_consumer_socket_timeout_ms: u32,
+
+    #[envconfig(default = "100")]
+    pub kafka_consumer_fetch_error_backoff_ms: u32,
+
     #[envconfig(default = "1")]
     pub kafka_consumer_fetch_min_bytes: u32,
 
-    #[envconfig(default = "52428800")] // 50MB
+    #[envconfig(default = "52428800")]
     pub kafka_consumer_fetch_max_bytes: u32,
 
-    #[envconfig(default = "500")]
+    /// 10MB — matches Node.js fetch.message.max.bytes
+    #[envconfig(default = "10485760")]
+    pub kafka_consumer_fetch_message_max_bytes: u32,
+
+    /// 50ms — matches Node.js default (aggressive fetch for low latency)
+    #[envconfig(default = "50")]
     pub kafka_consumer_fetch_wait_max_ms: u32,
 
     #[envconfig(default = "100000")]
     pub kafka_consumer_queued_min_messages: u32,
 
-    #[envconfig(default = "65536")] // 64MB
+    /// 100MB — matches Node.js default (reduced from rdkafka default of 1GB)
+    #[envconfig(default = "102400")]
     pub kafka_consumer_queued_max_messages_kbytes: u32,
 
-    /// Pod hostname from K8s, used for sticky partition assignment
+    /// Pod hostname from K8s, used as client.id and group.instance.id
+    /// for sticky partition assignment (same as Node.js hostname())
     #[envconfig(from = "HOSTNAME")]
     pub pod_hostname: Option<String>,
 
     // ---- Batching ----
-    /// Maximum number of messages to collect before dispatching a batch
+    /// Maximum number of messages to collect before dispatching a batch.
+    /// Matches Node.js CONSUMER_BATCH_SIZE default.
     #[envconfig(default = "500")]
-    pub batch_size: usize,
+    pub consumer_batch_size: usize,
 
     /// Maximum time to wait while collecting a batch (milliseconds)
-    #[envconfig(default = "100")]
-    pub batch_timeout_ms: u64,
+    #[envconfig(default = "500")]
+    pub consumer_batch_timeout_ms: u64,
 
     // ---- Worker transport ----
     /// Comma-separated list of worker HTTP URLs
@@ -82,6 +121,10 @@ pub struct Config {
     #[envconfig(default = "3")]
     pub max_retries: u32,
 
+    /// Shared secret for authenticating with Node.js workers (X-Internal-Api-Secret header)
+    #[envconfig(default = "")]
+    pub internal_api_secret: String,
+
     // ---- Health/metrics server ----
     #[envconfig(default = "0.0.0.0")]
     pub bind_host: String,
@@ -91,6 +134,28 @@ pub struct Config {
 
     #[envconfig(default = "true")]
     pub export_prometheus: bool,
+}
+
+/// Parse `KAFKA_CONSUMER_*` env vars into rdkafka config key-value pairs.
+///
+/// Mirrors the Node.js `getKafkaConfigFromEnv('CONSUMER')` behavior:
+/// strips the `KAFKA_CONSUMER_` prefix, replaces underscores with dots,
+/// and lowercases the key.
+///
+/// Example: `KAFKA_CONSUMER_METADATA_BROKER_LIST=kafka:9092`
+/// becomes `("metadata.broker.list", "kafka:9092")`
+fn parse_kafka_consumer_env_overrides() -> Vec<(String, String)> {
+    std::env::vars()
+        .filter(|(key, _)| key.starts_with("KAFKA_CONSUMER_"))
+        .map(|(key, value)| {
+            let rdkafka_key = key
+                .strip_prefix("KAFKA_CONSUMER_")
+                .unwrap()
+                .replace('_', ".")
+                .to_lowercase();
+            (rdkafka_key, value)
+        })
+        .collect()
 }
 
 impl Config {
@@ -106,23 +171,57 @@ impl Config {
             .collect()
     }
 
-    /// Build a fully-configured rdkafka ClientConfig using the ConsumerConfigBuilder.
+    /// Build a fully-configured rdkafka ClientConfig.
+    ///
+    /// Mirrors the Node.js KafkaConsumer constructor config with the same
+    /// defaults and override priority:
+    /// 1. Hardcoded defaults (from struct field defaults)
+    /// 2. `KAFKA_CONSUMER_*` env var overrides (same as Node.js getKafkaConfigFromEnv)
+    /// 3. Non-overridable settings (partition.assignment.strategy, enable.auto.offset.store)
     pub fn build_consumer_config(&self) -> ClientConfig {
-        ConsumerConfigBuilder::for_batch_consumer(&self.kafka_hosts, &self.kafka_consumer_group)
-            .with_tls(self.kafka_tls)
-            .with_max_partition_fetch_bytes(self.kafka_consumer_max_partition_fetch_bytes)
-            .with_topic_metadata_refresh_interval_ms(self.kafka_topic_metadata_refresh_interval_ms)
-            .with_metadata_max_age_ms(self.kafka_metadata_max_age_ms)
-            .with_sticky_partition_assignment(self.pod_hostname.as_deref())
-            .with_offset_reset(&self.kafka_consumer_offset_reset)
-            .with_fetch_min_bytes(self.kafka_consumer_fetch_min_bytes)
-            .with_fetch_max_bytes(self.kafka_consumer_fetch_max_bytes)
-            .with_fetch_wait_max_ms(self.kafka_consumer_fetch_wait_max_ms)
-            .with_queued_min_messages(self.kafka_consumer_queued_min_messages)
-            .with_queued_max_messages_kbytes(self.kafka_consumer_queued_max_messages_kbytes)
-            .with_max_poll_interval_ms(self.kafka_max_poll_interval_ms)
-            .with_session_timeout_ms(self.kafka_session_timeout_ms)
-            .with_heartbeat_interval_ms(self.kafka_heartbeat_interval_ms)
-            .build()
+        let mut builder = ConsumerConfigBuilder::for_batch_consumer(
+            &self.kafka_hosts,
+            &self.ingestion_consumer_group_id,
+        )
+        .with_tls(self.kafka_tls)
+        .with_offset_reset(&self.kafka_consumer_offset_reset)
+        .with_session_timeout_ms(self.kafka_consumer_session_timeout_ms)
+        .with_heartbeat_interval_ms(self.kafka_heartbeat_interval_ms)
+        .with_max_poll_interval_ms(self.kafka_consumer_max_poll_interval_ms)
+        .with_max_partition_fetch_bytes(self.kafka_consumer_max_partition_fetch_bytes)
+        .with_topic_metadata_refresh_interval_ms(self.kafka_topic_metadata_refresh_interval_ms)
+        .with_metadata_max_age_ms(self.kafka_consumer_metadata_max_age_ms)
+        .with_fetch_min_bytes(self.kafka_consumer_fetch_min_bytes)
+        .with_fetch_max_bytes(self.kafka_consumer_fetch_max_bytes)
+        .with_fetch_wait_max_ms(self.kafka_consumer_fetch_wait_max_ms)
+        .with_queued_min_messages(self.kafka_consumer_queued_min_messages)
+        .with_queued_max_messages_kbytes(self.kafka_consumer_queued_max_messages_kbytes)
+        .with_sticky_partition_assignment(self.pod_hostname.as_deref())
+        .set("security.protocol", &self.kafka_security_protocol)
+        .set(
+            "socket.timeout.ms",
+            &self.kafka_consumer_socket_timeout_ms.to_string(),
+        )
+        .set(
+            "fetch.error.backoff.ms",
+            &self.kafka_consumer_fetch_error_backoff_ms.to_string(),
+        )
+        .set(
+            "fetch.message.max.bytes",
+            &self.kafka_consumer_fetch_message_max_bytes.to_string(),
+        );
+
+        if !self.kafka_client_rack.is_empty() {
+            builder = builder.set("client.rack", &self.kafka_client_rack);
+        }
+
+        // Apply KAFKA_CONSUMER_* env var overrides (same as Node.js getKafkaConfigFromEnv)
+        let overrides = parse_kafka_consumer_env_overrides();
+        for (key, value) in &overrides {
+            info!(key = %key, value = %value, "Applying KAFKA_CONSUMER_ env override");
+            builder = builder.set(key, value);
+        }
+
+        builder.build()
     }
 }

--- a/rust/ingestion-consumer/src/consumer.rs
+++ b/rust/ingestion-consumer/src/consumer.rs
@@ -1,0 +1,266 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use futures::StreamExt;
+use lifecycle::Handle;
+use metrics::{counter, gauge, histogram};
+use rdkafka::consumer::{CommitMode, Consumer, StreamConsumer};
+use rdkafka::message::Message;
+use rdkafka::TopicPartitionList;
+use tracing::{error, info, warn};
+
+use crate::config::Config;
+use crate::router::MessageRouter;
+use crate::transport::HttpTransport;
+use crate::types::SerializedKafkaMessage;
+
+/// The main consumer loop: reads from Kafka, routes messages by distinct_id,
+/// dispatches sub-batches to workers via HTTP, and commits offsets on ACK.
+///
+/// This is the single-in-flight-batch version (Stage 2). It processes one
+/// batch at a time — no concurrent batch tracking or in-flight stickiness.
+pub struct IngestionConsumer {
+    consumer: StreamConsumer,
+    router: MessageRouter,
+    transport: Arc<HttpTransport>,
+    worker_urls: Vec<String>,
+    batch_size: usize,
+    batch_timeout: Duration,
+    handle: Handle,
+}
+
+impl IngestionConsumer {
+    pub fn new(
+        config: &Config,
+        transport: Arc<HttpTransport>,
+        handle: Handle,
+    ) -> anyhow::Result<Self> {
+        let worker_urls = config.worker_urls();
+        if worker_urls.is_empty() {
+            anyhow::bail!("No worker addresses configured");
+        }
+
+        let router = MessageRouter::new(worker_urls.len());
+
+        let client_config = config.build_consumer_config();
+        let consumer: StreamConsumer = client_config.create()?;
+        consumer.subscribe(&[&config.kafka_consumer_topic])?;
+
+        info!(
+            topic = %config.kafka_consumer_topic,
+            group = %config.kafka_consumer_group,
+            workers = worker_urls.len(),
+            batch_size = config.batch_size,
+            "Kafka consumer subscribed"
+        );
+
+        Ok(Self {
+            consumer,
+            router,
+            transport,
+            worker_urls,
+            batch_size: config.batch_size,
+            batch_timeout: Duration::from_millis(config.batch_timeout_ms),
+            handle,
+        })
+    }
+
+    /// Run the consumer loop until shutdown is signalled via the lifecycle handle.
+    /// Waits for all workers to be ready before starting to consume from Kafka.
+    pub async fn process(self) {
+        let _guard = self.handle.process_scope();
+
+        info!("Waiting for workers to be ready");
+        if let Err(err) = self
+            .transport
+            .wait_for_workers_ready(&self.worker_urls, &self.handle)
+            .await
+        {
+            error!(error = %err, "Failed waiting for workers");
+            self.handle
+                .signal_failure("Workers not ready before shutdown".to_string());
+            return;
+        }
+
+        info!("Consumer loop starting");
+
+        loop {
+            tokio::select! {
+                _ = self.handle.shutdown_recv() => {
+                    info!("Shutdown signal received, draining");
+                    break;
+                }
+                result = self.process_batch() => {
+                    match result {
+                        Ok(count) => {
+                            if count > 0 {
+                                self.handle.report_healthy();
+                                counter!("ingestion_consumer_batches_processed_total").increment(1);
+                            }
+                        }
+                        Err(err) => {
+                            error!(error = %err, "Batch processing failed");
+                            counter!("ingestion_consumer_batch_errors_total").increment(1);
+                            tokio::time::sleep(Duration::from_secs(1)).await;
+                        }
+                    }
+                }
+            }
+        }
+
+        info!("Consumer loop stopped");
+    }
+
+    /// Collect a batch, route it, scatter to workers, gather ACKs, commit offsets.
+    async fn process_batch(&self) -> anyhow::Result<usize> {
+        let (messages, offsets) = self.collect_batch().await?;
+        if messages.is_empty() {
+            return Ok(0);
+        }
+
+        let batch_size = messages.len();
+        let batch_id = make_batch_id();
+        let start = Instant::now();
+
+        counter!("ingestion_consumer_messages_received_total").increment(batch_size as u64);
+        gauge!("ingestion_consumer_batch_size").set(batch_size as f64);
+
+        // Route messages to workers
+        let groups = self.router.route_batch(messages);
+
+        // Scatter: send sub-batches to workers in parallel
+        let mut handles = Vec::with_capacity(groups.len());
+        for (worker_idx, sub_batch) in groups {
+            let transport = self.transport.clone();
+            let url = self.worker_urls[worker_idx].clone();
+            let bid = batch_id.clone();
+            handles.push(tokio::spawn(async move {
+                transport.send_batch(&url, &bid, sub_batch).await
+            }));
+        }
+
+        // Gather: wait for all workers to ACK
+        let mut total_accepted = 0u32;
+        for handle in handles {
+            let result = handle.await??;
+            total_accepted += result;
+        }
+
+        // All workers ACK'd — commit offsets
+        self.commit_offsets(&offsets)?;
+
+        let elapsed = start.elapsed();
+        histogram!("ingestion_consumer_batch_processing_duration_seconds")
+            .record(elapsed.as_secs_f64());
+        counter!("ingestion_consumer_messages_processed_total").increment(total_accepted as u64);
+
+        Ok(batch_size)
+    }
+
+    /// Collect messages from Kafka up to batch_size or batch_timeout.
+    async fn collect_batch(
+        &self,
+    ) -> anyhow::Result<(Vec<SerializedKafkaMessage>, HashMap<(String, i32), i64>)> {
+        let mut messages = Vec::with_capacity(self.batch_size);
+        let mut offsets: HashMap<(String, i32), i64> = HashMap::new();
+        let deadline = Instant::now() + self.batch_timeout;
+
+        let mut stream = self.consumer.stream();
+
+        loop {
+            if messages.len() >= self.batch_size {
+                break;
+            }
+
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            if remaining.is_zero() {
+                break;
+            }
+
+            match tokio::time::timeout(remaining, stream.next()).await {
+                Ok(Some(Ok(borrowed_message))) => {
+                    let topic = borrowed_message.topic().to_string();
+                    let partition = borrowed_message.partition();
+                    let offset = borrowed_message.offset();
+
+                    offsets
+                        .entry((topic.clone(), partition))
+                        .and_modify(|o| {
+                            if offset > *o {
+                                *o = offset;
+                            }
+                        })
+                        .or_insert(offset);
+
+                    let mut headers = HashMap::new();
+                    if let Some(rdkafka_headers) = borrowed_message.headers() {
+                        use rdkafka::message::Headers;
+                        for i in 0..rdkafka_headers.count() {
+                            let header = rdkafka_headers.get(i);
+                            if let Some(value) = header.value {
+                                if let Ok(value_str) = std::str::from_utf8(value) {
+                                    headers.insert(header.key.to_string(), value_str.to_string());
+                                }
+                            }
+                        }
+                    }
+
+                    let serialized = SerializedKafkaMessage {
+                        topic,
+                        partition,
+                        offset,
+                        timestamp: borrowed_message.timestamp().to_millis().unwrap_or(0),
+                        key: borrowed_message
+                            .key()
+                            .and_then(|k| std::str::from_utf8(k).ok())
+                            .map(|s| s.to_string()),
+                        value: borrowed_message
+                            .payload()
+                            .and_then(|v| std::str::from_utf8(v).ok())
+                            .map(|s| s.to_string()),
+                        headers,
+                    };
+
+                    messages.push(serialized);
+                }
+                Ok(Some(Err(err))) => {
+                    warn!(error = %err, "Kafka recv error");
+                    counter!("ingestion_consumer_kafka_errors_total").increment(1);
+                    break;
+                }
+                Ok(None) => break,
+                Err(_) => break, // Timeout
+            }
+        }
+
+        Ok((messages, offsets))
+    }
+
+    /// Commit the max offset for each topic-partition.
+    fn commit_offsets(&self, offsets: &HashMap<(String, i32), i64>) -> anyhow::Result<()> {
+        if offsets.is_empty() {
+            return Ok(());
+        }
+
+        let mut tpl = TopicPartitionList::new();
+        for ((topic, partition), offset) in offsets {
+            // Commit offset + 1 (Kafka convention: committed offset = next to read)
+            tpl.add_partition_offset(topic, *partition, rdkafka::Offset::Offset(offset + 1))?;
+        }
+
+        self.consumer.commit(&tpl, CommitMode::Async)?;
+        counter!("ingestion_consumer_offset_commits_total").increment(1);
+
+        Ok(())
+    }
+}
+
+fn make_batch_id() -> String {
+    let ts = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis();
+    let rand: u32 = rand::random();
+    format!("{ts:x}-{rand:08x}")
+}

--- a/rust/ingestion-consumer/src/consumer.rs
+++ b/rust/ingestion-consumer/src/consumer.rs
@@ -45,13 +45,13 @@ impl IngestionConsumer {
 
         let client_config = config.build_consumer_config();
         let consumer: StreamConsumer = client_config.create()?;
-        consumer.subscribe(&[&config.kafka_consumer_topic])?;
+        consumer.subscribe(&[&config.ingestion_consumer_consume_topic])?;
 
         info!(
-            topic = %config.kafka_consumer_topic,
-            group = %config.kafka_consumer_group,
+            topic = %config.ingestion_consumer_consume_topic,
+            group = %config.ingestion_consumer_group_id,
             workers = worker_urls.len(),
-            batch_size = config.batch_size,
+            batch_size = config.consumer_batch_size,
             "Kafka consumer subscribed"
         );
 
@@ -60,8 +60,8 @@ impl IngestionConsumer {
             router,
             transport,
             worker_urls,
-            batch_size: config.batch_size,
-            batch_timeout: Duration::from_millis(config.batch_timeout_ms),
+            batch_size: config.consumer_batch_size,
+            batch_timeout: Duration::from_millis(config.consumer_batch_timeout_ms),
             handle,
         })
     }

--- a/rust/ingestion-consumer/src/consumer.rs
+++ b/rust/ingestion-consumer/src/consumer.rs
@@ -147,7 +147,13 @@ impl IngestionConsumer {
             total_accepted += result;
         }
 
-        // All workers ACK'd — commit offsets
+        if total_accepted < batch_size as u32 {
+            anyhow::bail!(
+                "Workers accepted {total_accepted}/{batch_size} messages — not committing offsets"
+            );
+        }
+
+        // All workers ACK'd all messages — commit offsets
         self.commit_offsets(&offsets)?;
 
         let elapsed = start.elapsed();

--- a/rust/ingestion-consumer/src/kafka_config.rs
+++ b/rust/ingestion-consumer/src/kafka_config.rs
@@ -1,0 +1,197 @@
+use rdkafka::ClientConfig;
+
+/// Kafka consumer configuration builder with sensible defaults for PostHog services.
+///
+/// Three entry points provide appropriate defaults for each consumer type:
+/// - `for_batch_consumer`: Group-based consumer with full consumer-group settings
+///   (auto commit/store disabled, session/heartbeat/max.poll defaults).
+/// - `for_assigner_consumer`: Consumer driven by kafka-assigner with manual `assign()`.
+///   Uses `group.id` for offset storage but no group-coordination settings.
+/// - `for_watermark_consumer`: Assign-only consumer with minimal connection settings
+///   (no group-coordination defaults). `group.id` is still required by rdkafka but
+///   the consumer will not join a consumer group.
+///
+/// All `with_*` methods are available on all types; callers simply don't call group-only
+/// methods (session, heartbeat, max_poll, sticky, offset_reset) for non-group consumers.
+pub struct ConsumerConfigBuilder {
+    config: ClientConfig,
+}
+
+impl ConsumerConfigBuilder {
+    /// Create a config builder for a **group-based batch consumer** with PostHog defaults.
+    ///
+    /// Sets: auto.offset.store=false, auto.commit=false, socket.timeout.ms,
+    /// session.timeout.ms, heartbeat.interval.ms, max.poll.interval.ms.
+    pub fn for_batch_consumer(bootstrap_servers: &str, group_id: &str) -> Self {
+        let mut config = ClientConfig::new();
+
+        config
+            .set("bootstrap.servers", bootstrap_servers)
+            .set("group.id", group_id);
+
+        // Group-consumer defaults
+        config
+            .set("enable.auto.offset.store", "false")
+            .set("enable.auto.commit", "false")
+            .set("socket.timeout.ms", "10000")
+            .set("session.timeout.ms", "60000")
+            .set("heartbeat.interval.ms", "5000")
+            .set("max.poll.interval.ms", "300000");
+
+        Self { config }
+    }
+
+    /// Create a config builder for an **assign-only watermark consumer** with minimal defaults.
+    ///
+    /// Sets only bootstrap.servers, group.id (required by rdkafka), and socket.timeout.ms.
+    /// No session/heartbeat/max.poll/auto.commit/offset.store — those are irrelevant
+    /// when using manual partition assignment without consumer-group coordination.
+    pub fn for_watermark_consumer(bootstrap_servers: &str, group_id: &str) -> Self {
+        let mut config = ClientConfig::new();
+
+        config
+            .set("bootstrap.servers", bootstrap_servers)
+            .set("group.id", group_id)
+            .set("socket.timeout.ms", "10000");
+
+        Self { config }
+    }
+
+    /// Create a config builder for an **assigner-driven consumer** that uses manual
+    /// partition assignment via `assign()` instead of consumer-group rebalancing.
+    ///
+    /// Sets bootstrap.servers, group.id (needed for offset commits via `commit()`/`committed()`),
+    /// auto.offset.store=false, auto.commit=false, and socket.timeout.ms.
+    /// No session/heartbeat/max.poll — the kafka-assigner manages partition ownership externally.
+    pub fn for_assigner_consumer(bootstrap_servers: &str, group_id: &str) -> Self {
+        let mut config = ClientConfig::new();
+
+        config
+            .set("bootstrap.servers", bootstrap_servers)
+            .set("group.id", group_id)
+            .set("enable.auto.offset.store", "false")
+            .set("enable.auto.commit", "false")
+            .set("socket.timeout.ms", "10000");
+
+        Self { config }
+    }
+
+    /// Backward-compatible alias for `for_batch_consumer`.
+    pub fn new(bootstrap_servers: &str, group_id: &str) -> Self {
+        Self::for_batch_consumer(bootstrap_servers, group_id)
+    }
+
+    // ---- Shared connection/fetch settings (useful for both consumer types) ----
+
+    /// Enable TLS/SSL for Kafka connection
+    pub fn with_tls(mut self, enabled: bool) -> Self {
+        if enabled {
+            self.config
+                .set("security.protocol", "ssl")
+                .set("enable.ssl.certificate.verification", "false");
+        }
+        self
+    }
+
+    /// Add any custom configuration
+    pub fn set(mut self, key: &str, value: &str) -> Self {
+        self.config.set(key, value);
+        self
+    }
+
+    pub fn with_max_partition_fetch_bytes(mut self, bytes: u32) -> Self {
+        self.config
+            .set("max.partition.fetch.bytes", bytes.to_string());
+        self
+    }
+
+    pub fn with_topic_metadata_refresh_interval_ms(mut self, ms: u32) -> Self {
+        self.config
+            .set("topic.metadata.refresh.interval.ms", ms.to_string());
+        self
+    }
+
+    pub fn with_metadata_max_age_ms(mut self, ms: u32) -> Self {
+        self.config.set("metadata.max.age.ms", ms.to_string());
+        self
+    }
+
+    /// Set minimum bytes to fetch from broker (triggers fetch when buffer has less than this)
+    pub fn with_fetch_min_bytes(mut self, bytes: u32) -> Self {
+        self.config.set("fetch.min.bytes", bytes.to_string());
+        self
+    }
+
+    /// Set maximum bytes to fetch from broker in a single request
+    pub fn with_fetch_max_bytes(mut self, bytes: u32) -> Self {
+        self.config.set("fetch.max.bytes", bytes.to_string());
+        self
+    }
+
+    /// Set maximum wait time when fetch.min.bytes is not satisfied
+    pub fn with_fetch_wait_max_ms(mut self, ms: u32) -> Self {
+        self.config.set("fetch.wait.max.ms", ms.to_string());
+        self
+    }
+
+    /// Set minimum number of messages to queue for prefetching
+    pub fn with_queued_min_messages(mut self, messages: u32) -> Self {
+        self.config.set("queued.min.messages", messages.to_string());
+        self
+    }
+
+    /// Set maximum bytes to prefetch across all partitions (in KB)
+    pub fn with_queued_max_messages_kbytes(mut self, kbytes: u32) -> Self {
+        self.config
+            .set("queued.max.messages.kbytes", kbytes.to_string());
+        self
+    }
+
+    // ---- Group-consumer-only settings (batch consumer) ----
+
+    /// Override offset reset policy (group consumers only)
+    pub fn with_offset_reset(mut self, policy: &str) -> Self {
+        self.config.set("auto.offset.reset", policy);
+        self
+    }
+
+    /// Set maximum time between poll() calls before consumer leaves group
+    pub fn with_max_poll_interval_ms(mut self, ms: u32) -> Self {
+        self.config.set("max.poll.interval.ms", ms.to_string());
+        self
+    }
+
+    /// Set session timeout: how long broker waits for heartbeats before declaring consumer dead.
+    /// With static membership (group.instance.id), broker holds partition assignments for this
+    /// duration after a consumer disappears. Should be longer than typical pod restart time.
+    pub fn with_session_timeout_ms(mut self, ms: u32) -> Self {
+        self.config.set("session.timeout.ms", ms.to_string());
+        self
+    }
+
+    /// Set heartbeat interval: how often consumer sends heartbeats to broker.
+    /// Should be ~1/3 of session.timeout.ms to allow multiple missed heartbeats before timeout.
+    pub fn with_heartbeat_interval_ms(mut self, ms: u32) -> Self {
+        self.config.set("heartbeat.interval.ms", ms.to_string());
+        self
+    }
+
+    /// Enable sticky partition assignments based on the kafka client ID supplied.
+    /// Always uses cooperative-sticky strategy for consistent behavior across all pods.
+    /// When client_id is provided, also enables static membership for truly sticky assignments.
+    pub fn with_sticky_partition_assignment(mut self, client_id: Option<&str>) -> Self {
+        self.config
+            .set("partition.assignment.strategy", "cooperative-sticky");
+
+        if let Some(found_client_id) = client_id {
+            self.config.set("client.id", found_client_id);
+            self.config.set("group.instance.id", found_client_id);
+        }
+        self
+    }
+
+    /// Build the final configuration
+    pub fn build(self) -> ClientConfig {
+        self.config
+    }
+}

--- a/rust/ingestion-consumer/src/lib.rs
+++ b/rust/ingestion-consumer/src/lib.rs
@@ -1,0 +1,6 @@
+pub mod config;
+pub mod consumer;
+pub mod kafka_config;
+pub mod router;
+pub mod transport;
+pub mod types;

--- a/rust/ingestion-consumer/src/main.rs
+++ b/rust/ingestion-consumer/src/main.rs
@@ -100,9 +100,15 @@ async fn async_main(config: Config) -> Result<()> {
     let guard = manager.monitor_background();
 
     // Spawn the consumer task
+    let api_secret = if config.internal_api_secret.is_empty() {
+        None
+    } else {
+        Some(config.internal_api_secret.clone())
+    };
     let transport = Arc::new(HttpTransport::new(
         Duration::from_millis(config.http_timeout_ms),
         config.max_retries,
+        api_secret,
     ));
 
     let consumer = IngestionConsumer::new(&config, transport, consumer_handle)

--- a/rust/ingestion-consumer/src/main.rs
+++ b/rust/ingestion-consumer/src/main.rs
@@ -1,0 +1,156 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use axum::response::IntoResponse;
+use axum::routing::get;
+use axum::Router;
+use envconfig::Envconfig;
+use futures::future::ready;
+use lifecycle::{ComponentOptions, Manager};
+use metrics_exporter_prometheus::PrometheusBuilder;
+use tokio::net::TcpListener;
+use tracing::info;
+use tracing_subscriber::fmt;
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::util::SubscriberInitExt;
+use tracing_subscriber::{EnvFilter, Layer};
+
+use ingestion_consumer::config::Config;
+use ingestion_consumer::consumer::IngestionConsumer;
+use ingestion_consumer::transport::HttpTransport;
+
+common_alloc::used!();
+
+fn main() -> Result<()> {
+    let config = Config::init_from_env()
+        .context("Failed to load configuration from environment variables")?;
+
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .context("Failed to build tokio runtime")?;
+
+    runtime.block_on(async_main(config))
+}
+
+async fn async_main(config: Config) -> Result<()> {
+    let is_debug = std::env::var("RUST_LOG")
+        .map(|v| v.contains("debug"))
+        .unwrap_or(false);
+
+    let log_layer = if is_debug {
+        fmt::layer()
+            .with_target(true)
+            .with_level(true)
+            .with_ansi(true)
+            .with_filter(
+                EnvFilter::builder()
+                    .with_default_directive(tracing::level_filters::LevelFilter::INFO.into())
+                    .from_env_lossy(),
+            )
+            .boxed()
+    } else {
+        fmt::layer()
+            .json()
+            .flatten_event(true)
+            .with_current_span(true)
+            .with_filter(
+                EnvFilter::builder()
+                    .with_default_directive(tracing::level_filters::LevelFilter::INFO.into())
+                    .from_env_lossy(),
+            )
+            .boxed()
+    };
+
+    tracing_subscriber::registry().with(log_layer).init();
+
+    info!(?config, "Starting ingestion consumer");
+
+    // Lifecycle manager handles signals, health, and shutdown coordination
+    let mut manager = Manager::builder("ingestion-consumer")
+        .with_global_shutdown_timeout(Duration::from_secs(90))
+        .build();
+
+    let consumer_handle = manager.register(
+        "consumer",
+        ComponentOptions::new()
+            .with_graceful_shutdown(Duration::from_secs(60))
+            .with_liveness_deadline(Duration::from_secs(60))
+            .with_stall_threshold(3),
+    );
+
+    let metrics_handle =
+        manager.register("metrics", ComponentOptions::new().is_observability(true));
+
+    let readiness = manager.readiness_handler();
+    let liveness = manager.liveness_handler();
+
+    // Install Prometheus recorder
+    let recorder_handle = if config.export_prometheus {
+        Some(
+            PrometheusBuilder::new()
+                .install_recorder()
+                .expect("failed to install Prometheus recorder"),
+        )
+    } else {
+        None
+    };
+
+    let guard = manager.monitor_background();
+
+    // Spawn the consumer task
+    let transport = Arc::new(HttpTransport::new(
+        Duration::from_millis(config.http_timeout_ms),
+        config.max_retries,
+    ));
+
+    let consumer = IngestionConsumer::new(&config, transport, consumer_handle)
+        .context("Failed to create Kafka consumer")?;
+
+    tokio::spawn(async move {
+        consumer.process().await;
+    });
+
+    // Build and serve the health/metrics HTTP server
+    let mut app = Router::new()
+        .route("/", get(|| async { "ingestion consumer" }))
+        .route(
+            "/_readiness",
+            get({
+                let r = readiness.clone();
+                move || {
+                    let r = r.clone();
+                    async move { r.check().await }
+                }
+            }),
+        )
+        .route(
+            "/_liveness",
+            get({
+                let l = liveness.clone();
+                move || {
+                    let l = l.clone();
+                    async move { l.check().into_response() }
+                }
+            }),
+        );
+
+    if let Some(handle) = recorder_handle {
+        app = app.route("/metrics", get(move || ready(handle.render())));
+    }
+
+    let bind = config.bind_address();
+    info!(address = %bind, "Health/metrics server starting");
+
+    let listener = TcpListener::bind(&bind).await?;
+    axum::serve(listener, app)
+        .with_graceful_shutdown(metrics_handle.shutdown_signal())
+        .await?;
+    metrics_handle.work_completed();
+
+    guard.wait().await?;
+
+    info!("Ingestion consumer stopped");
+    Ok(())
+}

--- a/rust/ingestion-consumer/src/router.rs
+++ b/rust/ingestion-consumer/src/router.rs
@@ -48,6 +48,7 @@ impl MessageRouter {
         messages: Vec<SerializedKafkaMessage>,
     ) -> HashMap<usize, Vec<SerializedKafkaMessage>> {
         let mut groups: HashMap<usize, Vec<SerializedKafkaMessage>> = HashMap::new();
+        let mut unique_keys: std::collections::HashSet<String> = std::collections::HashSet::new();
         let mut missing_headers: u64 = 0;
 
         for message in messages {
@@ -55,6 +56,7 @@ impl MessageRouter {
             if key == ":" {
                 missing_headers += 1;
             }
+            unique_keys.insert(key.clone());
             let worker_idx = self.assign(&key);
             groups.entry(worker_idx).or_default().push(message);
         }
@@ -65,9 +67,7 @@ impl MessageRouter {
                 .increment(msgs.len() as u64);
         }
 
-        // Track how many distinct_ids are in this batch (proxy for routing spread)
-        let distinct_id_count = groups.len();
-        histogram!("ingestion_consumer_distinct_ids_per_batch").record(distinct_id_count as f64);
+        histogram!("ingestion_consumer_distinct_ids_per_batch").record(unique_keys.len() as f64);
 
         if missing_headers > 0 {
             counter!("ingestion_consumer_missing_routing_headers_total").increment(missing_headers);

--- a/rust/ingestion-consumer/src/router.rs
+++ b/rust/ingestion-consumer/src/router.rs
@@ -1,0 +1,157 @@
+use std::collections::HashMap;
+use std::hash::{Hash, Hasher};
+
+use metrics::{counter, histogram};
+
+use crate::types::SerializedKafkaMessage;
+
+/// Routes messages to workers using hash-based assignment on `token:distinct_id`.
+///
+/// All messages for the same distinct_id go to the same worker within a batch,
+/// preserving person batching semantics. Stage 4 replaces this with least-loaded
+/// assignment for better load distribution on skewed workloads.
+pub struct MessageRouter {
+    worker_count: usize,
+}
+
+impl MessageRouter {
+    pub fn new(worker_count: usize) -> Self {
+        assert!(worker_count > 0, "worker_count must be > 0");
+        Self { worker_count }
+    }
+
+    /// Extract the routing key from a message's headers (`token:distinct_id`).
+    fn routing_key(message: &SerializedKafkaMessage) -> String {
+        let token = message
+            .headers
+            .get("token")
+            .map(|s| s.as_str())
+            .unwrap_or("");
+        let distinct_id = message
+            .headers
+            .get("distinct_id")
+            .map(|s| s.as_str())
+            .unwrap_or("");
+        format!("{token}:{distinct_id}")
+    }
+
+    /// Assign a routing key to a worker index.
+    fn assign(&self, key: &str) -> usize {
+        let mut hasher = std::collections::hash_map::DefaultHasher::new();
+        key.hash(&mut hasher);
+        (hasher.finish() as usize) % self.worker_count
+    }
+
+    /// Route a batch of messages, grouping them by assigned worker index.
+    pub fn route_batch(
+        &self,
+        messages: Vec<SerializedKafkaMessage>,
+    ) -> HashMap<usize, Vec<SerializedKafkaMessage>> {
+        let mut groups: HashMap<usize, Vec<SerializedKafkaMessage>> = HashMap::new();
+        let mut missing_headers: u64 = 0;
+
+        for message in messages {
+            let key = Self::routing_key(&message);
+            if key == ":" {
+                missing_headers += 1;
+            }
+            let worker_idx = self.assign(&key);
+            groups.entry(worker_idx).or_default().push(message);
+        }
+
+        // Record per-worker message distribution
+        for (worker_idx, msgs) in &groups {
+            counter!("ingestion_consumer_messages_routed_total", "worker" => worker_idx.to_string())
+                .increment(msgs.len() as u64);
+        }
+
+        // Track how many distinct_ids are in this batch (proxy for routing spread)
+        let distinct_id_count = groups.len();
+        histogram!("ingestion_consumer_distinct_ids_per_batch").record(distinct_id_count as f64);
+
+        if missing_headers > 0 {
+            counter!("ingestion_consumer_missing_routing_headers_total").increment(missing_headers);
+        }
+
+        groups
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_message(token: &str, distinct_id: &str) -> SerializedKafkaMessage {
+        let mut headers = HashMap::new();
+        headers.insert("token".to_string(), token.to_string());
+        headers.insert("distinct_id".to_string(), distinct_id.to_string());
+        SerializedKafkaMessage {
+            topic: "test".to_string(),
+            partition: 0,
+            offset: 0,
+            timestamp: 0,
+            key: None,
+            value: None,
+            headers,
+        }
+    }
+
+    #[test]
+    fn same_distinct_id_routes_to_same_worker() {
+        let router = MessageRouter::new(4);
+        let m1 = make_message("tok", "user-1");
+        let m2 = make_message("tok", "user-1");
+
+        let key1 = MessageRouter::routing_key(&m1);
+        let key2 = MessageRouter::routing_key(&m2);
+        assert_eq!(router.assign(&key1), router.assign(&key2));
+    }
+
+    #[test]
+    fn route_batch_groups_by_worker() {
+        let router = MessageRouter::new(4);
+        let messages = vec![
+            make_message("tok", "user-1"),
+            make_message("tok", "user-2"),
+            make_message("tok", "user-1"),
+        ];
+
+        let groups = router.route_batch(messages);
+
+        let total: usize = groups.values().map(|v| v.len()).sum();
+        assert_eq!(total, 3);
+
+        // user-1 messages should be in the same group
+        let user1_worker = router.assign("tok:user-1");
+        let user1_msgs = &groups[&user1_worker];
+        assert!(user1_msgs.len() >= 2);
+    }
+
+    #[test]
+    fn empty_headers_produce_consistent_routing() {
+        let router = MessageRouter::new(4);
+        let m1 = SerializedKafkaMessage {
+            topic: "test".to_string(),
+            partition: 0,
+            offset: 0,
+            timestamp: 0,
+            key: None,
+            value: None,
+            headers: HashMap::new(),
+        };
+        let m2 = SerializedKafkaMessage {
+            topic: "test".to_string(),
+            partition: 0,
+            offset: 1,
+            timestamp: 0,
+            key: None,
+            value: None,
+            headers: HashMap::new(),
+        };
+
+        let key1 = MessageRouter::routing_key(&m1);
+        let key2 = MessageRouter::routing_key(&m2);
+        assert_eq!(key1, ":");
+        assert_eq!(router.assign(&key1), router.assign(&key2));
+    }
+}

--- a/rust/ingestion-consumer/src/transport.rs
+++ b/rust/ingestion-consumer/src/transport.rs
@@ -131,6 +131,9 @@ impl HttpTransport {
                         error = %err,
                         "Failed to send batch to worker"
                     );
+                    if !err.is_retriable() {
+                        return Err(err);
+                    }
                     last_err = Some(err);
                 }
             }
@@ -157,7 +160,7 @@ impl HttpTransport {
         let response = self.client.post(url).json(request).send().await?;
         let status = response.status();
 
-        if status.is_server_error() {
+        if status.is_client_error() || status.is_server_error() {
             let body = response.text().await.unwrap_or_default();
             return Err(TransportError::HttpStatus(status.as_u16(), body));
         }
@@ -180,4 +183,16 @@ pub enum TransportError {
 
     #[error("All retries exhausted")]
     RetriesExhausted,
+}
+
+impl TransportError {
+    /// 4xx errors are non-transient and should not be retried.
+    pub fn is_retriable(&self) -> bool {
+        match self {
+            TransportError::HttpStatus(status, _) => *status >= 500,
+            TransportError::Http(_) => true,
+            TransportError::WorkerError(_) => true,
+            TransportError::RetriesExhausted => false,
+        }
+    }
 }

--- a/rust/ingestion-consumer/src/transport.rs
+++ b/rust/ingestion-consumer/src/transport.rs
@@ -12,10 +12,11 @@ use crate::types::{IngestBatchRequest, IngestBatchResponse, SerializedKafkaMessa
 pub struct HttpTransport {
     client: reqwest::Client,
     max_retries: u32,
+    api_secret: Option<String>,
 }
 
 impl HttpTransport {
-    pub fn new(timeout: Duration, max_retries: u32) -> Self {
+    pub fn new(timeout: Duration, max_retries: u32, api_secret: Option<String>) -> Self {
         let client = reqwest::Client::builder()
             .timeout(timeout)
             .pool_max_idle_per_host(4)
@@ -25,12 +26,13 @@ impl HttpTransport {
         Self {
             client,
             max_retries,
+            api_secret,
         }
     }
 
-    /// Check if a worker is ready by probing its readiness endpoint.
+    /// Check if a worker is ready by probing its health endpoint.
     pub async fn check_ready(&self, worker_url: &str) -> bool {
-        let url = format!("{worker_url}/_readiness");
+        let url = format!("{worker_url}/_ready");
         match self.client.get(&url).send().await {
             Ok(resp) => resp.status().is_success(),
             Err(_) => false,
@@ -157,7 +159,11 @@ impl HttpTransport {
         url: &str,
         request: &IngestBatchRequest,
     ) -> Result<IngestBatchResponse, TransportError> {
-        let response = self.client.post(url).json(request).send().await?;
+        let mut req_builder = self.client.post(url).json(request);
+        if let Some(secret) = &self.api_secret {
+            req_builder = req_builder.header("X-Internal-Api-Secret", secret);
+        }
+        let response = req_builder.send().await?;
         let status = response.status();
 
         if status.is_client_error() || status.is_server_error() {

--- a/rust/ingestion-consumer/src/transport.rs
+++ b/rust/ingestion-consumer/src/transport.rs
@@ -1,0 +1,183 @@
+use std::time::Duration;
+
+use metrics::{counter, histogram};
+use tracing::{error, info, warn};
+
+use crate::types::{IngestBatchRequest, IngestBatchResponse, SerializedKafkaMessage};
+
+/// Sends batches to Node.js worker processes over HTTP.
+///
+/// Uses reqwest with connection pooling (one pool per worker URL).
+/// Retries on 5xx/timeout with exponential backoff.
+pub struct HttpTransport {
+    client: reqwest::Client,
+    max_retries: u32,
+}
+
+impl HttpTransport {
+    pub fn new(timeout: Duration, max_retries: u32) -> Self {
+        let client = reqwest::Client::builder()
+            .timeout(timeout)
+            .pool_max_idle_per_host(4)
+            .build()
+            .expect("failed to create HTTP client");
+
+        Self {
+            client,
+            max_retries,
+        }
+    }
+
+    /// Check if a worker is ready by probing its readiness endpoint.
+    pub async fn check_ready(&self, worker_url: &str) -> bool {
+        let url = format!("{worker_url}/_readiness");
+        match self.client.get(&url).send().await {
+            Ok(resp) => resp.status().is_success(),
+            Err(_) => false,
+        }
+    }
+
+    /// Wait until all workers are ready, polling with backoff.
+    /// Returns an error if shutdown is signalled before all workers are ready.
+    pub async fn wait_for_workers_ready(
+        &self,
+        worker_urls: &[String],
+        shutdown: &lifecycle::Handle,
+    ) -> anyhow::Result<()> {
+        let poll_interval = Duration::from_secs(2);
+
+        loop {
+            let mut all_ready = true;
+            for url in worker_urls {
+                if !self.check_ready(url).await {
+                    warn!(worker = %url, "Worker not ready");
+                    all_ready = false;
+                }
+            }
+
+            if all_ready {
+                info!(workers = worker_urls.len(), "All workers ready");
+                return Ok(());
+            }
+
+            tokio::select! {
+                _ = shutdown.shutdown_recv() => {
+                    anyhow::bail!("Shutdown received while waiting for workers");
+                }
+                _ = tokio::time::sleep(poll_interval) => {}
+            }
+        }
+    }
+
+    /// Send a sub-batch to a worker. Returns the number of accepted messages.
+    pub async fn send_batch(
+        &self,
+        worker_url: &str,
+        batch_id: &str,
+        messages: Vec<SerializedKafkaMessage>,
+    ) -> Result<u32, TransportError> {
+        let message_count = messages.len();
+        let request = IngestBatchRequest {
+            batch_id: batch_id.to_string(),
+            messages,
+        };
+
+        let url = format!("{worker_url}/ingest");
+
+        let mut last_err = None;
+        for attempt in 0..=self.max_retries {
+            if attempt > 0 {
+                let backoff = Duration::from_millis(100 * 2u64.pow(attempt - 1));
+                tokio::time::sleep(backoff).await;
+                counter!("ingestion_consumer_transport_retries_total", "worker" => worker_url.to_string())
+                    .increment(1);
+            }
+
+            let start = std::time::Instant::now();
+            match self.do_send(&url, &request).await {
+                Ok(response) => {
+                    let elapsed = start.elapsed();
+                    histogram!("ingestion_consumer_transport_duration_seconds", "worker" => worker_url.to_string())
+                        .record(elapsed.as_secs_f64());
+                    counter!("ingestion_consumer_transport_requests_total", "worker" => worker_url.to_string(), "status" => "ok")
+                        .increment(1);
+
+                    if response.status == "ok" {
+                        return Ok(response.accepted);
+                    }
+
+                    let err_msg = response.error.unwrap_or_default();
+                    warn!(
+                        worker = %worker_url,
+                        batch_id = %batch_id,
+                        attempt = attempt + 1,
+                        error = %err_msg,
+                        "Worker returned error status"
+                    );
+                    last_err = Some(TransportError::WorkerError(err_msg));
+                }
+                Err(err) => {
+                    let elapsed = start.elapsed();
+                    histogram!("ingestion_consumer_transport_duration_seconds", "worker" => worker_url.to_string())
+                        .record(elapsed.as_secs_f64());
+                    counter!("ingestion_consumer_transport_requests_total", "worker" => worker_url.to_string(), "status" => "error")
+                        .increment(1);
+
+                    warn!(
+                        worker = %worker_url,
+                        batch_id = %batch_id,
+                        attempt = attempt + 1,
+                        messages = message_count,
+                        error = %err,
+                        "Failed to send batch to worker"
+                    );
+                    last_err = Some(err);
+                }
+            }
+        }
+
+        let err = last_err.unwrap_or(TransportError::RetriesExhausted);
+        error!(
+            worker = %worker_url,
+            batch_id = %batch_id,
+            messages = message_count,
+            max_retries = self.max_retries,
+            "All retries exhausted"
+        );
+        counter!("ingestion_consumer_transport_exhausted_total", "worker" => worker_url.to_string())
+            .increment(1);
+        Err(err)
+    }
+
+    async fn do_send(
+        &self,
+        url: &str,
+        request: &IngestBatchRequest,
+    ) -> Result<IngestBatchResponse, TransportError> {
+        let response = self.client.post(url).json(request).send().await?;
+        let status = response.status();
+
+        if status.is_server_error() {
+            let body = response.text().await.unwrap_or_default();
+            return Err(TransportError::HttpStatus(status.as_u16(), body));
+        }
+
+        let parsed: IngestBatchResponse = response.json().await?;
+        Ok(parsed)
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum TransportError {
+    #[error("HTTP request failed: {0}")]
+    Http(#[from] reqwest::Error),
+
+    #[error("Worker returned HTTP {0}: {1}")]
+    HttpStatus(u16, String),
+
+    #[error("Worker returned error: {0}")]
+    WorkerError(String),
+
+    #[error("All retries exhausted")]
+    RetriesExhausted,
+}

--- a/rust/ingestion-consumer/src/types.rs
+++ b/rust/ingestion-consumer/src/types.rs
@@ -1,0 +1,32 @@
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+
+/// Matches `SerializedKafkaMessage` in `nodejs/src/ingestion/api/types.ts`.
+/// Values are raw UTF-8 strings (PostHog Kafka messages are always JSON text).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SerializedKafkaMessage {
+    pub topic: String,
+    pub partition: i32,
+    pub offset: i64,
+    pub timestamp: i64,
+    pub key: Option<String>,
+    pub value: Option<String>,
+    pub headers: HashMap<String, String>,
+}
+
+/// Matches `IngestBatchRequest` in `nodejs/src/ingestion/api/types.ts`.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct IngestBatchRequest {
+    pub batch_id: String,
+    pub messages: Vec<SerializedKafkaMessage>,
+}
+
+/// Matches `IngestBatchResponse` in `nodejs/src/ingestion/api/types.ts`.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct IngestBatchResponse {
+    pub batch_id: String,
+    pub status: String,
+    pub accepted: u32,
+    pub error: Option<String>,
+}

--- a/rust/ingestion-consumer/tests/transport_integration_test.rs
+++ b/rust/ingestion-consumer/tests/transport_integration_test.rs
@@ -94,7 +94,7 @@ async fn transport_sends_batch_and_receives_ack() {
     let received = Arc::new(Mutex::new(Vec::new()));
     let (url, _handle) = start_mock_worker(received.clone()).await;
 
-    let transport = HttpTransport::new(Duration::from_secs(5), 0);
+    let transport = HttpTransport::new(Duration::from_secs(5), 0, None);
 
     let messages = vec![
         make_message("tok1", "user-a", 0, r#"{"event":"$pageview"}"#),
@@ -126,7 +126,7 @@ async fn transport_sends_batch_and_receives_ack() {
 async fn transport_retries_on_server_error() {
     let (url, _handle) = start_failing_worker().await;
 
-    let transport = HttpTransport::new(Duration::from_secs(1), 2);
+    let transport = HttpTransport::new(Duration::from_secs(1), 2, None);
 
     let messages = vec![make_message("tok", "user", 0, "{}")];
 
@@ -136,7 +136,7 @@ async fn transport_retries_on_server_error() {
 
 #[tokio::test]
 async fn transport_fails_on_unreachable_worker() {
-    let transport = HttpTransport::new(Duration::from_secs(1), 0);
+    let transport = HttpTransport::new(Duration::from_secs(1), 0, None);
     let messages = vec![make_message("tok", "user", 0, "{}")];
 
     let result = transport
@@ -155,7 +155,7 @@ async fn router_and_transport_end_to_end() {
 
     let worker_urls = [url_1.clone(), url_2.clone()];
     let router = MessageRouter::new(worker_urls.len());
-    let transport = Arc::new(HttpTransport::new(Duration::from_secs(5), 0));
+    let transport = Arc::new(HttpTransport::new(Duration::from_secs(5), 0, None));
 
     // Create messages for multiple distinct_ids
     let messages = vec![
@@ -223,7 +223,7 @@ async fn wire_format_preserves_unicode_and_null_fields() {
     let received = Arc::new(Mutex::new(Vec::new()));
     let (url, _handle) = start_mock_worker(received.clone()).await;
 
-    let transport = HttpTransport::new(Duration::from_secs(5), 0);
+    let transport = HttpTransport::new(Duration::from_secs(5), 0, None);
 
     let messages = vec![SerializedKafkaMessage {
         topic: "test".to_string(),

--- a/rust/ingestion-consumer/tests/transport_integration_test.rs
+++ b/rust/ingestion-consumer/tests/transport_integration_test.rs
@@ -1,0 +1,248 @@
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use axum::extract::Json;
+use axum::routing::post;
+use axum::Router;
+use tokio::net::TcpListener;
+
+use ingestion_consumer::router::MessageRouter;
+use ingestion_consumer::transport::HttpTransport;
+use ingestion_consumer::types::{IngestBatchRequest, IngestBatchResponse, SerializedKafkaMessage};
+
+fn make_message(
+    token: &str,
+    distinct_id: &str,
+    offset: i64,
+    value: &str,
+) -> SerializedKafkaMessage {
+    let mut headers = HashMap::new();
+    headers.insert("token".to_string(), token.to_string());
+    headers.insert("distinct_id".to_string(), distinct_id.to_string());
+    SerializedKafkaMessage {
+        topic: "events_plugin_ingestion".to_string(),
+        partition: 0,
+        offset,
+        timestamp: 1700000000000,
+        key: Some(format!("{token}:{distinct_id}")),
+        value: Some(value.to_string()),
+        headers,
+    }
+}
+
+/// Spin up a mock worker that records received batches and returns OK.
+async fn start_mock_worker(
+    received: Arc<Mutex<Vec<IngestBatchRequest>>>,
+) -> (String, tokio::task::JoinHandle<()>) {
+    let app = Router::new().route(
+        "/ingest",
+        post({
+            let received = received.clone();
+            move |Json(req): Json<IngestBatchRequest>| {
+                let received = received.clone();
+                async move {
+                    let accepted = req.messages.len() as u32;
+                    received.lock().unwrap().push(req);
+                    Json(IngestBatchResponse {
+                        batch_id: "test".to_string(),
+                        status: "ok".to_string(),
+                        accepted,
+                        error: None,
+                    })
+                }
+            }
+        }),
+    );
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let url = format!("http://127.0.0.1:{}", addr.port());
+
+    let handle = tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+
+    (url, handle)
+}
+
+/// Spin up a mock worker that returns errors.
+async fn start_failing_worker() -> (String, tokio::task::JoinHandle<()>) {
+    let app = Router::new().route(
+        "/ingest",
+        post(|| async {
+            (
+                axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+                "internal error",
+            )
+        }),
+    );
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let url = format!("http://127.0.0.1:{}", addr.port());
+
+    let handle = tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+
+    (url, handle)
+}
+
+#[tokio::test]
+async fn transport_sends_batch_and_receives_ack() {
+    let received = Arc::new(Mutex::new(Vec::new()));
+    let (url, _handle) = start_mock_worker(received.clone()).await;
+
+    let transport = HttpTransport::new(Duration::from_secs(5), 0);
+
+    let messages = vec![
+        make_message("tok1", "user-a", 0, r#"{"event":"$pageview"}"#),
+        make_message("tok1", "user-a", 1, r#"{"event":"$identify"}"#),
+    ];
+
+    let accepted = transport
+        .send_batch(&url, "batch-1", messages)
+        .await
+        .unwrap();
+
+    assert_eq!(accepted, 2);
+
+    let batches = received.lock().unwrap();
+    assert_eq!(batches.len(), 1);
+    assert_eq!(batches[0].messages.len(), 2);
+    assert_eq!(batches[0].messages[0].offset, 0);
+    assert_eq!(batches[0].messages[1].offset, 1);
+
+    // Verify headers survived the round-trip
+    assert_eq!(batches[0].messages[0].headers.get("token").unwrap(), "tok1");
+    assert_eq!(
+        batches[0].messages[0].headers.get("distinct_id").unwrap(),
+        "user-a"
+    );
+}
+
+#[tokio::test]
+async fn transport_retries_on_server_error() {
+    let (url, _handle) = start_failing_worker().await;
+
+    let transport = HttpTransport::new(Duration::from_secs(1), 2);
+
+    let messages = vec![make_message("tok", "user", 0, "{}")];
+
+    let result = transport.send_batch(&url, "batch-retry", messages).await;
+    assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn transport_fails_on_unreachable_worker() {
+    let transport = HttpTransport::new(Duration::from_secs(1), 0);
+    let messages = vec![make_message("tok", "user", 0, "{}")];
+
+    let result = transport
+        .send_batch("http://127.0.0.1:1", "batch-fail", messages)
+        .await;
+    assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn router_and_transport_end_to_end() {
+    // Start 2 mock workers
+    let received_1 = Arc::new(Mutex::new(Vec::new()));
+    let received_2 = Arc::new(Mutex::new(Vec::new()));
+    let (url_1, _h1) = start_mock_worker(received_1.clone()).await;
+    let (url_2, _h2) = start_mock_worker(received_2.clone()).await;
+
+    let worker_urls = [url_1.clone(), url_2.clone()];
+    let router = MessageRouter::new(worker_urls.len());
+    let transport = Arc::new(HttpTransport::new(Duration::from_secs(5), 0));
+
+    // Create messages for multiple distinct_ids
+    let messages = vec![
+        make_message("tok", "user-1", 0, r#"{"event":"a"}"#),
+        make_message("tok", "user-2", 1, r#"{"event":"b"}"#),
+        make_message("tok", "user-1", 2, r#"{"event":"c"}"#),
+        make_message("tok", "user-3", 3, r#"{"event":"d"}"#),
+    ];
+
+    // Route
+    let groups = router.route_batch(messages);
+
+    // Scatter to workers
+    let mut handles = Vec::new();
+    for (worker_idx, sub_batch) in groups {
+        let t = transport.clone();
+        let url = worker_urls[worker_idx].clone();
+        handles.push(tokio::spawn(async move {
+            t.send_batch(&url, "batch-e2e", sub_batch).await.unwrap()
+        }));
+    }
+
+    // Gather
+    let mut total_accepted = 0u32;
+    for h in handles {
+        total_accepted += h.await.unwrap();
+    }
+
+    assert_eq!(total_accepted, 4);
+
+    // Verify all messages for the same distinct_id landed on the same worker
+    let batches_1 = received_1.lock().unwrap();
+    let batches_2 = received_2.lock().unwrap();
+
+    let all_messages: Vec<&SerializedKafkaMessage> = batches_1
+        .iter()
+        .chain(batches_2.iter())
+        .flat_map(|b| &b.messages)
+        .collect();
+    assert_eq!(all_messages.len(), 4);
+
+    // user-1 messages (offsets 0, 2) must be on the same worker
+    let user1_workers: Vec<usize> = all_messages
+        .iter()
+        .filter(|m| m.headers.get("distinct_id").map(|s| s.as_str()) == Some("user-1"))
+        .map(|m| {
+            if batches_1
+                .iter()
+                .any(|b| b.messages.iter().any(|bm| bm.offset == m.offset))
+            {
+                0
+            } else {
+                1
+            }
+        })
+        .collect();
+    assert!(
+        user1_workers.iter().all(|&w| w == user1_workers[0]),
+        "user-1 messages should all be on the same worker"
+    );
+}
+
+#[tokio::test]
+async fn wire_format_preserves_unicode_and_null_fields() {
+    let received = Arc::new(Mutex::new(Vec::new()));
+    let (url, _handle) = start_mock_worker(received.clone()).await;
+
+    let transport = HttpTransport::new(Duration::from_secs(5), 0);
+
+    let messages = vec![SerializedKafkaMessage {
+        topic: "test".to_string(),
+        partition: 0,
+        offset: 42,
+        timestamp: 0,
+        key: None,
+        value: Some(r#"{"name":"José 日本語 🎉"}"#.to_string()),
+        headers: HashMap::new(),
+    }];
+
+    transport
+        .send_batch(&url, "batch-unicode", messages)
+        .await
+        .unwrap();
+
+    let batches = received.lock().unwrap();
+    let msg = &batches[0].messages[0];
+    assert!(msg.key.is_none());
+    assert_eq!(msg.value.as_deref(), Some(r#"{"name":"José 日本語 🎉"}"#));
+    assert!(msg.headers.is_empty());
+}


### PR DESCRIPTION
## Problem

Our current ingestion implementation is single-threaded per Kafka consumer, capped at ~1.5 CPU per consumer. Scaling relies on repartitioning Kafka topics and increasing pod count, which is approaching its limits. We need multi-CPU concurrency per pod to handle 4-8x more traffic without repartitioning.

## Changes

This is a minimal first version of the consumer to validate whether the sidecar architecture is feasible. It processes one batch at a time with simple hash-based routing. Production hardening (least-loaded assignment, multiple in-flight batches, in-flight stickiness) will follow once we confirm the approach works end-to-end.

- Add a new `ingestion-consumer` Rust crate that reads from Kafka ingestion topics, routes messages by `token:distinct_id` header, and dispatches sub-batches to Node.js worker processes via HTTP
- Use hash-based routing to preserve per-distinct_id ordering (all messages for the same distinct_id go to the same worker within a batch)
- Reuse the production-hardened `ConsumerConfigBuilder` from kafka-deduplicator with full Kafka tuning (session/heartbeat/fetch/sticky assignment)
- Add HTTP transport with retry/backoff and worker readiness checks before consuming
- Integrate with the `lifecycle` crate for health monitoring, readiness/liveness probes, and coordinated graceful shutdown
- Add Prometheus metrics for routing distribution, transport latency, batch processing, and error tracking
- Add integration tests that spin up mock HTTP workers and verify the routing + transport contract end-to-end

## How did you test this code?

<!-- Briefly describe the steps you took, and what steps reviewers must take to get to where changes are, and what is the expected behavior. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
