### PR TITLE
refactor(funnels): replace legacy filters in trends actors test

### DIFF
--- a/posthog/hogql_queries/insights/funnels/test/test_funnel_trends_actors.py
+++ b/posthog/hogql_queries/insights/funnels/test/test_funnel_trends_actors.py
@@ -3,15 +3,7 @@ from datetime import datetime, timedelta
 from freezegun import freeze_time
 from posthog.test.base import APIBaseTest, ClickhouseTestMixin, snapshot_clickhouse_queries
 
-from posthog.schema import (
-    DateRange,
-    EventsNode,
-    FunnelConversionWindowTimeUnit,
-    FunnelsFilter,
-    FunnelsQuery,
-    FunnelVizType,
-    IntervalType,
-)
+from posthog.schema import DateRange, EventsNode, FunnelsFilter, FunnelsQuery, FunnelVizType, IntervalType
 
 from posthog.hogql_queries.insights.funnels.test.test_funnel_persons import get_actors
 from posthog.session_recordings.queries.test.session_replay_sql import produce_replay_summary

--- a/posthog/hogql_queries/insights/funnels/test/test_funnel_trends_actors.py
+++ b/posthog/hogql_queries/insights/funnels/test/test_funnel_trends_actors.py
@@ -3,7 +3,15 @@ from datetime import datetime, timedelta
 from freezegun import freeze_time
 from posthog.test.base import APIBaseTest, ClickhouseTestMixin, snapshot_clickhouse_queries
 
-from posthog.schema import DateRange, EventsNode, FunnelsFilter, FunnelsQuery, FunnelVizType, IntervalType
+from posthog.schema import (
+    DateRange,
+    EventsNode,
+    FunnelConversionWindowTimeUnit,
+    FunnelsFilter,
+    FunnelsQuery,
+    FunnelVizType,
+    IntervalType,
+)
 
 from posthog.hogql_queries.insights.funnels.test.test_funnel_persons import get_actors
 from posthog.session_recordings.queries.test.session_replay_sql import produce_replay_summary
@@ -20,7 +28,7 @@ funnels_query = FunnelsQuery(
     funnelsFilter=FunnelsFilter(
         funnelVizType=FunnelVizType.TRENDS,
         funnelWindowInterval=14,
-        funnelWindowIntervalUnit=IntervalType.DAY,
+        funnelWindowIntervalUnit=FunnelConversionWindowTimeUnit.DAY,
         funnelFromStep=0,
     ),
 )
@@ -61,6 +69,7 @@ class TestFunnelTrendsActors(ClickhouseTestMixin, APIBaseTest):
             last_timestamp=timestamp,
         )
 
+        assert funnels_query.funnelsFilter
         results = get_actors(
             funnels_query.model_copy(
                 update={"funnelsFilter": funnels_query.funnelsFilter.model_copy(update={"funnelToStep": 1})}

--- a/posthog/hogql_queries/insights/funnels/test/test_funnel_trends_actors.py
+++ b/posthog/hogql_queries/insights/funnels/test/test_funnel_trends_actors.py
@@ -27,8 +27,6 @@ funnels_query = FunnelsQuery(
     dateRange=DateRange(date_from="2021-05-01 00:00:00", date_to="2021-05-07 23:59:59"),
     funnelsFilter=FunnelsFilter(
         funnelVizType=FunnelVizType.TRENDS,
-        funnelWindowInterval=14,
-        funnelWindowIntervalUnit=FunnelConversionWindowTimeUnit.DAY,
         funnelFromStep=0,
     ),
 )

--- a/posthog/hogql_queries/insights/funnels/test/test_funnel_trends_actors.py
+++ b/posthog/hogql_queries/insights/funnels/test/test_funnel_trends_actors.py
@@ -3,25 +3,27 @@ from datetime import datetime, timedelta
 from freezegun import freeze_time
 from posthog.test.base import APIBaseTest, ClickhouseTestMixin, snapshot_clickhouse_queries
 
-from posthog.constants import INSIGHT_FUNNELS, FunnelVizType
-from posthog.hogql_queries.insights.funnels.test.test_funnel_persons import get_actors_legacy_filters
+from posthog.schema import DateRange, EventsNode, FunnelsFilter, FunnelsQuery, FunnelVizType, IntervalType
+
+from posthog.hogql_queries.insights.funnels.test.test_funnel_persons import get_actors
 from posthog.session_recordings.queries.test.session_replay_sql import produce_replay_summary
 from posthog.test.test_journeys import journeys_for
 
-filters = {
-    "insight": INSIGHT_FUNNELS,
-    "funnel_viz_type": FunnelVizType.TRENDS,
-    "interval": "day",
-    "date_from": "2021-05-01 00:00:00",
-    "date_to": "2021-05-07 23:59:59",
-    "funnel_window_days": 14,
-    "funnel_from_step": 0,
-    "events": [
-        {"id": "step one", "order": 0},
-        {"id": "step two", "order": 1},
-        {"id": "step three", "order": 2},
+funnels_query = FunnelsQuery(
+    series=[
+        EventsNode(event="step one"),
+        EventsNode(event="step two"),
+        EventsNode(event="step three"),
     ],
-}
+    interval=IntervalType.DAY,
+    dateRange=DateRange(date_from="2021-05-01 00:00:00", date_to="2021-05-07 23:59:59"),
+    funnelsFilter=FunnelsFilter(
+        funnelVizType=FunnelVizType.TRENDS,
+        funnelWindowInterval=14,
+        funnelWindowIntervalUnit=IntervalType.DAY,
+        funnelFromStep=0,
+    ),
+)
 
 
 @freeze_time("2021-05-01")
@@ -59,8 +61,10 @@ class TestFunnelTrendsActors(ClickhouseTestMixin, APIBaseTest):
             last_timestamp=timestamp,
         )
 
-        results = get_actors_legacy_filters(
-            {"funnel_to_step": 1, **filters},
+        results = get_actors(
+            funnels_query.model_copy(
+                update={"funnelsFilter": funnels_query.funnelsFilter.model_copy(update={"funnelToStep": 1})}
+            ),
             self.team,
             funnel_trends_drop_off=False,
             funnel_trends_entrance_period_start="2021-05-01 00:00:00",
@@ -109,8 +113,8 @@ class TestFunnelTrendsActors(ClickhouseTestMixin, APIBaseTest):
             last_timestamp=timestamp,
         )
 
-        results = get_actors_legacy_filters(
-            filters,
+        results = get_actors(
+            funnels_query,
             self.team,
             funnel_trends_drop_off=False,
             funnel_trends_entrance_period_start="2021-05-01 00:00:00",
@@ -148,8 +152,8 @@ class TestFunnelTrendsActors(ClickhouseTestMixin, APIBaseTest):
             last_timestamp=timestamp,
         )
 
-        results = get_actors_legacy_filters(
-            filters,
+        results = get_actors(
+            funnels_query,
             self.team,
             funnel_trends_drop_off=True,
             funnel_trends_entrance_period_start="2021-05-01 00:00:00",


### PR DESCRIPTION
## Problem

We want to get rid of legacy "filters".

## Changes

Replaces them in `posthog/hogql_queries/insights/funnels/test/test_funnel_trends_actors.py`.

## How did you test this code?

Tests still run