### PR TITLE
fix(stamphog): annotate stale review context

### DIFF
--- a/tools/pr-approval-agent/github.py
+++ b/tools/pr-approval-agent/github.py
@@ -54,6 +54,37 @@ class PRData:
 _TRUSTED_ASSOCIATIONS = {"MEMBER", "OWNER", "COLLABORATOR"}
 
 
+def _normalize_reviews_for_prompt(reviews_raw: list[dict], head_sha: str) -> list[dict]:
+    """Normalize top-level reviews for the reviewer prompt.
+
+    Preserve trusted/bot reviews, and annotate whether each review was left on
+    the current PR head. This lets the LLM distinguish active feedback from
+    older context that may already have been addressed in follow-up commits.
+    """
+    normalized_reviews = []
+    for review in reviews_raw:
+        if not (
+            review.get("author_association") in _TRUSTED_ASSOCIATIONS
+            or review.get("author_association") == "BOT"
+            or review.get("user", {}).get("type") == "Bot"
+        ):
+            continue
+
+        commit_id = review.get("commit_id")
+        normalized_reviews.append(
+            {
+                "user": review["user"]["login"],
+                "state": review["state"],
+                "body": review.get("body", ""),
+                "commit_id": commit_id,
+                "is_current_head": commit_id == head_sha,
+                "submitted_at": review.get("submitted_at"),
+            }
+        )
+
+    return normalized_reviews
+
+
 def _gh_api(endpoint: str, *, paginate: bool = False) -> dict | list:
     cmd = ["gh", "api", endpoint]
     if paginate:
@@ -246,17 +277,7 @@ def fetch_pr(pr_number: int, repo: str, repo_root: Path | None = None) -> PRData
         base_sha=base_sha,
         head_sha=head_sha,
         files=files,
-        reviews=[
-            {
-                "user": r["user"]["login"],
-                "state": r["state"],
-                "body": r.get("body", ""),
-            }
-            for r in reviews_raw
-            if r.get("author_association") in _TRUSTED_ASSOCIATIONS
-            or r.get("author_association") == "BOT"
-            or r.get("user", {}).get("type") == "Bot"
-        ],
+        reviews=_normalize_reviews_for_prompt(reviews_raw, head_sha),
         review_comments=review_comments,
         check_runs=check_runs_resp.get("check_runs", []),
     )

--- a/tools/pr-approval-agent/reviewer.py
+++ b/tools/pr-approval-agent/reviewer.py
@@ -133,6 +133,10 @@ REVIEWER_SYSTEM = textwrap.dedent(
       - ESCALATE: behavioral changes to business logic, API contracts, data models
 
     Review comments (inline feedback only, approval states are hidden):
+    - Top-level reviews are annotated as either "current head" or "older commit".
+      Treat reviews on the current head as active signals. Treat older-commit
+      reviews as historical context only, and only flag them if the current diff
+      still shows the same unresolved issue.
     - Comments are tagged [resolved], [outdated], or unmarked (unresolved).
       Resolution status is a signal, not gospel — use your judgment.
     - Resolved/outdated comments are usually fine, but still skim them.
@@ -293,8 +297,11 @@ class Reviewer:
             for r in pr.reviews:
                 safe_user = _sanitize_untrusted(r["user"], max_len=50)
                 safe_body = _sanitize_untrusted(r.get("body", ""), max_len=500)
+                review_scope = "current head" if r.get("is_current_head") else "older commit"
+                if r.get("commit_id") and not r.get("is_current_head"):
+                    review_scope = f"older commit {r['commit_id'][:7]}"
                 body_part = f": {safe_body}" if safe_body else ""
-                lines.append(f"  - @{safe_user} [{r['state']}]{body_part}")
+                lines.append(f"  - @{safe_user} [{r['state']}, {review_scope}]{body_part}")
             reviews_text = "\n".join(lines)
 
         review_comments = ""

--- a/tools/pr-approval-agent/reviewer.py
+++ b/tools/pr-approval-agent/reviewer.py
@@ -297,9 +297,12 @@ class Reviewer:
             for r in pr.reviews:
                 safe_user = _sanitize_untrusted(r["user"], max_len=50)
                 safe_body = _sanitize_untrusted(r.get("body", ""), max_len=500)
-                review_scope = "current head" if r.get("is_current_head") else "older commit"
-                if r.get("commit_id") and not r.get("is_current_head"):
+                if r.get("is_current_head"):
+                    review_scope = "current head"
+                elif r.get("commit_id"):
                     review_scope = f"older commit {r['commit_id'][:7]}"
+                else:
+                    review_scope = "older commit"
                 body_part = f": {safe_body}" if safe_body else ""
                 lines.append(f"  - @{safe_user} [{r['state']}, {review_scope}]{body_part}")
             reviews_text = "\n".join(lines)

--- a/tools/pr-approval-agent/test_github.py
+++ b/tools/pr-approval-agent/test_github.py
@@ -1,0 +1,62 @@
+"""Tests for GitHub review normalization used by the PR approval agent."""
+
+from github import _normalize_reviews_for_prompt
+
+
+def test_normalize_reviews_marks_current_head_and_preserves_stale_reviews() -> None:
+    head_sha = "072cdd75592bfd0bf0c016209385f20f85a45201"
+    current_review = {
+        "user": {"login": "stamphog", "type": "Bot"},
+        "state": "COMMENTED",
+        "body": "Current head concern",
+        "commit_id": head_sha,
+        "submitted_at": "2026-04-07T20:14:03Z",
+        "author_association": "BOT",
+    }
+    stale_review = {
+        "user": {"login": "greptile-apps", "type": "Bot"},
+        "state": "COMMENTED",
+        "body": "Older concern",
+        "commit_id": "3c51bb8de4c73929c5266986118a14b966cb6831",
+        "submitted_at": "2026-04-07T20:02:32Z",
+        "author_association": "BOT",
+    }
+
+    normalized = _normalize_reviews_for_prompt([current_review, stale_review], head_sha)
+
+    assert normalized == [
+        {
+            "user": "stamphog",
+            "state": "COMMENTED",
+            "body": "Current head concern",
+            "commit_id": head_sha,
+            "is_current_head": True,
+            "submitted_at": "2026-04-07T20:14:03Z",
+        },
+        {
+            "user": "greptile-apps",
+            "state": "COMMENTED",
+            "body": "Older concern",
+            "commit_id": "3c51bb8de4c73929c5266986118a14b966cb6831",
+            "is_current_head": False,
+            "submitted_at": "2026-04-07T20:02:32Z",
+        },
+    ]
+
+
+def test_normalize_reviews_filters_untrusted_reviewers() -> None:
+    normalized = _normalize_reviews_for_prompt(
+        [
+            {
+                "user": {"login": "external-user", "type": "User"},
+                "state": "COMMENTED",
+                "body": "Should not be included",
+                "commit_id": "abc123",
+                "submitted_at": "2026-04-07T20:14:03Z",
+                "author_association": "NONE",
+            }
+        ],
+        "abc123",
+    )
+
+    assert normalized == []

--- a/tools/pr-approval-agent/test_github.py
+++ b/tools/pr-approval-agent/test_github.py
@@ -1,5 +1,7 @@
 """Tests for GitHub review normalization used by the PR approval agent."""
 
+import pytest
+
 from github import _normalize_reviews_for_prompt
 
 
@@ -44,19 +46,32 @@ def test_normalize_reviews_marks_current_head_and_preserves_stale_reviews() -> N
     ]
 
 
