### PR TITLE
feat(phrocs): add config-driven hints with countdown bar

### DIFF
--- a/common/hogli/devenv/generator.py
+++ b/common/hogli/devenv/generator.py
@@ -121,6 +121,7 @@ class MprocsConfig(BaseModel):
     procs: dict[str, dict[str, Any]]
     mouse_scroll_speed: int = 1
     scrollback: int = 10000
+    hints: list[str] = []
     posthog_config: DevenvConfig | None = None  # embedded source config
 
     def to_yaml_dict(self) -> dict[str, Any]:
@@ -131,6 +132,8 @@ class MprocsConfig(BaseModel):
         result["procs"] = self.procs
         result["mouse_scroll_speed"] = self.mouse_scroll_speed
         result["scrollback"] = self.scrollback
+        if self.hints:
+            result["hints"] = self.hints
         return result
 
 
@@ -231,6 +234,16 @@ class MprocsGenerator(ConfigGenerator):
             procs=procs,
             mouse_scroll_speed=global_settings.get("mouse_scroll_speed", 1),
             scrollback=global_settings.get("scrollback", 10000),
+            hints=[
+                "Run `hogli doctor` for a quick health check",
+                "Run `hogli doctor:disk` to reclaim disk space",
+                "Run `hogli doctor:zombies` to find orphaned processes",
+                "Run `hogli dev:explain` to see why each service is running",
+                "Run `hogli dev:demo-data` to generate test data",
+                "Run `hogli migrations:run` to apply pending migrations",
+                "Run `hogli db:pg` to open a PostgreSQL shell",
+                "Run `hogli categories` to see all available commands",
+            ],
             posthog_config=source_config,
         )
 

--- a/tools/phrocs/internal/config/config.go
+++ b/tools/phrocs/internal/config/config.go
@@ -37,6 +37,7 @@ type Config struct {
 	MouseScrollSpeed int                   `yaml:"mouse_scroll_speed"`
 	ProcListWidth    int                   `yaml:"proc_list_width"`
 	Scrollback       int                   `yaml:"scrollback"`
+	Hints            []string              `yaml:"hints"`
 }
 
 // ResolveConfigPath returns the config file path to use. If explicit is

--- a/tools/phrocs/internal/hints/hints.go
+++ b/tools/phrocs/internal/hints/hints.go
@@ -1,0 +1,23 @@
+package hints
+
+// Provider cycles through config-supplied hint strings.
+type Provider struct {
+	hints []string
+	index int
+}
+
+// NewProvider creates a provider that cycles through the given hints.
+// If hints is empty, PickHint always returns "".
+func NewProvider(hints []string) *Provider {
+	return &Provider{hints: hints}
+}
+
+// PickHint returns the next hint, cycling through the list.
+func (p *Provider) PickHint() string {
+	if len(p.hints) == 0 {
+		return ""
+	}
+	hint := p.hints[p.index]
+	p.index = (p.index + 1) % len(p.hints)
+	return hint
+}

--- a/tools/phrocs/internal/hints/hints_test.go
+++ b/tools/phrocs/internal/hints/hints_test.go
@@ -1,0 +1,33 @@
+package hints
+
+import "testing"
+
+func TestPickHint_emptyReturnsEmpty(t *testing.T) {
+	p := NewProvider(nil)
+	if got := p.PickHint(); got != "" {
+		t.Errorf("expected empty, got %q", got)
+	}
+}
+
+func TestPickHint_cyclesThroughHints(t *testing.T) {
+	hints := []string{"a", "b", "c"}
+	p := NewProvider(hints)
+
+	for i := 0; i < 2; i++ {
+		for _, want := range hints {
+			got := p.PickHint()
+			if got != want {
+				t.Errorf("got %q, want %q", got, want)
+			}
+		}
+	}
+}
+
+func TestPickHint_singleHintRepeats(t *testing.T) {
+	p := NewProvider([]string{"only"})
+	for range 3 {
+		if got := p.PickHint(); got != "only" {
+			t.Errorf("got %q, want %q", got, "only")
+		}
+	}
+}

