### PR TITLE
feat: Add schema drill-down support to exec tool for large schemas

### DIFF
--- a/services/mcp/src/lib/analytics.ts
+++ b/services/mcp/src/lib/analytics.ts
@@ -34,11 +34,7 @@ export const getPostHogClient = (devMode?: boolean): PostHog => {
     return _client
 }
 
-export async function isFeatureFlagEnabled(
-    flagKey: string,
-    distinctId: string,
-    devMode?: boolean
-): Promise<boolean> {
+export async function isFeatureFlagEnabled(flagKey: string, distinctId: string, devMode?: boolean): Promise<boolean> {
     try {
         const client = getPostHogClient(devMode)
         const result = await client.isFeatureEnabled(flagKey, distinctId)

--- a/services/mcp/src/templates/instructions-v3.md
+++ b/services/mcp/src/templates/instructions-v3.md
@@ -28,12 +28,36 @@ posthog:exec({ "command": "search <regex_pattern>" })
 # Fallback: list all tools (only if you don't know what domain to search)
 posthog:exec({ "command": "tools" })
 
-# STEP 2: REQUIRED — Check schema BEFORE any call
+# STEP 2: REQUIRED — Check tool description and top-level schema
 posthog:exec({ "command": "info <tool_name>" })
 
-# STEP 3: Only after checking schema, call the tool
+# STEP 3: REQUIRED for complex fields — Get full schema for fields you need to populate
+# The info response may include drill-down hints for complex fields. For any field with
+# a "hint", you MUST run schema before constructing that field's value.
+posthog:exec({ "command": "schema <tool_name> <field_name>" })
+
+# STEP 4: Only after checking schema, call the tool
 posthog:exec({ "command": "call <tool_name> <json_input>" })
 ```
+
+**SCHEMA DRILL-DOWN RULE — HARD REQUIREMENT**
+
+The `info` command may return the full schema (for simple tools) or a top-level summary
+with drill-down hints (for complex tools). Look for `hint` fields in the response.
+
+If `info` returned a summary (fields have `hint` values), you MUST call
+`schema <tool_name> <field_name>` for each field you need to populate BEFORE
+constructing that field's value in a `call` command.
+
+If `schema` also returns a summary (because the field is too large),
+drill deeper using dot-notation: `schema <tool> <field>.<subfield>`.
+
+**NEVER** guess the structure of fields that have hints. **ALWAYS** drill down first.
+
+For query tools, you will typically need:
+- `schema <tool> series` — to see EventsNode/ActionsNode structure
+- `schema <tool> properties` — to see property filter structure
+- `schema <tool> breakdownFilter` — when using breakdowns
 
 **For multiple tools:** Run `info` for ALL tools first, then make your `call` commands.
 
@@ -43,10 +67,12 @@ posthog:exec({ "command": "call <tool_name> <json_input>" })
 User: How many weekly active users do we have?
 Assistant: I need to find the right query tool and data schema tool.
 [Runs posthog:exec({ "command": "search query-trends" }) and posthog:exec({ "command": "search read-data" }) in parallel]
-Assistant: Let me check the schemas for both tools.
+Assistant: Let me check the tool descriptions and schemas.
 [Runs posthog:exec({ "command": "info query-trends" }) and posthog:exec({ "command": "info read-data-schema" }) in parallel]
-Assistant: Now let me check what events are available.
-[Runs posthog:exec({ "command": "call read-data-schema {\"kind\": \"events\"}" })]
+Assistant: I see query-trends needs `series` (array with hint). Let me get the full field schema and discover events.
+[Runs posthog:exec({ "command": "schema query-trends series" }) and posthog:exec({ "command": "call read-data-schema {\"kind\": \"events\"}" }) in parallel]
+Assistant: Now I know the exact series structure and available events. Let me construct the query.
+[Runs posthog:exec({ "command": "call query-trends {...}" })]
 </example>
 
 <example>
@@ -80,6 +106,13 @@ WRONG — You must run `info feature-flag-list` FIRST to check the schema
 User: Query our events
 Assistant: [Calls three tools in parallel without any `info` calls first]
 WRONG — You must run `info` for ALL tools before making ANY `call` commands
+</bad-example>
+
+<bad-example>
+User: Show me a trends chart of signups
+Assistant: [Runs info query-trends, sees summary with hints, then immediately calls query-trends with guessed series structure]
+WRONG — info returned a summary with hint: "Run `schema query-trends series` for full structure".
+You MUST follow the hint and run `schema` before constructing the series field.
 </bad-example>
 
 **Handling errors:**

--- a/services/mcp/src/tools/exec.ts
+++ b/services/mcp/src/tools/exec.ts
@@ -1,130 +1,209 @@
-import { z } from 'zod'
+import { z } from "zod";
 
-import { formatResponse } from '@/lib/response'
+import { formatResponse } from "@/lib/response";
 
-import type { Context, Tool, ZodObjectAny } from './types'
+import {
+  TOKEN_CHAR_LIMIT,
+  listAvailablePaths,
+  resolveSchemaPath,
+  summarizeSchema,
+} from "./schema-utils";
+import type { Context, Tool, ZodObjectAny } from "./types";
 
 const ExecSchema = z.object({
-    command: z
-        .string()
-        .describe(
-            'CLI-style command string. Supported commands:\n' +
-                '  tools                         — list available tool names\n' +
-                '  search <regex_pattern>         — search tools by JavaScript regex (matches name, title, description)\n' +
-                '  info <tool_name>              — show tool name, description, and input schema\n' +
-                '  call <tool_name> <json_input> — call a tool with JSON input'
-        ),
-})
+  command: z
+    .string()
+    .describe(
+      "CLI-style command string. Supported commands:\n" +
+        "  tools                                    — list available tool names\n" +
+        "  search <regex_pattern>                   — search tools by JavaScript regex (matches name, title, description)\n" +
+        "  info <tool_name>                         — show tool name, description, and input schema (summarized if too large)\n" +
+        "  schema <tool_name> [field_path]          — drill into a specific field schema (supports dot-notation, e.g. series, breakdownFilter.breakdowns)\n" +
+        "  call <tool_name> <json_input>            — call a tool with JSON input",
+    ),
+});
 
-type ExecSchema = typeof ExecSchema
+type ExecSchema = typeof ExecSchema;
 
 function parseCommand(input: string): { verb: string; rest: string } {
-    const trimmed = input.trim()
-    const idx = trimmed.indexOf(' ')
-    if (idx === -1) {
-        return { verb: trimmed, rest: '' }
-    }
-    return { verb: trimmed.slice(0, idx), rest: trimmed.slice(idx + 1).trim() }
+  const trimmed = input.trim();
+  const idx = trimmed.indexOf(" ");
+  if (idx === -1) {
+    return { verb: trimmed, rest: "" };
+  }
+  return { verb: trimmed.slice(0, idx), rest: trimmed.slice(idx + 1).trim() };
 }
 
-function findTool(tools: Tool<ZodObjectAny>[], name: string): Tool<ZodObjectAny> {
-    const tool = tools.find((t) => t.name === name)
-    if (!tool) {
-        const available = tools.map((t) => t.name).join(', ')
-        throw new Error(`Unknown tool: "${name}". Available tools: ${available}`)
-    }
-    return tool
+function findTool(
+  tools: Tool<ZodObjectAny>[],
+  name: string,
+): Tool<ZodObjectAny> {
+  const tool = tools.find((t) => t.name === name);
+  if (!tool) {
+    const available = tools.map((t) => t.name).join(", ");
+    throw new Error(`Unknown tool: "${name}". Available tools: ${available}`);
+  }
+  return tool;
 }
 
 export function createExecTool(
-    allTools: Tool<ZodObjectAny>[],
-    context: Context,
-    instructions: string
+  allTools: Tool<ZodObjectAny>[],
+  context: Context,
+  instructions: string,
 ): Tool<ExecSchema> {
-    const description = instructions
+  const description = instructions;
 
-    return {
-        name: 'exec',
-        title: 'Execute PostHog command',
-        description,
-        schema: ExecSchema,
-        scopes: [],
-        annotations: {
-            destructiveHint: false,
-            idempotentHint: false,
-            openWorldHint: true,
-            readOnlyHint: false,
-        },
-        handler: async (_context: Context, params: z.infer<ExecSchema>) => {
-            const { verb, rest } = parseCommand(params.command)
+  return {
+    name: "exec",
+    title: "Execute PostHog command",
+    description,
+    schema: ExecSchema,
+    scopes: [],
+    annotations: {
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: true,
+      readOnlyHint: false,
+    },
+    handler: async (_context: Context, params: z.infer<ExecSchema>) => {
+      const { verb, rest } = parseCommand(params.command);
 
-            switch (verb) {
-                case 'tools': {
-                    return JSON.stringify(allTools.map((t) => t.name))
-                }
+      switch (verb) {
+        case "tools": {
+          return JSON.stringify(allTools.map((t) => t.name));
+        }
 
-                case 'search': {
-                    if (!rest) {
-                        throw new Error('Usage: search <regex_pattern>')
-                    }
-                    let regex: RegExp
-                    try {
-                        regex = new RegExp(rest, 'i')
-                    } catch {
-                        throw new Error(`Invalid regex pattern: "${rest}"`)
-                    }
-                    const matches = allTools
-                        .filter((t) => regex.test(t.name) || regex.test(t.title) || regex.test(t.description))
-                        .map((t) => t.name)
-                    if (matches.length === 0) {
-                        return JSON.stringify({
-                            matches: [],
-                            hint: `No tools matched "${rest}". Run "tools" to see all available tool names.`,
-                        })
-                    }
-                    return JSON.stringify(matches)
-                }
+        case "search": {
+          if (!rest) {
+            throw new Error("Usage: search <regex_pattern>");
+          }
+          let regex: RegExp;
+          try {
+            regex = new RegExp(rest, "i");
+          } catch {
+            throw new Error(`Invalid regex pattern: "${rest}"`);
+          }
+          const matches = allTools
+            .filter(
+              (t) =>
+                regex.test(t.name) ||
+                regex.test(t.title) ||
+                regex.test(t.description),
+            )
+            .map((t) => t.name);
+          if (matches.length === 0) {
+            return JSON.stringify({
+              matches: [],
+              hint: `No tools matched "${rest}". Run "tools" to see all available tool names.`,
+            });
+          }
+          return JSON.stringify(matches);
+        }
 
-                case 'info': {
-                    if (!rest) {
-                        throw new Error('Usage: info <tool_name>')
-                    }
-                    const tool = findTool(allTools, rest)
-                    return JSON.stringify({
-                        name: tool.name,
-                        title: tool.title,
-                        description: tool.description,
-                        annotations: tool.annotations,
-                        inputSchema: z.toJSONSchema(tool.schema),
-                    })
-                }
+        case "info": {
+          if (!rest) {
+            throw new Error("Usage: info <tool_name>");
+          }
+          const tool = findTool(allTools, rest);
+          const fullSchema = z.toJSONSchema(tool.schema);
+          const fullOutput = JSON.stringify({
+            name: tool.name,
+            title: tool.title,
+            description: tool.description,
+            annotations: tool.annotations,
+            inputSchema: fullSchema,
+          });
 
-                case 'call': {
-                    if (!rest) {
-                        throw new Error('Usage: call <tool_name> <json_input>')
-                    }
-                    const { verb: toolName, rest: jsonBody } = parseCommand(rest)
-                    const tool = findTool(allTools, toolName)
+          if (fullOutput.length <= TOKEN_CHAR_LIMIT) {
+            return fullOutput;
+          }
 
-                    let input: Record<string, unknown>
-                    if (!jsonBody) {
-                        input = {}
-                    } else {
-                        try {
-                            input = JSON.parse(jsonBody) as Record<string, unknown>
-                        } catch {
-                            throw new Error(`Invalid JSON input: ${jsonBody}`)
-                        }
-                    }
+          // Schema too large — return summary with drill-down hints
+          return JSON.stringify({
+            name: tool.name,
+            title: tool.title,
+            description: tool.description,
+            annotations: tool.annotations,
+            inputSchema: summarizeSchema(
+              fullSchema as Record<string, unknown>,
+              tool.name,
+            ),
+          });
+        }
 
-                    const result = await tool.handler(context, input)
-                    const useJson = tool._meta?.responseFormat === 'json'
-                    return useJson ? JSON.stringify(result) : formatResponse(result)
-                }
+        case "schema": {
+          if (!rest) {
+            throw new Error("Usage: schema <tool_name> [field_path]");
+          }
+          const { verb: schemaToolName, rest: fieldPath } = parseCommand(rest);
+          const schemaTool = findTool(allTools, schemaToolName);
+          const fullJsonSchema = z.toJSONSchema(schemaTool.schema) as Record<
+            string,
+            unknown
+          >;
 
-                default:
-                    throw new Error(`Unknown command: "${verb}". Supported commands: tools, search, info, call`)
+          if (!fieldPath) {
+            return JSON.stringify(
+              summarizeSchema(fullJsonSchema, schemaToolName),
+            );
+          }
+
+          const resolved = resolveSchemaPath(fullJsonSchema, fieldPath);
+          if (!resolved) {
+            const available = listAvailablePaths(fullJsonSchema, fieldPath);
+            throw new Error(
+              `Unknown path "${fieldPath}". Available: ${available.join(", ")}`,
+            );
+          }
+
+          const serialized = JSON.stringify({
+            field: fieldPath,
+            schema: resolved,
+          });
+          if (serialized.length <= TOKEN_CHAR_LIMIT) {
+            return serialized;
+          }
+
+          // Field schema too large — return summary with sub-path hints
+          return JSON.stringify({
+            field: fieldPath,
+            note: `Full schema is ${Math.ceil(serialized.length / 6000)}k+ tokens. Showing summary. Drill into sub-fields for details.`,
+            schema: summarizeSchema(
+              resolved as Record<string, unknown>,
+              schemaToolName,
+              fieldPath,
+            ),
+          });
+        }
+
+        case "call": {
+          if (!rest) {
+            throw new Error("Usage: call <tool_name> <json_input>");
+          }
+          const { verb: toolName, rest: jsonBody } = parseCommand(rest);
+          const tool = findTool(allTools, toolName);
+
+          let input: Record<string, unknown>;
+          if (!jsonBody) {
+            input = {};
+          } else {
+            try {
+              input = JSON.parse(jsonBody) as Record<string, unknown>;
+            } catch {
+              throw new Error(`Invalid JSON input: ${jsonBody}`);
             }
-        },
-    }
+          }
+
+          const result = await tool.handler(context, input);
+          const useJson = tool._meta?.responseFormat === "json";
+          return useJson ? JSON.stringify(result) : formatResponse(result);
+        }
+
+        default:
+          throw new Error(
+            `Unknown command: "${verb}". Supported commands: tools, search, info, schema, call`,
+          );
+      }
+    },
+  };
 }

--- a/services/mcp/src/tools/exec.ts
+++ b/services/mcp/src/tools/exec.ts
@@ -1,209 +1,180 @@
-import { z } from "zod";
+import { z } from 'zod'
 
-import { formatResponse } from "@/lib/response";
+import { formatResponse } from '@/lib/response'
 
-import {
-  TOKEN_CHAR_LIMIT,
-  listAvailablePaths,
-  resolveSchemaPath,
-  summarizeSchema,
-} from "./schema-utils";
-import type { Context, Tool, ZodObjectAny } from "./types";
+import { TOKEN_CHAR_LIMIT, listAvailablePaths, resolveSchemaPath, summarizeSchema } from './schema-utils'
+import type { Context, Tool, ZodObjectAny } from './types'
 
 const ExecSchema = z.object({
-  command: z
-    .string()
-    .describe(
-      "CLI-style command string. Supported commands:\n" +
-        "  tools                                    — list available tool names\n" +
-        "  search <regex_pattern>                   — search tools by JavaScript regex (matches name, title, description)\n" +
-        "  info <tool_name>                         — show tool name, description, and input schema (summarized if too large)\n" +
-        "  schema <tool_name> [field_path]          — drill into a specific field schema (supports dot-notation, e.g. series, breakdownFilter.breakdowns)\n" +
-        "  call <tool_name> <json_input>            — call a tool with JSON input",
-    ),
-});
+    command: z
+        .string()
+        .describe(
+            'CLI-style command string. Supported commands:\n' +
+                '  tools                                    — list available tool names\n' +
+                '  search <regex_pattern>                   — search tools by JavaScript regex (matches name, title, description)\n' +
+                '  info <tool_name>                         — show tool name, description, and input schema (summarized if too large)\n' +
+                '  schema <tool_name> [field_path]          — drill into a specific field schema (supports dot-notation, e.g. series, breakdownFilter.breakdowns)\n' +
+                '  call <tool_name> <json_input>            — call a tool with JSON input'
+        ),
+})
 
-type ExecSchema = typeof ExecSchema;
+type ExecSchema = typeof ExecSchema
 
 function parseCommand(input: string): { verb: string; rest: string } {
-  const trimmed = input.trim();
-  const idx = trimmed.indexOf(" ");
-  if (idx === -1) {
-    return { verb: trimmed, rest: "" };
-  }
-  return { verb: trimmed.slice(0, idx), rest: trimmed.slice(idx + 1).trim() };
+    const trimmed = input.trim()
+    const idx = trimmed.indexOf(' ')
+    if (idx === -1) {
+        return { verb: trimmed, rest: '' }
+    }
+    return { verb: trimmed.slice(0, idx), rest: trimmed.slice(idx + 1).trim() }
 }
 
-function findTool(
-  tools: Tool<ZodObjectAny>[],
-  name: string,
-): Tool<ZodObjectAny> {
-  const tool = tools.find((t) => t.name === name);
-  if (!tool) {
-    const available = tools.map((t) => t.name).join(", ");
-    throw new Error(`Unknown tool: "${name}". Available tools: ${available}`);
-  }
-  return tool;
+function findTool(tools: Tool<ZodObjectAny>[], name: string): Tool<ZodObjectAny> {
+    const tool = tools.find((t) => t.name === name)
+    if (!tool) {
+        const available = tools.map((t) => t.name).join(', ')
+        throw new Error(`Unknown tool: "${name}". Available tools: ${available}`)
+    }
+    return tool
 }
 
 export function createExecTool(
-  allTools: Tool<ZodObjectAny>[],
-  context: Context,
-  instructions: string,
+    allTools: Tool<ZodObjectAny>[],
+    context: Context,
+    instructions: string
 ): Tool<ExecSchema> {
-  const description = instructions;
+    const description = instructions
 
-  return {
-    name: "exec",
-    title: "Execute PostHog command",
-    description,
-    schema: ExecSchema,
-    scopes: [],
-    annotations: {
-      destructiveHint: false,
-      idempotentHint: false,
-      openWorldHint: true,
-      readOnlyHint: false,
-    },
-    handler: async (_context: Context, params: z.infer<ExecSchema>) => {
-      const { verb, rest } = parseCommand(params.command);
+    return {
+        name: 'exec',
+        title: 'Execute PostHog command',
+        description,
+        schema: ExecSchema,
+        scopes: [],
+        annotations: {
+            destructiveHint: false,
+            idempotentHint: false,
+            openWorldHint: true,
+            readOnlyHint: false,
+        },
+        handler: async (_context: Context, params: z.infer<ExecSchema>) => {
+            const { verb, rest } = parseCommand(params.command)
 
-      switch (verb) {
-        case "tools": {
-          return JSON.stringify(allTools.map((t) => t.name));
-        }
+            switch (verb) {
+                case 'tools': {
+                    return JSON.stringify(allTools.map((t) => t.name))
+                }
 
-        case "search": {
-          if (!rest) {
-            throw new Error("Usage: search <regex_pattern>");
-          }
-          let regex: RegExp;
-          try {
-            regex = new RegExp(rest, "i");
-          } catch {
-            throw new Error(`Invalid regex pattern: "${rest}"`);
-          }
-          const matches = allTools
-            .filter(
-              (t) =>
-                regex.test(t.name) ||
-                regex.test(t.title) ||
-                regex.test(t.description),
-            )
-            .map((t) => t.name);
-          if (matches.length === 0) {
-            return JSON.stringify({
-              matches: [],
-              hint: `No tools matched "${rest}". Run "tools" to see all available tool names.`,
-            });
-          }
-          return JSON.stringify(matches);
-        }
+                case 'search': {
+                    if (!rest) {
+                        throw new Error('Usage: search <regex_pattern>')
+                    }
+                    let regex: RegExp
+                    try {
+                        regex = new RegExp(rest, 'i')
+                    } catch {
+                        throw new Error(`Invalid regex pattern: "${rest}"`)
+                    }
+                    const matches = allTools
+                        .filter((t) => regex.test(t.name) || regex.test(t.title) || regex.test(t.description))
+                        .map((t) => t.name)
+                    if (matches.length === 0) {
+                        return JSON.stringify({
+                            matches: [],
+                            hint: `No tools matched "${rest}". Run "tools" to see all available tool names.`,
+                        })
+                    }
+                    return JSON.stringify(matches)
+                }
 
-        case "info": {
-          if (!rest) {
-            throw new Error("Usage: info <tool_name>");
-          }
-          const tool = findTool(allTools, rest);
-          const fullSchema = z.toJSONSchema(tool.schema);
-          const fullOutput = JSON.stringify({
-            name: tool.name,
-            title: tool.title,
-            description: tool.description,
-            annotations: tool.annotations,
-            inputSchema: fullSchema,
-          });
+                case 'info': {
+                    if (!rest) {
+                        throw new Error('Usage: info <tool_name>')
+                    }
+                    const tool = findTool(allTools, rest)
+                    const fullSchema = z.toJSONSchema(tool.schema)
+                    const fullOutput = JSON.stringify({
+                        name: tool.name,
+                        title: tool.title,
+                        description: tool.description,
+                        annotations: tool.annotations,
+                        inputSchema: fullSchema,
+                    })
 
-          if (fullOutput.length <= TOKEN_CHAR_LIMIT) {
-            return fullOutput;
-          }
+                    if (fullOutput.length <= TOKEN_CHAR_LIMIT) {
+                        return fullOutput
+                    }
 
-          // Schema too large — return summary with drill-down hints
-          return JSON.stringify({
-            name: tool.name,
-            title: tool.title,
-            description: tool.description,
-            annotations: tool.annotations,
-            inputSchema: summarizeSchema(
-              fullSchema as Record<string, unknown>,
-              tool.name,
-            ),
-          });
-        }
+                    // Schema too large — return summary with drill-down hints
+                    return JSON.stringify({
+                        name: tool.name,
+                        title: tool.title,
+                        description: tool.description,
+                        annotations: tool.annotations,
+                        inputSchema: summarizeSchema(fullSchema as Record<string, unknown>, tool.name),
+                    })
+                }
 
-        case "schema": {
-          if (!rest) {
-            throw new Error("Usage: schema <tool_name> [field_path]");
-          }
-          const { verb: schemaToolName, rest: fieldPath } = parseCommand(rest);
-          const schemaTool = findTool(allTools, schemaToolName);
-          const fullJsonSchema = z.toJSONSchema(schemaTool.schema) as Record<
-            string,
-            unknown
-          >;
+                case 'schema': {
+                    if (!rest) {
+                        throw new Error('Usage: schema <tool_name> [field_path]')
+                    }
+                    const { verb: schemaToolName, rest: fieldPath } = parseCommand(rest)
+                    const schemaTool = findTool(allTools, schemaToolName)
+                    const fullJsonSchema = z.toJSONSchema(schemaTool.schema) as Record<string, unknown>
 
-          if (!fieldPath) {
-            return JSON.stringify(
-              summarizeSchema(fullJsonSchema, schemaToolName),
-            );
-          }
+                    if (!fieldPath) {
+                        return JSON.stringify(summarizeSchema(fullJsonSchema, schemaToolName))
+                    }
 
-          const resolved = resolveSchemaPath(fullJsonSchema, fieldPath);
-          if (!resolved) {
-            const available = listAvailablePaths(fullJsonSchema, fieldPath);
-            throw new Error(
-              `Unknown path "${fieldPath}". Available: ${available.join(", ")}`,
-            );
-          }
+                    const resolved = resolveSchemaPath(fullJsonSchema, fieldPath)
+                    if (!resolved) {
+                        const available = listAvailablePaths(fullJsonSchema, fieldPath)
+                        throw new Error(`Unknown path "${fieldPath}". Available: ${available.join(', ')}`)
+                    }
 
-          const serialized = JSON.stringify({
-            field: fieldPath,
-            schema: resolved,
-          });
-          if (serialized.length <= TOKEN_CHAR_LIMIT) {
-            return serialized;
-          }
+                    const serialized = JSON.stringify({
+                        field: fieldPath,
+                        schema: resolved,
+                    })
+                    if (serialized.length <= TOKEN_CHAR_LIMIT) {
+                        return serialized
+                    }
 
-          // Field schema too large — return summary with sub-path hints
-          return JSON.stringify({
-            field: fieldPath,
-            note: `Full schema is ${Math.ceil(serialized.length / 6000)}k+ tokens. Showing summary. Drill into sub-fields for details.`,
-            schema: summarizeSchema(
-              resolved as Record<string, unknown>,
-              schemaToolName,
-              fieldPath,
-            ),
-          });
-        }
+                    // Field schema too large — return summary with sub-path hints
+                    return JSON.stringify({
+                        field: fieldPath,
+                        note: `Full schema is ${Math.ceil(serialized.length / 6000)}k+ tokens. Showing summary. Drill into sub-fields for details.`,
+                        schema: summarizeSchema(resolved as Record<string, unknown>, schemaToolName, fieldPath),
+                    })
+                }
 
-        case "call": {
-          if (!rest) {
-            throw new Error("Usage: call <tool_name> <json_input>");
-          }
-          const { verb: toolName, rest: jsonBody } = parseCommand(rest);
-          const tool = findTool(allTools, toolName);
+                case 'call': {
+                    if (!rest) {
+                        throw new Error('Usage: call <tool_name> <json_input>')
+                    }
+                    const { verb: toolName, rest: jsonBody } = parseCommand(rest)
+                    const tool = findTool(allTools, toolName)
 
-          let input: Record<string, unknown>;
-          if (!jsonBody) {
-            input = {};
-          } else {
-            try {
-              input = JSON.parse(jsonBody) as Record<string, unknown>;
-            } catch {
-              throw new Error(`Invalid JSON input: ${jsonBody}`);
+                    let input: Record<string, unknown>
+                    if (!jsonBody) {
+                        input = {}
+                    } else {
+                        try {
+                            input = JSON.parse(jsonBody) as Record<string, unknown>
+                        } catch {
+                            throw new Error(`Invalid JSON input: ${jsonBody}`)
+                        }
+                    }
+
+                    const result = await tool.handler(context, input)
+                    const useJson = tool._meta?.responseFormat === 'json'
+                    return useJson ? JSON.stringify(result) : formatResponse(result)
+                }
+
+                default:
+                    throw new Error(`Unknown command: "${verb}". Supported commands: tools, search, info, schema, call`)
             }
-          }
-
-          const result = await tool.handler(context, input);
-          const useJson = tool._meta?.responseFormat === "json";
-          return useJson ? JSON.stringify(result) : formatResponse(result);
-        }
-
-        default:
-          throw new Error(
-            `Unknown command: "${verb}". Supported commands: tools, search, info, schema, call`,
-          );
-      }
-    },
-  };
+        },
+    }
 }

--- a/services/mcp/src/tools/llmAnalytics/evaluations/testHog.ts
+++ b/services/mcp/src/tools/llmAnalytics/evaluations/testHog.ts
@@ -3,10 +3,7 @@ import { z } from 'zod'
 import type { Context, ToolBase } from '@/tools/types'
 
 const schema = z.object({
-    source: z
-        .string()
-        .min(1)
-        .describe('Hog source code to test. Must return a boolean (true = pass, false = fail).'),
+    source: z.string().min(1).describe('Hog source code to test. Must return a boolean (true = pass, false = fail).'),
     sample_count: z
         .number()
         .int()

--- a/services/mcp/src/tools/schema-utils.ts
+++ b/services/mcp/src/tools/schema-utils.ts
@@ -1,0 +1,291 @@
+/** Token-aware schema summarization and drill-down utilities for the exec tool. */
+
+// 16k tokens × 6 chars/token
+export const TOKEN_CHAR_LIMIT = 96_000;
+
+type JSONSchema = Record<string, unknown>;
+
+interface SummarizedProperty {
+  type?: string;
+  description?: string;
+  enum?: unknown[];
+  default?: unknown;
+  const?: unknown;
+  required?: boolean;
+  fields?: string[];
+  items?: string;
+  hint?: string;
+}
+
+interface SchemaSummary {
+  type: string;
+  required?: string[];
+  properties: Record<string, SummarizedProperty>;
+  note?: string;
+}
+
+/**
+ * Describe the type of a union (anyOf/oneOf) concisely.
+ * Extracts variant names from `title`, `description`, or `const` fields.
+ */
+function describeUnion(variants: JSONSchema[]): string {
+  const names: string[] = [];
+  for (const v of variants) {
+    if (typeof v.title === "string") {
+      names.push(v.title);
+    } else if (typeof v.const === "string") {
+      names.push(v.const);
+    }
+  }
+  if (names.length > 0 && names.length <= 6) {
+    return `union of ${variants.length} types (${names.join(", ")})`;
+  }
+  return `union of ${variants.length} types`;
+}
+
+/** Get the effective type string for a schema node. */
+function getTypeString(schema: JSONSchema): string {
+  if (typeof schema.type === "string") {
+    return schema.type;
+  }
+  if (Array.isArray(schema.type)) {
+    return (schema.type as string[]).filter((t) => t !== "null").join(" | ");
+  }
+  if (schema.anyOf || schema.oneOf) {
+    const variants = (schema.anyOf || schema.oneOf) as JSONSchema[];
+    // Filter out null types for optional unions
+    const nonNull = variants.filter((v) => v.type !== "null");
+    if (nonNull.length === 0) {
+      return "null";
+    }
+    return describeUnion(nonNull);
+  }
+  if (schema.const !== undefined) {
+    return "const";
+  }
+  return "unknown";
+}
+
+/** Check if a property has complex nested structure that needs drill-down. */
+function isComplex(schema: JSONSchema): boolean {
+  if (schema.type === "object" && schema.properties) {
+    return true;
+  }
+  if (schema.type === "array" && schema.items) {
+    const items = schema.items as JSONSchema;
+    if (items.type === "object" && items.properties) {
+      return true;
+    }
+    if (items.anyOf || items.oneOf) {
+      return true;
+    }
+  }
+  if (schema.anyOf || schema.oneOf) {
+    const variants = (schema.anyOf || schema.oneOf) as JSONSchema[];
+    const nonNull = variants.filter((v) => v.type !== "null");
+    // Simple nullable scalar is not complex
+    if (
+      nonNull.length <= 1 &&
+      nonNull.every((v) => typeof v.type === "string" && v.type !== "object")
+    ) {
+      return false;
+    }
+    return (
+      nonNull.length > 1 ||
+      nonNull.some((v) => v.type === "object" || v.type === "array")
+    );
+  }
+  return false;
+}
+
+/** Describe array items concisely. */
+function describeItems(items: JSONSchema): string {
+  if (items.anyOf || items.oneOf) {
+    const variants = (items.anyOf || items.oneOf) as JSONSchema[];
+    return describeUnion(variants.filter((v) => v.type !== "null"));
+  }
+  if (items.type === "object") {
+    const propNames = items.properties
+      ? Object.keys(items.properties as Record<string, unknown>)
+      : [];
+    if (propNames.length > 0) {
+      return `object with ${propNames.length} fields`;
+    }
+    return "object";
+  }
+  return getTypeString(items);
+}
+
+/**
+ * Summarize a JSON Schema's top-level properties.
+ * Produces field names, types, descriptions, and drill-down hints for complex fields.
+ */
+export function summarizeSchema(
+  schema: JSONSchema,
+  toolName: string,
+  fieldPath?: string,
+): SchemaSummary {
+  const properties = (schema.properties || {}) as Record<string, JSONSchema>;
+  const requiredFields = (schema.required || []) as string[];
+  const result: Record<string, SummarizedProperty> = {};
+  const pathPrefix = fieldPath ? `${fieldPath}.` : "";
+
+  for (const [name, prop] of Object.entries(properties)) {
+    const entry: SummarizedProperty = {};
+    const typeStr = getTypeString(prop);
+    entry.type = typeStr;
+
+    if (typeof prop.description === "string") {
+      entry.description = prop.description;
+    }
+    if (prop.enum) {
+      entry.enum = prop.enum as unknown[];
+    }
+    if (prop.default !== undefined) {
+      entry.default = prop.default;
+    }
+    if (prop.const !== undefined) {
+      entry.const = prop.const;
+    }
+    if (requiredFields.includes(name)) {
+      entry.required = true;
+    }
+
+    // For objects, list subfield names
+    if (prop.type === "object" && prop.properties) {
+      entry.fields = Object.keys(prop.properties as Record<string, unknown>);
+    }
+
+    // For arrays, describe items
+    if (prop.type === "array" && prop.items) {
+      entry.items = describeItems(prop.items as JSONSchema);
+    }
+
+    // Add drill-down hint for complex fields
+    if (isComplex(prop)) {
+      entry.hint = `Run \`schema ${toolName} ${pathPrefix}${name}\` for full structure`;
+    }
+
+    result[name] = entry;
+  }
+
+  return {
+    type: (schema.type as string) || "object",
+    ...(requiredFields.length > 0 ? { required: requiredFields } : {}),
+    properties: result,
+  };
+}
+
+/**
+ * Resolve a dot-separated path within a JSON Schema.
+ * Returns the sub-schema at that path, or null if invalid.
+ */
+export function resolveSchemaPath(
+  schema: JSONSchema,
+  dotPath: string,
+): JSONSchema | null {
+  const segments = dotPath.split(".");
+  let current: JSONSchema = schema;
+
+  for (const segment of segments) {
+    // Try properties first
+    if (current.properties) {
+      const props = current.properties as Record<string, JSONSchema>;
+      const prop = props[segment];
+      if (prop) {
+        current = prop;
+        continue;
+      }
+    }
+
+    // Try array items
+    if (current.type === "array" && current.items) {
+      const items = current.items as JSONSchema;
+      // If segment matches a property inside items
+      if (items.properties) {
+        const itemProps = items.properties as Record<string, JSONSchema>;
+        const itemProp = itemProps[segment];
+        if (itemProp) {
+          current = itemProp;
+          continue;
+        }
+      }
+      // If segment is numeric, descend into items
+      if (/^\d+$/.test(segment)) {
+        current = items;
+        continue;
+      }
+    }
+
+    // Try union variants (anyOf/oneOf)
+    const variants = (current.anyOf || current.oneOf) as
+      | JSONSchema[]
+      | undefined;
+    if (variants) {
+      if (/^\d+$/.test(segment)) {
+        const idx = parseInt(segment, 10);
+        const variant = variants[idx];
+        if (variant) {
+          current = variant;
+          continue;
+        }
+      }
+      // Try to find property across all object variants
+      let found = false;
+      for (const variant of variants) {
+        if (variant.properties) {
+          const variantProps = variant.properties as Record<string, JSONSchema>;
+          const variantProp = variantProps[segment];
+          if (variantProp) {
+            current = variantProp;
+            found = true;
+            break;
+          }
+        }
+      }
+      if (found) {
+        continue;
+      }
+    }
+
+    return null;
+  }
+
+  return current;
+}
+
+/**
+ * List available child paths from a schema node.
+ */
+export function listAvailablePaths(
+  schema: JSONSchema,
+  _parentPath: string,
+): string[] {
+  const paths: string[] = [];
+
+  if (schema.properties) {
+    paths.push(...Object.keys(schema.properties as Record<string, unknown>));
+  }
+
+  if (schema.type === "array" && schema.items) {
+    const items = schema.items as JSONSchema;
+    if (items.properties) {
+      paths.push(
+        ...Object.keys(items.properties as Record<string, unknown>).map(
+          (k) => `[items].${k}`,
+        ),
+      );
+    }
+  }
+
+  const variants = (schema.anyOf || schema.oneOf) as JSONSchema[] | undefined;
+  if (variants) {
+    for (let i = 0; i < variants.length; i++) {
+      const v = variants[i]!;
+      const label = typeof v.title === "string" ? `${i} (${v.title})` : `${i}`;
+      paths.push(label);
+    }
+  }
+
+  return paths;
+}

