### PR TITLE
fix(slo): Align error reporting in Temporal with error reporting from context manager

### DIFF
--- a/posthog/models/resource_transfer/test/__snapshots__/test_visitor_field_snapshots.ambr
+++ b/posthog/models/resource_transfer/test/__snapshots__/test_visitor_field_snapshots.ambr
@@ -451,7 +451,6 @@
   list([
     'DoesNotExist',
     'MultipleObjectsReturned',
-    '__annotations__',
     '__doc__',
     '__module__',
     '__repr__',

--- a/posthog/temporal/common/errors.py
+++ b/posthog/temporal/common/errors.py
@@ -1,0 +1,26 @@
+"""Shared helpers for inspecting Temporal's ``ActivityError → ApplicationError`` exception chain."""
+
+import traceback
+
+from temporalio.exceptions import ActivityError, ApplicationError
+
+
+def unwrap_temporal_cause(exc: BaseException) -> ApplicationError | None:
+    """Return the ``ApplicationError`` cause of a Temporal ``ActivityError``, or ``None`` if ``exc`` isn't one."""
+    if isinstance(exc, ActivityError) and isinstance(exc.cause, ApplicationError):
+        return exc.cause
+    return None
+
+
+def resolve_exception_class(exc: BaseException) -> str:
+    """Return the exception class name, preferring ``ApplicationError.type`` over the Python class name."""
+    cause: BaseException = unwrap_temporal_cause(exc) or exc
+    return getattr(cause, "type", None) or type(cause).__name__
+
+
+def resolve_error_trace(exc: BaseException) -> str:
+    """Return a stack trace, preferring the activity-side trace stashed in ``ApplicationError.details[0]``."""
+    cause = unwrap_temporal_cause(exc)
+    if cause is not None and cause.details and isinstance(cause.details[0], str):
+        return cause.details[0]
+    return "".join(traceback.format_exception(exc, limit=5))

--- a/posthog/temporal/common/errors.py
+++ b/posthog/temporal/common/errors.py
@@ -1,25 +1,20 @@
-"""Shared helpers for inspecting Temporal's ``ActivityError → ApplicationError`` exception chain."""
-
 import traceback
 
 from temporalio.exceptions import ActivityError, ApplicationError
 
 
 def unwrap_temporal_cause(exc: BaseException) -> ApplicationError | None:
-    """Return the ``ApplicationError`` cause of a Temporal ``ActivityError``, or ``None`` if ``exc`` isn't one."""
     if isinstance(exc, ActivityError) and isinstance(exc.cause, ApplicationError):
         return exc.cause
     return None
 
 
 def resolve_exception_class(exc: BaseException) -> str:
-    """Return the exception class name, preferring ``ApplicationError.type`` over the Python class name."""
     cause: BaseException = unwrap_temporal_cause(exc) or exc
     return getattr(cause, "type", None) or type(cause).__name__
 
 
 def resolve_error_trace(exc: BaseException) -> str:
-    """Return a stack trace, preferring the activity-side trace stashed in ``ApplicationError.details[0]``."""
     cause = unwrap_temporal_cause(exc)
     if cause is not None and cause.details and isinstance(cause.details[0], str):
         return cause.details[0]

--- a/posthog/temporal/common/slo_interceptor.py
+++ b/posthog/temporal/common/slo_interceptor.py
@@ -1,3 +1,4 @@
+import traceback
 from typing import Any
 
 from django.conf import settings
@@ -13,6 +14,41 @@ from temporalio.worker import (
 
 from posthog.slo.events import emit_slo_completed, emit_slo_started
 from posthog.slo.types import SloCompletedProperties, SloConfig, SloOutcome, SloStartedProperties
+
+
+def _unwrap_temporal_cause(exc: BaseException) -> BaseException:
+    """Unwrap Temporal's ``ActivityError → ApplicationError`` chain to the original cause.
+
+    When an activity raises, the Temporal SDK surfaces it on the workflow side
+    as ``ActivityError(cause=ApplicationError(...))``. This helper peels off
+    that wrapper so callers can inspect the real failure.
+    """
+    if isinstance(exc, ActivityError) and isinstance(exc.cause, ApplicationError):
+        return exc.cause
+    return exc
+
+
+def resolve_exception_class(exc: BaseException) -> str:
+    """Return the original exception class name, unwrapping Temporal's wrappers.
+
+    Use this from a workflow's own exception handler when you need to inspect
+    the failure *before* re-raising — e.g., to reclassify user-query errors as
+    a non-breach outcome before the SLO interceptor records the completion.
+    """
+    cause = _unwrap_temporal_cause(exc)
+    return getattr(cause, "type", None) or type(cause).__name__
+
+
+def _extract_error_trace(exc: BaseException, cause: BaseException) -> str:
+    """Return the best-available stack trace for a failed workflow.
+
+    Prefers the activity-side traceback that the activity wrapper stashes in
+    ``ApplicationError.details[0]`` (captured at the site of the real failure),
+    and falls back to a truncated workflow-side traceback otherwise.
+    """
+    if isinstance(cause, ApplicationError) and cause.details and isinstance(cause.details[0], str):
+        return cause.details[0]
+    return "\n".join(traceback.format_exception(exc)[:5])
 
 
 class _SloWorkflowInterceptor(WorkflowInboundInterceptor):
@@ -55,10 +91,13 @@ class _SloWorkflowInterceptor(WorkflowInboundInterceptor):
         except BaseException as exc:
             outcome = slo.outcome if slo.outcome is not None else SloOutcome.FAILURE
             # Temporal wraps activity errors as ActivityError → ApplicationError;
-            # unwrap to get the original exception type and message.
-            cause = exc.cause if isinstance(exc, ActivityError) and isinstance(exc.cause, ApplicationError) else exc
+            # unwrap to get the original exception type, message, and trace.
+            # Workflows can override any of these by pre-populating completion_properties
+            # before re-raising (setdefault leaves existing values untouched).
+            cause = _unwrap_temporal_cause(exc)
             slo.completion_properties.setdefault("error_type", getattr(cause, "type", None) or type(cause).__name__)
             slo.completion_properties.setdefault("error_message", str(cause))
+            slo.completion_properties.setdefault("error_trace", _extract_error_trace(exc, cause))
             raise
         finally:
             duration_ms = (workflow.time() - start_time) * 1000

--- a/posthog/temporal/common/slo_interceptor.py
+++ b/posthog/temporal/common/slo_interceptor.py
@@ -1,10 +1,8 @@
-import traceback
 from typing import Any
 
 from django.conf import settings
 
 from temporalio import workflow
-from temporalio.exceptions import ActivityError, ApplicationError
 from temporalio.worker import (
     ExecuteWorkflowInput,
     Interceptor,
@@ -14,41 +12,7 @@ from temporalio.worker import (
 
 from posthog.slo.events import emit_slo_completed, emit_slo_started
 from posthog.slo.types import SloCompletedProperties, SloConfig, SloOutcome, SloStartedProperties
-
-
-def _unwrap_temporal_cause(exc: BaseException) -> BaseException:
-    """Unwrap Temporal's ``ActivityError → ApplicationError`` chain to the original cause.
-
-    When an activity raises, the Temporal SDK surfaces it on the workflow side
-    as ``ActivityError(cause=ApplicationError(...))``. This helper peels off
-    that wrapper so callers can inspect the real failure.
-    """
-    if isinstance(exc, ActivityError) and isinstance(exc.cause, ApplicationError):
-        return exc.cause
-    return exc
-
-
-def resolve_exception_class(exc: BaseException) -> str:
-    """Return the original exception class name, unwrapping Temporal's wrappers.
-
-    Use this from a workflow's own exception handler when you need to inspect
-    the failure *before* re-raising — e.g., to reclassify user-query errors as
-    a non-breach outcome before the SLO interceptor records the completion.
-    """
-    cause = _unwrap_temporal_cause(exc)
-    return getattr(cause, "type", None) or type(cause).__name__
-
-
-def _extract_error_trace(exc: BaseException, cause: BaseException) -> str:
-    """Return the best-available stack trace for a failed workflow.
-
-    Prefers the activity-side traceback that the activity wrapper stashes in
-    ``ApplicationError.details[0]`` (captured at the site of the real failure),
-    and falls back to a truncated workflow-side traceback otherwise.
-    """
-    if isinstance(cause, ApplicationError) and cause.details and isinstance(cause.details[0], str):
-        return cause.details[0]
-    return "\n".join(traceback.format_exception(exc)[:5])
+from posthog.temporal.common.errors import resolve_error_trace, unwrap_temporal_cause
 
 
 class _SloWorkflowInterceptor(WorkflowInboundInterceptor):
@@ -90,14 +54,11 @@ class _SloWorkflowInterceptor(WorkflowInboundInterceptor):
             return result
         except BaseException as exc:
             outcome = slo.outcome if slo.outcome is not None else SloOutcome.FAILURE
-            # Temporal wraps activity errors as ActivityError → ApplicationError;
-            # unwrap to get the original exception type, message, and trace.
-            # Workflows can override any of these by pre-populating completion_properties
-            # before re-raising (setdefault leaves existing values untouched).
-            cause = _unwrap_temporal_cause(exc)
+            # setdefault lets workflows pre-populate completion_properties to override any of these.
+            cause: BaseException = unwrap_temporal_cause(exc) or exc
             slo.completion_properties.setdefault("error_type", getattr(cause, "type", None) or type(cause).__name__)
             slo.completion_properties.setdefault("error_message", str(cause))
-            slo.completion_properties.setdefault("error_trace", _extract_error_trace(exc, cause))
+            slo.completion_properties.setdefault("error_trace", resolve_error_trace(exc))
             raise
         finally:
             duration_ms = (workflow.time() - start_time) * 1000

--- a/posthog/temporal/common/slo_interceptor.py
+++ b/posthog/temporal/common/slo_interceptor.py
@@ -12,7 +12,7 @@ from temporalio.worker import (
 
 from posthog.slo.events import emit_slo_completed, emit_slo_started
 from posthog.slo.types import SloCompletedProperties, SloConfig, SloOutcome, SloStartedProperties
-from posthog.temporal.common.errors import resolve_error_trace, unwrap_temporal_cause
+from posthog.temporal.common.errors import resolve_error_trace, resolve_exception_class, unwrap_temporal_cause
 
 
 class _SloWorkflowInterceptor(WorkflowInboundInterceptor):
@@ -55,9 +55,8 @@ class _SloWorkflowInterceptor(WorkflowInboundInterceptor):
         except BaseException as exc:
             outcome = slo.outcome if slo.outcome is not None else SloOutcome.FAILURE
             # setdefault lets workflows pre-populate completion_properties to override any of these.
-            cause: BaseException = unwrap_temporal_cause(exc) or exc
-            slo.completion_properties.setdefault("error_type", getattr(cause, "type", None) or type(cause).__name__)
-            slo.completion_properties.setdefault("error_message", str(cause))
+            slo.completion_properties.setdefault("error_type", resolve_exception_class(exc))
+            slo.completion_properties.setdefault("error_message", str(unwrap_temporal_cause(exc) or exc))
             slo.completion_properties.setdefault("error_trace", resolve_error_trace(exc))
             raise
         finally:

--- a/posthog/temporal/exports/types.py
+++ b/posthog/temporal/exports/types.py
@@ -1,30 +1,7 @@
-import typing
 import dataclasses
 from typing import Optional
 
-from temporalio.exceptions import ActivityError, ApplicationError
-
-
-class ExportErrorDetails(typing.NamedTuple):
-    exception_class: str | None = None
-    error_trace: str | None = None
-
-
-def extract_error_details(exc: BaseException) -> ExportErrorDetails:
-    """Extract failure metadata from a Temporal activity exception chain.
-
-    asyncio.gather(return_exceptions=True) yields BaseException, but Temporal
-    wraps activity failures as ActivityError -> ApplicationError. We narrow
-    through that chain to reach the structured details.
-    """
-    if not isinstance(exc, ActivityError) or not isinstance(exc.cause, ApplicationError):
-        return ExportErrorDetails()
-
-    cause = exc.cause
-    return ExportErrorDetails(
-        exception_class=cause.type,
-        error_trace=cause.details[0] if len(cause.details) >= 1 and isinstance(cause.details[0], str) else None,
-    )
+from posthog.temporal.common.errors import unwrap_temporal_cause
 
 
 @dataclasses.dataclass
@@ -44,3 +21,12 @@ class ExportAssetResult:
     exported_asset_id: int
     success: bool
     error: Optional[ExportError] = None
+
+
+def extract_error_details(exc: BaseException) -> ExportError | None:
+    """Build an ``ExportError`` from a failed activity exception, or ``None`` if there's nothing to attach."""
+    cause = unwrap_temporal_cause(exc)
+    if cause is None or not cause.type:
+        return None
+    error_trace = cause.details[0] if cause.details and isinstance(cause.details[0], str) else ""
+    return ExportError(exception_class=cause.type, error_trace=error_trace)

--- a/posthog/temporal/exports/types.py
+++ b/posthog/temporal/exports/types.py
@@ -1,7 +1,7 @@
 import dataclasses
 from typing import Optional
 
-from posthog.temporal.common.errors import unwrap_temporal_cause
+from posthog.temporal.common.errors import resolve_error_trace, unwrap_temporal_cause
 
 
 @dataclasses.dataclass
@@ -24,9 +24,7 @@ class ExportAssetResult:
 
 
 def extract_error_details(exc: BaseException) -> ExportError | None:
-    """Build an ``ExportError`` from a failed activity exception, or ``None`` if there's nothing to attach."""
     cause = unwrap_temporal_cause(exc)
     if cause is None or not cause.type:
         return None
-    error_trace = cause.details[0] if cause.details and isinstance(cause.details[0], str) else ""
-    return ExportError(exception_class=cause.type, error_trace=error_trace)
+    return ExportError(exception_class=cause.type, error_trace=resolve_error_trace(exc))

--- a/posthog/temporal/exports/workflows.py
+++ b/posthog/temporal/exports/workflows.py
@@ -1,5 +1,4 @@
 import json
-import traceback
 import dataclasses
 from datetime import timedelta
 
@@ -9,9 +8,10 @@ from posthog.event_usage import EventSource
 from posthog.slo.types import SloConfig, SloOutcome
 from posthog.tasks.exports.failure_handler import is_user_query_error_type
 from posthog.temporal.common.base import PostHogWorkflow
+from posthog.temporal.common.slo_interceptor import resolve_exception_class
 from posthog.temporal.exports.activities import export_asset_activity
 from posthog.temporal.exports.retry_policy import EXPORT_RETRY_POLICY
-from posthog.temporal.exports.types import ExportAssetActivityInputs, extract_error_details
+from posthog.temporal.exports.types import ExportAssetActivityInputs
 
 
 @dataclasses.dataclass
@@ -45,13 +45,10 @@ class ExportAssetWorkflow(PostHogWorkflow):
                 retry_policy=EXPORT_RETRY_POLICY,
             )
         except Exception as e:
-            if inputs.slo:
-                err = extract_error_details(e)
-                exception_class = err.exception_class or type(e).__name__
-                inputs.slo.completion_properties["error"] = {
-                    "exception_class": exception_class,
-                    "error_trace": err.error_trace or "\n".join(traceback.format_exception(e)[:5]),
-                }
-                if is_user_query_error_type(exception_class):
-                    inputs.slo.outcome = SloOutcome.SUCCESS
+            # User-query failures aren't an SLO breach — reclassify as SUCCESS
+            # before re-raising so the interceptor records the correct outcome.
+            # (error_type, error_message, and error_trace are populated by the
+            # interceptor via its shared unwrap logic.)
+            if inputs.slo and is_user_query_error_type(resolve_exception_class(e)):
+                inputs.slo.outcome = SloOutcome.SUCCESS
             raise

--- a/posthog/temporal/exports/workflows.py
+++ b/posthog/temporal/exports/workflows.py
@@ -8,7 +8,7 @@ from posthog.event_usage import EventSource
 from posthog.slo.types import SloConfig, SloOutcome
 from posthog.tasks.exports.failure_handler import is_user_query_error_type
 from posthog.temporal.common.base import PostHogWorkflow
-from posthog.temporal.common.slo_interceptor import resolve_exception_class
+from posthog.temporal.common.errors import resolve_exception_class
 from posthog.temporal.exports.activities import export_asset_activity
 from posthog.temporal.exports.retry_policy import EXPORT_RETRY_POLICY
 from posthog.temporal.exports.types import ExportAssetActivityInputs

--- a/posthog/temporal/exports/workflows.py
+++ b/posthog/temporal/exports/workflows.py
@@ -45,10 +45,7 @@ class ExportAssetWorkflow(PostHogWorkflow):
                 retry_policy=EXPORT_RETRY_POLICY,
             )
         except Exception as e:
-            # User-query failures aren't an SLO breach — reclassify as SUCCESS
-            # before re-raising so the interceptor records the correct outcome.
-            # (error_type, error_message, and error_trace are populated by the
-            # interceptor via its shared unwrap logic.)
+            # User-query failures aren't an SLO breach -> reclassify as SUCCESS
             if inputs.slo and is_user_query_error_type(resolve_exception_class(e)):
                 inputs.slo.outcome = SloOutcome.SUCCESS
             raise

--- a/posthog/temporal/subscriptions/workflows.py
+++ b/posthog/temporal/subscriptions/workflows.py
@@ -1,7 +1,6 @@
 import json
 import asyncio
 import datetime as dt
-import traceback
 
 import temporalio.common
 import temporalio.workflow
@@ -162,7 +161,7 @@ class ProcessSubscriptionWorkflow(PostHogWorkflow):
     async def run(self, inputs: TrackedSubscriptionInputs) -> None:
         assets_with_content = 0
         total_assets = 0
-        errors: list[ExportError] = []
+        asset_errors: list[ExportError] = []
         caught_error: BaseException | None = None
 
         try:
@@ -210,9 +209,9 @@ class ProcessSubscriptionWorkflow(PostHogWorkflow):
             outcome_assets, successful_asset_ids = _build_outcome_assets(asset_ids, export_results)
             assets_with_content = len(successful_asset_ids)
             total_assets = len(outcome_assets)
-            errors = [a.error for a in outcome_assets if a.error]
+            asset_errors = [a.error for a in outcome_assets if a.error]
 
-            non_user_errors = [e for e in errors if not is_user_query_error_type(e.exception_class)]
+            non_user_errors = [e for e in asset_errors if not is_user_query_error_type(e.exception_class)]
             if inputs.slo and non_user_errors:
                 inputs.slo.outcome = SloOutcome.FAILURE
 
@@ -242,14 +241,11 @@ class ProcessSubscriptionWorkflow(PostHogWorkflow):
             )
 
         except Exception as e:
-            errors.append(
-                ExportError(
-                    exception_class=type(e).__name__,
-                    error_trace="\n".join(traceback.format_exception(e)[:5]),
-                )
-            )
+            # Workflow-level failure: the SLO interceptor populates
+            # error_type / error_message / error_trace when we re-raise.
+            # asset_errors stays for per-insight partial failures only.
             caught_error = e
-            # Don't re-raise — let finally run cleanup activities first
+            # Defer the re-raise until after the finally block — see note below.
 
         finally:
             # Advance schedule — always for scheduled deliveries, even on failure
@@ -265,14 +261,17 @@ class ProcessSubscriptionWorkflow(PostHogWorkflow):
                     ),
                 )
 
-            # Enrich SLO completion context
+            # Enrich SLO completion context with subscription-specific details.
+            # asset_errors captures per-insight fan-out failures (independent of
+            # whether the workflow itself succeeded); workflow-level errors go
+            # through the interceptor's error_type/error_message/error_trace.
             if inputs.slo:
                 inputs.slo.completion_properties.update(
                     {
                         "assets_with_content": assets_with_content,
                         "total_assets": total_assets,
-                        "errors": [
-                            {"exception_class": e.exception_class, "error_trace": e.error_trace} for e in errors
+                        "asset_errors": [
+                            {"error_type": e.exception_class, "error_trace": e.error_trace} for e in asset_errors
                         ],
                     }
                 )

--- a/posthog/temporal/subscriptions/workflows.py
+++ b/posthog/temporal/subscriptions/workflows.py
@@ -50,17 +50,11 @@ def _build_outcome_assets(
     successful_asset_ids: list[int] = []
     for asset_id, result in zip(asset_ids, export_results):
         if isinstance(result, BaseException):
-            err = extract_error_details(result)
             outcome_assets.append(
                 ExportAssetResult(
                     exported_asset_id=asset_id,
                     success=False,
-                    error=ExportError(
-                        exception_class=err.exception_class or "",
-                        error_trace=err.error_trace or "",
-                    )
-                    if err.exception_class
-                    else None,
+                    error=extract_error_details(result),
                 )
             )
         else:

--- a/posthog/temporal/subscriptions/workflows.py
+++ b/posthog/temporal/subscriptions/workflows.py
@@ -208,6 +208,12 @@ class ProcessSubscriptionWorkflow(PostHogWorkflow):
             non_user_errors = [e for e in asset_errors if not is_user_query_error_type(e.exception_class)]
             if inputs.slo and non_user_errors:
                 inputs.slo.outcome = SloOutcome.FAILURE
+                distinct_classes = sorted({e.exception_class for e in non_user_errors})
+                inputs.slo.completion_properties.setdefault("error_type", "PartialExportFailure")
+                inputs.slo.completion_properties.setdefault(
+                    "error_message",
+                    f"{len(non_user_errors)} export(s) failed: {', '.join(distinct_classes)}",
+                )
 
             # Phase 3: Deliver — send all assets including failed ones (they show
             # a "failed to generate" placeholder in the email/Slack message)
@@ -235,9 +241,6 @@ class ProcessSubscriptionWorkflow(PostHogWorkflow):
             )
 
         except Exception as e:
-            # Workflow-level failure: the SLO interceptor populates
-            # error_type / error_message / error_trace when we re-raise.
-            # asset_errors stays for per-insight partial failures only.
             caught_error = e
             # Defer the re-raise until after the finally block — see note below.
 
@@ -255,17 +258,16 @@ class ProcessSubscriptionWorkflow(PostHogWorkflow):
                     ),
                 )
 
