### PR TITLE
feat: Add ingestion api

### DIFF
--- a/nodejs/src/capabilities.ts
+++ b/nodejs/src/capabilities.ts
@@ -169,6 +169,8 @@ export function getPluginServerCapabilities(
         case PluginServerMode.ingestion_v2_testing:
         case PluginServerMode.ingestion_v2_combined:
             throw new Error(`Mode ${mode} is handled by IngestionGeneralServer, not PluginServer`)
+        case PluginServerMode.ingestion_api:
+            throw new Error(`Mode ${mode} is handled by IngestionApiServer, not PluginServer`)
         case PluginServerMode.cdp_hogflow_scheduler:
             return {
                 cdpHogflowScheduler: true,

--- a/nodejs/src/common/config.ts
+++ b/nodejs/src/common/config.ts
@@ -44,6 +44,7 @@ export enum PluginServerMode {
     ingestion_v2_combined = 'ingestion-v2-combined',
     ingestion_traces = 'ingestion-traces',
     cdp_hogflow_scheduler = 'cdp-hogflow-scheduler',
+    ingestion_api = 'ingestion-api',
 }
 
 export const stringToPluginServerMode = Object.fromEntries(

--- a/nodejs/src/index.ts
+++ b/nodejs/src/index.ts
@@ -5,6 +5,7 @@ import { defaultConfig } from '~/config/config'
 import { PluginServer } from '~/server'
 import { NodeServer } from '~/servers/base-server'
 import { ErrorTrackingServer } from '~/servers/error-tracking-server'
+import { IngestionApiServer } from '~/servers/ingestion-api-server'
 import { IngestionGeneralServer } from '~/servers/ingestion-general-server'
 import { IngestionLogsServer } from '~/servers/ingestion-logs-server'
 import { IngestionSessionReplayServer } from '~/servers/ingestion-session-replay-server'
@@ -18,6 +19,9 @@ function createServer(): NodeServer {
         case PluginServerMode.ingestion_v2_testing:
         case PluginServerMode.ingestion_v2_combined:
             return new IngestionGeneralServer()
+
+        case PluginServerMode.ingestion_api:
+            return new IngestionApiServer()
 
         case PluginServerMode.recordings_blob_ingestion_v2:
         case PluginServerMode.recordings_blob_ingestion_v2_overflow:

--- a/nodejs/src/ingestion/api/kafka-message-converter.test.ts
+++ b/nodejs/src/ingestion/api/kafka-message-converter.test.ts
@@ -30,7 +30,7 @@ describe('deserializeKafkaMessage', () => {
             { token: Buffer.from('my-token') },
             { distinct_id: Buffer.from('my-distinct-id') },
         ])
-        expect(message.size).toBe(serialized.value!.length)
+        expect(message.size).toBe(Buffer.byteLength(serialized.value!, 'utf-8'))
     })
 
     it('handles null key and value', () => {
@@ -82,5 +82,7 @@ describe('deserializeKafkaMessage', () => {
         const message = deserializeKafkaMessage(serialized)
 
         expect(message.value!.toString('utf-8')).toBe('{"name":"José 日本語 🎉"}')
+        // size should reflect byte length, not JS string length (multi-byte chars)
+        expect(message.size).toBe(Buffer.byteLength('{"name":"José 日本語 🎉"}', 'utf-8'))
     })
 })

--- a/nodejs/src/ingestion/api/kafka-message-converter.test.ts
+++ b/nodejs/src/ingestion/api/kafka-message-converter.test.ts
@@ -1,0 +1,86 @@
+import { deserializeKafkaMessage } from './kafka-message-converter'
+import { SerializedKafkaMessage } from './types'
+
+describe('deserializeKafkaMessage', () => {
+    it('converts a full message with all fields', () => {
+        const serialized: SerializedKafkaMessage = {
+            topic: 'events_plugin_ingestion',
+            partition: 3,
+            offset: 42,
+            timestamp: 1700000000000,
+            key: 'my-token:my-distinct-id',
+            value: '{"event":"$pageview","properties":{"$current_url":"https://example.com"}}',
+            headers: {
+                token: 'my-token',
+                distinct_id: 'my-distinct-id',
+            },
+        }
+
+        const message = deserializeKafkaMessage(serialized)
+
+        expect(message.topic).toBe('events_plugin_ingestion')
+        expect(message.partition).toBe(3)
+        expect(message.offset).toBe(42)
+        expect(message.timestamp).toBe(1700000000000)
+        expect(message.key).toEqual(Buffer.from('my-token:my-distinct-id'))
+        expect(message.value).toEqual(
+            Buffer.from('{"event":"$pageview","properties":{"$current_url":"https://example.com"}}')
+        )
+        expect(message.headers).toEqual([
+            { token: Buffer.from('my-token') },
+            { distinct_id: Buffer.from('my-distinct-id') },
+        ])
+        expect(message.size).toBe(serialized.value!.length)
+    })
+
+    it('handles null key and value', () => {
+        const serialized: SerializedKafkaMessage = {
+            topic: 'test-topic',
+            partition: 0,
+            offset: 0,
+            timestamp: 0,
+            key: null,
+            value: null,
+            headers: {},
+        }
+
+        const message = deserializeKafkaMessage(serialized)
+
+        expect(message.key).toBeUndefined()
+        expect(message.value).toBeNull()
+        expect(message.size).toBe(0)
+        expect(message.headers).toBeUndefined()
+    })
+
+    it('handles empty headers', () => {
+        const serialized: SerializedKafkaMessage = {
+            topic: 'test-topic',
+            partition: 0,
+            offset: 0,
+            timestamp: 0,
+            key: 'key',
+            value: '{}',
+            headers: {},
+        }
+
+        const message = deserializeKafkaMessage(serialized)
+
+        expect(message.headers).toBeUndefined()
+    })
+
+    it('handles unicode content in value', () => {
+        const serialized: SerializedKafkaMessage = {
+            topic: 'test-topic',
+            partition: 0,
+            offset: 0,
+            timestamp: 0,
+            key: null,
+            value: '{"name":"José 日本語 🎉"}',
+            headers: {},
+        }
+
+        const message = deserializeKafkaMessage(serialized)
+
+        expect(message.value!.toString('utf-8')).toBe('{"name":"José 日本語 🎉"}')
+    })
+})

--- a/nodejs/src/ingestion/api/kafka-message-converter.ts
+++ b/nodejs/src/ingestion/api/kafka-message-converter.ts
@@ -1,0 +1,24 @@
+import { Message, MessageHeader } from 'node-rdkafka'
+
+import { SerializedKafkaMessage } from './types'
+
+/**
+ * Converts a SerializedKafkaMessage (from the Rust consumer HTTP API)
+ * back into a node-rdkafka Message for the ingestion pipeline.
+ */
+export function deserializeKafkaMessage(serialized: SerializedKafkaMessage): Message {
+    const headers: MessageHeader[] = Object.entries(serialized.headers).map(([key, value]) => ({
+        [key]: Buffer.from(value, 'utf-8'),
+    }))
+
+    return {
+        topic: serialized.topic,
+        partition: serialized.partition,
+        offset: serialized.offset,
+        timestamp: serialized.timestamp,
+        size: serialized.value?.length ?? 0,
+        key: serialized.key ? Buffer.from(serialized.key, 'utf-8') : undefined,
+        value: serialized.value ? Buffer.from(serialized.value, 'utf-8') : null,
+        headers: headers.length > 0 ? headers : undefined,
+    }
+}

--- a/nodejs/src/ingestion/api/kafka-message-converter.ts
+++ b/nodejs/src/ingestion/api/kafka-message-converter.ts
@@ -11,14 +11,16 @@ export function deserializeKafkaMessage(serialized: SerializedKafkaMessage): Mes
         [key]: Buffer.from(value, 'utf-8'),
     }))
 
