### PR TITLE
feat: Allow client_id override in livestream

### DIFF
--- a/livestream/configs/configs.go
+++ b/livestream/configs/configs.go
@@ -41,6 +41,7 @@ type ConsumerConfig struct {
 	Topic            string `mapstructure:"topic"`
 	SecurityProtocol string `mapstructure:"security_protocol"`
 	GroupID          string `mapstructure:"group_id"`
+	ClientID         string `mapstructure:"client_id"`
 
 	// Timeout overrides — zero means use librdkafka defaults.
 	SessionTimeoutMs    int `mapstructure:"session_timeout_ms"`
@@ -103,6 +104,7 @@ func InitConfigs(filename, configPath string) {
 	_ = viper.BindEnv("consumers.event.topic")                 // LIVESTREAM_CONSUMERS_EVENT_TOPIC
 	_ = viper.BindEnv("consumers.event.security_protocol")     // LIVESTREAM_CONSUMERS_EVENT_SECURITY_PROTOCOL
 	_ = viper.BindEnv("consumers.event.group_id")              // LIVESTREAM_CONSUMERS_EVENT_GROUP_ID
+	_ = viper.BindEnv("consumers.event.client_id")             // LIVESTREAM_CONSUMERS_EVENT_CLIENT_ID
 	_ = viper.BindEnv("consumers.event.session_timeout_ms")    // LIVESTREAM_CONSUMERS_EVENT_SESSION_TIMEOUT_MS
 	_ = viper.BindEnv("consumers.event.heartbeat_interval_ms") // LIVESTREAM_CONSUMERS_EVENT_HEARTBEAT_INTERVAL_MS
 	_ = viper.BindEnv("consumers.event.max_poll_interval_ms")  // LIVESTREAM_CONSUMERS_EVENT_MAX_POLL_INTERVAL_MS
@@ -112,6 +114,7 @@ func InitConfigs(filename, configPath string) {
 	_ = viper.BindEnv("consumers.session_recording.topic")                 // LIVESTREAM_CONSUMERS_SESSION_RECORDING_TOPIC
 	_ = viper.BindEnv("consumers.session_recording.security_protocol")     // LIVESTREAM_CONSUMERS_SESSION_RECORDING_SECURITY_PROTOCOL
 	_ = viper.BindEnv("consumers.session_recording.group_id")              // LIVESTREAM_CONSUMERS_SESSION_RECORDING_GROUP_ID
+	_ = viper.BindEnv("consumers.session_recording.client_id")             // LIVESTREAM_CONSUMERS_SESSION_RECORDING_CLIENT_ID
 	_ = viper.BindEnv("consumers.session_recording.session_timeout_ms")    // LIVESTREAM_CONSUMERS_SESSION_RECORDING_SESSION_TIMEOUT_MS
 	_ = viper.BindEnv("consumers.session_recording.heartbeat_interval_ms") // LIVESTREAM_CONSUMERS_SESSION_RECORDING_HEARTBEAT_INTERVAL_MS
 	_ = viper.BindEnv("consumers.session_recording.max_poll_interval_ms")  // LIVESTREAM_CONSUMERS_SESSION_RECORDING_MAX_POLL_INTERVAL_MS
@@ -121,6 +124,7 @@ func InitConfigs(filename, configPath string) {
 	_ = viper.BindEnv("consumers.notification.topic")                 // LIVESTREAM_CONSUMERS_NOTIFICATION_TOPIC
 	_ = viper.BindEnv("consumers.notification.security_protocol")     // LIVESTREAM_CONSUMERS_NOTIFICATION_SECURITY_PROTOCOL
 	_ = viper.BindEnv("consumers.notification.group_id")              // LIVESTREAM_CONSUMERS_NOTIFICATION_GROUP_ID
+	_ = viper.BindEnv("consumers.notification.client_id")             // LIVESTREAM_CONSUMERS_NOTIFICATION_CLIENT_ID
 	_ = viper.BindEnv("consumers.notification.session_timeout_ms")    // LIVESTREAM_CONSUMERS_NOTIFICATION_SESSION_TIMEOUT_MS
 	_ = viper.BindEnv("consumers.notification.heartbeat_interval_ms") // LIVESTREAM_CONSUMERS_NOTIFICATION_HEARTBEAT_INTERVAL_MS
 	_ = viper.BindEnv("consumers.notification.max_poll_interval_ms")  // LIVESTREAM_CONSUMERS_NOTIFICATION_MAX_POLL_INTERVAL_MS

--- a/livestream/events/kafka.go
+++ b/livestream/events/kafka.go
@@ -296,6 +296,9 @@ func (c *PostHogKafkaConsumer) IncomingRatio() float64 {
 }
 
 func applyKafkaConfigOverrides(config *kafka.ConfigMap, consumerConfig configs.ConsumerConfig) {
+	if consumerConfig.ClientID != "" {
+		_ = config.SetKey("client.id", consumerConfig.ClientID)
+	}
 	if consumerConfig.SessionTimeoutMs > 0 {
 		_ = config.SetKey("session.timeout.ms", consumerConfig.SessionTimeoutMs)
 	}


### PR DESCRIPTION
## Problem

The livestream service connects to Warpstream without AZ awareness because there's no way to configure the Kafka `client.id` per consumer, which Warpstream uses for routing traffic to agents in the same availability zone.

## Changes

- Add a `ClientID` field to `ConsumerConfig` so each consumer (event, session recording, notification) can have its own `client.id`
- Bind per-consumer env vars: `LIVESTREAM_CONSUMERS_EVENT_CLIENT_ID`, `LIVESTREAM_CONSUMERS_SESSION_RECORDING_CLIENT_ID`, `LIVESTREAM_CONSUMERS_NOTIFICATION_CLIENT_ID`
- Apply `client.id` in `applyKafkaConfigOverrides`, which all three consumers already call


## How did you test this code?

<!-- Briefly describe the steps you took, and what steps reviewers must take to get to where changes are, and what is the expected behavior. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
