### PR TITLE
feat(capture v1): base Sink abstractions

### DIFF
--- a/rust/capture/src/v1/analytics/process.rs
+++ b/rust/capture/src/v1/analytics/process.rs
@@ -78,9 +78,9 @@ fn validate_events(context: &Context, batch: Batch) -> Result<HashMap<Uuid, Wrap
     let mut events: HashMap<Uuid, WrappedEvent> = HashMap::with_capacity(batch.batch.len());
 
     for event in batch.batch.into_iter() {
-        let uuid = Uuid::parse_str(&event.uuid).map_err(|_| Error::MissingEventUuid)?;
+        let uuid = Uuid::parse_str(event.uuid()).map_err(|_| Error::MissingEventUuid)?;
         if events.contains_key(&uuid) {
-            return Err(Error::DuplicateEventUuid(event.uuid));
+            return Err(Error::DuplicateEventUuid(event.uuid().to_owned()));
         }
 
         match validate_event(&event) {
@@ -259,7 +259,7 @@ async fn apply_restrictions(
             distinct_id: Some(&event.event.distinct_id),
             session_id: event.event.session_id.as_deref(),
             event_name: Some(&event.event.event),
-            event_uuid: Some(&event.event.uuid),
+            event_uuid: Some(event.event.uuid()),
             now_ts,
         };
 
@@ -570,9 +570,9 @@ mod tests {
             event: "$performance_event".to_string(),
             ..valid_event()
         };
-        let perf_uuid = Uuid::parse_str(&perf.uuid).unwrap();
+        let perf_uuid = Uuid::parse_str(perf.uuid()).unwrap();
         let normal = valid_event();
-        let normal_uuid = Uuid::parse_str(&normal.uuid).unwrap();
+        let normal_uuid = Uuid::parse_str(normal.uuid()).unwrap();
         let batch = valid_batch(vec![perf, normal]);
         let events = validate_events(&ctx, batch).unwrap();
         assert_eq!(events.len(), 2);
@@ -667,7 +667,7 @@ mod tests {
             properties: raw_obj("[1,2,3]"),
             ..valid_event()
         };
-        let uuid = Uuid::parse_str(&bad_event.uuid).unwrap();
+        let uuid = Uuid::parse_str(bad_event.uuid()).unwrap();
         let batch = Batch {
             created_at: "2026-03-19T14:30:00.000Z".to_string(),
             historical_migration: false,
@@ -1187,7 +1187,7 @@ mod tests {
         let limiter = mock_limiter(vec!["phc_tok:user-2"]);
         let ctx = td_context();
         let pre_drop = wrapped_event("$pageview", "user-1");
-        let pre_drop_uuid = Uuid::parse_str(&pre_drop.event.uuid).unwrap();
+        let pre_drop_uuid = Uuid::parse_str(pre_drop.event.uuid()).unwrap();
         let mut events = events_map(vec![pre_drop, wrapped_event("$identify", "user-2")]);
         // Simulate event already dropped by restrictions
         events.get_mut(&pre_drop_uuid).unwrap().result = EventResult::Drop;
@@ -1271,7 +1271,7 @@ mod tests {
         let mut ctx = test_utils::test_context();
         ctx.historical_migration = true;
         let ev = wrapped_event("$pageview", "user-1");
-        let uuid = Uuid::parse_str(&ev.event.uuid).unwrap();
+        let uuid = Uuid::parse_str(ev.event.uuid()).unwrap();
         let mut events = events_map(vec![ev]);
         events.get_mut(&uuid).unwrap().destination = Destination::Overflow;
 
@@ -1289,7 +1289,7 @@ mod tests {
         let mut ctx = test_utils::test_context();
         ctx.historical_migration = true;
         let ev = wrapped_event("$pageview", "user-1");
-        let uuid = Uuid::parse_str(&ev.event.uuid).unwrap();
+        let uuid = Uuid::parse_str(ev.event.uuid()).unwrap();
         let mut events = events_map(vec![ev]);
         let e = events.get_mut(&uuid).unwrap();
         e.result = EventResult::Drop;
@@ -1319,7 +1319,7 @@ mod tests {
         let mut ctx = test_utils::test_context();
         ctx.historical_migration = true;
         let dlq_ev = wrapped_event("$identify", "user-2");
-        let dlq_uuid = Uuid::parse_str(&dlq_ev.event.uuid).unwrap();
+        let dlq_uuid = Uuid::parse_str(dlq_ev.event.uuid()).unwrap();
         let mut events = events_map(vec![wrapped_event("$pageview", "user-1"), dlq_ev]);
         events.get_mut(&dlq_uuid).unwrap().destination = Destination::Dlq;
 

--- a/rust/capture/src/v1/analytics/types.rs
+++ b/rust/capture/src/v1/analytics/types.rs
@@ -59,6 +59,14 @@ pub struct Event {
     pub properties: Box<RawValue>,
 }
 
+impl Event {
+    /// Trimmed accessor for the raw UUID string. Prefer this over direct
+    /// field access so callers are insulated from client-submitted whitespace.
+    pub fn uuid(&self) -> &str {
+        self.uuid.trim()
+    }
+}
+
 #[derive(Debug)]
 pub struct WrappedEvent {
     pub event: Event,

--- a/rust/capture/src/v1/quota_limiter_shim.rs
+++ b/rust/capture/src/v1/quota_limiter_shim.rs
@@ -348,7 +348,7 @@ mod tests {
     async fn global_limit_preserves_all_event_states() {
         let limiter = build_limiter("tok", true, &[]).await;
         let bad = make_event("bad_event", None);
-        let bad_uuid = Uuid::parse_str(&bad.event.uuid).unwrap();
+        let bad_uuid = Uuid::parse_str(bad.event.uuid()).unwrap();
         let mut events = events_map(vec![make_event("$pageview", None), bad]);
         // Pre-mark one event as Drop (e.g. from validation)
         let bad_ev = events.get_mut(&bad_uuid).unwrap();
@@ -456,7 +456,7 @@ mod tests {
     async fn survey_limit_excludes_product_tour_events() {
         let limiter = build_limiter("tok", false, &[QuotaResource::Surveys]).await;
         let tour_ev = make_event("survey sent", Some("tour-123"));
-        let tour_uuid = Uuid::parse_str(&tour_ev.event.uuid).unwrap();
+        let tour_uuid = Uuid::parse_str(tour_ev.event.uuid()).unwrap();
         let mut events = events_map(vec![make_event("survey sent", None), tour_ev]);
 
         let result = apply_quota_limits(&limiter, "tok", &mut events).await;
@@ -606,7 +606,7 @@ mod tests {
         // No global limit, but exceptions limited
         let limiter = build_limiter("tok", false, &[QuotaResource::Exceptions]).await;
         let pv = make_event("$pageview", None);
-        let pv_uuid = Uuid::parse_str(&pv.event.uuid).unwrap();
+        let pv_uuid = Uuid::parse_str(pv.event.uuid()).unwrap();
         let mut events = events_map(vec![make_event("$exception", None), pv]);
         // Pre-mark pageview as Drop from a prior validation step
         let pv_ev = events.get_mut(&pv_uuid).unwrap();
@@ -622,7 +622,7 @@ mod tests {
     async fn mixed_pre_existing_and_scoped_still_ok_if_some_remain() {
         let limiter = build_limiter("tok", false, &[QuotaResource::Exceptions]).await;
         let pv = make_event("$pageview", None);
-        let pv_uuid = Uuid::parse_str(&pv.event.uuid).unwrap();
+        let pv_uuid = Uuid::parse_str(pv.event.uuid()).unwrap();
         let mut events = events_map(vec![
             make_event("$exception", None),
             pv,

--- a/rust/capture/src/v1/sinks/constants.rs
+++ b/rust/capture/src/v1/sinks/constants.rs
@@ -1,0 +1,27 @@
+use std::time::Duration;
+
+#[allow(dead_code)]
+pub(crate) const DEFAULT_PRODUCE_TIMEOUT: Duration = Duration::from_secs(30);
+
+// Lifecycle Handle configuration for v1 sinks.
+//
+// Timing chain (worst-case detection of a fully broken sink):
+//   1. Last successful heartbeat at t=0
+//   2. publish_batch runs for up to produce_timeout (30s), returns with 0 successes -> no heartbeat
+//   3. stats callback fires every statistics_interval_ms (10s) but brokers are down -> no heartbeat
+//   4. At t=30s liveness_deadline expires
+//   5. Next health_poll (within 2s) detects stall, stall_count=1 >= stall_threshold=1
+//   6. Global shutdown triggered at ~t=32s
+//
+// This matches the existing v0 capture setup (setup.rs + main.rs).
+
+/// The handle must receive a report_healthy() call within this window or
+/// the health poll considers it stalled. Set equal to produce_timeout so
+/// a single full-timeout batch is the minimum detection unit.
+#[allow(dead_code)]
+pub(crate) const SINK_LIVENESS_DEADLINE: Duration = Duration::from_secs(30);
+
+/// Consecutive stalled health polls before triggering global shutdown.
+/// 1 = immediate (first missed deadline triggers shutdown). Matches v0.
+#[allow(dead_code)]
+pub(crate) const SINK_STALL_THRESHOLD: u32 = 1;

--- a/rust/capture/src/v1/sinks/event.rs
+++ b/rust/capture/src/v1/sinks/event.rs
@@ -1,0 +1,83 @@
+use crate::v1::context::Context;
+use crate::v1::sinks::Destination;
+
+/// Transport-agnostic trait declaring an event's identity, routing intent,
+/// metadata, and serialization. The [`Sink`](super::sink::Sink) implementation
+/// resolves `destination()` to a concrete backend target using its own config.
+pub trait Event: Send + Sync {
+    /// UUID of the originating event -- correlation key for mapping results back.
+    fn uuid_key(&self) -> &str;
+
+    /// Whether this event should be published. Events returning false are
+    /// silently skipped by the Sink -- no `SinkResult` is returned for them.
+    fn should_publish(&self) -> bool;
+
+    /// Semantic routing destination. The Sink resolves this to a concrete
+    /// backend target (e.g. Kafka topic) using its own config.
+    fn destination(&self) -> &Destination;
+
+    /// Event-owned metadata as key-value pairs. The Sink merges these with
+    /// context-level headers before converting to transport-specific format.
+    fn headers(&self) -> Vec<(String, String)>;
+
+    /// Write the partition/routing key into a caller-provided buffer.
+    /// The caller clears `buf` between events; implementations just append.
+    fn write_partition_key(&self, ctx: &Context, buf: &mut String);
+
+    /// Serialize the event payload into a caller-provided buffer.
+    /// The caller clears `buf` between events; implementations just append.
+    fn serialize_into(&self, ctx: &Context, buf: &mut String) -> Result<(), String>;
+}
+
+/// Build the context-level headers that are identical for every event in a
+/// batch: token, server timestamp, and (optionally) historical_migration.
+/// Called once per batch; event-level headers are merged separately.
+pub fn build_context_headers(ctx: &Context) -> Vec<(String, String)> {
+    let mut headers = Vec::with_capacity(3);
+    headers.push(("token".into(), ctx.api_token.clone()));
+    headers.push(("now".into(), ctx.server_received_at.to_rfc3339()));
+    if ctx.historical_migration {
+        headers.push(("historical_migration".into(), "true".into()));
+    }
+    headers
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::v1::test_utils;
+
+    fn header_val(headers: &[(String, String)], key: &str) -> Option<String> {
+        headers
+            .iter()
+            .find(|(k, _)| k == key)
+            .map(|(_, v)| v.clone())
+    }
+
+    #[test]
+    fn context_headers_include_token_and_now() {
+        let ctx = test_utils::test_context();
+        let headers = build_context_headers(&ctx);
+        assert_eq!(header_val(&headers, "token"), Some(ctx.api_token.clone()));
+        assert!(header_val(&headers, "now").is_some());
+    }
+
+    #[test]
+    fn context_headers_include_historical_migration_when_set() {
+        let mut ctx = test_utils::test_context();
+        ctx.historical_migration = true;
+        let headers = build_context_headers(&ctx);
+        assert_eq!(
+            header_val(&headers, "historical_migration"),
+            Some("true".into())
+        );
+    }
+
+    #[test]
+    fn context_headers_omit_historical_migration_when_false() {
+        let mut ctx = test_utils::test_context();
+        ctx.historical_migration = false;
+        let headers = build_context_headers(&ctx);
+        assert!(header_val(&headers, "historical_migration").is_none());
+    }
+}

--- a/rust/capture/src/v1/sinks/event.rs
+++ b/rust/capture/src/v1/sinks/event.rs
@@ -1,3 +1,4 @@
+use common_types::CapturedEventHeaders;
 use uuid::Uuid;
 
 use crate::v1::context::Context;
@@ -18,9 +19,13 @@ pub trait Event: Send + Sync {
     /// backend target (e.g. Kafka topic, S3 bucket) using its own config.
     fn destination(&self) -> &Destination;
 
-    /// Event-owned metadata as key-value pairs. The Sink merges these with
-    /// context-level headers before converting to transport-specific format.
-    fn headers(&self) -> Vec<(String, String)>;
+    /// Resolve the full set of transport headers for this event, using the
+    /// supplied [`Context`] for batch-scoped fields (token, now,
+    /// historical_migration) alongside any event-owned fields. Sinks convert
+    /// the returned [`CapturedEventHeaders`] to their backend-specific format
+    /// (e.g. `rdkafka::message::OwnedHeaders` via the `From` impl in
+    /// `common_types`).
+    fn headers(&self, ctx: &Context) -> CapturedEventHeaders;
 
     /// Resolve the partition key for this message, and write
     /// to the supplied buffer. Called by Sinks that write to
@@ -29,57 +34,4 @@ pub trait Event: Send + Sync {
 
     /// Serialize the event payload into a caller-provided buffer.
     fn serialize_into(&self, ctx: &Context, buf: &mut String) -> Result<(), String>;
-}
-
-/// Build the context-level headers that are identical for every event in a
-/// batch: token, server timestamp, and (optionally) historical_migration.
-/// Called once per batch; event-level headers are merged separately.
-pub fn build_context_headers(ctx: &Context) -> Vec<(String, String)> {
-    let mut headers = Vec::with_capacity(3);
-    headers.push(("token".into(), ctx.api_token.clone()));
-    headers.push(("now".into(), ctx.server_received_at.to_rfc3339()));
-    if ctx.historical_migration {
-        headers.push(("historical_migration".into(), "true".into()));
-    }
-    headers
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::v1::test_utils;
-
-    fn header_val(headers: &[(String, String)], key: &str) -> Option<String> {
-        headers
-            .iter()
-            .find(|(k, _)| k == key)
-            .map(|(_, v)| v.clone())
-    }
-
-    #[test]
-    fn context_headers_include_token_and_now() {
-        let ctx = test_utils::test_context();
-        let headers = build_context_headers(&ctx);
-        assert_eq!(header_val(&headers, "token"), Some(ctx.api_token.clone()));
-        assert!(header_val(&headers, "now").is_some());
-    }
-
-    #[test]
-    fn context_headers_include_historical_migration_when_set() {
-        let mut ctx = test_utils::test_context();
-        ctx.historical_migration = true;
-        let headers = build_context_headers(&ctx);
-        assert_eq!(
-            header_val(&headers, "historical_migration"),
-            Some("true".into())
-        );
-    }
-
-    #[test]
-    fn context_headers_omit_historical_migration_when_false() {
-        let mut ctx = test_utils::test_context();
-        ctx.historical_migration = false;
-        let headers = build_context_headers(&ctx);
-        assert!(header_val(&headers, "historical_migration").is_none());
-    }
 }

--- a/rust/capture/src/v1/sinks/event.rs
+++ b/rust/capture/src/v1/sinks/event.rs
@@ -33,5 +33,5 @@ pub trait Event: Send + Sync {
     fn write_partition_key(&self, ctx: &Context, buf: &mut String);
 
     /// Serialize the event payload into a caller-provided buffer.
-    fn serialize_into(&self, ctx: &Context, buf: &mut String) -> Result<(), String>;
+    fn serialize_into(&self, ctx: &Context, buf: &mut String) -> anyhow::Result<()>;
 }

--- a/rust/capture/src/v1/sinks/event.rs
+++ b/rust/capture/src/v1/sinks/event.rs
@@ -1,3 +1,5 @@
+use uuid::Uuid;
+
 use crate::v1::context::Context;
 use crate::v1::sinks::Destination;
 
@@ -5,7 +7,11 @@ use crate::v1::sinks::Destination;
 /// metadata, and serialization. The [`Sink`](super::sink::Sink) implementation
 /// resolves `destination()` to a concrete backend target using its own config.
 pub trait Event: Send + Sync {
-    /// UUID of the originating event -- correlation key for mapping results back.
+    /// Pre-parsed UUID for result correlation. Copy, zero alloc.
+    fn uuid(&self) -> Uuid;
+
+    /// UUID of the originating event as a string -- zero-cost &str reference
+    /// for use inside the Sink implementations' event publishing loop.
     fn uuid_key(&self) -> &str;
 
     /// Whether this event should be published. Events returning false are

--- a/rust/capture/src/v1/sinks/event.rs
+++ b/rust/capture/src/v1/sinks/event.rs
@@ -10,10 +10,6 @@ pub trait Event: Send + Sync {
     /// Pre-parsed UUID for result correlation. Copy, zero alloc.
     fn uuid(&self) -> Uuid;
 
-    /// UUID of the originating event as a string -- zero-cost &str reference
-    /// for use inside the Sink implementations' event publishing loop.
-    fn uuid_key(&self) -> &str;
-
     /// Whether this event should be published. Events returning false are
     /// silently skipped by the Sink -- no `SinkResult` is returned for them.
     fn should_publish(&self) -> bool;

--- a/rust/capture/src/v1/sinks/event.rs
+++ b/rust/capture/src/v1/sinks/event.rs
@@ -13,19 +13,19 @@ pub trait Event: Send + Sync {
     fn should_publish(&self) -> bool;
 
     /// Semantic routing destination. The Sink resolves this to a concrete
-    /// backend target (e.g. Kafka topic) using its own config.
+    /// backend target (e.g. Kafka topic, S3 bucket) using its own config.
     fn destination(&self) -> &Destination;
 
     /// Event-owned metadata as key-value pairs. The Sink merges these with
     /// context-level headers before converting to transport-specific format.
     fn headers(&self) -> Vec<(String, String)>;
 
-    /// Write the partition/routing key into a caller-provided buffer.
-    /// The caller clears `buf` between events; implementations just append.
+    /// Resolve the partition key for this message, and write
+    /// to the supplied buffer. Called by Sinks that write to
+    /// event streams (Kafka, WarpStream etc.)
     fn write_partition_key(&self, ctx: &Context, buf: &mut String);
 
     /// Serialize the event payload into a caller-provided buffer.
-    /// The caller clears `buf` between events; implementations just append.
     fn serialize_into(&self, ctx: &Context, buf: &mut String) -> Result<(), String>;
 }
 

--- a/rust/capture/src/v1/sinks/mod.rs
+++ b/rust/capture/src/v1/sinks/mod.rs
@@ -1,3 +1,107 @@
+pub mod constants;
+pub mod event;
+pub mod sink;
 pub mod types;
 
-pub use types::Destination;
+use std::str::FromStr;
+
+pub use event::Event;
+pub use sink::Sink;
+pub use types::{Destination, Outcome, SinkResult};
+
+// ---------------------------------------------------------------------------
+// SinkName
+// ---------------------------------------------------------------------------
+
+/// Identity of a v1 sink target. Adding a new sink requires a new variant
+/// here plus its `as_str()`, `env_prefix()`, and `FromStr` arms.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum SinkName {
+    /// Primary MSK sink.
+    Msk,
+    /// Secondary MSK sink for upgrades, cutovers, or dual-writes.
+    MskAlt,
+    /// WarpStream sink for upgrades, cutovers, or dual-writes.
+    Ws,
+}
+
+impl SinkName {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Msk => "msk",
+            Self::MskAlt => "msk_alt",
+            Self::Ws => "ws",
+        }
+    }
+
+    pub fn env_prefix(&self) -> &'static str {
+        match self {
+            Self::Msk => "CAPTURE_V1_SINK_MSK_",
+            Self::MskAlt => "CAPTURE_V1_SINK_MSK_ALT_",
+            Self::Ws => "CAPTURE_V1_SINK_WS_",
+        }
+    }
+}
+
+impl FromStr for SinkName {
+    type Err = String;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.trim().to_lowercase().as_str() {
+            "msk" => Ok(Self::Msk),
+            "msk_alt" => Ok(Self::MskAlt),
+            "ws" => Ok(Self::Ws),
+            other => Err(format!("unknown sink: {other}")),
+        }
+    }
+}
+
+impl std::fmt::Display for SinkName {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_valid_names() {
+        assert_eq!("msk".parse::<SinkName>().unwrap(), SinkName::Msk);
+        assert_eq!("msk_alt".parse::<SinkName>().unwrap(), SinkName::MskAlt);
+        assert_eq!("ws".parse::<SinkName>().unwrap(), SinkName::Ws);
+    }
+
+    #[test]
+    fn parse_case_insensitive() {
+        assert_eq!("MSK".parse::<SinkName>().unwrap(), SinkName::Msk);
+        assert_eq!("Msk_Alt".parse::<SinkName>().unwrap(), SinkName::MskAlt);
+        assert_eq!("WS".parse::<SinkName>().unwrap(), SinkName::Ws);
+    }
+
+    #[test]
+    fn parse_unknown_name() {
+        assert!("foo".parse::<SinkName>().is_err());
+        assert!("warpstream".parse::<SinkName>().is_err());
+    }
+
+    #[test]
+    fn parse_empty_string() {
+        assert!("".parse::<SinkName>().is_err());
+    }
+
+    #[test]
+    fn env_prefix_correctness() {
+        assert_eq!(SinkName::Msk.env_prefix(), "CAPTURE_V1_SINK_MSK_");
+        assert_eq!(SinkName::MskAlt.env_prefix(), "CAPTURE_V1_SINK_MSK_ALT_");
+        assert_eq!(SinkName::Ws.env_prefix(), "CAPTURE_V1_SINK_WS_");
+    }
+
+    #[test]
+    fn as_str_round_trip() {
+        for name in [SinkName::Msk, SinkName::MskAlt, SinkName::Ws] {
+            let parsed: SinkName = name.as_str().parse().unwrap();
+            assert_eq!(parsed, name);
+        }
+    }
+}

--- a/rust/capture/src/v1/sinks/mod.rs
+++ b/rust/capture/src/v1/sinks/mod.rs
@@ -44,13 +44,13 @@ impl SinkName {
 }
 
 impl FromStr for SinkName {
-    type Err = String;
+    type Err = anyhow::Error;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s.trim().to_lowercase().as_str() {
             "msk" => Ok(Self::Msk),
             "msk_alt" => Ok(Self::MskAlt),
             "ws" => Ok(Self::Ws),
-            other => Err(format!("unknown sink: {other}")),
+            other => Err(anyhow::anyhow!("unknown sink: {other}")),
         }
     }
 }

--- a/rust/capture/src/v1/sinks/sink.rs
+++ b/rust/capture/src/v1/sinks/sink.rs
@@ -1,0 +1,24 @@
+use async_trait::async_trait;
+
+use crate::v1::context::Context;
+use crate::v1::sinks::event::Event;
+use crate::v1::sinks::types::SinkResult;
+use crate::v1::sinks::SinkName;
+
+/// Backend-agnostic publishing interface for a single sink target.
+#[async_trait]
+pub trait Sink: Send + Sync {
+    /// Identity of this sink (used for metrics and logging).
+    fn name(&self) -> SinkName;
+
+    /// Publish a batch of events. Returns one result per published event --
+    /// skipped events (should_publish false / Destination::Drop) produce no result.
+    async fn publish_batch(
+        &self,
+        ctx: &Context,
+        events: &[&(dyn Event + Send + Sync)],
+    ) -> Vec<Box<dyn SinkResult>>;
+
+    /// Flush the underlying producer for graceful shutdown.
+    async fn flush(&self) -> anyhow::Result<()>;
+}

--- a/rust/capture/src/v1/sinks/types.rs
+++ b/rust/capture/src/v1/sinks/types.rs
@@ -1,5 +1,8 @@
+use std::borrow::Cow;
+use std::collections::HashMap;
+use std::fmt;
+
 /// Kafka topic routing for a processed event.
-/// A future v1 sink will resolve these to concrete topic strings via `KafkaTopicConfig`.
 /// `Drop` means the event should not be produced at all.
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub enum Destination {
@@ -10,4 +13,139 @@ pub enum Destination {
     Dlq,
     Custom(String),
     Drop,
+}
+
+// ---------------------------------------------------------------------------
+// Outcome
+// ---------------------------------------------------------------------------
+
+/// What happened when a publish attempt resolved.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Outcome {
+    /// Pre-resolution default for metrics emitted before outcome is known.
+    InFlight,
+    Success,
+    Timeout,
+    RetriableError,
+    FatalError,
+}
+
+impl Outcome {
+    pub fn as_tag(&self) -> &'static str {
+        match self {
+            Self::InFlight => "in_flight",
+            Self::Success => "success",
+            Self::Timeout => "timeout",
+            Self::RetriableError => "retriable_error",
+            Self::FatalError => "fatal_error",
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// SinkResult
+// ---------------------------------------------------------------------------
+
+/// Backend-agnostic trait for introspecting per-event publish results.
+pub trait SinkResult: Send + Sync {
+    /// Correlation key -- the originating event's UUID.
+    fn key(&self) -> &str;
+
+    fn outcome(&self) -> Outcome;
+
+    /// Stable, low-cardinality tag for metrics. None on success.
+    fn cause(&self) -> Option<&'static str>;
+
+    /// Rich human-readable error detail for logging. None on success.
+    fn detail(&self) -> Option<Cow<'_, str>>;
+
+    /// Time between batch enqueue and this event's ack completion.
+    /// None if the event never entered the ack path (immediate error).
+    fn elapsed(&self) -> Option<chrono::Duration>;
+}
+
+// ---------------------------------------------------------------------------
+// BatchSummary
+// ---------------------------------------------------------------------------
+
+/// Aggregated stats for a batch of publish results.
+pub struct BatchSummary {
+    pub total: usize,
+    pub succeeded: usize,
+    pub retriable: usize,
+    pub fatal: usize,
+    pub timed_out: usize,
+    /// Counts keyed by cause tag (e.g. "queue_full", "timeout").
+    pub errors: HashMap<String, usize>,
+}
+
+impl BatchSummary {
+    pub fn from_results(results: &[Box<dyn SinkResult>]) -> Self {
+        let mut succeeded = 0usize;
+        let mut retriable = 0usize;
+        let mut fatal = 0usize;
+        let mut timed_out = 0usize;
+        let mut errors: HashMap<String, usize> = HashMap::new();
+
+        for r in results {
+            match r.outcome() {
+                Outcome::Success => succeeded += 1,
+                Outcome::Timeout => {
+                    timed_out += 1;
+                    if let Some(tag) = r.cause() {
+                        *errors.entry(tag.to_string()).or_default() += 1;
+                    }
+                }
+                Outcome::RetriableError => {
+                    retriable += 1;
+                    if let Some(tag) = r.cause() {
+                        *errors.entry(tag.to_string()).or_default() += 1;
+                    }
+                }
+                Outcome::FatalError => {
+                    fatal += 1;
+                    if let Some(tag) = r.cause() {
+                        *errors.entry(tag.to_string()).or_default() += 1;
+                    }
+                }
+                Outcome::InFlight => {}
+            }
+        }
+
+        Self {
+            total: results.len(),
+            succeeded,
+            retriable,
+            fatal,
+            timed_out,
+            errors,
+        }
+    }
+
+    pub fn all_ok(&self) -> bool {
+        self.retriable == 0 && self.fatal == 0 && self.timed_out == 0
+    }
+}
+
+impl fmt::Display for BatchSummary {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{} total, {} ok, {} retriable, {} fatal, {} timed_out",
+            self.total, self.succeeded, self.retriable, self.fatal, self.timed_out
+        )?;
+        if !self.errors.is_empty() {
+            let mut pairs: Vec<_> = self.errors.iter().collect();
+            pairs.sort_by_key(|(_, count)| std::cmp::Reverse(**count));
+            write!(f, " (")?;
+            for (i, (tag, count)) in pairs.iter().enumerate() {
+                if i > 0 {
+                    write!(f, ", ")?;
+                }
+                write!(f, "{}={}", tag, count)?;
+            }
+            write!(f, ")")?;
+        }
+        Ok(())
+    }
 }

--- a/rust/capture/src/v1/sinks/types.rs
+++ b/rust/capture/src/v1/sinks/types.rs
@@ -75,7 +75,7 @@ pub struct BatchSummary {
     pub fatal: usize,
     pub timed_out: usize,
     /// Counts keyed by cause tag (e.g. "queue_full", "timeout").
-    pub errors: HashMap<String, usize>,
+    pub errors: HashMap<&'static str, usize>,
 }
 
 impl BatchSummary {
@@ -84,7 +84,7 @@ impl BatchSummary {
         let mut retriable = 0usize;
         let mut fatal = 0usize;
         let mut timed_out = 0usize;
-        let mut errors: HashMap<String, usize> = HashMap::new();
+        let mut errors: HashMap<&'static str, usize> = HashMap::new();
 
         for r in results {
             match r.outcome() {
@@ -92,19 +92,19 @@ impl BatchSummary {
                 Outcome::Timeout => {
                     timed_out += 1;
                     if let Some(tag) = r.cause() {
-                        *errors.entry(tag.to_string()).or_default() += 1;
+                        *errors.entry(tag).or_default() += 1;
                     }
                 }
                 Outcome::RetriableError => {
                     retriable += 1;
                     if let Some(tag) = r.cause() {
-                        *errors.entry(tag.to_string()).or_default() += 1;
+                        *errors.entry(tag).or_default() += 1;
                     }
                 }
                 Outcome::FatalError => {
                     fatal += 1;
                     if let Some(tag) = r.cause() {
-                        *errors.entry(tag.to_string()).or_default() += 1;
+                        *errors.entry(tag).or_default() += 1;
                     }
                 }
             }

--- a/rust/capture/src/v1/sinks/types.rs
+++ b/rust/capture/src/v1/sinks/types.rs
@@ -24,8 +24,6 @@ pub enum Destination {
 /// What happened when a publish attempt resolved.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Outcome {
-    /// Pre-resolution default for metrics emitted before outcome is known.
-    InFlight,
     Success,
     Timeout,
     RetriableError,
@@ -35,7 +33,6 @@ pub enum Outcome {
 impl Outcome {
     pub fn as_tag(&self) -> &'static str {
         match self {
-            Self::InFlight => "in_flight",
             Self::Success => "success",
             Self::Timeout => "timeout",
             Self::RetriableError => "retriable_error",
@@ -63,7 +60,7 @@ pub trait SinkResult: Send + Sync {
 
     /// Time between batch enqueue and this event's ack completion.
     /// None if the event never entered the ack path (immediate error).
-    fn elapsed(&self) -> Option<chrono::Duration>;
+    fn elapsed(&self) -> Option<std::time::Duration>;
 }
 
 // ---------------------------------------------------------------------------
@@ -110,7 +107,6 @@ impl BatchSummary {
                         *errors.entry(tag.to_string()).or_default() += 1;
                     }
                 }
-                Outcome::InFlight => {}
             }
         }
 

--- a/rust/capture/src/v1/sinks/types.rs
+++ b/rust/capture/src/v1/sinks/types.rs
@@ -2,6 +2,8 @@ use std::borrow::Cow;
 use std::collections::HashMap;
 use std::fmt;
 
+use uuid::Uuid;
+
 /// Kafka topic routing for a processed event.
 /// `Drop` means the event should not be produced at all.
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
@@ -49,7 +51,7 @@ impl Outcome {
 /// Backend-agnostic trait for introspecting per-event publish results.
 pub trait SinkResult: Send + Sync {
     /// Correlation key -- the originating event's UUID.
-    fn key(&self) -> &str;
+    fn key(&self) -> Uuid;
 
     fn outcome(&self) -> Outcome;
 

--- a/rust/capture/src/v1/test_utils.rs
+++ b/rust/capture/src/v1/test_utils.rs
@@ -127,7 +127,7 @@ pub fn malformed_wrapped_event() -> WrappedEvent {
 pub fn events_map(events: Vec<WrappedEvent>) -> HashMap<Uuid, WrappedEvent> {
     events
         .into_iter()
-        .map(|e| (Uuid::parse_str(&e.event.uuid).unwrap(), e))
+        .map(|e| (Uuid::parse_str(e.event.uuid()).unwrap(), e))
         .collect()
 }
 

--- a/rust/capture/src/v1/test_utils.rs
+++ b/rust/capture/src/v1/test_utils.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 use std::collections::HashMap;
 use std::net::{IpAddr, Ipv4Addr};
 


### PR DESCRIPTION
## Problem
Extracted from [this PR](https://github.com/PostHog/posthog/pull/53501). Design doc [here](https://github.com/PostHog/posthog/blob/5d53bec73f5d9643fd4d37c119a1309bdf9dde1a/rust/capture/src/v1/sinks/DESIGN.md) for reference. Part 2 of a series.

This lays down the scaffold for the rest of the sink modules and Kafka-specific sink. The `v1::sinks::Sink` abstractions and `v1::sinks::Event` abstractions form the basis the rest will be implemented on.

* A `Sink` represents one instance of a storage client that publishes capture v1 events
* An `Event` is the contract specific implementations (for analytics events, `v1::analytics::WrappedEvent`) will meet to serialize themselves and surface metadata required for payload and storage-agnostic publishing and routing
* `SinkResult` is a storage-agnostic, per-event result type used to return granular publish results to the caller (v1 HTTP handler) for building responses, the `outcome()` will be used by the handler to classify and action on these results
* `BatchSummary` batches per-event results and error tags to keep logging and statting concise but granular wrt errors encountered etc.


The `Event` in particular is fairly Kafka-specific right now (`partition_key()`, `headers()`, etc.) and in some cases (future S3Sink etc.) some of these fields won't be called.

We _may_ opt to add more APIs to the contract as needed, if we implement those sinks in the future, but most likely for storage like S3, we'll resolve things like bucket paths on the top-level (env-based) `v1::sinks::s3::Config` and/or the `v1::Context` (request context) as we do now for `v1::kafka::sinks::Config`, and they won't be present on particular events anyway.

The reason for some of the Sink plumbing (`SinkName` etc.) included in these first few PRs will become more clear in the following PRs of the series. See the design doc linked above for details.
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally and in CI. Integration tests coming after the series is landed and `v1::analytics::WrappedEvent` serialization step is implemented
<!-- Briefly describe the steps you took, and what steps reviewers must take to get to where changes are, and what is the expected behavior. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
N/A
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update
N/A
<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
