### PR TITLE
feat(funnels): add empty state for incomplete dwh funnel steps

### DIFF
--- a/frontend/src/queries/nodes/InsightViz/InsightVizDisplay.tsx
+++ b/frontend/src/queries/nodes/InsightViz/InsightVizDisplay.tsx
@@ -11,6 +11,7 @@ import { FunnelCanvasLabel } from 'scenes/funnels/FunnelCanvasLabel'
 import { funnelDataLogic } from 'scenes/funnels/funnelDataLogic'
 import {
     BoxPlotMissingPropertyState,
+    FunnelDataWarehouseStepIncompleteState,
     FunnelSingleStepState,
     InsightEmptyState,
     InsightErrorState,
@@ -130,7 +131,6 @@ export function InsightVizDisplay({
 
     const { activeView } = useValues(insightNavLogic(insightProps))
 
-    const { isFunnelWithEnoughSteps, validationError, theme } = useValues(insightVizDataLogic(insightProps))
     const {
         isFunnels,
         isPaths,
@@ -149,10 +149,17 @@ export function InsightVizDisplay({
         display,
         series,
         insightData,
+        isFunnelWithEnoughSteps,
+        isFunnelWithIncompleteDataWarehouseStep,
+        validationError,
+        theme,
     } = useValues(insightVizDataLogic(insightProps))
     const { loadData } = useActions(insightVizDataLogic(insightProps))
     const { exportContext, queryId } = useValues(insightDataLogic(insightProps))
     const { hasFunnelResults } = useValues(funnelDataLogic(insightProps))
+
+    const isFlowViz = funnelsFilter?.funnelVizType === FunnelVizType.Flow
+    const actionable = !embedded && editMode
 
     // Empty states that completely replace the graph
     const BlockingEmptyState = (() => {
@@ -170,6 +177,15 @@ export function InsightVizDisplay({
         // Insight specific empty states - note order is important here
         if (display === ChartDisplayType.BoxPlot && (!series?.length || series.some((s) => !s?.math_property))) {
             return <BoxPlotMissingPropertyState />
+        }
+        if (activeView === InsightType.FUNNELS && !isFlowViz) {
+            if (isFunnelWithIncompleteDataWarehouseStep) {
+                return <FunnelDataWarehouseStepIncompleteState />
+            }
+
+            if (!isFunnelWithEnoughSteps) {
+                return <FunnelSingleStepState actionable={actionable} />
+            }
         }
 
         if (validationError) {
@@ -228,12 +244,8 @@ export function InsightVizDisplay({
             return <InsightRefreshDataHint onRetry={onRetry} />
         }
 
-        if (activeView === InsightType.FUNNELS) {
-            const isFlowViz = funnelsFilter?.funnelVizType === FunnelVizType.Flow
-            if (!isFunnelWithEnoughSteps && !isFlowViz) {
-                return <FunnelSingleStepState actionable={!embedded && editMode} />
-            }
-            if (!hasFunnelResults && !erroredQueryId && !insightDataLoading && !isFlowViz) {
+        if (activeView === InsightType.FUNNELS && !isFlowViz) {
+            if (!hasFunnelResults && !erroredQueryId && !insightDataLoading) {
                 return <InsightEmptyState heading={context?.emptyStateHeading} detail={context?.emptyStateDetail} />
             }
         }

--- a/frontend/src/scenes/insights/EmptyStates/EmptyStates.tsx
+++ b/frontend/src/scenes/insights/EmptyStates/EmptyStates.tsx
@@ -30,6 +30,7 @@ import { urls } from 'scenes/urls'
 import { actionsAndEventsToSeries } from '~/queries/nodes/InsightQuery/utils/filtersToQueryNode'
 import { seriesToActionsAndEvents } from '~/queries/nodes/InsightQuery/utils/queryNodeToFilter'
 import { FunnelsQuery, Node, NodeKind, QueryStatus } from '~/queries/schema/schema-general'
+import { isFunnelsDataWarehouseNode } from '~/queries/utils'
 import {
     AccessControlLevel,
     AccessControlResourceType,
@@ -663,6 +664,81 @@ export function FunnelSingleStepState({ actionable = true }: FunnelSingleStepSta
                     targetBlankIcon
                 >
                     Learn more about funnels in PostHog docs
+                </Link>
+            </div>
+        </div>
+    )
+}
+
+export function FunnelDataWarehouseStepIncompleteState(): JSX.Element {
+    const { insightProps } = useValues(insightLogic)
+    const { series } = useValues(funnelDataLogic(insightProps))
+
+    const incompleteSteps = (series || [])
+        .map((step, index) => {
+            if (!isFunnelsDataWarehouseNode(step)) {
+                return null
+            }
+
+            const missingFields = [
+                !step.table_name ? 'Table' : null,
+                !step.id_field ? 'Unique ID' : null,
+                !step.timestamp_field ? 'Timestamp' : null,
+                !step.aggregation_target_field ? 'Aggregation target' : null,
+            ].filter((field): field is string => field !== null)
+
+            if (missingFields.length === 0) {
+                return null
+            }
+
+            const stepName = step.custom_name || step.name || step.table_name
+            const stepLabel = `Step ${index + 1}`
+
+            return {
+                index,
+                label: stepName ? `${stepLabel} — ` + stepName : stepLabel,
+                missingFields,
+            }
+        })
+        .filter((step): step is NonNullable<typeof step> => step !== null)
+
+    return (
+        <div
+            data-attr="insight-empty-state"
+            className="flex flex-col items-center justify-center gap-2 rounded px-4 py-6 h-full w-full text-center text-balance"
+        >
+            <IconFunnels className="text-4xl shrink-0 text-muted mb-2" />
+
+            <h2 className="text-xl leading-tight font-medium mb-0">
+                Complete your data warehouse step{incompleteSteps.length === 1 ? '' : 's'}!
+            </h2>
+            <p className="text-sm text-muted mb-1">
+                {incompleteSteps.length > 1
+                    ? 'These funnel steps are missing required fields:'
+                    : 'This funnel step is missing required fields:'}
+            </p>
+            {incompleteSteps.length > 0 && (
+                <ul className="text-sm text-muted mb-1 list-disc list-inside text-left">
+                    {incompleteSteps.map((step) => (
+                        <li key={step.index}>
+                            <span className="font-medium text-primary">{step.label}</span>:{' '}
+                            {step.missingFields.join(', ')}
+                        </li>
+                    ))}
+                </ul>
+            )}
+            <p className="text-sm text-muted mb-1">
+                Click on the step to open it and fill in the missing fields to run this funnel.
+            </p>
+            <div className="mt-3">
+                <Link
+                    data-attr="funnels-incomplete-warehouse-step-help"
+                    to="https://posthog.com/docs/data-warehouse/insights#funnel-insights"
+                    target="_blank"
+                    className="flex items-center justify-center"
+                    targetBlankIcon
+                >
+                    Learn more about data warehouse funnels in PostHog docs
                 </Link>
             </div>
         </div>

--- a/frontend/src/scenes/insights/insightVizDataLogic.test.ts
+++ b/frontend/src/scenes/insights/insightVizDataLogic.test.ts
@@ -664,6 +664,75 @@ describe('insightVizDataLogic', () => {
         })
     })
 
+    describe('isFunnelWithIncompleteDataWarehouseStep', () => {
+        const queryWithSeries = (series: FunnelsQuery['series']): FunnelsQuery => ({
+            kind: NodeKind.FunnelsQuery,
+            series,
+        })
+
+        it('returns false for non-funnels and complete funnel steps', () => {
+            expectLogic(builtInsightVizDataLogic, () => {
+                builtInsightVizDataLogic.actions.updateQuerySource({
+                    kind: NodeKind.TrendsQuery,
+                    series: [
+                        {
+                            kind: NodeKind.DataWarehouseNode,
+                            id: 'warehouse_orders',
+                            name: 'Orders',
+                            table_name: 'warehouse_orders',
+                            timestamp_field: 'created_at',
+                            id_field: 'order_id',
+                            distinct_id_field: 'customer_id',
+                        },
+                    ],
+                } as TrendsQuery)
+            }).toMatchValues({ isFunnelWithIncompleteDataWarehouseStep: false })
+
+            expectLogic(builtInsightVizDataLogic, () => {
+                builtInsightVizDataLogic.actions.updateQuerySource(
+                    queryWithSeries([
+                        {
+                            kind: NodeKind.EventsNode,
+                            name: '$pageview',
+                            event: '$pageview',
+                        },
+                        {
+                            kind: NodeKind.FunnelsDataWarehouseNode,
+                            id: 'warehouse_orders',
+                            name: 'Orders',
+                            table_name: 'warehouse_orders',
+                            timestamp_field: 'created_at',
+                            id_field: 'order_id',
+                            aggregation_target_field: 'customer_id',
+                        },
+                    ])
+                )
+            }).toMatchValues({ isFunnelWithIncompleteDataWarehouseStep: false })
+        })
+
+        it('returns true when any funnel data warehouse step is missing a required field', () => {
+            expectLogic(builtInsightVizDataLogic, () => {
+                builtInsightVizDataLogic.actions.updateQuerySource(
+                    queryWithSeries([
+                        {
+                            kind: NodeKind.EventsNode,
+                            name: '$pageview',
+                            event: '$pageview',
+                        },
+                        {
+                            kind: NodeKind.FunnelsDataWarehouseNode,
+                            id: 'warehouse_orders',
+                            name: 'Orders',
+                            table_name: 'warehouse_orders',
+                            timestamp_field: 'created_at',
+                            id_field: 'order_id',
+                        } as FunnelsQuery['series'][number],
+                    ])
+                )
+            }).toMatchValues({ isFunnelWithIncompleteDataWarehouseStep: true })
+        })
+    })
+
     describe('validationError', () => {
         it('for standard funnel', async () => {
             const insight: Partial<InsightModel> = {

--- a/frontend/src/scenes/insights/insightVizDataLogic.ts
+++ b/frontend/src/scenes/insights/insightVizDataLogic.ts
@@ -75,6 +75,7 @@ import {
     isAnyDataWarehouseNode,
     isDataWarehouseNode,
     isEventsNode,
+    isFunnelsDataWarehouseNode,
     isFunnelsQuery,
     isInsightQueryNode,
     isInsightVizNode,
@@ -514,6 +515,16 @@ export const insightVizDataLogic = kea<insightVizDataLogicType>([
             (s) => [s.series],
             (series) => {
                 return (series?.length || 0) > 1
+            },
+        ],
+        isFunnelWithIncompleteDataWarehouseStep: [
+            (s) => [s.series],
+            (series) => {
+                return (series || []).some(
+                    (step) =>
+                        isFunnelsDataWarehouseNode(step) &&
+                        (!step.table_name || !step.id_field || !step.timestamp_field || !step.aggregation_target_field)
+                )
             },
         ],
 


### PR DESCRIPTION
## Problem

Incomplete funnels show up as validation error:


![Screenshot 2026-04-07 at 21.05.02.png](https://app.graphite.com/user-attachments/assets/b4d37844-d2ea-497c-be9a-3ac5db6f6377.png)

## Changes

Adds a dedicated empty state for this:

![Screenshot 2026-04-07 at 21.03.57.png](https://app.graphite.com/user-attachments/assets/c2695d7a-eed0-4f75-aeb2-e3423cbcccdf.png)

## How did you test this code?

Tried locally