### PR TITLE
fix(phai): margin nit for queued messages

### DIFF
--- a/frontend/src/scenes/max/components/QuestionInput.tsx
+++ b/frontend/src/scenes/max/components/QuestionInput.tsx
@@ -102,7 +102,7 @@ function QueuedMessageItem({
 
     return (
         <div className="group flex items-center gap-2 py-1 px-2 rounded-md hover:bg-bg-light">
-            <p className="flex-1 text-sm text-secondary truncate">{message.content}</p>
+            <p className="flex-1 text-sm text-secondary truncate mb-0">{message.content}</p>
             <div className="flex gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity">
                 <LemonButton
                     size="xsmall"


### PR DESCRIPTION
## Problem

- Queued messages have paragraph padding, which looks bad

## Changes

- Remove bottom margin padding

## How did you test this code?

- Tested in local

## Publish to changelog?

no

## Docs update

n/a