### PR TITLE
fix(llma): parse stringified structured message content

### DIFF
--- a/products/llm_analytics/frontend/utils.test.ts
+++ b/products/llm_analytics/frontend/utils.test.ts
@@ -637,6 +637,19 @@ describe('LLM Analytics utils', () => {
             expect(result[0].content).toEqual([{ type: 'text', text: 'Custom response' }])
         })
 
+        it('parses stringified structured content blocks for role-based messages', () => {
+            const stringifiedStructuredMessage = {
+                role: 'user',
+                content: JSON.stringify([{ type: 'text', text: 'lets respond inline to each bot to explain that its fine' }]),
+            }
+
+            const result = normalizeMessage(stringifiedStructuredMessage, 'user')
+
+            expect(result).toHaveLength(1)
+            expect(result[0].role).toBe('user')
+            expect(result[0].content).toEqual([{ type: 'text', text: 'lets respond inline to each bot to explain that its fine' }])
+        })
+
         it('handles LiteLLM choice wrapper and preserves nested role', () => {
             const liteLLMChoice = {
                 finish_reason: 'stop',

--- a/products/llm_analytics/frontend/utils.test.ts
+++ b/products/llm_analytics/frontend/utils.test.ts
@@ -637,17 +637,28 @@ describe('LLM Analytics utils', () => {
             expect(result[0].content).toEqual([{ type: 'text', text: 'Custom response' }])
         })
 
-        it('parses stringified structured content blocks for role-based messages', () => {
-            const stringifiedStructuredMessage = {
-                role: 'user',
-                content: JSON.stringify([{ type: 'text', text: 'lets respond inline to each bot to explain that its fine' }]),
-            }
-
-            const result = normalizeMessage(stringifiedStructuredMessage, 'user')
+        it.each([
+            [
+                'single text block',
+                {
+                    role: 'user',
+                    content: JSON.stringify([{ type: 'text', text: 'lets respond inline to each bot to explain that its fine' }]),
+                },
+                [{ type: 'text', text: 'lets respond inline to each bot to explain that its fine' }],
+            ],
+            ['plain string stays plain', { role: 'user', content: 'plain text' }, 'plain text'],
+            ['invalid JSON falls back to raw string', { role: 'user', content: '[not json' }, '[not json'],
+            [
+                'unknown block types stay as raw string',
+                { role: 'user', content: JSON.stringify([{ type: 'schema', definition: { foo: 'bar' } }]) },
+                '[{"type":"schema","definition":{"foo":"bar"}}]',
+            ],
+        ])('handles stringified structured content in OpenAI-compatible messages: %s', (_label, message, expectedContent) => {
+            const result = normalizeMessage(message, 'user')
 
             expect(result).toHaveLength(1)
             expect(result[0].role).toBe('user')
-            expect(result[0].content).toEqual([{ type: 'text', text: 'lets respond inline to each bot to explain that its fine' }])
+            expect(result[0].content).toEqual(expectedContent)
         })
 
         it('handles LiteLLM choice wrapper and preserves nested role', () => {

--- a/products/llm_analytics/frontend/utils.test.ts
+++ b/products/llm_analytics/frontend/utils.test.ts
@@ -655,6 +655,7 @@ describe('LLM Analytics utils', () => {
                 { role: 'user', content: JSON.stringify([{ type: 'schema', definition: { foo: 'bar' } }]) },
                 '[{"type":"schema","definition":{"foo":"bar"}}]',
             ],
+            ['empty structured array parses as empty array', { role: 'user', content: '[]' }, []],
         ])(
             'handles stringified structured content in OpenAI-compatible messages: %s',
             (_label, message, expectedContent) => {

--- a/products/llm_analytics/frontend/utils.test.ts
+++ b/products/llm_analytics/frontend/utils.test.ts
@@ -642,7 +642,9 @@ describe('LLM Analytics utils', () => {
                 'single text block',
                 {
                     role: 'user',
-                    content: JSON.stringify([{ type: 'text', text: 'lets respond inline to each bot to explain that its fine' }]),
+                    content: JSON.stringify([
+                        { type: 'text', text: 'lets respond inline to each bot to explain that its fine' },
+                    ]),
                 },
                 [{ type: 'text', text: 'lets respond inline to each bot to explain that its fine' }],
             ],
@@ -653,13 +655,16 @@ describe('LLM Analytics utils', () => {
                 { role: 'user', content: JSON.stringify([{ type: 'schema', definition: { foo: 'bar' } }]) },
                 '[{"type":"schema","definition":{"foo":"bar"}}]',
             ],
-        ])('handles stringified structured content in OpenAI-compatible messages: %s', (_label, message, expectedContent) => {
-            const result = normalizeMessage(message, 'user')
+        ])(
+            'handles stringified structured content in OpenAI-compatible messages: %s',
+            (_label, message, expectedContent) => {
+                const result = normalizeMessage(message, 'user')
 
-            expect(result).toHaveLength(1)
-            expect(result[0].role).toBe('user')
-            expect(result[0].content).toEqual(expectedContent)
-        })
+                expect(result).toHaveLength(1)
+                expect(result[0].role).toBe('user')
+                expect(result[0].content).toEqual(expectedContent)
+            }
+        )
 
         it('handles LiteLLM choice wrapper and preserves nested role', () => {
             const liteLLMChoice = {

--- a/products/llm_analytics/frontend/utils.ts
+++ b/products/llm_analytics/frontend/utils.ts
@@ -38,6 +38,7 @@ import {
     VercelSDKInputImageMessage,
     VercelSDKInputTextMessage,
     VercelSDKTextMessage,
+    MultiModalContentItem,
 } from './types'
 
 export interface PagedSearchOrderFilters {
@@ -716,6 +717,23 @@ export function normalizeRole(rawRole: unknown, fallback: string): string {
     return roleMap[lowercased] || lowercased
 }
 
+function parseStringifiedStructuredContent(content: string): string | MultiModalContentItem[] {
+    try {
+        const parsed = JSON.parse(content)
+        if (
+            Array.isArray(parsed) &&
+            parsed.length > 0 &&
+            parsed.every((item) => item && typeof item === 'object' && 'type' in item && typeof item.type === 'string')
+        ) {
+            return parsed as MultiModalContentItem[]
+        }
+    } catch {
+        // Keep the original text when it's not valid JSON.
+    }
+
+    return content
+}
+
 /**
  * Normalizes a message from an LLM provider into a format that is compatible with the PostHog LLM Analytics schema.
  *
@@ -818,7 +836,10 @@ export function normalizeMessage(rawMessage: unknown, defaultRole: string): Comp
             {
                 ...rawMessage,
                 role: roleToUse,
-                content: rawMessage.content,
+                content:
+                    typeof rawMessage.content === 'string'
+                        ? parseStringifiedStructuredContent(rawMessage.content)
+                        : rawMessage.content,
                 tool_calls: isOpenAICompatToolCallsArray(rawMessage.tool_calls)
                     ? parseOpenAIToolCalls(rawMessage.tool_calls)
                     : undefined,
@@ -984,7 +1005,10 @@ export function normalizeMessage(rawMessage: unknown, defaultRole: string): Comp
         return [
             {
                 role: roleToUse,
-                content: rawMessage.content,
+                content:
+                    typeof rawMessage.content === 'string'
+                        ? parseStringifiedStructuredContent(rawMessage.content)
+                        : rawMessage.content,
             },
         ]
     }

--- a/products/llm_analytics/frontend/utils.ts
+++ b/products/llm_analytics/frontend/utils.ts
@@ -731,8 +731,13 @@ const STRUCTURED_CONTENT_TYPES = new Set([
 ])
 
 function parseStringifiedStructuredContent(content: string): string | MultiModalContentItem[] {
+    const trimmed = content.trim()
+    if (!trimmed.startsWith('[')) {
+        return content
+    }
+
     try {
-        const parsed = JSON.parse(content)
+        const parsed = JSON.parse(trimmed)
         if (
             Array.isArray(parsed) &&
             (parsed.length === 0 ||

--- a/products/llm_analytics/frontend/utils.ts
+++ b/products/llm_analytics/frontend/utils.ts
@@ -717,13 +717,33 @@ export function normalizeRole(rawRole: unknown, fallback: string): string {
     return roleMap[lowercased] || lowercased
 }
 
+const STRUCTURED_CONTENT_TYPES = new Set([
+    'text',
+    'output_text',
+    'input_text',
+    'function',
+    'image',
+    'input_image',
+    'image_url',
+    'file',
+    'audio',
+    'document',
+])
+
 function parseStringifiedStructuredContent(content: string): string | MultiModalContentItem[] {
     try {
         const parsed = JSON.parse(content)
         if (
             Array.isArray(parsed) &&
             parsed.length > 0 &&
-            parsed.every((item) => item && typeof item === 'object' && 'type' in item && typeof item.type === 'string')
+            parsed.every(
+                (item) =>
+                    item &&
+                    typeof item === 'object' &&
+                    'type' in item &&
+                    typeof item.type === 'string' &&
+                    STRUCTURED_CONTENT_TYPES.has(item.type)
+            )
         ) {
             return parsed as MultiModalContentItem[]
         }
@@ -1005,10 +1025,7 @@ export function normalizeMessage(rawMessage: unknown, defaultRole: string): Comp
         return [
             {
                 role: roleToUse,
-                content:
-                    typeof rawMessage.content === 'string'
-                        ? parseStringifiedStructuredContent(rawMessage.content)
-                        : rawMessage.content,
+                content: rawMessage.content,
             },
         ]
     }

--- a/products/llm_analytics/frontend/utils.ts
+++ b/products/llm_analytics/frontend/utils.ts
@@ -735,15 +735,15 @@ function parseStringifiedStructuredContent(content: string): string | MultiModal
         const parsed = JSON.parse(content)
         if (
             Array.isArray(parsed) &&
-            parsed.length > 0 &&
-            parsed.every(
-                (item) =>
-                    item &&
-                    typeof item === 'object' &&
-                    'type' in item &&
-                    typeof item.type === 'string' &&
-                    STRUCTURED_CONTENT_TYPES.has(item.type)
-            )
+            (parsed.length === 0 ||
+                parsed.every(
+                    (item) =>
+                        item &&
+                        typeof item === 'object' &&
+                        'type' in item &&
+                        typeof item.type === 'string' &&
+                        STRUCTURED_CONTENT_TYPES.has(item.type)
+                ))
         ) {
             return parsed as MultiModalContentItem[]
         }


### PR DESCRIPTION
## Problem

Some pi-captured traces store user message content as a JSON string (for example, a stringified `[{\"type\":\"text\",\"text\":...}]` block array) instead of structured content blocks. In trace view, these messages render as raw JSON-like payloads instead of readable message text.

## Changes

- Added a defensive parser in LLM analytics message normalization to detect and parse stringified structured content block arrays.
- Applied parsing in the OpenAI-compatible message normalization path (where string content is handled).
- Restricted parsing to known/supported structured content block types to avoid reclassifying arbitrary `type` objects.
- Treated stringified empty arrays (`\"[]\"`) as valid structured content for consistent behavior.
- Expanded regression coverage with parameterized tests for:
  - valid stringified text blocks
  - plain strings that should stay plain
  - invalid JSON fallback
  - unknown block types staying as raw string
  - empty structured arrays

## How did you test this code?

- Ran targeted frontend test:
  - `cd frontend && pnpm jest products/llm_analytics/frontend/utils.test.ts --runInBand`
- Verified the new regression tests pass in that suite.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

no

## Docs update

no docs update needed

## 🤖 LLM context

Authored by an agent. Used repository code inspection and targeted Jest tests only.