### PR TITLE
fix(experiments): treat exposure criteria as dict in experiment actors query.

### DIFF
--- a/posthog/hogql_queries/experiments/experiment_query_runner.py
+++ b/posthog/hogql_queries/experiments/experiment_query_runner.py
@@ -456,7 +456,7 @@ class ExperimentQueryRunner(QueryRunner):
             kind="FunnelsQuery",
             series=self.metric.series,
             dateRange=self.date_range,
-            filterTestAccounts=self.experiment.exposure_criteria.filterTestAccounts
+            filterTestAccounts=self.experiment.exposure_criteria.get("filterTestAccounts", True)
             if self.experiment.exposure_criteria
             else False,
             funnelsFilter=FunnelsFilter(


### PR DESCRIPTION
## Problem

Exposure criteria is treated as a pydantic model when it should be treated as a dictionary.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Access the filter test accounts as a dictionary.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

![cat-type](https://github.com/user-attachments/assets/82752aae-eab6-49ee-9587-646c2590cde1)

<!-- Briefly describe the steps you took, and what steps reviewers must take to get to where changes are, and what is the expected behavior. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

do not publish to changelog

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
