### PR TITLE
feat(logs): add snooze/unsnooze UI with duration picker and expiry tooltip

### DIFF
--- a/products/logs/frontend/components/LogsAlerting/LogsAlertList.tsx
+++ b/products/logs/frontend/components/LogsAlerting/LogsAlertList.tsx
@@ -11,6 +11,7 @@ import { Tooltip } from 'lib/lemon-ui/Tooltip'
 import {
     LogsAlertConfigurationApi,
     LogsAlertSparklineBucketApi,
+    LogsAlertConfigurationStateEnumApi,
     ThresholdOperatorEnumApi,
 } from 'products/logs/frontend/generated/api.schemas'
 
@@ -35,6 +36,13 @@ function alertSparklineData(sparkline: readonly LogsAlertSparklineBucketApi[] | 
     ]
 }
 
+const SNOOZE_DURATIONS = [
+    { label: '30 minutes', minutes: 30 },
+    { label: '1 hour', minutes: 60 },
+    { label: '4 hours', minutes: 240 },
+    { label: '24 hours', minutes: 1440 },
+]
+
 function formatThreshold(alert: LogsAlertConfigurationApi): string {
     const operator = alert.threshold_operator === ThresholdOperatorEnumApi.Below ? '<' : '>'
     return `${operator} ${alert.threshold_count} in ${alert.window_minutes}m`
@@ -42,8 +50,15 @@ function formatThreshold(alert: LogsAlertConfigurationApi): string {
 
 export function LogsAlertList(): JSX.Element {
     const { alerts, alertsLoading } = useValues(logsAlertingLogic)
-    const { setEditingAlert, setIsCreating, deleteAlert, toggleAlertEnabled, viewCheckHistory } =
-        useActions(logsAlertingLogic)
+    const {
+        setEditingAlert,
+        setIsCreating,
+        deleteAlert,
+        toggleAlertEnabled,
+        viewCheckHistory,
+        snoozeAlert,
+        unsnoozeAlert,
+    } = useActions(logsAlertingLogic)
 
     const columns: LemonTableColumns<LogsAlertConfigurationApi> = [
         {
@@ -58,7 +73,7 @@ export function LogsAlertList(): JSX.Element {
         {
             title: 'Status',
             dataIndex: 'state',
-            render: (_, alert) => <LogsAlertStateIndicator state={alert.state} />,
+            render: (_, alert) => <LogsAlertStateIndicator state={alert.state} snoozeUntil={alert.snooze_until} />,
         },
         {
             title: 'Threshold',
@@ -102,6 +117,18 @@ export function LogsAlertList(): JSX.Element {
                                     label: 'View history',
                                     onClick: () => viewCheckHistory(alert),
                                 },
+                                alert.state === LogsAlertConfigurationStateEnumApi.Snoozed
+                                    ? {
+                                          label: 'Unsnooze',
+                                          onClick: () => unsnoozeAlert(alert.id),
+                                      }
+                                    : {
+                                          label: 'Snooze',
+                                          items: SNOOZE_DURATIONS.map((d) => ({
+                                              label: d.label,
+                                              onClick: () => snoozeAlert(alert.id, d.minutes),
+                                          })),
+                                      },
                                 {
                                     label: 'Edit',
                                     onClick: () => setEditingAlert(alert),

--- a/products/logs/frontend/components/LogsAlerting/LogsAlertStateIndicator.tsx
+++ b/products/logs/frontend/components/LogsAlerting/LogsAlertStateIndicator.tsx
@@ -1,5 +1,8 @@
 import { LemonTag, LemonTagType } from '@posthog/lemon-ui'
 
+import { TZLabel } from 'lib/components/TZLabel'
+import { Tooltip } from 'lib/lemon-ui/Tooltip'
+
 import { LogsAlertConfigurationStateEnumApi } from 'products/logs/frontend/generated/api.schemas'
 
 const STATE_CONFIG: Record<LogsAlertConfigurationStateEnumApi, { label: string; type: LemonTagType }> = {
@@ -10,7 +13,28 @@ const STATE_CONFIG: Record<LogsAlertConfigurationStateEnumApi, { label: string; 
     [LogsAlertConfigurationStateEnumApi.Snoozed]: { label: 'Snoozed', type: 'muted' },
 }
 
-export function LogsAlertStateIndicator({ state }: { state: LogsAlertConfigurationStateEnumApi }): JSX.Element {
+interface LogsAlertStateIndicatorProps {
+    state: LogsAlertConfigurationStateEnumApi
+    snoozeUntil?: string | null
+}
+
+export function LogsAlertStateIndicator({ state, snoozeUntil }: LogsAlertStateIndicatorProps): JSX.Element {
     const config = STATE_CONFIG[state] ?? { label: state, type: 'default' as LemonTagType }
-    return <LemonTag type={config.type}>{config.label}</LemonTag>
+    const tag = <LemonTag type={config.type}>{config.label}</LemonTag>
+
+    if (state === LogsAlertConfigurationStateEnumApi.Snoozed && snoozeUntil) {
+        return (
+            <Tooltip
+                title={
+                    <>
+                        Until <TZLabel time={snoozeUntil} timestampStyle="absolute" />
+                    </>
+                }
+            >
+                {tag}
+            </Tooltip>
+        )
+    }
+
+    return tag
 }

--- a/products/logs/frontend/components/LogsAlerting/logsAlertingLogic.ts
+++ b/products/logs/frontend/components/LogsAlerting/logsAlertingLogic.ts
@@ -4,6 +4,7 @@ import { loaders } from 'kea-loaders'
 import { lemonToast } from '@posthog/lemon-ui'
 
 import api from 'lib/api'
+import { dayjs } from 'lib/dayjs'
 import { teamLogic } from 'scenes/teamLogic'
 
 import {
@@ -38,6 +39,8 @@ export const logsAlertingLogic = kea<logsAlertingLogicType>([
         closeCheckHistory: true,
         setCheckHistoryOutcome: (outcome: string) => ({ outcome }),
         loadCheckHistoryPage: (url: string) => ({ url }),
+        snoozeAlert: (alertId: string, durationMinutes: number) => ({ alertId, durationMinutes }),
+        unsnoozeAlert: (alertId: string) => ({ alertId }),
     }),
 
     reducers({
@@ -146,6 +149,27 @@ export const logsAlertingLogic = kea<logsAlertingLogicType>([
         },
         setCheckHistoryOutcome: () => {
             actions.loadCheckHistory()
+        },
+        snoozeAlert: async ({ alertId, durationMinutes }) => {
+            const projectId = String(values.currentTeamId)
+            const snoozeUntil = dayjs().add(durationMinutes, 'minute').toISOString()
+            try {
+                await logsAlertsPartialUpdate(projectId, alertId, { snooze_until: snoozeUntil })
+                lemonToast.success('Alert snoozed')
+                actions.loadAlerts()
+            } catch {
+                lemonToast.error('Failed to snooze alert')
+            }
+        },
+        unsnoozeAlert: async ({ alertId }) => {
+            const projectId = String(values.currentTeamId)
+            try {
+                await logsAlertsPartialUpdate(projectId, alertId, { snooze_until: null })
+                lemonToast.success('Alert unsnoozed')
+                actions.loadAlerts()
+            } catch {
+                lemonToast.error('Failed to unsnooze alert')
+            }
         },
     })),
 


### PR DESCRIPTION
## Problem

Users with noisy log alerts have no way to temporarily silence them without disabling and re-enabling. When investigating an incident or during a deploy, repeated notifications are distracting. Users need a quick way to mute an alert for a set period and have it automatically resume.

## Changes

Adds snooze/unsnooze functionality to the logs alert list UI. Backend already supports `PATCH snooze_until` - this PR is frontend only.

- **Snooze sub-menu** in the More dropdown with preset durations (30m, 1h, 4h, 24h). Uses `LemonMenuOverlay` nested items.
- **Unsnooze** option replaces Snooze when alert is already snoozed.
- **Expiry tooltip** on the "Snoozed" state badge — hover shows "Until {absolute timestamp}" via `TZLabel`.
- All state in `logsAlertingLogic` — `snoozeAlert(alertId, durationMinutes)` and `unsnoozeAlert(alertId)` actions using `logsAlertsPartialUpdate`.

## How did you test this code?

- Tested locally: snoozed an alert, verified state changes to "Snoozed" with tooltip showing expiry time, verified unsnooze returns to NOT_FIRING
- Backend tests for snooze/unsnooze already exist

## Publish to changelog?

no

## Docs update

N/A