### PR TITLE
fix(exports): add error enrichment to SLO interceptor

### DIFF
--- a/posthog/temporal/common/slo_interceptor.py
+++ b/posthog/temporal/common/slo_interceptor.py
@@ -3,6 +3,7 @@ from typing import Any
 from django.conf import settings
 
 from temporalio import workflow
+from temporalio.exceptions import ActivityError, ApplicationError
 from temporalio.worker import (
     ExecuteWorkflowInput,
     Interceptor,
@@ -51,8 +52,13 @@ class _SloWorkflowInterceptor(WorkflowInboundInterceptor):
             result = await self.next.execute_workflow(input)
             outcome = slo.outcome if slo.outcome is not None else SloOutcome.SUCCESS
             return result
-        except BaseException:
+        except BaseException as exc:
             outcome = slo.outcome if slo.outcome is not None else SloOutcome.FAILURE
+            # Temporal wraps activity errors as ActivityError → ApplicationError;
+            # unwrap to get the original exception type and message.
+            cause = exc.cause if isinstance(exc, ActivityError) and isinstance(exc.cause, ApplicationError) else exc
+            slo.completion_properties.setdefault("error_type", getattr(cause, "type", None) or type(cause).__name__)
+            slo.completion_properties.setdefault("error_message", str(cause))
             raise
         finally:
             duration_ms = (workflow.time() - start_time) * 1000

--- a/posthog/temporal/tests/test_slo_interceptor.py
+++ b/posthog/temporal/tests/test_slo_interceptor.py
@@ -89,7 +89,7 @@ pytestmark = [pytest.mark.asyncio]
             _make_slo_config(),
             True,
             SloOutcome.FAILURE,
-            {},
+            {"error_type": "ApplicationError", "error_message": "boom"},
         ),
         (
             TrackedBusinessFailureWorkflow,


### PR DESCRIPTION
## Problem

The SLO interceptor for Temporal workflows was not capturing error details when workflows failed, making it difficult to analyze and debug workflow failures. Error information is crucial for monitoring and improving workflow reliability.

## Changes

- Enhanced the SLO interceptor to capture error type and message when workflows fail
- Added logic to unwrap Temporal's `ActivityError` → `ApplicationError` chain to get the original exception details
- Store error information in the SLO completion properties for better observability
- Updated test expectations to include the new error metadata

## How did you test this code?

The existing test suite was updated to verify that error information is properly captured in the SLO completion properties. The test now expects `error_type` and `error_message` fields to be populated when workflows fail with exceptions.

## Publish to changelog?

No

## Docs update

No documentation changes needed as this is an internal monitoring enhancement.