### PR TITLE
refactor(trends): replace filters with queries in dashboard tests

### DIFF
--- a/posthog/api/test/dashboards/test_dashboard.py
+++ b/posthog/api/test/dashboards/test_dashboard.py
@@ -14,7 +14,7 @@ from dateutil.parser import isoparse
 from parameterized import parameterized
 from rest_framework import status
 
-from posthog.schema import DateRange, EventPropertyFilter, EventsNode, TrendsQuery
+from posthog.schema import DateRange, EventPropertyFilter, EventsNode, PropertyOperator, TrendsQuery
 
 from posthog.api.test.dashboards import DashboardAPI
 from posthog.constants import AvailableFeature
@@ -1363,29 +1363,21 @@ class TestDashboard(APIBaseTest, QueryMatchingTest):
         self.assertEqual(response.json()["quick_filter_ids"], [str(qf1.id), str(qf2.id)])
 
     def test_return_cached_results_dashboard_has_filters(self):
-        # create a dashboard with no filters
-        dashboard: Dashboard = Dashboard.objects.create(team=self.team, name="dashboard")
-
-        filter_dict = {
-            "events": [{"id": "$pageview"}],
-            "properties": [{"key": "$browser", "value": "Mac OS X"}],
-            "date_from": "-7d",
-            "insight": "TRENDS",
-        }
-
-        # create two insights with a -7d date from filter
-        self.dashboard_api.create_insight({"filters": filter_dict, "dashboards": [dashboard.pk]})
-        self.dashboard_api.create_insight({"filters": filter_dict, "dashboards": [dashboard.pk]})
-
-        query = TrendsQuery(
+        # create a dashboard with two 7-day insights
+        query_7d = TrendsQuery(
             series=[EventsNode(event="$pageview")],
-            properties=[EventPropertyFilter(key="$browser", value="Mac OS X", operator="exact")],
+            properties=[EventPropertyFilter(key="$browser", value="Mac OS X", operator=PropertyOperator.EXACT)],
             dateRange=DateRange(date_from="-7d"),
         ).model_dump()
+        dashboard: Dashboard = Dashboard.objects.create(team=self.team, name="dashboard")
+        self.dashboard_api.create_insight({"query": query_7d, "dashboards": [dashboard.pk]})
+        self.dashboard_api.create_insight({"query": query_7d, "dashboards": [dashboard.pk]})
 
-        # cache insight results for trends with a -7d date from
-        response = self.client.post(f"/api/projects/{self.team.id}/query/", data={"query": query})
+        # warms the query cache for these 7-day insights
+        response = self.client.post(f"/api/projects/{self.team.pk}/query/", data={"query": query_7d})
         self.assertEqual(response.status_code, 200)
+
+        # confirm that the dashboard returns the cached result (8 days)
         dashboard_json = self.dashboard_api.get_dashboard(dashboard.pk)
         self.assertEqual(len(dashboard_json["tiles"][0]["insight"]["result"][0]["days"]), 8)
 
@@ -1395,26 +1387,22 @@ class TestDashboard(APIBaseTest, QueryMatchingTest):
             {"filters": {"date_from": "-24h"}},
         )
 
+        # check that the immediate dashboard response clears the old cached result (result is None),
+        # confirming stale 7-day data is not reused
         self.assertEqual(patch_response_json["tiles"][0]["insight"]["result"], None)
         dashboard.refresh_from_db()
         self.assertEqual(dashboard.filters, {"date_from": "-24h"})
 
-        # cache results
-        filter_dict["date_from"] = "-24h"
-        response = self.client.post(
-            f"/api/projects/{self.team.id}/query/",
-            data={
-                "query": TrendsQuery(
-                    series=[EventsNode(event="$pageview")],
-                    properties=[EventPropertyFilter(key="$browser", value="Mac OS X", operator="exact")],
-                    dateRange=DateRange(date_from="-24h"),
-                ).model_dump()
-            },
-        )
-
+        # warms the query cache for these 24-hour insights
+        query_24h = TrendsQuery(
+            series=[EventsNode(event="$pageview")],
+            properties=[EventPropertyFilter(key="$browser", value="Mac OS X", operator=PropertyOperator.EXACT)],
+            dateRange=DateRange(date_from="-24h"),
+        ).model_dump()
+        response = self.client.post(f"/api/projects/{self.team.pk}/query/", data={"query": query_24h})
         self.assertEqual(response.status_code, 200)
 
-        # Expecting this to only have one day as per the dashboard filter
+        # confirm that the dashboard returns the cached result (2 days)
         dashboard_json = self.dashboard_api.get_dashboard(dashboard.pk)
         self.assertEqual(len(dashboard_json["tiles"][0]["insight"]["result"][0]["days"]), 2)
 

--- a/posthog/api/test/dashboards/test_dashboard.py
+++ b/posthog/api/test/dashboards/test_dashboard.py
@@ -14,10 +14,11 @@ from dateutil.parser import isoparse
 from parameterized import parameterized
 from rest_framework import status
 
+from posthog.schema import DateRange, EventPropertyFilter, EventsNode, TrendsQuery
+
 from posthog.api.test.dashboards import DashboardAPI
 from posthog.constants import AvailableFeature
 from posthog.helpers.dashboard_templates import create_group_type_mapping_detail_dashboard
-from posthog.hogql_queries.legacy_compatibility.filter_to_query import filter_to_query
 from posthog.models import Filter, Insight, Team, User
 from posthog.models.activity_logging.activity_log import ActivityLog
 from posthog.models.file_system.file_system_view_log import FileSystemViewLog
@@ -1376,7 +1377,11 @@ class TestDashboard(APIBaseTest, QueryMatchingTest):
         self.dashboard_api.create_insight({"filters": filter_dict, "dashboards": [dashboard.pk]})
         self.dashboard_api.create_insight({"filters": filter_dict, "dashboards": [dashboard.pk]})
 
-        query = filter_to_query(filter_dict).model_dump()
+        query = TrendsQuery(
+            series=[EventsNode(event="$pageview")],
+            properties=[EventPropertyFilter(key="$browser", value="Mac OS X", operator="exact")],
+            dateRange=DateRange(date_from="-7d"),
+        ).model_dump()
 
         # cache insight results for trends with a -7d date from
         response = self.client.post(f"/api/projects/{self.team.id}/query/", data={"query": query})
@@ -1398,7 +1403,13 @@ class TestDashboard(APIBaseTest, QueryMatchingTest):
         filter_dict["date_from"] = "-24h"
         response = self.client.post(
             f"/api/projects/{self.team.id}/query/",
-            data={"query": filter_to_query(filter_dict).model_dump()},
+            data={
+                "query": TrendsQuery(
+                    series=[EventsNode(event="$pageview")],
+                    properties=[EventPropertyFilter(key="$browser", value="Mac OS X", operator="exact")],
+                    dateRange=DateRange(date_from="-24h"),
+                ).model_dump()
+            },
         )
 
         self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
## Problem

We want to get rid of legacy "filters".

## Changes

Replaces them in `posthog/api/test/dashboards/test_dashboard.py`.

## How did you test this code?

Tests still run