### PR TITLE
chore: add quill npm publish GitHub Actions workflow

### DIFF
--- a/.github/workflows/publish-quill-npm.yml
+++ b/.github/workflows/publish-quill-npm.yml
@@ -47,26 +47,12 @@ jobs:
             - name: Build quill packages
               run: pnpm quill:build
 
-            - name: Publish @posthog/quill-tokens
-              run: pnpm --filter @posthog/quill-tokens publish --tag ${{ inputs.tag }} --no-git-checks --access public
-              env:
-                  NODE_AUTH_TOKEN: ''
-                  NPM_CONFIG_PROVENANCE: true
-
-            - name: Publish @posthog/quill-primitives
-              run: pnpm --filter @posthog/quill-primitives publish --tag ${{ inputs.tag }} --no-git-checks --access public
-              env:
-                  NODE_AUTH_TOKEN: ''
-                  NPM_CONFIG_PROVENANCE: true
-
-            - name: Publish @posthog/quill-components
-              run: pnpm --filter @posthog/quill-components publish --tag ${{ inputs.tag }} --no-git-checks --access public
-              env:
-                  NODE_AUTH_TOKEN: ''
-                  NPM_CONFIG_PROVENANCE: true
-
-            - name: Publish @posthog/quill-blocks
-              run: pnpm --filter @posthog/quill-blocks publish --tag ${{ inputs.tag }} --no-git-checks --access public
+            - name: Publish quill packages
+              run: |
+                  for pkg in quill-tokens quill-primitives quill-components quill-blocks; do
+                    echo "Publishing @posthog/$pkg"
+                    pnpm --filter "@posthog/$pkg" publish --tag ${{ inputs.tag }} --no-git-checks --access public
+                  done
               env:
                   NODE_AUTH_TOKEN: ''
                   NPM_CONFIG_PROVENANCE: true
@@ -74,11 +60,12 @@ jobs:
             - name: Get published versions
               id: versions
               run: |
-                  TOKENS_VERSION=$(node -p "require('./packages/quill/packages/tokens/package.json').version")
-                  PRIMITIVES_VERSION=$(node -p "require('./packages/quill/packages/primitives/package.json').version")
-                  COMPONENTS_VERSION=$(node -p "require('./packages/quill/packages/components/package.json').version")
-                  BLOCKS_VERSION=$(node -p "require('./packages/quill/packages/blocks/package.json').version")
-                  echo "summary=@posthog/quill-tokens@$TOKENS_VERSION, @posthog/quill-primitives@$PRIMITIVES_VERSION, @posthog/quill-components@$COMPONENTS_VERSION, @posthog/quill-blocks@$BLOCKS_VERSION" >> $GITHUB_OUTPUT
+                  SUMMARY=""
+                  for pkg in quill-tokens quill-primitives quill-components quill-blocks; do
+                    VERSION=$(node -p "require('./packages/quill/packages/${pkg#quill-}/package.json').version")
+                    SUMMARY="$SUMMARY@posthog/$pkg@$VERSION, "
+                  done
+                  echo "summary=${SUMMARY%, }" >> $GITHUB_OUTPUT
 
             - name: Notify Slack
               if: ${{ !cancelled() }}

--- a/.github/workflows/publish-quill-npm.yml
+++ b/.github/workflows/publish-quill-npm.yml
@@ -24,6 +24,7 @@ jobs:
         name: Build and publish
         runs-on: ubuntu-24.04
         timeout-minutes: 15
+        environment: Release
         permissions:
             contents: read
             id-token: write
@@ -69,3 +70,22 @@ jobs:
               env:
                   NODE_AUTH_TOKEN: ''
                   NPM_CONFIG_PROVENANCE: true
+
+            - name: Get published versions
+              id: versions
+              run: |
+                  TOKENS_VERSION=$(node -p "require('./packages/quill/packages/tokens/package.json').version")
+                  PRIMITIVES_VERSION=$(node -p "require('./packages/quill/packages/primitives/package.json').version")
+                  COMPONENTS_VERSION=$(node -p "require('./packages/quill/packages/components/package.json').version")
+                  BLOCKS_VERSION=$(node -p "require('./packages/quill/packages/blocks/package.json').version")
+                  echo "summary=@posthog/quill-tokens@$TOKENS_VERSION, @posthog/quill-primitives@$PRIMITIVES_VERSION, @posthog/quill-components@$COMPONENTS_VERSION, @posthog/quill-blocks@$BLOCKS_VERSION" >> $GITHUB_OUTPUT
+
+            - name: Notify Slack
+              if: ${{ !cancelled() }}
+              uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
+              with:
+                  method: chat.postMessage
+                  token: ${{ secrets.SLACK_CLIENT_LIBRARIES_BOT_TOKEN }}
+                  payload: |
+                      channel: "${{ vars.SLACK_APPROVALS_CLIENT_LIBRARIES_CHANNEL_ID }}"
+                      text: "${{ job.status == 'success' && ':white_check_mark:' || ':red_circle:' }} Quill npm publish (${{ inputs.tag }}): ${{ job.status }}\n${{ steps.versions.outputs.summary }}\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>"

