### PR TITLE
feat(experiments): add debug queries tab and tag metric UUID

### DIFF
--- a/posthog/clickhouse/query_tagging.py
+++ b/posthog/clickhouse/query_tagging.py
@@ -170,6 +170,7 @@ class QueryTags(BaseModel):
     experiment_id: Optional[int] = None
     experiment_name: Optional[str] = None
     experiment_is_data_warehouse_query: Optional[bool] = None
+    experiment_metric_uuid: Optional[str] = None
     experiment_metric_name: Optional[str] = None
     experiment_execution_path: Optional[str] = None  # "direct_scan" or "precomputed"
 

--- a/posthog/hogql_queries/experiments/experiment_query_runner.py
+++ b/posthog/hogql_queries/experiments/experiment_query_runner.py
@@ -247,6 +247,7 @@ class ExperimentQueryRunner(QueryRunner):
             experiment_name=self.experiment.name,
             experiment_feature_flag_key=self.feature_flag.key,
             experiment_is_data_warehouse_query=self.is_data_warehouse_query,
+            experiment_metric_uuid=self.metric.uuid,
             experiment_metric_name=metric_name,
         )
 


### PR DESCRIPTION
## Problem

No way to see experiment query performance from the experiment page. Also, metric UUID wasn't tagged on queries.

## Changes

- Add `experiment_metric_uuid` to query tags
- Add `experiment_id` query param support to the debug CH queries API (reuses the existing `insight_id` pattern)
- Add a "Debug" tab to the experiment detail page (staff-only via superpowers) showing the debug queries panel filtered to that experiment
- Generalize the backend stats/hourly_stats methods to work with any `log_comment` field

## How did you test this code?

Existing tests pass. Not manually tested.

## 🤖 LLM context

Agent-authored.