### PR TITLE
feat: use settings component for support settings

### DIFF
--- a/frontend/src/scenes/settings/SettingsMap.tsx
+++ b/frontend/src/scenes/settings/SettingsMap.tsx
@@ -38,6 +38,12 @@ import {
 } from '~/layout/navigation-3000/sidepanel/panels/access_control/RolesAccessControls'
 import { AccessControlLevel, AccessControlResourceType, Realm } from '~/types'
 
+import { ApiSection } from 'products/conversations/frontend/scenes/settings/ApiSection'
+import { EmailSection } from 'products/conversations/frontend/scenes/settings/EmailSection'
+import { NotificationsSection } from 'products/conversations/frontend/scenes/settings/NotificationsSection'
+import { SlackSection } from 'products/conversations/frontend/scenes/settings/SlackSection'
+import { WidgetSection } from 'products/conversations/frontend/scenes/settings/WidgetSection'
+import { WorkflowsSection } from 'products/conversations/frontend/scenes/settings/WorkflowsSection'
 import { CustomerAnalyticsDashboardEvents } from 'products/customer_analytics/frontend/scenes/CustomerAnalyticsConfigurationScene/events/CustomerAnalyticsDashboardEvents'
 import { ExceptionAutocaptureToggle } from 'products/error_tracking/frontend/scenes/ErrorTrackingConfigurationScene/exception_autocapture/ExceptionAutocaptureSettings'
 import { SuppressionRules } from 'products/error_tracking/frontend/scenes/ErrorTrackingConfigurationScene/suppression_rules/SuppressionRules'
@@ -876,6 +882,56 @@ export const SETTINGS_MAP: SettingSection[] = [
                 platformSupport: FEATURE_SUPPORT.heatmaps,
                 component: <HeatmapsSettings />,
                 keywords: ['click map', 'scroll', 'rage click', 'mouse', 'touch'],
+            },
+        ],
+    },
+    {
+        level: 'environment',
+        id: 'environment-conversations',
+        title: 'Conversations',
+        group: 'Products',
+        flag: 'PRODUCT_SUPPORT',
+        settings: [
+            {
+                id: 'conversations-api',
+                title: 'Conversations',
+                component: <ApiSection />,
+                keywords: ['conversation', 'ticket', 'message', 'support'],
+            },
+            {
+                id: 'conversations-notifications',
+                title: 'Notifications',
+                component: <NotificationsSection />,
+                keywords: ['conversation', 'ticket', 'message', 'support'],
+            },
+            {
+                id: 'conversations-widget',
+                title: 'In-app widget',
+                component: <WidgetSection />,
+                allowForTeam: (t) => !!t?.conversations_enabled,
+                keywords: ['conversation', 'ticket', 'message', 'support'],
+            },
+            {
+                id: 'conversations-slack',
+                title: 'Slack channel',
+                component: <SlackSection />,
+                allowForTeam: (t) => !!t?.conversations_enabled,
+                keywords: ['conversation', 'ticket', 'message', 'support'],
+            },
+            {
+                id: 'conversations-email',
+                title: 'Email channel',
+                component: <EmailSection />,
+                allowForTeam: (t) => !!t?.conversations_enabled,
+                flag: 'PRODUCT_SUPPORT_EMAIL_CHANNEL',
+                keywords: ['conversation', 'ticket', 'message', 'support'],
+            },
+            {
+                id: 'conversations-workflows',
+                title: 'Workflows',
+                component: <WorkflowsSection />,
+                allowForTeam: (t) => !!t?.conversations_enabled,
+                keywords: ['conversation', 'ticket', 'message', 'support'],
             },
         ],
     },

--- a/frontend/src/scenes/settings/types.ts
+++ b/frontend/src/scenes/settings/types.ts
@@ -18,6 +18,7 @@ export type SettingLevelId = (typeof SettingLevelIds)[number]
 
 export type SettingSectionId =
     | 'environment-details'
+    | 'environment-conversations'
     | 'environment-customization'
     | 'environment-autocapture'
     | 'environment-heatmaps'
@@ -74,6 +75,12 @@ export type SettingSectionId =
     | 'mcp-servers'
 
 export type SettingId =
+    | 'conversations-api'
+    | 'conversations-notifications'
+    | 'conversations-slack'
+    | 'conversations-email'
+    | 'conversations-widget'
+    | 'conversations-workflows'
     | 'snippet-v2'
     | 'js-snippet-version'
     | 'replay-triggers'

