### PR TITLE
feat(stripe-mock): Add subscription_metadata and charge_metadata config

### DIFF
--- a/services/stripe-mock/src/stripe_mock/config.py
+++ b/services/stripe-mock/src/stripe_mock/config.py
@@ -88,6 +88,8 @@ class MockConfig(BaseModel):
     seed: int = 42
 
     customer_metadata: dict[str, str] = {}
+    subscription_metadata: dict[str, str] = {}
+    charge_metadata: dict[str, str] = {}
 
     customer_types: dict[str, int] = {
         "loyalists_monthly": 12,

--- a/services/stripe-mock/src/stripe_mock/data/scenarios.py
+++ b/services/stripe-mock/src/stripe_mock/data/scenarios.py
@@ -145,11 +145,12 @@ class ScenarioBuilder:
         if start_date > self.data_end:
             return
 
-        merged_metadata = {**self.cfg.customer_metadata, **(persona_metadata or {})}
+        customer_metadata = {**self.cfg.customer_metadata, **(persona_metadata or {})}
+        subscription_metadata = {**self.cfg.subscription_metadata, **(persona_metadata or {})}
 
         cust_idx = _next_id("cus")
         customer = make_customer(
-            cust_idx, start_date, name=name, email=email, currency=currency, metadata=merged_metadata
+            cust_idx, start_date, name=name, email=email, currency=currency, metadata=customer_metadata
         )
         self.customers.append(customer)
 
@@ -175,7 +176,7 @@ class ScenarioBuilder:
             currency=currency,
             interval=interval,
             product_id=product_id,
-            metadata=merged_metadata,
+            metadata=subscription_metadata,
         )
         if trial_days > 0:
             from datetime import timedelta
@@ -284,6 +285,7 @@ class ScenarioBuilder:
             sub["latest_invoice"] = invoice["id"]
 
             ch_idx = _next_id("ch")
+            charge_metadata = {**self.cfg.charge_metadata, **(persona_metadata or {})}
             charge = make_charge(
                 ch_idx,
                 invoice_date,
@@ -291,6 +293,7 @@ class ScenarioBuilder:
                 currency=currency,
                 customer_id=customer["id"],
                 invoice_id=invoice["id"],
+                metadata=charge_metadata,
             )
             self.charges.append(charge)
 

--- a/services/stripe-mock/stripe-mock.config.yaml
+++ b/services/stripe-mock/stripe-mock.config.yaml
@@ -9,10 +9,13 @@
 # end_date: "2026-03-01"
 # seed: 42
 
-# --- Customer metadata (injected into every customer.metadata field) ---
+# --- Metadata (injected into the metadata field of each object type) ---
 # customer_metadata:
 #   source: "stripe-mock"
 #   environment: "development"
+# subscription_metadata:
+#   posthog_person_distinct_id: "your_distinct_id"
+# charge_metadata: {}
 
 # --- Customer persona distribution (count per type) ---
 # customer_types:


### PR DESCRIPTION
## Problem

The stripe-mock service applied `customer_metadata` to all object types (customer, subscription, charge), making it impossible  
to test scenarios where `posthog_person_distinct_id` is set on subscriptions or charges but not on the customer.

Part of https://github.com/PostHog/posthog/issues/52270

## Changes

- Added `subscription_metadata` and `charge_metadata` config fields to stripe-mock, each injected only into their respective  
object type
- Updated default config comments with examples

## How did you test this code?

Verified stripe-mock generates correct per-object metadata via local dev testing.

## Publish to changelog?

No

## Docs update

no