### PR TITLE
feat(endpoints): make insight-based results consistent mat vs non-mat

### DIFF
--- a/posthog/hogql_queries/insights/trends/trends_query_runner.py
+++ b/posthog/hogql_queries/insights/trends/trends_query_runner.py
@@ -505,7 +505,9 @@ class TrendsQueryRunner(AnalyticsQueryRunner[TrendsQueryResponse]):
 
         return final_result, has_more
 
-    def build_series_response(self, response: HogQLQueryResponse, series: SeriesWithExtras, series_count: int):
+    def build_series_response(
+        self, response: HogQLQueryResponse, series: SeriesWithExtras, series_count: int
+    ) -> list[dict[str, Any]]:
         def get_value(name: str, val: Any):
             if name not in ["date", "total", "breakdown_value"]:
                 raise Exception("Column not found in hogql results")

--- a/posthog/hogql_queries/utils/query_date_range.py
+++ b/posthog/hogql_queries/utils/query_date_range.py
@@ -86,6 +86,17 @@ class QueryDateRange:
             # we can't support multiple week intervals without breaking backwards compatibility
             raise ValueError("IntervalType.WEEK cannot be used with interval_count > 1")
 
+    def pin_now(self, now: datetime) -> None:
+        """Replace the _now_ used by date computations (e.g. to match a materialized
+        snapshot time instead of request time).
+
+        Must be called before any date property is read — otherwise cached values
+        would be stale. Raises ``RuntimeError`` if that happens.
+        """
+        if "now_with_timezone" in self.__dict__:
+            raise RuntimeError("pin_now() called after now_with_timezone was already cached")
+        self._now_without_timezone = now
+
     def date_to(self) -> datetime:
         date_to = self.now_with_timezone
         delta_mapping = None

--- a/posthog/hogql_queries/utils/test/test_query_date_range.py
+++ b/posthog/hogql_queries/utils/test/test_query_date_range.py
@@ -259,6 +259,37 @@ class TestQueryDateRange(APIBaseTest):
         self.assertEqual(query_date_range.date_from(), parser.isoparse("2025-09-21T00:00:00Z"))
         self.assertEqual(query_date_range.date_to(), parser.isoparse("2025-09-27T23:59:59.999999Z"))
 