-def test_normalize_reviews_filters_untrusted_reviewers() -> None:
+@pytest.mark.parametrize(
+    "author_association,user_type,expected_count",
+    [
+        pytest.param("MEMBER", "User", 1, id="member-reviewer"),
+        pytest.param("OWNER", "User", 1, id="owner-reviewer"),
+        pytest.param("COLLABORATOR", "User", 1, id="collaborator-reviewer"),
+        pytest.param("BOT", "User", 1, id="bot-association"),
+        pytest.param("NONE", "Bot", 1, id="bot-user-type"),
+        pytest.param("NONE", "User", 0, id="untrusted-reviewer"),
+    ],
+)
+def test_normalize_reviews_filters_by_trust_source(
+    author_association: str, user_type: str, expected_count: int
+) -> None:
     normalized = _normalize_reviews_for_prompt(
         [
             {
-                "user": {"login": "external-user", "type": "User"},
+                "user": {"login": "reviewer", "type": user_type},
                 "state": "COMMENTED",
-                "body": "Should not be included",
+                "body": "Review body",
                 "commit_id": "abc123",
                 "submitted_at": "2026-04-07T20:14:03Z",
-                "author_association": "NONE",
+                "author_association": author_association,
             }
         ],
         "abc123",
     )
 
-    assert normalized == []
+    assert len(normalized) == expected_count


### PR DESCRIPTION
## Problem

Stamphog was repeatedly surfacing stale top-level review feedback because it only received prior review bodies and states, not the commit SHA those reviews were left on.

That made it hard for the reviewer to distinguish an active concern on the current head from a comment that may already have been addressed in a follow-up commit, which can slow reviews down and lower review quality.

## Changes

- Annotate top-level PR reviews with `commit_id`, `submitted_at`, and `is_current_head` in the GitHub fetch layer.
- Update the reviewer prompt and rendered review context so top-level reviews are explicitly labeled as either `current head` or `older commit`.
- Add focused tests for review normalization so current-head and stale reviews are both handled correctly.

## How did you test this code?

- `pytest tools/pr-approval-agent/test_gates.py tools/pr-approval-agent/test_github.py`

## Publish to changelog?

no

## Docs update

No docs update needed.

## 🤖 LLM context

Authored with Codex. I traced the PR approval agent workflow and found that prior top-level reviews were being fed back into the reviewer prompt without commit metadata. This PR keeps the review history but adds head-awareness so Stamphog can treat older reviews as historical context instead of active blockers by default.
