### PR TITLE
fix(error-tracking): declare issue merge schema

### DIFF
--- a/products/error_tracking/backend/api/issues.py
+++ b/products/error_tracking/backend/api/issues.py
@@ -4,6 +4,7 @@ from django.http import JsonResponse
 
 import structlog
 import posthoganalytics
+from drf_spectacular.utils import OpenApiResponse
 from loginas.utils import is_impersonated_session
 from rest_framework import request, serializers, status, viewsets
 from rest_framework.exceptions import NotFound, ValidationError
@@ -13,6 +14,7 @@ from posthog.schema import ProductKey
 
 from posthog.api.documentation import extend_schema, extend_schema_field
 from posthog.api.forbid_destroy_model import ForbidDestroyModel
+from posthog.api.mixins import ValidatedRequest, validated_request
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.api.utils import action
 from posthog.models.activity_logging.activity_log import Change, Detail, load_activity, log_activity
@@ -119,6 +121,18 @@ class ErrorTrackingIssueFullSerializer(serializers.ModelSerializer):
         return updated_instance
 
 
+class ErrorTrackingIssueMergeRequestSerializer(serializers.Serializer):
+    ids = serializers.ListField(
+        child=serializers.UUIDField(),
+        allow_empty=False,
+        help_text="IDs of the issues to merge into the current issue.",
+    )
+
+
+class ErrorTrackingIssueMergeResponseSerializer(serializers.Serializer):
+    success = serializers.BooleanField(help_text="Whether the merge completed successfully.")
+
+
 @extend_schema(tags=[ProductKey.ERROR_TRACKING])
 class ErrorTrackingIssueViewSet(TeamAndOrgViewSetMixin, ForbidDestroyModel, viewsets.ModelViewSet):
     scope_object = "error_tracking"
@@ -170,10 +184,14 @@ class ErrorTrackingIssueViewSet(TeamAndOrgViewSetMixin, ForbidDestroyModel, view
 
         return super().retrieve(request, *args, **kwargs)
 
+    @validated_request(
+        request_serializer=ErrorTrackingIssueMergeRequestSerializer,
+        responses={200: OpenApiResponse(response=ErrorTrackingIssueMergeResponseSerializer)},
+    )
     @action(methods=["POST"], detail=True)
-    def merge(self, request, **kwargs):
+    def merge(self, request: ValidatedRequest, **kwargs):
         issue: ErrorTrackingIssue = self.get_object()
-        ids: list[str] = request.data.get("ids", [])
+        ids = [str(issue_id) for issue_id in request.validated_data["ids"]]
         # Make sure we don't delete the issue being merged into (defensive of frontend bugs)
         ids = [x for x in ids if x != str(issue.id)]
         issue.merge(issue_ids=ids)

--- a/products/error_tracking/backend/api/test/test_error_tracking_api.py
+++ b/products/error_tracking/backend/api/test/test_error_tracking_api.py
@@ -171,6 +171,23 @@ class TestErrorTracking(APIBaseTest):
         assert ErrorTrackingIssueFingerprintV2.objects.filter(fingerprint="fingerprint_two", version=1).exists()
         assert ErrorTrackingIssue.objects.count() == 1
 
+    def test_issue_merge_requires_ids(self):
+        issue = self.create_issue(fingerprints=["fingerprint_one"])
+
+        response = self.client.post(
+            f"/api/environments/{self.team.id}/error_tracking/issues/{issue.id}/merge",
+            data={},
+            format="json",
+        )
+
+        assert response.status_code == 400
+        assert response.json() == {
+            "type": "validation_error",
+            "code": "required",
+            "detail": "This field is required.",
+            "attr": "ids",
+        }
+
     def test_can_start_symbol_set_upload(self) -> None:
         chunk_id = uuid7()
         response = self.client.post(

--- a/products/error_tracking/frontend/generated/api.schemas.ts
+++ b/products/error_tracking/frontend/generated/api.schemas.ts
@@ -293,6 +293,16 @@ export interface PatchedErrorTrackingIssueFullApi {
     readonly cohort?: PatchedErrorTrackingIssueFullApiCohort
 }
 
+export interface ErrorTrackingIssueMergeRequestApi {
+    /** IDs of the issues to merge into the current issue. */
+    ids: string[]
+}
+
+export interface ErrorTrackingIssueMergeResponseApi {
+    /** Whether the merge completed successfully. */
+    success: boolean
+}
+
 export interface ErrorTrackingReleaseApi {
     readonly id: string
     hash_id: string

--- a/products/error_tracking/frontend/generated/api.ts
+++ b/products/error_tracking/frontend/generated/api.ts
@@ -18,6 +18,8 @@ import type {
     ErrorTrackingGroupingRuleApi,
     ErrorTrackingGroupingRulesListParams,
     ErrorTrackingIssueFullApi,
+    ErrorTrackingIssueMergeRequestApi,
+    ErrorTrackingIssueMergeResponseApi,
     ErrorTrackingIssuesListParams,
     ErrorTrackingReleaseApi,
     ErrorTrackingReleasesList2Params,
@@ -719,14 +721,14 @@ export const getErrorTrackingIssuesMergeCreateUrl = (projectId: string, id: stri
 export const errorTrackingIssuesMergeCreate = async (
     projectId: string,
     id: string,
-    errorTrackingIssueFullApi: NonReadonly<ErrorTrackingIssueFullApi>,
+    errorTrackingIssueMergeRequestApi: ErrorTrackingIssueMergeRequestApi,
     options?: RequestInit
-): Promise<void> => {
-    return apiMutator<void>(getErrorTrackingIssuesMergeCreateUrl(projectId, id), {
+): Promise<ErrorTrackingIssueMergeResponseApi> => {
+    return apiMutator<ErrorTrackingIssueMergeResponseApi>(getErrorTrackingIssuesMergeCreateUrl(projectId, id), {
         ...options,
         method: 'POST',
         headers: { 'Content-Type': 'application/json', ...options?.headers },
-        body: JSON.stringify(errorTrackingIssueFullApi),
+        body: JSON.stringify(errorTrackingIssueMergeRequestApi),
     })
 }
 

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -14072,6 +14072,16 @@ export namespace Schemas {
       readonly cohort: ErrorTrackingIssueFullCohort;
     }
 
+    export interface ErrorTrackingIssueMergeRequest {
+      /** IDs of the issues to merge into the current issue. */
+      ids: string[];
+    }
+
+    export interface ErrorTrackingIssueMergeResponse {
+      /** Whether the merge completed successfully. */
+      success: boolean;
+    }
+
     export interface ErrorTrackingRelease {
       readonly id: string;
       hash_id: string;


### PR DESCRIPTION
## Problem

The error tracking issue merge endpoint accepted `{ ids: [...] }` at runtime, but the OpenAPI schema described it as a full issue payload. That made generated clients incorrect and blocked safe MCP generation for merge.

## Changes

- declare explicit request and response serializers for the issue merge action
- validate merge requests through `@validated_request`
- add a backend regression test for missing `ids`
- regenerate generated frontend and MCP API types that consume the OpenAPI schema

## How did you test this code?

- `uv run pytest products/error_tracking/backend/api/test/test_error_tracking_api.py -k issue_merge`
- `DEBUG=1 OPENAPI_INCLUDE_INTERNAL=1 OPENAPI_MOCK_INTERNAL_API_SECRET=1 uv run python manage.py spectacular --file frontend/tmp/openapi.json --format openapi-json`
- regenerated frontend and MCP types from the updated schema

## Publish to changelog?

no

## Docs update

No docs update needed. Schema and generated type fix only.
