### PR TITLE
fix(insights): gate legacy filter-based insight writes

### DIFF
--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -121,6 +121,7 @@ from common.hogvm.python.utils import HogVMException
 logger = structlog.get_logger(__name__)
 
 LEGACY_INSIGHT_ENDPOINTS_BLOCKED_FLAG = "legacy-insight-endpoints-disabled"
+LEGACY_INSIGHT_FILTERS_BLOCKED_FLAG = "legacy-insight-filters-disabled"
 
 
 EXPORT_QUERY_CACHE_MISS = Counter(
@@ -190,6 +191,26 @@ def is_legacy_insight_endpoint_blocked(user: Any, team: Team) -> bool:
 
     return posthoganalytics.feature_enabled(
         LEGACY_INSIGHT_ENDPOINTS_BLOCKED_FLAG,
+        str(distinct_id),
+        groups={
+            "organization": str(team.organization_id),
+            "project": str(team.id),
+        },
+        group_properties={
+            "organization": {"id": str(team.organization_id)},
+            "project": {"id": str(team.id)},
+        },
+        send_feature_flag_events=False,
+    )
+
+
+def is_legacy_insight_filters_blocked(user: Any, team: Team) -> bool:
+    distinct_id = getattr(user, "distinct_id", None)
+    if not distinct_id:
+        return False
+
+    return posthoganalytics.feature_enabled(
+        LEGACY_INSIGHT_FILTERS_BLOCKED_FLAG,
         str(distinct_id),
         groups={
             "organization": str(team.organization_id),
@@ -463,6 +484,12 @@ class InsightSerializer(InsightBasicSerializer):
             "refreshing",
             "is_cached",
         )
+
+    def validate(self, attrs: dict[str, Any]) -> dict[str, Any]:
+        using_legacy_filters = "filters" in attrs and attrs.get("filters") is not None and "query" not in attrs
+        if using_legacy_filters and is_legacy_insight_filters_blocked(self.context["request"].user, self.context["get_team"]()):
+            raise PermissionDenied("Creating or updating insights with legacy filters is not available for this user.")
+        return super().validate(attrs)
 
     @monitor(feature=Feature.INSIGHT, endpoint="insight", method="POST")
     def create(self, validated_data: dict, *args: Any, **kwargs: Any) -> Insight:

--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -486,8 +486,11 @@ class InsightSerializer(InsightBasicSerializer):
         )
 
     def validate(self, attrs: dict[str, Any]) -> dict[str, Any]:
-        using_legacy_filters = "filters" in attrs and attrs.get("filters") is not None and "query" not in attrs
-        if using_legacy_filters and is_legacy_insight_filters_blocked(self.context["request"].user, self.context["get_team"]()):
+        query = attrs.get("query") if "query" in attrs else None
+        using_legacy_filters = "filters" in attrs and attrs.get("filters") is not None and query in (None, {})
+        if using_legacy_filters and is_legacy_insight_filters_blocked(
+            self.context["request"].user, self.context["get_team"]()
+        ):
             raise PermissionDenied("Creating or updating insights with legacy filters is not available for this user.")
         return super().validate(attrs)
 

--- a/posthog/api/test/test_insight.py
+++ b/posthog/api/test/test_insight.py
@@ -97,6 +97,38 @@ class TestInsight(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
         ]
         self.assertEqual(len(legacy_calls), 1)
 
+    def test_creating_legacy_filter_insight_blocked_with_feature_flag(self) -> None:
+        with patch("posthog.api.insight.posthoganalytics.feature_enabled", return_value=True) as mock_feature_enabled:
+            response = self.client.post(
+                f"/api/projects/{self.team.id}/insights/",
+                {"name": "Legacy filter insight", "filters": {"insight": "TRENDS", "events": [{"id": "$pageview"}]}},
+            )
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(
+            response.json()["detail"], "Creating or updating insights with legacy filters is not available for this user."
+        )
+        legacy_filter_calls = [
+            c for c in mock_feature_enabled.call_args_list if c[0][0] == "legacy-insight-filters-disabled"
+        ]
+        self.assertEqual(len(legacy_filter_calls), 1)
+
+    def test_creating_query_insight_not_blocked_by_legacy_filter_flag(self) -> None:
+        with patch("posthog.api.insight.posthoganalytics.feature_enabled", return_value=True) as mock_feature_enabled:
+            response = self.client.post(
+                f"/api/projects/{self.team.id}/insights/",
+                {
+                    "name": "Query insight",
+                    "query": InsightVizNode(source=TrendsQuery(series=[EventsNode(event="$pageview")])).model_dump(),
+                },
+            )
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        legacy_filter_calls = [
+            c for c in mock_feature_enabled.call_args_list if c[0][0] == "legacy-insight-filters-disabled"
+        ]
+        self.assertEqual(len(legacy_filter_calls), 0)
+
     def test_get_insight_items(self) -> None:
         filter_dict = {
             "events": [{"id": "$pageview"}],

--- a/posthog/api/test/test_insight.py
+++ b/posthog/api/test/test_insight.py
@@ -106,7 +106,8 @@ class TestInsight(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
         self.assertEqual(
-            response.json()["detail"], "Creating or updating insights with legacy filters is not available for this user."
+            response.json()["detail"],
+            "Creating or updating insights with legacy filters is not available for this user.",
         )
         legacy_filter_calls = [
             c for c in mock_feature_enabled.call_args_list if c[0][0] == "legacy-insight-filters-disabled"


### PR DESCRIPTION
### Motivation

- Prevent new users from creating or updating insights using legacy `filters` payloads so the legacy filter path can be phased out and existing users can be contacted.

### Description

- Add `LEGACY_INSIGHT_FILTERS_BLOCKED_FLAG` and `is_legacy_insight_filters_blocked(user, team)` which mirrors the existing legacy endpoint gating logic using `posthoganalytics.feature_enabled` with org/project group targeting.
- Enforce the new gate in `InsightSerializer.validate(...)` to raise `PermissionDenied` when a request contains legacy `filters` (no `query`) and the flag is enabled.
- Add unit tests in `posthog/api/test/test_insight.py`: `test_creating_legacy_filter_insight_blocked_with_feature_flag` and `test_creating_query_insight_not_blocked_by_legacy_filter_flag` to cover blocked legacy-filter writes and allowed query-based writes.

### Testing

- Added unit tests as described above (files changed: `posthog/api/insight.py`, `posthog/api/test/test_insight.py`).
- Attempted to run targeted tests with `hogli test` but `hogli` was not available in the environment, causing the run to fail.
- Attempted to run `python -m pytest` for the two tests but the run failed due to missing local dependencies (`ModuleNotFoundError: No module named 'django'`).
- The tests are committed and should be picked up by CI where the full Django/test environment is available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d5f179916c83329cf7a8e6490f894c)