+    const valueBuffer = serialized.value ? Buffer.from(serialized.value, 'utf-8') : null
+
     return {
         topic: serialized.topic,
         partition: serialized.partition,
         offset: serialized.offset,
         timestamp: serialized.timestamp,
-        size: serialized.value?.length ?? 0,
+        size: valueBuffer?.byteLength ?? 0,
         key: serialized.key ? Buffer.from(serialized.key, 'utf-8') : undefined,
-        value: serialized.value ? Buffer.from(serialized.value, 'utf-8') : null,
+        value: valueBuffer,
         headers: headers.length > 0 ? headers : undefined,
     }
 }

--- a/nodejs/src/ingestion/api/types.ts
+++ b/nodejs/src/ingestion/api/types.ts
@@ -1,0 +1,29 @@
+/**
+ * Wire types for the ingestion worker HTTP API.
+ *
+ * These types define the contract between the Rust Kafka consumer
+ * and Node.js worker processes. Values are passed as raw UTF-8 strings
+ * since PostHog Kafka messages are always JSON-encoded text.
+ */
+
+export interface SerializedKafkaMessage {
+    topic: string
+    partition: number
+    offset: number
+    timestamp: number
+    key: string | null
+    value: string | null
+    headers: Record<string, string>
+}
+
+export interface IngestBatchRequest {
+    batch_id: string
+    messages: SerializedKafkaMessage[]
+}
+
+export interface IngestBatchResponse {
+    batch_id: string
+    status: 'ok' | 'error'
+    accepted: number
+    error?: string
+}