+    def test_pin_now_overrides_initial_now_before_cache(self):
+        initial_now = parser.isoparse("2021-08-25T00:00:00.000Z")
+        pinned_now = parser.isoparse("2021-07-01T00:00:00.000Z")
+        query_date_range = QueryDateRange(
+            team=self.team,
+            date_range=DateRange(date_from="-7d"),
+            interval=IntervalType.DAY,
+            now=initial_now,
+        )
+
+        query_date_range.pin_now(pinned_now)
+
+        # date_to / date_from must reflect pinned_now, not initial_now
+        self.assertEqual(query_date_range.date_to(), parser.isoparse("2021-07-01T23:59:59.999999Z"))
+        self.assertEqual(query_date_range.date_from(), parser.isoparse("2021-06-24T00:00:00Z"))
+
+    def test_pin_now_raises_after_derived_property_cached(self):
+        now = parser.isoparse("2021-08-25T00:00:00.000Z")
+        query_date_range = QueryDateRange(
+            team=self.team,
+            date_range=DateRange(date_from="-7d"),
+            interval=IntervalType.DAY,
+            now=now,
+        )
+        # Trigger the cached_property chain
+        _ = query_date_range.date_from()
+
+        with self.assertRaises(RuntimeError) as cm:
+            query_date_range.pin_now(parser.isoparse("2021-07-01T00:00:00.000Z"))
+        self.assertIn("now_with_timezone", str(cm.exception))
+
 
 class TestExactTimerange(APIBaseTest):
     INTERVALS = [
@@ -454,6 +485,17 @@ class TestQueryDateRangeWithIntervals(APIBaseTest):
     def test_constructor_initialization(self):
         query = QueryDateRangeWithIntervals(None, self.lookahead, self.team, IntervalType.DAY, self.now)
         self.assertEqual(query.lookahead, self.lookahead)
+
+    def test_pin_now_works_on_subclass(self):
+        initial_now = parser.isoparse("2021-08-25T00:00:00.000Z")
+        pinned_now = parser.isoparse("2021-07-01T00:00:00.000Z")
+        query = QueryDateRangeWithIntervals(None, 7, self.team, IntervalType.DAY, initial_now)
+
+        query.pin_now(pinned_now)
+
+        # date_to should reflect pinned_now (the subclass's date_to adds one interval
+        # and truncates to start of interval, so 2021-07-01 00:00:00 UTC becomes 2021-07-02 00:00:00 UTC)
+        self.assertEqual(query.date_to(), parser.isoparse("2021-07-02T00:00:00Z"))
 
     def test_determine_time_delta_valid(self):
         delta = QueryDateRangeWithIntervals.determine_time_delta(5, "day")

--- a/products/endpoints/backend/api.py
+++ b/products/endpoints/backend/api.py
@@ -85,6 +85,10 @@ from products.data_warehouse.backend.models.external_data_schema import (
     sync_frequency_interval_to_sync_frequency,
     sync_frequency_to_sync_frequency_interval,
 )
+from products.endpoints.backend.insight_transformers import (
+    MaterializedSeriesMismatchError,
+    transform_materialized_insight_response,
+)
 from products.endpoints.backend.materialization import (
     SUPPORTED_BUCKET_FUNCTIONS,
     VariablePlaceholderFinder,
@@ -1537,7 +1541,9 @@ class EndpointViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.Model
 
             pagination: EndpointPagination | None = None
 
-            if limit is not None:
+            # Only paginate flat-row HogQL results. Insight types get transformed
+            # into nested structures where flat-row LIMIT/OFFSET is meaningless.
+            if limit is not None and query_kind == "HogQLQuery":
                 pagination = EndpointPagination(limit=limit, offset=offset or 0, ceiling=original_limit)
                 pagination.apply_to(select_query)
 
@@ -1632,6 +1638,27 @@ class EndpointViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.Model
                     headers=deprecation_headers,
                     pagination=pagination,
                 )
+
+            INSIGHT_TRANSFORM_TYPES = {"TrendsQuery", "LifecycleQuery", "RetentionQuery"}
+            if query_kind in INSIGHT_TRANSFORM_TYPES:
+                try:
+                    transform_materialized_insight_response(
+                        result.data,
+                        query,
+                        self.team,
+                        now=saved_query.last_run_at,
+                    )
+                except MaterializedSeriesMismatchError:
+                    # Series drift: query was likely edited after materialization. Trigger a refresh
+                    # so the next request succeeds, but fail this one loudly rather than
+                    # returning wrong-labeled data.
+                    logger.warning(
+                        "Materialized endpoint series mismatch, triggering re-materialization",
+                        endpoint_name=endpoint.name,
+                        saved_query_id=saved_query.id,
+                    )
+                    trigger_saved_query_schedule(saved_query)
+                    raise
 
             return result
         except Exception as e:

--- a/products/endpoints/backend/insight_transformers.py
+++ b/products/endpoints/backend/insight_transformers.py
@@ -1,0 +1,169 @@
+"""Transform materialized insight endpoint responses from flat HogQL to rich insight format.
+
+When insight queries (TrendsQuery, RetentionQuery, LifecycleQuery) are materialized,
+the S3 table stores flat HogQL data. At read time, SELECT * returns flat rows.
+This module transforms those flat rows back into the insight-specific response shape
+that users expect (matching what the non-materialized path produces).
+"""
+
+from collections import defaultdict
+from datetime import datetime
+from typing import TYPE_CHECKING, Any, Union, cast
+
+import structlog
+
+from posthog.schema import HogQLQueryModifiers, HogQLQueryResponse
+
+from posthog.hogql_queries.query_runner import get_query_runner
+from posthog.models.team import Team
+
+if TYPE_CHECKING:
+    from posthog.hogql_queries.insights.lifecycle_query_runner import LifecycleQueryRunner
+    from posthog.hogql_queries.insights.retention_query_runner import RetentionQueryRunner
+    from posthog.hogql_queries.insights.trends.trends_query_runner import TrendsQueryRunner
+
+    InsightRunner = Union["LifecycleQueryRunner", "RetentionQueryRunner", "TrendsQueryRunner"]
+
+logger = structlog.get_logger(__name__)
+
+
+class MaterializedSeriesMismatchError(Exception):
+    """Raised when a materialized trends table's series count differs from the current query definition.
+
+    This indicates the endpoint query was edited after materialization and the stored table
+    is now stale. Callers should trigger a re-materialization.
+    """
+
+
+def transform_materialized_insight_response(
+    result: dict,
+    original_query: dict,
+    team: Team,
+    now: datetime | None = None,
+) -> None:
+    """Transform flat HogQL results in-place into insight-specific response shape.
+
+    Args:
+        result: The result.data dict from _execute_query_and_respond(). Modified in-place.
+        original_query: The original insight query definition (TrendsQuery, etc.)
+        team: The team for query runner context.
+        now: Pin date range to this timestamp (e.g., saved_query.last_run_at) instead of datetime.now().
+    """
+    query_kind = original_query.get("kind")
+
+    if query_kind == "TrendsQuery":
+        _transform_trends(result, original_query, team, now)
+    elif query_kind == "LifecycleQuery":
+        _transform_lifecycle(result, original_query, team, now)
+    elif query_kind == "RetentionQuery":
+        _transform_retention(result, original_query, team, now)
+
+
+def _make_runner(original_query: dict, team: Team, now: datetime | None = None) -> "InsightRunner":
+    """Instantiate a query runner from the original query for formatting context.
+
+    Callers are responsible for passing a TrendsQuery, LifecycleQuery, or RetentionQuery —
+    the return type is narrowed to the corresponding runner union so `query_date_range`,
+    `format_results` etc. are statically visible.
+    """
+    modifiers_dict = original_query.get("modifiers") or {}
+    modifiers = HogQLQueryModifiers(**modifiers_dict)
+    runner = cast(
+        "InsightRunner",
+        get_query_runner(
+            query=original_query,
+            team=team,
+            modifiers=modifiers,
+        ),
+    )
+    if now is not None:
+        # Pin the date range to materialization time so response labels reflect
+        # when the data was snapshotted, not when the request was served.
+        runner.query_date_range.pin_now(now)
+    return runner
+
+
+def _strip_hogql_fields(result: dict) -> None:
+    """Remove HogQL-specific fields that don't belong in insight responses."""
+    for field in ("columns", "types", "limit", "offset", "query"):
+        result.pop(field, None)
+
+
+def _transform_trends(result: dict, original_query: dict, team: Team, now: datetime | None = None) -> None:
+    runner = cast("TrendsQueryRunner", _make_runner(original_query, team, now))
+
+    columns = result.get("columns", [])
+    rows = result.get("results", [])
+
+    if not rows:
+        result["results"] = []
+        _strip_hogql_fields(result)
+        return
+
+    # Group rows by __series_index (trends uses named column access in build_series_response)
+    series_index_col = columns.index("__series_index") if "__series_index" in columns else None
+    groups: dict[int, list] = defaultdict(list)
+    for row in rows:
+        idx = row[series_index_col] if series_index_col is not None else 0
+        groups[idx].append(row)
+
+    per_series_responses: list[HogQLQueryResponse] = []
+    for series_idx in sorted(groups.keys()):
+        per_series_responses.append(
+            HogQLQueryResponse(
+                results=groups[series_idx],
+                columns=columns,
+            )
+        )
+
+    if len(per_series_responses) != len(runner.series):
+        raise MaterializedSeriesMismatchError(
+            f"Materialized table has {len(per_series_responses)} series "
+            f"but current query defines {len(runner.series)}. "
+            f"The endpoint query was likely edited after materialization."
+        )
+
+    # Call build_series_response per series, then format_results for post-processing
+    returned_results: list[list[dict[str, Any]]] = []
+    series_count = len(per_series_responses)
+    for i, response in enumerate(per_series_responses):
+        series_with_extra = runner.series[i]
+        returned_results.append(runner.build_series_response(response, series_with_extra, series_count))
+
+    final_result, has_more = runner.format_results(returned_results)
+
+    result["results"] = final_result
+    result["hasMore"] = has_more
+    _strip_hogql_fields(result)
+
+
+def _transform_lifecycle(result: dict, original_query: dict, team: Team, now: datetime | None = None) -> None:
+    runner = cast("LifecycleQueryRunner", _make_runner(original_query, team, now))
+
+    columns = result.get("columns", [])
+    rows = result.get("results", [])
+
+    if not rows:
+        result["results"] = []
+        _strip_hogql_fields(result)
+        return
+
+    response = HogQLQueryResponse(results=rows, columns=columns)
+    result["results"] = runner.format_results(response)
+    _strip_hogql_fields(result)
+
+
+def _transform_retention(result: dict, original_query: dict, team: Team, now: datetime | None = None) -> None:
+    runner = cast("RetentionQueryRunner", _make_runner(original_query, team, now))
+
+    columns = result.get("columns", [])
+    rows = result.get("results", [])
+
+    if not rows:
+        result["results"] = []
+        _strip_hogql_fields(result)
+        return
+
+    response = HogQLQueryResponse(results=rows, columns=columns)
+    result["results"] = runner.format_results(response)
+    _strip_hogql_fields(result)

--- a/products/endpoints/backend/materialization.py
+++ b/products/endpoints/backend/materialization.py
@@ -21,6 +21,31 @@ class VariableInHavingClauseError(ValueError):
     """Raised when a variable is used in a HAVING clause, which is not supported for materialization."""
 
 
+def inject_series_index(query_ast: ast.SelectQuery | ast.SelectSetQuery) -> None:
+    """Add a __series_index literal column to each sub-query in a UNION ALL.
+
+    For single SelectQuery: adds ``0 AS __series_index``.
+    For SelectSetQuery (multi-series UNION ALL): adds ``N AS __series_index``
+    to each sub-query so the materialized table can distinguish series.
+    """
+    if isinstance(query_ast, ast.SelectQuery):
+        _add_series_index_to_select(query_ast, 0)
+    elif isinstance(query_ast, ast.SelectSetQuery):
+        all_queries = query_ast.select_queries()
+        for i, sub_query in enumerate(all_queries):
+            if isinstance(sub_query, ast.SelectQuery):
+                _add_series_index_to_select(sub_query, i)
+
+
+def _add_series_index_to_select(query: ast.SelectQuery, index: int) -> None:
+    """Add ``{index} AS __series_index`` to a single SELECT query."""
+    series_col = ast.Alias(alias="__series_index", expr=ast.Constant(value=index))
+    query.select = [*list(query.select or []), series_col]
+
+    if query.group_by is not None:
+        query.group_by = [*list(query.group_by), ast.Field(chain=["__series_index"])]
+
+
 def convert_insight_query_to_hogql(query: dict[str, Any], team: Team) -> dict[str, Any]:
     query_kind = query.get("kind")
 
@@ -35,6 +60,11 @@ def convert_insight_query_to_hogql(query: dict[str, Any], team: Team) -> dict[st
     )
 
     combined_query_ast = query_runner.to_query()
+
+    # Only inject __series_index for types that have a corresponding transformer
+    SERIES_INDEX_QUERY_TYPES = {"TrendsQuery", "LifecycleQuery", "RetentionQuery"}
+    if query_kind in SERIES_INDEX_QUERY_TYPES:
+        inject_series_index(combined_query_ast)
 
     hogql_string = to_printed_hogql(combined_query_ast, team=team, modifiers=query_runner.modifiers)
 

--- a/products/endpoints/backend/models.py
+++ b/products/endpoints/backend/models.py
@@ -223,6 +223,20 @@ class EndpointVersion(UpdatedMetaFields, models.Model):
                 f"Query type '{query_kind}' cannot be materialized. Supported types: {supported}",
             )
 