--- a/tools/phrocs/internal/tui/app.go
+++ b/tools/phrocs/internal/tui/app.go
@@ -1,7 +1,6 @@
 package tui
 
 import (
-	"fmt"
 	"log"
 	"sort"
 	"strings"
@@ -242,12 +241,6 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		m.sortServices()
 		m.updateProcKeys()
-
-		if msg.Status == process.StatusCrashed && m.hintText == "" && !m.isAnyModalMode() {
-			m.hintText = fmt.Sprintf("%s crashed -- press 'r' to restart or 'i' for details", msg.Name)
-			m.hintSecsLeft = hintDurationSecs
-			cmds = append(cmds, hintCountdownTick())
-		}
 
 	case process.FocusMsg:
 		m.dbg("focus: proc=%s (via IPC)", msg.Name)

--- a/tools/phrocs/internal/tui/app.go
+++ b/tools/phrocs/internal/tui/app.go
@@ -1,9 +1,11 @@
 package tui
 
 import (
+	"fmt"
 	"log"
 	"sort"
 	"strings"
+	"time"
 
 	"charm.land/bubbles/v2/help"
 	"charm.land/bubbles/v2/spinner"
@@ -12,6 +14,7 @@ import (
 	"charm.land/lipgloss/v2"
 	"github.com/posthog/posthog/phrocs/internal/config"
 	"github.com/posthog/posthog/phrocs/internal/docker"
+	"github.com/posthog/posthog/phrocs/internal/hints"
 	"github.com/posthog/posthog/phrocs/internal/process"
 )
 
@@ -97,6 +100,11 @@ type Model struct {
 	setupError   string   // error message from applying changes
 	configPath   string   // path to the running config file
 
+	// Hints: transient footer messages with countdown
+	hintText      string
+	hintSecsLeft  int // seconds remaining on current hint
+	hintProvider  *hints.Provider
+
 	// Info mode: replaces the output viewport with process stats
 	infoMode bool
 
@@ -145,6 +153,7 @@ func New(mgr *process.Manager, cfg *config.Config, configPath string, logger *lo
 		hideHelp:         cfg.HideKeymapWindow,
 		procListWidth:    cfg.ProcListWidth,
 		configPath:       configPath,
+		hintProvider:     hints.NewProvider(cfg.Hints),
 		keys:             keys,
 		help:             h,
 		spinner:          spinner.New(spinner.WithSpinner(spinner.MiniDot)),
@@ -160,7 +169,7 @@ func (m Model) dbg(format string, args ...any) {
 
 // Note: Processes are started externally before p.Run()
 func (m Model) Init() tea.Cmd {
-	return tea.Batch(tea.RequestBackgroundColor, m.spinner.Tick)
+	return tea.Batch(tea.RequestBackgroundColor, m.spinner.Tick, hintCheckTick(hintInitialDelay))
 }
 
 func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
@@ -234,6 +243,12 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.sortServices()
 		m.updateProcKeys()
 
+		if msg.Status == process.StatusCrashed && m.hintText == "" && !m.isAnyModalMode() {
+			m.hintText = fmt.Sprintf("%s crashed -- press 'r' to restart or 'i' for details", msg.Name)
+			m.hintSecsLeft = hintDurationSecs
+			cmds = append(cmds, hintCountdownTick())
+		}
+
 	case process.FocusMsg:
 		m.dbg("focus: proc=%s (via IPC)", msg.Name)
 		for i, p := range m.services {
@@ -288,6 +303,28 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			if m.searchQuery != "" {
 				m.updateSearchForLine(msg.Line, lineIndex, evicted)
+			}
+		}
+
+	case hintCheckMsg:
+		if m.hintText == "" && !m.isAnyModalMode() {
+			if hint := m.hintProvider.PickHint(); hint != "" {
+				m.dbg("hint: show %q", hint)
+				m.hintText = hint
+				m.hintSecsLeft = hintDurationSecs
+				cmds = append(cmds, hintCountdownTick())
+			}
+		}
+		cmds = append(cmds, hintCheckTick(hintCheckInterval))
+
+	case hintCountdownMsg:
+		if m.hintText != "" {
+			m.hintSecsLeft--
+			if m.hintSecsLeft <= 0 {
+				m.dbg("hint: expired")
+				m.hintText = ""
+			} else {
+				cmds = append(cmds, hintCountdownTick())
 			}
 		}
 
@@ -618,4 +655,37 @@ func (m Model) toggleMetricsOnSelectedProc() {
 	if p := m.activeProc(); p != nil {
 		p.SetMetricsEnabled(true)
 	}
+}
+
+// ---------------------------------------------------------------------------
+// Hints
+// ---------------------------------------------------------------------------
+
+const (
+	hintInitialDelay  = 30 * time.Second
+	hintCheckInterval = 3 * time.Minute
+	hintDurationSecs  = 5
+	hintBarWidth      = 5
+)
+
+// hintCheckMsg fires periodically to see if a new hint should be shown.
+type hintCheckMsg struct{}
+
+// hintCountdownMsg fires every second to decrement the countdown bar.
+type hintCountdownMsg struct{}
+
+func hintCheckTick(delay time.Duration) tea.Cmd {
+	return tea.Tick(delay, func(time.Time) tea.Msg {
+		return hintCheckMsg{}
+	})
+}
+
+func hintCountdownTick() tea.Cmd {
+	return tea.Tick(time.Second, func(time.Time) tea.Msg {
+		return hintCountdownMsg{}
+	})
+}
+
+func (m Model) isAnyModalMode() bool {
+	return m.copyMode || m.searchMode || m.infoMode || m.setupMode || m.hedgehogMode
 }

--- a/tools/phrocs/internal/tui/app_test.go
+++ b/tools/phrocs/internal/tui/app_test.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	tea "charm.land/bubbletea/v2"
@@ -28,6 +29,17 @@ func testConfig(names ...string) *config.Config {
 func readyModel(t *testing.T, names ...string) Model {
 	t.Helper()
 	cfg := testConfig(names...)
+	mgr := process.NewManager(cfg)
+	m := New(mgr, cfg, "", nil)
+	next, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+	return next.(Model)
+}
+
+// readyModelWithHints returns a ready model with hint strings configured.
+func readyModelWithHints(t *testing.T, hints []string, names ...string) Model {
+	t.Helper()
+	cfg := testConfig(names...)
+	cfg.Hints = hints
 	mgr := process.NewManager(cfg)
 	m := New(mgr, cfg, "", nil)
 	next, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
@@ -1038,5 +1050,160 @@ func TestHedgehog_gravity(t *testing.T) {
 	}
 	if m.hedgehogVelY != 0 {
 		t.Errorf("velY should reset to 0 on landing, got %d", m.hedgehogVelY)
+	}
+}
+
+// ── Hints ────────────────────────────────────────────────────────────────────
+
+var testHints = []string{"hint one", "hint two", "hint three"}
+
+func TestHint_shownOnTickInNormalMode(t *testing.T) {
+	m := readyModelWithHints(t, testHints, "backend")
+
+	m = update(m, hintCheckMsg{})
+	if m.hintText == "" {
+		t.Error("expected a hint after tick in normal mode")
+	}
+	if m.hintSecsLeft != hintDurationSecs {
+		t.Errorf("hintSecsLeft: got %d, want %d", m.hintSecsLeft, hintDurationSecs)
+	}
+}
+
+func TestHint_notShownWithoutConfig(t *testing.T) {
+	m := readyModel(t, "backend") // no hints in config
+
+	m = update(m, hintCheckMsg{})
+	if m.hintText != "" {
+		t.Errorf("expected no hint without config, got %q", m.hintText)
+	}
+}
+
+func TestHint_notShownInCopyMode(t *testing.T) {
+	m := readyModelWithHints(t, testHints, "backend")
+	m.copyMode = true
+
+	m = update(m, hintCheckMsg{})
+	if m.hintText != "" {
+		t.Errorf("expected no hint in copy mode, got %q", m.hintText)
+	}
+}
+
+func TestHint_notShownInSearchMode(t *testing.T) {
+	m := readyModelWithHints(t, testHints, "backend")
+	m.searchMode = true
+
+	m = update(m, hintCheckMsg{})
+	if m.hintText != "" {
+		t.Errorf("expected no hint in search mode, got %q", m.hintText)
+	}
+}
+
+func TestHint_clearedOnKeypress(t *testing.T) {
+	m := readyModel(t, "backend")
+	m.hintText = "some hint"
+
+	m = update(m, keypress('j'))
+	if m.hintText != "" {
+		t.Errorf("hint should be cleared on keypress, got %q", m.hintText)
+	}
+}
+
+func TestHint_countdownDecrement(t *testing.T) {
+	m := readyModel(t, "backend")
+	m.hintText = "some hint"
+	m.hintSecsLeft = 5
+
+	m = update(m, hintCountdownMsg{})
+	if m.hintSecsLeft != 4 {
+		t.Errorf("hintSecsLeft: got %d, want 4", m.hintSecsLeft)
+	}
+	if m.hintText == "" {
+		t.Error("hint should still be active")
+	}
+}
+
+func TestHint_countdownExpires(t *testing.T) {
+	m := readyModel(t, "backend")
+	m.hintText = "some hint"
+	m.hintSecsLeft = 1
+
+	m = update(m, hintCountdownMsg{})
+	if m.hintText != "" {
+		t.Errorf("hint should be cleared when countdown reaches 0, got %q", m.hintText)
+	}
+}
+
+func TestHint_renderedInFooter(t *testing.T) {
+	m := readyModel(t, "backend")
+	m.hintText = "Press 'i' for process info"
+	m.hintSecsLeft = 8
+
+	footer := m.renderFooter()
+	if !strings.Contains(footer, "Press 'i' for process info") {
+		t.Errorf("footer should contain hint text, got: %s", footer)
+	}
+	if !strings.Contains(footer, "Hint:") {
+		t.Errorf("footer should contain 'Hint:' prefix, got: %s", footer)
+	}
+	if !strings.Contains(footer, "█") {
+		t.Errorf("footer should contain countdown bar, got: %s", footer)
+	}
+}
+
+func TestHint_crashSetsHintImmediately(t *testing.T) {
+	m := readyModel(t, "backend", "frontend")
+
+	m = update(m, process.StatusMsg{Name: "backend", Status: process.StatusCrashed})
+	if m.hintText == "" {
+		t.Error("expected crash hint")
+	}
+	if !strings.Contains(m.hintText, "backend crashed") {
+		t.Errorf("expected crash hint to mention process name, got %q", m.hintText)
+	}
+}
+
+func TestHint_crashDoesNotOverrideExisting(t *testing.T) {
+	m := readyModel(t, "backend", "frontend")
+	m.hintText = "existing hint"
+
+	m = update(m, process.StatusMsg{Name: "backend", Status: process.StatusCrashed})
+	if m.hintText != "existing hint" {
+		t.Errorf("crash should not override existing hint, got %q", m.hintText)
+	}
+}
+
+func TestHint_notShownInModalModes(t *testing.T) {
+	modes := []struct {
+		name string
+		set  func(*Model)
+	}{
+		{"info", func(m *Model) { m.infoMode = true }},
+		{"setup", func(m *Model) { m.setupMode = true }},
+		{"hedgehog", func(m *Model) { m.hedgehogMode = true }},
+	}
+	for _, tt := range modes {
+		t.Run(tt.name, func(t *testing.T) {
+			m := readyModelWithHints(t, testHints, "backend")
+			tt.set(&m)
+			m = update(m, hintCheckMsg{})
+			if m.hintText != "" {
+				t.Errorf("expected no hint in %s mode, got %q", tt.name, m.hintText)
+			}
+		})
+	}
+}
+
+func TestHint_navigationWorksWithActiveHint(t *testing.T) {
+	m := readyModel(t, "backend", "celery", "frontend")
+	m.hintText = "some hint"
+	m.hintSecsLeft = 5
+
+	// j should navigate AND clear the hint
+	m = update(m, keypress('j'))
+	if m.servicesCursor != 1 {
+		t.Errorf("cursor: got %d, want 1", m.servicesCursor)
+	}
+	if m.hintText != "" {
+		t.Errorf("hint should be cleared after navigation, got %q", m.hintText)
 	}
 }

--- a/tools/phrocs/internal/tui/app_test.go
+++ b/tools/phrocs/internal/tui/app_test.go
@@ -1150,28 +1150,6 @@ func TestHint_renderedInFooter(t *testing.T) {
 	}
 }
 
-func TestHint_crashSetsHintImmediately(t *testing.T) {
-	m := readyModel(t, "backend", "frontend")
-
-	m = update(m, process.StatusMsg{Name: "backend", Status: process.StatusCrashed})
-	if m.hintText == "" {
-		t.Error("expected crash hint")
-	}
-	if !strings.Contains(m.hintText, "backend crashed") {
-		t.Errorf("expected crash hint to mention process name, got %q", m.hintText)
-	}
-}
-
-func TestHint_crashDoesNotOverrideExisting(t *testing.T) {
-	m := readyModel(t, "backend", "frontend")
-	m.hintText = "existing hint"
-
-	m = update(m, process.StatusMsg{Name: "backend", Status: process.StatusCrashed})
-	if m.hintText != "existing hint" {
-		t.Errorf("crash should not override existing hint, got %q", m.hintText)
-	}
-}
-
 func TestHint_notShownInModalModes(t *testing.T) {
 	modes := []struct {
 		name string

--- a/tools/phrocs/internal/tui/keys.go
+++ b/tools/phrocs/internal/tui/keys.go
@@ -227,6 +227,9 @@ func (m *Model) updateProcKeys() {
 }
 
 func (m Model) handleNormalKey(msg tea.KeyPressMsg, cmds []tea.Cmd) (tea.Model, tea.Cmd) {
+	// Any keypress dismisses the active hint
+	m.hintText = ""
+
 	// When the active process is waiting for input, buffer keystrokes and send them on Enter.
 	p := m.activeProc()
 	procHasPrompt := p != nil && m.focusedPane == focusOutput && p.HasPrompt()

--- a/tools/phrocs/internal/tui/render.go
+++ b/tools/phrocs/internal/tui/render.go
@@ -272,6 +272,9 @@ func (m Model) renderFooter() string {
 			lipgloss.NewStyle().Foreground(colorYellow).Render(matchInfo),
 		)
 	}
+	if m.hintText != "" {
+		return footerStyle.Width(m.width - 2).Render(m.renderHintBar())
+	}
 	if m.hideHelp {
 		return ""
 	}
@@ -395,6 +398,22 @@ func (m Model) renderInfo() string {
 	lines = append(lines, row("  Buffered lines", fmt.Sprintf("%d", len(p.Lines()))))
 
 	return strings.Join(lines, "\n")
+}
+
+func (m Model) renderHintBar() string {
+	filled := m.hintSecsLeft
+	if filled > hintBarWidth {
+		filled = hintBarWidth
+	}
+	if filled < 0 {
+		filled = 0
+	}
+	empty := hintBarWidth - filled
+
+	bar := strings.Repeat("█", filled) + strings.Repeat("░", empty)
+	barStyled := lipgloss.NewStyle().Foreground(colorBrightBlack).Render(bar)
+
+	return hintStyle.Render("Hint: "+m.hintText) + "  " + barStyled
 }
 
 func formatDuration(d time.Duration) string {


### PR DESCRIPTION
## Problem

Developers running `hogli start` spend long sessions in phrocs but never see hogli's post-command hints (PR #53048) because phrocs takes over the terminal with an alternate screen. There's no way to surface useful tips about maintenance commands like `hogli doctor` or `hogli dev:explain` while the dev environment is running.

## Changes

Adds a config-driven hint system to phrocs that shows tips in the footer while the user is idle.

- **Config-driven**: hints are defined as a `hints: [...]` list in the mprocs YAML config, not hardcoded in phrocs. External repos using phrocs without this field see no hints.
- **Footer replacement**: hints temporarily replace the keybinding help in the footer (same pattern as copy/search/info modes), with a 5-second shrinking countdown bar (`█████` -> `░░░░░`). Any keypress dismisses immediately.
- **Cycling**: hints rotate every 3 minutes while idle, cycling through the list indefinitely.
- **PostHog hints**: the mprocs generator populates 8 hints about `hogli doctor`, `dev:explain`, `dev:demo-data`, `migrations:run`, `db:pg`, and `categories`.

**Files changed:**
- `tools/phrocs/internal/hints/hints.go` -- new package, trivial `Provider` that cycles `[]string`
- `tools/phrocs/internal/config/config.go` -- `Hints []string` field on `Config`
- `tools/phrocs/internal/tui/app.go` -- hint state, tick/countdown handlers
- `tools/phrocs/internal/tui/render.go` -- `renderHintBar()` with countdown
- `tools/phrocs/internal/tui/keys.go` -- dismiss on keypress
- `common/hogli/devenv/generator.py` -- `hints` field on `MprocsConfig`, populated in `generate()`

## How did you test this code?

- 45 phrocs tests pass (`go test ./...`)
- Built test binary with reduced initial delay (3s), ran against generated config, verified hints appear and cycle
- Verified hints dismiss on keypress
- Verified countdown bar shrinks and auto-clears after 5s
- Verified no hints shown when config has no `hints:` key

## Publish to changelog?

No

## Docs update

N/A

## LLM context

Co-authored with Claude Code (Opus 4.6). Explored 4 layout approaches (extra footer line, header, overlay, footer replacement), settled on transient footer replacement. Initially used `bubbles/timer` for countdown but switched to manual tick to avoid message type interference. Simplified from hardcoded hints + hogli state file reading to config-driven approach after feedback.