### PR TITLE
fix(retention): enable event name filters first_ever_occurrence

### DIFF
--- a/posthog/hogql_queries/insights/retention_query_runner.py
+++ b/posthog/hogql_queries/insights/retention_query_runner.py
@@ -226,6 +226,7 @@ class RetentionQueryRunner(AnalyticsQueryRunner[RetentionQueryResponse]):
         global_event_filters = self.events_where_clause(
             self.is_first_occurrence_matching_filters, self.is_first_ever_occurrence
         )
+        # Pre-filter events to only those we care about
         is_relevant_event = ast.Or(exprs=[self.start_entity_expr, self.return_entity_expr])
         if not self.is_first_ever_occurrence:
             global_event_filters.append(is_relevant_event)

--- a/posthog/hogql_queries/insights/retention_query_runner.py
+++ b/posthog/hogql_queries/insights/retention_query_runner.py
@@ -226,7 +226,11 @@ class RetentionQueryRunner(AnalyticsQueryRunner[RetentionQueryResponse]):
         global_event_filters = self.events_where_clause(
             self.is_first_occurrence_matching_filters, self.is_first_ever_occurrence
         )
-        # Pre-filter events to only those we care about
+        # Pre-filter events to only those we care about.
+        # For first_ever_occurrence, we can't use the full entity expression filter because
+        # start_entity_expr includes entity-level properties, and the anchor logic needs to
+        # see events that don't match those properties to compute the true first-ever timestamp.
+        # The event name pre-filter in events_where_clause is still applied.
         is_relevant_event = ast.Or(exprs=[self.start_entity_expr, self.return_entity_expr])
         if not self.is_first_ever_occurrence:
             global_event_filters.append(is_relevant_event)
@@ -360,20 +364,21 @@ class RetentionQueryRunner(AnalyticsQueryRunner[RetentionQueryResponse]):
             # when it's recurring, we only have to grab events for the period, rather than events for all time
             events_where.append(self.events_timestamp_filter)
 
