### PR TITLE
feat(llma): tag stamphog traces with ai_product property

### DIFF
--- a/tools/pr-approval-agent/reviewer.py
+++ b/tools/pr-approval-agent/reviewer.py
@@ -226,6 +226,7 @@ class Reviewer:
             posthog_kwargs = {
                 "posthog_distinct_id": "stamphog",
                 "posthog_properties": {
+                    "ai_product": "stamphog",
                     "stamphog_pr_number": pr.number,
                     "stamphog_repo": pr.repo,
                     "stamphog_author": pr.author,


### PR DESCRIPTION
## Problem

The stamphog PR approval agent now emits LLM Analytics events (since #53008), but its events don't carry the standard `ai_product` property that PostHog uses internally to identify which product a trace belongs to. Other internal AI products already use this convention:

- `ee/hogai/llm.py` → `ai_product = "posthog_ai"`
- `ee/hogai/session_summaries/tracking.py` → `ai_product = "signals"`
- `services/llm-gateway/.../posthog.py` → `ai_product = <product>`

Without this, stamphog traces can't be cleanly grouped/filtered alongside the other internal AI products in LLM Analytics.

## Changes

One-line addition to `tools/pr-approval-agent/reviewer.py`: include `"ai_product": "stamphog"` in the `posthog_properties` dict that's passed to `posthoganalytics.ai.claude_agent_sdk.query`. All other stamphog-specific properties (`stamphog_pr_number`, `stamphog_repo`, etc.) are unchanged.

## How did you test this code?

This is an agent-authored change. No new tests — it's a single property addition that flows through the existing SDK integration path added in #53008. Verified locally with `ruff check` and `ruff format`. The property will appear on the next stamphog run after merge.

## Publish to changelog?

No

## 🤖 LLM context

Authored by Claude (Opus 4.6) in a Claude Code session. Context: cut posthog-python v7.10.0 release earlier today, merged #53008 to wire stamphog into the SDK integration, and noticed stamphog wasn't using the internal `ai_product` convention for filtering in LLM Analytics. Convention confirmed by grepping `ee/hogai/` and `services/llm-gateway/` for existing usages.