+        # Block compare mode — materialization can't reconstruct doubled series
+        compare_filter = self.query.get("compareFilter") or {}
+        if compare_filter.get("compare"):
+            return False, "Compare mode is not supported for materialized endpoints."
+
+        # Block cohort breakdowns — they produce a UNION ALL across cohorts, which
+        # inject_series_index tags as separate series, causing a mismatch at read time.
+        breakdown_filter = self.query.get("breakdownFilter") or {}
+        if breakdown_filter.get("breakdown_type") == "cohort":
+            return False, "Cohort breakdowns are not supported for materialized endpoints."
+        for breakdown in breakdown_filter.get("breakdowns") or []:
+            if isinstance(breakdown, dict) and breakdown.get("type") == "cohort":
+                return False, "Cohort breakdowns are not supported for materialized endpoints."
+
         if self.query.get("variables"):
             from products.endpoints.backend.materialization import analyze_variables_for_materialization
 

--- a/products/endpoints/backend/tests/test_endpoint_materialization.py
+++ b/products/endpoints/backend/tests/test_endpoint_materialization.py
@@ -282,6 +282,50 @@ class TestEndpointMaterialization(ClickhouseTestMixin, APIBaseTest):
         # Should indicate variable metadata issue
         self.assertIn("Cannot materialize endpoint", response.json()["detail"])
 