-        if not is_first_ever_occurrence:
-            # Pre filter event
-            events = self.get_events_for_entity(self.start_event) + self.get_events_for_entity(self.return_event)
-            unique_events = set(events)
-            # Don't pre-filter if any of them is "All events"
-            if None not in unique_events:
-                events_where.append(
-                    ast.CompareOperation(
-                        left=ast.Field(chain=["event"]),
-                        # Sorting for consistent snapshots in tests
-                        right=ast.Tuple(exprs=[ast.Constant(value=event) for event in sorted(unique_events)]),  # type: ignore
-                        op=ast.CompareOperationOp.In,
-                    )
+        # Pre filter event name - safe for all retention types including first_ever_occurrence,
+        # since the minIf aggregates inside _get_first_time_anchor_expr only look at events
+        # matching these entity expressions anyway
+        events = self.get_events_for_entity(self.start_event) + self.get_events_for_entity(self.return_event)
+        unique_events = set(events)
+        # Don't pre-filter if any of them is "All events"
+        if None not in unique_events:
+            events_where.append(
+                ast.CompareOperation(
+                    left=ast.Field(chain=["event"]),
+                    # Sorting for consistent snapshots in tests
+                    right=ast.Tuple(exprs=[ast.Constant(value=event) for event in sorted(unique_events)]),  # type: ignore
+                    op=ast.CompareOperationOp.In,
                 )
+            )
 
         return events_where
 

--- a/posthog/hogql_queries/insights/retention_query_runner.py
+++ b/posthog/hogql_queries/insights/retention_query_runner.py
@@ -226,7 +226,6 @@ class RetentionQueryRunner(AnalyticsQueryRunner[RetentionQueryResponse]):
         global_event_filters = self.events_where_clause(
             self.is_first_occurrence_matching_filters, self.is_first_ever_occurrence
         )
-        # For first_ever_occurrence, skip entity expression filter (includes properties the anchor logic needs to bypass)
         is_relevant_event = ast.Or(exprs=[self.start_entity_expr, self.return_entity_expr])
         if not self.is_first_ever_occurrence:
             global_event_filters.append(is_relevant_event)

--- a/posthog/hogql_queries/insights/retention_query_runner.py
+++ b/posthog/hogql_queries/insights/retention_query_runner.py
@@ -226,11 +226,7 @@ class RetentionQueryRunner(AnalyticsQueryRunner[RetentionQueryResponse]):
         global_event_filters = self.events_where_clause(
             self.is_first_occurrence_matching_filters, self.is_first_ever_occurrence
         )
-        # Pre-filter events to only those we care about.
-        # For first_ever_occurrence, we can't use the full entity expression filter because
-        # start_entity_expr includes entity-level properties, and the anchor logic needs to
-        # see events that don't match those properties to compute the true first-ever timestamp.
-        # The event name pre-filter in events_where_clause is still applied.
+        # For first_ever_occurrence, skip entity expression filter (includes properties the anchor logic needs to bypass)
         is_relevant_event = ast.Or(exprs=[self.start_entity_expr, self.return_entity_expr])
         if not self.is_first_ever_occurrence:
             global_event_filters.append(is_relevant_event)
@@ -364,9 +360,7 @@ class RetentionQueryRunner(AnalyticsQueryRunner[RetentionQueryResponse]):
             # when it's recurring, we only have to grab events for the period, rather than events for all time
             events_where.append(self.events_timestamp_filter)
 
-        # Pre filter event name - safe for all retention types including first_ever_occurrence,
-        # since the minIf aggregates inside _get_first_time_anchor_expr only look at events
-        # matching these entity expressions anyway
+        # Pre-filter by event name
         events = self.get_events_for_entity(self.start_event) + self.get_events_for_entity(self.return_event)
         unique_events = set(events)
         # Don't pre-filter if any of them is "All events"

--- a/posthog/hogql_queries/insights/test/__snapshots__/test_retention_query_runner.ambr
+++ b/posthog/hogql_queries/insights/test/__snapshots__/test_retention_query_runner.ambr
@@ -341,6 +341,88 @@
                         use_hive_partitioning=0
   '''
 # ---
+# name: TestRetention.test_retention_first_time_vs_first_ever_occurrence
+  '''
+  SELECT actor_activity.start_interval_index AS start_event_matching_interval,
+         actor_activity.intervals_from_base AS intervals_from_base,
+         count(DISTINCT actor_activity.actor_id) AS count
+  FROM
+    (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS actor_id,
+            if(has(arraySort(groupUniqArrayIf(toStartOfDay(toTimeZone(events.timestamp, 'UTC')), and(and(equals(events.event, 'target_event'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'prop'), ''), 'null'), '^"|"$', ''), 'correct'), 0)), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1))), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')))))) AS _start_event_timestamps, toStartOfInterval(minIf(toTimeZone(events.timestamp, 'UTC'), and(equals(events.event, 'target_event'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'prop'), ''), 'null'), '^"|"$', ''), 'correct'), 0))), toIntervalDay(1))), _start_event_timestamps, []) AS start_event_timestamps,
+            arrayMap(x -> plus(toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1)), toIntervalDay(x)), range(0, 6)) AS date_range,
+            arraySort(groupUniqArrayIf(toStartOfDay(toTimeZone(events.timestamp, 'UTC')), and(equals(events.event, 'returning_event'), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1))), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')))))) AS return_event_timestamps,
+            arrayJoin(arrayFilter(x -> ifNull(greater(x, -1), 0), arrayMap((interval_index, interval_date) -> if(ifNull(equals(start_event_timestamps[1], interval_date), isNull(start_event_timestamps[1])
+                                                                                                                        and isNull(interval_date)), minus(interval_index, 1), -1), arrayEnumerate(date_range), date_range))) AS start_interval_index,
+            arrayJoin(arrayConcat(if(ifNull(equals(start_event_timestamps[1], date_range[plus(start_interval_index, 1)]), isNull(start_event_timestamps[1])
+                                            and isNull(date_range[plus(start_interval_index, 1)])), [0], []), arrayFilter(x -> ifNull(greater(x, 0), 0), arrayMap(_timestamp -> minus(indexOf(arraySlice(date_range, plus(start_interval_index, 1), 5), _timestamp), 1), return_event_timestamps)))) AS intervals_from_base
+     FROM events
+     LEFT OUTER JOIN
+       (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
+               person_distinct_id_overrides.distinct_id AS distinct_id
+        FROM person_distinct_id_overrides
+        WHERE equals(person_distinct_id_overrides.team_id, 99999)
+        GROUP BY person_distinct_id_overrides.distinct_id
+        HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+     WHERE and(equals(events.team_id, 99999), in(events.event, tuple('returning_event', 'target_event')), or(and(equals(events.event, 'target_event'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'prop'), ''), 'null'), '^"|"$', ''), 'correct'), 0)), equals(events.event, 'returning_event')))
+     GROUP BY actor_id
+     HAVING 1) AS actor_activity
+  GROUP BY start_event_matching_interval,
+           intervals_from_base
+  ORDER BY start_event_matching_interval ASC,
+           intervals_from_base ASC
+  LIMIT 100000 SETTINGS readonly=2,
+                        max_execution_time=600,
+                        allow_experimental_object_type=1,
+                        max_ast_elements=4000000,
+                        max_expanded_ast_elements=4000000,
+                        max_bytes_before_external_group_by=23622320128,
+                        transform_null_in=1,
+                        optimize_min_equality_disjunction_chain_length=4294967295,
+                        allow_experimental_join_condition=1,
+                        use_hive_partitioning=0
+  '''
+# ---
+# name: TestRetention.test_retention_first_time_vs_first_ever_occurrence.1
+  '''
+  SELECT actor_activity.start_interval_index AS start_event_matching_interval,
+         actor_activity.intervals_from_base AS intervals_from_base,
+         count(DISTINCT actor_activity.actor_id) AS count
+  FROM
+    (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS actor_id,
+            if(has(arraySort(groupUniqArrayIf(toStartOfDay(toTimeZone(events.timestamp, 'UTC')), and(and(equals(events.event, 'target_event'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'prop'), ''), 'null'), '^"|"$', ''), 'correct'), 0)), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1))), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')))))) AS _start_event_timestamps, toStartOfInterval(if(equals(minIf(toTimeZone(events.timestamp, 'UTC'), equals(events.event, 'target_event')), minIf(toTimeZone(events.timestamp, 'UTC'), and(equals(events.event, 'target_event'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'prop'), ''), 'null'), '^"|"$', ''), 'correct'), 0)))), minIf(toTimeZone(events.timestamp, 'UTC'), equals(events.event, 'target_event')), NULL), toIntervalDay(1))), _start_event_timestamps, []) AS start_event_timestamps,
+            arrayMap(x -> plus(toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1)), toIntervalDay(x)), range(0, 6)) AS date_range,
+            arraySort(groupUniqArrayIf(toStartOfDay(toTimeZone(events.timestamp, 'UTC')), and(equals(events.event, 'returning_event'), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1))), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')))))) AS return_event_timestamps,
+            arrayJoin(arrayFilter(x -> ifNull(greater(x, -1), 0), arrayMap((interval_index, interval_date) -> if(ifNull(equals(start_event_timestamps[1], interval_date), isNull(start_event_timestamps[1])
+                                                                                                                        and isNull(interval_date)), minus(interval_index, 1), -1), arrayEnumerate(date_range), date_range))) AS start_interval_index,
+            arrayJoin(arrayConcat(if(ifNull(equals(start_event_timestamps[1], date_range[plus(start_interval_index, 1)]), isNull(start_event_timestamps[1])
+                                            and isNull(date_range[plus(start_interval_index, 1)])), [0], []), arrayFilter(x -> ifNull(greater(x, 0), 0), arrayMap(_timestamp -> minus(indexOf(arraySlice(date_range, plus(start_interval_index, 1), 5), _timestamp), 1), return_event_timestamps)))) AS intervals_from_base
+     FROM events
+     LEFT OUTER JOIN
+       (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
+               person_distinct_id_overrides.distinct_id AS distinct_id
+        FROM person_distinct_id_overrides
+        WHERE equals(person_distinct_id_overrides.team_id, 99999)
+        GROUP BY person_distinct_id_overrides.distinct_id
+        HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+     WHERE and(equals(events.team_id, 99999), in(events.event, tuple('returning_event', 'target_event')))
+     GROUP BY actor_id
+     HAVING 1) AS actor_activity
+  GROUP BY start_event_matching_interval,
+           intervals_from_base
+  ORDER BY start_event_matching_interval ASC,
+           intervals_from_base ASC
+  LIMIT 100000 SETTINGS readonly=2,
+                        max_execution_time=600,
+                        allow_experimental_object_type=1,
+                        max_ast_elements=4000000,
+                        max_expanded_ast_elements=4000000,
+                        max_bytes_before_external_group_by=23622320128,
+                        transform_null_in=1,
+                        optimize_min_equality_disjunction_chain_length=4294967295,
+                        allow_experimental_join_condition=1,
+                        use_hive_partitioning=0
+  '''
+# ---
 # name: TestRetention.test_retention_with_user_properties_via_action
   '''
   SELECT actor_activity.start_interval_index AS start_event_matching_interval,