--- a/nodejs/src/servers/ingestion-api-server.ts
+++ b/nodejs/src/servers/ingestion-api-server.ts
@@ -388,6 +388,9 @@ export class IngestionApiServer implements NodeServer {
 
             // Wait for all side effects — the HTTP response is the ACK to the
             // Rust consumer, so all work must finish before responding.
+            // Note: the joined pipeline has a hardcoded concurrency of 1, so
+            // feed() will reject if a batch is already being processed. This
+            // is fine for now since we process each request sequentially.
             await Promise.all([this.promiseScheduler.waitForAll(), this.hogTransformer.processInvocationResults()])
 
             batchesProcessed.inc()

--- a/nodejs/src/servers/ingestion-api-server.ts
+++ b/nodejs/src/servers/ingestion-api-server.ts
@@ -1,0 +1,430 @@
+import { Message } from 'node-rdkafka'
+import { Counter, Histogram } from 'prom-client'
+
+import { IntegrationManagerService } from '~/cdp/services/managers/integration-manager.service'
+import { InternalCaptureService } from '~/common/services/internal-capture'
+
+import { initializePrometheusLabels } from '../api/router'
+import {
+    HogTransformerService,
+    HogTransformerServiceConfig,
+    HogTransformerServiceDeps,
+    createHogTransformerService,
+} from '../cdp/hog-transformations/hog-transformer.service'
+import { EncryptedFields } from '../cdp/utils/encryption-utils'
+import { CommonConfig } from '../common/config'
+import { defaultConfig } from '../config/config'
+import { createCookielessRedisConnectionConfig, createIngestionRedisConnectionConfig } from '../config/redis-pools'
+import { INGESTION_OUTPUT_DEFINITIONS } from '../ingestion/analytics/config/outputs'
+import { PRODUCER_CONFIG_MAP, ProducerName } from '../ingestion/analytics/config/producers'
+import {
+    JoinedIngestionPipelineConfig,
+    JoinedIngestionPipelineContext,
+    JoinedIngestionPipelineDeps,
+    JoinedIngestionPipelineInput,
+    createJoinedIngestionPipeline,
+} from '../ingestion/analytics/joined-ingestion-pipeline'
+import { deserializeKafkaMessage } from '../ingestion/api/kafka-message-converter'
+import { IngestBatchRequest, IngestBatchResponse } from '../ingestion/api/types'
+import { EventFilterManager } from '../ingestion/common/event-filters'
+import {
+    DatabaseConnectionConfig,
+    IngestionConsumerConfig,
+    KafkaBrokerConfig,
+    KafkaConsumerBaseConfig,
+    PersonHogConfig,
+    RedisConnectionsConfig,
+} from '../ingestion/config'
+import { CookielessManager } from '../ingestion/cookieless/cookieless-manager'
+import { parseSplitAiEventsConfig } from '../ingestion/event-processing/split-ai-events-step'
+import { KafkaProducerRegistry, resolveIngestionOutputs } from '../ingestion/outputs'
+import { buildGroupRepository, buildPersonRepository, createPersonHogClient } from '../ingestion/personhog'
+import { createOkContext } from '../ingestion/pipelines/helpers'
+import { TopHog } from '../ingestion/tophog'
+import { MainLaneOverflowRedirect } from '../ingestion/utils/overflow-redirect/main-lane-overflow-redirect'
+import { OverflowLaneOverflowRedirect } from '../ingestion/utils/overflow-redirect/overflow-lane-overflow-redirect'
+import { OverflowRedirectService } from '../ingestion/utils/overflow-redirect/overflow-redirect-service'
+import { RedisOverflowRepository } from '../ingestion/utils/overflow-redirect/overflow-redis-repository'
+import { HealthCheckResultOk, PluginServerService, RedisPool } from '../types'
+import { PostgresRouter } from '../utils/db/postgres'
+import { createRedisPoolFromConfig } from '../utils/db/redis'
+import { EventIngestionRestrictionManager } from '../utils/event-ingestion-restrictions'
+import { EventSchemaEnforcementManager } from '../utils/event-schema-enforcement-manager'
+import { GeoIPService } from '../utils/geoip'
+import { logger } from '../utils/logger'
+import { PromiseScheduler } from '../utils/promise-scheduler'
+import { PubSub } from '../utils/pubsub'
+import { TeamManager } from '../utils/team-manager'
+import { GroupTypeManager } from '../worker/ingestion/group-type-manager'
+import { BatchWritingGroupStore } from '../worker/ingestion/groups/batch-writing-group-store'
+import { ClickhouseGroupRepository } from '../worker/ingestion/groups/repositories/clickhouse-group-repository'
+import { PostgresGroupRepository } from '../worker/ingestion/groups/repositories/postgres-group-repository'
+import { BatchWritingPersonsStore } from '../worker/ingestion/persons/batch-writing-person-store'
+import { PersonsStore } from '../worker/ingestion/persons/persons-store'
+import { PostgresPersonRepository } from '../worker/ingestion/persons/repositories/postgres-person-repository'
+import { BaseServerConfig, CleanupResources, NodeServer, ServerLifecycle } from './base-server'
+
+export type IngestionApiServerConfig = BaseServerConfig &
+    IngestionConsumerConfig &
+    HogTransformerServiceConfig &
+    KafkaBrokerConfig &
+    DatabaseConnectionConfig &
+    RedisConnectionsConfig &
+    KafkaConsumerBaseConfig &
+    PersonHogConfig &
+    Pick<
+        CommonConfig,
+        | 'LOG_LEVEL'
+        | 'PLUGIN_SERVER_MODE'
+        | 'CLOUD_DEPLOYMENT'
+        | 'MMDB_FILE_LOCATION'
+        | 'CAPTURE_INTERNAL_URL'
+        | 'LAZY_LOADER_DEFAULT_BUFFER_MS'
+        | 'LAZY_LOADER_MAX_SIZE'
+        | 'TASKS_PER_WORKER'
+        | 'TASK_TIMEOUT'
+        | 'POSTHOG_API_KEY'
+        | 'POSTHOG_HOST_URL'
+        | 'HEALTHCHECK_MAX_STALE_SECONDS'
+        | 'KAFKA_HEALTHCHECK_SECONDS'
+    >
+
+const batchesProcessed = new Counter({
+    name: 'ingestion_api_batches_processed_total',
+    help: 'Total number of batches processed by the ingestion API',
+})
+
+const batchProcessingDuration = new Histogram({
+    name: 'ingestion_api_batch_processing_duration_ms',
+    help: 'Duration of batch processing in milliseconds',
+    buckets: [10, 50, 100, 250, 500, 1000, 2500, 5000, 10000],
+})
+
+const messagesProcessed = new Counter({
+    name: 'ingestion_api_messages_processed_total',
+    help: 'Total number of messages processed by the ingestion API',
+})
+
+const batchErrors = new Counter({
+    name: 'ingestion_api_batch_errors_total',
+    help: 'Total number of batch processing errors',
+})
+
+/**
+ * Ingestion API server that exposes the ingestion pipeline as an HTTP endpoint.
+ *
+ * Used as a sidecar alongside a Rust Kafka consumer — the consumer reads from
+ * Kafka, routes messages by distinct_id, and dispatches sub-batches to this
+ * server via POST /ingest.
+ *
+ * Infrastructure setup mirrors IngestionGeneralServer. The difference is that
+ * instead of subscribing to Kafka, this server accepts batches over HTTP.
+ */
+export class IngestionApiServer implements NodeServer {
+    readonly lifecycle: ServerLifecycle
+    private config: IngestionApiServerConfig
+
+    private postgres?: PostgresRouter
+    private ingestionProducerRegistry?: KafkaProducerRegistry<ProducerName>
+    private redisPool?: RedisPool
+    private cookielessRedisPool?: RedisPool
+    private cookielessManager?: CookielessManager
+    private pubsub?: PubSub
+
+    private joinedPipeline!: ReturnType<
+        typeof createJoinedIngestionPipeline<JoinedIngestionPipelineInput, JoinedIngestionPipelineContext>
+    >
+    private promiseScheduler = new PromiseScheduler()
+    private hogTransformer!: HogTransformerService
+    private topHog!: TopHog
+
+    constructor(config: Partial<IngestionApiServerConfig> = {}) {
+        this.config = { ...defaultConfig, ...config }
+        this.lifecycle = new ServerLifecycle(this.config)
+    }
+
+    async start(): Promise<void> {
+        return this.lifecycle.start(
+            () => this.startServices(),
+            () => this.getCleanupResources()
+        )
+    }
+
+    async stop(error?: Error): Promise<void> {
+        return this.lifecycle.stop(() => this.getCleanupResources(), error)
+    }
+
+    private async startServices(): Promise<void> {
+        initializePrometheusLabels(this.config.INGESTION_PIPELINE, this.config.INGESTION_LANE)
+
+        // 1. Shared infrastructure
+        logger.info('ℹ️', 'Connecting to shared infrastructure...')
+
+        this.postgres = new PostgresRouter(this.config, this.config.PLUGIN_SERVER_MODE!)
+        logger.info('👍', 'Postgres Router ready')
+
+        logger.info('🤔', 'Connecting to ingestion Redis...')
+        this.redisPool = createRedisPoolFromConfig({
+            connection: createIngestionRedisConnectionConfig(this.config),
+            poolMinSize: this.config.REDIS_POOL_MIN_SIZE,
+            poolMaxSize: this.config.REDIS_POOL_MAX_SIZE,
+        })
+        logger.info('👍', 'Ingestion Redis ready')
+
+        this.pubsub = new PubSub(this.redisPool)
+        await this.pubsub.start()
+
+        const teamManager = new TeamManager(this.postgres)
+
+        // 2. Ingestion + CDP shared services (geoip, repos, encryption)
+        const geoipService = new GeoIPService(this.config.MMDB_FILE_LOCATION)
+        await geoipService.get()
+
+        const personhogClient = createPersonHogClient(this.config)
+        const clientLabel = this.config.PLUGIN_SERVER_MODE ?? 'unknown'
+
+        const postgresPersonRepository = new PostgresPersonRepository(this.postgres, {
+            calculatePropertiesSize: this.config.PERSON_UPDATE_CALCULATE_PROPERTIES_SIZE,
+        })
+        const personRepository = buildPersonRepository(
+            personhogClient,
+            postgresPersonRepository,
+            this.config.PERSONHOG_PERSONS_ROLLOUT_PERCENTAGE,
+            clientLabel
+        )
+        const postgresGroupRepository = new PostgresGroupRepository(this.postgres)
+
+        const groupRepository = buildGroupRepository(
+            personhogClient,
+            postgresGroupRepository,
+            this.config.PERSONHOG_GROUPS_ROLLOUT_PERCENTAGE,
+            clientLabel
+        )
+
+        const encryptedFields = new EncryptedFields(this.config.ENCRYPTION_SALT_KEYS)
+        const integrationManager = new IntegrationManagerService(this.pubsub, this.postgres, encryptedFields)
+        const internalCaptureService = new InternalCaptureService(this.config)
+
+        // 3. Ingestion-specific services
+        logger.info('🤔', 'Connecting to cookieless Redis...')
+        this.cookielessRedisPool = createRedisPoolFromConfig({
+            connection: createCookielessRedisConnectionConfig(this.config),
+            poolMinSize: this.config.REDIS_POOL_MIN_SIZE,
+            poolMaxSize: this.config.REDIS_POOL_MAX_SIZE,
+        })
+        logger.info('👍', 'Cookieless Redis ready')
+
+        this.cookielessManager = new CookielessManager(this.config, this.cookielessRedisPool)
+        const groupTypeManager = new GroupTypeManager(groupRepository, teamManager)
+
+        // 4. Kafka producers for pipeline outputs (not consuming from Kafka)
+        this.ingestionProducerRegistry = new KafkaProducerRegistry(this.config.KAFKA_CLIENT_RACK, PRODUCER_CONFIG_MAP)
+        const ingestionOutputs = await resolveIngestionOutputs(
+            this.ingestionProducerRegistry,
+            INGESTION_OUTPUT_DEFINITIONS
+        )
+        const clickhouseGroupRepository = new ClickhouseGroupRepository(ingestionOutputs)
+
+        const topicFailures = await ingestionOutputs.checkTopics()
+        if (topicFailures.length > 0) {
+            throw new Error(`Output topic verification failed for: ${topicFailures.join(', ')}`)
+        }
+
+        // 5. HogTransformer
+        const hogTransformerDeps: HogTransformerServiceDeps = {
+            geoipService,
+            postgres: this.postgres,
+            pubSub: this.pubsub,
+            encryptedFields,
+            integrationManager,
+            monitoringOutputs: ingestionOutputs,
+            teamManager,
+            internalCaptureService,
+        }
+        this.hogTransformer = createHogTransformerService(this.config, hogTransformerDeps)
+        await this.hogTransformer.start()
+
+        // 6. Pipeline dependencies
+        const overflowRedisRepository = new RedisOverflowRepository({
+            redisPool: this.redisPool,
+            redisTTLSeconds: this.config.INGESTION_STATEFUL_OVERFLOW_REDIS_TTL_SECONDS,
+        })
+
+        let overflowRedirectService: OverflowRedirectService | undefined
+        if (this.overflowEnabled()) {
+            overflowRedirectService = new MainLaneOverflowRedirect({
+                redisRepository: overflowRedisRepository,
+                localCacheTTLSeconds: this.config.INGESTION_STATEFUL_OVERFLOW_LOCAL_CACHE_TTL_SECONDS,
+                bucketCapacity: this.config.EVENT_OVERFLOW_BUCKET_CAPACITY,
+                replenishRate: this.config.EVENT_OVERFLOW_BUCKET_REPLENISH_RATE,
+                statefulEnabled: this.config.INGESTION_STATEFUL_OVERFLOW_ENABLED,
+            })
+        }
+
+        let overflowLaneTTLRefreshService: OverflowRedirectService | undefined
+        if (this.config.INGESTION_LANE === 'overflow' && this.config.INGESTION_STATEFUL_OVERFLOW_ENABLED) {
+            overflowLaneTTLRefreshService = new OverflowLaneOverflowRedirect({
+                redisRepository: overflowRedisRepository,
+            })
+        }
+
+        const eventIngestionRestrictionManager = new EventIngestionRestrictionManager(this.redisPool, {
+            pipeline: 'analytics',
+            staticDropEventTokens: this.config.DROP_EVENTS_BY_TOKEN_DISTINCT_ID.split(',').filter(Boolean),
+            staticSkipPersonTokens: this.config.SKIP_PERSONS_PROCESSING_BY_TOKEN_DISTINCT_ID.split(',').filter(Boolean),
+            staticForceOverflowTokens:
+                this.config.INGESTION_FORCE_OVERFLOW_BY_TOKEN_DISTINCT_ID.split(',').filter(Boolean),
+        })
+
+        const personsStore: PersonsStore = new BatchWritingPersonsStore(personRepository, ingestionOutputs, {
+            dbWriteMode: this.config.PERSON_BATCH_WRITING_DB_WRITE_MODE,
+            useBatchUpdates: this.config.PERSON_BATCH_WRITING_USE_BATCH_UPDATES,
+            maxConcurrentUpdates: this.config.PERSON_BATCH_WRITING_MAX_CONCURRENT_UPDATES,
+            maxOptimisticUpdateRetries: this.config.PERSON_BATCH_WRITING_MAX_OPTIMISTIC_UPDATE_RETRIES,
+            optimisticUpdateRetryInterval: this.config.PERSON_BATCH_WRITING_OPTIMISTIC_UPDATE_RETRY_INTERVAL_MS,
+            updateAllProperties: this.config.PERSON_PROPERTIES_UPDATE_ALL,
+        })
+
+        const groupStore = new BatchWritingGroupStore(ingestionOutputs, groupRepository, clickhouseGroupRepository, {
+            maxConcurrentUpdates: this.config.GROUP_BATCH_WRITING_MAX_CONCURRENT_UPDATES,
+            maxOptimisticUpdateRetries: this.config.GROUP_BATCH_WRITING_MAX_OPTIMISTIC_UPDATE_RETRIES,
+            optimisticUpdateRetryInterval: this.config.GROUP_BATCH_WRITING_OPTIMISTIC_UPDATE_RETRY_INTERVAL_MS,
+        })
+
+        this.topHog = new TopHog({
+            outputs: ingestionOutputs,
+            pipeline: this.config.INGESTION_PIPELINE ?? 'unknown',
+            lane: this.config.INGESTION_LANE ?? 'unknown',
+        })
+        this.topHog.start()
+
+        // 7. Create the ingestion pipeline
+        const groupId = this.config.INGESTION_CONSUMER_GROUP_ID
+
+        const joinedPipelineConfig: JoinedIngestionPipelineConfig = {
+            eventSchemaEnforcementEnabled: this.config.EVENT_SCHEMA_ENFORCEMENT_ENABLED,
+            overflowEnabled: this.overflowEnabled(),
+            preservePartitionLocality: this.config.INGESTION_OVERFLOW_PRESERVE_PARTITION_LOCALITY,
+            personsPrefetchEnabled: this.config.PERSONS_PREFETCH_ENABLED,
+            cdpHogWatcherSampleRate: this.config.CDP_HOG_WATCHER_SAMPLE_RATE,
+            groupId,
+            outputs: ingestionOutputs,
+            splitAiEventsConfig: parseSplitAiEventsConfig(
+                this.config.INGESTION_AI_EVENT_SPLITTING_ENABLED,
+                this.config.INGESTION_AI_EVENT_SPLITTING_TEAMS,
+                this.config.INGESTION_AI_EVENT_SPLITTING_STRIP_HEAVY
+            ),
+            perDistinctIdOptions: {
+                SKIP_UPDATE_EVENT_AND_PROPERTIES_STEP: this.config.SKIP_UPDATE_EVENT_AND_PROPERTIES_STEP,
+                PERSON_MERGE_MOVE_DISTINCT_ID_LIMIT: this.config.PERSON_MERGE_MOVE_DISTINCT_ID_LIMIT,
+                PERSON_MERGE_ASYNC_ENABLED: this.config.PERSON_MERGE_ASYNC_ENABLED,
+                PERSON_MERGE_SYNC_BATCH_SIZE: this.config.PERSON_MERGE_SYNC_BATCH_SIZE,
+                PERSON_JSONB_SIZE_ESTIMATE_ENABLE: this.config.PERSON_JSONB_SIZE_ESTIMATE_ENABLE,
+                PERSON_PROPERTIES_UPDATE_ALL: this.config.PERSON_PROPERTIES_UPDATE_ALL,
+            },
+        }
+        const joinedPipelineDeps: JoinedIngestionPipelineDeps = {
+            personsStore,
+            groupStore,
+            hogTransformer: this.hogTransformer,
+            eventFilterManager: new EventFilterManager(this.postgres),
+            eventIngestionRestrictionManager,
+            eventSchemaEnforcementManager: new EventSchemaEnforcementManager(this.postgres),
+            promiseScheduler: this.promiseScheduler,
+            overflowRedirectService,
+            overflowLaneTTLRefreshService,
+            teamManager,
+            cookielessManager: this.cookielessManager,
+            groupTypeManager,
+            topHog: this.topHog,
+        }
+        this.joinedPipeline = createJoinedIngestionPipeline(joinedPipelineConfig, joinedPipelineDeps)
+
+        // 8. Register the ingest endpoint and service
+        this.lifecycle.expressApp.post('/ingest', async (req, res) => {
+            await this.handleIngestRequest(req, res)
+        })
+
+        const service: PluginServerService = {
+            id: 'ingestion-api',
+            onShutdown: async () => {
+                await this.topHog.stop()
+                await this.hogTransformer.stop()
+            },
+            healthcheck: () => this.isHealthy(),
+        }
+        this.lifecycle.services.push(service)
+    }
+
+    private async handleIngestRequest(
+        req: { body: IngestBatchRequest },
+        res: { status: (code: number) => { json: (body: IngestBatchResponse) => void } }
+    ): Promise<void> {
+        const { batch_id, messages: serializedMessages } = req.body
+
+        if (!serializedMessages || serializedMessages.length === 0) {
+            res.status(400).json({ batch_id: batch_id ?? '', status: 'error', accepted: 0, error: 'Empty batch' })
+            return
+        }
+
+        const startTime = Date.now()
+
+        try {
+            const messages: Message[] = serializedMessages.map(deserializeKafkaMessage)
+
+            const batch = messages.map((message) => createOkContext({ message }, { message }))
+            const feedResult = await this.joinedPipeline.feed(batch)
+            if (!feedResult.ok) {
+                throw new Error(`Pipeline rejected batch: ${feedResult.reason}`)
+            }
+
+            let result = await this.joinedPipeline.next()
+            while (result !== null) {
+                for (const sideEffect of result.sideEffects ?? []) {
+                    void this.promiseScheduler.schedule(sideEffect)
+                }
+                result = await this.joinedPipeline.next()
+            }
+
+            // Wait for all side effects — the HTTP response is the ACK to the
+            // Rust consumer, so all work must finish before responding.
+            await Promise.all([this.promiseScheduler.waitForAll(), this.hogTransformer.processInvocationResults()])
+
+            batchesProcessed.inc()
+            messagesProcessed.inc(messages.length)
+            batchProcessingDuration.observe(Date.now() - startTime)
+
+            res.status(200).json({ batch_id, status: 'ok', accepted: messages.length })
+        } catch (err) {
+            batchErrors.inc()
+            const message = err instanceof Error ? err.message : String(err)
+            logger.error('💥', 'Ingestion API batch processing failed', { batch_id, error: message })
+            res.status(500).json({ batch_id, status: 'error', accepted: 0, error: message })
+        }
+    }
+
+    private isHealthy() {
+        // TODO: add output producer health checks
+        return new HealthCheckResultOk()
+    }
+
+    private overflowEnabled(): boolean {
+        return (
+            !!this.config.INGESTION_CONSUMER_OVERFLOW_TOPIC &&
+            this.config.INGESTION_CONSUMER_OVERFLOW_TOPIC !== this.config.INGESTION_CONSUMER_CONSUME_TOPIC
+        )
+    }
+
+    private getCleanupResources(): CleanupResources {
+        return {
+            kafkaProducers: [],
+            redisPools: [this.redisPool, this.cookielessRedisPool].filter(Boolean) as RedisPool[],
+            postgres: this.postgres,
+            pubsub: this.pubsub,
+            additionalCleanup: async () => {
+                await this.ingestionProducerRegistry?.disconnectAll()
+                this.cookielessManager?.shutdown()
+            },
+        }
+    }
+}


### PR DESCRIPTION
## Problem

The ingestion evolution (Rust Kafka consumer + Node.js sidecars) requires the existing ingestion pipeline to be callable over HTTP. Today, the pipeline is tightly coupled to the Kafka consumer — there's no way to drive it from an external process.

## Changes

This is the Node.js side of the sidecar architecture. It exposes the existing ingestion pipeline as an HTTP endpoint so the Rust consumer can dispatch batches to it. No ingestion logic is changed — the pipeline runs identically to the current Kafka-driven path.

- Add `ingestion-api` server mode that starts the full ingestion pipeline infrastructure (Postgres, Redis, Kafka producers, HogTransformer) and exposes a `POST /ingest` endpoint instead of subscribing to Kafka
- Define wire types for the HTTP contract between the Rust consumer and Node.js workers (`SerializedKafkaMessage`, `IngestBatchRequest`, `IngestBatchResponse`)
- Add a deserializer that converts the wire format back to node-rdkafka `Message` objects for the pipeline
- Wait for all pipeline side effects before responding, since the HTTP response acts as the ACK to the Rust consumer
- Add Prometheus metrics for batch processing (count, duration, errors)
- Add unit tests for the message deserialization round-trip

## How did you test this code?

<!-- Briefly describe the steps you took, and what steps reviewers must take to get to where changes are, and what is the expected behavior. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