+    @parameterized.expand(
+        [
+            (
+                "legacy_breakdown_type",
+                {
+                    "kind": "TrendsQuery",
+                    "series": [{"kind": "EventsNode", "event": "$pageview"}],
+                    "dateRange": {"date_from": "-7d"},
+                    "breakdownFilter": {"breakdown_type": "cohort", "breakdown": 123},
+                },
+            ),
+            (
+                "new_breakdowns_cohort",
+                {
+                    "kind": "TrendsQuery",
+                    "series": [{"kind": "EventsNode", "event": "$pageview"}],
+                    "dateRange": {"date_from": "-7d"},
+                    "breakdownFilter": {"breakdowns": [{"type": "cohort", "property": 123}]},
+                },
+            ),
+        ]
+    )
+    def test_cannot_materialize_trends_with_cohort_breakdown(self, _name, query):
+        """Cohort breakdowns produce UNION ALL across cohorts, which inject_series_index
+        would tag as separate series — causing a mismatch loop at read time. Block upfront."""
+        endpoint = create_endpoint_with_version(
+            name=f"test_cohort_breakdown_{_name}",
+            team=self.team,
+            query=query,
+            created_by=self.user,
+        )
+
+        response = self.client.patch(
+            f"/api/environments/{self.team.id}/endpoints/{endpoint.name}/",
+            {
+                "is_materialized": True,
+                "sync_frequency": DataWarehouseSyncInterval.FIELD_24HOUR,
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("Cohort breakdowns are not supported", response.json()["detail"])
+
     def test_can_materialize_lifecycle_query(self):
         _create_event(
             team=self.team,

--- a/products/endpoints/backend/tests/test_insight_response_parity.py
+++ b/products/endpoints/backend/tests/test_insight_response_parity.py
@@ -1,0 +1,423 @@
+"""Tests proving materialized insight endpoints must produce the same response shape as non-materialized ones.
+
+These tests are written TDD-style: they define the expected contract and initially FAIL because the
+materialized path currently returns flat HogQL data instead of rich insight-specific responses.
+"""
+
+from datetime import date
+
+import pytest
+from posthog.test.base import APIBaseTest, ClickhouseTestMixin, _create_event, flush_persons_and_events
+from unittest import mock
+
+from django.utils import timezone
+
+from rest_framework import status
+
+from posthog.schema import (
+    Breakdown,
+    BreakdownFilter,
+    BreakdownType,
+    DataWarehouseSyncInterval,
+    EventsNode,
+    HogQLQueryResponse,
+    LifecycleQuery,
+    RetentionFilter,
+    RetentionQuery,
+    TrendsQuery,
+)
+
+from products.data_warehouse.backend.models import DataWarehouseTable
+from products.data_warehouse.backend.models.datawarehouse_saved_query import DataWarehouseSavedQuery
+from products.endpoints.backend.tests.conftest import create_endpoint_with_version
+
+pytestmark = [pytest.mark.django_db]
+
+# Fields that every TrendsQuery result dict must have
+TRENDS_REQUIRED_FIELDS = {"data", "labels", "days", "count", "label", "action"}
+# Fields that every LifecycleQuery result dict must have
+LIFECYCLE_REQUIRED_FIELDS = {"data", "labels", "days", "count", "label", "action", "status"}
+# Fields that every RetentionQuery result dict must have
+RETENTION_REQUIRED_FIELDS = {"values", "label", "date"}
+
+
+class TestInsightResponseParity(ClickhouseTestMixin, APIBaseTest):
+    """Materialized insight endpoints must return the same response shape as non-materialized ones."""
+
+    def setUp(self):
+        super().setUp()
+
+        for day in range(1, 11):
+            _create_event(
+                event="$pageview",
+                distinct_id="user1",
+                team=self.team,
+                timestamp=f"2026-01-{day:02d} 12:00:00",
+                properties={"$browser": "Chrome" if day % 2 == 0 else "Safari"},
+            )
+
+        flush_persons_and_events()
+
+        self.sync_workflow_patcher = mock.patch(
+            "products.data_warehouse.backend.data_load.saved_query_service.sync_saved_query_workflow"
+        )
+        self.workflow_exists_patcher = mock.patch(
+            "products.data_warehouse.backend.data_load.saved_query_service.saved_query_workflow_exists",
+            return_value=False,
+        )
+        self.sync_workflow_patcher.start()
+        self.workflow_exists_patcher.start()
+
+    def tearDown(self):
+        self.sync_workflow_patcher.stop()
+        self.workflow_exists_patcher.stop()
+        super().tearDown()
+
+    def _materialize_endpoint(self, endpoint):
+        """Enable materialization and set up a completed saved query with table."""
+        response = self.client.patch(
+            f"/api/environments/{self.team.id}/endpoints/{endpoint.name}/",
+            {"is_materialized": True, "sync_frequency": DataWarehouseSyncInterval.FIELD_24HOUR},
+            format="json",
+        )
+        assert response.status_code == status.HTTP_200_OK, response.json()
+
+        version = endpoint.versions.first()
+        version.refresh_from_db()
+        saved_query = version.saved_query
+        assert saved_query is not None
+
+        saved_query.status = DataWarehouseSavedQuery.Status.COMPLETED
+        saved_query.last_run_at = timezone.now()
+        saved_query.table = DataWarehouseTable.objects.create(
+            team=self.team,
+            name=f"{endpoint.name}_v1",
+            format=DataWarehouseTable.TableFormat.Parquet,
+            url_pattern=f"s3://test-bucket/{endpoint.name}_v1",
+        )
+        saved_query.save()
+
+        return saved_query
+
+    def _run_endpoint(self, endpoint, **kwargs):
+        return self.client.post(
+            f"/api/environments/{self.team.id}/endpoints/{endpoint.name}/run/",
+            {"refresh": "force", **kwargs},
+            format="json",
+        )
+
+    # =========================================================================
+    # TRENDS
+    # =========================================================================
+
+    def test_materialized_trends_has_insight_shape(self):
+        endpoint = create_endpoint_with_version(
+            name="trends_parity",
+            team=self.team,
+            query=TrendsQuery(
+                series=[EventsNode(event="$pageview")],
+                dateRange={"date_from": "2026-01-01", "date_to": "2026-01-10"},
+            ).model_dump(),
+            created_by=self.user,
+            is_active=True,
+        )
+
+        # Step 1: Execute inline — establish the baseline shape
+        inline_resp = self._run_endpoint(endpoint)
+        assert inline_resp.status_code == status.HTTP_200_OK
+        inline_results = inline_resp.json()["results"]
+        assert len(inline_results) > 0
+        assert isinstance(inline_results[0], dict)
+        for field in TRENDS_REQUIRED_FIELDS:
+            assert field in inline_results[0], f"Inline response missing '{field}'"
+
+        # Step 2: Set up materialization
+        self._materialize_endpoint(endpoint)
+
+        # Step 3: Mock process_query_model to return flat HogQL data
+        # (simulating what the materialized table would produce)
+        dates = [date(2026, 1, d) for d in range(1, 11)]
+        totals = [1.0] * 10
+        flat_response = HogQLQueryResponse(
+            results=[(dates, totals)],
+            columns=["date", "total"],
+            types=["Array(Date)", "Array(Float64)"],
+            hasMore=False,
+        )
+
+        with mock.patch(
+            "products.endpoints.backend.api.process_query_model",
+            return_value=flat_response,
+        ):
+            mat_resp = self._run_endpoint(endpoint)
+
+        assert mat_resp.status_code == status.HTTP_200_OK
+        mat_results = mat_resp.json()["results"]
+        assert len(mat_results) > 0
+
+        # The materialized response must have the same insight shape
+        first = mat_results[0]
+        assert isinstance(first, dict), f"Expected dict, got {type(first).__name__}: {first}"
+        for field in TRENDS_REQUIRED_FIELDS:
+            assert field in first, f"Materialized response missing '{field}'"
+
+        # Value assertions: the mock data has 10 days with count 1.0 each
+        assert first["data"] == [1.0] * 10, f"Unexpected data values: {first['data']}"
+        assert first["count"] == 10.0, f"Unexpected count: {first['count']}"
+        assert len(first["labels"]) == 10, f"Expected 10 labels, got {len(first['labels'])}"
+        assert len(first["days"]) == 10, f"Expected 10 days, got {len(first['days'])}"
+
+    def test_materialized_trends_with_breakdown_has_insight_shape(self):
+        endpoint = create_endpoint_with_version(
+            name="trends_bd_parity",
+            team=self.team,
+            query=TrendsQuery(
+                series=[EventsNode(event="$pageview")],
+                breakdownFilter=BreakdownFilter(breakdowns=[Breakdown(property="$browser", type=BreakdownType.EVENT)]),
+                dateRange={"date_from": "2026-01-01", "date_to": "2026-01-10"},
+            ).model_dump(),
+            created_by=self.user,
+            is_active=True,
+        )
+
+        # Step 1: Inline baseline
+        inline_resp = self._run_endpoint(endpoint)
+        assert inline_resp.status_code == status.HTTP_200_OK
+        inline_results = inline_resp.json()["results"]
+        assert len(inline_results) > 0
+        assert "breakdown_value" in inline_results[0]
+
+        # Step 2: Materialize
+        self._materialize_endpoint(endpoint)
+
+        # Step 3: Mock with breakdown_value column
+        dates = [date(2026, 1, d) for d in range(1, 11)]
+        flat_response = HogQLQueryResponse(
+            results=[
+                (dates, [1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0], ["Chrome"]),
+                (dates, [0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0], ["Safari"]),
+            ],
+            columns=["date", "total", "breakdown_value"],
+            types=["Array(Date)", "Array(Float64)", "Array(String)"],
+            hasMore=False,
+        )
+
+        with mock.patch(
+            "products.endpoints.backend.api.process_query_model",
+            return_value=flat_response,
+        ):
+            mat_resp = self._run_endpoint(endpoint, variables={"$browser": "Chrome"})
+
+        assert mat_resp.status_code == status.HTTP_200_OK, mat_resp.json()
+        mat_results = mat_resp.json()["results"]
+        assert len(mat_results) > 0
+
+        first = mat_results[0]
+        assert isinstance(first, dict), f"Expected dict, got {type(first).__name__}: {first}"
+        for field in TRENDS_REQUIRED_FIELDS:
+            assert field in first, f"Materialized breakdown response missing '{field}'"
+        assert "breakdown_value" in first, "Materialized breakdown response missing 'breakdown_value'"
+
+        # Value assertions: verify breakdown values are present and data has correct length
+        breakdown_values = [str(r["breakdown_value"]) for r in mat_results]
+        assert any("Chrome" in bv for bv in breakdown_values), (
+            f"Expected Chrome in breakdown values: {breakdown_values}"
+        )
+        assert len(first["data"]) == 10, f"Expected 10 data points, got {len(first['data'])}"
+
+    # =========================================================================
+    # LIFECYCLE
+    # =========================================================================
+
+    def test_materialized_lifecycle_has_insight_shape(self):
+        endpoint = create_endpoint_with_version(
+            name="lifecycle_parity",
+            team=self.team,
+            query=LifecycleQuery(
+                series=[EventsNode(event="$pageview")],
+                dateRange={"date_from": "2026-01-01", "date_to": "2026-01-10"},
+            ).model_dump(),
+            created_by=self.user,
+            is_active=True,
+        )
+
+        # Step 1: Inline baseline
+        inline_resp = self._run_endpoint(endpoint)
+        assert inline_resp.status_code == status.HTTP_200_OK
+        inline_results = inline_resp.json()["results"]
+        assert len(inline_results) > 0
+        assert isinstance(inline_results[0], dict)
+        for field in LIFECYCLE_REQUIRED_FIELDS:
+            assert field in inline_results[0], f"Inline lifecycle response missing '{field}'"
+
+        # Step 2: Materialize
+        self._materialize_endpoint(endpoint)
+
+        # Step 3: Mock with lifecycle columns in ALPHABETICAL order
+        # (matching real materialized table behavior — Delta/Parquet sorts columns)
+        dates = [date(2026, 1, d) for d in range(1, 11)]
+        flat_response = HogQLQueryResponse(
+            results=[
+                (dates, "new", [1, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
+                (dates, "returning", [0, 1, 1, 1, 1, 1, 1, 1, 1, 1]),
+                (dates, "resurrecting", [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
+                (dates, "dormant", [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
+            ],
+            columns=["date", "status", "total"],
+            types=["Array(Date)", "String", "Array(Int64)"],
+            hasMore=False,
+        )
+
+        with mock.patch(
+            "products.endpoints.backend.api.process_query_model",
+            return_value=flat_response,
+        ):
+            mat_resp = self._run_endpoint(endpoint)
+
+        assert mat_resp.status_code == status.HTTP_200_OK
+        mat_results = mat_resp.json()["results"]
+        assert len(mat_results) > 0
+
+        first = mat_results[0]
+        assert isinstance(first, dict), f"Expected dict, got {type(first).__name__}: {first}"
+        for field in LIFECYCLE_REQUIRED_FIELDS:
+            assert field in first, f"Materialized lifecycle response missing '{field}'"
+
+        # Value assertions: verify lifecycle statuses are present
+        statuses = {r["status"] for r in mat_results}
+        assert statuses == {"new", "returning", "resurrecting", "dormant"}, f"Unexpected statuses: {statuses}"
+        # Each status should have 10 data points
+        for r in mat_results:
+            assert len(r["data"]) == 10, f"Status {r['status']}: expected 10 data points, got {len(r['data'])}"
+
+    # =========================================================================
+    # RETENTION
+    # =========================================================================
+
+    def test_materialized_retention_has_insight_shape(self):
+        endpoint = create_endpoint_with_version(
+            name="retention_parity",
+            team=self.team,
+            query=RetentionQuery(
+                retentionFilter=RetentionFilter(),
+                dateRange={"date_from": "2026-01-01", "date_to": "2026-01-10"},
+            ).model_dump(),
+            created_by=self.user,
+            is_active=True,
+        )
+
+        # Step 1: Inline baseline
+        inline_resp = self._run_endpoint(endpoint)
+        assert inline_resp.status_code == status.HTTP_200_OK
+        inline_results = inline_resp.json()["results"]
+        assert len(inline_results) > 0
+        assert isinstance(inline_results[0], dict)
+        for field in RETENTION_REQUIRED_FIELDS:
+            assert field in inline_results[0], f"Inline retention response missing '{field}'"
+        # Retention results have nested "values" with "count" and "label"
+        assert isinstance(inline_results[0]["values"], list)
+        assert "count" in inline_results[0]["values"][0]
+        assert "label" in inline_results[0]["values"][0]
+
+        # Step 2: Materialize
+        self._materialize_endpoint(endpoint)
+
+        # Step 3: Mock with retention columns in ALPHABETICAL order
+        # (matching real materialized table behavior — Delta/Parquet sorts columns)
+        flat_response = HogQLQueryResponse(
+            results=[
+                (1, 0, 0),
+                (1, 1, 0),
+                (1, 0, 1),
+                (1, 1, 1),
+                (0, 0, 2),
+                (0, 1, 2),
+            ],
+            columns=["count", "intervals_from_base", "start_event_matching_interval"],
+            types=["UInt64", "Int64", "Int64"],
+            hasMore=False,
+        )
+
+        with mock.patch(
+            "products.endpoints.backend.api.process_query_model",
+            return_value=flat_response,
+        ):
+            mat_resp = self._run_endpoint(endpoint)
+
+        assert mat_resp.status_code == status.HTTP_200_OK
+        mat_results = mat_resp.json()["results"]
+        assert len(mat_results) > 0
+
+        first = mat_results[0]
+        assert isinstance(first, dict), f"Expected dict, got {type(first).__name__}: {first}"
+        for field in RETENTION_REQUIRED_FIELDS:
+            assert field in first, f"Materialized retention response missing '{field}'"
+        assert isinstance(first["values"], list), "Retention values should be a list"
+        assert "count" in first["values"][0], "Retention values missing 'count'"
+        assert "label" in first["values"][0], "Retention values missing 'label'"
+
+        # Value assertions: first cohort (interval 0) should have count=1 at base
+        assert first["values"][0]["count"] == 1, f"Expected count=1 at base, got {first['values'][0]['count']}"
+        # Retention creates one cohort per date interval in the range (10 days = 10 cohorts)
+        assert len(mat_results) >= 3, f"Expected at least 3 cohorts, got {len(mat_results)}"
+
+    # =========================================================================
+    # MULTI-SERIES TRENDS
+    # =========================================================================
+
+    def test_materialized_multi_series_trends_has_insight_shape(self):
+        endpoint = create_endpoint_with_version(
+            name="multi_trends_parity",
+            team=self.team,
+            query=TrendsQuery(
+                series=[
+                    EventsNode(event="$pageview"),
+                    EventsNode(event="$pageview", math="dau"),
+                ],
+                dateRange={"date_from": "2026-01-01", "date_to": "2026-01-10"},
+            ).model_dump(),
+            created_by=self.user,
+            is_active=True,
+        )
+
+        # Step 1: Inline baseline — should have results from both series
+        inline_resp = self._run_endpoint(endpoint)
+        assert inline_resp.status_code == status.HTTP_200_OK
+        inline_results = inline_resp.json()["results"]
+        assert len(inline_results) >= 2, f"Expected 2+ series, got {len(inline_results)}"
+
+        # Step 2: Materialize
+        self._materialize_endpoint(endpoint)
+
+        # Step 3: Mock with __series_index column in ALPHABETICAL order
+        # (matching real materialized table behavior — Delta/Parquet sorts columns)
+        dates = [date(2026, 1, d) for d in range(1, 11)]
+        flat_response = HogQLQueryResponse(
+            results=[
+                (0, dates, [1.0] * 10),  # series 0: count
+                (1, dates, [1.0] * 10),  # series 1: dau
+            ],
+            columns=["__series_index", "date", "total"],
+            types=["Int64", "Array(Date)", "Array(Float64)"],
+            hasMore=False,
+        )
+
+        with mock.patch(
+            "products.endpoints.backend.api.process_query_model",
+            return_value=flat_response,
+        ):
+            mat_resp = self._run_endpoint(endpoint)
+
+        assert mat_resp.status_code == status.HTTP_200_OK
+        mat_results = mat_resp.json()["results"]
+        assert len(mat_results) >= 2, f"Expected 2+ series in materialized response, got {len(mat_results)}"
+
+        for i, result in enumerate(mat_results):
+            assert isinstance(result, dict), f"Series {i}: expected dict, got {type(result).__name__}"
+            for field in TRENDS_REQUIRED_FIELDS:
+                assert field in result, f"Series {i}: materialized response missing '{field}'"
+
+        # Value assertions: both series should have 10 data points with count 1.0
+        for i, result in enumerate(mat_results):
+            assert result["data"] == [1.0] * 10, f"Series {i}: unexpected data values: {result['data']}"
+            assert result["count"] == 10.0, f"Series {i}: unexpected count: {result['count']}"


### PR DESCRIPTION
## Problem

non-materialized insight-based endpoints produce a rich JSON result, while materialized results come from a flat table.

we want the xp of materialization to go unnoticed to the user - so we need to bring the materialized route to return the same shape as non-materialized (this direction because most customers are already using mostly, if not _only_ non-materialized insight-based endpoints).

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

## Changes

- add a method for transforming the shape of results using the query runner's `format_results()` class methods

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

ran things locally

<!-- Briefly describe the steps you took, and what steps reviewers must take to get to where changes are, and what is the expected behavior. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Publish to changelog?

yes!! this is exciting!

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

please do. both for results parity, but also the new condition we have for materialization around cohort breakdowns.

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->