### PR TITLE
fix(experiments): better defaults for experiments, shared metrics and experiment holdout activity descriptors.

### DIFF
--- a/frontend/src/scenes/experiments/activity-descriptions/experimentChangeDescription.tsx
+++ b/frontend/src/scenes/experiments/activity-descriptions/experimentChangeDescription.tsx
@@ -98,7 +98,16 @@ export const getExperimentChangeDescription = (
                 )
             }
 
-            return null
+            if (action === 'changed' && after !== null) {
+                return (
+                    <span>
+                        changed the conclusion to <ExperimentConclusionTag conclusion={after as ExperimentConclusion} />
+                        &nbsp;for
+                    </span>
+                )
+            }
+
+            return 'updated conclusion for'
         })
         .with({ field: 'metrics', action: 'created', before: null }, () => 'added the first metric to')
         .with({ field: 'metrics', action: 'changed' }, ({ before, after }) =>
@@ -171,5 +180,13 @@ export const getExperimentChangeDescription = (
 
             return changes.filter(Boolean) as (string | JSX.Element)[]
         })
-        .otherwise(() => null)
+        .otherwise(({ field, action }) => {
+            // Fallback for unhandled fields - ensures all activity is visible
+            const fieldName = field.replace(/_/g, ' ')
+            return match(action)
+                .with('created', () => `added ${fieldName}`)
+                .with('deleted', () => `removed ${fieldName}`)
+                .with('changed', () => `updated ${fieldName}`)
+                .otherwise(() => `modified ${fieldName}`)
+        })
 }

--- a/frontend/src/scenes/experiments/activity-descriptions/holdoutChangeDescription.tsx
+++ b/frontend/src/scenes/experiments/activity-descriptions/holdoutChangeDescription.tsx
@@ -17,4 +17,15 @@ export const getHoldoutChangeDescription = (holdoutChange: ActivityChange): stri
         .with('filters', () => {
             return 'updated experiment holdout filters:'
         })
-        .exhaustive()
+        .otherwise(() => {
+            if (!holdoutChange.field) {
+                return 'updated experiment holdout'
+            }
+            // Fallback for unhandled fields - ensures all activity is visible
+            const fieldName = holdoutChange.field.replace(/_/g, ' ')
+            return match(holdoutChange.action)
+                .with('created', () => `added ${fieldName} to`)
+                .with('deleted', () => `removed ${fieldName} from`)
+                .with('changed', () => `updated ${fieldName} for`)
+                .otherwise(() => `modified ${fieldName} for`)
+        })

--- a/frontend/src/scenes/experiments/activity-descriptions/sharedMetricChangeDescription.tsx
+++ b/frontend/src/scenes/experiments/activity-descriptions/sharedMetricChangeDescription.tsx
@@ -22,7 +22,7 @@ export const nameOrLinkToSharedMetric = (name: string | null, id?: string): JSX.
  */
 type AllowedSharedMetricFields = Pick<SharedMetric, 'query'>
 
-export const getSharedMetricChangeDescription = (sharedMetricChange: ActivityChange): string | JSX.Element | null => {
+export const getSharedMetricChangeDescription = (sharedMetricChange: ActivityChange): string | JSX.Element => {
     /**
      * a little type assertion to force field into the allowed shared metric fields
      */
@@ -30,5 +30,16 @@ export const getSharedMetricChangeDescription = (sharedMetricChange: ActivityCha
         .with({ field: 'query' }, () => {
             return 'updated shared metric:'
         })
-        .otherwise(() => null)
+        .otherwise(() => {
+            if (!sharedMetricChange.field) {
+                return 'updated shared metric'
+            }
+            // Fallback for unhandled fields - ensures all activity is visible
+            const fieldName = sharedMetricChange.field.replace(/_/g, ' ')
+            return match(sharedMetricChange.action)
+                .with('created', () => `added ${fieldName} to`)
+                .with('deleted', () => `removed ${fieldName} from`)
+                .with('changed', () => `updated ${fieldName} for`)
+                .otherwise(() => `modified ${fieldName} for`)
+        })
 }

--- a/frontend/src/scenes/experiments/experimentActivityDescriber.tsx
+++ b/frontend/src/scenes/experiments/experimentActivityDescriber.tsx
@@ -264,10 +264,6 @@ export const experimentActivityDescriber = (logItem: ActivityLogItem): Humanized
                           )
                           .filter((part) => part !== null)
 
-            if (changes.length > 0 && listParts.length === 0) {
-                return { description: null }
-            }
-
             const suffix = match(updateLogDetail.type)
                 .with('shared_metric', () => nameOrLinkToSharedMetric(updateLogDetail.name, item_id))
                 .with('holdout', () => <strong>{updateLogDetail.name}</strong>)


### PR DESCRIPTION
## Problem

The activity log on experiments and shared metrics defaults to `null` when a field or action doesn't match. This creates a problem for the frontend pagination.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

We've added more sensible defaults to cover all the more conventional cases of field changes, not covered by the existing matchers.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

![cat-type](https://github.com/user-attachments/assets/8a032f0a-32c9-4b83-929a-e58784070566)

<!-- Briefly describe the steps you took, and what steps reviewers must take to get to where changes are, and what is the expected behavior. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

do not publish to changelog

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
