### PR TITLE
fix(exporter): Do not count user exceptions as SLO failures

### DIFF
--- a/posthog/temporal/exports/workflows.py
+++ b/posthog/temporal/exports/workflows.py
@@ -6,7 +6,8 @@ from datetime import timedelta
 import temporalio.workflow as wf
 
 from posthog.event_usage import EventSource
-from posthog.slo.types import SloConfig
+from posthog.slo.types import SloConfig, SloOutcome
+from posthog.tasks.exports.failure_handler import is_user_query_error_type
 from posthog.temporal.common.base import PostHogWorkflow
 from posthog.temporal.exports.activities import export_asset_activity
 from posthog.temporal.exports.retry_policy import EXPORT_RETRY_POLICY
@@ -46,8 +47,11 @@ class ExportAssetWorkflow(PostHogWorkflow):
         except Exception as e:
             if inputs.slo:
                 err = extract_error_details(e)
+                exception_class = err.exception_class or type(e).__name__
                 inputs.slo.completion_properties["error"] = {
-                    "exception_class": err.exception_class or type(e).__name__,
+                    "exception_class": exception_class,
                     "error_trace": err.error_trace or "\n".join(traceback.format_exception(e)[:5]),
                 }
+                if is_user_query_error_type(exception_class):
+                    inputs.slo.outcome = SloOutcome.SUCCESS
             raise

--- a/posthog/temporal/tests/test_export_workflow.py
+++ b/posthog/temporal/tests/test_export_workflow.py
@@ -148,23 +148,24 @@ async def test_transient_error_retries_and_succeeds(
 
 
 @pytest.mark.parametrize(
-    "error_factory,expected_exception_class,expected_call_count",
+    "error_factory,expected_exception_class,expected_call_count,expected_outcome",
     [
-        (lambda: QueryError("Invalid HogQL query"), "QueryError", 1),
-        (lambda: RuntimeError("Chrome crashed"), "RuntimeError", 1),
-        (lambda: CHQueryErrorS3Error("S3 error", code=499), "CHQueryErrorS3Error", 10),
+        (lambda: QueryError("Invalid HogQL query"), "QueryError", 1, SloOutcome.SUCCESS),
+        (lambda: RuntimeError("Chrome crashed"), "RuntimeError", 1, SloOutcome.FAILURE),
+        (lambda: CHQueryErrorS3Error("S3 error", code=499), "CHQueryErrorS3Error", 10, SloOutcome.FAILURE),
     ],
     ids=["non_retryable_user_error", "generic_runtime_error", "retryable_system_error"],
 )
 @patch("posthog.slo.events.posthoganalytics")
 @patch("posthog.temporal.exports.activities.exporter")
-async def test_export_failure_emits_slo_failure(
+async def test_export_failure_emits_slo_outcome(
     mock_exporter: MagicMock,
     mock_analytics: MagicMock,
     team,
     error_factory,
     expected_exception_class: str,
     expected_call_count: int,
+    expected_outcome: SloOutcome,
 ):
     asset = await sync_to_async(ExportedAsset.objects.create)(team=team, export_format=EXPORT_FORMAT)
 
@@ -182,6 +183,6 @@ async def test_export_failure_emits_slo_failure(
     assert call_count == expected_call_count
 
     props = _get_slo_completed_props(mock_analytics)
-    assert props["outcome"] == SloOutcome.FAILURE
+    assert props["outcome"] == expected_outcome
     assert props["error"] is not None
     assert expected_exception_class in str(props["error"])


### PR DESCRIPTION
## Problem

Export workflows currently mark all failures as SLO failures, even when the failure is due to user errors like invalid HogQL queries. This skews SLO metrics by counting user mistakes as system failures, making it harder to track actual system reliability. Additionally it also deviates from how the old system (celery) used to classify these and how the subscriptions classify them.

## Changes

- Set SLO outcome to `SUCCESS` when the error is classified as a user query error, while still preserving error details for debugging
- Update test cases to verify that user errors (like `QueryError`) result in `SloOutcome.SUCCESS` while system errors continue to result in `SloOutcome.FAILURE`

## How did you test this code?

Updated the existing test `test_export_failure_emits_slo_outcome` to include expected outcome verification for different error types:

- User query errors (`QueryError`) now expect `SloOutcome.SUCCESS`
- System errors (`RuntimeError`, `CHQueryErrorS3Error`) continue to expect `SloOutcome.FAILURE`

The test verifies that error details are still captured regardless of the outcome classification.

## Publish to changelog?

No

## Docs update

No docs update needed - this is an internal SLO tracking improvement.