### PR TITLE
feat(dashboard): hide dashboard zoom control on small screens

### DIFF
--- a/frontend/src/scenes/dashboard/DashboardZoomControl.tsx
+++ b/frontend/src/scenes/dashboard/DashboardZoomControl.tsx
@@ -15,7 +15,10 @@ interface DashboardZoomControlProps {
 
 export function DashboardZoomControl({ layoutZoom, setLayoutZoom }: DashboardZoomControlProps): JSX.Element | null {
     const { dashboard, currentLayoutSize } = useValues(dashboardLogic)
-    const isSmallLayout = currentLayoutSize === 'xs'
+
+    if (currentLayoutSize === 'xs') {
+        return null
+    }
 
     return (
         <div className="flex items-center gap-2 text-sm text-muted hidden md:flex">
@@ -25,7 +28,6 @@ export function DashboardZoomControl({ layoutZoom, setLayoutZoom }: DashboardZoo
                 intent="Toggle dashboard layout zoom while editing"
                 interaction="click"
                 scope={Scene.Dashboard}
-                disabled={isSmallLayout}
             >
                 <LemonButton
                     size="small"
@@ -36,7 +38,6 @@ export function DashboardZoomControl({ layoutZoom, setLayoutZoom }: DashboardZoo
                         setLayoutZoom(nextZoom)
                         eventUsageLogic.actions.reportDashboardLayoutZoomChanged(dashboard ?? null, nextZoom, 'button')
                     }}
-                    disabledReason={isSmallLayout ? 'Layout editing is disabled on smaller screens.' : undefined}
                     tooltip="Collapse/Expand view. Makes it easier to edit the layout for busier dashboards."
                 >
                     {layoutZoom < 1 ? 'Expand view' : 'Collapse view'}


### PR DESCRIPTION
## Problem

On small screens (more like tablet sizes specifically) we were still showing the dashboard zoom button, even if it was disabled.

This takes up precious real estate.

## Changes

Hide instead of disabling.

## How did you test this code?

Locally.
## Publish to changelog?

No.