--- a/posthog/hogql_queries/insights/test/test_retention_query_runner.py
+++ b/posthog/hogql_queries/insights/test/test_retention_query_runner.py
@@ -4531,6 +4531,7 @@ class TestRetention(ClickhouseTestMixin, APIBaseTest):
                 f"Missing expected {expected_type} at {expected_time} for person2 on day 1",
             )
 
+    @snapshot_clickhouse_queries
     def test_retention_first_time_vs_first_ever_occurrence(self):
         _create_person(team_id=self.team.pk, distinct_ids=["person1"])
         # First event, doesn't match property filter


### PR DESCRIPTION
## Problem

Support ticket https://posthoghelp.zendesk.com/agent/tickets/55213 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/56724)

Retention queries with `retention_first_ever_occurrence` were scanning ALL events across all history for a team, instead of filtering to just the relevant event types. For high-volume teams this caused queries to hit the 50 TiB ClickHouse read limit and fail entirely.

## Changes

- Enabled the `event IN (...)` pre-filter in `events_where_clause` for `first_ever_occurrence` retention type
- Added snapshot to the existing `test_retention_first_time_vs_first_ever_occurrence` test to capture generated SQL and prevent regression

## How did you test this code?

I've grabbed the CH queries and run these in metabase:

Failing query: https://metabase.prod-us.posthog.dev/question/2021-retention-error-55213
Succeeding query: https://metabase.prod-us.posthog.dev/question/2022-retention-error-fixed-55213


## Publish to changelog?

no

## 🤖 LLM context

Co-authored with Claude Code. The issue was identified while debugging a slow retention query, the query was hitting the 50 TiB ClickHouse read limit because `first_ever_occurrence` disabled both the timestamp filter (necessary for correctness) and the event name filter (unnecessary, and the root cause of the excessive scan).