### PR TITLE
feat(logs): add 1 minute option to alert window duration

### DIFF
--- a/products/logs/frontend/components/LogsAlerting/LogsAlertForm.tsx
+++ b/products/logs/frontend/components/LogsAlerting/LogsAlertForm.tsx
@@ -24,6 +24,7 @@ import { logsAlertFormLogic } from './logsAlertFormLogic'
 import { LogsAlertNotifications } from './LogsAlertNotifications'
 
 const WINDOW_OPTIONS = [
+    { value: 1, label: '1 minute' },
     { value: 5, label: '5 minutes' },
     { value: 10, label: '10 minutes' },
     { value: 15, label: '15 minutes' },


### PR DESCRIPTION
## Problem

Users need the ability to set shorter time windows for logs alerting to enable more responsive monitoring and faster detection of issues. The current minimum window of 5 minutes may be too long for critical systems that require immediate alerting.

## Changes

Added a 1-minute option to the time window selector in the logs alert form, allowing users to configure alerts with more granular timing for time-sensitive monitoring scenarios.

## How did you test this code?

Local dev

## Publish to changelog?

no

## Docs update

no