### PR TITLE
fix: Make `use_variant_type` not required for Databricks

### DIFF
--- a/frontend/src/scenes/data-pipelines/batch-exports/batchExportConfigFormLogic.test.ts
+++ b/frontend/src/scenes/data-pipelines/batch-exports/batchExportConfigFormLogic.test.ts
@@ -242,7 +242,6 @@ describe('batchExportConfigFormLogic', () => {
                     'catalog',
                     'schema',
                     'table_name',
-                    'use_variant_type',
                 ],
             },
             {

--- a/frontend/src/scenes/data-pipelines/batch-exports/batchExportConfigFormLogic.tsx
+++ b/frontend/src/scenes/data-pipelines/batch-exports/batchExportConfigFormLogic.tsx
@@ -948,15 +948,7 @@ export const batchExportConfigFormLogic = kea<batchExportConfigFormLogicType>([
                         'table_name',
                     ]
                 } else if (service === 'Databricks') {
-                    return [
-                        ...generalRequiredFields,
-                        'integration_id',
-                        'http_path',
-                        'catalog',
-                        'schema',
-                        'table_name',
-                        'use_variant_type',
-                    ]
+                    return [...generalRequiredFields, 'integration_id', 'http_path', 'catalog', 'schema', 'table_name']
                 } else if (service === 'AzureBlob') {
                     return [
                         ...generalRequiredFields,


### PR DESCRIPTION
## Problem

`use_variant_type` being required means it cannot be left unchecked (which is fine as both states are valid). Similarly to `use_json_type` this should not be required.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Make `use_variant_type` not required in the configuration form.
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took, and what steps reviewers must take to get to where changes are, and what is the expected behavior. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
