### PR TITLE
fix(recordings): fall back to nearest segment when export timestamp exceeds recording duration

### DIFF
--- a/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.test.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.test.ts
@@ -136,11 +136,10 @@ describe('findSegmentForTimestamp', () => {
         expect(result?.windowId).toBe(1)
     })
 
-    it('returns synthetic buffer when timestamp is after all segments', () => {
+    it('falls back to last segment with windowId when timestamp is after all segments', () => {
         const result = findSegmentForTimestamp(segments, 9999)
-        expect(result?.kind).toBe('buffer')
-        expect(result?.startTimestamp).toBe(9999)
-        expect(result?.endTimestamp).toBe(5001)
+        expect(result).toEqual(segments[2])
+        expect(result?.windowId).toBe(2)
     })
 
     it('skips segments without windowId when falling back', () => {

--- a/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
@@ -233,10 +233,16 @@ export function findSegmentForTimestamp(segments: RecordingSegment[], timestamp?
                 return segment
             }
         }
-        // Timestamp doesn't fall in any segment (e.g. timezone mismatch).
+        // Timestamp falls outside all segments (e.g. timezone mismatch, stale link).
         // Pick the nearest segment that has a windowId so the player can still boot.
         if (timestamp < segments[0].startTimestamp) {
             const nearest = segments.find((s) => s.windowId !== undefined)
+            if (nearest) {
+                return nearest
+            }
+        }
+        if (timestamp > segments[segments.length - 1].endTimestamp) {
+            const nearest = [...segments].reverse().find((s) => s.windowId !== undefined)
             if (nearest) {
                 return nearest
             }
@@ -1712,23 +1718,25 @@ export const sessionRecordingPlayerLogic = kea<sessionRecordingPlayerLogicType>(
             // Check if we're seeking to a new segment
             const segment = values.segmentForTimestamp(timestamp)
 
-            if (segment && !objectsEqual(segment, values.currentSegment)) {
+            // End-of-recording detection — independent of segment type so that
+            // findSegmentForTimestamp can safely return a real segment for
+            // past-end timestamps (needed for the image exporter to boot the
+            // rrweb replayer). See #49364 and #53550.
+            const isPastEnd = values.sessionPlayerData.end && timestamp >= values.sessionPlayerData.end.valueOf()
+            if (isPastEnd) {
+                actions.setEndReached(true)
+            } else if (segment && !objectsEqual(segment, values.currentSegment)) {
                 actions.setCurrentSegment(segment)
             }
 
             // If next time is greater than last buffered time, set to buffering
             else if (segment?.kind === 'buffer' || values.isWaitingForPlayableFullSnapshot) {
-                const isPastEnd = values.sessionPlayerData.end && timestamp >= values.sessionPlayerData.end.valueOf()
-                if (isPastEnd) {
-                    actions.setEndReached(true)
-                } else {
-                    values.player?.replayer?.pause()
-                    actions.startBuffer()
-                    actions.clearPlayerError()
+                values.player?.replayer?.pause()
+                actions.startBuffer()
+                actions.clearPlayerError()
 
-                    // if we're buffering, then be careful to ensure we're loading data
-                    actions.loadNextSnapshotSource()
-                }
+                // if we're buffering, then be careful to ensure we're loading data
+                actions.loadNextSnapshotSource()
             }
 
             // If not forced to play and if last playing state was pause, pause


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

Session recording image exports (via API) were failing with `TimeoutException` at a rate of ~5,700/week in US, concentrated on 5 teams. The headless Chromium exporter waited 40 seconds for `.replayer-wrapper` to appear in the DOM, but it never did.

**Root cause:** When the `t` (timestamp) parameter in the exporter URL exceeded the recording's duration, `findSegmentForTimestamp` returned a synthetic buffer segment with no `windowId`. The player's `tryInitReplayer` guard checks `windowId === undefined` and bails out — so the rrweb `Replayer` was never created, `.replayer-wrapper` never appeared, and the export timed out.

The "before start" case already had a fallback to the nearest segment with a `windowId` (added for timezone mismatch scenarios), but the "past end" case fell through to the synthetic buffer.

[example](https://us.posthog.com/project/106994/replay/019d6614-38ac-7215-bff5-7924b1d8d4ca?t=161697)

## Changes

Two changes that work together:

- findSegmentForTimestamp: falls back to the last segment with a valid windowId when the timestamp is past the end of all segments, mirroring the existing "beforestart" fallback. This ensures the rrweb replayer can boot for exports.
- seekToTimestamp: moves end-of-recording detection (isPastEnd → setEndReached) out from behind the segment?.kind === 'buffer' gate, making it an independentfirst check. This decouples end-of-playback detection from segment type, so returning a real segment for past-end timestamps (change 1) doesn't break normal playback.

**Context:** #49364 deliberately removed the past-end real-segment fallback because `seekToTimestamp` relied on getting a buffer segment to detect end-of-recording. Rather than reverting that fix, this PR fixes the underlying architectural issue — end detection should not depend on segment type.

## How did you test this code?

- [x] Updated existing test: `findSegmentForTimestamp` now returns the last segment with a `windowId` when timestamp is past all segments (was previously asserting synthetic buffer). This failed before the fix was added.
- [x] All 60 tests in `sessionRecordingPlayerLogic.test.ts` pass
- [ ] Will test it on production once this is released as well

<!-- Briefly describe the steps you took, and what steps reviewers must take to get to where changes are, and what is the expected behavior. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Publish to changelog?

No

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

No

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->