### PR TITLE
test: Add additional test flagged by graphite

### DIFF
--- a/posthog/temporal/tests/test_slo_interceptor.py
+++ b/posthog/temporal/tests/test_slo_interceptor.py
@@ -1,8 +1,10 @@
 import dataclasses
+from datetime import timedelta
 
 import pytest
 from unittest.mock import MagicMock, patch
 
+import temporalio.activity
 import temporalio.workflow
 from temporalio.exceptions import ApplicationError
 from temporalio.testing import WorkflowEnvironment
@@ -49,6 +51,22 @@ class TrackedBusinessFailureWorkflow:
         return "ok"
 
 
+@temporalio.activity.defn
+async def failing_activity() -> None:
+    raise ApplicationError("activity boom", type="ActivityBoom", non_retryable=True)
+
+
+@temporalio.workflow.defn(name="test-slo-activity-failure")
+class TrackedActivityFailureWorkflow:
+    @temporalio.workflow.run
+    async def run(self, inputs: TrackedWorkflowInput) -> str:
+        await temporalio.workflow.execute_activity(
+            failing_activity,
+            schedule_to_close_timeout=timedelta(seconds=10),
+        )
+        return "ok"
+
+
 @temporalio.workflow.defn(name="test-slo-untracked")
 class UntrackedWorkflow:
     @temporalio.workflow.run
@@ -92,6 +110,13 @@ pytestmark = [pytest.mark.asyncio]
             {"error_type": "ApplicationError", "error_message": "boom"},
         ),
         (
+            TrackedActivityFailureWorkflow,
+            _make_slo_config(),
+            True,
+            SloOutcome.FAILURE,
+            {"error_type": "ActivityBoom", "error_message": "ActivityBoom: activity boom"},
+        ),
+        (
             TrackedBusinessFailureWorkflow,
             _make_slo_config(),
             False,
@@ -99,7 +124,7 @@ pytestmark = [pytest.mark.asyncio]
             {"reason": "business logic"},
         ),
     ],
-    ids=["success_with_completion_props", "exception_failure", "business_logic_failure"],
+    ids=["success_with_completion_props", "exception_failure", "activity_failure_unwrap", "business_logic_failure"],
 )
 @patch("posthog.slo.events.posthoganalytics")
 async def test_interceptor_emits_slo_events(
@@ -115,7 +140,7 @@ async def test_interceptor_emits_slo_events(
             env.client,
             task_queue="test-slo",
             workflows=[workflow_cls],
-            activities=[],
+            activities=[failing_activity],
             interceptors=[SloInterceptor()],
             workflow_runner=UnsandboxedWorkflowRunner(),
         ):
@@ -174,7 +199,7 @@ async def test_interceptor_skips_untracked_workflows(
             env.client,
             task_queue="test-slo",
             workflows=[workflow_cls],
-            activities=[],
+            activities=[failing_activity],
             interceptors=[SloInterceptor()],
             workflow_runner=UnsandboxedWorkflowRunner(),
         ):


### PR DESCRIPTION
## Problem

Graphite left a comment here about a potential test gap (https://github.com/PostHog/posthog/pull/53582#issuecomment-4200659482) which seemed fair. This PR addresses that and adds the suggested test.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

## Changes

Add the suggested test

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

- CI is passing (test only change)

<!-- Briefly describe the steps you took, and what steps reviewers must take to get to where changes are, and what is the expected behavior. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Publish to changelog?

No

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

No

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->