### PR TITLE
feat(devex): build phrocs from source during flox activation

### DIFF
--- a/.flox/env/on-activate.sh
+++ b/.flox/env/on-activate.sh
@@ -232,6 +232,12 @@ if [[ -d "$UV_PROJECT_ENVIRONMENT/bin" ]]; then
   ) || true
 fi
 
+# ── Step 1b: Build phrocs from source ─────────────────────────────
+run_step "Build phrocs" make -C "$FLOX_ENV_PROJECT/tools/phrocs" build
+if [[ -f "$FLOX_ENV_PROJECT/tools/phrocs/dist/phrocs" && -d "$UV_PROJECT_ENVIRONMENT/bin" ]]; then
+  ln -sf "$FLOX_ENV_PROJECT/tools/phrocs/dist/phrocs" "$UV_PROJECT_ENVIRONMENT/bin/phrocs"
+fi
+
 # ── Step 2: Node packages ──────────────────────────────────────────
 run_step "Node packages" pnpm install
 


### PR DESCRIPTION
## Problem

Developers fall behind on phrocs updates because it's only distributed via a Homebrew cask. This creates version drift and requires manual `brew upgrade` steps.

## Changes

Build phrocs from source during flox `on-activate`, so the binary always matches the repo checkout. The built binary is symlinked into the venv `bin/` directory (already on `$PATH`).

Go's build cache makes no-change rebuilds sub-second, so repeat activations aren't slowed down.

## How did you test this code?

I'm an agent and haven't tested this manually. To verify:
1. Clear flox cache: `rm -rf .flox/cache`
2. Exit all flox shells
3. `flox activate` — confirm "Build phrocs" step appears with a checkmark
4. Run `which phrocs` — should point to `.flox/cache/venv/bin/phrocs`

## Publish to changelog?

No

## Docs update

N/A

## 🤖 LLM context

Co-authored by Claude Code. Single-step change to `.flox/env/on-activate.sh`.