### PR TITLE
fix(databricks): Raise non-retryable error on auth failure during PUT

### DIFF
--- a/products/batch_exports/backend/temporal/destinations/databricks_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/databricks_batch_export.py
@@ -930,7 +930,7 @@ async def _get_databricks_integration(inputs: DatabricksInsertInputs) -> Databri
     return DatabricksIntegration(integration)
 
 
-def _is_insufficient_permissions_error(err: ServerOperationError) -> bool:
+def _is_insufficient_permissions_error(err: DatabaseError) -> bool:
     """Check if the error is an insufficient permissions error."""
     if err.message is None:
         return False

--- a/products/batch_exports/backend/temporal/destinations/databricks_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/databricks_batch_export.py
@@ -514,10 +514,15 @@ class DatabricksClient:
 
     async def aput_file_stream_to_volume(self, file: io.BytesIO, volume_path: str, file_name: str):
         """Asynchronously put a local file stream to a Databricks volume."""
-        await self.execute_query(
-            f"PUT '__input_stream__' INTO '{volume_path}/{file_name}' OVERWRITE",
-            query_kwargs={"input_stream": file},
-        )
+        try:
+            await self.execute_query(
+                f"PUT '__input_stream__' INTO '{volume_path}/{file_name}' OVERWRITE",
+                query_kwargs={"input_stream": file},
+            )
+        except OperationalError as err:
+            if _is_insufficient_permissions_error(err):
+                raise DatabricksInsufficientPermissionsError(f"PUT INTO '{volume_path}/{file_name}'", err.message)
+            raise
 
     async def acopy_into_table_from_volume(
         self,
@@ -929,7 +934,11 @@ def _is_insufficient_permissions_error(err: ServerOperationError) -> bool:
     """Check if the error is an insufficient permissions error."""
     if err.message is None:
         return False
-    return "INSUFFICIENT_PERMISSIONS" in err.message or "PERMISSION_DENIED" in err.message
+    return (
+        "INSUFFICIENT_PERMISSIONS" in err.message
+        or "PERMISSION_DENIED" in err.message
+        or "AuthorizationFailure" in err.message
+    )
 
 
 def _is_warehouse_stopped_error(err: ServerOperationError) -> bool:


### PR DESCRIPTION
## Problem

Databricks `PUT` queries can fail with an `AuthorizationFailure` due to missing permissions. These errors are wrapped in an `OperationalError`, so we have to check the message to find them.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Raise a non-retryable permission error on authorization failure.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took, and what steps reviewers must take to get to where changes are, and what is the expected behavior. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
