### PR TITLE
fix(flags): add tooltip to Match by and Beta tag to Evaluation contexts

### DIFF
--- a/frontend/src/scenes/feature-flags/FeatureFlagEvaluationContexts.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagEvaluationContexts.tsx
@@ -173,7 +173,7 @@ export function FeatureFlagEvaluationContexts({
             {/* Evaluation contexts section */}
             <div className="flex flex-col gap-1">
                 <span className="text-sm font-medium inline-flex items-center gap-1">
-                    Evaluation contexts{' '}
+                    Evaluation contexts
                     <LemonTag type="warning" size="small">
                         BETA
                     </LemonTag>

--- a/frontend/src/scenes/feature-flags/FeatureFlagEvaluationContexts.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagEvaluationContexts.tsx
@@ -173,7 +173,10 @@ export function FeatureFlagEvaluationContexts({
             {/* Evaluation contexts section */}
             <div className="flex flex-col gap-1">
                 <span className="text-sm font-medium inline-flex items-center gap-1">
-                    Evaluation contexts
+                    Evaluation contexts{' '}
+                    <LemonTag type="warning" size="small">
+                        BETA
+                    </LemonTag>
                     {(context === 'form' || isEditingContexts) && (
                         <Tooltip
                             interactive

--- a/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditions.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditions.tsx
@@ -648,7 +648,9 @@ export function FeatureFlagReleaseConditions({
                 )}
             {!readOnly && showGroupsOptions && !hideMatchOptions && !showBucketingIdentifierUI && (
                 <div className="centered flex items-center gap-2">
-                    Match by
+                    <LemonLabel info="Changing match criteria may remove existing variants or payloads.">
+                        Match by
+                    </LemonLabel>
                     <LemonSelect
                         size="small"
                         dropdownMatchSelectWidth={false}
@@ -687,7 +689,12 @@ export function FeatureFlagReleaseConditions({
             )}
             {!readOnly && showGroupsOptions && !hideMatchOptions && showBucketingIdentifierUI && (
                 <div className="mb-4">
-                    <LemonLabel className="mb-2">Match by</LemonLabel>
+                    <LemonLabel
+                        className="mb-2"
+                        info="Changing match criteria may remove existing variants or payloads."
+                    >
+                        Match by
+                    </LemonLabel>
                     <LemonRadio
                         data-attr="feature-flag-aggregation-filter"
                         value={

--- a/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditionsCollapsible.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditionsCollapsible.tsx
@@ -955,7 +955,11 @@ export function FeatureFlagReleaseConditionsCollapsible({
 
             {!hideMatchOptions && (showGroupsOptions || onBucketingIdentifierChange) && (
                 <div>
-                    <LemonLabel className="mb-2" id="match-by-label">
+                    <LemonLabel
+                        className="mb-2"
+                        id="match-by-label"
+                        info="Changing match criteria may remove existing variants or payloads."
+                    >
                         Match by
                     </LemonLabel>
                     <div


### PR DESCRIPTION
## Problem

The feature flag UI was missing some helpful context for users:
1. The "Match by" section didn't warn that changing match criteria may remove existing variants or payloads (the same warning that exists on the flag type selector).
2. The "Evaluation contexts" feature is still in beta but wasn't marked as such.

## Changes

- Added info tooltip to all "Match by" labels with the text "Changing match criteria may remove existing variants or payloads." (in both `FeatureFlagReleaseConditions` and `FeatureFlagReleaseConditionsCollapsible`)
- Added a `BETA` LemonTag to the "Evaluation contexts" section header, matching the style used for Device ID matching

## How did you test this code?

This is an agent-authored PR with cosmetic UI-only changes (adding a tooltip and a tag). No manual testing was performed.

## Publish to changelog?

No

## 🤖 LLM context

Agent-authored PR. Two small UI tweaks to the feature flags form.