### PR TITLE
feat(cloud-agent): allow pending_user_message on initial cloud runs

### DIFF
--- a/products/tasks/backend/api.py
+++ b/products/tasks/backend/api.py
@@ -249,6 +249,9 @@ class TaskViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         sandbox_environment_id = request.validated_data.get("sandbox_environment_id")
 
         extra_state = None
+        if pending_user_message is not None:
+            extra_state = {"pending_user_message": pending_user_message}
+
         if resume_from_run_id:
             # prevent cross-task resume
             previous_run = task.runs.filter(id=resume_from_run_id).first()
@@ -257,11 +260,8 @@ class TaskViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
 
             # Derive snapshot_external_id from the validated previous run
             snapshot_ext_id = (previous_run.state or {}).get("snapshot_external_id")
-            extra_state = {
-                "resume_from_run_id": str(resume_from_run_id),
-            }
-            if pending_user_message is not None:
-                extra_state["pending_user_message"] = pending_user_message
+            extra_state = extra_state or {}
+            extra_state["resume_from_run_id"] = str(resume_from_run_id)
             if snapshot_ext_id:
                 extra_state["snapshot_external_id"] = snapshot_ext_id
 

--- a/products/tasks/backend/serializers.py
+++ b/products/tasks/backend/serializers.py
@@ -379,7 +379,7 @@ class TaskRunCreateRequestSerializer(serializers.Serializer):
         required=False,
         default=None,
         allow_blank=False,
-        help_text="Follow-up user message to include in the resumed run's prompt.",
+        help_text="Initial or follow-up user message to include in the run prompt.",
     )
     sandbox_environment_id = serializers.UUIDField(
         required=False,

--- a/products/tasks/backend/tests/test_api.py
+++ b/products/tasks/backend/tests/test_api.py
@@ -320,6 +320,25 @@ class TestTaskAPI(BaseTaskAPITest):
         self.assertEqual(task_run.state["sandbox_environment_id"], str(sandbox_environment.id))
         mock_workflow.assert_called_once()
 
+    @patch("products.tasks.backend.api.execute_task_processing_workflow")
+    def test_run_endpoint_persists_pending_user_message(self, mock_workflow):
+        task = self.create_task()
+
+        response = self.client.post(
+            f"/api/projects/@current/tasks/{task.id}/run/",
+            {"pending_user_message": "Read the attached file first"},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        run_id = response.json()["latest_run"]["id"]
+        task_run = TaskRun.objects.get(id=run_id)
+        self.assertEqual(
+            task_run.state["pending_user_message"],
+            "Read the attached file first",
+        )
+        mock_workflow.assert_called_once()
+
     def test_run_endpoint_rejects_invalid_sandbox_environment_id(self):
         task = self.create_task()
 

--- a/products/tasks/frontend/generated/api.schemas.ts
+++ b/products/tasks/frontend/generated/api.schemas.ts
@@ -249,7 +249,7 @@ export interface TaskRunCreateRequestApi {
     branch?: string | null
     /** ID of a previous run to resume from. Must belong to the same task. */
     resume_from_run_id?: string
-    /** Follow-up user message to include in the resumed run's prompt. */
+    /** Initial or follow-up user message to include in the run prompt. */
     pending_user_message?: string
     /** Optional sandbox environment to apply for this cloud run. */
     sandbox_environment_id?: string

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -30632,7 +30632,7 @@ export namespace Schemas {
       branch?: string | null;
       /** ID of a previous run to resume from. Must belong to the same task. */
       resume_from_run_id?: string;
-      /** Follow-up user message to include in the resumed run's prompt. */
+      /** Initial or follow-up user message to include in the run prompt. */
       pending_user_message?: string;
       /** Optional sandbox environment to apply for this cloud run. */
       sandbox_environment_id?: string;


### PR DESCRIPTION
## Problem

`pending_user_message` was only persisted in `extra_state` when resuming a run (`resume_from_run_id` set). Cloud attachments need to send structured prompts as `pending_user_message` on initial runs too.