### PR TITLE
fix(insights): fix bar chart click opening modal for wrong breakdown

### DIFF
--- a/frontend/src/scenes/insights/views/LineGraph/LineGraph.test.tsx
+++ b/frontend/src/scenes/insights/views/LineGraph/LineGraph.test.tsx
@@ -215,10 +215,7 @@ describe('LineGraph', () => {
         }
 
         it('selects the correct series in a stacked bar chart when clicking below center', () => {
-            // Click at y=220, inside Flutter bar (150-250) but below its center (200)
-            // Bug: sortPoints compares to element.y (top=150) vs Webapp's top (250).
-            //   distance to Flutter top: |220-150| = 70
-            //   distance to Webapp top: |220-250| = 30  ← Webapp wins (WRONG!)
+            // y=220 is inside Flutter (150-250) but below its center (200)
             const chart = makeMockChart()
             const payload = clickAndCapture(chart, makeEvent(220))
 
@@ -228,7 +225,6 @@ describe('LineGraph', () => {
         })
 
         it('selects the correct series in a stacked bar chart when clicking above center', () => {
-            // Click at y=180, inside Flutter bar (150-250) but above its center (200)
             const chart = makeMockChart()
             const payload = clickAndCapture(chart, makeEvent(180))
 
@@ -238,7 +234,6 @@ describe('LineGraph', () => {
         })
 
         it('selects the correct series when pointsIntersectingClick has a direct hit', () => {
-            // When Chart.js 'point' mode returns the correct bar, it should be used
             const directHit: InteractionItem[] = [{ element: barElements[1] as any, datasetIndex: 1, index: 0 }]
             const chart = makeMockChart(directHit)
             const payload = clickAndCapture(chart, makeEvent(200))
@@ -249,9 +244,7 @@ describe('LineGraph', () => {
         })
 
         it('uses tooltip reference point over click detection to match what user sees', () => {
-            // The tooltip shows Flutter (dataset 1) via 'nearest' mode, but
-            // click detection via 'point' mode hits Email (dataset 2).
-            // The tooltip should win since that's what the user sees.
+            // Tooltip says Flutter but click detection hits Email — tooltip should win
             const directHit: InteractionItem[] = [{ element: barElements[2] as any, datasetIndex: 2, index: 0 }]
             const tooltipDataPoints = [{ datasetIndex: 1, dataIndex: 0 }]
             const chart = makeMockChart(directHit, tooltipDataPoints)
@@ -263,12 +256,10 @@ describe('LineGraph', () => {
         })
 
         it('falls back to click detection when no tooltip is active', () => {
-            // No tooltip data — should use existing click detection logic
             const chart = makeMockChart([], undefined)
             const payload = clickAndCapture(chart, makeEvent(200))
 
             expect(payload).toBeTruthy()
-            // Falls back to pointsIntersectingLine sorted by center distance
             expect(payload!.points.referencePoint.dataset.label).toBe('Flutter')
         })
 

--- a/frontend/src/scenes/insights/views/LineGraph/LineGraph.test.tsx
+++ b/frontend/src/scenes/insights/views/LineGraph/LineGraph.test.tsx
@@ -1,5 +1,7 @@
 import { cleanup } from '@testing-library/react'
 
+import { ChartEvent, InteractionItem } from 'lib/Chart'
+
 import { NodeKind, TrendsQueryResponse } from '~/queries/schema/schema-general'
 import {
     buildTrendsQuery,
@@ -8,7 +10,9 @@ import {
     renderInsightPage,
     waitForChart,
 } from '~/test/insight-testing'
-import { ChartDisplayType } from '~/types'
+import { ChartDisplayType, GraphDataset, GraphPointPayload } from '~/types'
+
+import { onChartClick } from './LineGraph'
 
 jest.mock('lib/components/AutoSizer', () => ({
     AutoSizer: ({ renderProp }: { renderProp: (size: { height: number; width: number }) => React.ReactNode }) =>
@@ -150,6 +154,126 @@ describe('LineGraph', () => {
 
             const firstTickLabel = chart.axes.x.tickLabel(0)
             expect(firstTickLabel).toBe('Jun 10')
+        })
+    })
+
+    describe('onChartClick', () => {
+        // Stacked bar geometry (canvas coords, y=0 at top):
+        //   Email (dataset 2):      top=50,  base=150, center=100
+        //   Flutter (dataset 1):    top=150, base=250, center=200
+        //   Webapp DAU (dataset 0): top=250, base=350, center=300
+        const datasets: GraphDataset[] = [
+            { id: 0, label: 'Webapp DAU', data: [100], action: { order: 0 } } as GraphDataset,
+            { id: 1, label: 'Flutter', data: [100], action: { order: 1 } } as GraphDataset,
+            { id: 2, label: 'Email', data: [100], action: { order: 2 } } as GraphDataset,
+        ]
+
+        const barElements = [
+            { y: 250, base: 350, x: 100 }, // Webapp DAU (bottom of stack)
+            { y: 150, base: 250, x: 100 }, // Flutter (middle)
+            { y: 50, base: 150, x: 100 }, // Email (top)
+        ]
+
+        function makeIndexElements(): InteractionItem[] {
+            return barElements.map((el, i) => ({
+                element: el as any,
+                datasetIndex: i,
+                index: 0,
+            }))
+        }
+
+        function makeMockChart(pointHits: InteractionItem[] = []): any {
+            return {
+                getElementsAtEventForMode: (_event: Event, mode: string) => {
+                    if (mode === 'point') {
+                        return pointHits
+                    }
+                    return makeIndexElements()
+                },
+            }
+        }
+
+        function makeEvent(y: number): ChartEvent {
+            return {
+                type: 'click',
+                native: new MouseEvent('click'),
+                x: 100,
+                y,
+            }
+        }
+
+        function clickAndCapture(chart: any, event: ChartEvent): GraphPointPayload | undefined {
+            let captured: GraphPointPayload | undefined
+            onChartClick(event, chart, datasets, (payload) => {
+                captured = payload
+            })
+            return captured
+        }
+
+        it('selects the correct series in a stacked bar chart when clicking below center', () => {
+            // Click at y=220, inside Flutter bar (150-250) but below its center (200)
+            // Bug: sortPoints compares to element.y (top=150) vs Webapp's top (250).
+            //   distance to Flutter top: |220-150| = 70
+            //   distance to Webapp top: |220-250| = 30  ← Webapp wins (WRONG!)
+            const chart = makeMockChart()
+            const payload = clickAndCapture(chart, makeEvent(220))
+
+            expect(payload).toBeTruthy()
+            expect(payload!.points.referencePoint.dataset.label).toBe('Flutter')
+            expect(payload!.points.referencePoint.datasetIndex).toBe(1)
+        })
+
+        it('selects the correct series in a stacked bar chart when clicking above center', () => {
+            // Click at y=180, inside Flutter bar (150-250) but above its center (200)
+            const chart = makeMockChart()
+            const payload = clickAndCapture(chart, makeEvent(180))
+
+            expect(payload).toBeTruthy()
+            expect(payload!.points.referencePoint.dataset.label).toBe('Flutter')
+            expect(payload!.points.referencePoint.datasetIndex).toBe(1)
+        })
+
+        it('selects the correct series when pointsIntersectingClick has a direct hit', () => {
+            // When Chart.js 'point' mode returns the correct bar, it should be used
+            const directHit: InteractionItem[] = [{ element: barElements[1] as any, datasetIndex: 1, index: 0 }]
+            const chart = makeMockChart(directHit)
+            const payload = clickAndCapture(chart, makeEvent(200))
+
+            expect(payload).toBeTruthy()
+            expect(payload!.points.referencePoint.dataset.label).toBe('Flutter')
+            expect(payload!.points.clickedPointNotLine).toBe(true)
+        })
+
+        it('works correctly for line charts where elements have no base property', () => {
+            const lineDatasets: GraphDataset[] = [
+                { id: 0, label: 'Series A', data: [50], action: { order: 0 } } as GraphDataset,
+                { id: 1, label: 'Series B', data: [80], action: { order: 1 } } as GraphDataset,
+            ]
+            const lineElements = [
+                { y: 200, x: 100 }, // Series A
+                { y: 100, x: 100 }, // Series B (higher value = lower y)
+            ]
+            const chart = {
+                getElementsAtEventForMode: (_event: Event, mode: string) => {
+                    if (mode === 'point') {
+                        return []
+                    }
+                    return lineElements.map((el, i) => ({
+                        element: el as any,
+                        datasetIndex: i,
+                        index: 0,
+                    }))
+                },
+            }
+
+            // Click at y=110, closer to Series B (y=100)
+            let captured: GraphPointPayload | undefined
+            onChartClick(makeEvent(110), chart as any, lineDatasets, (payload) => {
+                captured = payload
+            })
+
+            expect(captured).toBeTruthy()
+            expect(captured!.points.referencePoint.dataset.label).toBe('Series B')
         })
     })
 })

--- a/frontend/src/scenes/insights/views/LineGraph/LineGraph.test.tsx
+++ b/frontend/src/scenes/insights/views/LineGraph/LineGraph.test.tsx
@@ -214,19 +214,12 @@ describe('LineGraph', () => {
             return captured
         }
 
-        it('selects the correct series in a stacked bar chart when clicking below center', () => {
-            // y=220 is inside Flutter (150-250) but below its center (200)
+        it.each([
+            ['below center (y=220)', 220],
+            ['above center (y=180)', 180],
+        ])('selects Flutter when clicking %s in a stacked bar chart', (_, y) => {
             const chart = makeMockChart()
-            const payload = clickAndCapture(chart, makeEvent(220))
-
-            expect(payload).toBeTruthy()
-            expect(payload!.points.referencePoint.dataset.label).toBe('Flutter')
-            expect(payload!.points.referencePoint.datasetIndex).toBe(1)
-        })
-
-        it('selects the correct series in a stacked bar chart when clicking above center', () => {
-            const chart = makeMockChart()
-            const payload = clickAndCapture(chart, makeEvent(180))
+            const payload = clickAndCapture(chart, makeEvent(y as number))
 
             expect(payload).toBeTruthy()
             expect(payload!.points.referencePoint.dataset.label).toBe('Flutter')
@@ -260,6 +253,17 @@ describe('LineGraph', () => {
             const payload = clickAndCapture(chart, makeEvent(200))
 
             expect(payload).toBeTruthy()
+            expect(payload!.points.referencePoint.dataset.label).toBe('Flutter')
+        })
+
+        it('ignores stale tooltip pointing to a different column than the click', () => {
+            // Tooltip cached from hovering a different data index (index=5) — should be ignored
+            const tooltipDataPoints = [{ datasetIndex: 1, dataIndex: 5 }]
+            const chart = makeMockChart([], tooltipDataPoints)
+            const payload = clickAndCapture(chart, makeEvent(200))
+
+            expect(payload).toBeTruthy()
+            // Falls back to click detection since tooltip column doesn't match
             expect(payload!.points.referencePoint.dataset.label).toBe('Flutter')
         })
 

--- a/frontend/src/scenes/insights/views/LineGraph/LineGraph.test.tsx
+++ b/frontend/src/scenes/insights/views/LineGraph/LineGraph.test.tsx
@@ -182,7 +182,10 @@ describe('LineGraph', () => {
             }))
         }
 
-        function makeMockChart(pointHits: InteractionItem[] = []): any {
+        function makeMockChart(
+            pointHits: InteractionItem[] = [],
+            tooltipDataPoints?: { datasetIndex: number; dataIndex: number }[]
+        ): any {
             return {
                 getElementsAtEventForMode: (_event: Event, mode: string) => {
                     if (mode === 'point') {
@@ -190,6 +193,7 @@ describe('LineGraph', () => {
                     }
                     return makeIndexElements()
                 },
+                tooltip: tooltipDataPoints ? { dataPoints: tooltipDataPoints } : undefined,
             }
         }
 
@@ -242,6 +246,30 @@ describe('LineGraph', () => {
             expect(payload).toBeTruthy()
             expect(payload!.points.referencePoint.dataset.label).toBe('Flutter')
             expect(payload!.points.clickedPointNotLine).toBe(true)
+        })
+
+        it('uses tooltip reference point over click detection to match what user sees', () => {
+            // The tooltip shows Flutter (dataset 1) via 'nearest' mode, but
+            // click detection via 'point' mode hits Email (dataset 2).
+            // The tooltip should win since that's what the user sees.
+            const directHit: InteractionItem[] = [{ element: barElements[2] as any, datasetIndex: 2, index: 0 }]
+            const tooltipDataPoints = [{ datasetIndex: 1, dataIndex: 0 }]
+            const chart = makeMockChart(directHit, tooltipDataPoints)
+            const payload = clickAndCapture(chart, makeEvent(200))
+
+            expect(payload).toBeTruthy()
+            expect(payload!.points.referencePoint.dataset.label).toBe('Flutter')
+            expect(payload!.points.referencePoint.datasetIndex).toBe(1)
+        })
+
+        it('falls back to click detection when no tooltip is active', () => {
+            // No tooltip data — should use existing click detection logic
+            const chart = makeMockChart([], undefined)
+            const payload = clickAndCapture(chart, makeEvent(200))
+
+            expect(payload).toBeTruthy()
+            // Falls back to pointsIntersectingLine sorted by center distance
+            expect(payload!.points.referencePoint.dataset.label).toBe('Flutter')
         })
 
         it('works correctly for line charts where elements have no base property', () => {

--- a/frontend/src/scenes/insights/views/LineGraph/LineGraph.tsx
+++ b/frontend/src/scenes/insights/views/LineGraph/LineGraph.tsx
@@ -118,10 +118,7 @@ export function onChartClick(
     // Get all points along line
     const sortPoints = (a: InteractionItem, b: InteractionItem): number => {
         const eventY = event.y ?? 0
-        // For bar elements, compare distance to the bar's vertical center
-        // rather than its top edge. Adjacent stacked bars share edges, so
-        // using the top causes off-by-one selection when clicking below a
-        // bar's center.
+        // Compare distance to bar center, not top edge (stacked bars share edges)
         const aEl = a.element as unknown as { y: number; base?: number }
         const bEl = b.element as unknown as { y: number; base?: number }
         const aY = aEl.base != null ? (aEl.y + aEl.base) / 2 : aEl.y
@@ -156,10 +153,7 @@ export function onChartClick(
 
     const clickedPointNotLine = pointsIntersectingClick.length !== 0
 
-    // Prefer the tooltip's active data point as the reference, since it
-    // matches what the user sees. The tooltip uses 'nearest' mode which
-    // can pick a different bar segment than the click handler's 'point'
-    // mode, causing the modal to open for the wrong breakdown.
+    // Use the tooltip's active data point so the modal matches what the user sees
     const tooltipDataPoint = chart.tooltip?.dataPoints?.[0]
     const referencePoint: GraphPoint = tooltipDataPoint
         ? {

--- a/frontend/src/scenes/insights/views/LineGraph/LineGraph.tsx
+++ b/frontend/src/scenes/insights/views/LineGraph/LineGraph.tsx
@@ -153,9 +153,15 @@ export function onChartClick(
 
     const clickedPointNotLine = pointsIntersectingClick.length !== 0
 
-    // Use the tooltip's active data point so the modal matches what the user sees
+    // Use the tooltip's active data point so the modal matches what the user sees,
+    // but only when the tooltip refers to the same data column as the click
     const tooltipDataPoint = chart.tooltip?.dataPoints?.[0]
-    const referencePoint: GraphPoint = tooltipDataPoint
+    const tooltipIsForThisColumn =
+        tooltipDataPoint != null &&
+        pointsIntersectingLine.some(
+            (p) => p.datasetIndex === tooltipDataPoint.datasetIndex && p.index === tooltipDataPoint.dataIndex
+        )
+    const referencePoint: GraphPoint = tooltipIsForThisColumn
         ? {
               datasetIndex: tooltipDataPoint.datasetIndex,
               index: tooltipDataPoint.dataIndex,

--- a/frontend/src/scenes/insights/views/LineGraph/LineGraph.tsx
+++ b/frontend/src/scenes/insights/views/LineGraph/LineGraph.tsx
@@ -116,10 +116,18 @@ export function onChartClick(
         return
     }
     // Get all points along line
-    const sortDirection = 'y'
-    const sortPoints = (a: InteractionItem, b: InteractionItem): number =>
-        Math.abs(a.element[sortDirection] - (event[sortDirection] ?? 0)) -
-        Math.abs(b.element[sortDirection] - (event[sortDirection] ?? 0))
+    const sortPoints = (a: InteractionItem, b: InteractionItem): number => {
+        const eventY = event.y ?? 0
+        // For bar elements, compare distance to the bar's vertical center
+        // rather than its top edge. Adjacent stacked bars share edges, so
+        // using the top causes off-by-one selection when clicking below a
+        // bar's center.
+        const aEl = a.element as any
+        const bEl = b.element as any
+        const aY = aEl.base != null ? (aEl.y + aEl.base) / 2 : aEl.y
+        const bY = bEl.base != null ? (bEl.y + bEl.base) / 2 : bEl.y
+        return Math.abs(aY - eventY) - Math.abs(bY - eventY)
+    }
     const pointsIntersectingLine = chart
         .getElementsAtEventForMode(
             nativeEvent,

--- a/frontend/src/scenes/insights/views/LineGraph/LineGraph.tsx
+++ b/frontend/src/scenes/insights/views/LineGraph/LineGraph.tsx
@@ -122,8 +122,8 @@ export function onChartClick(
         // rather than its top edge. Adjacent stacked bars share edges, so
         // using the top causes off-by-one selection when clicking below a
         // bar's center.
-        const aEl = a.element as any
-        const bEl = b.element as any
+        const aEl = a.element as unknown as { y: number; base?: number }
+        const bEl = b.element as unknown as { y: number; base?: number }
         const aY = aEl.base != null ? (aEl.y + aEl.base) / 2 : aEl.y
         const bY = bEl.base != null ? (bEl.y + bEl.base) / 2 : bEl.y
         return Math.abs(aY - eventY) - Math.abs(bY - eventY)
@@ -156,10 +156,21 @@ export function onChartClick(
 
     const clickedPointNotLine = pointsIntersectingClick.length !== 0
 
-    // Take first point when clicking a specific point.
-    const referencePoint: GraphPoint = clickedPointNotLine
-        ? { ...pointsIntersectingClick[0], dataset: datasets[pointsIntersectingClick[0].datasetIndex] }
-        : { ...pointsIntersectingLine[0], dataset: datasets[pointsIntersectingLine[0].datasetIndex] }
+    // Prefer the tooltip's active data point as the reference, since it
+    // matches what the user sees. The tooltip uses 'nearest' mode which
+    // can pick a different bar segment than the click handler's 'point'
+    // mode, causing the modal to open for the wrong breakdown.
+    const tooltipDataPoint = chart.tooltip?.dataPoints?.[0]
+    const referencePoint: GraphPoint = tooltipDataPoint
+        ? {
+              datasetIndex: tooltipDataPoint.datasetIndex,
+              index: tooltipDataPoint.dataIndex,
+              element: tooltipDataPoint.element,
+              dataset: datasets[tooltipDataPoint.datasetIndex],
+          }
+        : clickedPointNotLine
+          ? { ...pointsIntersectingClick[0], dataset: datasets[pointsIntersectingClick[0].datasetIndex] }
+          : { ...pointsIntersectingLine[0], dataset: datasets[pointsIntersectingLine[0].datasetIndex] }
 
     const crossDataset = datasets
         .filter((_dt) => !_dt.dotted)


### PR DESCRIPTION
## Problem

Clicking on a stacked bar chart opens the actors modal for the wrong breakdown. The tooltip correctly highlights one bar segment (e.g. "Chrome"), but the click handler selects a different one (e.g. "Safari") because they use different Chart.js interaction modes.

Closes #49776

## Changes

- Use the tooltip's active data point as the click reference, so the modal always matches what the user sees highlighted
- Fall back to existing click detection when no tooltip is active (e.g. programmatic clicks)
- Sort fallback uses bar center distance instead of top edge (stacked bars share edges)
- Remove `as any` casts in favor of typed assertions
- Add tests for tooltip-based reference and fallback behavior

## How did you test this code?

I'm an agent. I ran the `LineGraph.test.tsx` unit tests (11 passing), including 2 new tests that verify the tooltip reference takes precedence and the fallback works correctly. I was unable to manually verify in the browser because the local dev projects had no pageview data to render a stacked bar chart.

## Publish to changelog?