--- a/products/conversations/frontend/scenes/settings/EmailSection.tsx
+++ b/products/conversations/frontend/scenes/settings/EmailSection.tsx
@@ -266,7 +266,6 @@ export function EmailSection(): JSX.Element {
         <SceneSection
             title="Email channel"
             description="Receive customer emails as support tickets and reply directly from PostHog. Set up forwarding and verify your domain to enable two-way email."
-            className="mt-4"
         >
             <div className="flex flex-col gap-3 max-w-[800px]">
                 {emailConfigs.length > 0 && (

--- a/products/conversations/frontend/scenes/settings/NotificationsSection.tsx
+++ b/products/conversations/frontend/scenes/settings/NotificationsSection.tsx
@@ -16,7 +16,6 @@ export function NotificationsSection(): JSX.Element {
     return (
         <SceneSection
             title="Notifications"
-            className="mt-4"
             description="We recommend using workflows to set custom notifications, e.g. when a new ticket is created or a new message is received."
         >
             <LemonCard hoverEffect={false} className="flex flex-col gap-y-2 max-w-[800px] px-4 py-3">

--- a/products/conversations/frontend/scenes/settings/SecretApiKeySection.tsx
+++ b/products/conversations/frontend/scenes/settings/SecretApiKeySection.tsx
@@ -34,7 +34,6 @@ export function SecretApiKeySection(): JSX.Element {
         <SceneSection
             title="Secret API key"
             description="Authenticate external API requests for workflows. Generate a key to enable workflow integrations."
-            className="mt-4"
         >
             <LemonCard hoverEffect={false} className="flex flex-col gap-y-2 max-w-[800px] px-4 py-3">
                 <div>

--- a/products/conversations/frontend/scenes/settings/SlackSection.tsx
+++ b/products/conversations/frontend/scenes/settings/SlackSection.tsx
@@ -23,7 +23,6 @@ export function SlackSection(): JSX.Element {
                     </Link>
                 </>
             }
-            className="mt-4"
         >
             <LemonCard hoverEffect={false} className="flex flex-col gap-y-2 max-w-[800px] px-4 py-3">
                 <SlackChannelSection />

--- a/products/conversations/frontend/scenes/settings/SupportSettingsScene.tsx
+++ b/products/conversations/frontend/scenes/settings/SupportSettingsScene.tsx
@@ -1,21 +1,15 @@
-import { useValues } from 'kea'
+import { router } from 'kea-router'
 
-import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { SceneExport } from 'scenes/sceneTypes'
-import { teamLogic } from 'scenes/teamLogic'
+import { Settings } from 'scenes/settings/Settings'
 
 import { SceneContent } from '~/layout/scenes/components/SceneContent'
 import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
 import { ProductKey } from '~/queries/schema/schema-general'
 
 import { ScenesTabs } from '../../components/ScenesTabs'
-import { ApiSection } from './ApiSection'
-import { EmailSection } from './EmailSection'
-import { NotificationsSection } from './NotificationsSection'
-import { SecretApiKeySection } from './SecretApiKeySection'
-import { SlackSection } from './SlackSection'
-import { WidgetSection } from './WidgetSection'
-import { WorkflowsSection } from './WorkflowsSection'
+
+export const CONVERSATIONS_LOGIC_KEY = 'conversationsSettings'
 
 export const scene: SceneExport = {
     component: SupportSettingsScene,
@@ -23,9 +17,6 @@ export const scene: SceneExport = {
 }
 
 export function SupportSettingsScene(): JSX.Element {
-    const { currentTeam } = useValues(teamLogic)
-    const emailChannelEnabled = useFeatureFlag('PRODUCT_SUPPORT_EMAIL_CHANNEL')
-
     return (
         <SceneContent>
             <SceneTitleSection
@@ -36,17 +27,12 @@ export function SupportSettingsScene(): JSX.Element {
                 }}
             />
             <ScenesTabs />
-            <ApiSection />
-            {currentTeam?.conversations_enabled && (
-                <>
-                    <NotificationsSection />
-                    <SlackSection />
-                    {emailChannelEnabled && <EmailSection />}
-                    <WidgetSection />
-                    <WorkflowsSection />
-                    <SecretApiKeySection />
-                </>
-            )}
+            <Settings
+                logicKey={CONVERSATIONS_LOGIC_KEY}
+                sectionId="environment-conversations"
+                settingId={router.values.hashParams.selectedSetting || 'conversations-api'}
+                handleLocally
+            />
         </SceneContent>
     )
 }

--- a/products/conversations/frontend/scenes/settings/WidgetSection.tsx
+++ b/products/conversations/frontend/scenes/settings/WidgetSection.tsx
@@ -57,7 +57,6 @@ export function WidgetSection(): JSX.Element {
                     </Link>
                 </>
             }
-            className="mt-4"
         >
             <LemonCard hoverEffect={false} className="flex flex-col gap-y-2 max-w-[800px] px-4 py-3">
                 <div className="flex items-center gap-4 justify-between">

--- a/products/conversations/frontend/scenes/settings/WorkflowsSection.tsx
+++ b/products/conversations/frontend/scenes/settings/WorkflowsSection.tsx
@@ -2,6 +2,7 @@ import { LemonCard, Link } from '@posthog/lemon-ui'
 
 import { SceneSection } from '~/layout/scenes/components/SceneSection'
 
+import { SecretApiKeySection } from './SecretApiKeySection'
 export function WorkflowsSection(): JSX.Element {
     return (
         <SceneSection
@@ -14,7 +15,6 @@ export function WorkflowsSection(): JSX.Element {
                     </Link>
                 </>
             }
-            className="mt-4"
         >
             <LemonCard hoverEffect={false} className="max-w-[800px] px-4 py-3">
                 <div className="flex flex-col gap-4">
@@ -89,6 +89,7 @@ export function WorkflowsSection(): JSX.Element {
                     </div>
                 </div>
             </LemonCard>
+            <SecretApiKeySection />
         </SceneSection>
     )
 }


### PR DESCRIPTION
## Problem

Support settings screen became too big and cluttered

## Changes

Use standard `Settings` component instead


<img width="1118" height="347" alt="Screenshot 2026-04-07 at 13 23 59" src="https://github.com/user-attachments/assets/955eca7b-8b3d-40a7-a4fc-ac0643b53236" />
