### PR TITLE
fix(surveys): improve results loading states

### DIFF
--- a/frontend/src/lib/lemon-ui/LemonToast/LemonToast.tsx
+++ b/frontend/src/lib/lemon-ui/LemonToast/LemonToast.tsx
@@ -130,6 +130,20 @@ export const lemonToast = {
         })
         return id
     },
+    loading(message: string | JSX.Element, { button, ...toastOptions }: ToastOptionsWithButton = {}) {
+        const options = ensureToastId(toastOptions, 'loading', message)
+        const id = options.toastId!
+        queueMicrotask(() => {
+            if (cancelledIds.delete(id)) {
+                return
+            }
+            toast.loading(<ToastContent type="info" message={message} button={button} id={id} />, {
+                icon: <Spinner />,
+                ...options,
+            })
+        })
+        return id
+    },
     success(message: string | JSX.Element, { button, ...toastOptions }: ToastOptionsWithButton = {}) {
         const options = ensureToastId(toastOptions, 'success', message)
         const id = options.toastId!

--- a/frontend/src/scenes/surveys/SurveyStatsSummary.tsx
+++ b/frontend/src/scenes/surveys/SurveyStatsSummary.tsx
@@ -306,9 +306,13 @@ export const SurveyStatsSummary = memo(function SurveyStatsSummary(): JSX.Elemen
         surveyRates,
         surveyBaseStatsLoading,
         surveyDismissedAndSentCountLoading,
+        resultsRequeryInProgress,
     } = useValues(surveyLogic)
 
-    if (surveyBaseStatsLoading || surveyDismissedAndSentCountLoading) {
+    if (
+        !processedSurveyStats &&
+        (surveyBaseStatsLoading || surveyDismissedAndSentCountLoading || resultsRequeryInProgress)
+    ) {
         return <SurveyStatsSummarySkeleton />
     }
 

--- a/frontend/src/scenes/surveys/SurveyView.tsx
+++ b/frontend/src/scenes/surveys/SurveyView.tsx
@@ -65,6 +65,8 @@ import {
     SurveyQuestionType,
 } from '~/types'
 
+import { SurveyResultsRefreshStatus } from './components/SurveyResultsRefreshStatus'
+import { NEW_SURVEY } from './constants'
 import { SurveyHeadline } from './SurveyHeadline'
 import { canUseSurveyWizard, getSurveyResponse, isThumbQuestion } from './utils'
 
@@ -106,6 +108,7 @@ function SurveyViewLegacy({ id }: { id: string }): JSX.Element {
     const { currentOrganization } = useValues(organizationLogic)
     const { canCopyToProject } = useValues(interProjectCopyLogic)
     const { push } = useActions(router)
+    const isInitialSurveyLoad = surveyLoading && survey.id === NEW_SURVEY.id
 
     const hasMultipleProjects = currentOrganization?.teams && currentOrganization.teams.length > 1
 
@@ -116,7 +119,7 @@ function SurveyViewLegacy({ id }: { id: string }): JSX.Element {
     useFileSystemLogView({
         type: 'survey',
         ref: surveyId,
-        enabled: Boolean(surveyId && !surveyLoading),
+        enabled: Boolean(surveyId && !isInitialSurveyLoad),
     })
 
     useEffect(() => {
@@ -129,7 +132,7 @@ function SurveyViewLegacy({ id }: { id: string }): JSX.Element {
 
     return (
         <div>
-            {surveyLoading ? (
+            {isInitialSurveyLoad ? (
                 <LemonSkeleton />
             ) : (
                 <SceneContent>
@@ -421,6 +424,7 @@ export function SurveyResult({ disableEventsTable }: { disableEventsTable?: bool
         surveyLoading,
         surveyAsInsightURL,
         isAnyResultsLoading,
+        resultsRequeryInProgress,
         processedSurveyStats,
         archivedResponseUuids,
         isSurveyHeadlineEnabled,
@@ -430,6 +434,7 @@ export function SurveyResult({ disableEventsTable }: { disableEventsTable?: bool
         propertyFilters,
     } = useValues(surveyLogic)
     const { clearFilters } = useActions(surveyLogic)
+    const isInitialSurveyLoad = surveyLoading && survey.id === NEW_SURVEY.id
 
     /**
      * custom column renderer that does:
@@ -486,64 +491,78 @@ export function SurveyResult({ disableEventsTable }: { disableEventsTable?: bool
     }, [survey.questions])
 
     const atLeastOneResponse = !!processedSurveyStats?.[SurveyEventName.SENT].total_count
+    const isRefreshingResults = resultsRequeryInProgress || isAnyResultsLoading
     return (
         <div className="deprecated-space-y-4">
             {isSurveyHeadlineEnabled && <SurveyHeadline />}
             <SurveyResponseFilters />
-            <SurveyStatsSummary />
-            {isAnyResultsLoading || atLeastOneResponse ? (
+            {isRefreshingResults || atLeastOneResponse ? (
                 <>
-                    <SurveyResponsesByQuestionV2 />
-                    <LemonButton
-                        type="primary"
-                        data-attr="survey-results-explore"
-                        icon={<IconGraph />}
-                        to={surveyAsInsightURL}
-                        className="max-w-40"
+                    <SurveyResultsRefreshStatus visible={isRefreshingResults} />
+                    <div
+                        aria-busy={isRefreshingResults}
+                        className={
+                            isRefreshingResults
+                                ? 'opacity-75 transition-opacity duration-200 ease-out'
+                                : 'opacity-100 transition-opacity duration-200 ease-out'
+                        }
                     >
-                        Explore results
-                    </LemonButton>
-                    {!disableEventsTable &&
-                        (surveyLoading ? (
-                            <LemonSkeleton />
-                        ) : (
-                            <div className="survey-table-results">
-                                <Query
-                                    query={dataTableQuery}
-                                    context={{
-                                        columns: surveyColumnRenderers,
-                                        rowProps: (record: unknown) => {
-                                            // "mute" archived records
-                                            if (typeof record !== 'object' || !record || !('result' in record)) {
-                                                return {}
-                                            }
-                                            const result = record.result
-                                            if (!Array.isArray(result)) {
-                                                return {}
-                                            }
-                                            return {
-                                                className:
-                                                    result[0]?.uuid && archivedResponseUuids.has(result[0].uuid)
-                                                        ? 'opacity-50'
-                                                        : undefined,
-                                            }
-                                        },
-                                    }}
-                                />
-                            </div>
-                        ))}
+                        <SurveyStatsSummary />
+                        <SurveyResponsesByQuestionV2 />
+                        <LemonButton
+                            type="primary"
+                            data-attr="survey-results-explore"
+                            icon={<IconGraph />}
+                            to={surveyAsInsightURL}
+                            className="max-w-40"
+                        >
+                            Explore results
+                        </LemonButton>
+                        {!disableEventsTable &&
+                            (isInitialSurveyLoad ? (
+                                <LemonSkeleton />
+                            ) : (
+                                <div className="survey-table-results">
+                                    <Query
+                                        query={dataTableQuery}
+                                        context={{
+                                            columns: surveyColumnRenderers,
+                                            rowProps: (record: unknown) => {
+                                                // "mute" archived records
+                                                if (typeof record !== 'object' || !record || !('result' in record)) {
+                                                    return {}
+                                                }
+                                                const result = record.result
+                                                if (!Array.isArray(result)) {
+                                                    return {}
+                                                }
+                                                return {
+                                                    className:
+                                                        result[0]?.uuid && archivedResponseUuids.has(result[0].uuid)
+                                                            ? 'opacity-50'
+                                                            : undefined,
+                                                }
+                                            },
+                                        }}
+                                    />
+                                </div>
+                            ))}
+                    </div>
                 </>
             ) : (
-                <SurveyNoResponsesBanner
-                    type="survey"
-                    isFiltered={hasActiveFilters}
-                    onClearFilters={hasActiveFilters ? clearFilters : undefined}
-                    activeFilterTypes={{
-                        dateRange: hasActiveDateRange,
-                        answerFilters: hasActiveAnswerFilters,
-                        propertyFilters: propertyFilters.length > 0,
-                    }}
-                />
+                <>
+                    <SurveyStatsSummary />
+                    <SurveyNoResponsesBanner
+                        type="survey"
+                        isFiltered={hasActiveFilters}
+                        onClearFilters={hasActiveFilters ? clearFilters : undefined}
+                        activeFilterTypes={{
+                            dateRange: hasActiveDateRange,
+                            answerFilters: hasActiveAnswerFilters,
+                            propertyFilters: propertyFilters.length > 0,
+                        }}
+                    />
+                </>
             )}
         </div>
     )

--- a/frontend/src/scenes/surveys/SurveyViewRedesign/SurveyViewRedesign.tsx
+++ b/frontend/src/scenes/surveys/SurveyViewRedesign/SurveyViewRedesign.tsx
@@ -52,6 +52,8 @@ import {
     SurveyQuestionType,
 } from '~/types'
 
+import { SurveyResultsRefreshStatus } from '../components/SurveyResultsRefreshStatus'
+import { NEW_SURVEY } from '../constants'
 import { SurveyDraftContent } from './SurveyDraftContent'
 import { SurveyResultsFiltersBar } from './SurveyFilters'
 import { SurveyDetailsPanel, SurveyExportPanel, SurveyNotificationsPanel } from './SurveySidebar'
@@ -70,6 +72,7 @@ export function SurveyViewRedesign(): JSX.Element {
     const { canCopyToProject } = useValues(interProjectCopyLogic)
     const { push } = useActions(router)
     const { location, searchParams, hashParams } = useValues(router)
+    const isInitialSurveyLoad = surveyLoading && survey.id === NEW_SURVEY.id
 
     const hasMultipleProjects = currentOrganization?.teams && currentOrganization.teams.length > 1
     const surveyIdForTransfer = survey?.id && survey.id !== 'new' ? survey.id : null
@@ -200,7 +203,7 @@ export function SurveyViewRedesign(): JSX.Element {
         validPanelTabKeys,
     ])
 
-    if (surveyLoading) {
+    if (isInitialSurveyLoad) {
         return <LemonSkeleton />
     }
 
@@ -463,6 +466,7 @@ function SurveySummaryContent({ onViewResponses }: { onViewResponses: () => void
     const {
         survey,
         isAnyResultsLoading,
+        resultsRequeryInProgress,
         processedSurveyStats,
         isSurveyHeadlineEnabled,
         hasActiveFilters,
@@ -473,8 +477,9 @@ function SurveySummaryContent({ onViewResponses }: { onViewResponses: () => void
     const { clearFilters } = useActions(surveyLogic)
 
     const atLeastOneResponse = !!processedSurveyStats?.[SurveyEventName.SENT].total_count
+    const isRefreshingResults = resultsRequeryInProgress || isAnyResultsLoading
 
-    if (!isAnyResultsLoading && !atLeastOneResponse) {
+    if (!isRefreshingResults && !atLeastOneResponse) {
         return (
             <div className="px-4 pb-4">
                 <div className="mx-auto w-full max-w-[1200px] space-y-4">
@@ -499,45 +504,72 @@ function SurveySummaryContent({ onViewResponses }: { onViewResponses: () => void
         <div className="px-4 pb-4">
             <div className="mx-auto w-full max-w-[1200px] space-y-4">
                 <SurveyResultsFiltersBar />
-                <SurveyStatsSummary />
-                {isSurveyHeadlineEnabled && <SurveyHeadline />}
-
-                <div className="flex flex-col gap-2">
-                    {survey.questions.map((question, i) => {
-                        if (!question.id || question.type === SurveyQuestionType.Link) {
-                            return null
-                        }
-                        return (
-                            <div key={question.id} className="flex flex-col gap-2">
-                                <SurveyQuestionVisualization question={question} questionIndex={i} />
-                                <LemonDivider />
-                            </div>
-                        )
-                    })}
-                </div>
-                <LemonButton
-                    type="tertiary"
-                    data-attr="survey-results-view-responses"
-                    onClick={onViewResponses}
-                    size="small"
+                <SurveyResultsRefreshStatus visible={isRefreshingResults} />
+                <div
+                    aria-busy={isRefreshingResults}
+                    className={
+                        isRefreshingResults
+                            ? 'space-y-4 opacity-75 transition-opacity duration-200 ease-out'
+                            : 'space-y-4 opacity-100 transition-opacity duration-200 ease-out'
+                    }
                 >
-                    Looking for all responses?
-                </LemonButton>
+                    <SurveyStatsSummary />
+                    {isSurveyHeadlineEnabled && <SurveyHeadline />}
+
+                    <div className="flex flex-col gap-2">
+                        {survey.questions.map((question, i) => {
+                            if (!question.id || question.type === SurveyQuestionType.Link) {
+                                return null
+                            }
+                            return (
+                                <div key={question.id} className="flex flex-col gap-2">
+                                    <SurveyQuestionVisualization question={question} questionIndex={i} />
+                                    <LemonDivider />
+                                </div>
+                            )
+                        })}
+                    </div>
+                    <LemonButton
+                        type="tertiary"
+                        data-attr="survey-results-view-responses"
+                        onClick={onViewResponses}
+                        size="small"
+                    >
+                        Looking for all responses?
+                    </LemonButton>
+                </div>
             </div>
         </div>
     )
 }
 
 function SurveyResponsesContent(): JSX.Element {
-    const { dataTableQuery, surveyLoading, archivedResponseUuids } = useValues(surveyLogic)
+    const {
+        dataTableQuery,
+        survey,
+        surveyLoading,
+        archivedResponseUuids,
+        isAnyResultsLoading,
+        resultsRequeryInProgress,
+    } = useValues(surveyLogic)
+    const isInitialSurveyLoad = surveyLoading && survey.id === NEW_SURVEY.id
+    const isRefreshingResults = resultsRequeryInProgress || isAnyResultsLoading
 
     return (
         <div className="px-4 pb-4 space-y-4">
             <SurveyResultsFiltersBar />
-            {surveyLoading ? (
+            <SurveyResultsRefreshStatus visible={isRefreshingResults} />
+            {isInitialSurveyLoad ? (
                 <LemonSkeleton />
             ) : (
-                <div className="survey-table-results">
+                <div
+                    aria-busy={isRefreshingResults}
+                    className={
+                        isRefreshingResults
+                            ? 'survey-table-results opacity-75 transition-opacity duration-200 ease-out'
+                            : 'survey-table-results opacity-100 transition-opacity duration-200 ease-out'
+                    }
+                >
                     <Query
                         query={dataTableQuery}
                         context={{

--- a/frontend/src/scenes/surveys/components/SurveyResultsRefreshStatus.tsx
+++ b/frontend/src/scenes/surveys/components/SurveyResultsRefreshStatus.tsx
@@ -1,0 +1,21 @@
+import { LoadingBar } from 'lib/lemon-ui/LoadingBar'
+
+export function SurveyResultsRefreshStatus({ visible }: { visible: boolean }): JSX.Element {
+    return (
+        <div
+            className={visible ? 'h-2' : 'h-0'}
+            aria-live="polite"
+            aria-atomic="true"
+            role="status"
+            aria-label={visible ? 'Refreshing results' : undefined}
+        >
+            {visible ? (
+                <LoadingBar
+                    loadId="survey-results-refresh"
+                    wrapperClassName="w-full max-w-none my-0"
+                    className="h-1 rounded-full bg-border"
+                />
+            ) : null}
+        </div>
+    )
+}

--- a/frontend/src/scenes/surveys/components/SurveysTable.tsx
+++ b/frontend/src/scenes/surveys/components/SurveysTable.tsx
@@ -58,7 +58,9 @@ export function SurveysTable(): JSX.Element {
 
     const hasMultipleProjects = currentOrganization?.teams && currentOrganization.teams.length > 1
 
-    const shouldShowEmptyState = !dataLoading && surveys.length === 0
+    const isInitialDataLoad = surveys.length === 0 && hasNextPage
+    const isTableLoading = dataLoading || isInitialDataLoad
+    const shouldShowEmptyState = !isTableLoading && surveys.length === 0
 
     if (shouldShowEmptyState) {
         return <SurveysEmptyState />
@@ -144,16 +146,18 @@ export function SurveysTable(): JSX.Element {
                 nouns={['survey', 'surveys']}
                 data-attr="surveys-table"
                 emptyState={tab === SurveysTabs.Active ? 'No surveys. Create a new survey?' : 'No surveys found'}
-                loading={dataLoading}
+                loading={isTableLoading}
                 footer={
                     (searchTerm ? hasNextSearchPage : hasNextPage) && (
                         <div className="flex justify-center p-1">
                             <LemonButton
                                 onClick={searchTerm ? loadNextSearchPage : loadNextPage}
                                 className="min-w-full text-center"
-                                disabledReason={dataLoading ? 'Loading surveys' : ''}
+                                disabledReason={isTableLoading ? 'Loading surveys' : ''}
                             >
-                                <span className="flex-1 text-center">{dataLoading ? 'Loading...' : 'Load more'}</span>
+                                <span className="flex-1 text-center">
+                                    {isTableLoading ? 'Loading...' : 'Load more'}
+                                </span>
                             </LemonButton>
                         </div>
                     )

--- a/frontend/src/scenes/surveys/components/question-visualizations/SurveyQuestionVisualization.tsx
+++ b/frontend/src/scenes/surveys/components/question-visualizations/SurveyQuestionVisualization.tsx
@@ -195,8 +195,7 @@ function QuestionLoadingSkeleton({ question }: { question: SurveyQuestion }): JS
 }
 
 export function SurveyQuestionVisualization({ question, questionIndex, demoData }: Props): JSX.Element | null {
-    const { enrichedConsolidatedSurveyResults, consolidatedSurveyResultsLoading, surveyBaseStatsLoading } =
-        useValues(surveyLogic)
+    const { enrichedConsolidatedSurveyResults, isAnyResultsLoading, resultsRequeryInProgress } = useValues(surveyLogic)
 
     if (demoData) {
         return (
@@ -244,8 +243,9 @@ export function SurveyQuestionVisualization({ question, questionIndex, demoData 
 
     const processedData: QuestionProcessedResponses | undefined =
         enrichedConsolidatedSurveyResults?.responsesByQuestion[question.id]
+    const isRefreshingResults = resultsRequeryInProgress || isAnyResultsLoading
 
-    if (consolidatedSurveyResultsLoading || surveyBaseStatsLoading || !processedData) {
+    if (!processedData) {
         return (
             <div className="flex flex-col gap-2">
                 <QuestionTitle question={question} questionIndex={questionIndex} />
@@ -258,6 +258,18 @@ export function SurveyQuestionVisualization({ question, questionIndex, demoData 
     }
 
     if (processedData.totalResponses === 0 || processedData.data.length === 0) {
+        if (isRefreshingResults) {
+            return (
+                <div className="flex flex-col gap-2">
+                    <QuestionTitle question={question} questionIndex={questionIndex} />
+
+                    <div className="flex flex-col gap-4">
+                        <QuestionLoadingSkeleton question={question} />
+                    </div>
+                </div>
+            )
+        }
+
         const skipCount = 'noResponseCount' in processedData ? processedData.noResponseCount : 0
         return (
             <div className="flex flex-col gap-2">

--- a/frontend/src/scenes/surveys/surveyLogic.test.ts
+++ b/frontend/src/scenes/surveys/surveyLogic.test.ts
@@ -1,6 +1,7 @@
 import { router } from 'kea-router'
 import { expectLogic, partial } from 'kea-test-utils'
 
+import api from 'lib/api'
 import { dayjs } from 'lib/dayjs'
 import {
     mergeResponsesByQuestion,
@@ -1854,6 +1855,45 @@ describe('survey stats calculation', () => {
             processedSurveyStats: expectedStats,
             surveyRates: expectedRates,
         })
+    })
+})
+
+describe('surveyLogic archived response refresh', () => {
+    let logic: ReturnType<typeof surveyLogic.build>
+
+    beforeEach(async () => {
+        initKeaTests()
+
+        useMocks({
+            get: {
+                '/api/projects/:team/surveys/': () => [200, { count: 0, results: [], next: null, previous: null }],
+                '/api/projects/:team/surveys/test-survey/': () => [200, createPersistedSurvey()],
+                '/api/projects/:team/surveys/test-survey/archived-response-uuids/': () => [200, []],
+            },
+        })
+
+        jest.spyOn(api, 'queryHogQL').mockResolvedValue({ results: [] } as any)
+        jest.spyOn(api.surveys, 'archiveResponse').mockResolvedValue({ success: true })
+
+        logic = surveyLogic({ id: 'test-survey' })
+        logic.mount()
+        await expectLogic(logic).toFinishAllListeners()
+
+        jest.clearAllMocks()
+    })
+
+    it('reloads survey results explicitly after archiving a response', async () => {
+        await expectLogic(logic, () => {
+            logic.actions.archiveResponse('response-1')
+        }).toDispatchActions([
+            'archiveResponse',
+            'startResultsRequery',
+            'loadArchivedResponseUuidsSuccess',
+            'loadSurveyBaseStats',
+            'loadSurveyDismissedAndSentCount',
+        ])
+
+        expect(api.surveys.archiveResponse).toHaveBeenCalledWith('test-survey', 'response-1')
     })
 })
 

--- a/frontend/src/scenes/surveys/surveyLogic.test.ts
+++ b/frontend/src/scenes/surveys/surveyLogic.test.ts
@@ -1495,6 +1495,52 @@ describe('surveyLogic filters for surveys responses', () => {
         }).toDispatchActions(['setAnswerFilters', 'loadSurveyBaseStats', 'loadSurveyDismissedAndSentCount'])
     })
 
+    it('clears filters with a single results reload', async () => {
+        await expectLogic(logic, () => {
+            logic.actions.loadSurveySuccess(MULTIPLE_CHOICE_SURVEY)
+            logic.actions.setAnswerFilters(
+                [
+                    {
+                        key: SurveyEventProperties.SURVEY_RESPONSE,
+                        value: 'test response',
+                        operator: PropertyOperator.IContains,
+                        type: PropertyFilterType.Event,
+                    },
+                ],
+                false
+            )
+            logic.actions.setPropertyFilters(
+                [
+                    {
+                        key: 'email',
+                        value: 'test@posthog.com',
+                        operator: PropertyOperator.Exact,
+                        type: PropertyFilterType.Person,
+                    },
+                ],
+                false
+            )
+            logic.actions.setDateRange(
+                {
+                    date_from: dayjs().subtract(7, 'day').format('YYYY-MM-DD'),
+                    date_to: dayjs().format('YYYY-MM-DD'),
+                },
+                false
+            )
+        }).toDispatchActions(['loadSurveySuccess'])
+
+        await expectLogic(logic, () => {
+            logic.actions.clearFilters()
+        }).toDispatchActions([
+            'clearFilters',
+            'setAnswerFilters',
+            'setPropertyFilters',
+            'setDateRange',
+            'loadSurveyBaseStats',
+            'loadSurveyDismissedAndSentCount',
+        ])
+    })
+
     describe('interval selection', () => {
         it('starts with null interval', async () => {
             await expectLogic(logic).toMatchValues({

--- a/frontend/src/scenes/surveys/surveyLogic.tsx
+++ b/frontend/src/scenes/surveys/surveyLogic.tsx
@@ -74,6 +74,7 @@ import {
 } from '~/types'
 
 import {
+    LOADING_SURVEY_RESULTS_TOAST_ID,
     NEW_SURVEY,
     NewSurvey,
     SURVEY_CREATED_SOURCE,
@@ -528,7 +529,10 @@ export const surveyLogic = kea<surveyLogicType>([
         resetSurveyAdaptiveSampling: true,
         resetSurveyResponseLimits: true,
         setFlagPropertyErrors: (errors: any) => ({ errors }),
-        setPropertyFilters: (propertyFilters: AnyPropertyFilter[]) => ({ propertyFilters }),
+        setPropertyFilters: (propertyFilters: AnyPropertyFilter[], reloadResults: boolean = true) => ({
+            propertyFilters,
+            reloadResults,
+        }),
         setAnswerFilters: (filters: EventPropertyFilter[], reloadResults: boolean = true) => ({
             filters,
             reloadResults,
@@ -543,6 +547,8 @@ export const surveyLogic = kea<surveyLogicType>([
         setShowArchivedResponses: (show: boolean) => ({ show }),
         archiveResponse: (responseUuid: string) => ({ responseUuid }),
         unarchiveResponse: (responseUuid: string) => ({ responseUuid }),
+        startResultsRequery: true,
+        markResultsRequeryCompleted: true,
         toggleSurveyNotificationEnabled: (notificationId: string, enabled: boolean) => ({
             notificationId,
             enabled,
@@ -914,10 +920,24 @@ export const surveyLogic = kea<surveyLogicType>([
     })),
     listeners(({ actions, values }) => {
         let reloadDebounceTimer: ReturnType<typeof setTimeout> | null = null
+        const maybeCompleteResultsRequery = (): void => {
+            setTimeout(() => {
+                if (!values.resultsRequeryInProgress || values.isAnyResultsLoading) {
+                    return
+                }
+
+                actions.markResultsRequeryCompleted()
+            }, 0)
+        }
         const reloadAllSurveyResults = (): void => {
             if (reloadDebounceTimer) {
                 clearTimeout(reloadDebounceTimer)
             }
+
+            if (!values.resultsRequeryInProgress) {
+                actions.startResultsRequery()
+            }
+
             reloadDebounceTimer = setTimeout(() => {
                 actions.loadSurveyBaseStats()
                 actions.loadSurveyDismissedAndSentCount()
@@ -1022,6 +1042,11 @@ export const surveyLogic = kea<surveyLogicType>([
                 } catch {
                     // Person enrichment is best-effort — don't block survey results
                 }
+
+                maybeCompleteResultsRequery()
+            },
+            loadConsolidatedSurveyResultsFailure: () => {
+                maybeCompleteResultsRequery()
             },
             loadSurveyBaseStatsSuccess: () => {
                 if (!values.isSurveyHeadlineEnabled || !values.dataProcessingAccepted) {
@@ -1041,6 +1066,24 @@ export const surveyLogic = kea<surveyLogicType>([
                 if (needsGeneration || isStale) {
                     actions.loadSurveyHeadline(true)
                 }
+            },
+            loadSurveyBaseStatsFailure: () => {
+                maybeCompleteResultsRequery()
+            },
+            loadSurveyDismissedAndSentCountSuccess: () => {
+                maybeCompleteResultsRequery()
+            },
+            loadSurveyDismissedAndSentCountFailure: () => {
+                maybeCompleteResultsRequery()
+            },
+            startResultsRequery: () => {
+                lemonToast.loading('Refreshing results...', {
+                    toastId: LOADING_SURVEY_RESULTS_TOAST_ID,
+                    autoClose: false,
+                })
+            },
+            markResultsRequeryCompleted: () => {
+                lemonToast.dismiss(LOADING_SURVEY_RESULTS_TOAST_ID)
             },
             resetSurveyResponseLimits: () => {
                 actions.setSurveyValue('responses_limit', null)
@@ -1094,8 +1137,10 @@ export const surveyLogic = kea<surveyLogicType>([
                     5
                 )
             },
-            setPropertyFilters: () => {
-                reloadAllSurveyResults()
+            setPropertyFilters: ({ reloadResults }) => {
+                if (reloadResults) {
+                    reloadAllSurveyResults()
+                }
             },
             setAnswerFilters: ({ reloadResults }) => {
                 if (reloadResults) {
@@ -1109,18 +1154,23 @@ export const surveyLogic = kea<surveyLogicType>([
             },
             clearFilters: () => {
                 const survey = values.survey as Survey
-                actions.setAnswerFilters(values.defaultAnswerFilters)
-                actions.setPropertyFilters([])
-                actions.setDateRange({
-                    date_from: getSurveyStartDateForQuery(survey),
-                    date_to: getSurveyEndDateForQuery(survey),
-                })
+                actions.setAnswerFilters(values.defaultAnswerFilters, false)
+                actions.setPropertyFilters([], false)
+                actions.setDateRange(
+                    {
+                        date_from: getSurveyStartDateForQuery(survey),
+                        date_to: getSurveyEndDateForQuery(survey),
+                    },
+                    false
+                )
+                reloadAllSurveyResults()
             },
             setShowArchivedResponses: () => {
                 reloadAllSurveyResults()
             },
             archiveResponse: async ({ responseUuid }) => {
                 try {
+                    actions.startResultsRequery()
                     await api.surveys.archiveResponse(values.survey.id, responseUuid)
 
                     const updatedUuids = new Set<string>(values.archivedResponseUuids)
@@ -1129,6 +1179,7 @@ export const surveyLogic = kea<surveyLogicType>([
 
                     lemonToast.success('Response archived')
                 } catch (error) {
+                    actions.markResultsRequeryCompleted()
                     lemonToast.error('Failed to archive response')
                     posthog.captureException(error, {
                         action: 'archive-survey-response',
@@ -1140,6 +1191,7 @@ export const surveyLogic = kea<surveyLogicType>([
             },
             unarchiveResponse: async ({ responseUuid }) => {
                 try {
+                    actions.startResultsRequery()
                     await api.surveys.unarchiveResponse(values.survey.id, responseUuid)
 
                     const updatedUuids = new Set<string>(values.archivedResponseUuids)
@@ -1148,6 +1200,7 @@ export const surveyLogic = kea<surveyLogicType>([
 
                     lemonToast.success('Response unarchived')
                 } catch (error) {
+                    actions.markResultsRequeryCompleted()
                     lemonToast.error('Failed to unarchive response')
                     posthog.captureException(error, {
                         action: 'unarchive-survey-response',
@@ -1196,6 +1249,15 @@ export const surveyLogic = kea<surveyLogicType>([
             { persist: true },
             {
                 setFilterSurveyStatsByDistinctId: (_, { filterByDistinctId }) => filterByDistinctId,
+            },
+        ],
+        resultsRequeryInProgress: [
+            false,
+            {
+                startResultsRequery: () => true,
+                markResultsRequeryCompleted: () => false,
+                loadSurveySuccess: () => false,
+                resetSurvey: () => false,
             },
         ],
         isEditingSurvey: [
@@ -1527,13 +1589,24 @@ export const surveyLogic = kea<surveyLogicType>([
             },
         ],
         isAnyResultsLoading: [
-            (s) => [s.surveyBaseStatsLoading, s.surveyDismissedAndSentCountLoading, s.consolidatedSurveyResultsLoading],
+            (s) => [
+                s.archivedResponseUuidsLoading,
+                s.surveyBaseStatsLoading,
+                s.surveyDismissedAndSentCountLoading,
+                s.consolidatedSurveyResultsLoading,
+            ],
             (
+                archivedResponseUuidsLoading: boolean,
                 surveyBaseStatsLoading: boolean,
                 surveyDismissedAndSentCountLoading: boolean,
                 consolidatedSurveyResultsLoading: boolean
             ) => {
-                return consolidatedSurveyResultsLoading || surveyBaseStatsLoading || surveyDismissedAndSentCountLoading
+                return (
+                    archivedResponseUuidsLoading ||
+                    consolidatedSurveyResultsLoading ||
+                    surveyBaseStatsLoading ||
+                    surveyDismissedAndSentCountLoading
+                )
             },
         ],
         defaultAnswerFilters: [

--- a/frontend/src/scenes/surveys/surveyLogic.tsx
+++ b/frontend/src/scenes/surveys/surveyLogic.tsx
@@ -761,9 +761,10 @@ export const surveyLogic = kea<surveyLogicType>([
                         },
                     }
                 )
-                actions.setBaseStatsResults(response.results as SurveyBaseStatsResult)
+                const results = (response.results as SurveyBaseStatsResult | undefined) ?? null
+                actions.setBaseStatsResults(results)
                 actions.loadConsolidatedSurveyResults()
-                return response.results as SurveyBaseStatsResult
+                return results
             },
         },
         surveyDismissedAndSentCount: {

--- a/frontend/src/scenes/surveys/surveyLogic.tsx
+++ b/frontend/src/scenes/surveys/surveyLogic.tsx
@@ -998,7 +998,13 @@ export const surveyLogic = kea<surveyLogicType>([
                 }
             },
             loadArchivedResponseUuidsSuccess: () => {
-                if (values.survey.id !== NEW_SURVEY.id && values.survey.start_date) {
+                // Initial survey load fetches archived UUIDs before any results requery is active.
+                // Archive/unarchive flows update this state manually and trigger the results reload explicitly.
+                if (
+                    values.survey.id !== NEW_SURVEY.id &&
+                    values.survey.start_date &&
+                    !values.resultsRequeryInProgress
+                ) {
                     actions.loadSurveyBaseStats()
                     actions.loadSurveyDismissedAndSentCount()
                 }
@@ -1183,6 +1189,8 @@ export const surveyLogic = kea<surveyLogicType>([
                     const updatedUuids = new Set<string>(values.archivedResponseUuids)
                     updatedUuids.add(responseUuid)
                     actions.loadArchivedResponseUuidsSuccess(updatedUuids)
+                    actions.loadSurveyBaseStats()
+                    actions.loadSurveyDismissedAndSentCount()
 
                     lemonToast.success('Response archived')
                 } catch (error) {
@@ -1204,6 +1212,8 @@ export const surveyLogic = kea<surveyLogicType>([
                     const updatedUuids = new Set<string>(values.archivedResponseUuids)
                     updatedUuids.delete(responseUuid)
                     actions.loadArchivedResponseUuidsSuccess(updatedUuids)
+                    actions.loadSurveyBaseStats()
+                    actions.loadSurveyDismissedAndSentCount()
 
                     lemonToast.success('Response unarchived')
                 } catch (error) {

--- a/frontend/src/scenes/surveys/surveyLogic.tsx
+++ b/frontend/src/scenes/surveys/surveyLogic.tsx
@@ -1,4 +1,4 @@
-import { actions, afterMount, connect, kea, key, listeners, path, props, reducers, selectors } from 'kea'
+import { actions, afterMount, connect, events, kea, key, listeners, path, props, reducers, selectors } from 'kea'
 import { forms } from 'kea-forms'
 import { loaders } from 'kea-loaders'
 import { actionToUrl, router, urlToAction } from 'kea-router'
@@ -918,27 +918,33 @@ export const surveyLogic = kea<surveyLogicType>([
             },
         ],
     })),
-    listeners(({ actions, values }) => {
-        let reloadDebounceTimer: ReturnType<typeof setTimeout> | null = null
+    listeners(({ actions, values, cache, props }) => {
         const maybeCompleteResultsRequery = (): void => {
-            setTimeout(() => {
-                if (!values.resultsRequeryInProgress || values.isAnyResultsLoading) {
+            if (cache.resultsRequeryCompletionTimer) {
+                clearTimeout(cache.resultsRequeryCompletionTimer)
+            }
+
+            cache.resultsRequeryCompletionTimer = setTimeout(() => {
+                cache.resultsRequeryCompletionTimer = null
+
+                const mountedLogic = surveyLogic.findMounted(props)
+                if (!mountedLogic?.values.resultsRequeryInProgress || mountedLogic.values.isAnyResultsLoading) {
                     return
                 }
 
-                actions.markResultsRequeryCompleted()
+                mountedLogic.actions.markResultsRequeryCompleted()
             }, 0)
         }
         const reloadAllSurveyResults = (): void => {
-            if (reloadDebounceTimer) {
-                clearTimeout(reloadDebounceTimer)
+            if (cache.reloadDebounceTimer) {
+                clearTimeout(cache.reloadDebounceTimer)
             }
 
             if (!values.resultsRequeryInProgress) {
                 actions.startResultsRequery()
             }
 
-            reloadDebounceTimer = setTimeout(() => {
+            cache.reloadDebounceTimer = setTimeout(() => {
                 actions.loadSurveyBaseStats()
                 actions.loadSurveyDismissedAndSentCount()
             }, 300)
@@ -1008,11 +1014,13 @@ export const surveyLogic = kea<surveyLogicType>([
                 }
 
                 if (distinctIds.size === 0) {
+                    maybeCompleteResultsRequery()
                     return
                 }
 
                 const teamId = teamLogic.values.currentTeamId
                 if (!teamId) {
+                    maybeCompleteResultsRequery()
                     return
                 }
 
@@ -1049,23 +1057,21 @@ export const surveyLogic = kea<surveyLogicType>([
                 maybeCompleteResultsRequery()
             },
             loadSurveyBaseStatsSuccess: () => {
-                if (!values.isSurveyHeadlineEnabled || !values.dataProcessingAccepted) {
-                    return
+                if (values.isSurveyHeadlineEnabled && values.dataProcessingAccepted) {
+                    const currentCount = values.processedSurveyStats?.[SurveyEventName.SENT]?.total_count ?? 0
+                    const cachedCount = values.survey.headline_response_count ?? 0
+
+                    if (currentCount > 0) {
+                        const needsGeneration = !values.survey.headline_summary
+                        const isStale = currentCount > cachedCount + 5
+
+                        if (needsGeneration || isStale) {
+                            actions.loadSurveyHeadline(true)
+                        }
+                    }
                 }
 
-                const currentCount = values.processedSurveyStats?.[SurveyEventName.SENT]?.total_count ?? 0
-                const cachedCount = values.survey.headline_response_count ?? 0
-
-                if (currentCount === 0) {
-                    return
-                }
-
-                const needsGeneration = !values.survey.headline_summary
-                const isStale = currentCount > cachedCount + 5
-
-                if (needsGeneration || isStale) {
-                    actions.loadSurveyHeadline(true)
-                }
+                maybeCompleteResultsRequery()
             },
             loadSurveyBaseStatsFailure: () => {
                 maybeCompleteResultsRequery()
@@ -1230,6 +1236,19 @@ export const surveyLogic = kea<surveyLogicType>([
             },
         }
     }),
+    events(({ cache }) => ({
+        beforeUnmount: () => {
+            if (cache.reloadDebounceTimer) {
+                clearTimeout(cache.reloadDebounceTimer)
+                cache.reloadDebounceTimer = null
+            }
+
+            if (cache.resultsRequeryCompletionTimer) {
+                clearTimeout(cache.resultsRequeryCompletionTimer)
+                cache.resultsRequeryCompletionTimer = null
+            }
+        },
+    })),
     reducers({
         personNames: [
             {} as Record<string, string>,


### PR DESCRIPTION
## Problem

Survey loading on the results page felt rough in a few ways:
- empty states could flash before the underlying queries had actually finished
- updating survey metadata could briefly force the page back into a full loading state
- filter and archive changes would replace visible results with loading placeholders instead of keeping stale data visible while new results were computed

This made the surveys experience feel jumpy and harder to trust, especially when iterating on filters.

## Changes

- limit the full-page survey skeleton to the initial survey fetch so title and metadata updates do not reload the entire page
- keep stale survey results visible during refreshes and show a dedicated loading bar plus loading toast while survey results are recomputed
- suppress survey and question empty states until refreshes have actually settled, including the clear-filters and no-results-to-results transitions
- avoid multiple result reloads when clearing filters by resetting filter state atomically and issuing a single refresh
- make the surveys list empty state wait for the initial table load to finish before rendering
- add a `lemonToast.loading(...)` helper for the survey refresh toast

## How did you test this code?

- `hogli test frontend/src/scenes/surveys/surveysLogic.test.ts frontend/src/scenes/surveys/surveyLogic.test.ts`
- `pnpm --filter=@posthog/frontend typescript:check` was attempted, but `tsc` ran out of memory in this environment before completing
- I reviewed the full diff for regressions around stale-state handling, refresh completion, and empty-state gating

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

no

## Docs update

No docs update needed.

## 🤖 LLM context

Authored in Codex. Main work included:
- iterating on stale-while-refreshing survey results UX
- fixing empty-state flicker during initial loads and filter resets
- adding a loading toast plus local loading bar treatment for survey result recomputations
- reviewing the final diff and rerunning the relevant survey Jest suites before opening this PR

Follow-up scope I would keep separate from this PR: add stage-level observability for survey result refreshes, especially because the Responses tab's raw table query still runs through the generic `Query` lifecycle and is not fully represented by the new survey-specific loading state.
