### PR TITLE
fix: Fix rust crypto install in kafka-assigner

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -5033,6 +5033,7 @@ dependencies = [
  "kube",
  "prost 0.13.5",
  "rdkafka",
+ "rustls 0.23.37",
  "serde",
  "serde_json",
  "serial_test",

--- a/rust/kafka-assigner/Cargo.toml
+++ b/rust/kafka-assigner/Cargo.toml
@@ -14,6 +14,7 @@ etcd-client = "0.18"
 kafka-assigner-proto = { path = "../kafka-assigner-proto" }
 prost = { workspace = true }
 rdkafka = { workspace = true }
+rustls = { version = "0.23", default-features = false, features = ["ring", "std"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/rust/kafka-assigner/src/main.rs
+++ b/rust/kafka-assigner/src/main.rs
@@ -19,6 +19,10 @@ use tracing_subscriber::EnvFilter;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    rustls::crypto::ring::default_provider()
+        .install_default()
+        .expect("Failed to install rustls crypto provider");
+
     tracing_subscriber::registry()
         .with(EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")))
         .with(tracing_subscriber::fmt::layer())


### PR DESCRIPTION
## Problem

The kafka-assigner panics at startup when K8s awareness is enabled because the `kube` crate uses `rustls` internally but no crypto provider is installed, causing `kube::Client::try_default()` to fail.

## Changes

- Add `rustls` dependency with the `ring` crypto backend to kafka-assigner
- Install the `ring` crypto provider at the top of `main()` before any TLS connections are made, matching the pattern used in cymbal

## How did you test this code?

<!-- Briefly describe the steps you took, and what steps reviewers must take to get to where changes are, and what is the expected behavior. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
