### PR TITLE
chore(modeling): clickhouse jobs created even when duckgres_only

### DIFF
--- a/posthog/temporal/data_modeling/workflows/materialize_view.py
+++ b/posthog/temporal/data_modeling/workflows/materialize_view.py
@@ -125,16 +125,8 @@ class MaterializeViewWorkflow(PostHogWorkflow):
         start_time = temporalio.workflow.now()
         parent_info = temporalio.workflow.info().parent
         parent_workflow_id = parent_info.workflow_id if parent_info else None
-        job_id = await temporalio.workflow.execute_activity(
-            create_data_modeling_job_activity,
-            CreateDataModelingJobInputs(
-                team_id=inputs.team_id,
-                node_id=inputs.node_id,
-                dag_id=inputs.dag_id,
-                parent_workflow_id=parent_workflow_id,
-            ),
-            start_to_close_timeout=dt.timedelta(minutes=1),
-        )
+        job_id = None
+        duckgres_job_id = None
 
         # check whether duckgres shadow is enabled before creating the job
         duckgres_enabled = await temporalio.workflow.execute_activity(
@@ -175,6 +167,16 @@ class MaterializeViewWorkflow(PostHogWorkflow):
             )
 
         if not inputs.duckgres_only:
+            job_id = await temporalio.workflow.execute_activity(
+                create_data_modeling_job_activity,
+                CreateDataModelingJobInputs(
+                    team_id=inputs.team_id,
+                    node_id=inputs.node_id,
+                    dag_id=inputs.dag_id,
+                    parent_workflow_id=parent_workflow_id,
+                ),
+                start_to_close_timeout=dt.timedelta(minutes=1),
+            )
             try:
                 materialize_result = await temporalio.workflow.execute_activity(
                     materialize_view_activity,
@@ -347,6 +349,11 @@ class MaterializeViewWorkflow(PostHogWorkflow):
                     extra=inputs.properties_to_log,
                 )
                 capture_exception(shadow_err)
+        # fallback to duckgres job if no clickhouse job was run
+        if job_id is None:
+            if duckgres_job_id is None:
+                raise temporalio.exceptions.ApplicationError("No data modeling job was created")
+            job_id = duckgres_job_id
         return MaterializeViewWorkflowResult(
             job_id=job_id,
             node_id=inputs.node_id,


### PR DESCRIPTION
## Problem

creating unnecessary data modeling jobs when duckgres_only. the jobs don't run anything against CH. they just sit and await their inevitable death when preemption rolls around 

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

## Changes

don't create them

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took, and what steps reviewers must take to get to where changes are, and what is the expected behavior. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

didn't

## Publish to changelog?

no

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->