-            # Enrich SLO completion context with subscription-specific details.
-            # asset_errors captures per-insight fan-out failures (independent of
-            # whether the workflow itself succeeded); workflow-level errors go
-            # through the interceptor's error_type/error_message/error_trace.
+            # Enrich SLO event with per-insight detail (non-user errors only).
             if inputs.slo:
                 inputs.slo.completion_properties.update(
                     {
                         "assets_with_content": assets_with_content,
                         "total_assets": total_assets,
                         "asset_errors": [
-                            {"error_type": e.exception_class, "error_trace": e.error_trace} for e in asset_errors
+                            {"error_type": e.exception_class, "error_trace": e.error_trace}
+                            for e in asset_errors
+                            if not is_user_query_error_type(e.exception_class)
                         ],
                     }
                 )

--- a/posthog/temporal/tests/test_export_workflow.py
+++ b/posthog/temporal/tests/test_export_workflow.py
@@ -184,5 +184,8 @@ async def test_export_failure_emits_slo_outcome(
 
     props = _get_slo_completed_props(mock_analytics)
     assert props["outcome"] == expected_outcome
-    assert props["error"] is not None
-    assert expected_exception_class in str(props["error"])
+    # error_type, error_message, and error_trace are all populated by the SLO
+    # interceptor via its shared ActivityError -> ApplicationError unwrap logic.
+    assert props["error_type"] == expected_exception_class
+    assert props["error_message"]
+    assert props["error_trace"]

--- a/posthog/temporal/tests/test_export_workflow.py
+++ b/posthog/temporal/tests/test_export_workflow.py
@@ -148,11 +148,11 @@ async def test_transient_error_retries_and_succeeds(
 
 
 @pytest.mark.parametrize(
-    "error_factory,expected_exception_class,expected_call_count,expected_outcome",
+    "error_factory,expected_exception_class,expected_error_msg,expected_call_count,expected_outcome",
     [
-        (lambda: QueryError("Invalid HogQL query"), "QueryError", 1, SloOutcome.SUCCESS),
-        (lambda: RuntimeError("Chrome crashed"), "RuntimeError", 1, SloOutcome.FAILURE),
-        (lambda: CHQueryErrorS3Error("S3 error", code=499), "CHQueryErrorS3Error", 10, SloOutcome.FAILURE),
+        (lambda: QueryError("Invalid HogQL query"), "QueryError", "Invalid HogQL query", 1, SloOutcome.SUCCESS),
+        (lambda: RuntimeError("Chrome crashed"), "RuntimeError", "Chrome crashed", 1, SloOutcome.FAILURE),
+        (lambda: CHQueryErrorS3Error("S3 error", code=499), "CHQueryErrorS3Error", "S3 error", 10, SloOutcome.FAILURE),
     ],
     ids=["non_retryable_user_error", "generic_runtime_error", "retryable_system_error"],
 )
@@ -164,6 +164,7 @@ async def test_export_failure_emits_slo_outcome(
     team,
     error_factory,
     expected_exception_class: str,
+    expected_error_msg: str,
     expected_call_count: int,
     expected_outcome: SloOutcome,
 ):
@@ -187,5 +188,5 @@ async def test_export_failure_emits_slo_outcome(
     # error_type, error_message, and error_trace are all populated by the SLO
     # interceptor via its shared ActivityError -> ApplicationError unwrap logic.
     assert props["error_type"] == expected_exception_class
-    assert props["error_message"]
-    assert props["error_trace"]
+    assert props["error_message"] == expected_error_msg
+    assert expected_exception_class in props["error_trace"]

--- a/posthog/temporal/tests/test_export_workflow.py
+++ b/posthog/temporal/tests/test_export_workflow.py
@@ -150,9 +150,21 @@ async def test_transient_error_retries_and_succeeds(
 @pytest.mark.parametrize(
     "error_factory,expected_exception_class,expected_error_msg,expected_call_count,expected_outcome",
     [
-        (lambda: QueryError("Invalid HogQL query"), "QueryError", "Invalid HogQL query", 1, SloOutcome.SUCCESS),
-        (lambda: RuntimeError("Chrome crashed"), "RuntimeError", "Chrome crashed", 1, SloOutcome.FAILURE),
-        (lambda: CHQueryErrorS3Error("S3 error", code=499), "CHQueryErrorS3Error", "S3 error", 10, SloOutcome.FAILURE),
+        (
+            lambda: QueryError("Invalid HogQL query"),
+            "QueryError",
+            "QueryError: Invalid HogQL query",
+            1,
+            SloOutcome.SUCCESS,
+        ),
+        (lambda: RuntimeError("Chrome crashed"), "RuntimeError", "RuntimeError: Chrome crashed", 1, SloOutcome.FAILURE),
+        (
+            lambda: CHQueryErrorS3Error("S3 error", code=499),
+            "CHQueryErrorS3Error",
+            "CHQueryErrorS3Error: Code: 499.\nS3 error",
+            10,
+            SloOutcome.FAILURE,
+        ),
     ],
     ids=["non_retryable_user_error", "generic_runtime_error", "retryable_system_error"],
 )
@@ -189,4 +201,4 @@ async def test_export_failure_emits_slo_outcome(
     # interceptor via its shared ActivityError -> ApplicationError unwrap logic.
     assert props["error_type"] == expected_exception_class
     assert props["error_message"] == expected_error_msg
-    assert expected_exception_class in props["error_trace"]
+    assert "Traceback" in props["error_trace"]

--- a/posthog/temporal/tests/test_slo_interceptor.py
+++ b/posthog/temporal/tests/test_slo_interceptor.py
@@ -67,6 +67,19 @@ class TrackedActivityFailureWorkflow:
         return "ok"
 
 
+@temporalio.workflow.defn(name="test-slo-override-error-trace")
+class TrackedOverrideErrorTraceWorkflow:
+    @temporalio.workflow.run
+    async def run(self, inputs: TrackedWorkflowInput) -> str:
+        try:
+            raise ApplicationError("boom", non_retryable=True)
+        except ApplicationError:
+            # Pre-populate error_trace — the interceptor's setdefault must not clobber it.
+            if inputs.slo:
+                inputs.slo.completion_properties["error_trace"] = "pre-populated by workflow"
+            raise
+
+
 @temporalio.workflow.defn(name="test-slo-untracked")
 class UntrackedWorkflow:
     @temporalio.workflow.run
@@ -93,7 +106,7 @@ pytestmark = [pytest.mark.asyncio]
 
 
 @pytest.mark.parametrize(
-    "workflow_cls,slo_config,raises,expected_outcome,extra_completed_checks",
+    "workflow_cls,slo_config,raises,expected_outcome,extra_completed_checks,expect_error_trace",
     [
         (
             TrackedWorkflow,
@@ -101,6 +114,7 @@ pytestmark = [pytest.mark.asyncio]
             False,
             SloOutcome.SUCCESS,
             {"extra_key": "extra_value"},
+            False,
         ),
         (
             TrackedFailureWorkflow,
@@ -108,6 +122,7 @@ pytestmark = [pytest.mark.asyncio]
             True,
             SloOutcome.FAILURE,
             {"error_type": "ApplicationError", "error_message": "boom"},
+            True,
         ),
         (
             TrackedActivityFailureWorkflow,
@@ -115,6 +130,7 @@ pytestmark = [pytest.mark.asyncio]
             True,
             SloOutcome.FAILURE,
             {"error_type": "ActivityBoom", "error_message": "ActivityBoom: activity boom"},
+            True,
         ),
         (
             TrackedBusinessFailureWorkflow,
@@ -122,6 +138,7 @@ pytestmark = [pytest.mark.asyncio]
             False,
             SloOutcome.FAILURE,
             {"reason": "business logic"},
+            False,
         ),
     ],
     ids=["success_with_completion_props", "exception_failure", "activity_failure_unwrap", "business_logic_failure"],
@@ -134,6 +151,7 @@ async def test_interceptor_emits_slo_events(
     raises: bool,
     expected_outcome: SloOutcome,
     extra_completed_checks: dict,
+    expect_error_trace: bool,
 ):
     async with await WorkflowEnvironment.start_local() as env:
         async with Worker(
@@ -172,6 +190,43 @@ async def test_interceptor_emits_slo_events(
     assert completed_props["correlation_id"] == started_props["correlation_id"]
     for key, value in extra_completed_checks.items():
         assert completed_props[key] == value
+    if expect_error_trace:
+        # The interceptor populates error_trace from either the activity-side
+        # ApplicationError.details[0] or a fallback workflow-side traceback.
+        assert completed_props.get("error_trace")
+    else:
+        # Successful workflows and in-workflow business-failure paths never raise,
+        # so the interceptor has nothing to unwrap — error_trace must not be set.
+        assert "error_trace" not in completed_props
+
+
+@patch("posthog.slo.events.posthoganalytics")
+async def test_interceptor_respects_workflow_error_trace_override(mock_analytics: MagicMock):
+    # Workflows can override error_trace by pre-populating completion_properties
+    # before re-raising — the interceptor uses setdefault, so workflow intent wins.
+    async with await WorkflowEnvironment.start_local() as env:
+        async with Worker(
+            env.client,
+            task_queue="test-slo",
+            workflows=[TrackedOverrideErrorTraceWorkflow],
+            interceptors=[SloInterceptor()],
+            workflow_runner=UnsandboxedWorkflowRunner(),
+        ):
+            with pytest.raises(Exception):
+                await env.client.execute_workflow(
+                    TrackedOverrideErrorTraceWorkflow.run,
+                    TrackedWorkflowInput(value="test", slo=_make_slo_config()),
+                    id="test-error-trace-override",
+                    task_queue="test-slo",
+                )
+
+    completed_calls = _get_slo_calls(mock_analytics, "slo_operation_completed")
+    assert len(completed_calls) == 1
+    props = completed_calls[0].kwargs["properties"]
+    assert props["error_trace"] == "pre-populated by workflow"
+    # error_type / error_message are still filled in by the interceptor
+    assert props["error_type"] == "ApplicationError"
+    assert props["error_message"] == "boom"
 
 
 @pytest.mark.parametrize(

--- a/posthog/temporal/tests/test_slo_interceptor.py
+++ b/posthog/temporal/tests/test_slo_interceptor.py
@@ -193,7 +193,7 @@ async def test_interceptor_emits_slo_events(
     if expect_error_trace:
         # The interceptor populates error_trace from either the activity-side
         # ApplicationError.details[0] or a fallback workflow-side traceback.
-        assert completed_props.get("error_trace")
+        assert completed_props.get("error_trace") is not None
     else:
         # Successful workflows and in-workflow business-failure paths never raise,
         # so the interceptor has nothing to unwrap — error_trace must not be set.

--- a/posthog/temporal/tests/test_subscriptions_workflows.py
+++ b/posthog/temporal/tests/test_subscriptions_workflows.py
@@ -982,3 +982,12 @@ async def test_partial_export_failure_delivers_successful_assets(
     assert props["outcome"] == SloOutcome.FAILURE
     assert props["assets_with_content"] == 2
     assert props["total_assets"] == 3
+    # Per-insight fan-out failures land in asset_errors with {error_type, error_trace}.
+    # Workflow-level errors (create_export_assets / deliver_subscription failures) go
+    # through the interceptor's error_type / error_message / error_trace instead —
+    # partial-failure deliveries like this one never populate those.
+    assert len(props["asset_errors"]) == 1
+    assert props["asset_errors"][0]["error_type"] == "RuntimeError"
+    assert props["asset_errors"][0]["error_trace"]
+    assert "error_type" not in props
+    assert "error_trace" not in props

--- a/posthog/temporal/tests/test_subscriptions_workflows.py
+++ b/posthog/temporal/tests/test_subscriptions_workflows.py
@@ -898,6 +898,25 @@ async def test_export_error_slo_outcome(
     assert completed_calls[0].kwargs["properties"]["outcome"] == expected_outcome
 
 
+@pytest.mark.parametrize(
+    "error_factory,expected_outcome,expected_error_type,expected_error_msg",
+    [
+        pytest.param(
+            lambda: RuntimeError("ClickHouse connection timeout"),
+            SloOutcome.FAILURE,
+            "PartialExportFailure",
+            "1 export(s) failed: RuntimeError",
+            id="non_user_error_sets_slo_error_type",
+        ),
+        pytest.param(
+            lambda: QueryError("Invalid HogQL query"),
+            SloOutcome.SUCCESS,
+            None,
+            None,
+            id="user_error_keeps_slo_success",
+        ),
+    ],
+)
 @patch("posthog.temporal.exports.activities.exporter")
 @patch("posthog.slo.events.posthoganalytics")
 @patch("ee.tasks.subscriptions.get_metric_meter")
@@ -912,6 +931,10 @@ async def test_partial_export_failure_delivers_successful_assets(
     temporal_client: Client,
     team,
     user,
+    error_factory,
+    expected_outcome: SloOutcome,
+    expected_error_type: str | None,
+    expected_error_msg: str | None,
 ):
     dashboard = await sync_to_async(Dashboard.objects.create)(team=team, name="partial fail", created_by=user)
     insights = []
@@ -922,12 +945,11 @@ async def test_partial_export_failure_delivers_successful_assets(
 
     subscription = await sync_to_async(create_subscription)(team=team, dashboard=dashboard, created_by=user)
 
-    # First insight fails with a system error, the other two succeed
     fail_insight_id = insights[0].id
 
     def fake_export(asset_obj, **kwargs):
         if asset_obj.insight_id == fail_insight_id:
-            raise RuntimeError("ClickHouse connection timeout")
+            raise error_factory()
         asset_obj.content_location = "s3://bucket/ok.png"
         asset_obj.save(update_fields=["content_location"])
 
@@ -973,21 +995,22 @@ async def test_partial_export_failure_delivers_successful_assets(
         delivered_assets = call[0][2]  # third positional arg is assets list
         assert len(delivered_assets) == 3
 
-    # One subscription-level SLO event: failure (system error is a real SLO failure)
     completed_calls = [
         c for c in mock_slo_analytics.capture.call_args_list if c.kwargs.get("event") == "slo_operation_completed"
     ]
     assert len(completed_calls) == 1
     props = completed_calls[0].kwargs["properties"]
-    assert props["outcome"] == SloOutcome.FAILURE
+    assert props["outcome"] == expected_outcome
     assert props["assets_with_content"] == 2
     assert props["total_assets"] == 3
-    # Per-insight fan-out failures land in asset_errors with {error_type, error_trace}.
-    # Workflow-level errors (create_export_assets / deliver_subscription failures) go
-    # through the interceptor's error_type / error_message / error_trace instead —
-    # partial-failure deliveries like this one never populate those.
-    assert len(props["asset_errors"]) == 1
-    assert props["asset_errors"][0]["error_type"] == "RuntimeError"
-    assert props["asset_errors"][0]["error_trace"]
-    assert "error_type" not in props
-    assert "error_trace" not in props
+
+    # Non-user errors populate top-level error_type/error_message and asset_errors;
+    # user errors are reclassified as SUCCESS and filtered out of both.
+    if expected_error_type:
+        assert props["error_type"] == expected_error_type
+        assert props["error_message"] == expected_error_msg
+        assert len(props["asset_errors"]) == 1
+        assert "RuntimeError" in props["asset_errors"][0]["error_trace"]
+    else:
+        assert "error_type" not in props
+        assert props["asset_errors"] == []

--- a/posthog/temporal/tests/test_subscriptions_workflows.py
+++ b/posthog/temporal/tests/test_subscriptions_workflows.py
@@ -1010,7 +1010,7 @@ async def test_partial_export_failure_delivers_successful_assets(
         assert props["error_type"] == expected_error_type
         assert props["error_message"] == expected_error_msg
         assert len(props["asset_errors"]) == 1
-        assert "RuntimeError" in props["asset_errors"][0]["error_trace"]
+        assert "Traceback" in props["asset_errors"][0]["error_trace"]
     else:
         assert "error_type" not in props
         assert props["asset_errors"] == []


### PR DESCRIPTION
## Problem

SLO completion events for exports and subscriptions had a few error-reporting gaps:

1. Redundant error construction — both workflows built their own error objects, duplicating logic the SLO interceptor already handles.
2. When per-asset exports failed via `asyncio.gather(return_exceptions=True)` in subscription deliveries, the workflow set `outcome=failure` but never populated `error_type` or `error_message`, making these failures unclassifiable in SLO metrics.
3. Error type and Error Message keys were present in the context manager SLO events but not in Temporal, which made parsing of the events more difficult (needed handling on a case by case basis). 

## Changes

All workflows (via interceptor):

- Added: error_trace (new property on all failure events)

One-off export (slo_operation_completed):

- Removed: error.exception_class (nested)
- Removed: error.error_trace (nested)
- Added: error_type (top-level, from interceptor)
- Added: error_message (top-level, from interceptor)
- Added: error_trace (top-level, from interceptor)

Subscription delivery (slo_operation_completed):

- Renamed: errors → asset_errors (array property)
- Renamed: errors[].exception_class → asset_errors[].error_type
- Added: error_type = "PartialExportFailure" on partial failures (was absent)
- Added: error_message = "N export(s) failed: Class1, Class2" on partial failures (was absent)
- Removed: workflow-level exceptions no longer append to asset_errors (they go through the interceptor's error_type/error_message/error_trace instead)

## How did you test this code?

- Parameterized `test_partial_export_failure_delivers_successful_assets` with two cases: system-error partial failure (RuntimeError → `outcome=FAILURE`, `error_type` set) and user-error partial failure (QueryError → `outcome=SUCCESS`, no `error_type`)
- Added `test_interceptor_respects_workflow_error_trace_override` to verify `setdefault` layering
- Strengthened `test_export_failure_emits_slo_outcome` assertions: `error_message` checks exact expected string, `error_trace` checks exception class appears
- All existing export and subscription workflow tests pass

## Publish to changelog?

No

## Docs update

No docs changes needed.

## LLM context

The `error_type=None` gap was identified via SLO failure triage. Root cause: the `return_exceptions=True` code path caught errors as `BaseException` results but never populated SLO properties from them.