### PR TITLE
fix(tracing): fix sparkline query

### DIFF
--- a/products/tracing/backend/logic.py
+++ b/products/tracing/backend/logic.py
@@ -174,12 +174,44 @@ class TraceSpansQueryRunnerMixin(QueryRunner):
 
     @cached_property
     def query_date_range(self) -> QueryDateRange:
-        return QueryDateRange(
+        qdr = QueryDateRange(
             date_range=self.query.dateRange,
             team=self.team,
             interval=IntervalType.MINUTE,
             interval_count=2,
             now=dt.datetime.now(),
+        )
+
+        _step = (qdr.date_to() - qdr.date_from()) / 50
+        interval_type = IntervalType.SECOND
+
+        def find_closest(target, arr):
+            if not arr:
+                raise ValueError("Input array cannot be empty")
+            closest_number = min(arr, key=lambda x: (abs(x - target), x))
+
+            return closest_number
+
+        # set the number of intervals to a "round" number of minutes
+        # it's hard to reason about the rate of logs on e.g. 13 minute intervals
+        # the min interval is 1 minute and max interval is 1 day
+        interval_count = find_closest(
+            _step.total_seconds(),
+            [1, 5, 10] + [x * 60 for x in [1, 2, 5, 10, 15, 30, 60, 120, 240, 360, 720, 1440]],
+        )
+
+        if _step >= dt.timedelta(minutes=1):
+            interval_type = IntervalType.MINUTE
+            interval_count //= 60
+
+        return QueryDateRange(
+            date_range=self.query.dateRange,
+            team=self.team,
+            interval=interval_type,
+            interval_count=int(interval_count),
+            now=dt.datetime.now(),
+            timezone_info=ZoneInfo("UTC"),
+            exact_timerange=True,
         )
 
     @cached_property

--- a/products/tracing/backend/sparkline_query_runner.py
+++ b/products/tracing/backend/sparkline_query_runner.py
@@ -1,6 +1,6 @@
 from zoneinfo import ZoneInfo
 
-from posthog.schema import HogQLFilters, TraceSpansQueryResponse
+from posthog.schema import TraceSpansQueryResponse
 
 from posthog.hogql import ast
 from posthog.hogql.parser import parse_select
@@ -20,7 +20,7 @@ class TraceSpansSparklineQueryRunner(TraceSpansQueryRunner):
             team=self.team,
             workload=Workload.LOGS,
             timings=self.timings,
-            filters=HogQLFilters(dateRange=self.query.dateRange),
+            limit_context=self.limit_context,
             settings=self.settings,
         )
 
@@ -39,16 +39,50 @@ class TraceSpansSparklineQueryRunner(TraceSpansQueryRunner):
     def to_query(self) -> ast.SelectQuery:
         query = parse_select(
             """
-            SELECT
-                toStartOfFiveMinutes(timestamp) AS bucket,
-                service_name,
-                count() AS count
-            FROM posthog.trace_spans
-            WHERE {where} AND is_root_span = 1
-            GROUP BY bucket, service_name
-            ORDER BY bucket ASC
-            """,
-            placeholders={"where": self.where()},
+                SELECT
+                    am.time_bucket AS time,
+                    {breakdown_field},
+                    ifNull(ac.event_count, 0) AS count
+                FROM (
+                    SELECT
+                        dateAdd({date_from_start_of_interval}, {number_interval_period}) AS time_bucket
+                    FROM numbers(
+                        floor(
+                            dateDiff({interval},
+                                        {date_from_start_of_interval},
+                                        {date_to_start_of_interval}) / {interval_count} + 1
+                                    )
+                        )
+                    WHERE
+                        time_bucket >= {date_from_start_of_interval} and
+                        time_bucket <= greatest(
+                            {date_from_start_of_interval},
+                            toStartOfInterval({date_to} - toIntervalSecond(1), {one_interval_period})
+                        )
+                ) AS am
+                LEFT JOIN (
+                    SELECT
+                        toStartOfInterval({time_field}, {one_interval_period}) AS time,
+                        {breakdown_field},
+                        count() AS event_count
+                    FROM posthog.trace_spans
+                    WHERE {where} AND time >= {date_from_start_of_interval} AND time <= {date_to}
+                    GROUP BY {breakdown_field}, time
+                ) AS ac ON am.time_bucket = ac.time
+                ORDER BY time asc, {breakdown_field} desc
+                LIMIT 10 BY time LIMIT 10000
+        """,
+            placeholders={
+                **self.query_date_range.to_placeholders(),
+                # The sparkline projection is aggregated over "toStartOfMinute(timestamp)"
+                # so if we use `timestamp` we don't use the projection (even if we're calling toStartOfInterval on it)
+                # explicitly use toStartOfMinute(timestamp) as the time field unless we're using a sub-minute interval
+                "time_field": ast.Call(name="toStartOfMinute", args=[ast.Field(chain=["timestamp"])])
+                if self.query_date_range.interval_name != "second"
+                else ast.Field(chain=["timestamp"]),
+                "where": self.where(),
+                "breakdown_field": ast.Field(chain=["service_name"]),
+            },
         )
         assert isinstance(query, ast.SelectQuery)
         return query


### PR DESCRIPTION
## Problem

the sparkline query was wrong in 2 ways

1. it was being truncated due to having the default `limit 100`, which is way too low
2. it wasn't using the projection optimisation due to filtering to root spans - I think we want all spans here anyway
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

make sparkline not filter by spans, and limit to top 10 per timebucket instead of 100 total

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
locally
<!-- Briefly describe the steps you took, and what steps reviewers must take to get to where changes are, and what is the expected behavior. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
no
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
