### PR TITLE
chore(llma): document prompt-list content modes in skills store

### DIFF
--- a/products/llm_analytics/skills/skills-store/SKILL.md
+++ b/products/llm_analytics/skills/skills-store/SKILL.md
@@ -36,6 +36,21 @@ posthog:prompt-list
 { "search": "llm" }
 ```
 
+By default `prompt-list` returns only metadata (name, version, size) and omits prompt bodies,
+so responses stay small even when there are many skills.
+The intended flow is **list to discover the name, then `prompt-get` the one you actually want**.
+
+If you need a snippet to disambiguate between similarly-named skills without a follow-up fetch,
+ask for previews:
+
+```json
+posthog:prompt-list
+{ "content": "preview" }
+```
+
+`content=full` is also available but should be avoided —
+it returns every prompt body in one call and is almost never what you want.
+
 ## Loading and using a skill
 
 ### Step 1 — Fetch the skill by name


### PR DESCRIPTION
## Problem

PR #53503 changed the MCP `prompt-list` tool to default to `content=none` (metadata only), but the `skills-store` skill still describes the old behavior implicitly. Without a note, agents reading the skill don't learn that previews are now opt-in or why the list-then-get pattern is the cheap one.

## Changes

- Add a short paragraph to `products/llm_analytics/skills/skills-store/SKILL.md` explaining that `prompt-list` returns metadata only by default
- Document the `content=preview` escape hatch for disambiguation
- Discourage `content=full` as the wrong default for agent workflows

No code changes — purely a skill documentation update.

## How did you test this code?

Agent-authored PR — no tests, this is documentation only. The skill was read end-to-end to confirm the new section flows naturally with the existing list/get instructions.

## Publish to changelog?

no

## Docs update

No docs update needed.

## 🤖 LLM context

Authored by Claude Code in the same session as #53503 as a small follow-up to bring the only consumer-facing skill in line with the new MCP default.