--- a/.github/workflows/publish-quill-npm.yml
+++ b/.github/workflows/publish-quill-npm.yml
@@ -1,0 +1,71 @@
+name: Publish Quill npm packages
+
+on:
+    workflow_dispatch:
+        inputs:
+            tag:
+                description: 'npm dist-tag (e.g. alpha, latest)'
+                required: true
+                default: 'alpha'
+                type: choice
+                options:
+                    - alpha
+                    - latest
+
+permissions:
+    contents: read
+
+concurrency:
+    group: ${{ github.workflow }}
+    cancel-in-progress: false
+
+jobs:
+    publish:
+        name: Build and publish
+        runs-on: ubuntu-24.04
+        timeout-minutes: 15
+        permissions:
+            contents: read
+            id-token: write
+        steps:
+            - uses: actions/checkout@v6
+
+            - name: Install pnpm
+              uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
+
+            - name: Set up Node.js
+              uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+              with:
+                  node-version-file: .nvmrc
+                  registry-url: https://registry.npmjs.org
+                  cache: 'pnpm'
+
+            - name: Install dependencies
+              run: pnpm install --frozen-lockfile
+
+            - name: Build quill packages
+              run: pnpm quill:build
+
+            - name: Publish @posthog/quill-tokens
+              run: pnpm --filter @posthog/quill-tokens publish --tag ${{ inputs.tag }} --no-git-checks --access public
+              env:
+                  NODE_AUTH_TOKEN: ''
+                  NPM_CONFIG_PROVENANCE: true
+
+            - name: Publish @posthog/quill-primitives
+              run: pnpm --filter @posthog/quill-primitives publish --tag ${{ inputs.tag }} --no-git-checks --access public
+              env:
+                  NODE_AUTH_TOKEN: ''
+                  NPM_CONFIG_PROVENANCE: true
+
+            - name: Publish @posthog/quill-components
+              run: pnpm --filter @posthog/quill-components publish --tag ${{ inputs.tag }} --no-git-checks --access public
+              env:
+                  NODE_AUTH_TOKEN: ''
+                  NPM_CONFIG_PROVENANCE: true
+
+            - name: Publish @posthog/quill-blocks
+              run: pnpm --filter @posthog/quill-blocks publish --tag ${{ inputs.tag }} --no-git-checks --access public
+              env:
+                  NODE_AUTH_TOKEN: ''
+                  NPM_CONFIG_PROVENANCE: true

--- a/.github/workflows/publish-quill-npm.yml
+++ b/.github/workflows/publish-quill-npm.yml
@@ -51,11 +51,12 @@ jobs:
               run: |
                   for pkg in quill-tokens quill-primitives quill-components quill-blocks; do
                     echo "Publishing @posthog/$pkg"
-                    pnpm --filter "@posthog/$pkg" publish --tag ${{ inputs.tag }} --no-git-checks --access public
+                    pnpm --filter "@posthog/$pkg" publish --tag "$NPM_TAG" --no-git-checks --access public
                   done
               env:
                   NODE_AUTH_TOKEN: ''
                   NPM_CONFIG_PROVENANCE: true
+                  NPM_TAG: ${{ inputs.tag }}
 
             - name: Get published versions
               id: versions

--- a/.github/workflows/publish-quill-npm.yml
+++ b/.github/workflows/publish-quill-npm.yml
@@ -42,7 +42,7 @@ jobs:
                   cache: 'pnpm'
 
             - name: Install dependencies
-              run: pnpm install --frozen-lockfile
+              run: pnpm install --frozen-lockfile --filter "@posthog/quill-*" --filter "@posthog/quill"
 
             - name: Build quill packages
               run: pnpm quill:build


### PR DESCRIPTION
## Problem

We need a CI workflow to publish quill packages to npm using trusted publishing (OIDC), rather than relying on manual `pnpm publish` commands.

## Changes

- Add `.github/workflows/publish-quill-npm.yml` — manually triggered workflow that builds and publishes all 4 quill packages in dependency order (tokens → primitives → components → blocks)
- Uses `id-token: write` + `NPM_CONFIG_PROVENANCE: true` for trusted publishing (no npm token secret needed)
- Uses `environment: Release` to gate publishes behind team approval
- Supports `alpha` and `latest` dist-tags via workflow input
- Posts result to `#approvals-client-libraries` Slack channel

## Setup checklist

Per [handbook/engineering/sdks/releases](https://posthog.com/handbook/engineering/sdks/releases):

### Trusted publishing (step 6)
- [ ] Run `npx setup-npm-trusted-publish @posthog/quill-tokens`
- [ ] Run `npx setup-npm-trusted-publish @posthog/quill-primitives`
- [ ] Run `npx setup-npm-trusted-publish @posthog/quill-components`
- [ ] Run `npx setup-npm-trusted-publish @posthog/quill-blocks`

### Environment (step 3)
- [ ] Create `Release` environment in repo settings with protection rules:
  - Required reviewers: `PostHog/client-libraries-approvers` and `PostHog/team-client-libraries`
  - Prevent self-review: checked
  - Allow administrators to bypass: unchecked

### Team access (step 2)
- [ ] Verify `@PostHog/client-libraries-approvers` and `@PostHog/team-client-libraries` have at least write access to the repo

### Org secrets (step 5)
- [ ] Grant repo access to org secret: `SLACK_CLIENT_LIBRARIES_BOT_TOKEN`
- [ ] Grant repo access to org variable: `SLACK_APPROVALS_CLIENT_LIBRARIES_CHANNEL_ID`

### PR review (step 9)
- [x] Request review from `@PostHog/client-libraries-approvers`

## How did you test this code?

Workflow config only — validated structure against existing `build-hogql-parser-npm.yml` workflow and the [SDK releases handbook](https://posthog.com/handbook/engineering/sdks/releases).

## Publish to changelog?

No