### PR TITLE
fix(error-tracking): support token scopes on issue actions

### DIFF
--- a/posthog/api/test/test_personal_api_keys.py
+++ b/posthog/api/test/test_personal_api_keys.py
@@ -17,6 +17,8 @@ from posthog.models.personal_api_key import LEGACY_PERSONAL_API_KEY_SALT, Person
 from posthog.models.team.team import Team
 from posthog.models.utils import SHA256_HASH_PREFIX, generate_random_token_personal, hash_key_value
 
+from products.error_tracking.backend.models import ErrorTrackingIssue
+
 
 class TestPersonalAPIKeysAPI(APIBaseTest):
     def test_create_personal_api_key(self):
@@ -611,6 +613,36 @@ class TestPersonalAPIKeysWithScopeAPIAuthentication(PersonalAPIKeysBaseTest):
     def test_allows_action_with_required_scopes(self):
         response = self._do_request(f"/api/projects/{self.team.id}/feature_flags/local_evaluation")
         assert response.status_code == status.HTTP_200_OK
+
+    def test_allows_custom_error_tracking_read_action(self):
+        self.key.scopes = ["error_tracking:read"]
+        self.key.save()
+        ErrorTrackingIssue.objects.create(team=self.team, name="TypeError")
+
+        response = self.client.get(
+            f"/api/environments/{self.team.id}/error_tracking/issues/values?key=name&value=Type",
+            headers={"authorization": f"Bearer {self.value}"},
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json() == {"results": [{"name": "TypeError"}], "refreshing": False}
+
+    def test_allows_custom_error_tracking_write_action(self):
+        self.key.scopes = ["error_tracking:write"]
+        self.key.save()
+        target_issue = ErrorTrackingIssue.objects.create(team=self.team)
+        source_issue = ErrorTrackingIssue.objects.create(team=self.team)
+
+        response = self.client.post(
+            f"/api/environments/{self.team.id}/error_tracking/issues/{target_issue.id}/merge",
+            {"ids": [str(source_issue.id)]},
+            format="json",
+            headers={"authorization": f"Bearer {self.value}"},
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json() == {"success": True}
+        assert ErrorTrackingIssue.objects.filter(team=self.team).count() == 1
 
     def test_errors_for_action_without_required_scopes(self):
         response = self._do_request(f"/api/projects/{self.team.id}/insights/my_last_viewed")

--- a/posthog/test/test_permissions.py
+++ b/posthog/test/test_permissions.py
@@ -1,3 +1,4 @@
+import json
 from datetime import timedelta
 
 from posthog.test.base import BaseTest
@@ -17,6 +18,8 @@ from posthog.models.oauth import OAuthAccessToken, OAuthApplication
 from posthog.models.organization import OrganizationMembership
 from posthog.permissions import AccessControlPermission
 from posthog.rbac.user_access_control import UserAccessControl
+
+from products.error_tracking.backend.models import ErrorTrackingIssue
 
 try:
     from ee.models.rbac.access_control import AccessControl
@@ -619,6 +622,23 @@ class TestOAuthAccessTokenAPIScopePermission(BaseTest):
         """OAuth token can access endpoints that match its scopes"""
         response = self._do_request(f"/api/projects/{self.team.id}/feature_flags/local_evaluation")
         self.assertEqual(response.status_code, 200)
+
+    def test_allows_custom_error_tracking_write_action(self):
+        """OAuth token can access custom error tracking write actions via scope_object_write_actions"""
+        self.access_token.scope = "error_tracking:write"
+        self.access_token.save()
+        issue = ErrorTrackingIssue.objects.create(team=self.team)
+
+        response = self.client.generic(
+            "PATCH",
+            f"/api/environments/{self.team.id}/error_tracking/issues/{issue.id}/assign",
+            json.dumps({"assignee": None}),
+            content_type="application/json",
+            headers={"authorization": f"Bearer {self.access_token.token}"},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"success": True})
 
     def test_forbids_action_with_other_scope(self):
         """OAuth token cannot access endpoints requiring different scopes"""

--- a/products/error_tracking/backend/api/issues.py
+++ b/products/error_tracking/backend/api/issues.py
@@ -120,6 +120,20 @@ class ErrorTrackingIssueFullSerializer(serializers.ModelSerializer):
 @extend_schema(tags=[ProductKey.ERROR_TRACKING])
 class ErrorTrackingIssueViewSet(TeamAndOrgViewSetMixin, ForbidDestroyModel, viewsets.ModelViewSet):
     scope_object = "error_tracking"
+    # These override the base defaults, so keep the standard DRF actions too.
+    scope_object_read_actions = ["list", "retrieve", "values"]
+    scope_object_write_actions = [
+        "create",
+        "update",
+        "partial_update",
+        "patch",
+        "destroy",
+        "merge",
+        "split",
+        "assign",
+        "cohort",
+        "bulk",
+    ]
     queryset = ErrorTrackingIssue.objects.with_first_seen().all()
     serializer_class = ErrorTrackingIssueFullSerializer
 


### PR DESCRIPTION
## Problem

Error tracking issue custom actions like `merge`, `assign`, `bulk`, and `values` were missing API token scope mappings. Session-authenticated web flows worked, but Personal API keys and OAuth tokens could get `This action does not support Personal API Key access` for the same endpoints.

From my understanding, this is also needed to make those tools available through MCP

## Changes

- add explicit `scope_object_read_actions` / `scope_object_write_actions` on `ErrorTrackingIssueViewSet`
- include the standard DRF actions plus error-tracking custom actions such as `merge`, `split`, `assign`, `cohort`, `bulk`, and `values`
- add Personal API key regressions for custom error-tracking read and write actions
- add OAuth regression coverage for a custom error-tracking write action

## How did you test this code?

- `uv run pytest products/error_tracking/backend/api/test/test_error_tracking_api.py -k issue_merge`
- `uv run pytest posthog/api/test/test_personal_api_keys.py -k custom_error_tracking`
- `uv run pytest posthog/test/test_permissions.py -k custom_error_tracking_write_action`

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

no

## Docs update

No docs update needed.