--- a/services/mcp/src/tools/schema-utils.ts
+++ b/services/mcp/src/tools/schema-utils.ts
@@ -1,27 +1,27 @@
 /** Token-aware schema summarization and drill-down utilities for the exec tool. */
 
 // 16k tokens × 6 chars/token
-export const TOKEN_CHAR_LIMIT = 96_000;
+export const TOKEN_CHAR_LIMIT = 96_000
 
-type JSONSchema = Record<string, unknown>;
+type JSONSchema = Record<string, unknown>
 
 interface SummarizedProperty {
-  type?: string;
-  description?: string;
-  enum?: unknown[];
-  default?: unknown;
-  const?: unknown;
-  required?: boolean;
-  fields?: string[];
-  items?: string;
-  hint?: string;
+    type?: string
+    description?: string
+    enum?: unknown[]
+    default?: unknown
+    const?: unknown
+    required?: boolean
+    fields?: string[]
+    items?: string
+    hint?: string
 }
 
 interface SchemaSummary {
-  type: string;
-  required?: string[];
-  properties: Record<string, SummarizedProperty>;
-  note?: string;
+    type: string
+    required?: string[]
+    properties: Record<string, SummarizedProperty>
+    note?: string
 }
 
 /**
@@ -29,263 +29,239 @@ interface SchemaSummary {
  * Extracts variant names from `title`, `description`, or `const` fields.
  */
 function describeUnion(variants: JSONSchema[]): string {
-  const names: string[] = [];
-  for (const v of variants) {
-    if (typeof v.title === "string") {
-      names.push(v.title);
-    } else if (typeof v.const === "string") {
-      names.push(v.const);
+    const names: string[] = []
+    for (const v of variants) {
+        if (typeof v.title === 'string') {
+            names.push(v.title)
+        } else if (typeof v.const === 'string') {
+            names.push(v.const)
+        }
     }
-  }
-  if (names.length > 0 && names.length <= 6) {
-    return `union of ${variants.length} types (${names.join(", ")})`;
-  }
-  return `union of ${variants.length} types`;
+    if (names.length > 0 && names.length <= 6) {
+        return `union of ${variants.length} types (${names.join(', ')})`
+    }
+    return `union of ${variants.length} types`
 }
 
 /** Get the effective type string for a schema node. */
 function getTypeString(schema: JSONSchema): string {
-  if (typeof schema.type === "string") {
-    return schema.type;
-  }
-  if (Array.isArray(schema.type)) {
-    return (schema.type as string[]).filter((t) => t !== "null").join(" | ");
-  }
-  if (schema.anyOf || schema.oneOf) {
-    const variants = (schema.anyOf || schema.oneOf) as JSONSchema[];
-    // Filter out null types for optional unions
-    const nonNull = variants.filter((v) => v.type !== "null");
-    if (nonNull.length === 0) {
-      return "null";
+    if (typeof schema.type === 'string') {
+        return schema.type
     }
-    return describeUnion(nonNull);
-  }
-  if (schema.const !== undefined) {
-    return "const";
-  }
-  return "unknown";
+    if (Array.isArray(schema.type)) {
+        return (schema.type as string[]).filter((t) => t !== 'null').join(' | ')
+    }
+    if (schema.anyOf || schema.oneOf) {
+        const variants = (schema.anyOf || schema.oneOf) as JSONSchema[]
+        // Filter out null types for optional unions
+        const nonNull = variants.filter((v) => v.type !== 'null')
+        if (nonNull.length === 0) {
+            return 'null'
+        }
+        return describeUnion(nonNull)
+    }
+    if (schema.const !== undefined) {
+        return 'const'
+    }
+    return 'unknown'
 }
 
 /** Check if a property has complex nested structure that needs drill-down. */
 function isComplex(schema: JSONSchema): boolean {
-  if (schema.type === "object" && schema.properties) {
-    return true;
-  }
-  if (schema.type === "array" && schema.items) {
-    const items = schema.items as JSONSchema;
-    if (items.type === "object" && items.properties) {
-      return true;
+    if (schema.type === 'object' && schema.properties) {
+        return true
     }
-    if (items.anyOf || items.oneOf) {
-      return true;
+    if (schema.type === 'array' && schema.items) {
+        const items = schema.items as JSONSchema
+        if (items.type === 'object' && items.properties) {
+            return true
+        }
+        if (items.anyOf || items.oneOf) {
+            return true
+        }
     }
-  }
-  if (schema.anyOf || schema.oneOf) {
-    const variants = (schema.anyOf || schema.oneOf) as JSONSchema[];
-    const nonNull = variants.filter((v) => v.type !== "null");
-    // Simple nullable scalar is not complex
-    if (
-      nonNull.length <= 1 &&
-      nonNull.every((v) => typeof v.type === "string" && v.type !== "object")
-    ) {
-      return false;
+    if (schema.anyOf || schema.oneOf) {
+        const variants = (schema.anyOf || schema.oneOf) as JSONSchema[]
+        const nonNull = variants.filter((v) => v.type !== 'null')
+        // Simple nullable scalar is not complex
+        if (nonNull.length <= 1 && nonNull.every((v) => typeof v.type === 'string' && v.type !== 'object')) {
+            return false
+        }
+        return nonNull.length > 1 || nonNull.some((v) => v.type === 'object' || v.type === 'array')
     }
-    return (
-      nonNull.length > 1 ||
-      nonNull.some((v) => v.type === "object" || v.type === "array")
-    );
-  }
-  return false;
+    return false
 }
 
 /** Describe array items concisely. */
 function describeItems(items: JSONSchema): string {
-  if (items.anyOf || items.oneOf) {
-    const variants = (items.anyOf || items.oneOf) as JSONSchema[];
-    return describeUnion(variants.filter((v) => v.type !== "null"));
-  }
-  if (items.type === "object") {
-    const propNames = items.properties
-      ? Object.keys(items.properties as Record<string, unknown>)
-      : [];
-    if (propNames.length > 0) {
-      return `object with ${propNames.length} fields`;
+    if (items.anyOf || items.oneOf) {
+        const variants = (items.anyOf || items.oneOf) as JSONSchema[]
+        return describeUnion(variants.filter((v) => v.type !== 'null'))
     }
-    return "object";
-  }
-  return getTypeString(items);
+    if (items.type === 'object') {
+        const propNames = items.properties ? Object.keys(items.properties as Record<string, unknown>) : []
+        if (propNames.length > 0) {
+            return `object with ${propNames.length} fields`
+        }
+        return 'object'
+    }
+    return getTypeString(items)
 }
 
 /**
  * Summarize a JSON Schema's top-level properties.
  * Produces field names, types, descriptions, and drill-down hints for complex fields.
  */
-export function summarizeSchema(
-  schema: JSONSchema,
-  toolName: string,
-  fieldPath?: string,
-): SchemaSummary {
-  const properties = (schema.properties || {}) as Record<string, JSONSchema>;
-  const requiredFields = (schema.required || []) as string[];
-  const result: Record<string, SummarizedProperty> = {};
-  const pathPrefix = fieldPath ? `${fieldPath}.` : "";
+export function summarizeSchema(schema: JSONSchema, toolName: string, fieldPath?: string): SchemaSummary {
+    const properties = (schema.properties || {}) as Record<string, JSONSchema>
+    const requiredFields = (schema.required || []) as string[]
+    const result: Record<string, SummarizedProperty> = {}
+    const pathPrefix = fieldPath ? `${fieldPath}.` : ''
 
-  for (const [name, prop] of Object.entries(properties)) {
-    const entry: SummarizedProperty = {};
-    const typeStr = getTypeString(prop);
-    entry.type = typeStr;
+    for (const [name, prop] of Object.entries(properties)) {
+        const entry: SummarizedProperty = {}
+        const typeStr = getTypeString(prop)
+        entry.type = typeStr
 
-    if (typeof prop.description === "string") {
-      entry.description = prop.description;
-    }
-    if (prop.enum) {
-      entry.enum = prop.enum as unknown[];
-    }
-    if (prop.default !== undefined) {
-      entry.default = prop.default;
-    }
-    if (prop.const !== undefined) {
-      entry.const = prop.const;
-    }
-    if (requiredFields.includes(name)) {
-      entry.required = true;
+        if (typeof prop.description === 'string') {
+            entry.description = prop.description
+        }
+        if (prop.enum) {
+            entry.enum = prop.enum as unknown[]
+        }
+        if (prop.default !== undefined) {
+            entry.default = prop.default
+        }
+        if (prop.const !== undefined) {
+            entry.const = prop.const
+        }
+        if (requiredFields.includes(name)) {
+            entry.required = true
+        }
+
+        // For objects, list subfield names
+        if (prop.type === 'object' && prop.properties) {
+            entry.fields = Object.keys(prop.properties as Record<string, unknown>)
+        }
+
+        // For arrays, describe items
+        if (prop.type === 'array' && prop.items) {
+            entry.items = describeItems(prop.items as JSONSchema)
+        }
+
+        // Add drill-down hint for complex fields
+        if (isComplex(prop)) {
+            entry.hint = `Run \`schema ${toolName} ${pathPrefix}${name}\` for full structure`
+        }
+
+        result[name] = entry
     }
 
-    // For objects, list subfield names
-    if (prop.type === "object" && prop.properties) {
-      entry.fields = Object.keys(prop.properties as Record<string, unknown>);
+    return {
+        type: (schema.type as string) || 'object',
+        ...(requiredFields.length > 0 ? { required: requiredFields } : {}),
+        properties: result,
     }
-
-    // For arrays, describe items
-    if (prop.type === "array" && prop.items) {
-      entry.items = describeItems(prop.items as JSONSchema);
-    }
-
-    // Add drill-down hint for complex fields
-    if (isComplex(prop)) {
-      entry.hint = `Run \`schema ${toolName} ${pathPrefix}${name}\` for full structure`;
-    }
-
-    result[name] = entry;
-  }
-
-  return {
-    type: (schema.type as string) || "object",
-    ...(requiredFields.length > 0 ? { required: requiredFields } : {}),
-    properties: result,
-  };
 }
 
 /**
  * Resolve a dot-separated path within a JSON Schema.
  * Returns the sub-schema at that path, or null if invalid.
  */
-export function resolveSchemaPath(
-  schema: JSONSchema,
-  dotPath: string,
-): JSONSchema | null {
-  const segments = dotPath.split(".");
-  let current: JSONSchema = schema;
+export function resolveSchemaPath(schema: JSONSchema, dotPath: string): JSONSchema | null {
+    const segments = dotPath.split('.')
+    let current: JSONSchema = schema
 
-  for (const segment of segments) {
-    // Try properties first
-    if (current.properties) {
-      const props = current.properties as Record<string, JSONSchema>;
-      const prop = props[segment];
-      if (prop) {
-        current = prop;
-        continue;
-      }
+    for (const segment of segments) {
+        // Try properties first
+        if (current.properties) {
+            const props = current.properties as Record<string, JSONSchema>
+            const prop = props[segment]
+            if (prop) {
+                current = prop
+                continue
+            }
+        }
+
+        // Try array items
+        if (current.type === 'array' && current.items) {
+            const items = current.items as JSONSchema
+            // If segment matches a property inside items
+            if (items.properties) {
+                const itemProps = items.properties as Record<string, JSONSchema>
+                const itemProp = itemProps[segment]
+                if (itemProp) {
+                    current = itemProp
+                    continue
+                }
+            }
+            // If segment is numeric, descend into items
+            if (/^\d+$/.test(segment)) {
+                current = items
+                continue
+            }
+        }
+
+        // Try union variants (anyOf/oneOf)
+        const variants = (current.anyOf || current.oneOf) as JSONSchema[] | undefined
+        if (variants) {
+            if (/^\d+$/.test(segment)) {
+                const idx = parseInt(segment, 10)
+                const variant = variants[idx]
+                if (variant) {
+                    current = variant
+                    continue
+                }
+            }
+            // Try to find property across all object variants
+            let found = false
+            for (const variant of variants) {
+                if (variant.properties) {
+                    const variantProps = variant.properties as Record<string, JSONSchema>
+                    const variantProp = variantProps[segment]
+                    if (variantProp) {
+                        current = variantProp
+                        found = true
+                        break
+                    }
+                }
+            }
+            if (found) {
+                continue
+            }
+        }
+
+        return null
     }
 
-    // Try array items
-    if (current.type === "array" && current.items) {
-      const items = current.items as JSONSchema;
-      // If segment matches a property inside items
-      if (items.properties) {
-        const itemProps = items.properties as Record<string, JSONSchema>;
-        const itemProp = itemProps[segment];
-        if (itemProp) {
-          current = itemProp;
-          continue;
-        }
-      }
-      // If segment is numeric, descend into items
-      if (/^\d+$/.test(segment)) {
-        current = items;
-        continue;
-      }
-    }
-
-    // Try union variants (anyOf/oneOf)
-    const variants = (current.anyOf || current.oneOf) as
-      | JSONSchema[]
-      | undefined;
-    if (variants) {
-      if (/^\d+$/.test(segment)) {
-        const idx = parseInt(segment, 10);
-        const variant = variants[idx];
-        if (variant) {
-          current = variant;
-          continue;
-        }
-      }
-      // Try to find property across all object variants
-      let found = false;
-      for (const variant of variants) {
-        if (variant.properties) {
-          const variantProps = variant.properties as Record<string, JSONSchema>;
-          const variantProp = variantProps[segment];
-          if (variantProp) {
-            current = variantProp;
-            found = true;
-            break;
-          }
-        }
-      }
-      if (found) {
-        continue;
-      }
-    }
-
-    return null;
-  }
-
-  return current;
+    return current
 }
 
 /**
  * List available child paths from a schema node.
  */
-export function listAvailablePaths(
-  schema: JSONSchema,
-  _parentPath: string,
-): string[] {
-  const paths: string[] = [];
+export function listAvailablePaths(schema: JSONSchema): string[] {
+    const paths: string[] = []
 
-  if (schema.properties) {
-    paths.push(...Object.keys(schema.properties as Record<string, unknown>));
-  }
-
-  if (schema.type === "array" && schema.items) {
-    const items = schema.items as JSONSchema;
-    if (items.properties) {
-      paths.push(
-        ...Object.keys(items.properties as Record<string, unknown>).map(
-          (k) => `[items].${k}`,
-        ),
-      );
+    if (schema.properties) {
+        paths.push(...Object.keys(schema.properties as Record<string, unknown>))
     }
-  }
 
-  const variants = (schema.anyOf || schema.oneOf) as JSONSchema[] | undefined;
-  if (variants) {
-    for (let i = 0; i < variants.length; i++) {
-      const v = variants[i]!;
-      const label = typeof v.title === "string" ? `${i} (${v.title})` : `${i}`;
-      paths.push(label);
+    if (schema.type === 'array' && schema.items) {
+        const items = schema.items as JSONSchema
+        if (items.properties) {
+            paths.push(...Object.keys(items.properties as Record<string, unknown>).map((k) => `[items].${k}`))
+        }
     }
-  }
 
-  return paths;
+    const variants = (schema.anyOf || schema.oneOf) as JSONSchema[] | undefined
+    if (variants) {
+        for (let i = 0; i < variants.length; i++) {
+            const v = variants[i]!
+            const label = typeof v.title === 'string' ? `${i} (${v.title})` : `${i}`
+            paths.push(label)
+        }
+    }
+
+    return paths
 }

--- a/services/mcp/tests/unit/schema-utils.test.ts
+++ b/services/mcp/tests/unit/schema-utils.test.ts
@@ -1,0 +1,277 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  TOKEN_CHAR_LIMIT,
+  listAvailablePaths,
+  resolveSchemaPath,
+  summarizeSchema,
+} from "../../src/tools/schema-utils";
+
+describe("schema-utils", () => {
+  describe("summarizeSchema", () => {
+    it("summarizes simple scalar fields without hints", () => {
+      const schema = {
+        type: "object",
+        required: ["name"],
+        properties: {
+          name: { type: "string", description: "The name" },
+          count: { type: "number", default: 10 },
+          status: { type: "string", enum: ["active", "inactive"] },
+        },
+      };
+
+      const result = summarizeSchema(schema, "my-tool");
+
+      expect(result.type).toBe("object");
+      expect(result.required).toEqual(["name"]);
+      expect(result.properties.name).toEqual({
+        type: "string",
+        description: "The name",
+        required: true,
+      });
+      expect(result.properties.count).toEqual({
+        type: "number",
+        default: 10,
+      });
+      expect(result.properties.status).toEqual({
+        type: "string",
+        enum: ["active", "inactive"],
+      });
+      // No hints on simple fields
+      expect(result.properties.name!.hint).toBeUndefined();
+      expect(result.properties.count!.hint).toBeUndefined();
+      expect(result.properties.status!.hint).toBeUndefined();
+    });
+
+    it("adds hints for object fields with properties", () => {
+      const schema = {
+        type: "object",
+        properties: {
+          filter: {
+            type: "object",
+            description: "Filter config",
+            properties: {
+              key: { type: "string" },
+              value: { type: "string" },
+            },
+          },
+        },
+      };
+
+      const result = summarizeSchema(schema, "my-tool");
+
+      expect(result.properties.filter!.hint).toBe(
+        "Run `schema my-tool filter` for full structure",
+      );
+      expect(result.properties.filter!.fields).toEqual(["key", "value"]);
+    });
+
+    it("adds hints for arrays with complex items", () => {
+      const schema = {
+        type: "object",
+        properties: {
+          series: {
+            type: "array",
+            description: "Series list",
+            items: {
+              anyOf: [
+                {
+                  type: "object",
+                  title: "EventsNode",
+                  properties: { event: { type: "string" } },
+                },
+                {
+                  type: "object",
+                  title: "ActionsNode",
+                  properties: { id: { type: "number" } },
+                },
+              ],
+            },
+          },
+        },
+      };
+
+      const result = summarizeSchema(schema, "query-trends");
+
+      expect(result.properties.series!.hint).toBe(
+        "Run `schema query-trends series` for full structure",
+      );
+      expect(result.properties.series!.items).toBe(
+        "union of 2 types (EventsNode, ActionsNode)",
+      );
+    });
+
+    it("does not add hints for arrays with simple items", () => {
+      const schema = {
+        type: "object",
+        properties: {
+          tags: {
+            type: "array",
+            items: { type: "string" },
+          },
+        },
+      };
+
+      const result = summarizeSchema(schema, "my-tool");
+
+      expect(result.properties.tags!.hint).toBeUndefined();
+      expect(result.properties.tags!.items).toBe("string");
+    });
+
+    it("does not add hints for nullable scalar unions", () => {
+      const schema = {
+        type: "object",
+        properties: {
+          name: {
+            anyOf: [{ type: "string" }, { type: "null" }],
+          },
+        },
+      };
+
+      const result = summarizeSchema(schema, "my-tool");
+
+      expect(result.properties.name!.hint).toBeUndefined();
+    });
+
+    it("includes fieldPath in hints when provided", () => {
+      const schema = {
+        type: "object",
+        properties: {
+          nested: {
+            type: "object",
+            properties: {
+              deep: { type: "string" },
+            },
+          },
+        },
+      };
+
+      const result = summarizeSchema(schema, "my-tool", "parent");
+
+      expect(result.properties.nested!.hint).toBe(
+        "Run `schema my-tool parent.nested` for full structure",
+      );
+    });
+  });
+
+  describe("resolveSchemaPath", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        name: { type: "string" },
+        filter: {
+          type: "object",
+          properties: {
+            key: { type: "string" },
+            value: { type: "number" },
+          },
+        },
+        series: {
+          type: "array",
+          items: {
+            type: "object",
+            properties: {
+              event: { type: "string" },
+              math: { type: "string", enum: ["total", "dau"] },
+            },
+          },
+        },
+        variant: {
+          anyOf: [
+            {
+              type: "object",
+              title: "TypeA",
+              properties: { a: { type: "string" } },
+            },
+            {
+              type: "object",
+              title: "TypeB",
+              properties: { b: { type: "number" } },
+            },
+          ],
+        },
+      },
+    };
+
+    it("resolves top-level properties", () => {
+      expect(resolveSchemaPath(schema, "name")).toEqual({ type: "string" });
+    });
+
+    it("resolves nested object properties via dot path", () => {
+      expect(resolveSchemaPath(schema, "filter.key")).toEqual({
+        type: "string",
+      });
+    });
+
+    it("resolves array item properties", () => {
+      expect(resolveSchemaPath(schema, "series.event")).toEqual({
+        type: "string",
+      });
+    });
+
+    it("resolves union variants by index", () => {
+      expect(resolveSchemaPath(schema, "variant.0")).toEqual({
+        type: "object",
+        title: "TypeA",
+        properties: { a: { type: "string" } },
+      });
+    });
+
+    it("returns null for invalid paths", () => {
+      expect(resolveSchemaPath(schema, "nonexistent")).toBeNull();
+      expect(resolveSchemaPath(schema, "filter.nonexistent")).toBeNull();
+    });
+  });
+
+  describe("listAvailablePaths", () => {
+    it("lists property names for objects", () => {
+      const schema = {
+        type: "object",
+        properties: {
+          name: { type: "string" },
+          age: { type: "number" },
+        },
+      };
+
+      expect(listAvailablePaths(schema, "")).toEqual(["name", "age"]);
+    });
+
+    it("lists union variant indices with titles", () => {
+      const schema = {
+        anyOf: [
+          { type: "object", title: "TypeA" },
+          { type: "object", title: "TypeB" },
+        ],
+      };
+
+      expect(listAvailablePaths(schema, "")).toEqual([
+        "0 (TypeA)",
+        "1 (TypeB)",
+      ]);
+    });
+
+    it("lists array item properties", () => {
+      const schema = {
+        type: "array",
+        items: {
+          type: "object",
+          properties: {
+            event: { type: "string" },
+            math: { type: "string" },
+          },
+        },
+      };
+
+      expect(listAvailablePaths(schema, "")).toEqual([
+        "[items].event",
+        "[items].math",
+      ]);
+    });
+  });
+
+  describe("TOKEN_CHAR_LIMIT", () => {
+    it("is 96000 (16k tokens × 6 chars/token)", () => {
+      expect(TOKEN_CHAR_LIMIT).toBe(96_000);
+    });
+  });
+});

--- a/services/mcp/tests/unit/schema-utils.test.ts
+++ b/services/mcp/tests/unit/schema-utils.test.ts
@@ -1,277 +1,258 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from 'vitest'
 
-import {
-  TOKEN_CHAR_LIMIT,
-  listAvailablePaths,
-  resolveSchemaPath,
-  summarizeSchema,
-} from "../../src/tools/schema-utils";
+import { TOKEN_CHAR_LIMIT, listAvailablePaths, resolveSchemaPath, summarizeSchema } from '../../src/tools/schema-utils'
 
-describe("schema-utils", () => {
-  describe("summarizeSchema", () => {
-    it("summarizes simple scalar fields without hints", () => {
-      const schema = {
-        type: "object",
-        required: ["name"],
-        properties: {
-          name: { type: "string", description: "The name" },
-          count: { type: "number", default: 10 },
-          status: { type: "string", enum: ["active", "inactive"] },
-        },
-      };
-
-      const result = summarizeSchema(schema, "my-tool");
-
-      expect(result.type).toBe("object");
-      expect(result.required).toEqual(["name"]);
-      expect(result.properties.name).toEqual({
-        type: "string",
-        description: "The name",
-        required: true,
-      });
-      expect(result.properties.count).toEqual({
-        type: "number",
-        default: 10,
-      });
-      expect(result.properties.status).toEqual({
-        type: "string",
-        enum: ["active", "inactive"],
-      });
-      // No hints on simple fields
-      expect(result.properties.name!.hint).toBeUndefined();
-      expect(result.properties.count!.hint).toBeUndefined();
-      expect(result.properties.status!.hint).toBeUndefined();
-    });
-
-    it("adds hints for object fields with properties", () => {
-      const schema = {
-        type: "object",
-        properties: {
-          filter: {
-            type: "object",
-            description: "Filter config",
-            properties: {
-              key: { type: "string" },
-              value: { type: "string" },
-            },
-          },
-        },
-      };
-
-      const result = summarizeSchema(schema, "my-tool");
-
-      expect(result.properties.filter!.hint).toBe(
-        "Run `schema my-tool filter` for full structure",
-      );
-      expect(result.properties.filter!.fields).toEqual(["key", "value"]);
-    });
-
-    it("adds hints for arrays with complex items", () => {
-      const schema = {
-        type: "object",
-        properties: {
-          series: {
-            type: "array",
-            description: "Series list",
-            items: {
-              anyOf: [
-                {
-                  type: "object",
-                  title: "EventsNode",
-                  properties: { event: { type: "string" } },
+describe('schema-utils', () => {
+    describe('summarizeSchema', () => {
+        it('summarizes simple scalar fields without hints', () => {
+            const schema = {
+                type: 'object',
+                required: ['name'],
+                properties: {
+                    name: { type: 'string', description: 'The name' },
+                    count: { type: 'number', default: 10 },
+                    status: { type: 'string', enum: ['active', 'inactive'] },
                 },
-                {
-                  type: "object",
-                  title: "ActionsNode",
-                  properties: { id: { type: "number" } },
+            }
+
+            const result = summarizeSchema(schema, 'my-tool')
+
+            expect(result.type).toBe('object')
+            expect(result.required).toEqual(['name'])
+            expect(result.properties.name).toEqual({
+                type: 'string',
+                description: 'The name',
+                required: true,
+            })
+            expect(result.properties.count).toEqual({
+                type: 'number',
+                default: 10,
+            })
+            expect(result.properties.status).toEqual({
+                type: 'string',
+                enum: ['active', 'inactive'],
+            })
+            // No hints on simple fields
+            expect(result.properties.name!.hint).toBeUndefined()
+            expect(result.properties.count!.hint).toBeUndefined()
+            expect(result.properties.status!.hint).toBeUndefined()
+        })
+
+        it('adds hints for object fields with properties', () => {
+            const schema = {
+                type: 'object',
+                properties: {
+                    filter: {
+                        type: 'object',
+                        description: 'Filter config',
+                        properties: {
+                            key: { type: 'string' },
+                            value: { type: 'string' },
+                        },
+                    },
                 },
-              ],
-            },
-          },
-        },
-      };
+            }
 
-      const result = summarizeSchema(schema, "query-trends");
+            const result = summarizeSchema(schema, 'my-tool')
 
-      expect(result.properties.series!.hint).toBe(
-        "Run `schema query-trends series` for full structure",
-      );
-      expect(result.properties.series!.items).toBe(
-        "union of 2 types (EventsNode, ActionsNode)",
-      );
-    });
+            expect(result.properties.filter!.hint).toBe('Run `schema my-tool filter` for full structure')
+            expect(result.properties.filter!.fields).toEqual(['key', 'value'])
+        })
 
-    it("does not add hints for arrays with simple items", () => {
-      const schema = {
-        type: "object",
-        properties: {
-          tags: {
-            type: "array",
-            items: { type: "string" },
-          },
-        },
-      };
+        it('adds hints for arrays with complex items', () => {
+            const schema = {
+                type: 'object',
+                properties: {
+                    series: {
+                        type: 'array',
+                        description: 'Series list',
+                        items: {
+                            anyOf: [
+                                {
+                                    type: 'object',
+                                    title: 'EventsNode',
+                                    properties: { event: { type: 'string' } },
+                                },
+                                {
+                                    type: 'object',
+                                    title: 'ActionsNode',
+                                    properties: { id: { type: 'number' } },
+                                },
+                            ],
+                        },
+                    },
+                },
+            }
 
-      const result = summarizeSchema(schema, "my-tool");
+            const result = summarizeSchema(schema, 'query-trends')
 
-      expect(result.properties.tags!.hint).toBeUndefined();
-      expect(result.properties.tags!.items).toBe("string");
-    });
+            expect(result.properties.series!.hint).toBe('Run `schema query-trends series` for full structure')
+            expect(result.properties.series!.items).toBe('union of 2 types (EventsNode, ActionsNode)')
+        })
 
-    it("does not add hints for nullable scalar unions", () => {
-      const schema = {
-        type: "object",
-        properties: {
-          name: {
-            anyOf: [{ type: "string" }, { type: "null" }],
-          },
-        },
-      };
+        it('does not add hints for arrays with simple items', () => {
+            const schema = {
+                type: 'object',
+                properties: {
+                    tags: {
+                        type: 'array',
+                        items: { type: 'string' },
+                    },
+                },
+            }
 
-      const result = summarizeSchema(schema, "my-tool");
+            const result = summarizeSchema(schema, 'my-tool')
 
-      expect(result.properties.name!.hint).toBeUndefined();
-    });
+            expect(result.properties.tags!.hint).toBeUndefined()
+            expect(result.properties.tags!.items).toBe('string')
+        })
 
-    it("includes fieldPath in hints when provided", () => {
-      const schema = {
-        type: "object",
-        properties: {
-          nested: {
-            type: "object",
+        it('does not add hints for nullable scalar unions', () => {
+            const schema = {
+                type: 'object',
+                properties: {
+                    name: {
+                        anyOf: [{ type: 'string' }, { type: 'null' }],
+                    },
+                },
+            }
+
+            const result = summarizeSchema(schema, 'my-tool')
+
+            expect(result.properties.name!.hint).toBeUndefined()
+        })
+
+        it('includes fieldPath in hints when provided', () => {
+            const schema = {
+                type: 'object',
+                properties: {
+                    nested: {
+                        type: 'object',
+                        properties: {
+                            deep: { type: 'string' },
+                        },
+                    },
+                },
+            }
+
+            const result = summarizeSchema(schema, 'my-tool', 'parent')
+
+            expect(result.properties.nested!.hint).toBe('Run `schema my-tool parent.nested` for full structure')
+        })
+    })
+
+    describe('resolveSchemaPath', () => {
+        const schema = {
+            type: 'object',
             properties: {
-              deep: { type: "string" },
+                name: { type: 'string' },
+                filter: {
+                    type: 'object',
+                    properties: {
+                        key: { type: 'string' },
+                        value: { type: 'number' },
+                    },
+                },
+                series: {
+                    type: 'array',
+                    items: {
+                        type: 'object',
+                        properties: {
+                            event: { type: 'string' },
+                            math: { type: 'string', enum: ['total', 'dau'] },
+                        },
+                    },
+                },
+                variant: {
+                    anyOf: [
+                        {
+                            type: 'object',
+                            title: 'TypeA',
+                            properties: { a: { type: 'string' } },
+                        },
+                        {
+                            type: 'object',
+                            title: 'TypeB',
+                            properties: { b: { type: 'number' } },
+                        },
+                    ],
+                },
             },
-          },
-        },
-      };
+        }
 
-      const result = summarizeSchema(schema, "my-tool", "parent");
+        it('resolves top-level properties', () => {
+            expect(resolveSchemaPath(schema, 'name')).toEqual({ type: 'string' })
+        })
 
-      expect(result.properties.nested!.hint).toBe(
-        "Run `schema my-tool parent.nested` for full structure",
-      );
-    });
-  });
+        it('resolves nested object properties via dot path', () => {
+            expect(resolveSchemaPath(schema, 'filter.key')).toEqual({
+                type: 'string',
+            })
+        })
 
-  describe("resolveSchemaPath", () => {
-    const schema = {
-      type: "object",
-      properties: {
-        name: { type: "string" },
-        filter: {
-          type: "object",
-          properties: {
-            key: { type: "string" },
-            value: { type: "number" },
-          },
-        },
-        series: {
-          type: "array",
-          items: {
-            type: "object",
-            properties: {
-              event: { type: "string" },
-              math: { type: "string", enum: ["total", "dau"] },
-            },
-          },
-        },
-        variant: {
-          anyOf: [
-            {
-              type: "object",
-              title: "TypeA",
-              properties: { a: { type: "string" } },
-            },
-            {
-              type: "object",
-              title: "TypeB",
-              properties: { b: { type: "number" } },
-            },
-          ],
-        },
-      },
-    };
+        it('resolves array item properties', () => {
+            expect(resolveSchemaPath(schema, 'series.event')).toEqual({
+                type: 'string',
+            })
+        })
 
-    it("resolves top-level properties", () => {
-      expect(resolveSchemaPath(schema, "name")).toEqual({ type: "string" });
-    });
+        it('resolves union variants by index', () => {
+            expect(resolveSchemaPath(schema, 'variant.0')).toEqual({
+                type: 'object',
+                title: 'TypeA',
+                properties: { a: { type: 'string' } },
+            })
+        })
 
-    it("resolves nested object properties via dot path", () => {
-      expect(resolveSchemaPath(schema, "filter.key")).toEqual({
-        type: "string",
-      });
-    });
+        it('returns null for invalid paths', () => {
+            expect(resolveSchemaPath(schema, 'nonexistent')).toBeNull()
+            expect(resolveSchemaPath(schema, 'filter.nonexistent')).toBeNull()
+        })
+    })
 
-    it("resolves array item properties", () => {
-      expect(resolveSchemaPath(schema, "series.event")).toEqual({
-        type: "string",
-      });
-    });
+    describe('listAvailablePaths', () => {
+        it('lists property names for objects', () => {
+            const schema = {
+                type: 'object',
+                properties: {
+                    name: { type: 'string' },
+                    age: { type: 'number' },
+                },
+            }
 
-    it("resolves union variants by index", () => {
-      expect(resolveSchemaPath(schema, "variant.0")).toEqual({
-        type: "object",
-        title: "TypeA",
-        properties: { a: { type: "string" } },
-      });
-    });
+            expect(listAvailablePaths(schema, '')).toEqual(['name', 'age'])
+        })
 
-    it("returns null for invalid paths", () => {
-      expect(resolveSchemaPath(schema, "nonexistent")).toBeNull();
-      expect(resolveSchemaPath(schema, "filter.nonexistent")).toBeNull();
-    });
-  });
+        it('lists union variant indices with titles', () => {
+            const schema = {
+                anyOf: [
+                    { type: 'object', title: 'TypeA' },
+                    { type: 'object', title: 'TypeB' },
+                ],
+            }
 
-  describe("listAvailablePaths", () => {
-    it("lists property names for objects", () => {
-      const schema = {
-        type: "object",
-        properties: {
-          name: { type: "string" },
-          age: { type: "number" },
-        },
-      };
+            expect(listAvailablePaths(schema, '')).toEqual(['0 (TypeA)', '1 (TypeB)'])
+        })
 
-      expect(listAvailablePaths(schema, "")).toEqual(["name", "age"]);
-    });
+        it('lists array item properties', () => {
+            const schema = {
+                type: 'array',
+                items: {
+                    type: 'object',
+                    properties: {
+                        event: { type: 'string' },
+                        math: { type: 'string' },
+                    },
+                },
+            }
 
-    it("lists union variant indices with titles", () => {
-      const schema = {
-        anyOf: [
-          { type: "object", title: "TypeA" },
-          { type: "object", title: "TypeB" },
-        ],
-      };
+            expect(listAvailablePaths(schema, '')).toEqual(['[items].event', '[items].math'])
+        })
+    })
 
-      expect(listAvailablePaths(schema, "")).toEqual([
-        "0 (TypeA)",
-        "1 (TypeB)",
-      ]);
-    });
-
-    it("lists array item properties", () => {
-      const schema = {
-        type: "array",
-        items: {
-          type: "object",
-          properties: {
-            event: { type: "string" },
-            math: { type: "string" },
-          },
-        },
-      };
-
-      expect(listAvailablePaths(schema, "")).toEqual([
-        "[items].event",
-        "[items].math",
-      ]);
-    });
-  });
-
-  describe("TOKEN_CHAR_LIMIT", () => {
-    it("is 96000 (16k tokens × 6 chars/token)", () => {
-      expect(TOKEN_CHAR_LIMIT).toBe(96_000);
-    });
-  });
-});
+    describe('TOKEN_CHAR_LIMIT', () => {
+        it('is 96000 (16k tokens × 6 chars/token)', () => {
+            expect(TOKEN_CHAR_LIMIT).toBe(96_000)
+        })
+    })
+})


### PR DESCRIPTION
## Problem

The `exec` tool's `info` command returns the full JSON schema for tools, which can be extremely large for complex tools like query builders. This causes token bloat and makes it difficult for LLMs to understand which fields need to be populated.

Users need a way to:
1. Get a high-level summary of tool schemas without token overhead
2. Drill down into specific fields to understand their structure
3. Navigate complex nested schemas using dot-notation paths

## Changes

### New `schema` command for the exec tool
- Added `schema <tool_name> [field_path]` command to drill into specific fields
- Supports dot-notation for nested paths (e.g., `schema query-trends series.0.event`)
- Returns full schema if under token limit, otherwise returns summarized version with sub-path hints

### New schema-utils module (`services/mcp/src/tools/schema-utils.ts`)
- `summarizeSchema()`: Produces concise summaries of JSON schemas with drill-down hints for complex fields
- `resolveSchemaPath()`: Resolves dot-separated paths within schemas (handles objects, arrays, unions)
- `listAvailablePaths()`: Lists available child paths for error messages
- `TOKEN_CHAR_LIMIT`: Set to 96,000 chars (16k tokens × 6 chars/token) for token-aware responses

### Updated `info` command behavior
- Now checks response size against token limit
- Returns full schema if under limit (backward compatible)
- Returns summarized schema with drill-down hints if too large
- Hints guide users to use `schema` command for complex fields

### Updated instructions
- Added STEP 3 for schema drill-down before calling tools
- Added "SCHEMA DRILL-DOWN RULE" section explaining when to use `schema` command
- Clarified that complex fields (with hints) must be drilled into before use
- Added examples for common query tool fields (series, properties, breakdownFilter)

### Code formatting
- Standardized quote style to double quotes throughout exec.ts
- Applied consistent indentation and formatting

## How did you test this code?

Added comprehensive unit tests in `services/mcp/tests/unit/schema-utils.test.ts`:
- `summarizeSchema()`: Tests scalar fields, object fields with hints, complex arrays, nullable unions, and fieldPath inclusion
- `resolveSchemaPath()`: Tests top-level properties, nested objects, array items, union variants, and invalid paths
- `listAvailablePaths()`: Tests property listing, union variants with titles, and array item properties
- `TOKEN_CHAR_LIMIT`: Verifies constant value

All tests pass and cover the core functionality of schema navigation and summarization.

## Publish to changelog?

Yes - this adds a new `schema` command to the exec tool that enables better schema exploration for complex tools.

https://claude.ai/code/session_01JKzGNYxVu2WXEtuXD51GZC