### PR TITLE
docs(llma): migrate onboarding docs to OpenTelemetry auto-instrumentation

### DIFF
--- a/docs/onboarding/llm-analytics/anthropic.tsx
+++ b/docs/onboarding/llm-analytics/anthropic.tsx
@@ -3,7 +3,7 @@ import { OnboardingComponentsContext, createInstallation } from 'scenes/onboardi
 import { StepDefinition } from '../steps'
 
 export const getAnthropicSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
-    const { CodeBlock, Markdown, Blockquote, dedent, snippets } = ctx
+    const { CodeBlock, CalloutBox, Markdown, Blockquote, dedent, snippets } = ctx
 
     const NotableGenerationProperties = snippets?.NotableGenerationProperties
 
@@ -13,6 +13,17 @@ export const getAnthropicSteps = (ctx: OnboardingComponentsContext): StepDefinit
             badge: 'required',
             content: (
                 <>
+                    <CalloutBox type="info" icon="IconInfo" title="Migrating from the SDK wrapper?">
+                        <Markdown>
+                            These docs now use OpenTelemetry auto-instrumentation, which is the recommended approach.
+                            The previous PostHog SDK wrapper is still available — see the
+                            [Node.js](https://github.com/PostHog/posthog-js/tree/e08ff1be/examples/example-ai-anthropic)
+                            and
+                            [Python](https://github.com/PostHog/posthog-python/tree/7223c52/examples/example-ai-anthropic)
+                            wrapper examples.
+                        </Markdown>
+                    </CalloutBox>
+
                     <Markdown>
                         Install the OpenTelemetry SDK, the Anthropic instrumentation, and the Anthropic SDK.
                     </Markdown>

--- a/docs/onboarding/llm-analytics/anthropic.tsx
+++ b/docs/onboarding/llm-analytics/anthropic.tsx
@@ -3,7 +3,7 @@ import { OnboardingComponentsContext, createInstallation } from 'scenes/onboardi
 import { StepDefinition } from '../steps'
 
 export const getAnthropicSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
-    const { CodeBlock, CalloutBox, Markdown, Blockquote, dedent, snippets } = ctx
+    const { CodeBlock, Markdown, Blockquote, dedent, snippets } = ctx
 
     const NotableGenerationProperties = snippets?.NotableGenerationProperties
 
@@ -35,13 +35,6 @@ export const getAnthropicSteps = (ctx: OnboardingComponentsContext): StepDefinit
                             },
                         ]}
                     />
-
-                    <CalloutBox type="fyi" icon="IconInfo" title="No proxy">
-                        <Markdown>
-                            These SDKs **do not** proxy your calls. They only send analytics data to PostHog in the
-                            background.
-                        </Markdown>
-                    </CalloutBox>
                 </>
             ),
         },

--- a/docs/onboarding/llm-analytics/anthropic.tsx
+++ b/docs/onboarding/llm-analytics/anthropic.tsx
@@ -9,13 +9,12 @@ export const getAnthropicSteps = (ctx: OnboardingComponentsContext): StepDefinit
 
     return [
         {
-            title: 'Install the PostHog SDK',
+            title: 'Install dependencies',
             badge: 'required',
             content: (
                 <>
                     <Markdown>
-                        Setting up analytics starts with installing the PostHog SDK for your language. LLM analytics
-                        works best with our Python and Node SDKs.
+                        Install the OpenTelemetry SDK, the Anthropic instrumentation, and the Anthropic SDK.
                     </Markdown>
 
                     <CodeBlock
@@ -24,70 +23,36 @@ export const getAnthropicSteps = (ctx: OnboardingComponentsContext): StepDefinit
                                 language: 'bash',
                                 file: 'Python',
                                 code: dedent`
-                                    pip install posthog
+                                    pip install anthropic opentelemetry-sdk opentelemetry-exporter-otlp-proto-http opentelemetry-instrumentation-anthropic
                                 `,
                             },
                             {
                                 language: 'bash',
                                 file: 'Node',
                                 code: dedent`
-                                    npm install @posthog/ai posthog-node
-                                `,
-                            },
-                        ]}
-                    />
-                </>
-            ),
-        },
-        {
-            title: 'Install the Anthropic SDK',
-            badge: 'required',
-            content: (
-                <>
-                    <Markdown>
-                        Install the Anthropic SDK. The PostHog SDK instruments your LLM calls by wrapping the Anthropic
-                        client. The PostHog SDK **does not** proxy your calls.
-                    </Markdown>
-
-                    <CodeBlock
-                        blocks={[
-                            {
-                                language: 'bash',
-                                file: 'Python',
-                                code: dedent`
-                                    pip install anthropic
-                                `,
-                            },
-                            {
-                                language: 'bash',
-                                file: 'Node',
-                                code: dedent`
-                                    npm install @anthropic-ai/sdk
+                                    npm install @anthropic-ai/sdk @posthog/ai @opentelemetry/sdk-node @opentelemetry/resources @traceloop/instrumentation-anthropic
                                 `,
                             },
                         ]}
                     />
 
-                    <CalloutBox type="fyi" icon="IconInfo" title="Proxy note">
+                    <CalloutBox type="fyi" icon="IconInfo" title="No proxy">
                         <Markdown>
-                            These SDKs **do not** proxy your calls. They only fire off an async call to PostHog in the
-                            background to send the data. You can also use LLM analytics with other SDKs or our API, but
-                            you will need to capture the data in the right format. See the schema in the [manual capture
-                            section](https://posthog.com/docs/llm-analytics/installation/manual-capture) for more
-                            details.
+                            These SDKs **do not** proxy your calls. They only send analytics data to PostHog in the
+                            background.
                         </Markdown>
                     </CalloutBox>
                 </>
             ),
         },
         {
-            title: 'Initialize PostHog and the Anthropic wrapper',
+            title: 'Set up OpenTelemetry tracing',
             badge: 'required',
             content: (
                 <>
                     <Markdown>
-                        Initialize PostHog with your project token and host from [your project
-                        settings](https://app.posthog.com/settings/project), then pass it to our Anthropic wrapper.
+                        Configure OpenTelemetry to auto-instrument Anthropic SDK calls and export traces to PostHog.
+                        PostHog converts `gen_ai.*` spans into `$ai_generation` events automatically.
                     </Markdown>
 
                     <CodeBlock
@@ -96,36 +61,108 @@ export const getAnthropicSteps = (ctx: OnboardingComponentsContext): StepDefinit
                                 language: 'python',
                                 file: 'Python',
                                 code: dedent`
-                                    from posthog.ai.anthropic import Anthropic
-                                    from posthog import Posthog
+                                    from opentelemetry import trace
+                                    from opentelemetry.sdk.trace import TracerProvider
+                                    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+                                    from opentelemetry.sdk.resources import Resource, SERVICE_NAME
+                                    from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+                                    from opentelemetry.instrumentation.anthropic import AnthropicInstrumentor
 
-                                    posthog = Posthog(
-                                        "<ph_project_token>",
-                                        host="<ph_client_api_host>"
+                                    resource = Resource(attributes={
+                                        SERVICE_NAME: "my-app",
+                                        "user.id": "user_123", # optional: identifies the user in PostHog
+                                    })
+
+                                    exporter = OTLPSpanExporter(
+                                        endpoint="<ph_client_api_host>/i/v0/ai/otel",
+                                        headers={"Authorization": "Bearer <ph_project_token>"},
                                     )
 
-                                    client = Anthropic(
-                                        api_key="sk-ant-api...", # Replace with your Anthropic API key
-                                        posthog_client=posthog # This is an optional parameter. If it is not provided, a default client will be used.
-                                    )
+                                    provider = TracerProvider(resource=resource)
+                                    provider.add_span_processor(SimpleSpanProcessor(exporter))
+                                    trace.set_tracer_provider(provider)
+
+                                    AnthropicInstrumentor().instrument()
                                 `,
                             },
                             {
                                 language: 'typescript',
                                 file: 'Node',
                                 code: dedent`
-                                    import { Anthropic } from '@posthog/ai'
-                                    import { PostHog } from 'posthog-node'
+                                    import { NodeSDK, tracing } from '@opentelemetry/sdk-node'
+                                    import { resourceFromAttributes } from '@opentelemetry/resources'
+                                    import { PostHogTraceExporter } from '@posthog/ai/otel'
+                                    import { AnthropicInstrumentation } from '@traceloop/instrumentation-anthropic'
 
-                                    const phClient = new PostHog(
-                                      '<ph_project_token>',
-                                      { host: '<ph_client_api_host>' }
+                                    const sdk = new NodeSDK({
+                                      resource: resourceFromAttributes({
+                                        'service.name': 'my-app',
+                                        'user.id': 'user_123', // optional: identifies the user in PostHog
+                                      }),
+                                      spanProcessors: [
+                                        new tracing.SimpleSpanProcessor(
+                                          new PostHogTraceExporter({
+                                            apiKey: '<ph_project_token>',
+                                            host: '<ph_client_api_host>',
+                                          })
+                                        ),
+                                      ],
+                                      instrumentations: [new AnthropicInstrumentation()],
+                                    })
+                                    sdk.start()
+                                `,
+                            },
+                        ]}
+                    />
+                </>
+            ),
+        },
+        {
+            title: 'Call Anthropic',
+            badge: 'required',
+            content: (
+                <>
+                    <Markdown>
+                        Now, when you use the Anthropic SDK to call LLMs, PostHog automatically captures
+                        `$ai_generation` events via the OpenTelemetry instrumentation.
+                    </Markdown>
+
+                    <CodeBlock
+                        blocks={[
+                            {
+                                language: 'python',
+                                file: 'Python',
+                                code: dedent`
+                                    import anthropic
+
+                                    client = anthropic.Anthropic(api_key="sk-ant-api...")
+
+                                    response = client.messages.create(
+                                        model="claude-sonnet-4-20250514",
+                                        max_tokens=1024,
+                                        messages=[
+                                            {"role": "user", "content": "Tell me a fun fact about hedgehogs"}
+                                        ],
                                     )
 
-                                    const client = new Anthropic({
-                                      apiKey: 'sk-ant-api...', // Replace with your Anthropic API key
-                                      posthog: phClient
+                                    print(response.content[0].text)
+                                `,
+                            },
+                            {
+                                language: 'typescript',
+                                file: 'Node',
+                                code: dedent`
+                                    import Anthropic from '@anthropic-ai/sdk'
+
+                                    const client = new Anthropic({ apiKey: 'sk-ant-api...' })
+
+                                    const response = await client.messages.create({
+                                      model: 'claude-sonnet-4-20250514',
+                                      max_tokens: 1024,
+                                      messages: [{ role: 'user', content: 'Tell me a fun fact about hedgehogs' }],
                                     })
+
+                                    console.log(response.content[0].text)
                                 `,
                             },
                         ]}
@@ -137,79 +174,12 @@ export const getAnthropicSteps = (ctx: OnboardingComponentsContext): StepDefinit
                             `AnthropicVertex`, and the async versions of those.
                         </Markdown>
                     </Blockquote>
-                </>
-            ),
-        },
-        {
-            title: 'Call Anthropic LLMs',
-            badge: 'required',
-            content: (
-                <>
-                    <Markdown>
-                        Now, when you use the Anthropic SDK to call LLMs, PostHog automatically captures an
-                        `$ai_generation` event. You can enrich the event with additional data such as the trace ID,
-                        distinct ID, custom properties, groups, and privacy mode options.
-                    </Markdown>
-
-                    <CodeBlock
-                        blocks={[
-                            {
-                                language: 'python',
-                                file: 'Python',
-                                code: dedent`
-                                    response = client.messages.create(
-                                        model="claude-3-opus-20240229",
-                                        messages=[
-                                            {
-                                                "role": "user",
-                                                "content": "Tell me a fun fact about hedgehogs"
-                                            }
-                                        ],
-                                        posthog_distinct_id="user_123", # optional
-                                        posthog_trace_id="trace_123", # optional
-                                        posthog_properties={"conversation_id": "abc123", "paid": True}, # optional
-                                        posthog_groups={"company": "company_id_in_your_db"},  # optional
-                                        posthog_privacy_mode=False # optional
-                                    )
-
-                                    print(response.content[0].text)
-                                `,
-                            },
-                            {
-                                language: 'typescript',
-                                file: 'Node',
-                                code: dedent`
-                                    const response = await client.messages.create({
-                                      model: "claude-3-5-sonnet-latest",
-                                      messages: [
-                                        {
-                                          role: "user",
-                                          content: "Tell me a fun fact about hedgehogs"
-                                        }
-                                      ],
-                                      posthogDistinctId: "user_123", // optional
-                                      posthogTraceId: "trace_123", // optional
-                                      posthogProperties: { conversationId: "abc123", paid: true }, // optional
-                                      posthogGroups: { company: "company_id_in_your_db" }, // optional
-                                      posthogPrivacyMode: false // optional
-                                    })
-
-                                    console.log(response.content[0].text)
-                                    phClient.shutdown()
-                                `,
-                            },
-                        ]}
-                    />
 
                     <Blockquote>
                         <Markdown>
-                            {dedent`
-                            **Notes:**
-                            - This also works when message streams are used (e.g. \`stream=True\` or \`client.messages.stream(...)\`).
-                            - If you want to capture LLM events anonymously, **don't** pass a distinct ID to the request.
-
-                            See our docs on [anonymous vs identified events](https://posthog.com/docs/data/anonymous-vs-identified-events) to learn more.
-                            `}
+                            **Note:** If you want to capture LLM events anonymously, omit the `user.id` resource
+                            attribute. See our docs on [anonymous vs identified
+                            events](https://posthog.com/docs/data/anonymous-vs-identified-events) to learn more.
                         </Markdown>
                     </Blockquote>
 

--- a/docs/onboarding/llm-analytics/anthropic.tsx
+++ b/docs/onboarding/llm-analytics/anthropic.tsx
@@ -13,14 +13,17 @@ export const getAnthropicSteps = (ctx: OnboardingComponentsContext): StepDefinit
             badge: 'required',
             content: (
                 <>
-                    <CalloutBox type="info" icon="IconInfo" title="Migrating from the SDK wrapper?">
+                    <CalloutBox type="info" icon="IconInfo" title="Full working examples">
                         <Markdown>
-                            These docs now use OpenTelemetry auto-instrumentation, which is the recommended approach.
-                            The previous PostHog SDK wrapper is still available — see the
-                            [Node.js](https://github.com/PostHog/posthog-js/tree/e08ff1be/examples/example-ai-anthropic)
-                            and
-                            [Python](https://github.com/PostHog/posthog-python/tree/7223c52/examples/example-ai-anthropic)
-                            wrapper examples.
+                            See the complete
+                            [Node.js](https://github.com/PostHog/posthog-js/tree/main/examples/example-ai-anthropic) and
+                            [Python](https://github.com/PostHog/posthog-python/tree/master/examples/example-ai-anthropic)
+                            examples on GitHub. If you're using the PostHog SDK wrapper instead of OpenTelemetry, see
+                            the [Node.js
+                            wrapper](https://github.com/PostHog/posthog-js/tree/e08ff1be/examples/example-ai-anthropic)
+                            and [Python
+                            wrapper](https://github.com/PostHog/posthog-python/tree/7223c52/examples/example-ai-anthropic)
+                            examples.
                         </Markdown>
                     </CalloutBox>
 

--- a/docs/onboarding/llm-analytics/anthropic.tsx
+++ b/docs/onboarding/llm-analytics/anthropic.tsx
@@ -63,7 +63,8 @@ export const getAnthropicSteps = (ctx: OnboardingComponentsContext): StepDefinit
 
                                     resource = Resource(attributes={
                                         SERVICE_NAME: "my-app",
-                                        "user.id": "user_123", # optional: identifies the user in PostHog
+                                        "posthog.distinct_id": "user_123", # optional: identifies the user in PostHog
+                                        "foo": "bar", # custom properties are passed through
                                     })
 
                                     exporter = OTLPSpanExporter(
@@ -90,7 +91,8 @@ export const getAnthropicSteps = (ctx: OnboardingComponentsContext): StepDefinit
                                     const sdk = new NodeSDK({
                                       resource: resourceFromAttributes({
                                         'service.name': 'my-app',
-                                        'user.id': 'user_123', // optional: identifies the user in PostHog
+                                        'posthog.distinct_id': 'user_123', // optional: identifies the user in PostHog
+                                        foo: 'bar', // custom properties are passed through
                                       }),
                                       spanProcessors: [
                                         new tracing.SimpleSpanProcessor(
@@ -170,8 +172,8 @@ export const getAnthropicSteps = (ctx: OnboardingComponentsContext): StepDefinit
 
                     <Blockquote>
                         <Markdown>
-                            **Note:** If you want to capture LLM events anonymously, omit the `user.id` resource
-                            attribute. See our docs on [anonymous vs identified
+                            **Note:** If you want to capture LLM events anonymously, omit the `posthog.distinct_id`
+                            resource attribute. See our docs on [anonymous vs identified
                             events](https://posthog.com/docs/data/anonymous-vs-identified-events) to learn more.
                         </Markdown>
                     </Blockquote>

--- a/docs/onboarding/llm-analytics/anthropic.tsx
+++ b/docs/onboarding/llm-analytics/anthropic.tsx
@@ -37,7 +37,7 @@ export const getAnthropicSteps = (ctx: OnboardingComponentsContext): StepDefinit
                                 language: 'bash',
                                 file: 'Python',
                                 code: dedent`
-                                    pip install anthropic opentelemetry-sdk opentelemetry-exporter-otlp-proto-http opentelemetry-instrumentation-anthropic
+                                    pip install anthropic opentelemetry-sdk posthog[otel] opentelemetry-instrumentation-anthropic
                                 `,
                             },
                             {
@@ -70,9 +70,8 @@ export const getAnthropicSteps = (ctx: OnboardingComponentsContext): StepDefinit
                                 code: dedent`
                                     from opentelemetry import trace
                                     from opentelemetry.sdk.trace import TracerProvider
-                                    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
                                     from opentelemetry.sdk.resources import Resource, SERVICE_NAME
-                                    from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+                                    from posthog.ai.otel import PostHogSpanProcessor
                                     from opentelemetry.instrumentation.anthropic import AnthropicInstrumentor
 
                                     resource = Resource(attributes={
@@ -81,13 +80,13 @@ export const getAnthropicSteps = (ctx: OnboardingComponentsContext): StepDefinit
                                         "foo": "bar", # custom properties are passed through
                                     })
 
-                                    exporter = OTLPSpanExporter(
-                                        endpoint="<ph_client_api_host>/i/v0/ai/otel",
-                                        headers={"Authorization": "Bearer <ph_project_token>"},
-                                    )
-
                                     provider = TracerProvider(resource=resource)
-                                    provider.add_span_processor(SimpleSpanProcessor(exporter))
+                                    provider.add_span_processor(
+                                        PostHogSpanProcessor(
+                                            api_key="<ph_project_token>",
+                                            host="<ph_client_api_host>",
+                                        )
+                                    )
                                     trace.set_tracer_provider(provider)
 
                                     AnthropicInstrumentor().instrument()

--- a/docs/onboarding/llm-analytics/anthropic.tsx
+++ b/docs/onboarding/llm-analytics/anthropic.tsx
@@ -97,9 +97,9 @@ export const getAnthropicSteps = (ctx: OnboardingComponentsContext): StepDefinit
                                 language: 'typescript',
                                 file: 'Node',
                                 code: dedent`
-                                    import { NodeSDK, tracing } from '@opentelemetry/sdk-node'
+                                    import { NodeSDK } from '@opentelemetry/sdk-node'
                                     import { resourceFromAttributes } from '@opentelemetry/resources'
-                                    import { PostHogTraceExporter } from '@posthog/ai/otel'
+                                    import { PostHogSpanProcessor } from '@posthog/ai/otel'
                                     import { AnthropicInstrumentation } from '@traceloop/instrumentation-anthropic'
 
                                     const sdk = new NodeSDK({
@@ -109,12 +109,10 @@ export const getAnthropicSteps = (ctx: OnboardingComponentsContext): StepDefinit
                                         foo: 'bar', // custom properties are passed through
                                       }),
                                       spanProcessors: [
-                                        new tracing.SimpleSpanProcessor(
-                                          new PostHogTraceExporter({
-                                            apiKey: '<ph_project_token>',
-                                            host: '<ph_client_api_host>',
-                                          })
-                                        ),
+                                        new PostHogSpanProcessor({
+                                          apiKey: '<ph_project_token>',
+                                          host: '<ph_client_api_host>',
+                                        }),
                                       ],
                                       instrumentations: [new AnthropicInstrumentation()],
                                     })

--- a/docs/onboarding/llm-analytics/autogen.tsx
+++ b/docs/onboarding/llm-analytics/autogen.tsx
@@ -3,94 +3,75 @@ import { OnboardingComponentsContext, createInstallation } from 'scenes/onboardi
 import { StepDefinition } from '../steps'
 
 export const getAutoGenSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
-    const { CodeBlock, CalloutBox, Markdown, dedent, snippets } = ctx
+    const { CodeBlock, CalloutBox, Markdown, Blockquote, dedent, snippets } = ctx
 
     const NotableGenerationProperties = snippets?.NotableGenerationProperties
 
     return [
         {
-            title: 'Install the PostHog SDK',
+            title: 'Install dependencies',
             badge: 'required',
             content: (
                 <>
-                    <Markdown>
-                        Setting up analytics starts with installing the PostHog SDK. The AutoGen integration uses
-                        PostHog's OpenAI wrapper since AutoGen uses OpenAI under the hood.
-                    </Markdown>
+                    <CalloutBox type="info" icon="IconInfo" title="Full working examples">
+                        <Markdown>
+                            See the complete [Python
+                            example](https://github.com/PostHog/posthog-python/tree/master/examples/example-ai-autogen)
+                            on GitHub. If you're using the PostHog SDK wrapper instead of OpenTelemetry, see the [Python
+                            wrapper
+                            example](https://github.com/PostHog/posthog-python/tree/7223c52/examples/example-ai-autogen).
+                        </Markdown>
+                    </CalloutBox>
+
+                    <Markdown>Install the OpenTelemetry SDK, the OpenAI instrumentation, and AutoGen.</Markdown>
 
                     <CodeBlock
                         language="bash"
                         code={dedent`
-                            pip install posthog
+                            pip install autogen-agentchat "autogen-ext[openai]" openai opentelemetry-sdk opentelemetry-exporter-otlp-proto-http opentelemetry-instrumentation-openai-v2
                         `}
                     />
                 </>
             ),
         },
         {
-            title: 'Install AutoGen',
+            title: 'Set up OpenTelemetry tracing',
             badge: 'required',
             content: (
                 <>
                     <Markdown>
-                        Install AutoGen with the OpenAI extension. PostHog instruments your LLM calls by wrapping the
-                        OpenAI client that AutoGen uses internally.
-                    </Markdown>
-
-                    <CodeBlock
-                        language="bash"
-                        code={dedent`
-                            pip install "autogen-agentchat" "autogen-ext[openai]"
-                        `}
-                    />
-                </>
-            ),
-        },
-        {
-            title: 'Initialize PostHog and AutoGen',
-            badge: 'required',
-            content: (
-                <>
-                    <Markdown>
-                        Initialize PostHog with your project token and host from [your project
-                        settings](https://app.posthog.com/settings/project), then create a PostHog OpenAI wrapper and
-                        pass it to AutoGen's `OpenAIChatCompletionClient`.
+                        Configure OpenTelemetry to auto-instrument OpenAI SDK calls and export traces to PostHog.
+                        PostHog converts `gen_ai.*` spans into `$ai_generation` events automatically.
                     </Markdown>
 
                     <CodeBlock
                         language="python"
                         code={dedent`
-                            import asyncio
-                            from posthog.ai.openai import OpenAI
-                            from posthog import Posthog
-                            from autogen_agentchat.agents import AssistantAgent
-                            from autogen_ext.models.openai import OpenAIChatCompletionClient
+                            from opentelemetry import trace
+                            from opentelemetry.sdk.trace import TracerProvider
+                            from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+                            from opentelemetry.sdk.resources import Resource, SERVICE_NAME
+                            from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+                            from opentelemetry.instrumentation.openai_v2 import OpenAIInstrumentor
 
-                            posthog = Posthog(
-                                "<ph_project_token>",
-                                host="<ph_client_api_host>"
+                            resource = Resource(attributes={
+                                SERVICE_NAME: "my-app",
+                                "posthog.distinct_id": "user_123", # optional: identifies the user in PostHog
+                                "foo": "bar", # custom properties are passed through
+                            })
+
+                            exporter = OTLPSpanExporter(
+                                endpoint="<ph_client_api_host>/i/v0/ai/otel",
+                                headers={"Authorization": "Bearer <ph_project_token>"},
                             )
 
-                            openai_client = OpenAI(
-                                api_key="your_openai_api_key",
-                                posthog_client=posthog,
-                            )
+                            provider = TracerProvider(resource=resource)
+                            provider.add_span_processor(SimpleSpanProcessor(exporter))
+                            trace.set_tracer_provider(provider)
 
-                            model_client = OpenAIChatCompletionClient(
-                                model="gpt-4o",
-                                openai_client=openai_client,
-                            )
+                            OpenAIInstrumentor().instrument()
                         `}
                     />
-
-                    <CalloutBox type="fyi" icon="IconInfo" title="How this works">
-                        <Markdown>
-                            AutoGen's `OpenAIChatCompletionClient` accepts a custom OpenAI client via the
-                            `openai_client` parameter. PostHog's `OpenAI` wrapper is a proper subclass of
-                            `openai.OpenAI`, so it works directly. PostHog captures `$ai_generation` events
-                            automatically without proxying your calls.
-                        </Markdown>
-                    </CalloutBox>
                 </>
             ),
         },
@@ -101,12 +82,20 @@ export const getAutoGenSteps = (ctx: OnboardingComponentsContext): StepDefinitio
                 <>
                     <Markdown>
                         Use AutoGen as normal. PostHog automatically captures an `$ai_generation` event for each LLM
-                        call made through the wrapped OpenAI client.
+                        call made through the OpenAI SDK that AutoGen uses internally.
                     </Markdown>
 
                     <CodeBlock
                         language="python"
                         code={dedent`
+                            import asyncio
+                            from autogen_agentchat.agents import AssistantAgent
+                            from autogen_ext.models.openai import OpenAIChatCompletionClient
+
+                            model_client = OpenAIChatCompletionClient(
+                                model="gpt-4o",
+                                api_key="your_openai_api_key",
+                            )
                             agent = AssistantAgent("assistant", model_client=model_client)
 
                             async def main():
@@ -117,6 +106,14 @@ export const getAutoGenSteps = (ctx: OnboardingComponentsContext): StepDefinitio
                             asyncio.run(main())
                         `}
                     />
+
+                    <Blockquote>
+                        <Markdown>
+                            **Note:** If you want to capture LLM events anonymously, omit the `posthog.distinct_id`
+                            resource attribute. See our docs on [anonymous vs identified
+                            events](https://posthog.com/docs/data/anonymous-vs-identified-events) to learn more.
+                        </Markdown>
+                    </Blockquote>
 
                     <Markdown>
                         {dedent`

--- a/docs/onboarding/llm-analytics/autogen.tsx
+++ b/docs/onboarding/llm-analytics/autogen.tsx
@@ -28,7 +28,7 @@ export const getAutoGenSteps = (ctx: OnboardingComponentsContext): StepDefinitio
                     <CodeBlock
                         language="bash"
                         code={dedent`
-                            pip install autogen-agentchat "autogen-ext[openai]" openai opentelemetry-sdk opentelemetry-exporter-otlp-proto-http opentelemetry-instrumentation-openai-v2
+                            pip install autogen-agentchat "autogen-ext[openai]" openai opentelemetry-sdk posthog[otel] opentelemetry-instrumentation-openai-v2
                         `}
                     />
                 </>
@@ -49,9 +49,8 @@ export const getAutoGenSteps = (ctx: OnboardingComponentsContext): StepDefinitio
                         code={dedent`
                             from opentelemetry import trace
                             from opentelemetry.sdk.trace import TracerProvider
-                            from opentelemetry.sdk.trace.export import SimpleSpanProcessor
                             from opentelemetry.sdk.resources import Resource, SERVICE_NAME
-                            from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+                            from posthog.ai.otel import PostHogSpanProcessor
                             from opentelemetry.instrumentation.openai_v2 import OpenAIInstrumentor
 
                             resource = Resource(attributes={
@@ -60,13 +59,13 @@ export const getAutoGenSteps = (ctx: OnboardingComponentsContext): StepDefinitio
                                 "foo": "bar", # custom properties are passed through
                             })
 
-                            exporter = OTLPSpanExporter(
-                                endpoint="<ph_client_api_host>/i/v0/ai/otel",
-                                headers={"Authorization": "Bearer <ph_project_token>"},
-                            )
-
                             provider = TracerProvider(resource=resource)
-                            provider.add_span_processor(SimpleSpanProcessor(exporter))
+                            provider.add_span_processor(
+                                PostHogSpanProcessor(
+                                    api_key="<ph_project_token>",
+                                    host="<ph_client_api_host>",
+                                )
+                            )
                             trace.set_tracer_provider(provider)
 
                             OpenAIInstrumentor().instrument()

--- a/docs/onboarding/llm-analytics/aws-bedrock.tsx
+++ b/docs/onboarding/llm-analytics/aws-bedrock.tsx
@@ -83,17 +83,19 @@ export const getAWSBedrockSteps = (ctx: OnboardingComponentsContext): StepDefini
                                 code: dedent`
                                     import { NodeSDK } from '@opentelemetry/sdk-node'
                                     import { resourceFromAttributes } from '@opentelemetry/resources'
-                                    import { PostHogTraceExporter } from '@posthog/ai/otel'
+                                    import { PostHogSpanProcessor } from '@posthog/ai/otel'
                                     import { AwsInstrumentation } from '@opentelemetry/instrumentation-aws-sdk'
 
                                     const sdk = new NodeSDK({
                                       resource: resourceFromAttributes({
                                         'service.name': 'my-ai-app',
                                       }),
-                                      traceExporter: new PostHogTraceExporter({
-                                        apiKey: '<ph_project_token>',
-                                        host: '<ph_client_api_host>',
-                                      }),
+                                      spanProcessors: [
+                                        new PostHogSpanProcessor({
+                                          apiKey: '<ph_project_token>',
+                                          host: '<ph_client_api_host>',
+                                        }),
+                                      ],
                                       instrumentations: [new AwsInstrumentation()],
                                     })
                                     sdk.start()

--- a/docs/onboarding/llm-analytics/aws-bedrock.tsx
+++ b/docs/onboarding/llm-analytics/aws-bedrock.tsx
@@ -23,7 +23,7 @@ export const getAWSBedrockSteps = (ctx: OnboardingComponentsContext): StepDefini
                                 language: 'bash',
                                 file: 'Python',
                                 code: dedent`
-                                    pip install boto3 opentelemetry-instrumentation-botocore opentelemetry-sdk opentelemetry-exporter-otlp-proto-http
+                                    pip install boto3 opentelemetry-instrumentation-botocore opentelemetry-sdk posthog[otel]
                                 `,
                             },
                             {
@@ -56,22 +56,21 @@ export const getAWSBedrockSteps = (ctx: OnboardingComponentsContext): StepDefini
                                 code: dedent`
                                     from opentelemetry import trace
                                     from opentelemetry.sdk.trace import TracerProvider
-                                    from opentelemetry.sdk.trace.export import BatchSpanProcessor
                                     from opentelemetry.sdk.resources import Resource, SERVICE_NAME
-                                    from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+                                    from posthog.ai.otel import PostHogSpanProcessor
                                     from opentelemetry.instrumentation.botocore import BotocoreInstrumentor
 
                                     resource = Resource(attributes={
                                         SERVICE_NAME: "my-ai-app",
                                     })
 
-                                    exporter = OTLPSpanExporter(
-                                        endpoint="<ph_client_api_host>/i/v0/ai/otel",
-                                        headers={"Authorization": "Bearer <ph_project_token>"},
-                                    )
-
                                     provider = TracerProvider(resource=resource)
-                                    provider.add_span_processor(BatchSpanProcessor(exporter))
+                                    provider.add_span_processor(
+                                        PostHogSpanProcessor(
+                                            api_key="<ph_project_token>",
+                                            host="<ph_client_api_host>",
+                                        )
+                                    )
                                     trace.set_tracer_provider(provider)
 
                                     BotocoreInstrumentor().instrument()

--- a/docs/onboarding/llm-analytics/azure-openai.tsx
+++ b/docs/onboarding/llm-analytics/azure-openai.tsx
@@ -3,7 +3,7 @@ import { OnboardingComponentsContext, createInstallation } from 'scenes/onboardi
 import { StepDefinition } from '../steps'
 
 export const getAzureOpenAISteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
-    const { CodeBlock, CalloutBox, Markdown, Blockquote, dedent, snippets } = ctx
+    const { CodeBlock, Markdown, Blockquote, dedent, snippets } = ctx
 
     const NotableGenerationProperties = snippets?.NotableGenerationProperties
 
@@ -33,13 +33,6 @@ export const getAzureOpenAISteps = (ctx: OnboardingComponentsContext): StepDefin
                             },
                         ]}
                     />
-
-                    <CalloutBox type="fyi" icon="IconInfo" title="No proxy">
-                        <Markdown>
-                            These SDKs **do not** proxy your calls. They only send analytics data to PostHog in the
-                            background.
-                        </Markdown>
-                    </CalloutBox>
                 </>
             ),
         },

--- a/docs/onboarding/llm-analytics/azure-openai.tsx
+++ b/docs/onboarding/llm-analytics/azure-openai.tsx
@@ -13,14 +13,18 @@ export const getAzureOpenAISteps = (ctx: OnboardingComponentsContext): StepDefin
             badge: 'required',
             content: (
                 <>
-                    <CalloutBox type="info" icon="IconInfo" title="Migrating from the SDK wrapper?">
+                    <CalloutBox type="info" icon="IconInfo" title="Full working examples">
                         <Markdown>
-                            These docs now use OpenTelemetry auto-instrumentation, which is the recommended approach.
-                            The previous PostHog SDK wrapper is still available — see the
-                            [Node.js](https://github.com/PostHog/posthog-js/tree/e08ff1be/examples/example-ai-azure-openai)
+                            See the complete
+                            [Node.js](https://github.com/PostHog/posthog-js/tree/main/examples/example-ai-azure-openai)
                             and
-                            [Python](https://github.com/PostHog/posthog-python/tree/7223c52/examples/example-ai-azure-openai)
-                            wrapper examples.
+                            [Python](https://github.com/PostHog/posthog-python/tree/master/examples/example-ai-azure-openai)
+                            examples on GitHub. If you're using the PostHog SDK wrapper instead of OpenTelemetry, see
+                            the [Node.js
+                            wrapper](https://github.com/PostHog/posthog-js/tree/e08ff1be/examples/example-ai-azure-openai)
+                            and [Python
+                            wrapper](https://github.com/PostHog/posthog-python/tree/7223c52/examples/example-ai-azure-openai)
+                            examples.
                         </Markdown>
                     </CalloutBox>
 

--- a/docs/onboarding/llm-analytics/azure-openai.tsx
+++ b/docs/onboarding/llm-analytics/azure-openai.tsx
@@ -61,7 +61,8 @@ export const getAzureOpenAISteps = (ctx: OnboardingComponentsContext): StepDefin
 
                                     resource = Resource(attributes={
                                         SERVICE_NAME: "my-app",
-                                        "user.id": "user_123", # optional: identifies the user in PostHog
+                                        "posthog.distinct_id": "user_123", # optional: identifies the user in PostHog
+                                        "foo": "bar", # custom properties are passed through
                                     })
 
                                     exporter = OTLPSpanExporter(
@@ -88,7 +89,8 @@ export const getAzureOpenAISteps = (ctx: OnboardingComponentsContext): StepDefin
                                     const sdk = new NodeSDK({
                                       resource: resourceFromAttributes({
                                         'service.name': 'my-app',
-                                        'user.id': 'user_123', // optional: identifies the user in PostHog
+                                        'posthog.distinct_id': 'user_123', // optional: identifies the user in PostHog
+                                        foo: 'bar', // custom properties are passed through
                                       }),
                                       spanProcessors: [
                                         new tracing.SimpleSpanProcessor(
@@ -167,8 +169,8 @@ export const getAzureOpenAISteps = (ctx: OnboardingComponentsContext): StepDefin
 
                     <Blockquote>
                         <Markdown>
-                            **Note:** If you want to capture LLM events anonymously, omit the `user.id` resource
-                            attribute. See our docs on [anonymous vs identified
+                            **Note:** If you want to capture LLM events anonymously, omit the `posthog.distinct_id`
+                            resource attribute. See our docs on [anonymous vs identified
                             events](https://posthog.com/docs/data/anonymous-vs-identified-events) to learn more.
                         </Markdown>
                     </Blockquote>

--- a/docs/onboarding/llm-analytics/azure-openai.tsx
+++ b/docs/onboarding/llm-analytics/azure-openai.tsx
@@ -9,11 +9,11 @@ export const getAzureOpenAISteps = (ctx: OnboardingComponentsContext): StepDefin
 
     return [
         {
-            title: 'Install the SDKs',
+            title: 'Install dependencies',
             badge: 'required',
             content: (
                 <>
-                    <Markdown>Setting up analytics starts with installing the PostHog and OpenAI SDKs.</Markdown>
+                    <Markdown>Install the OpenTelemetry SDK, the OpenAI instrumentation, and the OpenAI SDK.</Markdown>
 
                     <CodeBlock
                         blocks={[
@@ -21,31 +21,36 @@ export const getAzureOpenAISteps = (ctx: OnboardingComponentsContext): StepDefin
                                 language: 'bash',
                                 file: 'Python',
                                 code: dedent`
-                                    pip install posthog openai
+                                    pip install openai opentelemetry-sdk opentelemetry-exporter-otlp-proto-http opentelemetry-instrumentation-openai-v2
                                 `,
                             },
                             {
                                 language: 'bash',
                                 file: 'Node',
                                 code: dedent`
-                                    npm install @posthog/ai posthog-node openai
+                                    npm install openai @posthog/ai @opentelemetry/sdk-node @opentelemetry/resources @opentelemetry/instrumentation-openai
                                 `,
                             },
                         ]}
                     />
+
+                    <CalloutBox type="fyi" icon="IconInfo" title="No proxy">
+                        <Markdown>
+                            These SDKs **do not** proxy your calls. They only send analytics data to PostHog in the
+                            background.
+                        </Markdown>
+                    </CalloutBox>
                 </>
             ),
         },
         {
-            title: 'Initialize PostHog and Azure OpenAI client',
+            title: 'Set up OpenTelemetry tracing',
             badge: 'required',
             content: (
                 <>
                     <Markdown>
-                        We call Azure OpenAI through PostHog's AzureOpenAI wrapper to capture all the details of the
-                        call. Initialize PostHog with your PostHog project token and host from [your project
-                        settings](https://app.posthog.com/settings/project), then pass the PostHog client along with
-                        your Azure OpenAI config (the API key, API version, and endpoint) to our AzureOpenAI wrapper.
+                        Configure OpenTelemetry to auto-instrument OpenAI SDK calls and export traces to PostHog.
+                        PostHog converts `gen_ai.*` spans into `$ai_generation` events automatically.
                     </Markdown>
 
                     <CodeBlock
@@ -54,63 +59,59 @@ export const getAzureOpenAISteps = (ctx: OnboardingComponentsContext): StepDefin
                                 language: 'python',
                                 file: 'Python',
                                 code: dedent`
-                                    from posthog.ai.openai import AzureOpenAI
-                                    from posthog import Posthog
+                                    from opentelemetry import trace
+                                    from opentelemetry.sdk.trace import TracerProvider
+                                    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+                                    from opentelemetry.sdk.resources import Resource, SERVICE_NAME
+                                    from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+                                    from opentelemetry.instrumentation.openai_v2 import OpenAIInstrumentor
 
-                                    posthog = Posthog(
-                                        "<ph_project_token>",
-                                        host="<ph_client_api_host>"
+                                    resource = Resource(attributes={
+                                        SERVICE_NAME: "my-app",
+                                        "user.id": "user_123", # optional: identifies the user in PostHog
+                                    })
+
+                                    exporter = OTLPSpanExporter(
+                                        endpoint="<ph_client_api_host>/i/v0/ai/otel",
+                                        headers={"Authorization": "Bearer <ph_project_token>"},
                                     )
 
-                                    client = AzureOpenAI(
-                                        api_key="<azure_openai_api_key>",
-                                        api_version="2024-10-21",
-                                        azure_endpoint="https://<your-resource>.openai.azure.com",
-                                        posthog_client=posthog
-                                    )
+                                    provider = TracerProvider(resource=resource)
+                                    provider.add_span_processor(SimpleSpanProcessor(exporter))
+                                    trace.set_tracer_provider(provider)
+
+                                    OpenAIInstrumentor().instrument()
                                 `,
                             },
                             {
                                 language: 'typescript',
                                 file: 'Node',
                                 code: dedent`
-                                    import { AzureOpenAI } from '@posthog/ai'
-                                    import { PostHog } from 'posthog-node'
+                                    import { NodeSDK, tracing } from '@opentelemetry/sdk-node'
+                                    import { resourceFromAttributes } from '@opentelemetry/resources'
+                                    import { PostHogTraceExporter } from '@posthog/ai/otel'
+                                    import { OpenAIInstrumentation } from '@opentelemetry/instrumentation-openai'
 
-                                    const phClient = new PostHog(
-                                      '<ph_project_token>',
-                                      { host: '<ph_client_api_host>' }
-                                    );
-
-                                    const client = new AzureOpenAI({
-                                      apiKey: '<azure_openai_api_key>',
-                                      apiVersion: '2024-10-21',
-                                      endpoint: 'https://<your-resource>.openai.azure.com',
-                                      posthog: phClient,
-                                    });
-
-                                    // ... your code here ...
-
-                                    // IMPORTANT: Shutdown the client when you're done to ensure all events are sent
-                                    phClient.shutdown()
+                                    const sdk = new NodeSDK({
+                                      resource: resourceFromAttributes({
+                                        'service.name': 'my-app',
+                                        'user.id': 'user_123', // optional: identifies the user in PostHog
+                                      }),
+                                      spanProcessors: [
+                                        new tracing.SimpleSpanProcessor(
+                                          new PostHogTraceExporter({
+                                            apiKey: '<ph_project_token>',
+                                            host: '<ph_client_api_host>',
+                                          })
+                                        ),
+                                      ],
+                                      instrumentations: [new OpenAIInstrumentation()],
+                                    })
+                                    sdk.start()
                                 `,
                             },
                         ]}
                     />
-
-                    <Blockquote>
-                        <Markdown>**Note:** This also works with the `AsyncAzureOpenAI` client.</Markdown>
-                    </Blockquote>
-
-                    <CalloutBox type="fyi" icon="IconInfo" title="Proxy note">
-                        <Markdown>
-                            These SDKs **do not** proxy your calls. They only fire off an async call to PostHog in the
-                            background to send the data. You can also use LLM analytics with other SDKs or our API, but
-                            you will need to capture the data in the right format. See the schema in the [manual capture
-                            section](https://posthog.com/docs/llm-analytics/installation/manual-capture) for more
-                            details.
-                        </Markdown>
-                    </CalloutBox>
                 </>
             ),
         },
@@ -120,9 +121,8 @@ export const getAzureOpenAISteps = (ctx: OnboardingComponentsContext): StepDefin
             content: (
                 <>
                     <Markdown>
-                        Now, when you call Azure OpenAI, PostHog automatically captures an `$ai_generation` event. You
-                        can also capture or modify additional properties with the distinct ID, trace ID, properties,
-                        groups, and privacy mode parameters.
+                        Now, when you call Azure OpenAI, PostHog automatically captures `$ai_generation` events via the
+                        OpenTelemetry instrumentation.
                     </Markdown>
 
                     <CodeBlock
@@ -131,16 +131,19 @@ export const getAzureOpenAISteps = (ctx: OnboardingComponentsContext): StepDefin
                                 language: 'python',
                                 file: 'Python',
                                 code: dedent`
+                                    import openai
+
+                                    client = openai.AzureOpenAI(
+                                        api_key="<azure_openai_api_key>",
+                                        api_version="2024-10-21",
+                                        azure_endpoint="https://<your-resource>.openai.azure.com",
+                                    )
+
                                     response = client.chat.completions.create(
                                         model="<your-deployment-name>",
                                         messages=[
                                             {"role": "user", "content": "Tell me a fun fact about hedgehogs"}
                                         ],
-                                        posthog_distinct_id="user_123", # optional
-                                        posthog_trace_id="trace_123", # optional
-                                        posthog_properties={"conversation_id": "abc123", "paid": True}, # optional
-                                        posthog_groups={"company": "company_id_in_your_db"},  # optional
-                                        posthog_privacy_mode=False # optional
                                     )
 
                                     print(response.choices[0].message.content)
@@ -150,17 +153,20 @@ export const getAzureOpenAISteps = (ctx: OnboardingComponentsContext): StepDefin
                                 language: 'typescript',
                                 file: 'Node',
                                 code: dedent`
-                                    const completion = await client.chat.completions.create({
-                                        model: "<your-deployment-name>",
-                                        messages: [{ role: "user", content: "Tell me a fun fact about hedgehogs" }],
-                                        posthogDistinctId: "user_123", // optional
-                                        posthogTraceId: "trace_123", // optional
-                                        posthogProperties: { conversation_id: "abc123", paid: true }, // optional
-                                        posthogGroups: { company: "company_id_in_your_db" }, // optional
-                                        posthogPrivacyMode: false // optional
-                                    });
+                                    import { AzureOpenAI } from 'openai'
 
-                                    console.log(completion.choices[0].message.content)
+                                    const client = new AzureOpenAI({
+                                      apiKey: '<azure_openai_api_key>',
+                                      apiVersion: '2024-10-21',
+                                      endpoint: 'https://<your-resource>.openai.azure.com',
+                                    })
+
+                                    const response = await client.chat.completions.create({
+                                      model: '<your-deployment-name>',
+                                      messages: [{ role: 'user', content: 'Tell me a fun fact about hedgehogs' }],
+                                    })
+
+                                    console.log(response.choices[0].message.content)
                                 `,
                             },
                         ]}
@@ -168,13 +174,9 @@ export const getAzureOpenAISteps = (ctx: OnboardingComponentsContext): StepDefin
 
                     <Blockquote>
                         <Markdown>
-                            {dedent`
-                            **Notes:**
-                            - This works with responses where \`stream=True\`.
-                            - If you want to capture LLM events anonymously, **don't** pass a distinct ID to the request.
-
-                            See our docs on [anonymous vs identified events](https://posthog.com/docs/data/anonymous-vs-identified-events) to learn more.
-                            `}
+                            **Note:** If you want to capture LLM events anonymously, omit the `user.id` resource
+                            attribute. See our docs on [anonymous vs identified
+                            events](https://posthog.com/docs/data/anonymous-vs-identified-events) to learn more.
                         </Markdown>
                     </Blockquote>
 

--- a/docs/onboarding/llm-analytics/azure-openai.tsx
+++ b/docs/onboarding/llm-analytics/azure-openai.tsx
@@ -3,7 +3,7 @@ import { OnboardingComponentsContext, createInstallation } from 'scenes/onboardi
 import { StepDefinition } from '../steps'
 
 export const getAzureOpenAISteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
-    const { CodeBlock, Markdown, Blockquote, dedent, snippets } = ctx
+    const { CodeBlock, CalloutBox, Markdown, Blockquote, dedent, snippets } = ctx
 
     const NotableGenerationProperties = snippets?.NotableGenerationProperties
 
@@ -13,6 +13,17 @@ export const getAzureOpenAISteps = (ctx: OnboardingComponentsContext): StepDefin
             badge: 'required',
             content: (
                 <>
+                    <CalloutBox type="info" icon="IconInfo" title="Migrating from the SDK wrapper?">
+                        <Markdown>
+                            These docs now use OpenTelemetry auto-instrumentation, which is the recommended approach.
+                            The previous PostHog SDK wrapper is still available — see the
+                            [Node.js](https://github.com/PostHog/posthog-js/tree/e08ff1be/examples/example-ai-azure-openai)
+                            and
+                            [Python](https://github.com/PostHog/posthog-python/tree/7223c52/examples/example-ai-azure-openai)
+                            wrapper examples.
+                        </Markdown>
+                    </CalloutBox>
+
                     <Markdown>Install the OpenTelemetry SDK, the OpenAI instrumentation, and the OpenAI SDK.</Markdown>
 
                     <CodeBlock

--- a/docs/onboarding/llm-analytics/azure-openai.tsx
+++ b/docs/onboarding/llm-analytics/azure-openai.tsx
@@ -96,9 +96,9 @@ export const getAzureOpenAISteps = (ctx: OnboardingComponentsContext): StepDefin
                                 language: 'typescript',
                                 file: 'Node',
                                 code: dedent`
-                                    import { NodeSDK, tracing } from '@opentelemetry/sdk-node'
+                                    import { NodeSDK } from '@opentelemetry/sdk-node'
                                     import { resourceFromAttributes } from '@opentelemetry/resources'
-                                    import { PostHogTraceExporter } from '@posthog/ai/otel'
+                                    import { PostHogSpanProcessor } from '@posthog/ai/otel'
                                     import { OpenAIInstrumentation } from '@opentelemetry/instrumentation-openai'
 
                                     const sdk = new NodeSDK({
@@ -108,12 +108,10 @@ export const getAzureOpenAISteps = (ctx: OnboardingComponentsContext): StepDefin
                                         foo: 'bar', // custom properties are passed through
                                       }),
                                       spanProcessors: [
-                                        new tracing.SimpleSpanProcessor(
-                                          new PostHogTraceExporter({
-                                            apiKey: '<ph_project_token>',
-                                            host: '<ph_client_api_host>',
-                                          })
-                                        ),
+                                        new PostHogSpanProcessor({
+                                          apiKey: '<ph_project_token>',
+                                          host: '<ph_client_api_host>',
+                                        }),
                                       ],
                                       instrumentations: [new OpenAIInstrumentation()],
                                     })

--- a/docs/onboarding/llm-analytics/azure-openai.tsx
+++ b/docs/onboarding/llm-analytics/azure-openai.tsx
@@ -36,7 +36,7 @@ export const getAzureOpenAISteps = (ctx: OnboardingComponentsContext): StepDefin
                                 language: 'bash',
                                 file: 'Python',
                                 code: dedent`
-                                    pip install openai opentelemetry-sdk opentelemetry-exporter-otlp-proto-http opentelemetry-instrumentation-openai-v2
+                                    pip install openai opentelemetry-sdk posthog[otel] opentelemetry-instrumentation-openai-v2
                                 `,
                             },
                             {
@@ -69,9 +69,8 @@ export const getAzureOpenAISteps = (ctx: OnboardingComponentsContext): StepDefin
                                 code: dedent`
                                     from opentelemetry import trace
                                     from opentelemetry.sdk.trace import TracerProvider
-                                    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
                                     from opentelemetry.sdk.resources import Resource, SERVICE_NAME
-                                    from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+                                    from posthog.ai.otel import PostHogSpanProcessor
                                     from opentelemetry.instrumentation.openai_v2 import OpenAIInstrumentor
 
                                     resource = Resource(attributes={
@@ -80,13 +79,13 @@ export const getAzureOpenAISteps = (ctx: OnboardingComponentsContext): StepDefin
                                         "foo": "bar", # custom properties are passed through
                                     })
 
-                                    exporter = OTLPSpanExporter(
-                                        endpoint="<ph_client_api_host>/i/v0/ai/otel",
-                                        headers={"Authorization": "Bearer <ph_project_token>"},
-                                    )
-
                                     provider = TracerProvider(resource=resource)
-                                    provider.add_span_processor(SimpleSpanProcessor(exporter))
+                                    provider.add_span_processor(
+                                        PostHogSpanProcessor(
+                                            api_key="<ph_project_token>",
+                                            host="<ph_client_api_host>",
+                                        )
+                                    )
                                     trace.set_tracer_provider(provider)
 
                                     OpenAIInstrumentor().instrument()

--- a/docs/onboarding/llm-analytics/cerebras.tsx
+++ b/docs/onboarding/llm-analytics/cerebras.tsx
@@ -13,14 +13,17 @@ export const getCerebrasSteps = (ctx: OnboardingComponentsContext): StepDefiniti
             badge: 'required',
             content: (
                 <>
-                    <CalloutBox type="info" icon="IconInfo" title="Migrating from the SDK wrapper?">
+                    <CalloutBox type="info" icon="IconInfo" title="Full working examples">
                         <Markdown>
-                            These docs now use OpenTelemetry auto-instrumentation, which is the recommended approach.
-                            The previous PostHog SDK wrapper is still available — see the
-                            [Node.js](https://github.com/PostHog/posthog-js/tree/e08ff1be/examples/example-ai-cerebras)
-                            and
-                            [Python](https://github.com/PostHog/posthog-python/tree/7223c52/examples/example-ai-cerebras)
-                            wrapper examples.
+                            See the complete
+                            [Node.js](https://github.com/PostHog/posthog-js/tree/main/examples/example-ai-cerebras) and
+                            [Python](https://github.com/PostHog/posthog-python/tree/master/examples/example-ai-cerebras)
+                            examples on GitHub. If you're using the PostHog SDK wrapper instead of OpenTelemetry, see
+                            the [Node.js
+                            wrapper](https://github.com/PostHog/posthog-js/tree/e08ff1be/examples/example-ai-cerebras)
+                            and [Python
+                            wrapper](https://github.com/PostHog/posthog-python/tree/7223c52/examples/example-ai-cerebras)
+                            examples.
                         </Markdown>
                     </CalloutBox>
 

--- a/docs/onboarding/llm-analytics/cerebras.tsx
+++ b/docs/onboarding/llm-analytics/cerebras.tsx
@@ -3,7 +3,7 @@ import { OnboardingComponentsContext, createInstallation } from 'scenes/onboardi
 import { StepDefinition } from '../steps'
 
 export const getCerebrasSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
-    const { CodeBlock, Markdown, Blockquote, dedent, snippets } = ctx
+    const { CodeBlock, CalloutBox, Markdown, Blockquote, dedent, snippets } = ctx
 
     const NotableGenerationProperties = snippets?.NotableGenerationProperties
 
@@ -13,6 +13,17 @@ export const getCerebrasSteps = (ctx: OnboardingComponentsContext): StepDefiniti
             badge: 'required',
             content: (
                 <>
+                    <CalloutBox type="info" icon="IconInfo" title="Migrating from the SDK wrapper?">
+                        <Markdown>
+                            These docs now use OpenTelemetry auto-instrumentation, which is the recommended approach.
+                            The previous PostHog SDK wrapper is still available — see the
+                            [Node.js](https://github.com/PostHog/posthog-js/tree/e08ff1be/examples/example-ai-cerebras)
+                            and
+                            [Python](https://github.com/PostHog/posthog-python/tree/7223c52/examples/example-ai-cerebras)
+                            wrapper examples.
+                        </Markdown>
+                    </CalloutBox>
+
                     <Markdown>Install the OpenTelemetry SDK, the OpenAI instrumentation, and the OpenAI SDK.</Markdown>
 
                     <CodeBlock

--- a/docs/onboarding/llm-analytics/cerebras.tsx
+++ b/docs/onboarding/llm-analytics/cerebras.tsx
@@ -3,7 +3,7 @@ import { OnboardingComponentsContext, createInstallation } from 'scenes/onboardi
 import { StepDefinition } from '../steps'
 
 export const getCerebrasSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
-    const { CodeBlock, CalloutBox, Markdown, Blockquote, dedent, snippets } = ctx
+    const { CodeBlock, Markdown, Blockquote, dedent, snippets } = ctx
 
     const NotableGenerationProperties = snippets?.NotableGenerationProperties
 
@@ -33,13 +33,6 @@ export const getCerebrasSteps = (ctx: OnboardingComponentsContext): StepDefiniti
                             },
                         ]}
                     />
-
-                    <CalloutBox type="fyi" icon="IconInfo" title="No proxy">
-                        <Markdown>
-                            These SDKs **do not** proxy your calls. They only send analytics data to PostHog in the
-                            background.
-                        </Markdown>
-                    </CalloutBox>
                 </>
             ),
         },

--- a/docs/onboarding/llm-analytics/cerebras.tsx
+++ b/docs/onboarding/llm-analytics/cerebras.tsx
@@ -9,14 +9,11 @@ export const getCerebrasSteps = (ctx: OnboardingComponentsContext): StepDefiniti
 
     return [
         {
-            title: 'Install the PostHog SDK',
+            title: 'Install dependencies',
             badge: 'required',
             content: (
                 <>
-                    <Markdown>
-                        Setting up analytics starts with installing the PostHog SDK for your language. LLM analytics
-                        works best with our Python and Node SDKs.
-                    </Markdown>
+                    <Markdown>Install the OpenTelemetry SDK, the OpenAI instrumentation, and the OpenAI SDK.</Markdown>
 
                     <CodeBlock
                         blocks={[
@@ -24,63 +21,36 @@ export const getCerebrasSteps = (ctx: OnboardingComponentsContext): StepDefiniti
                                 language: 'bash',
                                 file: 'Python',
                                 code: dedent`
-                                    pip install posthog
+                                    pip install openai opentelemetry-sdk opentelemetry-exporter-otlp-proto-http opentelemetry-instrumentation-openai-v2
                                 `,
                             },
                             {
                                 language: 'bash',
                                 file: 'Node',
                                 code: dedent`
-                                    npm install @posthog/ai posthog-node
+                                    npm install openai @posthog/ai @opentelemetry/sdk-node @opentelemetry/resources @opentelemetry/instrumentation-openai
                                 `,
                             },
                         ]}
                     />
-                </>
-            ),
-        },
-        {
-            title: 'Install the OpenAI SDK',
-            badge: 'required',
-            content: (
-                <>
-                    <Markdown>
-                        Install the OpenAI SDK. The PostHog SDK instruments your LLM calls by wrapping the OpenAI
-                        client. The PostHog SDK **does not** proxy your calls.
-                    </Markdown>
 
-                    <CodeBlock
-                        blocks={[
-                            {
-                                language: 'bash',
-                                file: 'Python',
-                                code: dedent`
-                                    pip install openai
-                                `,
-                            },
-                            {
-                                language: 'bash',
-                                file: 'Node',
-                                code: dedent`
-                                    npm install openai
-                                `,
-                            },
-                        ]}
-                    />
+                    <CalloutBox type="fyi" icon="IconInfo" title="No proxy">
+                        <Markdown>
+                            These SDKs **do not** proxy your calls. They only send analytics data to PostHog in the
+                            background.
+                        </Markdown>
+                    </CalloutBox>
                 </>
             ),
         },
         {
-            title: 'Initialize PostHog and OpenAI client',
+            title: 'Set up OpenTelemetry tracing',
             badge: 'required',
             content: (
                 <>
                     <Markdown>
-                        We call Cerebras through the OpenAI client and generate a response. We'll use PostHog's OpenAI
-                        provider to capture all the details of the call. Initialize PostHog with your PostHog project
-                        token and host from [your project settings](https://app.posthog.com/settings/project), then pass
-                        the PostHog client along with the Cerebras config (the base URL and API key) to our OpenAI
-                        wrapper.
+                        Configure OpenTelemetry to auto-instrument OpenAI SDK calls and export traces to PostHog.
+                        PostHog converts `gen_ai.*` spans into `$ai_generation` events automatically.
                     </Markdown>
 
                     <CodeBlock
@@ -89,61 +59,59 @@ export const getCerebrasSteps = (ctx: OnboardingComponentsContext): StepDefiniti
                                 language: 'python',
                                 file: 'Python',
                                 code: dedent`
-                                    from posthog.ai.openai import OpenAI
-                                    from posthog import Posthog
+                                    from opentelemetry import trace
+                                    from opentelemetry.sdk.trace import TracerProvider
+                                    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+                                    from opentelemetry.sdk.resources import Resource, SERVICE_NAME
+                                    from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+                                    from opentelemetry.instrumentation.openai_v2 import OpenAIInstrumentor
 
-                                    posthog = Posthog(
-                                        "<ph_project_token>",
-                                        host="<ph_client_api_host>"
+                                    resource = Resource(attributes={
+                                        SERVICE_NAME: "my-app",
+                                        "user.id": "user_123", # optional: identifies the user in PostHog
+                                    })
+
+                                    exporter = OTLPSpanExporter(
+                                        endpoint="<ph_client_api_host>/i/v0/ai/otel",
+                                        headers={"Authorization": "Bearer <ph_project_token>"},
                                     )
 
-                                    client = OpenAI(
-                                        base_url="https://api.cerebras.ai/v1",
-                                        api_key="<cerebras_api_key>",
-                                        posthog_client=posthog
-                                    )
+                                    provider = TracerProvider(resource=resource)
+                                    provider.add_span_processor(SimpleSpanProcessor(exporter))
+                                    trace.set_tracer_provider(provider)
+
+                                    OpenAIInstrumentor().instrument()
                                 `,
                             },
                             {
                                 language: 'typescript',
                                 file: 'Node',
                                 code: dedent`
-                                    import { OpenAI } from '@posthog/ai'
-                                    import { PostHog } from 'posthog-node'
+                                    import { NodeSDK, tracing } from '@opentelemetry/sdk-node'
+                                    import { resourceFromAttributes } from '@opentelemetry/resources'
+                                    import { PostHogTraceExporter } from '@posthog/ai/otel'
+                                    import { OpenAIInstrumentation } from '@opentelemetry/instrumentation-openai'
 
-                                    const phClient = new PostHog(
-                                      '<ph_project_token>',
-                                      { host: '<ph_client_api_host>' }
-                                    );
-
-                                    const openai = new OpenAI({
-                                      baseURL: 'https://api.cerebras.ai/v1',
-                                      apiKey: '<cerebras_api_key>',
-                                      posthog: phClient,
-                                    });
-
-                                    // ... your code here ...
-
-                                    // IMPORTANT: Shutdown the client when you're done to ensure all events are sent
-                                    phClient.shutdown()
+                                    const sdk = new NodeSDK({
+                                      resource: resourceFromAttributes({
+                                        'service.name': 'my-app',
+                                        'user.id': 'user_123', // optional: identifies the user in PostHog
+                                      }),
+                                      spanProcessors: [
+                                        new tracing.SimpleSpanProcessor(
+                                          new PostHogTraceExporter({
+                                            apiKey: '<ph_project_token>',
+                                            host: '<ph_client_api_host>',
+                                          })
+                                        ),
+                                      ],
+                                      instrumentations: [new OpenAIInstrumentation()],
+                                    })
+                                    sdk.start()
                                 `,
                             },
                         ]}
                     />
-
-                    <Blockquote>
-                        <Markdown>**Note:** This also works with the `AsyncOpenAI` client.</Markdown>
-                    </Blockquote>
-
-                    <CalloutBox type="fyi" icon="IconInfo" title="Proxy note">
-                        <Markdown>
-                            These SDKs **do not** proxy your calls. They only fire off an async call to PostHog in the
-                            background to send the data. You can also use LLM analytics with other SDKs or our API, but
-                            you will need to capture the data in the right format. See the schema in the [manual capture
-                            section](https://posthog.com/docs/llm-analytics/installation/manual-capture) for more
-                            details.
-                        </Markdown>
-                    </CalloutBox>
                 </>
             ),
         },
@@ -153,9 +121,8 @@ export const getCerebrasSteps = (ctx: OnboardingComponentsContext): StepDefiniti
             content: (
                 <>
                     <Markdown>
-                        Now, when you call Cerebras with the OpenAI SDK, PostHog automatically captures an
-                        `$ai_generation` event. You can also capture or modify additional properties with the distinct
-                        ID, trace ID, properties, groups, and privacy mode parameters.
+                        Now, when you use the OpenAI SDK to call Cerebras, PostHog automatically captures
+                        `$ai_generation` events via the OpenTelemetry instrumentation.
                     </Markdown>
 
                     <CodeBlock
@@ -164,16 +131,19 @@ export const getCerebrasSteps = (ctx: OnboardingComponentsContext): StepDefiniti
                                 language: 'python',
                                 file: 'Python',
                                 code: dedent`
+                                    import openai
+
+                                    client = openai.OpenAI(
+                                        base_url="https://api.cerebras.ai/v1",
+                                        api_key="<cerebras_api_key>",
+                                    )
+
                                     response = client.chat.completions.create(
                                         model="llama-3.3-70b",
+                                        max_completion_tokens=1024,
                                         messages=[
                                             {"role": "user", "content": "Tell me a fun fact about hedgehogs"}
                                         ],
-                                        posthog_distinct_id="user_123", # optional
-                                        posthog_trace_id="trace_123", # optional
-                                        posthog_properties={"conversation_id": "abc123", "paid": True}, # optional
-                                        posthog_groups={"company": "company_id_in_your_db"},  # optional
-                                        posthog_privacy_mode=False # optional
                                     )
 
                                     print(response.choices[0].message.content)
@@ -183,17 +153,20 @@ export const getCerebrasSteps = (ctx: OnboardingComponentsContext): StepDefiniti
                                 language: 'typescript',
                                 file: 'Node',
                                 code: dedent`
-                                    const completion = await openai.chat.completions.create({
-                                        model: "llama-3.3-70b",
-                                        messages: [{ role: "user", content: "Tell me a fun fact about hedgehogs" }],
-                                        posthogDistinctId: "user_123", // optional
-                                        posthogTraceId: "trace_123", // optional
-                                        posthogProperties: { conversation_id: "abc123", paid: true }, // optional
-                                        posthogGroups: { company: "company_id_in_your_db" }, // optional
-                                        posthogPrivacyMode: false // optional
-                                    });
+                                    import OpenAI from 'openai'
 
-                                    console.log(completion.choices[0].message.content)
+                                    const client = new OpenAI({
+                                      baseURL: 'https://api.cerebras.ai/v1',
+                                      apiKey: '<cerebras_api_key>',
+                                    })
+
+                                    const response = await client.chat.completions.create({
+                                      model: 'llama-3.3-70b',
+                                      max_completion_tokens: 1024,
+                                      messages: [{ role: 'user', content: 'Tell me a fun fact about hedgehogs' }],
+                                    })
+
+                                    console.log(response.choices[0].message.content)
                                 `,
                             },
                         ]}
@@ -202,12 +175,7 @@ export const getCerebrasSteps = (ctx: OnboardingComponentsContext): StepDefiniti
                     <Blockquote>
                         <Markdown>
                             {dedent`
-                            **Notes:**
-                            - We also support the old \`chat.completions\` API.
-                            - This works with responses where \`stream=True\`.
-                            - If you want to capture LLM events anonymously, **don't** pass a distinct ID to the request.
-
-                            See our docs on [anonymous vs identified events](https://posthog.com/docs/data/anonymous-vs-identified-events) to learn more.
+                            **Note:** If you want to capture LLM events anonymously, omit the \`user.id\` resource attribute. See our docs on [anonymous vs identified events](https://posthog.com/docs/data/anonymous-vs-identified-events) to learn more.
                             `}
                         </Markdown>
                     </Blockquote>

--- a/docs/onboarding/llm-analytics/cerebras.tsx
+++ b/docs/onboarding/llm-analytics/cerebras.tsx
@@ -61,7 +61,8 @@ export const getCerebrasSteps = (ctx: OnboardingComponentsContext): StepDefiniti
 
                                     resource = Resource(attributes={
                                         SERVICE_NAME: "my-app",
-                                        "user.id": "user_123", # optional: identifies the user in PostHog
+                                        "posthog.distinct_id": "user_123", # optional: identifies the user in PostHog
+                                        "foo": "bar", # custom properties are passed through
                                     })
 
                                     exporter = OTLPSpanExporter(
@@ -88,7 +89,8 @@ export const getCerebrasSteps = (ctx: OnboardingComponentsContext): StepDefiniti
                                     const sdk = new NodeSDK({
                                       resource: resourceFromAttributes({
                                         'service.name': 'my-app',
-                                        'user.id': 'user_123', // optional: identifies the user in PostHog
+                                        'posthog.distinct_id': 'user_123', // optional: identifies the user in PostHog
+                                        foo: 'bar', // custom properties are passed through
                                       }),
                                       spanProcessors: [
                                         new tracing.SimpleSpanProcessor(
@@ -168,7 +170,7 @@ export const getCerebrasSteps = (ctx: OnboardingComponentsContext): StepDefiniti
                     <Blockquote>
                         <Markdown>
                             {dedent`
-                            **Note:** If you want to capture LLM events anonymously, omit the \`user.id\` resource attribute. See our docs on [anonymous vs identified events](https://posthog.com/docs/data/anonymous-vs-identified-events) to learn more.
+                            **Note:** If you want to capture LLM events anonymously, omit the \`posthog.distinct_id\` resource attribute. See our docs on [anonymous vs identified events](https://posthog.com/docs/data/anonymous-vs-identified-events) to learn more.
                             `}
                         </Markdown>
                     </Blockquote>

--- a/docs/onboarding/llm-analytics/cerebras.tsx
+++ b/docs/onboarding/llm-analytics/cerebras.tsx
@@ -95,9 +95,9 @@ export const getCerebrasSteps = (ctx: OnboardingComponentsContext): StepDefiniti
                                 language: 'typescript',
                                 file: 'Node',
                                 code: dedent`
-                                    import { NodeSDK, tracing } from '@opentelemetry/sdk-node'
+                                    import { NodeSDK } from '@opentelemetry/sdk-node'
                                     import { resourceFromAttributes } from '@opentelemetry/resources'
-                                    import { PostHogTraceExporter } from '@posthog/ai/otel'
+                                    import { PostHogSpanProcessor } from '@posthog/ai/otel'
                                     import { OpenAIInstrumentation } from '@opentelemetry/instrumentation-openai'
 
                                     const sdk = new NodeSDK({
@@ -107,12 +107,10 @@ export const getCerebrasSteps = (ctx: OnboardingComponentsContext): StepDefiniti
                                         foo: 'bar', // custom properties are passed through
                                       }),
                                       spanProcessors: [
-                                        new tracing.SimpleSpanProcessor(
-                                          new PostHogTraceExporter({
-                                            apiKey: '<ph_project_token>',
-                                            host: '<ph_client_api_host>',
-                                          })
-                                        ),
+                                        new PostHogSpanProcessor({
+                                          apiKey: '<ph_project_token>',
+                                          host: '<ph_client_api_host>',
+                                        }),
                                       ],
                                       instrumentations: [new OpenAIInstrumentation()],
                                     })

--- a/docs/onboarding/llm-analytics/cerebras.tsx
+++ b/docs/onboarding/llm-analytics/cerebras.tsx
@@ -35,7 +35,7 @@ export const getCerebrasSteps = (ctx: OnboardingComponentsContext): StepDefiniti
                                 language: 'bash',
                                 file: 'Python',
                                 code: dedent`
-                                    pip install openai opentelemetry-sdk opentelemetry-exporter-otlp-proto-http opentelemetry-instrumentation-openai-v2
+                                    pip install openai opentelemetry-sdk posthog[otel] opentelemetry-instrumentation-openai-v2
                                 `,
                             },
                             {
@@ -68,9 +68,8 @@ export const getCerebrasSteps = (ctx: OnboardingComponentsContext): StepDefiniti
                                 code: dedent`
                                     from opentelemetry import trace
                                     from opentelemetry.sdk.trace import TracerProvider
-                                    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
                                     from opentelemetry.sdk.resources import Resource, SERVICE_NAME
-                                    from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+                                    from posthog.ai.otel import PostHogSpanProcessor
                                     from opentelemetry.instrumentation.openai_v2 import OpenAIInstrumentor
 
                                     resource = Resource(attributes={
@@ -79,13 +78,13 @@ export const getCerebrasSteps = (ctx: OnboardingComponentsContext): StepDefiniti
                                         "foo": "bar", # custom properties are passed through
                                     })
 
-                                    exporter = OTLPSpanExporter(
-                                        endpoint="<ph_client_api_host>/i/v0/ai/otel",
-                                        headers={"Authorization": "Bearer <ph_project_token>"},
-                                    )
-
                                     provider = TracerProvider(resource=resource)
-                                    provider.add_span_processor(SimpleSpanProcessor(exporter))
+                                    provider.add_span_processor(
+                                        PostHogSpanProcessor(
+                                            api_key="<ph_project_token>",
+                                            host="<ph_client_api_host>",
+                                        )
+                                    )
                                     trace.set_tracer_provider(provider)
 
                                     OpenAIInstrumentor().instrument()

--- a/docs/onboarding/llm-analytics/cohere.tsx
+++ b/docs/onboarding/llm-analytics/cohere.tsx
@@ -9,14 +9,11 @@ export const getCohereSteps = (ctx: OnboardingComponentsContext): StepDefinition
 
     return [
         {
-            title: 'Install the PostHog SDK',
+            title: 'Install dependencies',
             badge: 'required',
             content: (
                 <>
-                    <Markdown>
-                        Setting up analytics starts with installing the PostHog SDK for your language. LLM analytics
-                        works best with our Python and Node SDKs.
-                    </Markdown>
+                    <Markdown>Install the OpenTelemetry SDK, the OpenAI instrumentation, and the OpenAI SDK.</Markdown>
 
                     <CodeBlock
                         blocks={[
@@ -24,63 +21,36 @@ export const getCohereSteps = (ctx: OnboardingComponentsContext): StepDefinition
                                 language: 'bash',
                                 file: 'Python',
                                 code: dedent`
-                                    pip install posthog
+                                    pip install openai opentelemetry-sdk opentelemetry-exporter-otlp-proto-http opentelemetry-instrumentation-openai-v2
                                 `,
                             },
                             {
                                 language: 'bash',
                                 file: 'Node',
                                 code: dedent`
-                                    npm install @posthog/ai posthog-node
+                                    npm install openai @posthog/ai @opentelemetry/sdk-node @opentelemetry/resources @opentelemetry/instrumentation-openai
                                 `,
                             },
                         ]}
                     />
-                </>
-            ),
-        },
-        {
-            title: 'Install the OpenAI SDK',
-            badge: 'required',
-            content: (
-                <>
-                    <Markdown>
-                        Install the OpenAI SDK. The PostHog SDK instruments your LLM calls by wrapping the OpenAI
-                        client. The PostHog SDK **does not** proxy your calls.
-                    </Markdown>
 
-                    <CodeBlock
-                        blocks={[
-                            {
-                                language: 'bash',
-                                file: 'Python',
-                                code: dedent`
-                                    pip install openai
-                                `,
-                            },
-                            {
-                                language: 'bash',
-                                file: 'Node',
-                                code: dedent`
-                                    npm install openai
-                                `,
-                            },
-                        ]}
-                    />
+                    <CalloutBox type="fyi" icon="IconInfo" title="No proxy">
+                        <Markdown>
+                            These SDKs **do not** proxy your calls. They only send analytics data to PostHog in the
+                            background.
+                        </Markdown>
+                    </CalloutBox>
                 </>
             ),
         },
         {
-            title: 'Initialize PostHog and OpenAI client',
+            title: 'Set up OpenTelemetry tracing',
             badge: 'required',
             content: (
                 <>
                     <Markdown>
-                        We call Cohere through the OpenAI-compatible API and generate a response. We'll use PostHog's
-                        OpenAI provider to capture all the details of the call. Initialize PostHog with your PostHog
-                        project token and host from [your project settings](https://app.posthog.com/settings/project),
-                        then pass the PostHog client along with the Cohere config (the base URL and API key) to our
-                        OpenAI wrapper.
+                        Configure OpenTelemetry to auto-instrument OpenAI SDK calls and export traces to PostHog.
+                        PostHog converts `gen_ai.*` spans into `$ai_generation` events automatically.
                     </Markdown>
 
                     <CodeBlock
@@ -89,61 +59,59 @@ export const getCohereSteps = (ctx: OnboardingComponentsContext): StepDefinition
                                 language: 'python',
                                 file: 'Python',
                                 code: dedent`
-                                    from posthog.ai.openai import OpenAI
-                                    from posthog import Posthog
+                                    from opentelemetry import trace
+                                    from opentelemetry.sdk.trace import TracerProvider
+                                    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+                                    from opentelemetry.sdk.resources import Resource, SERVICE_NAME
+                                    from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+                                    from opentelemetry.instrumentation.openai_v2 import OpenAIInstrumentor
 
-                                    posthog = Posthog(
-                                        "<ph_project_token>",
-                                        host="<ph_client_api_host>"
+                                    resource = Resource(attributes={
+                                        SERVICE_NAME: "my-app",
+                                        "user.id": "user_123", # optional: identifies the user in PostHog
+                                    })
+
+                                    exporter = OTLPSpanExporter(
+                                        endpoint="<ph_client_api_host>/i/v0/ai/otel",
+                                        headers={"Authorization": "Bearer <ph_project_token>"},
                                     )
 
-                                    client = OpenAI(
-                                        base_url="https://api.cohere.ai/compatibility/v1",
-                                        api_key="<cohere_api_key>",
-                                        posthog_client=posthog
-                                    )
+                                    provider = TracerProvider(resource=resource)
+                                    provider.add_span_processor(SimpleSpanProcessor(exporter))
+                                    trace.set_tracer_provider(provider)
+
+                                    OpenAIInstrumentor().instrument()
                                 `,
                             },
                             {
                                 language: 'typescript',
                                 file: 'Node',
                                 code: dedent`
-                                    import { OpenAI } from '@posthog/ai'
-                                    import { PostHog } from 'posthog-node'
+                                    import { NodeSDK, tracing } from '@opentelemetry/sdk-node'
+                                    import { resourceFromAttributes } from '@opentelemetry/resources'
+                                    import { PostHogTraceExporter } from '@posthog/ai/otel'
+                                    import { OpenAIInstrumentation } from '@opentelemetry/instrumentation-openai'
 
-                                    const phClient = new PostHog(
-                                      '<ph_project_token>',
-                                      { host: '<ph_client_api_host>' }
-                                    );
-
-                                    const openai = new OpenAI({
-                                      baseURL: 'https://api.cohere.ai/compatibility/v1',
-                                      apiKey: '<cohere_api_key>',
-                                      posthog: phClient,
-                                    });
-
-                                    // ... your code here ...
-
-                                    // IMPORTANT: Shutdown the client when you're done to ensure all events are sent
-                                    phClient.shutdown()
+                                    const sdk = new NodeSDK({
+                                      resource: resourceFromAttributes({
+                                        'service.name': 'my-app',
+                                        'user.id': 'user_123', // optional: identifies the user in PostHog
+                                      }),
+                                      spanProcessors: [
+                                        new tracing.SimpleSpanProcessor(
+                                          new PostHogTraceExporter({
+                                            apiKey: '<ph_project_token>',
+                                            host: '<ph_client_api_host>',
+                                          })
+                                        ),
+                                      ],
+                                      instrumentations: [new OpenAIInstrumentation()],
+                                    })
+                                    sdk.start()
                                 `,
                             },
                         ]}
                     />
-
-                    <Blockquote>
-                        <Markdown>**Note:** This also works with the `AsyncOpenAI` client.</Markdown>
-                    </Blockquote>
-
-                    <CalloutBox type="fyi" icon="IconInfo" title="Proxy note">
-                        <Markdown>
-                            These SDKs **do not** proxy your calls. They only fire off an async call to PostHog in the
-                            background to send the data. You can also use LLM analytics with other SDKs or our API, but
-                            you will need to capture the data in the right format. See the schema in the [manual capture
-                            section](https://posthog.com/docs/llm-analytics/installation/manual-capture) for more
-                            details.
-                        </Markdown>
-                    </CalloutBox>
                 </>
             ),
         },
@@ -153,9 +121,8 @@ export const getCohereSteps = (ctx: OnboardingComponentsContext): StepDefinition
             content: (
                 <>
                     <Markdown>
-                        Now, when you call Cohere with the OpenAI SDK, PostHog automatically captures an
-                        `$ai_generation` event. You can also capture or modify additional properties with the distinct
-                        ID, trace ID, properties, groups, and privacy mode parameters.
+                        Now, when you use the OpenAI SDK to call Cohere, PostHog automatically captures `$ai_generation`
+                        events via the OpenTelemetry instrumentation.
                     </Markdown>
 
                     <CodeBlock
@@ -164,16 +131,19 @@ export const getCohereSteps = (ctx: OnboardingComponentsContext): StepDefinition
                                 language: 'python',
                                 file: 'Python',
                                 code: dedent`
+                                    import openai
+
+                                    client = openai.OpenAI(
+                                        base_url="https://api.cohere.ai/compatibility/v1",
+                                        api_key="<cohere_api_key>",
+                                    )
+
                                     response = client.chat.completions.create(
                                         model="command-a-03-2025",
+                                        max_completion_tokens=1024,
                                         messages=[
                                             {"role": "user", "content": "Tell me a fun fact about hedgehogs"}
                                         ],
-                                        posthog_distinct_id="user_123", # optional
-                                        posthog_trace_id="trace_123", # optional
-                                        posthog_properties={"conversation_id": "abc123", "paid": True}, # optional
-                                        posthog_groups={"company": "company_id_in_your_db"},  # optional
-                                        posthog_privacy_mode=False # optional
                                     )
 
                                     print(response.choices[0].message.content)
@@ -183,17 +153,20 @@ export const getCohereSteps = (ctx: OnboardingComponentsContext): StepDefinition
                                 language: 'typescript',
                                 file: 'Node',
                                 code: dedent`
-                                    const completion = await openai.chat.completions.create({
-                                        model: "command-a-03-2025",
-                                        messages: [{ role: "user", content: "Tell me a fun fact about hedgehogs" }],
-                                        posthogDistinctId: "user_123", // optional
-                                        posthogTraceId: "trace_123", // optional
-                                        posthogProperties: { conversation_id: "abc123", paid: true }, // optional
-                                        posthogGroups: { company: "company_id_in_your_db" }, // optional
-                                        posthogPrivacyMode: false // optional
-                                    });
+                                    import OpenAI from 'openai'
 
-                                    console.log(completion.choices[0].message.content)
+                                    const client = new OpenAI({
+                                      baseURL: 'https://api.cohere.ai/compatibility/v1',
+                                      apiKey: '<cohere_api_key>',
+                                    })
+
+                                    const response = await client.chat.completions.create({
+                                      model: 'command-a-03-2025',
+                                      max_completion_tokens: 1024,
+                                      messages: [{ role: 'user', content: 'Tell me a fun fact about hedgehogs' }],
+                                    })
+
+                                    console.log(response.choices[0].message.content)
                                 `,
                             },
                         ]}
@@ -201,14 +174,9 @@ export const getCohereSteps = (ctx: OnboardingComponentsContext): StepDefinition
 
                     <Blockquote>
                         <Markdown>
-                            {dedent`
-                            **Notes:**
-                            - We also support the old \`chat.completions\` API.
-                            - This works with responses where \`stream=True\`.
-                            - If you want to capture LLM events anonymously, **don't** pass a distinct ID to the request.
-
-                            See our docs on [anonymous vs identified events](https://posthog.com/docs/data/anonymous-vs-identified-events) to learn more.
-                            `}
+                            **Note:** If you want to capture LLM events anonymously, omit the `user.id` resource
+                            attribute. See our docs on [anonymous vs identified
+                            events](https://posthog.com/docs/data/anonymous-vs-identified-events) to learn more.
                         </Markdown>
                     </Blockquote>
 

--- a/docs/onboarding/llm-analytics/cohere.tsx
+++ b/docs/onboarding/llm-analytics/cohere.tsx
@@ -61,7 +61,8 @@ export const getCohereSteps = (ctx: OnboardingComponentsContext): StepDefinition
 
                                     resource = Resource(attributes={
                                         SERVICE_NAME: "my-app",
-                                        "user.id": "user_123", # optional: identifies the user in PostHog
+                                        "posthog.distinct_id": "user_123", # optional: identifies the user in PostHog
+                                        "foo": "bar", # custom properties are passed through
                                     })
 
                                     exporter = OTLPSpanExporter(
@@ -88,7 +89,8 @@ export const getCohereSteps = (ctx: OnboardingComponentsContext): StepDefinition
                                     const sdk = new NodeSDK({
                                       resource: resourceFromAttributes({
                                         'service.name': 'my-app',
-                                        'user.id': 'user_123', // optional: identifies the user in PostHog
+                                        'posthog.distinct_id': 'user_123', // optional: identifies the user in PostHog
+                                        foo: 'bar', // custom properties are passed through
                                       }),
                                       spanProcessors: [
                                         new tracing.SimpleSpanProcessor(
@@ -167,8 +169,8 @@ export const getCohereSteps = (ctx: OnboardingComponentsContext): StepDefinition
 
                     <Blockquote>
                         <Markdown>
-                            **Note:** If you want to capture LLM events anonymously, omit the `user.id` resource
-                            attribute. See our docs on [anonymous vs identified
+                            **Note:** If you want to capture LLM events anonymously, omit the `posthog.distinct_id`
+                            resource attribute. See our docs on [anonymous vs identified
                             events](https://posthog.com/docs/data/anonymous-vs-identified-events) to learn more.
                         </Markdown>
                     </Blockquote>

--- a/docs/onboarding/llm-analytics/cohere.tsx
+++ b/docs/onboarding/llm-analytics/cohere.tsx
@@ -13,14 +13,17 @@ export const getCohereSteps = (ctx: OnboardingComponentsContext): StepDefinition
             badge: 'required',
             content: (
                 <>
-                    <CalloutBox type="info" icon="IconInfo" title="Migrating from the SDK wrapper?">
+                    <CalloutBox type="info" icon="IconInfo" title="Full working examples">
                         <Markdown>
-                            These docs now use OpenTelemetry auto-instrumentation, which is the recommended approach.
-                            The previous PostHog SDK wrapper is still available — see the
-                            [Node.js](https://github.com/PostHog/posthog-js/tree/e08ff1be/examples/example-ai-cohere)
-                            and
-                            [Python](https://github.com/PostHog/posthog-python/tree/7223c52/examples/example-ai-cohere)
-                            wrapper examples.
+                            See the complete
+                            [Node.js](https://github.com/PostHog/posthog-js/tree/main/examples/example-ai-cohere) and
+                            [Python](https://github.com/PostHog/posthog-python/tree/master/examples/example-ai-cohere)
+                            examples on GitHub. If you're using the PostHog SDK wrapper instead of OpenTelemetry, see
+                            the [Node.js
+                            wrapper](https://github.com/PostHog/posthog-js/tree/e08ff1be/examples/example-ai-cohere) and
+                            [Python
+                            wrapper](https://github.com/PostHog/posthog-python/tree/7223c52/examples/example-ai-cohere)
+                            examples.
                         </Markdown>
                     </CalloutBox>
 

--- a/docs/onboarding/llm-analytics/cohere.tsx
+++ b/docs/onboarding/llm-analytics/cohere.tsx
@@ -3,7 +3,7 @@ import { OnboardingComponentsContext, createInstallation } from 'scenes/onboardi
 import { StepDefinition } from '../steps'
 
 export const getCohereSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
-    const { CodeBlock, Markdown, Blockquote, dedent, snippets } = ctx
+    const { CodeBlock, CalloutBox, Markdown, Blockquote, dedent, snippets } = ctx
 
     const NotableGenerationProperties = snippets?.NotableGenerationProperties
 
@@ -13,6 +13,17 @@ export const getCohereSteps = (ctx: OnboardingComponentsContext): StepDefinition
             badge: 'required',
             content: (
                 <>
+                    <CalloutBox type="info" icon="IconInfo" title="Migrating from the SDK wrapper?">
+                        <Markdown>
+                            These docs now use OpenTelemetry auto-instrumentation, which is the recommended approach.
+                            The previous PostHog SDK wrapper is still available — see the
+                            [Node.js](https://github.com/PostHog/posthog-js/tree/e08ff1be/examples/example-ai-cohere)
+                            and
+                            [Python](https://github.com/PostHog/posthog-python/tree/7223c52/examples/example-ai-cohere)
+                            wrapper examples.
+                        </Markdown>
+                    </CalloutBox>
+
                     <Markdown>Install the OpenTelemetry SDK, the OpenAI instrumentation, and the OpenAI SDK.</Markdown>
 
                     <CodeBlock

--- a/docs/onboarding/llm-analytics/cohere.tsx
+++ b/docs/onboarding/llm-analytics/cohere.tsx
@@ -3,7 +3,7 @@ import { OnboardingComponentsContext, createInstallation } from 'scenes/onboardi
 import { StepDefinition } from '../steps'
 
 export const getCohereSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
-    const { CodeBlock, CalloutBox, Markdown, Blockquote, dedent, snippets } = ctx
+    const { CodeBlock, Markdown, Blockquote, dedent, snippets } = ctx
 
     const NotableGenerationProperties = snippets?.NotableGenerationProperties
 
@@ -33,13 +33,6 @@ export const getCohereSteps = (ctx: OnboardingComponentsContext): StepDefinition
                             },
                         ]}
                     />
-
-                    <CalloutBox type="fyi" icon="IconInfo" title="No proxy">
-                        <Markdown>
-                            These SDKs **do not** proxy your calls. They only send analytics data to PostHog in the
-                            background.
-                        </Markdown>
-                    </CalloutBox>
                 </>
             ),
         },

--- a/docs/onboarding/llm-analytics/cohere.tsx
+++ b/docs/onboarding/llm-analytics/cohere.tsx
@@ -95,9 +95,9 @@ export const getCohereSteps = (ctx: OnboardingComponentsContext): StepDefinition
                                 language: 'typescript',
                                 file: 'Node',
                                 code: dedent`
-                                    import { NodeSDK, tracing } from '@opentelemetry/sdk-node'
+                                    import { NodeSDK } from '@opentelemetry/sdk-node'
                                     import { resourceFromAttributes } from '@opentelemetry/resources'
-                                    import { PostHogTraceExporter } from '@posthog/ai/otel'
+                                    import { PostHogSpanProcessor } from '@posthog/ai/otel'
                                     import { OpenAIInstrumentation } from '@opentelemetry/instrumentation-openai'
 
                                     const sdk = new NodeSDK({
@@ -107,12 +107,10 @@ export const getCohereSteps = (ctx: OnboardingComponentsContext): StepDefinition
                                         foo: 'bar', // custom properties are passed through
                                       }),
                                       spanProcessors: [
-                                        new tracing.SimpleSpanProcessor(
-                                          new PostHogTraceExporter({
-                                            apiKey: '<ph_project_token>',
-                                            host: '<ph_client_api_host>',
-                                          })
-                                        ),
+                                        new PostHogSpanProcessor({
+                                          apiKey: '<ph_project_token>',
+                                          host: '<ph_client_api_host>',
+                                        }),
                                       ],
                                       instrumentations: [new OpenAIInstrumentation()],
                                     })

--- a/docs/onboarding/llm-analytics/cohere.tsx
+++ b/docs/onboarding/llm-analytics/cohere.tsx
@@ -35,7 +35,7 @@ export const getCohereSteps = (ctx: OnboardingComponentsContext): StepDefinition
                                 language: 'bash',
                                 file: 'Python',
                                 code: dedent`
-                                    pip install openai opentelemetry-sdk opentelemetry-exporter-otlp-proto-http opentelemetry-instrumentation-openai-v2
+                                    pip install openai opentelemetry-sdk posthog[otel] opentelemetry-instrumentation-openai-v2
                                 `,
                             },
                             {
@@ -68,9 +68,8 @@ export const getCohereSteps = (ctx: OnboardingComponentsContext): StepDefinition
                                 code: dedent`
                                     from opentelemetry import trace
                                     from opentelemetry.sdk.trace import TracerProvider
-                                    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
                                     from opentelemetry.sdk.resources import Resource, SERVICE_NAME
-                                    from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+                                    from posthog.ai.otel import PostHogSpanProcessor
                                     from opentelemetry.instrumentation.openai_v2 import OpenAIInstrumentor
 
                                     resource = Resource(attributes={
@@ -79,13 +78,13 @@ export const getCohereSteps = (ctx: OnboardingComponentsContext): StepDefinition
                                         "foo": "bar", # custom properties are passed through
                                     })
 
-                                    exporter = OTLPSpanExporter(
-                                        endpoint="<ph_client_api_host>/i/v0/ai/otel",
-                                        headers={"Authorization": "Bearer <ph_project_token>"},
-                                    )
-
                                     provider = TracerProvider(resource=resource)
-                                    provider.add_span_processor(SimpleSpanProcessor(exporter))
+                                    provider.add_span_processor(
+                                        PostHogSpanProcessor(
+                                            api_key="<ph_project_token>",
+                                            host="<ph_client_api_host>",
+                                        )
+                                    )
                                     trace.set_tracer_provider(provider)
 
                                     OpenAIInstrumentor().instrument()

--- a/docs/onboarding/llm-analytics/deepseek.tsx
+++ b/docs/onboarding/llm-analytics/deepseek.tsx
@@ -13,14 +13,17 @@ export const getDeepSeekSteps = (ctx: OnboardingComponentsContext): StepDefiniti
             badge: 'required',
             content: (
                 <>
-                    <CalloutBox type="info" icon="IconInfo" title="Migrating from the SDK wrapper?">
+                    <CalloutBox type="info" icon="IconInfo" title="Full working examples">
                         <Markdown>
-                            These docs now use OpenTelemetry auto-instrumentation, which is the recommended approach.
-                            The previous PostHog SDK wrapper is still available — see the
-                            [Node.js](https://github.com/PostHog/posthog-js/tree/e08ff1be/examples/example-ai-deepseek)
-                            and
-                            [Python](https://github.com/PostHog/posthog-python/tree/7223c52/examples/example-ai-deepseek)
-                            wrapper examples.
+                            See the complete
+                            [Node.js](https://github.com/PostHog/posthog-js/tree/main/examples/example-ai-deepseek) and
+                            [Python](https://github.com/PostHog/posthog-python/tree/master/examples/example-ai-deepseek)
+                            examples on GitHub. If you're using the PostHog SDK wrapper instead of OpenTelemetry, see
+                            the [Node.js
+                            wrapper](https://github.com/PostHog/posthog-js/tree/e08ff1be/examples/example-ai-deepseek)
+                            and [Python
+                            wrapper](https://github.com/PostHog/posthog-python/tree/7223c52/examples/example-ai-deepseek)
+                            examples.
                         </Markdown>
                     </CalloutBox>
 

--- a/docs/onboarding/llm-analytics/deepseek.tsx
+++ b/docs/onboarding/llm-analytics/deepseek.tsx
@@ -9,14 +9,11 @@ export const getDeepSeekSteps = (ctx: OnboardingComponentsContext): StepDefiniti
 
     return [
         {
-            title: 'Install the PostHog SDK',
+            title: 'Install dependencies',
             badge: 'required',
             content: (
                 <>
-                    <Markdown>
-                        Setting up analytics starts with installing the PostHog SDK for your language. LLM analytics
-                        works best with our Python and Node SDKs.
-                    </Markdown>
+                    <Markdown>Install the OpenTelemetry SDK, the OpenAI instrumentation, and the OpenAI SDK.</Markdown>
 
                     <CodeBlock
                         blocks={[
@@ -24,63 +21,36 @@ export const getDeepSeekSteps = (ctx: OnboardingComponentsContext): StepDefiniti
                                 language: 'bash',
                                 file: 'Python',
                                 code: dedent`
-                                    pip install posthog
+                                    pip install openai opentelemetry-sdk opentelemetry-exporter-otlp-proto-http opentelemetry-instrumentation-openai-v2
                                 `,
                             },
                             {
                                 language: 'bash',
                                 file: 'Node',
                                 code: dedent`
-                                    npm install @posthog/ai posthog-node
+                                    npm install openai @posthog/ai @opentelemetry/sdk-node @opentelemetry/resources @opentelemetry/instrumentation-openai
                                 `,
                             },
                         ]}
                     />
-                </>
-            ),
-        },
-        {
-            title: 'Install the OpenAI SDK',
-            badge: 'required',
-            content: (
-                <>
-                    <Markdown>
-                        Install the OpenAI SDK. The PostHog SDK instruments your LLM calls by wrapping the OpenAI
-                        client. The PostHog SDK **does not** proxy your calls.
-                    </Markdown>
 
-                    <CodeBlock
-                        blocks={[
-                            {
-                                language: 'bash',
-                                file: 'Python',
-                                code: dedent`
-                                    pip install openai
-                                `,
-                            },
-                            {
-                                language: 'bash',
-                                file: 'Node',
-                                code: dedent`
-                                    npm install openai
-                                `,
-                            },
-                        ]}
-                    />
+                    <CalloutBox type="fyi" icon="IconInfo" title="No proxy">
+                        <Markdown>
+                            These SDKs **do not** proxy your calls. They only send analytics data to PostHog in the
+                            background.
+                        </Markdown>
+                    </CalloutBox>
                 </>
             ),
         },
         {
-            title: 'Initialize PostHog and OpenAI client',
+            title: 'Set up OpenTelemetry tracing',
             badge: 'required',
             content: (
                 <>
                     <Markdown>
-                        We call DeepSeek through the OpenAI client and generate a response. We'll use PostHog's OpenAI
-                        provider to capture all the details of the call. Initialize PostHog with your PostHog project
-                        token and host from [your project settings](https://app.posthog.com/settings/project), then pass
-                        the PostHog client along with the DeepSeek config (the base URL and API key) to our OpenAI
-                        wrapper.
+                        Configure OpenTelemetry to auto-instrument OpenAI SDK calls and export traces to PostHog.
+                        PostHog converts `gen_ai.*` spans into `$ai_generation` events automatically.
                     </Markdown>
 
                     <CodeBlock
@@ -89,61 +59,59 @@ export const getDeepSeekSteps = (ctx: OnboardingComponentsContext): StepDefiniti
                                 language: 'python',
                                 file: 'Python',
                                 code: dedent`
-                                    from posthog.ai.openai import OpenAI
-                                    from posthog import Posthog
+                                    from opentelemetry import trace
+                                    from opentelemetry.sdk.trace import TracerProvider
+                                    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+                                    from opentelemetry.sdk.resources import Resource, SERVICE_NAME
+                                    from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+                                    from opentelemetry.instrumentation.openai_v2 import OpenAIInstrumentor
 
-                                    posthog = Posthog(
-                                        "<ph_project_token>",
-                                        host="<ph_client_api_host>"
+                                    resource = Resource(attributes={
+                                        SERVICE_NAME: "my-app",
+                                        "user.id": "user_123", # optional: identifies the user in PostHog
+                                    })
+
+                                    exporter = OTLPSpanExporter(
+                                        endpoint="<ph_client_api_host>/i/v0/ai/otel",
+                                        headers={"Authorization": "Bearer <ph_project_token>"},
                                     )
 
-                                    client = OpenAI(
-                                        base_url="https://api.deepseek.com",
-                                        api_key="<deepseek_api_key>",
-                                        posthog_client=posthog
-                                    )
+                                    provider = TracerProvider(resource=resource)
+                                    provider.add_span_processor(SimpleSpanProcessor(exporter))
+                                    trace.set_tracer_provider(provider)
+
+                                    OpenAIInstrumentor().instrument()
                                 `,
                             },
                             {
                                 language: 'typescript',
                                 file: 'Node',
                                 code: dedent`
-                                    import { OpenAI } from '@posthog/ai'
-                                    import { PostHog } from 'posthog-node'
+                                    import { NodeSDK, tracing } from '@opentelemetry/sdk-node'
+                                    import { resourceFromAttributes } from '@opentelemetry/resources'
+                                    import { PostHogTraceExporter } from '@posthog/ai/otel'
+                                    import { OpenAIInstrumentation } from '@opentelemetry/instrumentation-openai'
 
-                                    const phClient = new PostHog(
-                                      '<ph_project_token>',
-                                      { host: '<ph_client_api_host>' }
-                                    );
-
-                                    const openai = new OpenAI({
-                                      baseURL: 'https://api.deepseek.com',
-                                      apiKey: '<deepseek_api_key>',
-                                      posthog: phClient,
-                                    });
-
-                                    // ... your code here ...
-
-                                    // IMPORTANT: Shutdown the client when you're done to ensure all events are sent
-                                    phClient.shutdown()
+                                    const sdk = new NodeSDK({
+                                      resource: resourceFromAttributes({
+                                        'service.name': 'my-app',
+                                        'user.id': 'user_123', // optional: identifies the user in PostHog
+                                      }),
+                                      spanProcessors: [
+                                        new tracing.SimpleSpanProcessor(
+                                          new PostHogTraceExporter({
+                                            apiKey: '<ph_project_token>',
+                                            host: '<ph_client_api_host>',
+                                          })
+                                        ),
+                                      ],
+                                      instrumentations: [new OpenAIInstrumentation()],
+                                    })
+                                    sdk.start()
                                 `,
                             },
                         ]}
                     />
-
-                    <Blockquote>
-                        <Markdown>**Note:** This also works with the `AsyncOpenAI` client.</Markdown>
-                    </Blockquote>
-
-                    <CalloutBox type="fyi" icon="IconInfo" title="Proxy note">
-                        <Markdown>
-                            These SDKs **do not** proxy your calls. They only fire off an async call to PostHog in the
-                            background to send the data. You can also use LLM analytics with other SDKs or our API, but
-                            you will need to capture the data in the right format. See the schema in the [manual capture
-                            section](https://posthog.com/docs/llm-analytics/installation/manual-capture) for more
-                            details.
-                        </Markdown>
-                    </CalloutBox>
                 </>
             ),
         },
@@ -153,9 +121,8 @@ export const getDeepSeekSteps = (ctx: OnboardingComponentsContext): StepDefiniti
             content: (
                 <>
                     <Markdown>
-                        Now, when you call DeepSeek with the OpenAI SDK, PostHog automatically captures an
-                        `$ai_generation` event. You can also capture or modify additional properties with the distinct
-                        ID, trace ID, properties, groups, and privacy mode parameters.
+                        Now, when you use the OpenAI SDK to call DeepSeek, PostHog automatically captures
+                        `$ai_generation` events via the OpenTelemetry instrumentation.
                     </Markdown>
 
                     <CodeBlock
@@ -164,16 +131,19 @@ export const getDeepSeekSteps = (ctx: OnboardingComponentsContext): StepDefiniti
                                 language: 'python',
                                 file: 'Python',
                                 code: dedent`
+                                    import openai
+
+                                    client = openai.OpenAI(
+                                        base_url="https://api.deepseek.com",
+                                        api_key="<deepseek_api_key>",
+                                    )
+
                                     response = client.chat.completions.create(
                                         model="deepseek-chat",
+                                        max_completion_tokens=1024,
                                         messages=[
                                             {"role": "user", "content": "Tell me a fun fact about hedgehogs"}
                                         ],
-                                        posthog_distinct_id="user_123", # optional
-                                        posthog_trace_id="trace_123", # optional
-                                        posthog_properties={"conversation_id": "abc123", "paid": True}, # optional
-                                        posthog_groups={"company": "company_id_in_your_db"},  # optional
-                                        posthog_privacy_mode=False # optional
                                     )
 
                                     print(response.choices[0].message.content)
@@ -183,17 +153,20 @@ export const getDeepSeekSteps = (ctx: OnboardingComponentsContext): StepDefiniti
                                 language: 'typescript',
                                 file: 'Node',
                                 code: dedent`
-                                    const completion = await openai.chat.completions.create({
-                                        model: "deepseek-chat",
-                                        messages: [{ role: "user", content: "Tell me a fun fact about hedgehogs" }],
-                                        posthogDistinctId: "user_123", // optional
-                                        posthogTraceId: "trace_123", // optional
-                                        posthogProperties: { conversation_id: "abc123", paid: true }, // optional
-                                        posthogGroups: { company: "company_id_in_your_db" }, // optional
-                                        posthogPrivacyMode: false // optional
-                                    });
+                                    import OpenAI from 'openai'
 
-                                    console.log(completion.choices[0].message.content)
+                                    const client = new OpenAI({
+                                      baseURL: 'https://api.deepseek.com',
+                                      apiKey: '<deepseek_api_key>',
+                                    })
+
+                                    const response = await client.chat.completions.create({
+                                      model: 'deepseek-chat',
+                                      max_completion_tokens: 1024,
+                                      messages: [{ role: 'user', content: 'Tell me a fun fact about hedgehogs' }],
+                                    })
+
+                                    console.log(response.choices[0].message.content)
                                 `,
                             },
                         ]}
@@ -201,14 +174,9 @@ export const getDeepSeekSteps = (ctx: OnboardingComponentsContext): StepDefiniti
 
                     <Blockquote>
                         <Markdown>
-                            {dedent`
-                            **Notes:**
-                            - We also support the old \`chat.completions\` API.
-                            - This works with responses where \`stream=True\`.
-                            - If you want to capture LLM events anonymously, **don't** pass a distinct ID to the request.
-
-                            See our docs on [anonymous vs identified events](https://posthog.com/docs/data/anonymous-vs-identified-events) to learn more.
-                            `}
+                            **Note:** If you want to capture LLM events anonymously, omit the `user.id` resource
+                            attribute. See our docs on [anonymous vs identified
+                            events](https://posthog.com/docs/data/anonymous-vs-identified-events) to learn more.
                         </Markdown>
                     </Blockquote>
 

--- a/docs/onboarding/llm-analytics/deepseek.tsx
+++ b/docs/onboarding/llm-analytics/deepseek.tsx
@@ -3,7 +3,7 @@ import { OnboardingComponentsContext, createInstallation } from 'scenes/onboardi
 import { StepDefinition } from '../steps'
 
 export const getDeepSeekSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
-    const { CodeBlock, CalloutBox, Markdown, Blockquote, dedent, snippets } = ctx
+    const { CodeBlock, Markdown, Blockquote, dedent, snippets } = ctx
 
     const NotableGenerationProperties = snippets?.NotableGenerationProperties
 
@@ -33,13 +33,6 @@ export const getDeepSeekSteps = (ctx: OnboardingComponentsContext): StepDefiniti
                             },
                         ]}
                     />
-
-                    <CalloutBox type="fyi" icon="IconInfo" title="No proxy">
-                        <Markdown>
-                            These SDKs **do not** proxy your calls. They only send analytics data to PostHog in the
-                            background.
-                        </Markdown>
-                    </CalloutBox>
                 </>
             ),
         },

--- a/docs/onboarding/llm-analytics/deepseek.tsx
+++ b/docs/onboarding/llm-analytics/deepseek.tsx
@@ -61,7 +61,8 @@ export const getDeepSeekSteps = (ctx: OnboardingComponentsContext): StepDefiniti
 
                                     resource = Resource(attributes={
                                         SERVICE_NAME: "my-app",
-                                        "user.id": "user_123", # optional: identifies the user in PostHog
+                                        "posthog.distinct_id": "user_123", # optional: identifies the user in PostHog
+                                        "foo": "bar", # custom properties are passed through
                                     })
 
                                     exporter = OTLPSpanExporter(
@@ -88,7 +89,8 @@ export const getDeepSeekSteps = (ctx: OnboardingComponentsContext): StepDefiniti
                                     const sdk = new NodeSDK({
                                       resource: resourceFromAttributes({
                                         'service.name': 'my-app',
-                                        'user.id': 'user_123', // optional: identifies the user in PostHog
+                                        'posthog.distinct_id': 'user_123', // optional: identifies the user in PostHog
+                                        foo: 'bar', // custom properties are passed through
                                       }),
                                       spanProcessors: [
                                         new tracing.SimpleSpanProcessor(
@@ -167,8 +169,8 @@ export const getDeepSeekSteps = (ctx: OnboardingComponentsContext): StepDefiniti
 
                     <Blockquote>
                         <Markdown>
-                            **Note:** If you want to capture LLM events anonymously, omit the `user.id` resource
-                            attribute. See our docs on [anonymous vs identified
+                            **Note:** If you want to capture LLM events anonymously, omit the `posthog.distinct_id`
+                            resource attribute. See our docs on [anonymous vs identified
                             events](https://posthog.com/docs/data/anonymous-vs-identified-events) to learn more.
                         </Markdown>
                     </Blockquote>

--- a/docs/onboarding/llm-analytics/deepseek.tsx
+++ b/docs/onboarding/llm-analytics/deepseek.tsx
@@ -3,7 +3,7 @@ import { OnboardingComponentsContext, createInstallation } from 'scenes/onboardi
 import { StepDefinition } from '../steps'
 
 export const getDeepSeekSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
-    const { CodeBlock, Markdown, Blockquote, dedent, snippets } = ctx
+    const { CodeBlock, CalloutBox, Markdown, Blockquote, dedent, snippets } = ctx
 
     const NotableGenerationProperties = snippets?.NotableGenerationProperties
 
@@ -13,6 +13,17 @@ export const getDeepSeekSteps = (ctx: OnboardingComponentsContext): StepDefiniti
             badge: 'required',
             content: (
                 <>
+                    <CalloutBox type="info" icon="IconInfo" title="Migrating from the SDK wrapper?">
+                        <Markdown>
+                            These docs now use OpenTelemetry auto-instrumentation, which is the recommended approach.
+                            The previous PostHog SDK wrapper is still available — see the
+                            [Node.js](https://github.com/PostHog/posthog-js/tree/e08ff1be/examples/example-ai-deepseek)
+                            and
+                            [Python](https://github.com/PostHog/posthog-python/tree/7223c52/examples/example-ai-deepseek)
+                            wrapper examples.
+                        </Markdown>
+                    </CalloutBox>
+
                     <Markdown>Install the OpenTelemetry SDK, the OpenAI instrumentation, and the OpenAI SDK.</Markdown>
 
                     <CodeBlock

--- a/docs/onboarding/llm-analytics/deepseek.tsx
+++ b/docs/onboarding/llm-analytics/deepseek.tsx
@@ -35,7 +35,7 @@ export const getDeepSeekSteps = (ctx: OnboardingComponentsContext): StepDefiniti
                                 language: 'bash',
                                 file: 'Python',
                                 code: dedent`
-                                    pip install openai opentelemetry-sdk opentelemetry-exporter-otlp-proto-http opentelemetry-instrumentation-openai-v2
+                                    pip install openai opentelemetry-sdk posthog[otel] opentelemetry-instrumentation-openai-v2
                                 `,
                             },
                             {
@@ -68,9 +68,8 @@ export const getDeepSeekSteps = (ctx: OnboardingComponentsContext): StepDefiniti
                                 code: dedent`
                                     from opentelemetry import trace
                                     from opentelemetry.sdk.trace import TracerProvider
-                                    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
                                     from opentelemetry.sdk.resources import Resource, SERVICE_NAME
-                                    from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+                                    from posthog.ai.otel import PostHogSpanProcessor
                                     from opentelemetry.instrumentation.openai_v2 import OpenAIInstrumentor
 
                                     resource = Resource(attributes={
@@ -79,13 +78,13 @@ export const getDeepSeekSteps = (ctx: OnboardingComponentsContext): StepDefiniti
                                         "foo": "bar", # custom properties are passed through
                                     })
 
-                                    exporter = OTLPSpanExporter(
-                                        endpoint="<ph_client_api_host>/i/v0/ai/otel",
-                                        headers={"Authorization": "Bearer <ph_project_token>"},
-                                    )
-
                                     provider = TracerProvider(resource=resource)
-                                    provider.add_span_processor(SimpleSpanProcessor(exporter))
+                                    provider.add_span_processor(
+                                        PostHogSpanProcessor(
+                                            api_key="<ph_project_token>",
+                                            host="<ph_client_api_host>",
+                                        )
+                                    )
                                     trace.set_tracer_provider(provider)
 
                                     OpenAIInstrumentor().instrument()

--- a/docs/onboarding/llm-analytics/deepseek.tsx
+++ b/docs/onboarding/llm-analytics/deepseek.tsx
@@ -95,9 +95,9 @@ export const getDeepSeekSteps = (ctx: OnboardingComponentsContext): StepDefiniti
                                 language: 'typescript',
                                 file: 'Node',
                                 code: dedent`
-                                    import { NodeSDK, tracing } from '@opentelemetry/sdk-node'
+                                    import { NodeSDK } from '@opentelemetry/sdk-node'
                                     import { resourceFromAttributes } from '@opentelemetry/resources'
-                                    import { PostHogTraceExporter } from '@posthog/ai/otel'
+                                    import { PostHogSpanProcessor } from '@posthog/ai/otel'
                                     import { OpenAIInstrumentation } from '@opentelemetry/instrumentation-openai'
 
                                     const sdk = new NodeSDK({
@@ -107,12 +107,10 @@ export const getDeepSeekSteps = (ctx: OnboardingComponentsContext): StepDefiniti
                                         foo: 'bar', // custom properties are passed through
                                       }),
                                       spanProcessors: [
-                                        new tracing.SimpleSpanProcessor(
-                                          new PostHogTraceExporter({
-                                            apiKey: '<ph_project_token>',
-                                            host: '<ph_client_api_host>',
-                                          })
-                                        ),
+                                        new PostHogSpanProcessor({
+                                          apiKey: '<ph_project_token>',
+                                          host: '<ph_client_api_host>',
+                                        }),
                                       ],
                                       instrumentations: [new OpenAIInstrumentation()],
                                     })

--- a/docs/onboarding/llm-analytics/fireworks-ai.tsx
+++ b/docs/onboarding/llm-analytics/fireworks-ai.tsx
@@ -13,14 +13,18 @@ export const getFireworksAISteps = (ctx: OnboardingComponentsContext): StepDefin
             badge: 'required',
             content: (
                 <>
-                    <CalloutBox type="info" icon="IconInfo" title="Migrating from the SDK wrapper?">
+                    <CalloutBox type="info" icon="IconInfo" title="Full working examples">
                         <Markdown>
-                            These docs now use OpenTelemetry auto-instrumentation, which is the recommended approach.
-                            The previous PostHog SDK wrapper is still available — see the
-                            [Node.js](https://github.com/PostHog/posthog-js/tree/e08ff1be/examples/example-ai-fireworks-ai)
+                            See the complete
+                            [Node.js](https://github.com/PostHog/posthog-js/tree/main/examples/example-ai-fireworks-ai)
                             and
-                            [Python](https://github.com/PostHog/posthog-python/tree/7223c52/examples/example-ai-fireworks-ai)
-                            wrapper examples.
+                            [Python](https://github.com/PostHog/posthog-python/tree/master/examples/example-ai-fireworks-ai)
+                            examples on GitHub. If you're using the PostHog SDK wrapper instead of OpenTelemetry, see
+                            the [Node.js
+                            wrapper](https://github.com/PostHog/posthog-js/tree/e08ff1be/examples/example-ai-fireworks-ai)
+                            and [Python
+                            wrapper](https://github.com/PostHog/posthog-python/tree/7223c52/examples/example-ai-fireworks-ai)
+                            examples.
                         </Markdown>
                     </CalloutBox>
 

--- a/docs/onboarding/llm-analytics/fireworks-ai.tsx
+++ b/docs/onboarding/llm-analytics/fireworks-ai.tsx
@@ -3,7 +3,7 @@ import { OnboardingComponentsContext, createInstallation } from 'scenes/onboardi
 import { StepDefinition } from '../steps'
 
 export const getFireworksAISteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
-    const { CodeBlock, CalloutBox, Markdown, Blockquote, dedent, snippets } = ctx
+    const { CodeBlock, Markdown, Blockquote, dedent, snippets } = ctx
 
     const NotableGenerationProperties = snippets?.NotableGenerationProperties
 
@@ -33,13 +33,6 @@ export const getFireworksAISteps = (ctx: OnboardingComponentsContext): StepDefin
                             },
                         ]}
                     />
-
-                    <CalloutBox type="fyi" icon="IconInfo" title="No proxy">
-                        <Markdown>
-                            These SDKs **do not** proxy your calls. They only send analytics data to PostHog in the
-                            background.
-                        </Markdown>
-                    </CalloutBox>
                 </>
             ),
         },

--- a/docs/onboarding/llm-analytics/fireworks-ai.tsx
+++ b/docs/onboarding/llm-analytics/fireworks-ai.tsx
@@ -61,7 +61,8 @@ export const getFireworksAISteps = (ctx: OnboardingComponentsContext): StepDefin
 
                                     resource = Resource(attributes={
                                         SERVICE_NAME: "my-app",
-                                        "user.id": "user_123", # optional: identifies the user in PostHog
+                                        "posthog.distinct_id": "user_123", # optional: identifies the user in PostHog
+                                        "foo": "bar", # custom properties are passed through
                                     })
 
                                     exporter = OTLPSpanExporter(
@@ -88,7 +89,8 @@ export const getFireworksAISteps = (ctx: OnboardingComponentsContext): StepDefin
                                     const sdk = new NodeSDK({
                                       resource: resourceFromAttributes({
                                         'service.name': 'my-app',
-                                        'user.id': 'user_123', // optional: identifies the user in PostHog
+                                        'posthog.distinct_id': 'user_123', // optional: identifies the user in PostHog
+                                        foo: 'bar', // custom properties are passed through
                                       }),
                                       spanProcessors: [
                                         new tracing.SimpleSpanProcessor(
@@ -167,8 +169,8 @@ export const getFireworksAISteps = (ctx: OnboardingComponentsContext): StepDefin
 
                     <Blockquote>
                         <Markdown>
-                            **Note:** If you want to capture LLM events anonymously, omit the `user.id` resource
-                            attribute. See our docs on [anonymous vs identified
+                            **Note:** If you want to capture LLM events anonymously, omit the `posthog.distinct_id`
+                            resource attribute. See our docs on [anonymous vs identified
                             events](https://posthog.com/docs/data/anonymous-vs-identified-events) to learn more.
                         </Markdown>
                     </Blockquote>

--- a/docs/onboarding/llm-analytics/fireworks-ai.tsx
+++ b/docs/onboarding/llm-analytics/fireworks-ai.tsx
@@ -3,7 +3,7 @@ import { OnboardingComponentsContext, createInstallation } from 'scenes/onboardi
 import { StepDefinition } from '../steps'
 
 export const getFireworksAISteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
-    const { CodeBlock, Markdown, Blockquote, dedent, snippets } = ctx
+    const { CodeBlock, CalloutBox, Markdown, Blockquote, dedent, snippets } = ctx
 
     const NotableGenerationProperties = snippets?.NotableGenerationProperties
 
@@ -13,6 +13,17 @@ export const getFireworksAISteps = (ctx: OnboardingComponentsContext): StepDefin
             badge: 'required',
             content: (
                 <>
+                    <CalloutBox type="info" icon="IconInfo" title="Migrating from the SDK wrapper?">
+                        <Markdown>
+                            These docs now use OpenTelemetry auto-instrumentation, which is the recommended approach.
+                            The previous PostHog SDK wrapper is still available — see the
+                            [Node.js](https://github.com/PostHog/posthog-js/tree/e08ff1be/examples/example-ai-fireworks-ai)
+                            and
+                            [Python](https://github.com/PostHog/posthog-python/tree/7223c52/examples/example-ai-fireworks-ai)
+                            wrapper examples.
+                        </Markdown>
+                    </CalloutBox>
+
                     <Markdown>Install the OpenTelemetry SDK, the OpenAI instrumentation, and the OpenAI SDK.</Markdown>
 
                     <CodeBlock

--- a/docs/onboarding/llm-analytics/fireworks-ai.tsx
+++ b/docs/onboarding/llm-analytics/fireworks-ai.tsx
@@ -9,14 +9,11 @@ export const getFireworksAISteps = (ctx: OnboardingComponentsContext): StepDefin
 
     return [
         {
-            title: 'Install the PostHog SDK',
+            title: 'Install dependencies',
             badge: 'required',
             content: (
                 <>
-                    <Markdown>
-                        Setting up analytics starts with installing the PostHog SDK for your language. LLM analytics
-                        works best with our Python and Node SDKs.
-                    </Markdown>
+                    <Markdown>Install the OpenTelemetry SDK, the OpenAI instrumentation, and the OpenAI SDK.</Markdown>
 
                     <CodeBlock
                         blocks={[
@@ -24,63 +21,36 @@ export const getFireworksAISteps = (ctx: OnboardingComponentsContext): StepDefin
                                 language: 'bash',
                                 file: 'Python',
                                 code: dedent`
-                                    pip install posthog
+                                    pip install openai opentelemetry-sdk opentelemetry-exporter-otlp-proto-http opentelemetry-instrumentation-openai-v2
                                 `,
                             },
                             {
                                 language: 'bash',
                                 file: 'Node',
                                 code: dedent`
-                                    npm install @posthog/ai posthog-node
+                                    npm install openai @posthog/ai @opentelemetry/sdk-node @opentelemetry/resources @opentelemetry/instrumentation-openai
                                 `,
                             },
                         ]}
                     />
-                </>
-            ),
-        },
-        {
-            title: 'Install the OpenAI SDK',
-            badge: 'required',
-            content: (
-                <>
-                    <Markdown>
-                        Install the OpenAI SDK. The PostHog SDK instruments your LLM calls by wrapping the OpenAI
-                        client. The PostHog SDK **does not** proxy your calls.
-                    </Markdown>
 
-                    <CodeBlock
-                        blocks={[
-                            {
-                                language: 'bash',
-                                file: 'Python',
-                                code: dedent`
-                                    pip install openai
-                                `,
-                            },
-                            {
-                                language: 'bash',
-                                file: 'Node',
-                                code: dedent`
-                                    npm install openai
-                                `,
-                            },
-                        ]}
-                    />
+                    <CalloutBox type="fyi" icon="IconInfo" title="No proxy">
+                        <Markdown>
+                            These SDKs **do not** proxy your calls. They only send analytics data to PostHog in the
+                            background.
+                        </Markdown>
+                    </CalloutBox>
                 </>
             ),
         },
         {
-            title: 'Initialize PostHog and OpenAI client',
+            title: 'Set up OpenTelemetry tracing',
             badge: 'required',
             content: (
                 <>
                     <Markdown>
-                        We call Fireworks AI through the OpenAI client and generate a response. We'll use PostHog's
-                        OpenAI provider to capture all the details of the call. Initialize PostHog with your PostHog
-                        project token and host from [your project settings](https://app.posthog.com/settings/project),
-                        then pass the PostHog client along with the Fireworks AI config (the base URL and API key) to
-                        our OpenAI wrapper.
+                        Configure OpenTelemetry to auto-instrument OpenAI SDK calls and export traces to PostHog.
+                        PostHog converts `gen_ai.*` spans into `$ai_generation` events automatically.
                     </Markdown>
 
                     <CodeBlock
@@ -89,61 +59,59 @@ export const getFireworksAISteps = (ctx: OnboardingComponentsContext): StepDefin
                                 language: 'python',
                                 file: 'Python',
                                 code: dedent`
-                                    from posthog.ai.openai import OpenAI
-                                    from posthog import Posthog
+                                    from opentelemetry import trace
+                                    from opentelemetry.sdk.trace import TracerProvider
+                                    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+                                    from opentelemetry.sdk.resources import Resource, SERVICE_NAME
+                                    from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+                                    from opentelemetry.instrumentation.openai_v2 import OpenAIInstrumentor
 
-                                    posthog = Posthog(
-                                        "<ph_project_token>",
-                                        host="<ph_client_api_host>"
+                                    resource = Resource(attributes={
+                                        SERVICE_NAME: "my-app",
+                                        "user.id": "user_123", # optional: identifies the user in PostHog
+                                    })
+
+                                    exporter = OTLPSpanExporter(
+                                        endpoint="<ph_client_api_host>/i/v0/ai/otel",
+                                        headers={"Authorization": "Bearer <ph_project_token>"},
                                     )
 
-                                    client = OpenAI(
-                                        base_url="https://api.fireworks.ai/inference/v1",
-                                        api_key="<fireworks_api_key>",
-                                        posthog_client=posthog
-                                    )
+                                    provider = TracerProvider(resource=resource)
+                                    provider.add_span_processor(SimpleSpanProcessor(exporter))
+                                    trace.set_tracer_provider(provider)
+
+                                    OpenAIInstrumentor().instrument()
                                 `,
                             },
                             {
                                 language: 'typescript',
                                 file: 'Node',
                                 code: dedent`
-                                    import { OpenAI } from '@posthog/ai'
-                                    import { PostHog } from 'posthog-node'
+                                    import { NodeSDK, tracing } from '@opentelemetry/sdk-node'
+                                    import { resourceFromAttributes } from '@opentelemetry/resources'
+                                    import { PostHogTraceExporter } from '@posthog/ai/otel'
+                                    import { OpenAIInstrumentation } from '@opentelemetry/instrumentation-openai'
 
-                                    const phClient = new PostHog(
-                                      '<ph_project_token>',
-                                      { host: '<ph_client_api_host>' }
-                                    );
-
-                                    const openai = new OpenAI({
-                                      baseURL: 'https://api.fireworks.ai/inference/v1',
-                                      apiKey: '<fireworks_api_key>',
-                                      posthog: phClient,
-                                    });
-
-                                    // ... your code here ...
-
-                                    // IMPORTANT: Shutdown the client when you're done to ensure all events are sent
-                                    phClient.shutdown()
+                                    const sdk = new NodeSDK({
+                                      resource: resourceFromAttributes({
+                                        'service.name': 'my-app',
+                                        'user.id': 'user_123', // optional: identifies the user in PostHog
+                                      }),
+                                      spanProcessors: [
+                                        new tracing.SimpleSpanProcessor(
+                                          new PostHogTraceExporter({
+                                            apiKey: '<ph_project_token>',
+                                            host: '<ph_client_api_host>',
+                                          })
+                                        ),
+                                      ],
+                                      instrumentations: [new OpenAIInstrumentation()],
+                                    })
+                                    sdk.start()
                                 `,
                             },
                         ]}
                     />
-
-                    <Blockquote>
-                        <Markdown>**Note:** This also works with the `AsyncOpenAI` client.</Markdown>
-                    </Blockquote>
-
-                    <CalloutBox type="fyi" icon="IconInfo" title="Proxy note">
-                        <Markdown>
-                            These SDKs **do not** proxy your calls. They only fire off an async call to PostHog in the
-                            background to send the data. You can also use LLM analytics with other SDKs or our API, but
-                            you will need to capture the data in the right format. See the schema in the [manual capture
-                            section](https://posthog.com/docs/llm-analytics/installation/manual-capture) for more
-                            details.
-                        </Markdown>
-                    </CalloutBox>
                 </>
             ),
         },
@@ -153,9 +121,8 @@ export const getFireworksAISteps = (ctx: OnboardingComponentsContext): StepDefin
             content: (
                 <>
                     <Markdown>
-                        Now, when you call Fireworks AI with the OpenAI SDK, PostHog automatically captures an
-                        `$ai_generation` event. You can also capture or modify additional properties with the distinct
-                        ID, trace ID, properties, groups, and privacy mode parameters.
+                        Now, when you use the OpenAI SDK to call Fireworks AI, PostHog automatically captures
+                        `$ai_generation` events via the OpenTelemetry instrumentation.
                     </Markdown>
 
                     <CodeBlock
@@ -164,16 +131,19 @@ export const getFireworksAISteps = (ctx: OnboardingComponentsContext): StepDefin
                                 language: 'python',
                                 file: 'Python',
                                 code: dedent`
+                                    import openai
+
+                                    client = openai.OpenAI(
+                                        base_url="https://api.fireworks.ai/inference/v1",
+                                        api_key="<fireworks_api_key>",
+                                    )
+
                                     response = client.chat.completions.create(
                                         model="accounts/fireworks/models/llama-v3p3-70b-instruct",
+                                        max_completion_tokens=1024,
                                         messages=[
                                             {"role": "user", "content": "Tell me a fun fact about hedgehogs"}
                                         ],
-                                        posthog_distinct_id="user_123", # optional
-                                        posthog_trace_id="trace_123", # optional
-                                        posthog_properties={"conversation_id": "abc123", "paid": True}, # optional
-                                        posthog_groups={"company": "company_id_in_your_db"},  # optional
-                                        posthog_privacy_mode=False # optional
                                     )
 
                                     print(response.choices[0].message.content)
@@ -183,17 +153,20 @@ export const getFireworksAISteps = (ctx: OnboardingComponentsContext): StepDefin
                                 language: 'typescript',
                                 file: 'Node',
                                 code: dedent`
-                                    const completion = await openai.chat.completions.create({
-                                        model: "accounts/fireworks/models/llama-v3p3-70b-instruct",
-                                        messages: [{ role: "user", content: "Tell me a fun fact about hedgehogs" }],
-                                        posthogDistinctId: "user_123", // optional
-                                        posthogTraceId: "trace_123", // optional
-                                        posthogProperties: { conversation_id: "abc123", paid: true }, // optional
-                                        posthogGroups: { company: "company_id_in_your_db" }, // optional
-                                        posthogPrivacyMode: false // optional
-                                    });
+                                    import OpenAI from 'openai'
 
-                                    console.log(completion.choices[0].message.content)
+                                    const client = new OpenAI({
+                                      baseURL: 'https://api.fireworks.ai/inference/v1',
+                                      apiKey: '<fireworks_api_key>',
+                                    })
+
+                                    const response = await client.chat.completions.create({
+                                      model: 'accounts/fireworks/models/llama-v3p3-70b-instruct',
+                                      max_completion_tokens: 1024,
+                                      messages: [{ role: 'user', content: 'Tell me a fun fact about hedgehogs' }],
+                                    })
+
+                                    console.log(response.choices[0].message.content)
                                 `,
                             },
                         ]}
@@ -201,14 +174,9 @@ export const getFireworksAISteps = (ctx: OnboardingComponentsContext): StepDefin
 
                     <Blockquote>
                         <Markdown>
-                            {dedent`
-                            **Notes:**
-                            - We also support the old \`chat.completions\` API.
-                            - This works with responses where \`stream=True\`.
-                            - If you want to capture LLM events anonymously, **don't** pass a distinct ID to the request.
-
-                            See our docs on [anonymous vs identified events](https://posthog.com/docs/data/anonymous-vs-identified-events) to learn more.
-                            `}
+                            **Note:** If you want to capture LLM events anonymously, omit the `user.id` resource
+                            attribute. See our docs on [anonymous vs identified
+                            events](https://posthog.com/docs/data/anonymous-vs-identified-events) to learn more.
                         </Markdown>
                     </Blockquote>
 

--- a/docs/onboarding/llm-analytics/fireworks-ai.tsx
+++ b/docs/onboarding/llm-analytics/fireworks-ai.tsx
@@ -36,7 +36,7 @@ export const getFireworksAISteps = (ctx: OnboardingComponentsContext): StepDefin
                                 language: 'bash',
                                 file: 'Python',
                                 code: dedent`
-                                    pip install openai opentelemetry-sdk opentelemetry-exporter-otlp-proto-http opentelemetry-instrumentation-openai-v2
+                                    pip install openai opentelemetry-sdk posthog[otel] opentelemetry-instrumentation-openai-v2
                                 `,
                             },
                             {
@@ -69,9 +69,8 @@ export const getFireworksAISteps = (ctx: OnboardingComponentsContext): StepDefin
                                 code: dedent`
                                     from opentelemetry import trace
                                     from opentelemetry.sdk.trace import TracerProvider
-                                    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
                                     from opentelemetry.sdk.resources import Resource, SERVICE_NAME
-                                    from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+                                    from posthog.ai.otel import PostHogSpanProcessor
                                     from opentelemetry.instrumentation.openai_v2 import OpenAIInstrumentor
 
                                     resource = Resource(attributes={
@@ -80,13 +79,13 @@ export const getFireworksAISteps = (ctx: OnboardingComponentsContext): StepDefin
                                         "foo": "bar", # custom properties are passed through
                                     })
 
-                                    exporter = OTLPSpanExporter(
-                                        endpoint="<ph_client_api_host>/i/v0/ai/otel",
-                                        headers={"Authorization": "Bearer <ph_project_token>"},
-                                    )
-
                                     provider = TracerProvider(resource=resource)
-                                    provider.add_span_processor(SimpleSpanProcessor(exporter))
+                                    provider.add_span_processor(
+                                        PostHogSpanProcessor(
+                                            api_key="<ph_project_token>",
+                                            host="<ph_client_api_host>",
+                                        )
+                                    )
                                     trace.set_tracer_provider(provider)
 
                                     OpenAIInstrumentor().instrument()

--- a/docs/onboarding/llm-analytics/fireworks-ai.tsx
+++ b/docs/onboarding/llm-analytics/fireworks-ai.tsx
@@ -96,9 +96,9 @@ export const getFireworksAISteps = (ctx: OnboardingComponentsContext): StepDefin
                                 language: 'typescript',
                                 file: 'Node',
                                 code: dedent`
-                                    import { NodeSDK, tracing } from '@opentelemetry/sdk-node'
+                                    import { NodeSDK } from '@opentelemetry/sdk-node'
                                     import { resourceFromAttributes } from '@opentelemetry/resources'
-                                    import { PostHogTraceExporter } from '@posthog/ai/otel'
+                                    import { PostHogSpanProcessor } from '@posthog/ai/otel'
                                     import { OpenAIInstrumentation } from '@opentelemetry/instrumentation-openai'
 
                                     const sdk = new NodeSDK({
@@ -108,12 +108,10 @@ export const getFireworksAISteps = (ctx: OnboardingComponentsContext): StepDefin
                                         foo: 'bar', // custom properties are passed through
                                       }),
                                       spanProcessors: [
-                                        new tracing.SimpleSpanProcessor(
-                                          new PostHogTraceExporter({
-                                            apiKey: '<ph_project_token>',
-                                            host: '<ph_client_api_host>',
-                                          })
-                                        ),
+                                        new PostHogSpanProcessor({
+                                          apiKey: '<ph_project_token>',
+                                          host: '<ph_client_api_host>',
+                                        }),
                                       ],
                                       instrumentations: [new OpenAIInstrumentation()],
                                     })

--- a/docs/onboarding/llm-analytics/groq.tsx
+++ b/docs/onboarding/llm-analytics/groq.tsx
@@ -9,14 +9,11 @@ export const getGroqSteps = (ctx: OnboardingComponentsContext): StepDefinition[]
 
     return [
         {
-            title: 'Install the PostHog SDK',
+            title: 'Install dependencies',
             badge: 'required',
             content: (
                 <>
-                    <Markdown>
-                        Setting up analytics starts with installing the PostHog SDK for your language. LLM analytics
-                        works best with our Python and Node SDKs.
-                    </Markdown>
+                    <Markdown>Install the OpenTelemetry SDK, the OpenAI instrumentation, and the OpenAI SDK.</Markdown>
 
                     <CodeBlock
                         blocks={[
@@ -24,62 +21,36 @@ export const getGroqSteps = (ctx: OnboardingComponentsContext): StepDefinition[]
                                 language: 'bash',
                                 file: 'Python',
                                 code: dedent`
-                                    pip install posthog
+                                    pip install openai opentelemetry-sdk opentelemetry-exporter-otlp-proto-http opentelemetry-instrumentation-openai-v2
                                 `,
                             },
                             {
                                 language: 'bash',
                                 file: 'Node',
                                 code: dedent`
-                                    npm install @posthog/ai posthog-node
+                                    npm install openai @posthog/ai @opentelemetry/sdk-node @opentelemetry/resources @opentelemetry/instrumentation-openai
                                 `,
                             },
                         ]}
                     />
-                </>
-            ),
-        },
-        {
-            title: 'Install the OpenAI SDK',
-            badge: 'required',
-            content: (
-                <>
-                    <Markdown>
-                        Install the OpenAI SDK. The PostHog SDK instruments your LLM calls by wrapping the OpenAI
-                        client. The PostHog SDK **does not** proxy your calls.
-                    </Markdown>
 
-                    <CodeBlock
-                        blocks={[
-                            {
-                                language: 'bash',
-                                file: 'Python',
-                                code: dedent`
-                                    pip install openai
-                                `,
-                            },
-                            {
-                                language: 'bash',
-                                file: 'Node',
-                                code: dedent`
-                                    npm install openai
-                                `,
-                            },
-                        ]}
-                    />
+                    <CalloutBox type="fyi" icon="IconInfo" title="No proxy">
+                        <Markdown>
+                            These SDKs **do not** proxy your calls. They only send analytics data to PostHog in the
+                            background.
+                        </Markdown>
+                    </CalloutBox>
                 </>
             ),
         },
         {
-            title: 'Initialize PostHog and OpenAI client',
+            title: 'Set up OpenTelemetry tracing',
             badge: 'required',
             content: (
                 <>
                     <Markdown>
-                        We call Groq through the OpenAI client and generate a response. We'll use PostHog's OpenAI
-                        provider to capture all the details of the call. Initialize PostHog with your PostHog project
-                        token and host from [your project settings](https://app.posthog.com/settings/project), then pass
-                        the PostHog client along with the Groq config (the base URL and API key) to our OpenAI wrapper.
+                        Configure OpenTelemetry to auto-instrument OpenAI SDK calls and export traces to PostHog.
+                        PostHog converts `gen_ai.*` spans into `$ai_generation` events automatically.
                     </Markdown>
 
                     <CodeBlock
@@ -88,61 +59,59 @@ export const getGroqSteps = (ctx: OnboardingComponentsContext): StepDefinition[]
                                 language: 'python',
                                 file: 'Python',
                                 code: dedent`
-                                    from posthog.ai.openai import OpenAI
-                                    from posthog import Posthog
+                                    from opentelemetry import trace
+                                    from opentelemetry.sdk.trace import TracerProvider
+                                    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+                                    from opentelemetry.sdk.resources import Resource, SERVICE_NAME
+                                    from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+                                    from opentelemetry.instrumentation.openai_v2 import OpenAIInstrumentor
 
-                                    posthog = Posthog(
-                                        "<ph_project_token>",
-                                        host="<ph_client_api_host>"
+                                    resource = Resource(attributes={
+                                        SERVICE_NAME: "my-app",
+                                        "user.id": "user_123", # optional: identifies the user in PostHog
+                                    })
+
+                                    exporter = OTLPSpanExporter(
+                                        endpoint="<ph_client_api_host>/i/v0/ai/otel",
+                                        headers={"Authorization": "Bearer <ph_project_token>"},
                                     )
 
-                                    client = OpenAI(
-                                        base_url="https://api.groq.com/openai/v1",
-                                        api_key="<groq_api_key>",
-                                        posthog_client=posthog
-                                    )
+                                    provider = TracerProvider(resource=resource)
+                                    provider.add_span_processor(SimpleSpanProcessor(exporter))
+                                    trace.set_tracer_provider(provider)
+
+                                    OpenAIInstrumentor().instrument()
                                 `,
                             },
                             {
                                 language: 'typescript',
                                 file: 'Node',
                                 code: dedent`
-                                    import { OpenAI } from '@posthog/ai'
-                                    import { PostHog } from 'posthog-node'
+                                    import { NodeSDK, tracing } from '@opentelemetry/sdk-node'
+                                    import { resourceFromAttributes } from '@opentelemetry/resources'
+                                    import { PostHogTraceExporter } from '@posthog/ai/otel'
+                                    import { OpenAIInstrumentation } from '@opentelemetry/instrumentation-openai'
 
-                                    const phClient = new PostHog(
-                                      '<ph_project_token>',
-                                      { host: '<ph_client_api_host>' }
-                                    );
-
-                                    const openai = new OpenAI({
-                                      baseURL: 'https://api.groq.com/openai/v1',
-                                      apiKey: '<groq_api_key>',
-                                      posthog: phClient,
-                                    });
-
-                                    // ... your code here ...
-
-                                    // IMPORTANT: Shutdown the client when you're done to ensure all events are sent
-                                    phClient.shutdown()
+                                    const sdk = new NodeSDK({
+                                      resource: resourceFromAttributes({
+                                        'service.name': 'my-app',
+                                        'user.id': 'user_123', // optional: identifies the user in PostHog
+                                      }),
+                                      spanProcessors: [
+                                        new tracing.SimpleSpanProcessor(
+                                          new PostHogTraceExporter({
+                                            apiKey: '<ph_project_token>',
+                                            host: '<ph_client_api_host>',
+                                          })
+                                        ),
+                                      ],
+                                      instrumentations: [new OpenAIInstrumentation()],
+                                    })
+                                    sdk.start()
                                 `,
                             },
                         ]}
                     />
-
-                    <Blockquote>
-                        <Markdown>**Note:** This also works with the `AsyncOpenAI` client.</Markdown>
-                    </Blockquote>
-
-                    <CalloutBox type="fyi" icon="IconInfo" title="Proxy note">
-                        <Markdown>
-                            These SDKs **do not** proxy your calls. They only fire off an async call to PostHog in the
-                            background to send the data. You can also use LLM analytics with other SDKs or our API, but
-                            you will need to capture the data in the right format. See the schema in the [manual capture
-                            section](https://posthog.com/docs/llm-analytics/installation/manual-capture) for more
-                            details.
-                        </Markdown>
-                    </CalloutBox>
                 </>
             ),
         },
@@ -152,9 +121,8 @@ export const getGroqSteps = (ctx: OnboardingComponentsContext): StepDefinition[]
             content: (
                 <>
                     <Markdown>
-                        Now, when you call Groq with the OpenAI SDK, PostHog automatically captures an `$ai_generation`
-                        event. You can also capture or modify additional properties with the distinct ID, trace ID,
-                        properties, groups, and privacy mode parameters.
+                        Now, when you use the OpenAI SDK to call Groq, PostHog automatically captures `$ai_generation`
+                        events via the OpenTelemetry instrumentation.
                     </Markdown>
 
                     <CodeBlock
@@ -163,16 +131,19 @@ export const getGroqSteps = (ctx: OnboardingComponentsContext): StepDefinition[]
                                 language: 'python',
                                 file: 'Python',
                                 code: dedent`
+                                    import openai
+
+                                    client = openai.OpenAI(
+                                        base_url="https://api.groq.com/openai/v1",
+                                        api_key="<groq_api_key>",
+                                    )
+
                                     response = client.chat.completions.create(
                                         model="llama-3.3-70b-versatile",
+                                        max_completion_tokens=1024,
                                         messages=[
                                             {"role": "user", "content": "Tell me a fun fact about hedgehogs"}
                                         ],
-                                        posthog_distinct_id="user_123", # optional
-                                        posthog_trace_id="trace_123", # optional
-                                        posthog_properties={"conversation_id": "abc123", "paid": True}, # optional
-                                        posthog_groups={"company": "company_id_in_your_db"},  # optional
-                                        posthog_privacy_mode=False # optional
                                     )
 
                                     print(response.choices[0].message.content)
@@ -182,17 +153,20 @@ export const getGroqSteps = (ctx: OnboardingComponentsContext): StepDefinition[]
                                 language: 'typescript',
                                 file: 'Node',
                                 code: dedent`
-                                    const completion = await openai.chat.completions.create({
-                                        model: "llama-3.3-70b-versatile",
-                                        messages: [{ role: "user", content: "Tell me a fun fact about hedgehogs" }],
-                                        posthogDistinctId: "user_123", // optional
-                                        posthogTraceId: "trace_123", // optional
-                                        posthogProperties: { conversation_id: "abc123", paid: true }, // optional
-                                        posthogGroups: { company: "company_id_in_your_db" }, // optional
-                                        posthogPrivacyMode: false // optional
-                                    });
+                                    import OpenAI from 'openai'
 
-                                    console.log(completion.choices[0].message.content)
+                                    const client = new OpenAI({
+                                      baseURL: 'https://api.groq.com/openai/v1',
+                                      apiKey: '<groq_api_key>',
+                                    })
+
+                                    const response = await client.chat.completions.create({
+                                      model: 'llama-3.3-70b-versatile',
+                                      max_completion_tokens: 1024,
+                                      messages: [{ role: 'user', content: 'Tell me a fun fact about hedgehogs' }],
+                                    })
+
+                                    console.log(response.choices[0].message.content)
                                 `,
                             },
                         ]}
@@ -200,14 +174,9 @@ export const getGroqSteps = (ctx: OnboardingComponentsContext): StepDefinition[]
 
                     <Blockquote>
                         <Markdown>
-                            {dedent`
-                            **Notes:**
-                            - We also support the old \`chat.completions\` API.
-                            - This works with responses where \`stream=True\`.
-                            - If you want to capture LLM events anonymously, **don't** pass a distinct ID to the request.
-
-                            See our docs on [anonymous vs identified events](https://posthog.com/docs/data/anonymous-vs-identified-events) to learn more.
-                            `}
+                            **Note:** If you want to capture LLM events anonymously, omit the `user.id` resource
+                            attribute. See our docs on [anonymous vs identified
+                            events](https://posthog.com/docs/data/anonymous-vs-identified-events) to learn more.
                         </Markdown>
                     </Blockquote>
 

--- a/docs/onboarding/llm-analytics/groq.tsx
+++ b/docs/onboarding/llm-analytics/groq.tsx
@@ -3,7 +3,7 @@ import { OnboardingComponentsContext, createInstallation } from 'scenes/onboardi
 import { StepDefinition } from '../steps'
 
 export const getGroqSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
-    const { CodeBlock, Markdown, Blockquote, dedent, snippets } = ctx
+    const { CodeBlock, CalloutBox, Markdown, Blockquote, dedent, snippets } = ctx
 
     const NotableGenerationProperties = snippets?.NotableGenerationProperties
 
@@ -13,6 +13,16 @@ export const getGroqSteps = (ctx: OnboardingComponentsContext): StepDefinition[]
             badge: 'required',
             content: (
                 <>
+                    <CalloutBox type="info" icon="IconInfo" title="Migrating from the SDK wrapper?">
+                        <Markdown>
+                            These docs now use OpenTelemetry auto-instrumentation, which is the recommended approach.
+                            The previous PostHog SDK wrapper is still available — see the
+                            [Node.js](https://github.com/PostHog/posthog-js/tree/e08ff1be/examples/example-ai-groq) and
+                            [Python](https://github.com/PostHog/posthog-python/tree/7223c52/examples/example-ai-groq)
+                            wrapper examples.
+                        </Markdown>
+                    </CalloutBox>
+
                     <Markdown>Install the OpenTelemetry SDK, the OpenAI instrumentation, and the OpenAI SDK.</Markdown>
 
                     <CodeBlock

--- a/docs/onboarding/llm-analytics/groq.tsx
+++ b/docs/onboarding/llm-analytics/groq.tsx
@@ -61,7 +61,8 @@ export const getGroqSteps = (ctx: OnboardingComponentsContext): StepDefinition[]
 
                                     resource = Resource(attributes={
                                         SERVICE_NAME: "my-app",
-                                        "user.id": "user_123", # optional: identifies the user in PostHog
+                                        "posthog.distinct_id": "user_123", # optional: identifies the user in PostHog
+                                        "foo": "bar", # custom properties are passed through
                                     })
 
                                     exporter = OTLPSpanExporter(
@@ -88,7 +89,8 @@ export const getGroqSteps = (ctx: OnboardingComponentsContext): StepDefinition[]
                                     const sdk = new NodeSDK({
                                       resource: resourceFromAttributes({
                                         'service.name': 'my-app',
-                                        'user.id': 'user_123', // optional: identifies the user in PostHog
+                                        'posthog.distinct_id': 'user_123', // optional: identifies the user in PostHog
+                                        foo: 'bar', // custom properties are passed through
                                       }),
                                       spanProcessors: [
                                         new tracing.SimpleSpanProcessor(
@@ -167,8 +169,8 @@ export const getGroqSteps = (ctx: OnboardingComponentsContext): StepDefinition[]
 
                     <Blockquote>
                         <Markdown>
-                            **Note:** If you want to capture LLM events anonymously, omit the `user.id` resource
-                            attribute. See our docs on [anonymous vs identified
+                            **Note:** If you want to capture LLM events anonymously, omit the `posthog.distinct_id`
+                            resource attribute. See our docs on [anonymous vs identified
                             events](https://posthog.com/docs/data/anonymous-vs-identified-events) to learn more.
                         </Markdown>
                     </Blockquote>

--- a/docs/onboarding/llm-analytics/groq.tsx
+++ b/docs/onboarding/llm-analytics/groq.tsx
@@ -3,7 +3,7 @@ import { OnboardingComponentsContext, createInstallation } from 'scenes/onboardi
 import { StepDefinition } from '../steps'
 
 export const getGroqSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
-    const { CodeBlock, CalloutBox, Markdown, Blockquote, dedent, snippets } = ctx
+    const { CodeBlock, Markdown, Blockquote, dedent, snippets } = ctx
 
     const NotableGenerationProperties = snippets?.NotableGenerationProperties
 
@@ -33,13 +33,6 @@ export const getGroqSteps = (ctx: OnboardingComponentsContext): StepDefinition[]
                             },
                         ]}
                     />
-
-                    <CalloutBox type="fyi" icon="IconInfo" title="No proxy">
-                        <Markdown>
-                            These SDKs **do not** proxy your calls. They only send analytics data to PostHog in the
-                            background.
-                        </Markdown>
-                    </CalloutBox>
                 </>
             ),
         },

--- a/docs/onboarding/llm-analytics/groq.tsx
+++ b/docs/onboarding/llm-analytics/groq.tsx
@@ -13,13 +13,17 @@ export const getGroqSteps = (ctx: OnboardingComponentsContext): StepDefinition[]
             badge: 'required',
             content: (
                 <>
-                    <CalloutBox type="info" icon="IconInfo" title="Migrating from the SDK wrapper?">
+                    <CalloutBox type="info" icon="IconInfo" title="Full working examples">
                         <Markdown>
-                            These docs now use OpenTelemetry auto-instrumentation, which is the recommended approach.
-                            The previous PostHog SDK wrapper is still available — see the
-                            [Node.js](https://github.com/PostHog/posthog-js/tree/e08ff1be/examples/example-ai-groq) and
-                            [Python](https://github.com/PostHog/posthog-python/tree/7223c52/examples/example-ai-groq)
-                            wrapper examples.
+                            See the complete
+                            [Node.js](https://github.com/PostHog/posthog-js/tree/main/examples/example-ai-groq) and
+                            [Python](https://github.com/PostHog/posthog-python/tree/master/examples/example-ai-groq)
+                            examples on GitHub. If you're using the PostHog SDK wrapper instead of OpenTelemetry, see
+                            the [Node.js
+                            wrapper](https://github.com/PostHog/posthog-js/tree/e08ff1be/examples/example-ai-groq) and
+                            [Python
+                            wrapper](https://github.com/PostHog/posthog-python/tree/7223c52/examples/example-ai-groq)
+                            examples.
                         </Markdown>
                     </CalloutBox>
 

--- a/docs/onboarding/llm-analytics/groq.tsx
+++ b/docs/onboarding/llm-analytics/groq.tsx
@@ -95,9 +95,9 @@ export const getGroqSteps = (ctx: OnboardingComponentsContext): StepDefinition[]
                                 language: 'typescript',
                                 file: 'Node',
                                 code: dedent`
-                                    import { NodeSDK, tracing } from '@opentelemetry/sdk-node'
+                                    import { NodeSDK } from '@opentelemetry/sdk-node'
                                     import { resourceFromAttributes } from '@opentelemetry/resources'
-                                    import { PostHogTraceExporter } from '@posthog/ai/otel'
+                                    import { PostHogSpanProcessor } from '@posthog/ai/otel'
                                     import { OpenAIInstrumentation } from '@opentelemetry/instrumentation-openai'
 
                                     const sdk = new NodeSDK({
@@ -107,12 +107,10 @@ export const getGroqSteps = (ctx: OnboardingComponentsContext): StepDefinition[]
                                         foo: 'bar', // custom properties are passed through
                                       }),
                                       spanProcessors: [
-                                        new tracing.SimpleSpanProcessor(
-                                          new PostHogTraceExporter({
-                                            apiKey: '<ph_project_token>',
-                                            host: '<ph_client_api_host>',
-                                          })
-                                        ),
+                                        new PostHogSpanProcessor({
+                                          apiKey: '<ph_project_token>',
+                                          host: '<ph_client_api_host>',
+                                        }),
                                       ],
                                       instrumentations: [new OpenAIInstrumentation()],
                                     })

--- a/docs/onboarding/llm-analytics/groq.tsx
+++ b/docs/onboarding/llm-analytics/groq.tsx
@@ -35,7 +35,7 @@ export const getGroqSteps = (ctx: OnboardingComponentsContext): StepDefinition[]
                                 language: 'bash',
                                 file: 'Python',
                                 code: dedent`
-                                    pip install openai opentelemetry-sdk opentelemetry-exporter-otlp-proto-http opentelemetry-instrumentation-openai-v2
+                                    pip install openai opentelemetry-sdk posthog[otel] opentelemetry-instrumentation-openai-v2
                                 `,
                             },
                             {
@@ -68,9 +68,8 @@ export const getGroqSteps = (ctx: OnboardingComponentsContext): StepDefinition[]
                                 code: dedent`
                                     from opentelemetry import trace
                                     from opentelemetry.sdk.trace import TracerProvider
-                                    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
                                     from opentelemetry.sdk.resources import Resource, SERVICE_NAME
-                                    from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+                                    from posthog.ai.otel import PostHogSpanProcessor
                                     from opentelemetry.instrumentation.openai_v2 import OpenAIInstrumentor
 
                                     resource = Resource(attributes={
@@ -79,13 +78,13 @@ export const getGroqSteps = (ctx: OnboardingComponentsContext): StepDefinition[]
                                         "foo": "bar", # custom properties are passed through
                                     })
 
-                                    exporter = OTLPSpanExporter(
-                                        endpoint="<ph_client_api_host>/i/v0/ai/otel",
-                                        headers={"Authorization": "Bearer <ph_project_token>"},
-                                    )
-
                                     provider = TracerProvider(resource=resource)
-                                    provider.add_span_processor(SimpleSpanProcessor(exporter))
+                                    provider.add_span_processor(
+                                        PostHogSpanProcessor(
+                                            api_key="<ph_project_token>",
+                                            host="<ph_client_api_host>",
+                                        )
+                                    )
                                     trace.set_tracer_provider(provider)
 
                                     OpenAIInstrumentor().instrument()

--- a/docs/onboarding/llm-analytics/helicone.tsx
+++ b/docs/onboarding/llm-analytics/helicone.tsx
@@ -9,7 +9,7 @@ export const getHeliconeSteps = (ctx: OnboardingComponentsContext): StepDefiniti
 
     return [
         {
-            title: 'Install the PostHog SDK',
+            title: 'Install dependencies',
             badge: 'required',
             content: (
                 <>
@@ -21,10 +21,7 @@ export const getHeliconeSteps = (ctx: OnboardingComponentsContext): StepDefiniti
                         </Markdown>
                     </CalloutBox>
 
-                    <Markdown>
-                        Setting up analytics starts with installing the PostHog SDK for your language. LLM analytics
-                        works best with our Python and Node SDKs.
-                    </Markdown>
+                    <Markdown>Install the OpenTelemetry SDK, the OpenAI instrumentation, and the OpenAI SDK.</Markdown>
 
                     <CodeBlock
                         blocks={[
@@ -32,63 +29,36 @@ export const getHeliconeSteps = (ctx: OnboardingComponentsContext): StepDefiniti
                                 language: 'bash',
                                 file: 'Python',
                                 code: dedent`
-                                    pip install posthog
+                                    pip install openai opentelemetry-sdk opentelemetry-exporter-otlp-proto-http opentelemetry-instrumentation-openai-v2
                                 `,
                             },
                             {
                                 language: 'bash',
                                 file: 'Node',
                                 code: dedent`
-                                    npm install @posthog/ai posthog-node
+                                    npm install openai @posthog/ai @opentelemetry/sdk-node @opentelemetry/resources @opentelemetry/instrumentation-openai
                                 `,
                             },
                         ]}
                     />
-                </>
-            ),
-        },
-        {
-            title: 'Install the OpenAI SDK',
-            badge: 'required',
-            content: (
-                <>
-                    <Markdown>
-                        Install the OpenAI SDK. The PostHog SDK instruments your LLM calls by wrapping the OpenAI
-                        client. The PostHog SDK **does not** proxy your calls.
-                    </Markdown>
 
-                    <CodeBlock
-                        blocks={[
-                            {
-                                language: 'bash',
-                                file: 'Python',
-                                code: dedent`
-                                    pip install openai
-                                `,
-                            },
-                            {
-                                language: 'bash',
-                                file: 'Node',
-                                code: dedent`
-                                    npm install openai
-                                `,
-                            },
-                        ]}
-                    />
+                    <CalloutBox type="fyi" icon="IconInfo" title="No proxy">
+                        <Markdown>
+                            These SDKs **do not** proxy your calls. They only send analytics data to PostHog in the
+                            background.
+                        </Markdown>
+                    </CalloutBox>
                 </>
             ),
         },
         {
-            title: 'Initialize PostHog and OpenAI client',
+            title: 'Set up OpenTelemetry tracing',
             badge: 'required',
             content: (
                 <>
                     <Markdown>
-                        We call Helicone through the OpenAI client and generate a response. We'll use PostHog's OpenAI
-                        provider to capture all the details of the call. Initialize PostHog with your PostHog project
-                        token and host from [your project settings](https://app.posthog.com/settings/project), then pass
-                        the PostHog client along with the Helicone config (the base URL and API key) to our OpenAI
-                        wrapper.
+                        Configure OpenTelemetry to auto-instrument OpenAI SDK calls and export traces to PostHog.
+                        PostHog converts `gen_ai.*` spans into `$ai_generation` events automatically.
                     </Markdown>
 
                     <CodeBlock
@@ -97,61 +67,59 @@ export const getHeliconeSteps = (ctx: OnboardingComponentsContext): StepDefiniti
                                 language: 'python',
                                 file: 'Python',
                                 code: dedent`
-                                    from posthog.ai.openai import OpenAI
-                                    from posthog import Posthog
+                                    from opentelemetry import trace
+                                    from opentelemetry.sdk.trace import TracerProvider
+                                    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+                                    from opentelemetry.sdk.resources import Resource, SERVICE_NAME
+                                    from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+                                    from opentelemetry.instrumentation.openai_v2 import OpenAIInstrumentor
 
-                                    posthog = Posthog(
-                                        "<ph_project_token>",
-                                        host="<ph_client_api_host>"
+                                    resource = Resource(attributes={
+                                        SERVICE_NAME: "my-app",
+                                        "user.id": "user_123", # optional: identifies the user in PostHog
+                                    })
+
+                                    exporter = OTLPSpanExporter(
+                                        endpoint="<ph_client_api_host>/i/v0/ai/otel",
+                                        headers={"Authorization": "Bearer <ph_project_token>"},
                                     )
 
-                                    client = OpenAI(
-                                        base_url="https://ai-gateway.helicone.ai/",
-                                        api_key="<helicone_api_key>",
-                                        posthog_client=posthog
-                                    )
+                                    provider = TracerProvider(resource=resource)
+                                    provider.add_span_processor(SimpleSpanProcessor(exporter))
+                                    trace.set_tracer_provider(provider)
+
+                                    OpenAIInstrumentor().instrument()
                                 `,
                             },
                             {
                                 language: 'typescript',
                                 file: 'Node',
                                 code: dedent`
-                                    import { OpenAI } from '@posthog/ai'
-                                    import { PostHog } from 'posthog-node'
+                                    import { NodeSDK, tracing } from '@opentelemetry/sdk-node'
+                                    import { resourceFromAttributes } from '@opentelemetry/resources'
+                                    import { PostHogTraceExporter } from '@posthog/ai/otel'
+                                    import { OpenAIInstrumentation } from '@opentelemetry/instrumentation-openai'
 
-                                    const phClient = new PostHog(
-                                      '<ph_project_token>',
-                                      { host: '<ph_client_api_host>' }
-                                    );
-
-                                    const openai = new OpenAI({
-                                      baseURL: 'https://ai-gateway.helicone.ai/',
-                                      apiKey: '<helicone_api_key>',
-                                      posthog: phClient,
-                                    });
-
-                                    // ... your code here ...
-
-                                    // IMPORTANT: Shutdown the client when you're done to ensure all events are sent
-                                    phClient.shutdown()
+                                    const sdk = new NodeSDK({
+                                      resource: resourceFromAttributes({
+                                        'service.name': 'my-app',
+                                        'user.id': 'user_123', // optional: identifies the user in PostHog
+                                      }),
+                                      spanProcessors: [
+                                        new tracing.SimpleSpanProcessor(
+                                          new PostHogTraceExporter({
+                                            apiKey: '<ph_project_token>',
+                                            host: '<ph_client_api_host>',
+                                          })
+                                        ),
+                                      ],
+                                      instrumentations: [new OpenAIInstrumentation()],
+                                    })
+                                    sdk.start()
                                 `,
                             },
                         ]}
                     />
-
-                    <Blockquote>
-                        <Markdown>**Note:** This also works with the `AsyncOpenAI` client.</Markdown>
-                    </Blockquote>
-
-                    <CalloutBox type="fyi" icon="IconInfo" title="Proxy note">
-                        <Markdown>
-                            These SDKs **do not** proxy your calls. They only fire off an async call to PostHog in the
-                            background to send the data. You can also use LLM analytics with other SDKs or our API, but
-                            you will need to capture the data in the right format. See the schema in the [manual capture
-                            section](https://posthog.com/docs/llm-analytics/installation/manual-capture) for more
-                            details.
-                        </Markdown>
-                    </CalloutBox>
                 </>
             ),
         },
@@ -161,9 +129,8 @@ export const getHeliconeSteps = (ctx: OnboardingComponentsContext): StepDefiniti
             content: (
                 <>
                     <Markdown>
-                        Now, when you call Helicone with the OpenAI SDK, PostHog automatically captures an
-                        `$ai_generation` event. You can also capture or modify additional properties with the distinct
-                        ID, trace ID, properties, groups, and privacy mode parameters.
+                        Now, when you call Helicone with the OpenAI SDK, PostHog automatically captures `$ai_generation`
+                        events via the OpenTelemetry instrumentation.
                     </Markdown>
 
                     <CodeBlock
@@ -172,16 +139,18 @@ export const getHeliconeSteps = (ctx: OnboardingComponentsContext): StepDefiniti
                                 language: 'python',
                                 file: 'Python',
                                 code: dedent`
+                                    import openai
+
+                                    client = openai.OpenAI(
+                                        base_url="https://ai-gateway.helicone.ai/",
+                                        api_key="<helicone_api_key>",
+                                    )
+
                                     response = client.chat.completions.create(
                                         model="gpt-5-mini",
                                         messages=[
                                             {"role": "user", "content": "Tell me a fun fact about hedgehogs"}
                                         ],
-                                        posthog_distinct_id="user_123", # optional
-                                        posthog_trace_id="trace_123", # optional
-                                        posthog_properties={"conversation_id": "abc123", "paid": True}, # optional
-                                        posthog_groups={"company": "company_id_in_your_db"},  # optional
-                                        posthog_privacy_mode=False # optional
                                     )
 
                                     print(response.choices[0].message.content)
@@ -191,17 +160,19 @@ export const getHeliconeSteps = (ctx: OnboardingComponentsContext): StepDefiniti
                                 language: 'typescript',
                                 file: 'Node',
                                 code: dedent`
-                                    const completion = await openai.chat.completions.create({
-                                        model: "gpt-5-mini",
-                                        messages: [{ role: "user", content: "Tell me a fun fact about hedgehogs" }],
-                                        posthogDistinctId: "user_123", // optional
-                                        posthogTraceId: "trace_123", // optional
-                                        posthogProperties: { conversation_id: "abc123", paid: true }, // optional
-                                        posthogGroups: { company: "company_id_in_your_db" }, // optional
-                                        posthogPrivacyMode: false // optional
-                                    });
+                                    import OpenAI from 'openai'
 
-                                    console.log(completion.choices[0].message.content)
+                                    const client = new OpenAI({
+                                      baseURL: 'https://ai-gateway.helicone.ai/',
+                                      apiKey: '<helicone_api_key>',
+                                    })
+
+                                    const response = await client.chat.completions.create({
+                                      model: 'gpt-5-mini',
+                                      messages: [{ role: 'user', content: 'Tell me a fun fact about hedgehogs' }],
+                                    })
+
+                                    console.log(response.choices[0].message.content)
                                 `,
                             },
                         ]}
@@ -209,14 +180,9 @@ export const getHeliconeSteps = (ctx: OnboardingComponentsContext): StepDefiniti
 
                     <Blockquote>
                         <Markdown>
-                            {dedent`
-                            **Notes:**
-                            - We also support the old \`chat.completions\` API.
-                            - This works with responses where \`stream=True\`.
-                            - If you want to capture LLM events anonymously, **don't** pass a distinct ID to the request.
-
-                            See our docs on [anonymous vs identified events](https://posthog.com/docs/data/anonymous-vs-identified-events) to learn more.
-                            `}
+                            **Note:** If you want to capture LLM events anonymously, omit the `user.id` resource
+                            attribute. See our docs on [anonymous vs identified
+                            events](https://posthog.com/docs/data/anonymous-vs-identified-events) to learn more.
                         </Markdown>
                     </Blockquote>
 

--- a/docs/onboarding/llm-analytics/helicone.tsx
+++ b/docs/onboarding/llm-analytics/helicone.tsx
@@ -41,13 +41,6 @@ export const getHeliconeSteps = (ctx: OnboardingComponentsContext): StepDefiniti
                             },
                         ]}
                     />
-
-                    <CalloutBox type="fyi" icon="IconInfo" title="No proxy">
-                        <Markdown>
-                            These SDKs **do not** proxy your calls. They only send analytics data to PostHog in the
-                            background.
-                        </Markdown>
-                    </CalloutBox>
                 </>
             ),
         },

--- a/docs/onboarding/llm-analytics/helicone.tsx
+++ b/docs/onboarding/llm-analytics/helicone.tsx
@@ -13,14 +13,17 @@ export const getHeliconeSteps = (ctx: OnboardingComponentsContext): StepDefiniti
             badge: 'required',
             content: (
                 <>
-                    <CalloutBox type="info" icon="IconInfo" title="Migrating from the SDK wrapper?">
+                    <CalloutBox type="info" icon="IconInfo" title="Full working examples">
                         <Markdown>
-                            These docs now use OpenTelemetry auto-instrumentation, which is the recommended approach.
-                            The previous PostHog SDK wrapper is still available — see the
-                            [Node.js](https://github.com/PostHog/posthog-js/tree/e08ff1be/examples/example-ai-helicone)
-                            and
-                            [Python](https://github.com/PostHog/posthog-python/tree/7223c52/examples/example-ai-helicone)
-                            wrapper examples.
+                            See the complete
+                            [Node.js](https://github.com/PostHog/posthog-js/tree/main/examples/example-ai-helicone) and
+                            [Python](https://github.com/PostHog/posthog-python/tree/master/examples/example-ai-helicone)
+                            examples on GitHub. If you're using the PostHog SDK wrapper instead of OpenTelemetry, see
+                            the [Node.js
+                            wrapper](https://github.com/PostHog/posthog-js/tree/e08ff1be/examples/example-ai-helicone)
+                            and [Python
+                            wrapper](https://github.com/PostHog/posthog-python/tree/7223c52/examples/example-ai-helicone)
+                            examples.
                         </Markdown>
                     </CalloutBox>
 

--- a/docs/onboarding/llm-analytics/helicone.tsx
+++ b/docs/onboarding/llm-analytics/helicone.tsx
@@ -13,6 +13,17 @@ export const getHeliconeSteps = (ctx: OnboardingComponentsContext): StepDefiniti
             badge: 'required',
             content: (
                 <>
+                    <CalloutBox type="info" icon="IconInfo" title="Migrating from the SDK wrapper?">
+                        <Markdown>
+                            These docs now use OpenTelemetry auto-instrumentation, which is the recommended approach.
+                            The previous PostHog SDK wrapper is still available — see the
+                            [Node.js](https://github.com/PostHog/posthog-js/tree/e08ff1be/examples/example-ai-helicone)
+                            and
+                            [Python](https://github.com/PostHog/posthog-python/tree/7223c52/examples/example-ai-helicone)
+                            wrapper examples.
+                        </Markdown>
+                    </CalloutBox>
+
                     <CalloutBox type="fyi" icon="IconInfo" title="About Helicone">
                         <Markdown>
                             Helicone is an open-source AI gateway that provides access to 100+ LLM providers through an

--- a/docs/onboarding/llm-analytics/helicone.tsx
+++ b/docs/onboarding/llm-analytics/helicone.tsx
@@ -69,7 +69,8 @@ export const getHeliconeSteps = (ctx: OnboardingComponentsContext): StepDefiniti
 
                                     resource = Resource(attributes={
                                         SERVICE_NAME: "my-app",
-                                        "user.id": "user_123", # optional: identifies the user in PostHog
+                                        "posthog.distinct_id": "user_123", # optional: identifies the user in PostHog
+                                        "foo": "bar", # custom properties are passed through
                                     })
 
                                     exporter = OTLPSpanExporter(
@@ -96,7 +97,8 @@ export const getHeliconeSteps = (ctx: OnboardingComponentsContext): StepDefiniti
                                     const sdk = new NodeSDK({
                                       resource: resourceFromAttributes({
                                         'service.name': 'my-app',
-                                        'user.id': 'user_123', // optional: identifies the user in PostHog
+                                        'posthog.distinct_id': 'user_123', // optional: identifies the user in PostHog
+                                        foo: 'bar', // custom properties are passed through
                                       }),
                                       spanProcessors: [
                                         new tracing.SimpleSpanProcessor(
@@ -173,8 +175,8 @@ export const getHeliconeSteps = (ctx: OnboardingComponentsContext): StepDefiniti
 
                     <Blockquote>
                         <Markdown>
-                            **Note:** If you want to capture LLM events anonymously, omit the `user.id` resource
-                            attribute. See our docs on [anonymous vs identified
+                            **Note:** If you want to capture LLM events anonymously, omit the `posthog.distinct_id`
+                            resource attribute. See our docs on [anonymous vs identified
                             events](https://posthog.com/docs/data/anonymous-vs-identified-events) to learn more.
                         </Markdown>
                     </Blockquote>

--- a/docs/onboarding/llm-analytics/helicone.tsx
+++ b/docs/onboarding/llm-analytics/helicone.tsx
@@ -103,9 +103,9 @@ export const getHeliconeSteps = (ctx: OnboardingComponentsContext): StepDefiniti
                                 language: 'typescript',
                                 file: 'Node',
                                 code: dedent`
-                                    import { NodeSDK, tracing } from '@opentelemetry/sdk-node'
+                                    import { NodeSDK } from '@opentelemetry/sdk-node'
                                     import { resourceFromAttributes } from '@opentelemetry/resources'
-                                    import { PostHogTraceExporter } from '@posthog/ai/otel'
+                                    import { PostHogSpanProcessor } from '@posthog/ai/otel'
                                     import { OpenAIInstrumentation } from '@opentelemetry/instrumentation-openai'
 
                                     const sdk = new NodeSDK({
@@ -115,12 +115,10 @@ export const getHeliconeSteps = (ctx: OnboardingComponentsContext): StepDefiniti
                                         foo: 'bar', // custom properties are passed through
                                       }),
                                       spanProcessors: [
-                                        new tracing.SimpleSpanProcessor(
-                                          new PostHogTraceExporter({
-                                            apiKey: '<ph_project_token>',
-                                            host: '<ph_client_api_host>',
-                                          })
-                                        ),
+                                        new PostHogSpanProcessor({
+                                          apiKey: '<ph_project_token>',
+                                          host: '<ph_client_api_host>',
+                                        }),
                                       ],
                                       instrumentations: [new OpenAIInstrumentation()],
                                     })

--- a/docs/onboarding/llm-analytics/helicone.tsx
+++ b/docs/onboarding/llm-analytics/helicone.tsx
@@ -43,7 +43,7 @@ export const getHeliconeSteps = (ctx: OnboardingComponentsContext): StepDefiniti
                                 language: 'bash',
                                 file: 'Python',
                                 code: dedent`
-                                    pip install openai opentelemetry-sdk opentelemetry-exporter-otlp-proto-http opentelemetry-instrumentation-openai-v2
+                                    pip install openai opentelemetry-sdk posthog[otel] opentelemetry-instrumentation-openai-v2
                                 `,
                             },
                             {
@@ -76,9 +76,8 @@ export const getHeliconeSteps = (ctx: OnboardingComponentsContext): StepDefiniti
                                 code: dedent`
                                     from opentelemetry import trace
                                     from opentelemetry.sdk.trace import TracerProvider
-                                    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
                                     from opentelemetry.sdk.resources import Resource, SERVICE_NAME
-                                    from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+                                    from posthog.ai.otel import PostHogSpanProcessor
                                     from opentelemetry.instrumentation.openai_v2 import OpenAIInstrumentor
 
                                     resource = Resource(attributes={
@@ -87,13 +86,13 @@ export const getHeliconeSteps = (ctx: OnboardingComponentsContext): StepDefiniti
                                         "foo": "bar", # custom properties are passed through
                                     })
 
-                                    exporter = OTLPSpanExporter(
-                                        endpoint="<ph_client_api_host>/i/v0/ai/otel",
-                                        headers={"Authorization": "Bearer <ph_project_token>"},
-                                    )
-
                                     provider = TracerProvider(resource=resource)
-                                    provider.add_span_processor(SimpleSpanProcessor(exporter))
+                                    provider.add_span_processor(
+                                        PostHogSpanProcessor(
+                                            api_key="<ph_project_token>",
+                                            host="<ph_client_api_host>",
+                                        )
+                                    )
                                     trace.set_tracer_provider(provider)
 
                                     OpenAIInstrumentor().instrument()

--- a/docs/onboarding/llm-analytics/hugging-face.tsx
+++ b/docs/onboarding/llm-analytics/hugging-face.tsx
@@ -61,7 +61,8 @@ export const getHuggingFaceSteps = (ctx: OnboardingComponentsContext): StepDefin
 
                                     resource = Resource(attributes={
                                         SERVICE_NAME: "my-app",
-                                        "user.id": "user_123", # optional: identifies the user in PostHog
+                                        "posthog.distinct_id": "user_123", # optional: identifies the user in PostHog
+                                        "foo": "bar", # custom properties are passed through
                                     })
 
                                     exporter = OTLPSpanExporter(
@@ -88,7 +89,8 @@ export const getHuggingFaceSteps = (ctx: OnboardingComponentsContext): StepDefin
                                     const sdk = new NodeSDK({
                                       resource: resourceFromAttributes({
                                         'service.name': 'my-app',
-                                        'user.id': 'user_123', // optional: identifies the user in PostHog
+                                        'posthog.distinct_id': 'user_123', // optional: identifies the user in PostHog
+                                        foo: 'bar', // custom properties are passed through
                                       }),
                                       spanProcessors: [
                                         new tracing.SimpleSpanProcessor(
@@ -168,7 +170,7 @@ export const getHuggingFaceSteps = (ctx: OnboardingComponentsContext): StepDefin
                     <Blockquote>
                         <Markdown>
                             {dedent`
-                            **Note:** If you want to capture LLM events anonymously, omit the \`user.id\` resource attribute. See our docs on [anonymous vs identified events](https://posthog.com/docs/data/anonymous-vs-identified-events) to learn more.
+                            **Note:** If you want to capture LLM events anonymously, omit the \`posthog.distinct_id\` resource attribute. See our docs on [anonymous vs identified events](https://posthog.com/docs/data/anonymous-vs-identified-events) to learn more.
                             `}
                         </Markdown>
                     </Blockquote>

--- a/docs/onboarding/llm-analytics/hugging-face.tsx
+++ b/docs/onboarding/llm-analytics/hugging-face.tsx
@@ -9,14 +9,11 @@ export const getHuggingFaceSteps = (ctx: OnboardingComponentsContext): StepDefin
 
     return [
         {
-            title: 'Install the PostHog SDK',
+            title: 'Install dependencies',
             badge: 'required',
             content: (
                 <>
-                    <Markdown>
-                        Setting up analytics starts with installing the PostHog SDK for your language. LLM analytics
-                        works best with our Python and Node SDKs.
-                    </Markdown>
+                    <Markdown>Install the OpenTelemetry SDK, the OpenAI instrumentation, and the OpenAI SDK.</Markdown>
 
                     <CodeBlock
                         blocks={[
@@ -24,63 +21,36 @@ export const getHuggingFaceSteps = (ctx: OnboardingComponentsContext): StepDefin
                                 language: 'bash',
                                 file: 'Python',
                                 code: dedent`
-                                    pip install posthog
+                                    pip install openai opentelemetry-sdk opentelemetry-exporter-otlp-proto-http opentelemetry-instrumentation-openai-v2
                                 `,
                             },
                             {
                                 language: 'bash',
                                 file: 'Node',
                                 code: dedent`
-                                    npm install @posthog/ai posthog-node
+                                    npm install openai @posthog/ai @opentelemetry/sdk-node @opentelemetry/resources @opentelemetry/instrumentation-openai
                                 `,
                             },
                         ]}
                     />
-                </>
-            ),
-        },
-        {
-            title: 'Install the OpenAI SDK',
-            badge: 'required',
-            content: (
-                <>
-                    <Markdown>
-                        Install the OpenAI SDK. The PostHog SDK instruments your LLM calls by wrapping the OpenAI
-                        client. The PostHog SDK **does not** proxy your calls.
-                    </Markdown>
 
-                    <CodeBlock
-                        blocks={[
-                            {
-                                language: 'bash',
-                                file: 'Python',
-                                code: dedent`
-                                    pip install openai
-                                `,
-                            },
-                            {
-                                language: 'bash',
-                                file: 'Node',
-                                code: dedent`
-                                    npm install openai
-                                `,
-                            },
-                        ]}
-                    />
+                    <CalloutBox type="fyi" icon="IconInfo" title="No proxy">
+                        <Markdown>
+                            These SDKs **do not** proxy your calls. They only send analytics data to PostHog in the
+                            background.
+                        </Markdown>
+                    </CalloutBox>
                 </>
             ),
         },
         {
-            title: 'Initialize PostHog and OpenAI client',
+            title: 'Set up OpenTelemetry tracing',
             badge: 'required',
             content: (
                 <>
                     <Markdown>
-                        We call Hugging Face Inference API through the OpenAI-compatible endpoint and generate a
-                        response. We'll use PostHog's OpenAI provider to capture all the details of the call. Initialize
-                        PostHog with your PostHog project token and host from [your project
-                        settings](https://app.posthog.com/settings/project), then pass the PostHog client along with the
-                        Hugging Face config (the base URL and API key) to our OpenAI wrapper.
+                        Configure OpenTelemetry to auto-instrument OpenAI SDK calls and export traces to PostHog.
+                        PostHog converts `gen_ai.*` spans into `$ai_generation` events automatically.
                     </Markdown>
 
                     <CodeBlock
@@ -89,61 +59,59 @@ export const getHuggingFaceSteps = (ctx: OnboardingComponentsContext): StepDefin
                                 language: 'python',
                                 file: 'Python',
                                 code: dedent`
-                                    from posthog.ai.openai import OpenAI
-                                    from posthog import Posthog
+                                    from opentelemetry import trace
+                                    from opentelemetry.sdk.trace import TracerProvider
+                                    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+                                    from opentelemetry.sdk.resources import Resource, SERVICE_NAME
+                                    from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+                                    from opentelemetry.instrumentation.openai_v2 import OpenAIInstrumentor
 
-                                    posthog = Posthog(
-                                        "<ph_project_token>",
-                                        host="<ph_client_api_host>"
+                                    resource = Resource(attributes={
+                                        SERVICE_NAME: "my-app",
+                                        "user.id": "user_123", # optional: identifies the user in PostHog
+                                    })
+
+                                    exporter = OTLPSpanExporter(
+                                        endpoint="<ph_client_api_host>/i/v0/ai/otel",
+                                        headers={"Authorization": "Bearer <ph_project_token>"},
                                     )
 
-                                    client = OpenAI(
-                                        base_url="https://router.huggingface.co/v1/",
-                                        api_key="<huggingface_api_key>",
-                                        posthog_client=posthog
-                                    )
+                                    provider = TracerProvider(resource=resource)
+                                    provider.add_span_processor(SimpleSpanProcessor(exporter))
+                                    trace.set_tracer_provider(provider)
+
+                                    OpenAIInstrumentor().instrument()
                                 `,
                             },
                             {
                                 language: 'typescript',
                                 file: 'Node',
                                 code: dedent`
-                                    import { OpenAI } from '@posthog/ai'
-                                    import { PostHog } from 'posthog-node'
+                                    import { NodeSDK, tracing } from '@opentelemetry/sdk-node'
+                                    import { resourceFromAttributes } from '@opentelemetry/resources'
+                                    import { PostHogTraceExporter } from '@posthog/ai/otel'
+                                    import { OpenAIInstrumentation } from '@opentelemetry/instrumentation-openai'
 
-                                    const phClient = new PostHog(
-                                      '<ph_project_token>',
-                                      { host: '<ph_client_api_host>' }
-                                    );
-
-                                    const openai = new OpenAI({
-                                      baseURL: 'https://router.huggingface.co/v1/',
-                                      apiKey: '<huggingface_api_key>',
-                                      posthog: phClient,
-                                    });
-
-                                    // ... your code here ...
-
-                                    // IMPORTANT: Shutdown the client when you're done to ensure all events are sent
-                                    phClient.shutdown()
+                                    const sdk = new NodeSDK({
+                                      resource: resourceFromAttributes({
+                                        'service.name': 'my-app',
+                                        'user.id': 'user_123', // optional: identifies the user in PostHog
+                                      }),
+                                      spanProcessors: [
+                                        new tracing.SimpleSpanProcessor(
+                                          new PostHogTraceExporter({
+                                            apiKey: '<ph_project_token>',
+                                            host: '<ph_client_api_host>',
+                                          })
+                                        ),
+                                      ],
+                                      instrumentations: [new OpenAIInstrumentation()],
+                                    })
+                                    sdk.start()
                                 `,
                             },
                         ]}
                     />
-
-                    <Blockquote>
-                        <Markdown>**Note:** This also works with the `AsyncOpenAI` client.</Markdown>
-                    </Blockquote>
-
-                    <CalloutBox type="fyi" icon="IconInfo" title="Proxy note">
-                        <Markdown>
-                            These SDKs **do not** proxy your calls. They only fire off an async call to PostHog in the
-                            background to send the data. You can also use LLM analytics with other SDKs or our API, but
-                            you will need to capture the data in the right format. See the schema in the [manual capture
-                            section](https://posthog.com/docs/llm-analytics/installation/manual-capture) for more
-                            details.
-                        </Markdown>
-                    </CalloutBox>
                 </>
             ),
         },
@@ -153,9 +121,8 @@ export const getHuggingFaceSteps = (ctx: OnboardingComponentsContext): StepDefin
             content: (
                 <>
                     <Markdown>
-                        Now, when you call Hugging Face with the OpenAI SDK, PostHog automatically captures an
-                        `$ai_generation` event. You can also capture or modify additional properties with the distinct
-                        ID, trace ID, properties, groups, and privacy mode parameters.
+                        Now, when you use the OpenAI SDK to call Hugging Face, PostHog automatically captures
+                        `$ai_generation` events via the OpenTelemetry instrumentation.
                     </Markdown>
 
                     <CodeBlock
@@ -164,16 +131,19 @@ export const getHuggingFaceSteps = (ctx: OnboardingComponentsContext): StepDefin
                                 language: 'python',
                                 file: 'Python',
                                 code: dedent`
+                                    import openai
+
+                                    client = openai.OpenAI(
+                                        base_url="https://router.huggingface.co/v1/",
+                                        api_key="<huggingface_api_key>",
+                                    )
+
                                     response = client.chat.completions.create(
                                         model="meta-llama/Llama-3.3-70B-Instruct",
+                                        max_completion_tokens=1024,
                                         messages=[
                                             {"role": "user", "content": "Tell me a fun fact about hedgehogs"}
                                         ],
-                                        posthog_distinct_id="user_123", # optional
-                                        posthog_trace_id="trace_123", # optional
-                                        posthog_properties={"conversation_id": "abc123", "paid": True}, # optional
-                                        posthog_groups={"company": "company_id_in_your_db"},  # optional
-                                        posthog_privacy_mode=False # optional
                                     )
 
                                     print(response.choices[0].message.content)
@@ -183,17 +153,20 @@ export const getHuggingFaceSteps = (ctx: OnboardingComponentsContext): StepDefin
                                 language: 'typescript',
                                 file: 'Node',
                                 code: dedent`
-                                    const completion = await openai.chat.completions.create({
-                                        model: "meta-llama/Llama-3.3-70B-Instruct",
-                                        messages: [{ role: "user", content: "Tell me a fun fact about hedgehogs" }],
-                                        posthogDistinctId: "user_123", // optional
-                                        posthogTraceId: "trace_123", // optional
-                                        posthogProperties: { conversation_id: "abc123", paid: true }, // optional
-                                        posthogGroups: { company: "company_id_in_your_db" }, // optional
-                                        posthogPrivacyMode: false // optional
-                                    });
+                                    import OpenAI from 'openai'
 
-                                    console.log(completion.choices[0].message.content)
+                                    const client = new OpenAI({
+                                      baseURL: 'https://router.huggingface.co/v1/',
+                                      apiKey: '<huggingface_api_key>',
+                                    })
+
+                                    const response = await client.chat.completions.create({
+                                      model: 'meta-llama/Llama-3.3-70B-Instruct',
+                                      max_completion_tokens: 1024,
+                                      messages: [{ role: 'user', content: 'Tell me a fun fact about hedgehogs' }],
+                                    })
+
+                                    console.log(response.choices[0].message.content)
                                 `,
                             },
                         ]}
@@ -202,12 +175,7 @@ export const getHuggingFaceSteps = (ctx: OnboardingComponentsContext): StepDefin
                     <Blockquote>
                         <Markdown>
                             {dedent`
-                            **Notes:**
-                            - We also support the old \`chat.completions\` API.
-                            - This works with responses where \`stream=True\`.
-                            - If you want to capture LLM events anonymously, **don't** pass a distinct ID to the request.
-
-                            See our docs on [anonymous vs identified events](https://posthog.com/docs/data/anonymous-vs-identified-events) to learn more.
+                            **Note:** If you want to capture LLM events anonymously, omit the \`user.id\` resource attribute. See our docs on [anonymous vs identified events](https://posthog.com/docs/data/anonymous-vs-identified-events) to learn more.
                             `}
                         </Markdown>
                     </Blockquote>

--- a/docs/onboarding/llm-analytics/hugging-face.tsx
+++ b/docs/onboarding/llm-analytics/hugging-face.tsx
@@ -3,7 +3,7 @@ import { OnboardingComponentsContext, createInstallation } from 'scenes/onboardi
 import { StepDefinition } from '../steps'
 
 export const getHuggingFaceSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
-    const { CodeBlock, Markdown, Blockquote, dedent, snippets } = ctx
+    const { CodeBlock, CalloutBox, Markdown, Blockquote, dedent, snippets } = ctx
 
     const NotableGenerationProperties = snippets?.NotableGenerationProperties
 
@@ -13,6 +13,17 @@ export const getHuggingFaceSteps = (ctx: OnboardingComponentsContext): StepDefin
             badge: 'required',
             content: (
                 <>
+                    <CalloutBox type="info" icon="IconInfo" title="Migrating from the SDK wrapper?">
+                        <Markdown>
+                            These docs now use OpenTelemetry auto-instrumentation, which is the recommended approach.
+                            The previous PostHog SDK wrapper is still available — see the
+                            [Node.js](https://github.com/PostHog/posthog-js/tree/e08ff1be/examples/example-ai-hugging-face)
+                            and
+                            [Python](https://github.com/PostHog/posthog-python/tree/7223c52/examples/example-ai-hugging-face)
+                            wrapper examples.
+                        </Markdown>
+                    </CalloutBox>
+
                     <Markdown>Install the OpenTelemetry SDK, the OpenAI instrumentation, and the OpenAI SDK.</Markdown>
 
                     <CodeBlock

--- a/docs/onboarding/llm-analytics/hugging-face.tsx
+++ b/docs/onboarding/llm-analytics/hugging-face.tsx
@@ -3,7 +3,7 @@ import { OnboardingComponentsContext, createInstallation } from 'scenes/onboardi
 import { StepDefinition } from '../steps'
 
 export const getHuggingFaceSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
-    const { CodeBlock, CalloutBox, Markdown, Blockquote, dedent, snippets } = ctx
+    const { CodeBlock, Markdown, Blockquote, dedent, snippets } = ctx
 
     const NotableGenerationProperties = snippets?.NotableGenerationProperties
 
@@ -33,13 +33,6 @@ export const getHuggingFaceSteps = (ctx: OnboardingComponentsContext): StepDefin
                             },
                         ]}
                     />
-
-                    <CalloutBox type="fyi" icon="IconInfo" title="No proxy">
-                        <Markdown>
-                            These SDKs **do not** proxy your calls. They only send analytics data to PostHog in the
-                            background.
-                        </Markdown>
-                    </CalloutBox>
                 </>
             ),
         },

--- a/docs/onboarding/llm-analytics/hugging-face.tsx
+++ b/docs/onboarding/llm-analytics/hugging-face.tsx
@@ -13,14 +13,18 @@ export const getHuggingFaceSteps = (ctx: OnboardingComponentsContext): StepDefin
             badge: 'required',
             content: (
                 <>
-                    <CalloutBox type="info" icon="IconInfo" title="Migrating from the SDK wrapper?">
+                    <CalloutBox type="info" icon="IconInfo" title="Full working examples">
                         <Markdown>
-                            These docs now use OpenTelemetry auto-instrumentation, which is the recommended approach.
-                            The previous PostHog SDK wrapper is still available — see the
-                            [Node.js](https://github.com/PostHog/posthog-js/tree/e08ff1be/examples/example-ai-hugging-face)
+                            See the complete
+                            [Node.js](https://github.com/PostHog/posthog-js/tree/main/examples/example-ai-hugging-face)
                             and
-                            [Python](https://github.com/PostHog/posthog-python/tree/7223c52/examples/example-ai-hugging-face)
-                            wrapper examples.
+                            [Python](https://github.com/PostHog/posthog-python/tree/master/examples/example-ai-hugging-face)
+                            examples on GitHub. If you're using the PostHog SDK wrapper instead of OpenTelemetry, see
+                            the [Node.js
+                            wrapper](https://github.com/PostHog/posthog-js/tree/e08ff1be/examples/example-ai-hugging-face)
+                            and [Python
+                            wrapper](https://github.com/PostHog/posthog-python/tree/7223c52/examples/example-ai-hugging-face)
+                            examples.
                         </Markdown>
                     </CalloutBox>
 

--- a/docs/onboarding/llm-analytics/hugging-face.tsx
+++ b/docs/onboarding/llm-analytics/hugging-face.tsx
@@ -96,9 +96,9 @@ export const getHuggingFaceSteps = (ctx: OnboardingComponentsContext): StepDefin
                                 language: 'typescript',
                                 file: 'Node',
                                 code: dedent`
-                                    import { NodeSDK, tracing } from '@opentelemetry/sdk-node'
+                                    import { NodeSDK } from '@opentelemetry/sdk-node'
                                     import { resourceFromAttributes } from '@opentelemetry/resources'
-                                    import { PostHogTraceExporter } from '@posthog/ai/otel'
+                                    import { PostHogSpanProcessor } from '@posthog/ai/otel'
                                     import { OpenAIInstrumentation } from '@opentelemetry/instrumentation-openai'
 
                                     const sdk = new NodeSDK({
@@ -108,12 +108,10 @@ export const getHuggingFaceSteps = (ctx: OnboardingComponentsContext): StepDefin
                                         foo: 'bar', // custom properties are passed through
                                       }),
                                       spanProcessors: [
-                                        new tracing.SimpleSpanProcessor(
-                                          new PostHogTraceExporter({
-                                            apiKey: '<ph_project_token>',
-                                            host: '<ph_client_api_host>',
-                                          })
-                                        ),
+                                        new PostHogSpanProcessor({
+                                          apiKey: '<ph_project_token>',
+                                          host: '<ph_client_api_host>',
+                                        }),
                                       ],
                                       instrumentations: [new OpenAIInstrumentation()],
                                     })

--- a/docs/onboarding/llm-analytics/hugging-face.tsx
+++ b/docs/onboarding/llm-analytics/hugging-face.tsx
@@ -36,7 +36,7 @@ export const getHuggingFaceSteps = (ctx: OnboardingComponentsContext): StepDefin
                                 language: 'bash',
                                 file: 'Python',
                                 code: dedent`
-                                    pip install openai opentelemetry-sdk opentelemetry-exporter-otlp-proto-http opentelemetry-instrumentation-openai-v2
+                                    pip install openai opentelemetry-sdk posthog[otel] opentelemetry-instrumentation-openai-v2
                                 `,
                             },
                             {
@@ -69,9 +69,8 @@ export const getHuggingFaceSteps = (ctx: OnboardingComponentsContext): StepDefin
                                 code: dedent`
                                     from opentelemetry import trace
                                     from opentelemetry.sdk.trace import TracerProvider
-                                    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
                                     from opentelemetry.sdk.resources import Resource, SERVICE_NAME
-                                    from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+                                    from posthog.ai.otel import PostHogSpanProcessor
                                     from opentelemetry.instrumentation.openai_v2 import OpenAIInstrumentor
 
                                     resource = Resource(attributes={
@@ -80,13 +79,13 @@ export const getHuggingFaceSteps = (ctx: OnboardingComponentsContext): StepDefin
                                         "foo": "bar", # custom properties are passed through
                                     })
 
-                                    exporter = OTLPSpanExporter(
-                                        endpoint="<ph_client_api_host>/i/v0/ai/otel",
-                                        headers={"Authorization": "Bearer <ph_project_token>"},
-                                    )
-
                                     provider = TracerProvider(resource=resource)
-                                    provider.add_span_processor(SimpleSpanProcessor(exporter))
+                                    provider.add_span_processor(
+                                        PostHogSpanProcessor(
+                                            api_key="<ph_project_token>",
+                                            host="<ph_client_api_host>",
+                                        )
+                                    )
                                     trace.set_tracer_provider(provider)
 
                                     OpenAIInstrumentor().instrument()

--- a/docs/onboarding/llm-analytics/instructor.tsx
+++ b/docs/onboarding/llm-analytics/instructor.tsx
@@ -3,20 +3,32 @@ import { OnboardingComponentsContext, createInstallation } from 'scenes/onboardi
 import { StepDefinition } from '../steps'
 
 export const getInstructorSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
-    const { CodeBlock, CalloutBox, Markdown, dedent, snippets } = ctx
+    const { CodeBlock, CalloutBox, Markdown, Blockquote, dedent, snippets } = ctx
 
     const NotableGenerationProperties = snippets?.NotableGenerationProperties
 
     return [
         {
-            title: 'Install the PostHog SDK',
+            title: 'Install dependencies',
             badge: 'required',
             content: (
                 <>
-                    <Markdown>
-                        Setting up analytics starts with installing the PostHog SDK for your language. LLM analytics
-                        works best with our Python and Node SDKs.
-                    </Markdown>
+                    <CalloutBox type="info" icon="IconInfo" title="Full working examples">
+                        <Markdown>
+                            See the complete
+                            [Node.js](https://github.com/PostHog/posthog-js/tree/main/examples/example-ai-instructor)
+                            and
+                            [Python](https://github.com/PostHog/posthog-python/tree/master/examples/example-ai-instructor)
+                            examples on GitHub. If you're using the PostHog SDK wrapper instead of OpenTelemetry, see
+                            the [Node.js
+                            wrapper](https://github.com/PostHog/posthog-js/tree/e08ff1be/examples/example-ai-instructor)
+                            and [Python
+                            wrapper](https://github.com/PostHog/posthog-python/tree/7223c52/examples/example-ai-instructor)
+                            examples.
+                        </Markdown>
+                    </CalloutBox>
+
+                    <Markdown>Install the OpenTelemetry SDK, the OpenAI instrumentation, and Instructor.</Markdown>
 
                     <CodeBlock
                         blocks={[
@@ -24,14 +36,14 @@ export const getInstructorSteps = (ctx: OnboardingComponentsContext): StepDefini
                                 language: 'bash',
                                 file: 'Python',
                                 code: dedent`
-                                    pip install posthog
+                                    pip install instructor openai opentelemetry-sdk opentelemetry-exporter-otlp-proto-http opentelemetry-instrumentation-openai-v2
                                 `,
                             },
                             {
                                 language: 'bash',
                                 file: 'Node',
                                 code: dedent`
-                                    npm install @posthog/ai posthog-node
+                                    npm install @instructor-ai/instructor openai zod @posthog/ai @opentelemetry/sdk-node @opentelemetry/resources @opentelemetry/instrumentation-openai
                                 `,
                             },
                         ]}
@@ -40,29 +52,72 @@ export const getInstructorSteps = (ctx: OnboardingComponentsContext): StepDefini
             ),
         },
         {
-            title: 'Install Instructor and OpenAI SDKs',
+            title: 'Set up OpenTelemetry tracing',
             badge: 'required',
             content: (
                 <>
                     <Markdown>
-                        Install Instructor and the OpenAI SDK. PostHog instruments your LLM calls by wrapping the OpenAI
-                        client, which Instructor uses under the hood.
+                        Configure OpenTelemetry to auto-instrument OpenAI SDK calls and export traces to PostHog.
+                        PostHog converts `gen_ai.*` spans into `$ai_generation` events automatically.
                     </Markdown>
 
                     <CodeBlock
                         blocks={[
                             {
-                                language: 'bash',
+                                language: 'python',
                                 file: 'Python',
                                 code: dedent`
-                                    pip install instructor openai
+                                    from opentelemetry import trace
+                                    from opentelemetry.sdk.trace import TracerProvider
+                                    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+                                    from opentelemetry.sdk.resources import Resource, SERVICE_NAME
+                                    from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+                                    from opentelemetry.instrumentation.openai_v2 import OpenAIInstrumentor
+
+                                    resource = Resource(attributes={
+                                        SERVICE_NAME: "my-app",
+                                        "posthog.distinct_id": "user_123", # optional: identifies the user in PostHog
+                                        "foo": "bar", # custom properties are passed through
+                                    })
+
+                                    exporter = OTLPSpanExporter(
+                                        endpoint="<ph_client_api_host>/i/v0/ai/otel",
+                                        headers={"Authorization": "Bearer <ph_project_token>"},
+                                    )
+
+                                    provider = TracerProvider(resource=resource)
+                                    provider.add_span_processor(SimpleSpanProcessor(exporter))
+                                    trace.set_tracer_provider(provider)
+
+                                    OpenAIInstrumentor().instrument()
                                 `,
                             },
                             {
-                                language: 'bash',
+                                language: 'typescript',
                                 file: 'Node',
                                 code: dedent`
-                                    npm install @instructor-ai/instructor openai zod@3
+                                    import { NodeSDK, tracing } from '@opentelemetry/sdk-node'
+                                    import { resourceFromAttributes } from '@opentelemetry/resources'
+                                    import { PostHogTraceExporter } from '@posthog/ai/otel'
+                                    import { OpenAIInstrumentation } from '@opentelemetry/instrumentation-openai'
+
+                                    const sdk = new NodeSDK({
+                                      resource: resourceFromAttributes({
+                                        'service.name': 'my-app',
+                                        'posthog.distinct_id': 'user_123', // optional: identifies the user in PostHog
+                                        foo: 'bar', // custom properties are passed through
+                                      }),
+                                      spanProcessors: [
+                                        new tracing.SimpleSpanProcessor(
+                                          new PostHogTraceExporter({
+                                            apiKey: '<ph_project_token>',
+                                            host: '<ph_client_api_host>',
+                                          })
+                                        ),
+                                      ],
+                                      instrumentations: [new OpenAIInstrumentation()],
+                                    })
+                                    sdk.start()
                                 `,
                             },
                         ]}
@@ -71,14 +126,13 @@ export const getInstructorSteps = (ctx: OnboardingComponentsContext): StepDefini
             ),
         },
         {
-            title: 'Initialize PostHog and Instructor',
+            title: 'Extract structured data',
             badge: 'required',
             content: (
                 <>
                     <Markdown>
-                        Initialize PostHog with your project token and host from [your project
-                        settings](https://app.posthog.com/settings/project), then create a PostHog OpenAI wrapper and
-                        pass it to Instructor.
+                        Use Instructor to extract structured data from LLM responses. PostHog automatically captures an
+                        `$ai_generation` event for each call made through the OpenAI SDK that Instructor wraps.
                     </Markdown>
 
                     <CodeBlock
@@ -88,119 +142,59 @@ export const getInstructorSteps = (ctx: OnboardingComponentsContext): StepDefini
                                 file: 'Python',
                                 code: dedent`
                                     import instructor
+                                    import openai
                                     from pydantic import BaseModel
-                                    from posthog.ai.openai import OpenAI
-                                    from posthog import Posthog
 
-                                    posthog = Posthog(
-                                        "<ph_project_token>",
-                                        host="<ph_client_api_host>"
-                                    )
-
-                                    openai_client = OpenAI(
-                                        api_key="your_openai_api_key",
-                                        posthog_client=posthog
-                                    )
-
-                                    client = instructor.from_openai(openai_client)
-                                `,
-                            },
-                            {
-                                language: 'typescript',
-                                file: 'Node',
-                                code: dedent`
-                                    import Instructor from '@instructor-ai/instructor'
-                                    import { OpenAI } from '@posthog/ai'
-                                    import { PostHog } from 'posthog-node'
-                                    import { z } from 'zod'
-
-                                    const phClient = new PostHog(
-                                      '<ph_project_token>',
-                                      { host: '<ph_client_api_host>' }
-                                    );
-
-                                    const openai = new OpenAI({
-                                      apiKey: 'your_openai_api_key',
-                                      posthog: phClient,
-                                    });
-
-                                    const client = Instructor({ client: openai, mode: 'TOOLS' })
-                                `,
-                            },
-                        ]}
-                    />
-
-                    <CalloutBox type="fyi" icon="IconInfo" title="How this works">
-                        <Markdown>
-                            PostHog's `OpenAI` wrapper is a proper subclass of `openai.OpenAI`, so it works directly
-                            with `instructor.from_openai()`. PostHog captures `$ai_generation` events automatically
-                            without proxying your calls.
-                        </Markdown>
-                    </CalloutBox>
-                </>
-            ),
-        },
-        {
-            title: 'Use Instructor with structured outputs',
-            badge: 'required',
-            content: (
-                <>
-                    <Markdown>
-                        Now use Instructor to extract structured data from LLM responses. PostHog automatically captures
-                        an `$ai_generation` event for each call.
-                    </Markdown>
-
-                    <CodeBlock
-                        blocks={[
-                            {
-                                language: 'python',
-                                file: 'Python',
-                                code: dedent`
-                                    class UserInfo(BaseModel):
+                                    class User(BaseModel):
                                         name: str
                                         age: int
 
+                                    client = instructor.from_openai(openai.OpenAI(api_key="your_openai_api_key"))
+
                                     user = client.chat.completions.create(
-                                        model="gpt-5-mini",
-                                        response_model=UserInfo,
-                                        messages=[
-                                            {"role": "user", "content": "John Doe is 30 years old."}
-                                        ],
-                                        posthog_distinct_id="user_123",
-                                        posthog_trace_id="trace_123",
-                                        posthog_properties={"conversation_id": "abc123"},
+                                        model="gpt-4o-mini",
+                                        response_model=User,
+                                        messages=[{"role": "user", "content": "Extract: John is 30 years old"}],
                                     )
 
-                                    print(f"{user.name} is {user.age} years old")
+                                    print(user)
                                 `,
                             },
                             {
                                 language: 'typescript',
                                 file: 'Node',
                                 code: dedent`
-                                    const UserInfo = z.object({
+                                    import OpenAI from 'openai'
+                                    import Instructor from '@instructor-ai/instructor'
+                                    import { z } from 'zod'
+
+                                    const oai = new OpenAI({ apiKey: 'your_openai_api_key' })
+                                    const client = Instructor({ client: oai, mode: 'TOOLS' })
+
+                                    const UserSchema = z.object({
                                       name: z.string(),
                                       age: z.number(),
                                     })
 
                                     const user = await client.chat.completions.create({
-                                      model: 'gpt-5-mini',
-                                      response_model: { schema: UserInfo, name: 'UserInfo' },
-                                      messages: [
-                                        { role: 'user', content: 'John Doe is 30 years old.' }
-                                      ],
-                                      posthogDistinctId: 'user_123',
-                                      posthogTraceId: 'trace_123',
-                                      posthogProperties: { conversation_id: 'abc123' },
+                                      model: 'gpt-4o-mini',
+                                      response_model: { schema: UserSchema, name: 'User' },
+                                      messages: [{ role: 'user', content: 'Extract: John is 30 years old' }],
                                     })
 
-                                    console.log(\`\${user.name} is \${user.age} years old\`)
-
-                                    phClient.shutdown()
+                                    console.log(user)
                                 `,
                             },
                         ]}
                     />
+
+                    <Blockquote>
+                        <Markdown>
+                            **Note:** If you want to capture LLM events anonymously, omit the `posthog.distinct_id`
+                            resource attribute. See our docs on [anonymous vs identified
+                            events](https://posthog.com/docs/data/anonymous-vs-identified-events) to learn more.
+                        </Markdown>
+                    </Blockquote>
 
                     <Markdown>
                         {dedent`

--- a/docs/onboarding/llm-analytics/instructor.tsx
+++ b/docs/onboarding/llm-analytics/instructor.tsx
@@ -96,9 +96,9 @@ export const getInstructorSteps = (ctx: OnboardingComponentsContext): StepDefini
                                 language: 'typescript',
                                 file: 'Node',
                                 code: dedent`
-                                    import { NodeSDK, tracing } from '@opentelemetry/sdk-node'
+                                    import { NodeSDK } from '@opentelemetry/sdk-node'
                                     import { resourceFromAttributes } from '@opentelemetry/resources'
-                                    import { PostHogTraceExporter } from '@posthog/ai/otel'
+                                    import { PostHogSpanProcessor } from '@posthog/ai/otel'
                                     import { OpenAIInstrumentation } from '@opentelemetry/instrumentation-openai'
 
                                     const sdk = new NodeSDK({
@@ -108,12 +108,10 @@ export const getInstructorSteps = (ctx: OnboardingComponentsContext): StepDefini
                                         foo: 'bar', // custom properties are passed through
                                       }),
                                       spanProcessors: [
-                                        new tracing.SimpleSpanProcessor(
-                                          new PostHogTraceExporter({
-                                            apiKey: '<ph_project_token>',
-                                            host: '<ph_client_api_host>',
-                                          })
-                                        ),
+                                        new PostHogSpanProcessor({
+                                          apiKey: '<ph_project_token>',
+                                          host: '<ph_client_api_host>',
+                                        }),
                                       ],
                                       instrumentations: [new OpenAIInstrumentation()],
                                     })

--- a/docs/onboarding/llm-analytics/instructor.tsx
+++ b/docs/onboarding/llm-analytics/instructor.tsx
@@ -36,7 +36,7 @@ export const getInstructorSteps = (ctx: OnboardingComponentsContext): StepDefini
                                 language: 'bash',
                                 file: 'Python',
                                 code: dedent`
-                                    pip install instructor openai opentelemetry-sdk opentelemetry-exporter-otlp-proto-http opentelemetry-instrumentation-openai-v2
+                                    pip install instructor openai opentelemetry-sdk posthog[otel] opentelemetry-instrumentation-openai-v2
                                 `,
                             },
                             {
@@ -69,9 +69,8 @@ export const getInstructorSteps = (ctx: OnboardingComponentsContext): StepDefini
                                 code: dedent`
                                     from opentelemetry import trace
                                     from opentelemetry.sdk.trace import TracerProvider
-                                    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
                                     from opentelemetry.sdk.resources import Resource, SERVICE_NAME
-                                    from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+                                    from posthog.ai.otel import PostHogSpanProcessor
                                     from opentelemetry.instrumentation.openai_v2 import OpenAIInstrumentor
 
                                     resource = Resource(attributes={
@@ -80,13 +79,13 @@ export const getInstructorSteps = (ctx: OnboardingComponentsContext): StepDefini
                                         "foo": "bar", # custom properties are passed through
                                     })
 
-                                    exporter = OTLPSpanExporter(
-                                        endpoint="<ph_client_api_host>/i/v0/ai/otel",
-                                        headers={"Authorization": "Bearer <ph_project_token>"},
-                                    )
-
                                     provider = TracerProvider(resource=resource)
-                                    provider.add_span_processor(SimpleSpanProcessor(exporter))
+                                    provider.add_span_processor(
+                                        PostHogSpanProcessor(
+                                            api_key="<ph_project_token>",
+                                            host="<ph_client_api_host>",
+                                        )
+                                    )
                                     trace.set_tracer_provider(provider)
 
                                     OpenAIInstrumentor().instrument()

--- a/docs/onboarding/llm-analytics/langchain.tsx
+++ b/docs/onboarding/llm-analytics/langchain.tsx
@@ -63,7 +63,8 @@ export const getLangChainSteps = (ctx: OnboardingComponentsContext): StepDefinit
 
                                     resource = Resource(attributes={
                                         SERVICE_NAME: "my-app",
-                                        "user.id": "user_123", # optional: identifies the user in PostHog
+                                        "posthog.distinct_id": "user_123", # optional: identifies the user in PostHog
+                                        "foo": "bar", # custom properties are passed through
                                     })
 
                                     exporter = OTLPSpanExporter(
@@ -90,7 +91,8 @@ export const getLangChainSteps = (ctx: OnboardingComponentsContext): StepDefinit
                                     const sdk = new NodeSDK({
                                       resource: resourceFromAttributes({
                                         'service.name': 'my-app',
-                                        'user.id': 'user_123', // optional: identifies the user in PostHog
+                                        'posthog.distinct_id': 'user_123', // optional: identifies the user in PostHog
+                                        foo: 'bar', // custom properties are passed through
                                       }),
                                       spanProcessors: [
                                         new tracing.SimpleSpanProcessor(
@@ -167,8 +169,8 @@ export const getLangChainSteps = (ctx: OnboardingComponentsContext): StepDefinit
 
                     <Blockquote>
                         <Markdown>
-                            **Note:** If you want to capture LLM events anonymously, omit the `user.id` resource
-                            attribute. See our docs on [anonymous vs identified
+                            **Note:** If you want to capture LLM events anonymously, omit the `posthog.distinct_id`
+                            resource attribute. See our docs on [anonymous vs identified
                             events](https://posthog.com/docs/data/anonymous-vs-identified-events) to learn more.
                         </Markdown>
                     </Blockquote>

--- a/docs/onboarding/llm-analytics/langchain.tsx
+++ b/docs/onboarding/llm-analytics/langchain.tsx
@@ -13,14 +13,17 @@ export const getLangChainSteps = (ctx: OnboardingComponentsContext): StepDefinit
             badge: 'required',
             content: (
                 <>
-                    <CalloutBox type="info" icon="IconInfo" title="Migrating from the SDK wrapper?">
+                    <CalloutBox type="info" icon="IconInfo" title="Full working examples">
                         <Markdown>
-                            These docs now use OpenTelemetry auto-instrumentation, which is the recommended approach.
-                            The previous PostHog SDK wrapper is still available — see the
-                            [Node.js](https://github.com/PostHog/posthog-js/tree/e08ff1be/examples/example-ai-langchain)
-                            and
-                            [Python](https://github.com/PostHog/posthog-python/tree/7223c52/examples/example-ai-langchain)
-                            wrapper examples.
+                            See the complete
+                            [Node.js](https://github.com/PostHog/posthog-js/tree/main/examples/example-ai-langchain) and
+                            [Python](https://github.com/PostHog/posthog-python/tree/master/examples/example-ai-langchain)
+                            examples on GitHub. If you're using the PostHog SDK wrapper instead of OpenTelemetry, see
+                            the [Node.js
+                            wrapper](https://github.com/PostHog/posthog-js/tree/e08ff1be/examples/example-ai-langchain)
+                            and [Python
+                            wrapper](https://github.com/PostHog/posthog-python/tree/7223c52/examples/example-ai-langchain)
+                            examples.
                         </Markdown>
                     </CalloutBox>
 

--- a/docs/onboarding/llm-analytics/langchain.tsx
+++ b/docs/onboarding/llm-analytics/langchain.tsx
@@ -3,7 +3,7 @@ import { OnboardingComponentsContext, createInstallation } from 'scenes/onboardi
 import { StepDefinition } from '../steps'
 
 export const getLangChainSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
-    const { CodeBlock, CalloutBox, Markdown, dedent, snippets } = ctx
+    const { CodeBlock, Markdown, dedent, snippets } = ctx
 
     const NotableGenerationProperties = snippets?.NotableGenerationProperties
 
@@ -35,13 +35,6 @@ export const getLangChainSteps = (ctx: OnboardingComponentsContext): StepDefinit
                             },
                         ]}
                     />
-
-                    <CalloutBox type="fyi" icon="IconInfo" title="No proxy">
-                        <Markdown>
-                            These SDKs **do not** proxy your calls. They only send analytics data to PostHog in the
-                            background.
-                        </Markdown>
-                    </CalloutBox>
                 </>
             ),
         },

--- a/docs/onboarding/llm-analytics/langchain.tsx
+++ b/docs/onboarding/llm-analytics/langchain.tsx
@@ -3,19 +3,18 @@ import { OnboardingComponentsContext, createInstallation } from 'scenes/onboardi
 import { StepDefinition } from '../steps'
 
 export const getLangChainSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
-    const { CodeBlock, CalloutBox, Markdown, Blockquote, dedent, snippets } = ctx
+    const { CodeBlock, CalloutBox, Markdown, dedent, snippets } = ctx
 
     const NotableGenerationProperties = snippets?.NotableGenerationProperties
 
     return [
         {
-            title: 'Install the PostHog SDK',
+            title: 'Install dependencies',
             badge: 'required',
             content: (
                 <>
                     <Markdown>
-                        Setting up analytics starts with installing the PostHog SDK for your language. LLM analytics
-                        works best with our Python and Node SDKs.
+                        Install the OpenTelemetry SDK, the LangChain instrumentation, and LangChain with OpenAI.
                     </Markdown>
 
                     <CodeBlock
@@ -24,73 +23,36 @@ export const getLangChainSteps = (ctx: OnboardingComponentsContext): StepDefinit
                                 language: 'bash',
                                 file: 'Python',
                                 code: dedent`
-                                    pip install posthog
+                                    pip install langchain langchain-openai opentelemetry-sdk opentelemetry-exporter-otlp-proto-http opentelemetry-instrumentation-langchain
                                 `,
                             },
                             {
                                 language: 'bash',
                                 file: 'Node',
                                 code: dedent`
-                                    npm install @posthog/ai posthog-node
-                                `,
-                            },
-                        ]}
-                    />
-                </>
-            ),
-        },
-        {
-            title: 'Install LangChain and OpenAI SDKs',
-            badge: 'required',
-            content: (
-                <>
-                    <Markdown>
-                        Install LangChain. The PostHog SDK instruments your LLM calls by wrapping LangChain. The PostHog
-                        SDK **does not** proxy your calls.
-                    </Markdown>
-
-                    <CodeBlock
-                        blocks={[
-                            {
-                                language: 'bash',
-                                file: 'Python',
-                                code: dedent`
-                                    pip install langchain openai langchain-openai
-                                `,
-                            },
-                            {
-                                language: 'bash',
-                                file: 'Node',
-                                code: dedent`
-                                    npm install langchain @langchain/core @langchain/openai @posthog/ai
+                                    npm install langchain @langchain/core @langchain/openai @posthog/ai @opentelemetry/sdk-node @opentelemetry/resources @traceloop/instrumentation-langchain
                                 `,
                             },
                         ]}
                     />
 
-                    <CalloutBox type="fyi" icon="IconInfo" title="Proxy note">
+                    <CalloutBox type="fyi" icon="IconInfo" title="No proxy">
                         <Markdown>
-                            These SDKs **do not** proxy your calls. They only fire off an async call to PostHog in the
-                            background to send the data. You can also use LLM analytics with other SDKs or our API, but
-                            you will need to capture the data in the right format. See the schema in the [manual capture
-                            section](https://posthog.com/docs/llm-analytics/installation/manual-capture) for more
-                            details.
+                            These SDKs **do not** proxy your calls. They only send analytics data to PostHog in the
+                            background.
                         </Markdown>
                     </CalloutBox>
                 </>
             ),
         },
         {
-            title: 'Initialize PostHog and LangChain',
+            title: 'Set up OpenTelemetry tracing',
             badge: 'required',
             content: (
                 <>
                     <Markdown>
-                        Initialize PostHog with your project token and host from [your project
-                        settings](https://app.posthog.com/settings/project), then pass it to the LangChain
-                        `CallbackHandler` wrapper. Optionally, you can provide a user distinct ID, trace ID, PostHog
-                        properties, [groups](https://posthog.com/docs/product-analytics/group-analytics), and privacy
-                        mode.
+                        Configure OpenTelemetry to auto-instrument LangChain calls and export traces to PostHog. PostHog
+                        converts `gen_ai.*` spans into `$ai_generation` events automatically.
                     </Markdown>
 
                     <CodeBlock
@@ -99,61 +61,59 @@ export const getLangChainSteps = (ctx: OnboardingComponentsContext): StepDefinit
                                 language: 'python',
                                 file: 'Python',
                                 code: dedent`
-                                    from posthog.ai.langchain import CallbackHandler
-                                    from langchain_openai import ChatOpenAI
-                                    from langchain_core.prompts import ChatPromptTemplate
-                                    from posthog import Posthog
+                                    from opentelemetry import trace
+                                    from opentelemetry.sdk.trace import TracerProvider
+                                    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+                                    from opentelemetry.sdk.resources import Resource, SERVICE_NAME
+                                    from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+                                    from opentelemetry.instrumentation.langchain import LangchainInstrumentor
 
-                                    posthog = Posthog(
-                                        "<ph_project_token>",
-                                        host="<ph_client_api_host>"
+                                    resource = Resource(attributes={
+                                        SERVICE_NAME: "my-app",
+                                        "user.id": "user_123", # optional: identifies the user in PostHog
+                                    })
+
+                                    exporter = OTLPSpanExporter(
+                                        endpoint="<ph_client_api_host>/i/v0/ai/otel",
+                                        headers={"Authorization": "Bearer <ph_project_token>"},
                                     )
 
-                                    callback_handler = CallbackHandler(
-                                        client=posthog, # This is an optional parameter. If it is not provided, a default client will be used.
-                                        distinct_id="user_123", # optional
-                                        trace_id="trace_456", # optional
-                                        properties={"conversation_id": "abc123"}, # optional
-                                        groups={"company": "company_id_in_your_db"}, # optional
-                                        privacy_mode=False # optional
-                                    )
+                                    provider = TracerProvider(resource=resource)
+                                    provider.add_span_processor(SimpleSpanProcessor(exporter))
+                                    trace.set_tracer_provider(provider)
+
+                                    LangchainInstrumentor().instrument()
                                 `,
                             },
                             {
                                 language: 'typescript',
                                 file: 'Node',
                                 code: dedent`
-                                    import { PostHog } from 'posthog-node';
-                                    import { LangChainCallbackHandler } from '@posthog/ai';
-                                    import { ChatOpenAI } from '@langchain/openai';
-                                    import { ChatPromptTemplate } from '@langchain/core/prompts';
+                                    import { NodeSDK, tracing } from '@opentelemetry/sdk-node'
+                                    import { resourceFromAttributes } from '@opentelemetry/resources'
+                                    import { PostHogTraceExporter } from '@posthog/ai/otel'
+                                    import { LangChainInstrumentation } from '@traceloop/instrumentation-langchain'
 
-                                    const phClient = new PostHog(
-                                      '<ph_project_token>',
-                                      { host: '<ph_client_api_host>' }
-                                    );
-
-                                    const callbackHandler = new LangChainCallbackHandler({
-                                      client: phClient,
-                                      distinctId: 'user_123', // optional
-                                      traceId: 'trace_456', // optional
-                                      properties: { conversationId: 'abc123' }, // optional
-                                      groups: { company: 'company_id_in_your_db' }, // optional
-                                      privacyMode: false, // optional
-                                      debug: false // optional - when true, logs all events to console
-                                    });
+                                    const sdk = new NodeSDK({
+                                      resource: resourceFromAttributes({
+                                        'service.name': 'my-app',
+                                        'user.id': 'user_123', // optional: identifies the user in PostHog
+                                      }),
+                                      spanProcessors: [
+                                        new tracing.SimpleSpanProcessor(
+                                          new PostHogTraceExporter({
+                                            apiKey: '<ph_project_token>',
+                                            host: '<ph_client_api_host>',
+                                          })
+                                        ),
+                                      ],
+                                      instrumentations: [new LangChainInstrumentation()],
+                                    })
+                                    sdk.start()
                                 `,
                             },
                         ]}
                     />
-
-                    <Blockquote>
-                        <Markdown>
-                            **Note:** If you want to capture LLM events anonymously, **don't** pass a distinct ID to the
-                            `CallbackHandler`. See our docs on [anonymous vs identified
-                            events](https://posthog.com/docs/data/anonymous-vs-identified-events) to learn more.
-                        </Markdown>
-                    </Blockquote>
                 </>
             ),
         },
@@ -163,8 +123,8 @@ export const getLangChainSteps = (ctx: OnboardingComponentsContext): StepDefinit
             content: (
                 <>
                     <Markdown>
-                        When you invoke your chain, pass the `callback_handler` in the `config` as part of your
-                        `callbacks`:
+                        Use LangChain as normal. The OpenTelemetry instrumentation automatically captures
+                        `$ai_generation` events for each LLM call — no callback handlers needed.
                     </Markdown>
 
                     <CodeBlock
@@ -173,6 +133,9 @@ export const getLangChainSteps = (ctx: OnboardingComponentsContext): StepDefinit
                                 language: 'python',
                                 file: 'Python',
                                 code: dedent`
+                                    from langchain_openai import ChatOpenAI
+                                    from langchain_core.prompts import ChatPromptTemplate
+
                                     prompt = ChatPromptTemplate.from_messages([
                                         ("system", "You are a helpful assistant."),
                                         ("user", "{input}")
@@ -181,11 +144,7 @@ export const getLangChainSteps = (ctx: OnboardingComponentsContext): StepDefinit
                                     model = ChatOpenAI(openai_api_key="your_openai_api_key")
                                     chain = prompt | model
 
-                                    # Execute the chain with the callback handler
-                                    response = chain.invoke(
-                                        {"input": "Tell me a joke about programming"},
-                                        config={"callbacks": [callback_handler]}
-                                    )
+                                    response = chain.invoke({"input": "Tell me a joke about programming"})
 
                                     print(response.content)
                                 `,
@@ -194,25 +153,20 @@ export const getLangChainSteps = (ctx: OnboardingComponentsContext): StepDefinit
                                 language: 'typescript',
                                 file: 'Node',
                                 code: dedent`
+                                    import { ChatOpenAI } from '@langchain/openai'
+                                    import { ChatPromptTemplate } from '@langchain/core/prompts'
+
                                     const prompt = ChatPromptTemplate.fromMessages([
                                       ["system", "You are a helpful assistant."],
                                       ["user", "{input}"]
-                                    ]);
+                                    ])
 
-                                    const model = new ChatOpenAI({
-                                      apiKey: "your_openai_api_key"
-                                    });
+                                    const model = new ChatOpenAI({ apiKey: "your_openai_api_key" })
+                                    const chain = prompt.pipe(model)
 
-                                    const chain = prompt.pipe(model);
+                                    const response = await chain.invoke({ input: "Tell me a joke about programming" })
 
-                                    // Execute the chain with the callback handler
-                                    const response = await chain.invoke(
-                                      { input: "Tell me a joke about programming" },
-                                      { callbacks: [callbackHandler] }
-                                    );
-
-                                    console.log(response.content);
-                                    phClient.shutdown();
+                                    console.log(response.content)
                                 `,
                             },
                         ]}

--- a/docs/onboarding/llm-analytics/langchain.tsx
+++ b/docs/onboarding/llm-analytics/langchain.tsx
@@ -3,7 +3,7 @@ import { OnboardingComponentsContext, createInstallation } from 'scenes/onboardi
 import { StepDefinition } from '../steps'
 
 export const getLangChainSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
-    const { CodeBlock, Markdown, Blockquote, dedent, snippets } = ctx
+    const { CodeBlock, CalloutBox, Markdown, Blockquote, dedent, snippets } = ctx
 
     const NotableGenerationProperties = snippets?.NotableGenerationProperties
 
@@ -13,6 +13,17 @@ export const getLangChainSteps = (ctx: OnboardingComponentsContext): StepDefinit
             badge: 'required',
             content: (
                 <>
+                    <CalloutBox type="info" icon="IconInfo" title="Migrating from the SDK wrapper?">
+                        <Markdown>
+                            These docs now use OpenTelemetry auto-instrumentation, which is the recommended approach.
+                            The previous PostHog SDK wrapper is still available — see the
+                            [Node.js](https://github.com/PostHog/posthog-js/tree/e08ff1be/examples/example-ai-langchain)
+                            and
+                            [Python](https://github.com/PostHog/posthog-python/tree/7223c52/examples/example-ai-langchain)
+                            wrapper examples.
+                        </Markdown>
+                    </CalloutBox>
+
                     <Markdown>
                         Install the OpenTelemetry SDK, the LangChain instrumentation, and LangChain with OpenAI.
                     </Markdown>

--- a/docs/onboarding/llm-analytics/langchain.tsx
+++ b/docs/onboarding/llm-analytics/langchain.tsx
@@ -3,7 +3,7 @@ import { OnboardingComponentsContext, createInstallation } from 'scenes/onboardi
 import { StepDefinition } from '../steps'
 
 export const getLangChainSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
-    const { CodeBlock, Markdown, dedent, snippets } = ctx
+    const { CodeBlock, Markdown, Blockquote, dedent, snippets } = ctx
 
     const NotableGenerationProperties = snippets?.NotableGenerationProperties
 
@@ -164,6 +164,14 @@ export const getLangChainSteps = (ctx: OnboardingComponentsContext): StepDefinit
                             },
                         ]}
                     />
+
+                    <Blockquote>
+                        <Markdown>
+                            **Note:** If you want to capture LLM events anonymously, omit the `user.id` resource
+                            attribute. See our docs on [anonymous vs identified
+                            events](https://posthog.com/docs/data/anonymous-vs-identified-events) to learn more.
+                        </Markdown>
+                    </Blockquote>
 
                     <Markdown>
                         PostHog automatically captures an `$ai_generation` event along with these properties:

--- a/docs/onboarding/llm-analytics/langchain.tsx
+++ b/docs/onboarding/llm-analytics/langchain.tsx
@@ -37,7 +37,7 @@ export const getLangChainSteps = (ctx: OnboardingComponentsContext): StepDefinit
                                 language: 'bash',
                                 file: 'Python',
                                 code: dedent`
-                                    pip install langchain langchain-openai opentelemetry-sdk opentelemetry-exporter-otlp-proto-http opentelemetry-instrumentation-langchain
+                                    pip install langchain langchain-core langchain-openai opentelemetry-sdk opentelemetry-exporter-otlp-proto-http opentelemetry-instrumentation-langchain
                                 `,
                             },
                             {

--- a/docs/onboarding/llm-analytics/langchain.tsx
+++ b/docs/onboarding/llm-analytics/langchain.tsx
@@ -97,9 +97,9 @@ export const getLangChainSteps = (ctx: OnboardingComponentsContext): StepDefinit
                                 language: 'typescript',
                                 file: 'Node',
                                 code: dedent`
-                                    import { NodeSDK, tracing } from '@opentelemetry/sdk-node'
+                                    import { NodeSDK } from '@opentelemetry/sdk-node'
                                     import { resourceFromAttributes } from '@opentelemetry/resources'
-                                    import { PostHogTraceExporter } from '@posthog/ai/otel'
+                                    import { PostHogSpanProcessor } from '@posthog/ai/otel'
                                     import { LangChainInstrumentation } from '@traceloop/instrumentation-langchain'
 
                                     const sdk = new NodeSDK({
@@ -109,12 +109,10 @@ export const getLangChainSteps = (ctx: OnboardingComponentsContext): StepDefinit
                                         foo: 'bar', // custom properties are passed through
                                       }),
                                       spanProcessors: [
-                                        new tracing.SimpleSpanProcessor(
-                                          new PostHogTraceExporter({
-                                            apiKey: '<ph_project_token>',
-                                            host: '<ph_client_api_host>',
-                                          })
-                                        ),
+                                        new PostHogSpanProcessor({
+                                          apiKey: '<ph_project_token>',
+                                          host: '<ph_client_api_host>',
+                                        }),
                                       ],
                                       instrumentations: [new LangChainInstrumentation()],
                                     })

--- a/docs/onboarding/llm-analytics/langchain.tsx
+++ b/docs/onboarding/llm-analytics/langchain.tsx
@@ -37,7 +37,7 @@ export const getLangChainSteps = (ctx: OnboardingComponentsContext): StepDefinit
                                 language: 'bash',
                                 file: 'Python',
                                 code: dedent`
-                                    pip install langchain langchain-core langchain-openai opentelemetry-sdk opentelemetry-exporter-otlp-proto-http opentelemetry-instrumentation-langchain
+                                    pip install langchain langchain-core langchain-openai opentelemetry-sdk posthog[otel] opentelemetry-instrumentation-langchain
                                 `,
                             },
                             {
@@ -70,9 +70,8 @@ export const getLangChainSteps = (ctx: OnboardingComponentsContext): StepDefinit
                                 code: dedent`
                                     from opentelemetry import trace
                                     from opentelemetry.sdk.trace import TracerProvider
-                                    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
                                     from opentelemetry.sdk.resources import Resource, SERVICE_NAME
-                                    from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+                                    from posthog.ai.otel import PostHogSpanProcessor
                                     from opentelemetry.instrumentation.langchain import LangchainInstrumentor
 
                                     resource = Resource(attributes={
@@ -81,13 +80,13 @@ export const getLangChainSteps = (ctx: OnboardingComponentsContext): StepDefinit
                                         "foo": "bar", # custom properties are passed through
                                     })
 
-                                    exporter = OTLPSpanExporter(
-                                        endpoint="<ph_client_api_host>/i/v0/ai/otel",
-                                        headers={"Authorization": "Bearer <ph_project_token>"},
-                                    )
-
                                     provider = TracerProvider(resource=resource)
-                                    provider.add_span_processor(SimpleSpanProcessor(exporter))
+                                    provider.add_span_processor(
+                                        PostHogSpanProcessor(
+                                            api_key="<ph_project_token>",
+                                            host="<ph_client_api_host>",
+                                        )
+                                    )
                                     trace.set_tracer_provider(provider)
 
                                     LangchainInstrumentor().instrument()

--- a/docs/onboarding/llm-analytics/langgraph.tsx
+++ b/docs/onboarding/llm-analytics/langgraph.tsx
@@ -13,14 +13,17 @@ export const getLangGraphSteps = (ctx: OnboardingComponentsContext): StepDefinit
             badge: 'required',
             content: (
                 <>
-                    <CalloutBox type="info" icon="IconInfo" title="Migrating from the SDK wrapper?">
+                    <CalloutBox type="info" icon="IconInfo" title="Full working examples">
                         <Markdown>
-                            These docs now use OpenTelemetry auto-instrumentation, which is the recommended approach.
-                            The previous PostHog SDK wrapper is still available — see the
-                            [Node.js](https://github.com/PostHog/posthog-js/tree/e08ff1be/examples/example-ai-langgraph)
-                            and
-                            [Python](https://github.com/PostHog/posthog-python/tree/7223c52/examples/example-ai-langgraph)
-                            wrapper examples.
+                            See the complete
+                            [Node.js](https://github.com/PostHog/posthog-js/tree/main/examples/example-ai-langgraph) and
+                            [Python](https://github.com/PostHog/posthog-python/tree/master/examples/example-ai-langgraph)
+                            examples on GitHub. If you're using the PostHog SDK wrapper instead of OpenTelemetry, see
+                            the [Node.js
+                            wrapper](https://github.com/PostHog/posthog-js/tree/e08ff1be/examples/example-ai-langgraph)
+                            and [Python
+                            wrapper](https://github.com/PostHog/posthog-python/tree/7223c52/examples/example-ai-langgraph)
+                            examples.
                         </Markdown>
                     </CalloutBox>
 

--- a/docs/onboarding/llm-analytics/langgraph.tsx
+++ b/docs/onboarding/llm-analytics/langgraph.tsx
@@ -9,13 +9,12 @@ export const getLangGraphSteps = (ctx: OnboardingComponentsContext): StepDefinit
 
     return [
         {
-            title: 'Install the PostHog SDK',
+            title: 'Install dependencies',
             badge: 'required',
             content: (
                 <>
                     <Markdown>
-                        Setting up analytics starts with installing the PostHog SDK for your language. LLM analytics
-                        works best with our Python and Node SDKs.
+                        Install the OpenTelemetry SDK, the LangChain instrumentation, and LangGraph with OpenAI.
                     </Markdown>
 
                     <CodeBlock
@@ -24,60 +23,37 @@ export const getLangGraphSteps = (ctx: OnboardingComponentsContext): StepDefinit
                                 language: 'bash',
                                 file: 'Python',
                                 code: dedent`
-                                    pip install posthog
+                                    pip install langgraph langchain-openai opentelemetry-sdk opentelemetry-exporter-otlp-proto-http opentelemetry-instrumentation-langchain
                                 `,
                             },
                             {
                                 language: 'bash',
                                 file: 'Node',
                                 code: dedent`
-                                    npm install @posthog/ai posthog-node
+                                    npm install @langchain/langgraph @langchain/openai @langchain/core @posthog/ai @opentelemetry/sdk-node @opentelemetry/resources @traceloop/instrumentation-langchain
                                 `,
                             },
                         ]}
                     />
-                </>
-            ),
-        },
-        {
-            title: 'Install LangGraph',
-            badge: 'required',
-            content: (
-                <>
-                    <Markdown>
-                        Install LangGraph and LangChain. PostHog instruments your LLM calls through LangChain-compatible
-                        callback handlers that LangGraph supports.
-                    </Markdown>
 
-                    <CodeBlock
-                        blocks={[
-                            {
-                                language: 'bash',
-                                file: 'Python',
-                                code: dedent`
-                                    pip install langgraph langchain-openai
-                                `,
-                            },
-                            {
-                                language: 'bash',
-                                file: 'Node',
-                                code: dedent`
-                                    npm install @langchain/langgraph @langchain/openai @langchain/core
-                                `,
-                            },
-                        ]}
-                    />
+                    <CalloutBox type="fyi" icon="IconInfo" title="No proxy">
+                        <Markdown>
+                            These SDKs **do not** proxy your calls. They only send analytics data to PostHog in the
+                            background.
+                        </Markdown>
+                    </CalloutBox>
                 </>
             ),
         },
         {
-            title: 'Initialize PostHog',
+            title: 'Set up OpenTelemetry tracing',
             badge: 'required',
             content: (
                 <>
                     <Markdown>
-                        Initialize PostHog with your project token and host from [your project
-                        settings](https://app.posthog.com/settings/project), then create a LangChain `CallbackHandler`.
+                        Configure OpenTelemetry to auto-instrument LangChain calls and export traces to PostHog.
+                        LangGraph is built on LangChain, so the same instrumentation captures all LLM calls. PostHog
+                        converts `gen_ai.*` spans into `$ai_generation` events automatically.
                     </Markdown>
 
                     <CodeBlock
@@ -86,56 +62,59 @@ export const getLangGraphSteps = (ctx: OnboardingComponentsContext): StepDefinit
                                 language: 'python',
                                 file: 'Python',
                                 code: dedent`
-                                    from posthog.ai.langchain import CallbackHandler
-                                    from posthog import Posthog
+                                    from opentelemetry import trace
+                                    from opentelemetry.sdk.trace import TracerProvider
+                                    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+                                    from opentelemetry.sdk.resources import Resource, SERVICE_NAME
+                                    from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+                                    from opentelemetry.instrumentation.langchain import LangchainInstrumentor
 
-                                    posthog = Posthog(
-                                        "<ph_project_token>",
-                                        host="<ph_client_api_host>"
+                                    resource = Resource(attributes={
+                                        SERVICE_NAME: "my-app",
+                                        "user.id": "user_123", # optional: identifies the user in PostHog
+                                    })
+
+                                    exporter = OTLPSpanExporter(
+                                        endpoint="<ph_client_api_host>/i/v0/ai/otel",
+                                        headers={"Authorization": "Bearer <ph_project_token>"},
                                     )
 
-                                    callback_handler = CallbackHandler(
-                                        client=posthog,
-                                        distinct_id="user_123", # optional
-                                        trace_id="trace_456", # optional
-                                        properties={"conversation_id": "abc123"}, # optional
-                                        groups={"company": "company_id_in_your_db"}, # optional
-                                        privacy_mode=False # optional
-                                    )
+                                    provider = TracerProvider(resource=resource)
+                                    provider.add_span_processor(SimpleSpanProcessor(exporter))
+                                    trace.set_tracer_provider(provider)
+
+                                    LangchainInstrumentor().instrument()
                                 `,
                             },
                             {
                                 language: 'typescript',
                                 file: 'Node',
                                 code: dedent`
-                                    import { PostHog } from 'posthog-node';
-                                    import { LangChainCallbackHandler } from '@posthog/ai';
+                                    import { NodeSDK, tracing } from '@opentelemetry/sdk-node'
+                                    import { resourceFromAttributes } from '@opentelemetry/resources'
+                                    import { PostHogTraceExporter } from '@posthog/ai/otel'
+                                    import { LangChainInstrumentation } from '@traceloop/instrumentation-langchain'
 
-                                    const phClient = new PostHog(
-                                      '<ph_project_token>',
-                                      { host: '<ph_client_api_host>' }
-                                    );
-
-                                    const callbackHandler = new LangChainCallbackHandler({
-                                      client: phClient,
-                                      distinctId: 'user_123', // optional
-                                      traceId: 'trace_456', // optional
-                                      properties: { conversationId: 'abc123' }, // optional
-                                      groups: { company: 'company_id_in_your_db' }, // optional
-                                      privacyMode: false, // optional
-                                    });
+                                    const sdk = new NodeSDK({
+                                      resource: resourceFromAttributes({
+                                        'service.name': 'my-app',
+                                        'user.id': 'user_123', // optional: identifies the user in PostHog
+                                      }),
+                                      spanProcessors: [
+                                        new tracing.SimpleSpanProcessor(
+                                          new PostHogTraceExporter({
+                                            apiKey: '<ph_project_token>',
+                                            host: '<ph_client_api_host>',
+                                          })
+                                        ),
+                                      ],
+                                      instrumentations: [new LangChainInstrumentation()],
+                                    })
+                                    sdk.start()
                                 `,
                             },
                         ]}
                     />
-
-                    <CalloutBox type="fyi" icon="IconInfo" title="How this works">
-                        <Markdown>
-                            LangGraph is built on LangChain, so it supports LangChain-compatible callback handlers.
-                            PostHog's `CallbackHandler` captures `$ai_generation` events and trace hierarchy
-                            automatically without proxying your calls.
-                        </Markdown>
-                    </CalloutBox>
                 </>
             ),
         },
@@ -145,8 +124,8 @@ export const getLangGraphSteps = (ctx: OnboardingComponentsContext): StepDefinit
             content: (
                 <>
                     <Markdown>
-                        Pass the `callback_handler` in the `config` when invoking your LangGraph graph. PostHog
-                        automatically captures generation events for each LLM call.
+                        Use LangGraph as normal. The OpenTelemetry instrumentation automatically captures
+                        `$ai_generation` events for each LLM call — no callback handlers needed.
                     </Markdown>
 
                     <CodeBlock
@@ -168,8 +147,7 @@ export const getLangGraphSteps = (ctx: OnboardingComponentsContext): StepDefinit
                                     agent = create_react_agent(model, tools=[get_weather])
 
                                     result = agent.invoke(
-                                        {"messages": [{"role": "user", "content": "What's the weather in Paris?"}]},
-                                        config={"callbacks": [callback_handler]}
+                                        {"messages": [{"role": "user", "content": "What's the weather in Paris?"}]}
                                     )
 
                                     print(result["messages"][-1].content)
@@ -199,12 +177,10 @@ export const getLangGraphSteps = (ctx: OnboardingComponentsContext): StepDefinit
                                     const agent = createReactAgent({ llm: model, tools: [getWeather] });
 
                                     const result = await agent.invoke(
-                                      { messages: [{ role: 'user', content: "What's the weather in Paris?" }] },
-                                      { callbacks: [callbackHandler] }
+                                      { messages: [{ role: 'user', content: "What's the weather in Paris?" }] }
                                     );
 
                                     console.log(result.messages[result.messages.length - 1].content);
-                                    phClient.shutdown();
                                 `,
                             },
                         ]}

--- a/docs/onboarding/llm-analytics/langgraph.tsx
+++ b/docs/onboarding/llm-analytics/langgraph.tsx
@@ -3,7 +3,7 @@ import { OnboardingComponentsContext, createInstallation } from 'scenes/onboardi
 import { StepDefinition } from '../steps'
 
 export const getLangGraphSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
-    const { CodeBlock, Markdown, dedent, snippets } = ctx
+    const { CodeBlock, Markdown, Blockquote, dedent, snippets } = ctx
 
     const NotableGenerationProperties = snippets?.NotableGenerationProperties
 
@@ -178,6 +178,14 @@ export const getLangGraphSteps = (ctx: OnboardingComponentsContext): StepDefinit
                             },
                         ]}
                     />
+
+                    <Blockquote>
+                        <Markdown>
+                            **Note:** If you want to capture LLM events anonymously, omit the `user.id` resource
+                            attribute. See our docs on [anonymous vs identified
+                            events](https://posthog.com/docs/data/anonymous-vs-identified-events) to learn more.
+                        </Markdown>
+                    </Blockquote>
 
                     <Markdown>
                         {dedent`

--- a/docs/onboarding/llm-analytics/langgraph.tsx
+++ b/docs/onboarding/llm-analytics/langgraph.tsx
@@ -3,7 +3,7 @@ import { OnboardingComponentsContext, createInstallation } from 'scenes/onboardi
 import { StepDefinition } from '../steps'
 
 export const getLangGraphSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
-    const { CodeBlock, Markdown, Blockquote, dedent, snippets } = ctx
+    const { CodeBlock, CalloutBox, Markdown, Blockquote, dedent, snippets } = ctx
 
     const NotableGenerationProperties = snippets?.NotableGenerationProperties
 
@@ -13,6 +13,17 @@ export const getLangGraphSteps = (ctx: OnboardingComponentsContext): StepDefinit
             badge: 'required',
             content: (
                 <>
+                    <CalloutBox type="info" icon="IconInfo" title="Migrating from the SDK wrapper?">
+                        <Markdown>
+                            These docs now use OpenTelemetry auto-instrumentation, which is the recommended approach.
+                            The previous PostHog SDK wrapper is still available — see the
+                            [Node.js](https://github.com/PostHog/posthog-js/tree/e08ff1be/examples/example-ai-langgraph)
+                            and
+                            [Python](https://github.com/PostHog/posthog-python/tree/7223c52/examples/example-ai-langgraph)
+                            wrapper examples.
+                        </Markdown>
+                    </CalloutBox>
+
                     <Markdown>
                         Install the OpenTelemetry SDK, the LangChain instrumentation, and LangGraph with OpenAI.
                     </Markdown>

--- a/docs/onboarding/llm-analytics/langgraph.tsx
+++ b/docs/onboarding/llm-analytics/langgraph.tsx
@@ -3,7 +3,7 @@ import { OnboardingComponentsContext, createInstallation } from 'scenes/onboardi
 import { StepDefinition } from '../steps'
 
 export const getLangGraphSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
-    const { CodeBlock, CalloutBox, Markdown, dedent, snippets } = ctx
+    const { CodeBlock, Markdown, dedent, snippets } = ctx
 
     const NotableGenerationProperties = snippets?.NotableGenerationProperties
 
@@ -35,13 +35,6 @@ export const getLangGraphSteps = (ctx: OnboardingComponentsContext): StepDefinit
                             },
                         ]}
                     />
-
-                    <CalloutBox type="fyi" icon="IconInfo" title="No proxy">
-                        <Markdown>
-                            These SDKs **do not** proxy your calls. They only send analytics data to PostHog in the
-                            background.
-                        </Markdown>
-                    </CalloutBox>
                 </>
             ),
         },

--- a/docs/onboarding/llm-analytics/langgraph.tsx
+++ b/docs/onboarding/llm-analytics/langgraph.tsx
@@ -64,7 +64,8 @@ export const getLangGraphSteps = (ctx: OnboardingComponentsContext): StepDefinit
 
                                     resource = Resource(attributes={
                                         SERVICE_NAME: "my-app",
-                                        "user.id": "user_123", # optional: identifies the user in PostHog
+                                        "posthog.distinct_id": "user_123", # optional: identifies the user in PostHog
+                                        "foo": "bar", # custom properties are passed through
                                     })
 
                                     exporter = OTLPSpanExporter(
@@ -91,7 +92,8 @@ export const getLangGraphSteps = (ctx: OnboardingComponentsContext): StepDefinit
                                     const sdk = new NodeSDK({
                                       resource: resourceFromAttributes({
                                         'service.name': 'my-app',
-                                        'user.id': 'user_123', // optional: identifies the user in PostHog
+                                        'posthog.distinct_id': 'user_123', // optional: identifies the user in PostHog
+                                        foo: 'bar', // custom properties are passed through
                                       }),
                                       spanProcessors: [
                                         new tracing.SimpleSpanProcessor(
@@ -181,8 +183,8 @@ export const getLangGraphSteps = (ctx: OnboardingComponentsContext): StepDefinit
 
                     <Blockquote>
                         <Markdown>
-                            **Note:** If you want to capture LLM events anonymously, omit the `user.id` resource
-                            attribute. See our docs on [anonymous vs identified
+                            **Note:** If you want to capture LLM events anonymously, omit the `posthog.distinct_id`
+                            resource attribute. See our docs on [anonymous vs identified
                             events](https://posthog.com/docs/data/anonymous-vs-identified-events) to learn more.
                         </Markdown>
                     </Blockquote>

--- a/docs/onboarding/llm-analytics/langgraph.tsx
+++ b/docs/onboarding/llm-analytics/langgraph.tsx
@@ -98,9 +98,9 @@ export const getLangGraphSteps = (ctx: OnboardingComponentsContext): StepDefinit
                                 language: 'typescript',
                                 file: 'Node',
                                 code: dedent`
-                                    import { NodeSDK, tracing } from '@opentelemetry/sdk-node'
+                                    import { NodeSDK } from '@opentelemetry/sdk-node'
                                     import { resourceFromAttributes } from '@opentelemetry/resources'
-                                    import { PostHogTraceExporter } from '@posthog/ai/otel'
+                                    import { PostHogSpanProcessor } from '@posthog/ai/otel'
                                     import { LangChainInstrumentation } from '@traceloop/instrumentation-langchain'
 
                                     const sdk = new NodeSDK({
@@ -110,12 +110,10 @@ export const getLangGraphSteps = (ctx: OnboardingComponentsContext): StepDefinit
                                         foo: 'bar', // custom properties are passed through
                                       }),
                                       spanProcessors: [
-                                        new tracing.SimpleSpanProcessor(
-                                          new PostHogTraceExporter({
-                                            apiKey: '<ph_project_token>',
-                                            host: '<ph_client_api_host>',
-                                          })
-                                        ),
+                                        new PostHogSpanProcessor({
+                                          apiKey: '<ph_project_token>',
+                                          host: '<ph_client_api_host>',
+                                        }),
                                       ],
                                       instrumentations: [new LangChainInstrumentation()],
                                     })

--- a/docs/onboarding/llm-analytics/langgraph.tsx
+++ b/docs/onboarding/llm-analytics/langgraph.tsx
@@ -37,14 +37,14 @@ export const getLangGraphSteps = (ctx: OnboardingComponentsContext): StepDefinit
                                 language: 'bash',
                                 file: 'Python',
                                 code: dedent`
-                                    pip install langgraph langchain-openai opentelemetry-sdk opentelemetry-exporter-otlp-proto-http opentelemetry-instrumentation-langchain
+                                    pip install langgraph langchain-core langchain-openai opentelemetry-sdk opentelemetry-exporter-otlp-proto-http opentelemetry-instrumentation-langchain
                                 `,
                             },
                             {
                                 language: 'bash',
                                 file: 'Node',
                                 code: dedent`
-                                    npm install @langchain/langgraph @langchain/openai @langchain/core @posthog/ai @opentelemetry/sdk-node @opentelemetry/resources @traceloop/instrumentation-langchain
+                                    npm install @langchain/langgraph @langchain/openai @langchain/core zod @posthog/ai @opentelemetry/sdk-node @opentelemetry/resources @traceloop/instrumentation-langchain
                                 `,
                             },
                         ]}

--- a/docs/onboarding/llm-analytics/langgraph.tsx
+++ b/docs/onboarding/llm-analytics/langgraph.tsx
@@ -37,7 +37,7 @@ export const getLangGraphSteps = (ctx: OnboardingComponentsContext): StepDefinit
                                 language: 'bash',
                                 file: 'Python',
                                 code: dedent`
-                                    pip install langgraph langchain-core langchain-openai opentelemetry-sdk opentelemetry-exporter-otlp-proto-http opentelemetry-instrumentation-langchain
+                                    pip install langgraph langchain-core langchain-openai opentelemetry-sdk posthog[otel] opentelemetry-instrumentation-langchain
                                 `,
                             },
                             {
@@ -71,9 +71,8 @@ export const getLangGraphSteps = (ctx: OnboardingComponentsContext): StepDefinit
                                 code: dedent`
                                     from opentelemetry import trace
                                     from opentelemetry.sdk.trace import TracerProvider
-                                    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
                                     from opentelemetry.sdk.resources import Resource, SERVICE_NAME
-                                    from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+                                    from posthog.ai.otel import PostHogSpanProcessor
                                     from opentelemetry.instrumentation.langchain import LangchainInstrumentor
 
                                     resource = Resource(attributes={
@@ -82,13 +81,13 @@ export const getLangGraphSteps = (ctx: OnboardingComponentsContext): StepDefinit
                                         "foo": "bar", # custom properties are passed through
                                     })
 
-                                    exporter = OTLPSpanExporter(
-                                        endpoint="<ph_client_api_host>/i/v0/ai/otel",
-                                        headers={"Authorization": "Bearer <ph_project_token>"},
-                                    )
-
                                     provider = TracerProvider(resource=resource)
-                                    provider.add_span_processor(SimpleSpanProcessor(exporter))
+                                    provider.add_span_processor(
+                                        PostHogSpanProcessor(
+                                            api_key="<ph_project_token>",
+                                            host="<ph_client_api_host>",
+                                        )
+                                    )
                                     trace.set_tracer_provider(provider)
 
                                     LangchainInstrumentor().instrument()

--- a/docs/onboarding/llm-analytics/llamaindex.tsx
+++ b/docs/onboarding/llm-analytics/llamaindex.tsx
@@ -48,7 +48,8 @@ export const getLlamaIndexSteps = (ctx: OnboardingComponentsContext): StepDefini
 
                             resource = Resource(attributes={
                                 SERVICE_NAME: "my-app",
-                                "user.id": "user_123", # optional: identifies the user in PostHog
+                                "posthog.distinct_id": "user_123", # optional: identifies the user in PostHog
+                                        "foo": "bar", # custom properties are passed through
                             })
 
                             exporter = OTLPSpanExporter(
@@ -100,8 +101,8 @@ export const getLlamaIndexSteps = (ctx: OnboardingComponentsContext): StepDefini
 
                     <Blockquote>
                         <Markdown>
-                            **Note:** If you want to capture LLM events anonymously, omit the `user.id` resource
-                            attribute. See our docs on [anonymous vs identified
+                            **Note:** If you want to capture LLM events anonymously, omit the `posthog.distinct_id`
+                            resource attribute. See our docs on [anonymous vs identified
                             events](https://posthog.com/docs/data/anonymous-vs-identified-events) to learn more.
                         </Markdown>
                     </Blockquote>

--- a/docs/onboarding/llm-analytics/llamaindex.tsx
+++ b/docs/onboarding/llm-analytics/llamaindex.tsx
@@ -3,94 +3,66 @@ import { OnboardingComponentsContext, createInstallation } from 'scenes/onboardi
 import { StepDefinition } from '../steps'
 
 export const getLlamaIndexSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
-    const { CodeBlock, CalloutBox, Markdown, dedent, snippets } = ctx
+    const { CodeBlock, Markdown, dedent, snippets } = ctx
 
     const NotableGenerationProperties = snippets?.NotableGenerationProperties
 
     return [
         {
-            title: 'Install the PostHog SDK',
+            title: 'Install dependencies',
             badge: 'required',
             content: (
                 <>
                     <Markdown>
-                        Setting up analytics starts with installing the PostHog SDK. The LlamaIndex integration uses
-                        PostHog's OpenAI wrapper.
+                        Install LlamaIndex, OpenAI, and the OpenTelemetry SDK with the LlamaIndex instrumentation.
                     </Markdown>
 
                     <CodeBlock
                         language="bash"
                         code={dedent`
-                            pip install posthog
+                            pip install llama-index llama-index-llms-openai opentelemetry-sdk opentelemetry-exporter-otlp-proto-http opentelemetry-instrumentation-llamaindex
                         `}
                     />
                 </>
             ),
         },
         {
-            title: 'Install LlamaIndex',
+            title: 'Set up OpenTelemetry tracing',
             badge: 'required',
             content: (
                 <>
                     <Markdown>
-                        Install LlamaIndex with the OpenAI integration. PostHog instruments your LLM calls by wrapping
-                        the OpenAI client that LlamaIndex uses.
-                    </Markdown>
-
-                    <CodeBlock
-                        language="bash"
-                        code={dedent`
-                            pip install llama-index llama-index-llms-openai
-                        `}
-                    />
-                </>
-            ),
-        },
-        {
-            title: 'Initialize PostHog and LlamaIndex',
-            badge: 'required',
-            content: (
-                <>
-                    <Markdown>
-                        Initialize PostHog with your project token and host from [your project
-                        settings](https://app.posthog.com/settings/project), then create a PostHog OpenAI wrapper and
-                        pass it to LlamaIndex's `OpenAI` LLM class.
+                        Configure OpenTelemetry to auto-instrument LlamaIndex calls and export traces to PostHog.
+                        PostHog converts `gen_ai.*` spans into `$ai_generation` events automatically.
                     </Markdown>
 
                     <CodeBlock
                         language="python"
                         code={dedent`
-                            from llama_index.llms.openai import OpenAI as LlamaOpenAI
-                            from posthog.ai.openai import OpenAI
-                            from posthog import Posthog
+                            from opentelemetry import trace
+                            from opentelemetry.sdk.trace import TracerProvider
+                            from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+                            from opentelemetry.sdk.resources import Resource, SERVICE_NAME
+                            from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+                            from opentelemetry.instrumentation.llamaindex import LlamaIndexInstrumentor
 
-                            posthog = Posthog(
-                                "<ph_project_token>",
-                                host="<ph_client_api_host>"
+                            resource = Resource(attributes={
+                                SERVICE_NAME: "my-app",
+                                "user.id": "user_123", # optional: identifies the user in PostHog
+                            })
+
+                            exporter = OTLPSpanExporter(
+                                endpoint="<ph_client_api_host>/i/v0/ai/otel",
+                                headers={"Authorization": "Bearer <ph_project_token>"},
                             )
 
-                            openai_client = OpenAI(
-                                api_key="your_openai_api_key",
-                                posthog_client=posthog
-                            )
+                            provider = TracerProvider(resource=resource)
+                            provider.add_span_processor(SimpleSpanProcessor(exporter))
+                            trace.set_tracer_provider(provider)
 
-                            llm = LlamaOpenAI(
-                                model="gpt-5-mini",
-                                api_key="your_openai_api_key",
-                            )
-                            llm._client = openai_client
+                            LlamaIndexInstrumentor().instrument()
                         `}
                     />
-
-                    <CalloutBox type="fyi" icon="IconInfo" title="How this works">
-                        <Markdown>
-                            PostHog's `OpenAI` wrapper is a proper subclass of `openai.OpenAI`, so it can replace the
-                            internal client used by LlamaIndex's OpenAI LLM. PostHog captures `$ai_generation` events
-                            automatically without proxying your calls. **Note:** This approach accesses an internal
-                            attribute (`_client`) which may change in future LlamaIndex versions. Check for updates if
-                            you encounter issues after upgrading LlamaIndex.
-                        </Markdown>
-                    </CalloutBox>
                 </>
             ),
         },
@@ -100,14 +72,17 @@ export const getLlamaIndexSteps = (ctx: OnboardingComponentsContext): StepDefini
             content: (
                 <>
                     <Markdown>
-                        Use LlamaIndex as normal. PostHog automatically captures an `$ai_generation` event for each LLM
-                        call made through the wrapped client.
+                        Use LlamaIndex as normal. The OpenTelemetry instrumentation automatically captures
+                        `$ai_generation` events for each LLM call.
                     </Markdown>
 
                     <CodeBlock
                         language="python"
                         code={dedent`
+                            from llama_index.llms.openai import OpenAI
                             from llama_index.core import VectorStoreIndex, SimpleDirectoryReader
+
+                            llm = OpenAI(model="gpt-4o-mini", api_key="your_openai_api_key")
 
                             # Load your documents
                             documents = SimpleDirectoryReader("data").load_data()

--- a/docs/onboarding/llm-analytics/llamaindex.tsx
+++ b/docs/onboarding/llm-analytics/llamaindex.tsx
@@ -3,7 +3,7 @@ import { OnboardingComponentsContext, createInstallation } from 'scenes/onboardi
 import { StepDefinition } from '../steps'
 
 export const getLlamaIndexSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
-    const { CodeBlock, Markdown, Blockquote, dedent, snippets } = ctx
+    const { CodeBlock, CalloutBox, Markdown, Blockquote, dedent, snippets } = ctx
 
     const NotableGenerationProperties = snippets?.NotableGenerationProperties
 
@@ -13,6 +13,14 @@ export const getLlamaIndexSteps = (ctx: OnboardingComponentsContext): StepDefini
             badge: 'required',
             content: (
                 <>
+                    <CalloutBox type="info" icon="IconInfo" title="Migrating from the SDK wrapper?">
+                        <Markdown>
+                            These docs now use OpenTelemetry auto-instrumentation, which is the recommended approach.
+                            The previous PostHog SDK wrapper is still available — see the [Python wrapper
+                            example](https://github.com/PostHog/posthog-python/tree/7223c52/examples/example-ai-llamaindex).
+                        </Markdown>
+                    </CalloutBox>
+
                     <Markdown>
                         Install LlamaIndex, OpenAI, and the OpenTelemetry SDK with the LlamaIndex instrumentation.
                     </Markdown>

--- a/docs/onboarding/llm-analytics/llamaindex.tsx
+++ b/docs/onboarding/llm-analytics/llamaindex.tsx
@@ -3,7 +3,7 @@ import { OnboardingComponentsContext, createInstallation } from 'scenes/onboardi
 import { StepDefinition } from '../steps'
 
 export const getLlamaIndexSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
-    const { CodeBlock, Markdown, dedent, snippets } = ctx
+    const { CodeBlock, Markdown, Blockquote, dedent, snippets } = ctx
 
     const NotableGenerationProperties = snippets?.NotableGenerationProperties
 
@@ -97,6 +97,14 @@ export const getLlamaIndexSteps = (ctx: OnboardingComponentsContext): StepDefini
                             print(response)
                         `}
                     />
+
+                    <Blockquote>
+                        <Markdown>
+                            **Note:** If you want to capture LLM events anonymously, omit the `user.id` resource
+                            attribute. See our docs on [anonymous vs identified
+                            events](https://posthog.com/docs/data/anonymous-vs-identified-events) to learn more.
+                        </Markdown>
+                    </Blockquote>
 
                     <Markdown>
                         {dedent`

--- a/docs/onboarding/llm-analytics/llamaindex.tsx
+++ b/docs/onboarding/llm-analytics/llamaindex.tsx
@@ -13,10 +13,12 @@ export const getLlamaIndexSteps = (ctx: OnboardingComponentsContext): StepDefini
             badge: 'required',
             content: (
                 <>
-                    <CalloutBox type="info" icon="IconInfo" title="Migrating from the SDK wrapper?">
+                    <CalloutBox type="info" icon="IconInfo" title="Full working examples">
                         <Markdown>
-                            These docs now use OpenTelemetry auto-instrumentation, which is the recommended approach.
-                            The previous PostHog SDK wrapper is still available — see the [Python wrapper
+                            See the complete [Python
+                            example](https://github.com/PostHog/posthog-python/tree/master/examples/example-ai-llamaindex)
+                            on GitHub. If you're using the PostHog SDK wrapper instead of OpenTelemetry, see the [Python
+                            wrapper
                             example](https://github.com/PostHog/posthog-python/tree/7223c52/examples/example-ai-llamaindex).
                         </Markdown>
                     </CalloutBox>

--- a/docs/onboarding/llm-analytics/llamaindex.tsx
+++ b/docs/onboarding/llm-analytics/llamaindex.tsx
@@ -30,7 +30,7 @@ export const getLlamaIndexSteps = (ctx: OnboardingComponentsContext): StepDefini
                     <CodeBlock
                         language="bash"
                         code={dedent`
-                            pip install llama-index llama-index-llms-openai opentelemetry-sdk opentelemetry-exporter-otlp-proto-http opentelemetry-instrumentation-llamaindex
+                            pip install llama-index llama-index-llms-openai opentelemetry-sdk posthog[otel] opentelemetry-instrumentation-llamaindex
                         `}
                     />
                 </>
@@ -51,9 +51,8 @@ export const getLlamaIndexSteps = (ctx: OnboardingComponentsContext): StepDefini
                         code={dedent`
                             from opentelemetry import trace
                             from opentelemetry.sdk.trace import TracerProvider
-                            from opentelemetry.sdk.trace.export import SimpleSpanProcessor
                             from opentelemetry.sdk.resources import Resource, SERVICE_NAME
-                            from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+                            from posthog.ai.otel import PostHogSpanProcessor
                             from opentelemetry.instrumentation.llamaindex import LlamaIndexInstrumentor
 
                             resource = Resource(attributes={
@@ -62,13 +61,13 @@ export const getLlamaIndexSteps = (ctx: OnboardingComponentsContext): StepDefini
                                         "foo": "bar", # custom properties are passed through
                             })
 
-                            exporter = OTLPSpanExporter(
-                                endpoint="<ph_client_api_host>/i/v0/ai/otel",
-                                headers={"Authorization": "Bearer <ph_project_token>"},
-                            )
-
                             provider = TracerProvider(resource=resource)
-                            provider.add_span_processor(SimpleSpanProcessor(exporter))
+                            provider.add_span_processor(
+                                PostHogSpanProcessor(
+                                    api_key="<ph_project_token>",
+                                    host="<ph_client_api_host>",
+                                )
+                            )
                             trace.set_tracer_provider(provider)
 
                             LlamaIndexInstrumentor().instrument()

--- a/docs/onboarding/llm-analytics/manual.tsx
+++ b/docs/onboarding/llm-analytics/manual.tsx
@@ -298,13 +298,16 @@ export const getManualSteps = (ctx: OnboardingComponentsContext): StepDefinition
                             ))}
                         </Tab.Panels>
                     </Tab.Group>
-
+                </>
+            ),
+        },
+        {
+            title: 'Event properties',
+            content: (
+                <>
                     <Markdown>
-                        {dedent`
-                            ### Event Properties
-
-                            Each event type has specific properties. See the tabs below for detailed property documentation for each event type.
-                        `}
+                        Each event type has specific properties. See the tabs below for detailed property documentation
+                        for each event type.
                     </Markdown>
 
                     <Tab.Group tabs={['Generation', 'Trace', 'Span', 'Embedding']}>

--- a/docs/onboarding/llm-analytics/mastra.tsx
+++ b/docs/onboarding/llm-analytics/mastra.tsx
@@ -9,126 +9,122 @@ export const getMastraSteps = (ctx: OnboardingComponentsContext): StepDefinition
 
     return [
         {
-            title: 'Install the PostHog SDK',
+            title: 'Install dependencies',
             badge: 'required',
             content: (
                 <>
-                    <Markdown>Setting up analytics starts with installing the PostHog SDK.</Markdown>
-
-                    <CodeBlock
-                        language="bash"
-                        code={dedent`
-                            npm install @posthog/ai posthog-node
-                        `}
-                    />
-                </>
-            ),
-        },
-        {
-            title: 'Install Mastra',
-            badge: 'required',
-            content: (
-                <>
-                    <Markdown>
-                        Install Mastra and a model provider SDK. Mastra uses the Vercel AI SDK under the hood, so you
-                        can use any Vercel AI-compatible model provider.
-                    </Markdown>
-
-                    <CodeBlock
-                        language="bash"
-                        code={dedent`
-                            npm install @mastra/core @ai-sdk/openai
-                        `}
-                    />
-
-                    <CalloutBox type="fyi" icon="IconInfo" title="Proxy note">
+                    <CalloutBox type="info" icon="IconInfo" title="Full working examples">
                         <Markdown>
-                            These SDKs **do not** proxy your calls. They only fire off an async call to PostHog in the
-                            background to send the data. You can also use LLM analytics with other SDKs or our API, but
-                            you will need to capture the data in the right format. See the schema in the [manual capture
-                            section](https://posthog.com/docs/llm-analytics/installation/manual-capture) for more
-                            details.
+                            See the complete [Node.js
+                            example](https://github.com/PostHog/posthog-js/tree/main/examples/example-ai-mastra) on
+                            GitHub. If you're using the PostHog SDK wrapper instead, see the [Node.js wrapper
+                            example](https://github.com/PostHog/posthog-js/tree/e08ff1be/examples/example-ai-mastra).
                         </Markdown>
                     </CalloutBox>
-                </>
-            ),
-        },
-        {
-            title: 'Initialize PostHog and wrap your model',
-            badge: 'required',
-            content: (
-                <>
+
                     <Markdown>
-                        Initialize PostHog with your project token and host from [your project
-                        settings](https://app.posthog.com/settings/project), then use `withTracing` from `@posthog/ai`
-                        to wrap the model you pass to your Mastra agent.
+                        Install Mastra with the official `@mastra/posthog` exporter. Mastra's observability system sends
+                        traces to PostHog as `$ai_generation` events automatically.
                     </Markdown>
 
                     <CodeBlock
-                        language="typescript"
+                        language="bash"
                         code={dedent`
-                            import { Agent } from "@mastra/core/agent";
-                            import { PostHog } from "posthog-node";
-                            import { withTracing } from "@posthog/ai";
-                            import { createOpenAI } from "@ai-sdk/openai";
-
-                            const phClient = new PostHog(
-                              '<ph_project_token>',
-                              { host: '<ph_client_api_host>' }
-                            );
-
-                            const openaiClient = createOpenAI({
-                              apiKey: 'your_openai_api_key',
-                              compatibility: 'strict'
-                            });
-
-                            const agent = new Agent({
-                              name: "my-agent",
-                              instructions: "You are a helpful assistant.",
-                              model: withTracing(openaiClient("gpt-4o"), phClient, {
-                                posthogDistinctId: "user_123", // optional
-                                posthogTraceId: "trace_123", // optional
-                                posthogProperties: { conversationId: "abc123" }, // optional
-                                posthogPrivacyMode: false, // optional
-                                posthogGroups: { company: "companyIdInYourDb" }, // optional
-                              }),
-                            });
+                            npm install @mastra/core @mastra/observability @mastra/posthog
                         `}
                     />
-
-                    <Markdown>
-                        You can enrich LLM events with additional data by passing parameters such as the trace ID,
-                        distinct ID, custom properties, groups, and privacy mode options.
-                    </Markdown>
                 </>
             ),
         },
         {
-            title: 'Use your Mastra agent',
+            title: 'Configure Mastra with the PostHog exporter',
             badge: 'required',
             content: (
                 <>
                     <Markdown>
-                        Now, when your Mastra agent makes LLM calls, PostHog automatically captures an `$ai_generation`
-                        event for each one.
+                        Initialize Mastra with an `Observability` config that uses the `PosthogExporter`. Pass your
+                        PostHog project token and host from [your project
+                        settings](https://app.posthog.com/settings/project).
                     </Markdown>
 
                     <CodeBlock
                         language="typescript"
                         code={dedent`
-                            const result = await agent.generate("What is the capital of France?");
+                            import { Mastra } from '@mastra/core'
+                            import { Agent } from '@mastra/core/agent'
+                            import { Observability } from '@mastra/observability'
+                            import { PosthogExporter } from '@mastra/posthog'
 
-                            console.log(result.text);
+                            const weatherAgent = new Agent({
+                              id: 'weather-agent',
+                              name: 'Weather Agent',
+                              instructions: 'You are a helpful assistant with access to weather data.',
+                              model: { id: 'openai/gpt-4o-mini' },
+                            })
 
-                            phClient.shutdown();
+                            const mastra = new Mastra({
+                              agents: { weatherAgent },
+                              observability: new Observability({
+                                configs: {
+                                  posthog: {
+                                    serviceName: 'my-app',
+                                    exporters: [
+                                      new PosthogExporter({
+                                        apiKey: '<ph_project_token>',
+                                        host: '<ph_client_api_host>',
+                                        defaultDistinctId: 'user_123', // fallback if no userId in metadata
+                                      }),
+                                    ],
+                                  },
+                                },
+                              }),
+                            })
+                        `}
+                    />
+                </>
+            ),
+        },
+        {
+            title: 'Run your agent',
+            badge: 'required',
+            content: (
+                <>
+                    <Markdown>
+                        Use Mastra as normal. The `PosthogExporter` automatically captures `$ai_generation` events for
+                        each LLM call, including token usage, cost, latency, and the full conversation.
+                    </Markdown>
+
+                    <Markdown>
+                        Pass `tracingOptions.metadata` to `generate()` to attach per-request metadata. The `userId`
+                        field maps to PostHog's distinct ID, `sessionId` maps to `$ai_session_id`, and any other keys
+                        are passed through as custom event properties.
+                    </Markdown>
+
+                    <CodeBlock
+                        language="typescript"
+                        code={dedent`
+                            const agent = mastra.getAgent('weatherAgent')
+
+                            const result = await agent.generate("What's the weather in Dublin?", {
+                              tracingOptions: {
+                                metadata: {
+                                  userId: 'user_123', // becomes distinct_id
+                                  sessionId: 'session_abc', // becomes $ai_session_id
+                                  conversation_id: 'abc-123', // custom property
+                                },
+                              },
+                            })
+
+                            console.log(result.text)
                         `}
                     />
 
                     <Blockquote>
                         <Markdown>
-                            **Note:** If you want to capture LLM events anonymously, **don't** pass a distinct ID to the
-                            request. See our docs on [anonymous vs identified
-                            events](https://posthog.com/docs/data/anonymous-vs-identified-events) to learn more.
+                            **Note:** If you want to capture LLM events anonymously, omit `userId` from
+                            `tracingOptions.metadata` and don't set `defaultDistinctId`. See our docs on [anonymous vs
+                            identified events](https://posthog.com/docs/data/anonymous-vs-identified-events) to learn
+                            more.
                         </Markdown>
                     </Blockquote>
 

--- a/docs/onboarding/llm-analytics/mirascope.tsx
+++ b/docs/onboarding/llm-analytics/mirascope.tsx
@@ -3,112 +3,109 @@ import { OnboardingComponentsContext, createInstallation } from 'scenes/onboardi
 import { StepDefinition } from '../steps'
 
 export const getMirascopeSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
-    const { CodeBlock, CalloutBox, Markdown, dedent, snippets } = ctx
+    const { CodeBlock, CalloutBox, Markdown, Blockquote, dedent, snippets } = ctx
 
     const NotableGenerationProperties = snippets?.NotableGenerationProperties
 
     return [
         {
-            title: 'Install the PostHog SDK',
+            title: 'Install dependencies',
             badge: 'required',
             content: (
                 <>
-                    <Markdown>
-                        Setting up analytics starts with installing the PostHog SDK. The Mirascope integration uses
-                        PostHog's OpenAI wrapper since Mirascope supports passing a custom OpenAI client.
-                    </Markdown>
-
-                    <CodeBlock
-                        language="bash"
-                        code={dedent`
-                            pip install posthog
-                        `}
-                    />
-                </>
-            ),
-        },
-        {
-            title: 'Install Mirascope',
-            badge: 'required',
-            content: (
-                <>
-                    <Markdown>
-                        Install Mirascope with OpenAI support. PostHog instruments your LLM calls by wrapping the OpenAI
-                        client that Mirascope uses under the hood.
-                    </Markdown>
-
-                    <CodeBlock
-                        language="bash"
-                        code={dedent`
-                            pip install mirascope openai
-                        `}
-                    />
-                </>
-            ),
-        },
-        {
-            title: 'Initialize PostHog and Mirascope',
-            badge: 'required',
-            content: (
-                <>
-                    <Markdown>
-                        Initialize PostHog with your project token and host from [your project
-                        settings](https://app.posthog.com/settings/project), then create a PostHog OpenAI wrapper and
-                        pass it to Mirascope's `@call` decorator via the `client` parameter.
-                    </Markdown>
-
-                    <CodeBlock
-                        language="python"
-                        code={dedent`
-                            from mirascope.llm import call
-                            from posthog.ai.openai import OpenAI
-                            from posthog import Posthog
-
-                            posthog = Posthog(
-                                "<ph_project_token>",
-                                host="<ph_client_api_host>"
-                            )
-
-                            openai_client = OpenAI(
-                                api_key="your_openai_api_key",
-                                posthog_client=posthog
-                            )
-                        `}
-                    />
-
-                    <CalloutBox type="fyi" icon="IconInfo" title="How this works">
+                    <CalloutBox type="info" icon="IconInfo" title="Full working examples">
                         <Markdown>
-                            Mirascope's `@call` decorator accepts a `client` parameter for passing a custom OpenAI
-                            client. PostHog's `OpenAI` wrapper is a proper subclass of `openai.OpenAI`, so it works
-                            directly. PostHog captures `$ai_generation` events automatically without proxying your
-                            calls.
+                            See the complete [Python
+                            example](https://github.com/PostHog/posthog-python/tree/master/examples/example-ai-mirascope)
+                            on GitHub. If you're using the PostHog SDK wrapper instead of OpenTelemetry, see the [Python
+                            wrapper
+                            example](https://github.com/PostHog/posthog-python/tree/7223c52/examples/example-ai-mirascope).
                         </Markdown>
                     </CalloutBox>
+
+                    <Markdown>Install the OpenTelemetry SDK, the OpenAI instrumentation, and Mirascope.</Markdown>
+
+                    <CodeBlock
+                        language="bash"
+                        code={dedent`
+                            pip install "mirascope[openai]" opentelemetry-sdk opentelemetry-exporter-otlp-proto-http opentelemetry-instrumentation-openai-v2
+                        `}
+                    />
                 </>
             ),
         },
         {
-            title: 'Make your first call',
+            title: 'Set up OpenTelemetry tracing',
             badge: 'required',
             content: (
                 <>
                     <Markdown>
-                        Use Mirascope as normal, passing the wrapped client to the call decorator. PostHog automatically
-                        captures an `$ai_generation` event for each LLM call.
+                        Configure OpenTelemetry to auto-instrument OpenAI SDK calls and export traces to PostHog.
+                        PostHog converts `gen_ai.*` spans into `$ai_generation` events automatically.
                     </Markdown>
 
                     <CodeBlock
                         language="python"
                         code={dedent`
-                            @call(model="openai/gpt-5-mini", client=openai_client)
-                            def recommend_book(genre: str):
-                                return f"Recommend a {genre} book."
+                            from opentelemetry import trace
+                            from opentelemetry.sdk.trace import TracerProvider
+                            from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+                            from opentelemetry.sdk.resources import Resource, SERVICE_NAME
+                            from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+                            from opentelemetry.instrumentation.openai_v2 import OpenAIInstrumentor
 
-                            response = recommend_book("fantasy")
+                            resource = Resource(attributes={
+                                SERVICE_NAME: "my-app",
+                                "posthog.distinct_id": "user_123", # optional: identifies the user in PostHog
+                                "foo": "bar", # custom properties are passed through
+                            })
 
+                            exporter = OTLPSpanExporter(
+                                endpoint="<ph_client_api_host>/i/v0/ai/otel",
+                                headers={"Authorization": "Bearer <ph_project_token>"},
+                            )
+
+                            provider = TracerProvider(resource=resource)
+                            provider.add_span_processor(SimpleSpanProcessor(exporter))
+                            trace.set_tracer_provider(provider)
+
+                            OpenAIInstrumentor().instrument()
+                        `}
+                    />
+                </>
+            ),
+        },
+        {
+            title: 'Call your LLMs',
+            badge: 'required',
+            content: (
+                <>
+                    <Markdown>
+                        Use Mirascope as normal. PostHog automatically captures an `$ai_generation` event for each LLM
+                        call made through the OpenAI SDK that Mirascope uses internally.
+                    </Markdown>
+
+                    <CodeBlock
+                        language="python"
+                        code={dedent`
+                            from mirascope.core import openai, prompt_template
+
+                            @openai.call("gpt-4o-mini")
+                            @prompt_template("Tell me a fun fact about {topic}")
+                            def fun_fact(topic: str): ...
+
+                            response = fun_fact("hedgehogs")
                             print(response.content)
                         `}
                     />
+
+                    <Blockquote>
+                        <Markdown>
+                            **Note:** If you want to capture LLM events anonymously, omit the `posthog.distinct_id`
+                            resource attribute. See our docs on [anonymous vs identified
+                            events](https://posthog.com/docs/data/anonymous-vs-identified-events) to learn more.
+                        </Markdown>
+                    </Blockquote>
 
                     <Markdown>
                         {dedent`

--- a/docs/onboarding/llm-analytics/mirascope.tsx
+++ b/docs/onboarding/llm-analytics/mirascope.tsx
@@ -28,7 +28,7 @@ export const getMirascopeSteps = (ctx: OnboardingComponentsContext): StepDefinit
                     <CodeBlock
                         language="bash"
                         code={dedent`
-                            pip install "mirascope[openai]" opentelemetry-sdk opentelemetry-exporter-otlp-proto-http opentelemetry-instrumentation-openai-v2
+                            pip install "mirascope[openai]" opentelemetry-sdk posthog[otel] opentelemetry-instrumentation-openai-v2
                         `}
                     />
                 </>
@@ -49,9 +49,8 @@ export const getMirascopeSteps = (ctx: OnboardingComponentsContext): StepDefinit
                         code={dedent`
                             from opentelemetry import trace
                             from opentelemetry.sdk.trace import TracerProvider
-                            from opentelemetry.sdk.trace.export import SimpleSpanProcessor
                             from opentelemetry.sdk.resources import Resource, SERVICE_NAME
-                            from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+                            from posthog.ai.otel import PostHogSpanProcessor
                             from opentelemetry.instrumentation.openai_v2 import OpenAIInstrumentor
 
                             resource = Resource(attributes={
@@ -60,13 +59,13 @@ export const getMirascopeSteps = (ctx: OnboardingComponentsContext): StepDefinit
                                 "foo": "bar", # custom properties are passed through
                             })
 
-                            exporter = OTLPSpanExporter(
-                                endpoint="<ph_client_api_host>/i/v0/ai/otel",
-                                headers={"Authorization": "Bearer <ph_project_token>"},
-                            )
-
                             provider = TracerProvider(resource=resource)
-                            provider.add_span_processor(SimpleSpanProcessor(exporter))
+                            provider.add_span_processor(
+                                PostHogSpanProcessor(
+                                    api_key="<ph_project_token>",
+                                    host="<ph_client_api_host>",
+                                )
+                            )
                             trace.set_tracer_provider(provider)
 
                             OpenAIInstrumentor().instrument()

--- a/docs/onboarding/llm-analytics/mistral.tsx
+++ b/docs/onboarding/llm-analytics/mistral.tsx
@@ -3,7 +3,7 @@ import { OnboardingComponentsContext, createInstallation } from 'scenes/onboardi
 import { StepDefinition } from '../steps'
 
 export const getMistralSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
-    const { CodeBlock, CalloutBox, Markdown, Blockquote, dedent, snippets } = ctx
+    const { CodeBlock, Markdown, Blockquote, dedent, snippets } = ctx
 
     const NotableGenerationProperties = snippets?.NotableGenerationProperties
 
@@ -33,13 +33,6 @@ export const getMistralSteps = (ctx: OnboardingComponentsContext): StepDefinitio
                             },
                         ]}
                     />
-
-                    <CalloutBox type="fyi" icon="IconInfo" title="No proxy">
-                        <Markdown>
-                            These SDKs **do not** proxy your calls. They only send analytics data to PostHog in the
-                            background.
-                        </Markdown>
-                    </CalloutBox>
                 </>
             ),
         },

--- a/docs/onboarding/llm-analytics/mistral.tsx
+++ b/docs/onboarding/llm-analytics/mistral.tsx
@@ -9,14 +9,11 @@ export const getMistralSteps = (ctx: OnboardingComponentsContext): StepDefinitio
 
     return [
         {
-            title: 'Install the PostHog SDK',
+            title: 'Install dependencies',
             badge: 'required',
             content: (
                 <>
-                    <Markdown>
-                        Setting up analytics starts with installing the PostHog SDK for your language. LLM analytics
-                        works best with our Python and Node SDKs.
-                    </Markdown>
+                    <Markdown>Install the OpenTelemetry SDK, the OpenAI instrumentation, and the OpenAI SDK.</Markdown>
 
                     <CodeBlock
                         blocks={[
@@ -24,63 +21,36 @@ export const getMistralSteps = (ctx: OnboardingComponentsContext): StepDefinitio
                                 language: 'bash',
                                 file: 'Python',
                                 code: dedent`
-                                    pip install posthog
+                                    pip install openai opentelemetry-sdk opentelemetry-exporter-otlp-proto-http opentelemetry-instrumentation-openai-v2
                                 `,
                             },
                             {
                                 language: 'bash',
                                 file: 'Node',
                                 code: dedent`
-                                    npm install @posthog/ai posthog-node
+                                    npm install openai @posthog/ai @opentelemetry/sdk-node @opentelemetry/resources @opentelemetry/instrumentation-openai
                                 `,
                             },
                         ]}
                     />
-                </>
-            ),
-        },
-        {
-            title: 'Install the OpenAI SDK',
-            badge: 'required',
-            content: (
-                <>
-                    <Markdown>
-                        Install the OpenAI SDK. The PostHog SDK instruments your LLM calls by wrapping the OpenAI
-                        client. The PostHog SDK **does not** proxy your calls.
-                    </Markdown>
 
-                    <CodeBlock
-                        blocks={[
-                            {
-                                language: 'bash',
-                                file: 'Python',
-                                code: dedent`
-                                    pip install openai
-                                `,
-                            },
-                            {
-                                language: 'bash',
-                                file: 'Node',
-                                code: dedent`
-                                    npm install openai
-                                `,
-                            },
-                        ]}
-                    />
+                    <CalloutBox type="fyi" icon="IconInfo" title="No proxy">
+                        <Markdown>
+                            These SDKs **do not** proxy your calls. They only send analytics data to PostHog in the
+                            background.
+                        </Markdown>
+                    </CalloutBox>
                 </>
             ),
         },
         {
-            title: 'Initialize PostHog and OpenAI client',
+            title: 'Set up OpenTelemetry tracing',
             badge: 'required',
             content: (
                 <>
                     <Markdown>
-                        We call Mistral through the OpenAI client and generate a response. We'll use PostHog's OpenAI
-                        provider to capture all the details of the call. Initialize PostHog with your PostHog project
-                        token and host from [your project settings](https://app.posthog.com/settings/project), then pass
-                        the PostHog client along with the Mistral config (the base URL and API key) to our OpenAI
-                        wrapper.
+                        Configure OpenTelemetry to auto-instrument OpenAI SDK calls and export traces to PostHog.
+                        PostHog converts `gen_ai.*` spans into `$ai_generation` events automatically.
                     </Markdown>
 
                     <CodeBlock
@@ -89,61 +59,59 @@ export const getMistralSteps = (ctx: OnboardingComponentsContext): StepDefinitio
                                 language: 'python',
                                 file: 'Python',
                                 code: dedent`
-                                    from posthog.ai.openai import OpenAI
-                                    from posthog import Posthog
+                                    from opentelemetry import trace
+                                    from opentelemetry.sdk.trace import TracerProvider
+                                    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+                                    from opentelemetry.sdk.resources import Resource, SERVICE_NAME
+                                    from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+                                    from opentelemetry.instrumentation.openai_v2 import OpenAIInstrumentor
 
-                                    posthog = Posthog(
-                                        "<ph_project_token>",
-                                        host="<ph_client_api_host>"
+                                    resource = Resource(attributes={
+                                        SERVICE_NAME: "my-app",
+                                        "user.id": "user_123", # optional: identifies the user in PostHog
+                                    })
+
+                                    exporter = OTLPSpanExporter(
+                                        endpoint="<ph_client_api_host>/i/v0/ai/otel",
+                                        headers={"Authorization": "Bearer <ph_project_token>"},
                                     )
 
-                                    client = OpenAI(
-                                        base_url="https://api.mistral.ai/v1",
-                                        api_key="<mistral_api_key>",
-                                        posthog_client=posthog
-                                    )
+                                    provider = TracerProvider(resource=resource)
+                                    provider.add_span_processor(SimpleSpanProcessor(exporter))
+                                    trace.set_tracer_provider(provider)
+
+                                    OpenAIInstrumentor().instrument()
                                 `,
                             },
                             {
                                 language: 'typescript',
                                 file: 'Node',
                                 code: dedent`
-                                    import { OpenAI } from '@posthog/ai'
-                                    import { PostHog } from 'posthog-node'
+                                    import { NodeSDK, tracing } from '@opentelemetry/sdk-node'
+                                    import { resourceFromAttributes } from '@opentelemetry/resources'
+                                    import { PostHogTraceExporter } from '@posthog/ai/otel'
+                                    import { OpenAIInstrumentation } from '@opentelemetry/instrumentation-openai'
 
-                                    const phClient = new PostHog(
-                                      '<ph_project_token>',
-                                      { host: '<ph_client_api_host>' }
-                                    );
-
-                                    const openai = new OpenAI({
-                                      baseURL: 'https://api.mistral.ai/v1',
-                                      apiKey: '<mistral_api_key>',
-                                      posthog: phClient,
-                                    });
-
-                                    // ... your code here ...
-
-                                    // IMPORTANT: Shutdown the client when you're done to ensure all events are sent
-                                    phClient.shutdown()
+                                    const sdk = new NodeSDK({
+                                      resource: resourceFromAttributes({
+                                        'service.name': 'my-app',
+                                        'user.id': 'user_123', // optional: identifies the user in PostHog
+                                      }),
+                                      spanProcessors: [
+                                        new tracing.SimpleSpanProcessor(
+                                          new PostHogTraceExporter({
+                                            apiKey: '<ph_project_token>',
+                                            host: '<ph_client_api_host>',
+                                          })
+                                        ),
+                                      ],
+                                      instrumentations: [new OpenAIInstrumentation()],
+                                    })
+                                    sdk.start()
                                 `,
                             },
                         ]}
                     />
-
-                    <Blockquote>
-                        <Markdown>**Note:** This also works with the `AsyncOpenAI` client.</Markdown>
-                    </Blockquote>
-
-                    <CalloutBox type="fyi" icon="IconInfo" title="Proxy note">
-                        <Markdown>
-                            These SDKs **do not** proxy your calls. They only fire off an async call to PostHog in the
-                            background to send the data. You can also use LLM analytics with other SDKs or our API, but
-                            you will need to capture the data in the right format. See the schema in the [manual capture
-                            section](https://posthog.com/docs/llm-analytics/installation/manual-capture) for more
-                            details.
-                        </Markdown>
-                    </CalloutBox>
                 </>
             ),
         },
@@ -153,9 +121,8 @@ export const getMistralSteps = (ctx: OnboardingComponentsContext): StepDefinitio
             content: (
                 <>
                     <Markdown>
-                        Now, when you call Mistral with the OpenAI SDK, PostHog automatically captures an
-                        `$ai_generation` event. You can also capture or modify additional properties with the distinct
-                        ID, trace ID, properties, groups, and privacy mode parameters.
+                        Now, when you use the OpenAI SDK to call Mistral, PostHog automatically captures
+                        `$ai_generation` events via the OpenTelemetry instrumentation.
                     </Markdown>
 
                     <CodeBlock
@@ -164,16 +131,19 @@ export const getMistralSteps = (ctx: OnboardingComponentsContext): StepDefinitio
                                 language: 'python',
                                 file: 'Python',
                                 code: dedent`
+                                    import openai
+
+                                    client = openai.OpenAI(
+                                        base_url="https://api.mistral.ai/v1",
+                                        api_key="<mistral_api_key>",
+                                    )
+
                                     response = client.chat.completions.create(
                                         model="mistral-large-latest",
+                                        max_completion_tokens=1024,
                                         messages=[
                                             {"role": "user", "content": "Tell me a fun fact about hedgehogs"}
                                         ],
-                                        posthog_distinct_id="user_123", # optional
-                                        posthog_trace_id="trace_123", # optional
-                                        posthog_properties={"conversation_id": "abc123", "paid": True}, # optional
-                                        posthog_groups={"company": "company_id_in_your_db"},  # optional
-                                        posthog_privacy_mode=False # optional
                                     )
 
                                     print(response.choices[0].message.content)
@@ -183,17 +153,20 @@ export const getMistralSteps = (ctx: OnboardingComponentsContext): StepDefinitio
                                 language: 'typescript',
                                 file: 'Node',
                                 code: dedent`
-                                    const completion = await openai.chat.completions.create({
-                                        model: "mistral-large-latest",
-                                        messages: [{ role: "user", content: "Tell me a fun fact about hedgehogs" }],
-                                        posthogDistinctId: "user_123", // optional
-                                        posthogTraceId: "trace_123", // optional
-                                        posthogProperties: { conversation_id: "abc123", paid: true }, // optional
-                                        posthogGroups: { company: "company_id_in_your_db" }, // optional
-                                        posthogPrivacyMode: false // optional
-                                    });
+                                    import OpenAI from 'openai'
 
-                                    console.log(completion.choices[0].message.content)
+                                    const client = new OpenAI({
+                                      baseURL: 'https://api.mistral.ai/v1',
+                                      apiKey: '<mistral_api_key>',
+                                    })
+
+                                    const response = await client.chat.completions.create({
+                                      model: 'mistral-large-latest',
+                                      max_completion_tokens: 1024,
+                                      messages: [{ role: 'user', content: 'Tell me a fun fact about hedgehogs' }],
+                                    })
+
+                                    console.log(response.choices[0].message.content)
                                 `,
                             },
                         ]}
@@ -201,14 +174,9 @@ export const getMistralSteps = (ctx: OnboardingComponentsContext): StepDefinitio
 
                     <Blockquote>
                         <Markdown>
-                            {dedent`
-                            **Notes:**
-                            - We also support the old \`chat.completions\` API.
-                            - This works with responses where \`stream=True\`.
-                            - If you want to capture LLM events anonymously, **don't** pass a distinct ID to the request.
-
-                            See our docs on [anonymous vs identified events](https://posthog.com/docs/data/anonymous-vs-identified-events) to learn more.
-                            `}
+                            **Note:** If you want to capture LLM events anonymously, omit the `user.id` resource
+                            attribute. See our docs on [anonymous vs identified
+                            events](https://posthog.com/docs/data/anonymous-vs-identified-events) to learn more.
                         </Markdown>
                     </Blockquote>
 

--- a/docs/onboarding/llm-analytics/mistral.tsx
+++ b/docs/onboarding/llm-analytics/mistral.tsx
@@ -13,14 +13,17 @@ export const getMistralSteps = (ctx: OnboardingComponentsContext): StepDefinitio
             badge: 'required',
             content: (
                 <>
-                    <CalloutBox type="info" icon="IconInfo" title="Migrating from the SDK wrapper?">
+                    <CalloutBox type="info" icon="IconInfo" title="Full working examples">
                         <Markdown>
-                            These docs now use OpenTelemetry auto-instrumentation, which is the recommended approach.
-                            The previous PostHog SDK wrapper is still available — see the
-                            [Node.js](https://github.com/PostHog/posthog-js/tree/e08ff1be/examples/example-ai-mistral)
-                            and
-                            [Python](https://github.com/PostHog/posthog-python/tree/7223c52/examples/example-ai-mistral)
-                            wrapper examples.
+                            See the complete
+                            [Node.js](https://github.com/PostHog/posthog-js/tree/main/examples/example-ai-mistral) and
+                            [Python](https://github.com/PostHog/posthog-python/tree/master/examples/example-ai-mistral)
+                            examples on GitHub. If you're using the PostHog SDK wrapper instead of OpenTelemetry, see
+                            the [Node.js
+                            wrapper](https://github.com/PostHog/posthog-js/tree/e08ff1be/examples/example-ai-mistral)
+                            and [Python
+                            wrapper](https://github.com/PostHog/posthog-python/tree/7223c52/examples/example-ai-mistral)
+                            examples.
                         </Markdown>
                     </CalloutBox>
 

--- a/docs/onboarding/llm-analytics/mistral.tsx
+++ b/docs/onboarding/llm-analytics/mistral.tsx
@@ -3,7 +3,7 @@ import { OnboardingComponentsContext, createInstallation } from 'scenes/onboardi
 import { StepDefinition } from '../steps'
 
 export const getMistralSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
-    const { CodeBlock, Markdown, Blockquote, dedent, snippets } = ctx
+    const { CodeBlock, CalloutBox, Markdown, Blockquote, dedent, snippets } = ctx
 
     const NotableGenerationProperties = snippets?.NotableGenerationProperties
 
@@ -13,6 +13,17 @@ export const getMistralSteps = (ctx: OnboardingComponentsContext): StepDefinitio
             badge: 'required',
             content: (
                 <>
+                    <CalloutBox type="info" icon="IconInfo" title="Migrating from the SDK wrapper?">
+                        <Markdown>
+                            These docs now use OpenTelemetry auto-instrumentation, which is the recommended approach.
+                            The previous PostHog SDK wrapper is still available — see the
+                            [Node.js](https://github.com/PostHog/posthog-js/tree/e08ff1be/examples/example-ai-mistral)
+                            and
+                            [Python](https://github.com/PostHog/posthog-python/tree/7223c52/examples/example-ai-mistral)
+                            wrapper examples.
+                        </Markdown>
+                    </CalloutBox>
+
                     <Markdown>Install the OpenTelemetry SDK, the OpenAI instrumentation, and the OpenAI SDK.</Markdown>
 
                     <CodeBlock

--- a/docs/onboarding/llm-analytics/mistral.tsx
+++ b/docs/onboarding/llm-analytics/mistral.tsx
@@ -61,7 +61,8 @@ export const getMistralSteps = (ctx: OnboardingComponentsContext): StepDefinitio
 
                                     resource = Resource(attributes={
                                         SERVICE_NAME: "my-app",
-                                        "user.id": "user_123", # optional: identifies the user in PostHog
+                                        "posthog.distinct_id": "user_123", # optional: identifies the user in PostHog
+                                        "foo": "bar", # custom properties are passed through
                                     })
 
                                     exporter = OTLPSpanExporter(
@@ -88,7 +89,8 @@ export const getMistralSteps = (ctx: OnboardingComponentsContext): StepDefinitio
                                     const sdk = new NodeSDK({
                                       resource: resourceFromAttributes({
                                         'service.name': 'my-app',
-                                        'user.id': 'user_123', // optional: identifies the user in PostHog
+                                        'posthog.distinct_id': 'user_123', // optional: identifies the user in PostHog
+                                        foo: 'bar', // custom properties are passed through
                                       }),
                                       spanProcessors: [
                                         new tracing.SimpleSpanProcessor(
@@ -167,8 +169,8 @@ export const getMistralSteps = (ctx: OnboardingComponentsContext): StepDefinitio
 
                     <Blockquote>
                         <Markdown>
-                            **Note:** If you want to capture LLM events anonymously, omit the `user.id` resource
-                            attribute. See our docs on [anonymous vs identified
+                            **Note:** If you want to capture LLM events anonymously, omit the `posthog.distinct_id`
+                            resource attribute. See our docs on [anonymous vs identified
                             events](https://posthog.com/docs/data/anonymous-vs-identified-events) to learn more.
                         </Markdown>
                     </Blockquote>

--- a/docs/onboarding/llm-analytics/mistral.tsx
+++ b/docs/onboarding/llm-analytics/mistral.tsx
@@ -35,7 +35,7 @@ export const getMistralSteps = (ctx: OnboardingComponentsContext): StepDefinitio
                                 language: 'bash',
                                 file: 'Python',
                                 code: dedent`
-                                    pip install openai opentelemetry-sdk opentelemetry-exporter-otlp-proto-http opentelemetry-instrumentation-openai-v2
+                                    pip install openai opentelemetry-sdk posthog[otel] opentelemetry-instrumentation-openai-v2
                                 `,
                             },
                             {
@@ -68,9 +68,8 @@ export const getMistralSteps = (ctx: OnboardingComponentsContext): StepDefinitio
                                 code: dedent`
                                     from opentelemetry import trace
                                     from opentelemetry.sdk.trace import TracerProvider
-                                    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
                                     from opentelemetry.sdk.resources import Resource, SERVICE_NAME
-                                    from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+                                    from posthog.ai.otel import PostHogSpanProcessor
                                     from opentelemetry.instrumentation.openai_v2 import OpenAIInstrumentor
 
                                     resource = Resource(attributes={
@@ -79,13 +78,13 @@ export const getMistralSteps = (ctx: OnboardingComponentsContext): StepDefinitio
                                         "foo": "bar", # custom properties are passed through
                                     })
 
-                                    exporter = OTLPSpanExporter(
-                                        endpoint="<ph_client_api_host>/i/v0/ai/otel",
-                                        headers={"Authorization": "Bearer <ph_project_token>"},
-                                    )
-
                                     provider = TracerProvider(resource=resource)
-                                    provider.add_span_processor(SimpleSpanProcessor(exporter))
+                                    provider.add_span_processor(
+                                        PostHogSpanProcessor(
+                                            api_key="<ph_project_token>",
+                                            host="<ph_client_api_host>",
+                                        )
+                                    )
                                     trace.set_tracer_provider(provider)
 
                                     OpenAIInstrumentor().instrument()

--- a/docs/onboarding/llm-analytics/mistral.tsx
+++ b/docs/onboarding/llm-analytics/mistral.tsx
@@ -95,9 +95,9 @@ export const getMistralSteps = (ctx: OnboardingComponentsContext): StepDefinitio
                                 language: 'typescript',
                                 file: 'Node',
                                 code: dedent`
-                                    import { NodeSDK, tracing } from '@opentelemetry/sdk-node'
+                                    import { NodeSDK } from '@opentelemetry/sdk-node'
                                     import { resourceFromAttributes } from '@opentelemetry/resources'
-                                    import { PostHogTraceExporter } from '@posthog/ai/otel'
+                                    import { PostHogSpanProcessor } from '@posthog/ai/otel'
                                     import { OpenAIInstrumentation } from '@opentelemetry/instrumentation-openai'
 
                                     const sdk = new NodeSDK({
@@ -107,12 +107,10 @@ export const getMistralSteps = (ctx: OnboardingComponentsContext): StepDefinitio
                                         foo: 'bar', // custom properties are passed through
                                       }),
                                       spanProcessors: [
-                                        new tracing.SimpleSpanProcessor(
-                                          new PostHogTraceExporter({
-                                            apiKey: '<ph_project_token>',
-                                            host: '<ph_client_api_host>',
-                                          })
-                                        ),
+                                        new PostHogSpanProcessor({
+                                          apiKey: '<ph_project_token>',
+                                          host: '<ph_client_api_host>',
+                                        }),
                                       ],
                                       instrumentations: [new OpenAIInstrumentation()],
                                     })

--- a/docs/onboarding/llm-analytics/ollama.tsx
+++ b/docs/onboarding/llm-analytics/ollama.tsx
@@ -3,7 +3,7 @@ import { OnboardingComponentsContext, createInstallation } from 'scenes/onboardi
 import { StepDefinition } from '../steps'
 
 export const getOllamaSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
-    const { CodeBlock, Markdown, Blockquote, dedent, snippets } = ctx
+    const { CodeBlock, CalloutBox, Markdown, Blockquote, dedent, snippets } = ctx
 
     const NotableGenerationProperties = snippets?.NotableGenerationProperties
 
@@ -13,6 +13,17 @@ export const getOllamaSteps = (ctx: OnboardingComponentsContext): StepDefinition
             badge: 'required',
             content: (
                 <>
+                    <CalloutBox type="info" icon="IconInfo" title="Migrating from the SDK wrapper?">
+                        <Markdown>
+                            These docs now use OpenTelemetry auto-instrumentation, which is the recommended approach.
+                            The previous PostHog SDK wrapper is still available — see the
+                            [Node.js](https://github.com/PostHog/posthog-js/tree/e08ff1be/examples/example-ai-ollama)
+                            and
+                            [Python](https://github.com/PostHog/posthog-python/tree/7223c52/examples/example-ai-ollama)
+                            wrapper examples.
+                        </Markdown>
+                    </CalloutBox>
+
                     <Markdown>Install the OpenTelemetry SDK, the OpenAI instrumentation, and the OpenAI SDK.</Markdown>
 
                     <CodeBlock

--- a/docs/onboarding/llm-analytics/ollama.tsx
+++ b/docs/onboarding/llm-analytics/ollama.tsx
@@ -61,7 +61,8 @@ export const getOllamaSteps = (ctx: OnboardingComponentsContext): StepDefinition
 
                                     resource = Resource(attributes={
                                         SERVICE_NAME: "my-app",
-                                        "user.id": "user_123", # optional: identifies the user in PostHog
+                                        "posthog.distinct_id": "user_123", # optional: identifies the user in PostHog
+                                        "foo": "bar", # custom properties are passed through
                                     })
 
                                     exporter = OTLPSpanExporter(
@@ -88,7 +89,8 @@ export const getOllamaSteps = (ctx: OnboardingComponentsContext): StepDefinition
                                     const sdk = new NodeSDK({
                                       resource: resourceFromAttributes({
                                         'service.name': 'my-app',
-                                        'user.id': 'user_123', // optional: identifies the user in PostHog
+                                        'posthog.distinct_id': 'user_123', // optional: identifies the user in PostHog
+                                        foo: 'bar', // custom properties are passed through
                                       }),
                                       spanProcessors: [
                                         new tracing.SimpleSpanProcessor(
@@ -168,7 +170,7 @@ export const getOllamaSteps = (ctx: OnboardingComponentsContext): StepDefinition
                     <Blockquote>
                         <Markdown>
                             {dedent`
-                            **Note:** If you want to capture LLM events anonymously, omit the \`user.id\` resource attribute. See our docs on [anonymous vs identified events](https://posthog.com/docs/data/anonymous-vs-identified-events) to learn more.
+                            **Note:** If you want to capture LLM events anonymously, omit the \`posthog.distinct_id\` resource attribute. See our docs on [anonymous vs identified events](https://posthog.com/docs/data/anonymous-vs-identified-events) to learn more.
                             `}
                         </Markdown>
                     </Blockquote>

--- a/docs/onboarding/llm-analytics/ollama.tsx
+++ b/docs/onboarding/llm-analytics/ollama.tsx
@@ -13,14 +13,17 @@ export const getOllamaSteps = (ctx: OnboardingComponentsContext): StepDefinition
             badge: 'required',
             content: (
                 <>
-                    <CalloutBox type="info" icon="IconInfo" title="Migrating from the SDK wrapper?">
+                    <CalloutBox type="info" icon="IconInfo" title="Full working examples">
                         <Markdown>
-                            These docs now use OpenTelemetry auto-instrumentation, which is the recommended approach.
-                            The previous PostHog SDK wrapper is still available — see the
-                            [Node.js](https://github.com/PostHog/posthog-js/tree/e08ff1be/examples/example-ai-ollama)
-                            and
-                            [Python](https://github.com/PostHog/posthog-python/tree/7223c52/examples/example-ai-ollama)
-                            wrapper examples.
+                            See the complete
+                            [Node.js](https://github.com/PostHog/posthog-js/tree/main/examples/example-ai-ollama) and
+                            [Python](https://github.com/PostHog/posthog-python/tree/master/examples/example-ai-ollama)
+                            examples on GitHub. If you're using the PostHog SDK wrapper instead of OpenTelemetry, see
+                            the [Node.js
+                            wrapper](https://github.com/PostHog/posthog-js/tree/e08ff1be/examples/example-ai-ollama) and
+                            [Python
+                            wrapper](https://github.com/PostHog/posthog-python/tree/7223c52/examples/example-ai-ollama)
+                            examples.
                         </Markdown>
                     </CalloutBox>
 

--- a/docs/onboarding/llm-analytics/ollama.tsx
+++ b/docs/onboarding/llm-analytics/ollama.tsx
@@ -3,7 +3,7 @@ import { OnboardingComponentsContext, createInstallation } from 'scenes/onboardi
 import { StepDefinition } from '../steps'
 
 export const getOllamaSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
-    const { CodeBlock, CalloutBox, Markdown, Blockquote, dedent, snippets } = ctx
+    const { CodeBlock, Markdown, Blockquote, dedent, snippets } = ctx
 
     const NotableGenerationProperties = snippets?.NotableGenerationProperties
 
@@ -33,13 +33,6 @@ export const getOllamaSteps = (ctx: OnboardingComponentsContext): StepDefinition
                             },
                         ]}
                     />
-
-                    <CalloutBox type="fyi" icon="IconInfo" title="No proxy">
-                        <Markdown>
-                            These SDKs **do not** proxy your calls. They only send analytics data to PostHog in the
-                            background.
-                        </Markdown>
-                    </CalloutBox>
                 </>
             ),
         },

--- a/docs/onboarding/llm-analytics/ollama.tsx
+++ b/docs/onboarding/llm-analytics/ollama.tsx
@@ -9,84 +9,48 @@ export const getOllamaSteps = (ctx: OnboardingComponentsContext): StepDefinition
 
     return [
         {
-            title: 'Install the PostHog SDK',
+            title: 'Install dependencies',
             badge: 'required',
             content: (
                 <>
-                    <CalloutBox type="fyi" icon="IconInfo" title="Note">
+                    <Markdown>Install the OpenTelemetry SDK, the OpenAI instrumentation, and the OpenAI SDK.</Markdown>
+
+                    <CodeBlock
+                        blocks={[
+                            {
+                                language: 'bash',
+                                file: 'Python',
+                                code: dedent`
+                                    pip install openai opentelemetry-sdk opentelemetry-exporter-otlp-proto-http opentelemetry-instrumentation-openai-v2
+                                `,
+                            },
+                            {
+                                language: 'bash',
+                                file: 'Node',
+                                code: dedent`
+                                    npm install openai @posthog/ai @opentelemetry/sdk-node @opentelemetry/resources @opentelemetry/instrumentation-openai
+                                `,
+                            },
+                        ]}
+                    />
+
+                    <CalloutBox type="fyi" icon="IconInfo" title="No proxy">
                         <Markdown>
-                            **Note:** Make sure Ollama is running locally before making API calls. You can start it with
-                            `ollama serve`.
+                            These SDKs **do not** proxy your calls. They only send analytics data to PostHog in the
+                            background.
                         </Markdown>
                     </CalloutBox>
-
-                    <Markdown>
-                        Setting up analytics starts with installing the PostHog SDK for your language. LLM analytics
-                        works best with our Python and Node SDKs.
-                    </Markdown>
-
-                    <CodeBlock
-                        blocks={[
-                            {
-                                language: 'bash',
-                                file: 'Python',
-                                code: dedent`
-                                    pip install posthog
-                                `,
-                            },
-                            {
-                                language: 'bash',
-                                file: 'Node',
-                                code: dedent`
-                                    npm install @posthog/ai posthog-node
-                                `,
-                            },
-                        ]}
-                    />
                 </>
             ),
         },
         {
-            title: 'Install the OpenAI SDK',
+            title: 'Set up OpenTelemetry tracing',
             badge: 'required',
             content: (
                 <>
                     <Markdown>
-                        Install the OpenAI SDK. The PostHog SDK instruments your LLM calls by wrapping the OpenAI
-                        client. The PostHog SDK **does not** proxy your calls.
-                    </Markdown>
-
-                    <CodeBlock
-                        blocks={[
-                            {
-                                language: 'bash',
-                                file: 'Python',
-                                code: dedent`
-                                    pip install openai
-                                `,
-                            },
-                            {
-                                language: 'bash',
-                                file: 'Node',
-                                code: dedent`
-                                    npm install openai
-                                `,
-                            },
-                        ]}
-                    />
-                </>
-            ),
-        },
-        {
-            title: 'Initialize PostHog and OpenAI client',
-            badge: 'required',
-            content: (
-                <>
-                    <Markdown>
-                        We call Ollama through the OpenAI client and generate a response. We'll use PostHog's OpenAI
-                        provider to capture all the details of the call. Initialize PostHog with your PostHog project
-                        token and host from [your project settings](https://app.posthog.com/settings/project), then pass
-                        the PostHog client along with the Ollama config (the base URL) to our OpenAI wrapper.
+                        Configure OpenTelemetry to auto-instrument OpenAI SDK calls and export traces to PostHog.
+                        PostHog converts `gen_ai.*` spans into `$ai_generation` events automatically.
                     </Markdown>
 
                     <CodeBlock
@@ -95,61 +59,59 @@ export const getOllamaSteps = (ctx: OnboardingComponentsContext): StepDefinition
                                 language: 'python',
                                 file: 'Python',
                                 code: dedent`
-                                    from posthog.ai.openai import OpenAI
-                                    from posthog import Posthog
+                                    from opentelemetry import trace
+                                    from opentelemetry.sdk.trace import TracerProvider
+                                    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+                                    from opentelemetry.sdk.resources import Resource, SERVICE_NAME
+                                    from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+                                    from opentelemetry.instrumentation.openai_v2 import OpenAIInstrumentor
 
-                                    posthog = Posthog(
-                                        "<ph_project_token>",
-                                        host="<ph_client_api_host>"
+                                    resource = Resource(attributes={
+                                        SERVICE_NAME: "my-app",
+                                        "user.id": "user_123", # optional: identifies the user in PostHog
+                                    })
+
+                                    exporter = OTLPSpanExporter(
+                                        endpoint="<ph_client_api_host>/i/v0/ai/otel",
+                                        headers={"Authorization": "Bearer <ph_project_token>"},
                                     )
 
-                                    client = OpenAI(
-                                        base_url="http://localhost:11434/v1",
-                                        api_key="ollama",
-                                        posthog_client=posthog
-                                    )
+                                    provider = TracerProvider(resource=resource)
+                                    provider.add_span_processor(SimpleSpanProcessor(exporter))
+                                    trace.set_tracer_provider(provider)
+
+                                    OpenAIInstrumentor().instrument()
                                 `,
                             },
                             {
                                 language: 'typescript',
                                 file: 'Node',
                                 code: dedent`
-                                    import { OpenAI } from '@posthog/ai'
-                                    import { PostHog } from 'posthog-node'
+                                    import { NodeSDK, tracing } from '@opentelemetry/sdk-node'
+                                    import { resourceFromAttributes } from '@opentelemetry/resources'
+                                    import { PostHogTraceExporter } from '@posthog/ai/otel'
+                                    import { OpenAIInstrumentation } from '@opentelemetry/instrumentation-openai'
 
-                                    const phClient = new PostHog(
-                                      '<ph_project_token>',
-                                      { host: '<ph_client_api_host>' }
-                                    );
-
-                                    const openai = new OpenAI({
-                                      baseURL: 'http://localhost:11434/v1',
-                                      apiKey: 'ollama',
-                                      posthog: phClient,
-                                    });
-
-                                    // ... your code here ...
-
-                                    // IMPORTANT: Shutdown the client when you're done to ensure all events are sent
-                                    phClient.shutdown()
+                                    const sdk = new NodeSDK({
+                                      resource: resourceFromAttributes({
+                                        'service.name': 'my-app',
+                                        'user.id': 'user_123', // optional: identifies the user in PostHog
+                                      }),
+                                      spanProcessors: [
+                                        new tracing.SimpleSpanProcessor(
+                                          new PostHogTraceExporter({
+                                            apiKey: '<ph_project_token>',
+                                            host: '<ph_client_api_host>',
+                                          })
+                                        ),
+                                      ],
+                                      instrumentations: [new OpenAIInstrumentation()],
+                                    })
+                                    sdk.start()
                                 `,
                             },
                         ]}
                     />
-
-                    <Blockquote>
-                        <Markdown>**Note:** This also works with the `AsyncOpenAI` client.</Markdown>
-                    </Blockquote>
-
-                    <CalloutBox type="fyi" icon="IconInfo" title="Proxy note">
-                        <Markdown>
-                            These SDKs **do not** proxy your calls. They only fire off an async call to PostHog in the
-                            background to send the data. You can also use LLM analytics with other SDKs or our API, but
-                            you will need to capture the data in the right format. See the schema in the [manual capture
-                            section](https://posthog.com/docs/llm-analytics/installation/manual-capture) for more
-                            details.
-                        </Markdown>
-                    </CalloutBox>
                 </>
             ),
         },
@@ -159,9 +121,8 @@ export const getOllamaSteps = (ctx: OnboardingComponentsContext): StepDefinition
             content: (
                 <>
                     <Markdown>
-                        Now, when you call Ollama with the OpenAI SDK, PostHog automatically captures an
-                        `$ai_generation` event. You can also capture or modify additional properties with the distinct
-                        ID, trace ID, properties, groups, and privacy mode parameters.
+                        Now, when you use the OpenAI SDK to call Ollama, PostHog automatically captures `$ai_generation`
+                        events via the OpenTelemetry instrumentation.
                     </Markdown>
 
                     <CodeBlock
@@ -170,16 +131,19 @@ export const getOllamaSteps = (ctx: OnboardingComponentsContext): StepDefinition
                                 language: 'python',
                                 file: 'Python',
                                 code: dedent`
+                                    import openai
+
+                                    client = openai.OpenAI(
+                                        base_url="http://localhost:11434/v1",
+                                        api_key="ollama",
+                                    )
+
                                     response = client.chat.completions.create(
                                         model="llama3.2",
+                                        max_completion_tokens=1024,
                                         messages=[
                                             {"role": "user", "content": "Tell me a fun fact about hedgehogs"}
                                         ],
-                                        posthog_distinct_id="user_123", # optional
-                                        posthog_trace_id="trace_123", # optional
-                                        posthog_properties={"conversation_id": "abc123", "paid": True}, # optional
-                                        posthog_groups={"company": "company_id_in_your_db"},  # optional
-                                        posthog_privacy_mode=False # optional
                                     )
 
                                     print(response.choices[0].message.content)
@@ -189,17 +153,20 @@ export const getOllamaSteps = (ctx: OnboardingComponentsContext): StepDefinition
                                 language: 'typescript',
                                 file: 'Node',
                                 code: dedent`
-                                    const completion = await openai.chat.completions.create({
-                                        model: "llama3.2",
-                                        messages: [{ role: "user", content: "Tell me a fun fact about hedgehogs" }],
-                                        posthogDistinctId: "user_123", // optional
-                                        posthogTraceId: "trace_123", // optional
-                                        posthogProperties: { conversation_id: "abc123", paid: true }, // optional
-                                        posthogGroups: { company: "company_id_in_your_db" }, // optional
-                                        posthogPrivacyMode: false // optional
-                                    });
+                                    import OpenAI from 'openai'
 
-                                    console.log(completion.choices[0].message.content)
+                                    const client = new OpenAI({
+                                      baseURL: 'http://localhost:11434/v1',
+                                      apiKey: 'ollama',
+                                    })
+
+                                    const response = await client.chat.completions.create({
+                                      model: 'llama3.2',
+                                      max_completion_tokens: 1024,
+                                      messages: [{ role: 'user', content: 'Tell me a fun fact about hedgehogs' }],
+                                    })
+
+                                    console.log(response.choices[0].message.content)
                                 `,
                             },
                         ]}
@@ -208,12 +175,7 @@ export const getOllamaSteps = (ctx: OnboardingComponentsContext): StepDefinition
                     <Blockquote>
                         <Markdown>
                             {dedent`
-                            **Notes:**
-                            - We also support the old \`chat.completions\` API.
-                            - This works with responses where \`stream=True\`.
-                            - If you want to capture LLM events anonymously, **don't** pass a distinct ID to the request.
-
-                            See our docs on [anonymous vs identified events](https://posthog.com/docs/data/anonymous-vs-identified-events) to learn more.
+                            **Note:** If you want to capture LLM events anonymously, omit the \`user.id\` resource attribute. See our docs on [anonymous vs identified events](https://posthog.com/docs/data/anonymous-vs-identified-events) to learn more.
                             `}
                         </Markdown>
                     </Blockquote>

--- a/docs/onboarding/llm-analytics/ollama.tsx
+++ b/docs/onboarding/llm-analytics/ollama.tsx
@@ -95,9 +95,9 @@ export const getOllamaSteps = (ctx: OnboardingComponentsContext): StepDefinition
                                 language: 'typescript',
                                 file: 'Node',
                                 code: dedent`
-                                    import { NodeSDK, tracing } from '@opentelemetry/sdk-node'
+                                    import { NodeSDK } from '@opentelemetry/sdk-node'
                                     import { resourceFromAttributes } from '@opentelemetry/resources'
-                                    import { PostHogTraceExporter } from '@posthog/ai/otel'
+                                    import { PostHogSpanProcessor } from '@posthog/ai/otel'
                                     import { OpenAIInstrumentation } from '@opentelemetry/instrumentation-openai'
 
                                     const sdk = new NodeSDK({
@@ -107,12 +107,10 @@ export const getOllamaSteps = (ctx: OnboardingComponentsContext): StepDefinition
                                         foo: 'bar', // custom properties are passed through
                                       }),
                                       spanProcessors: [
-                                        new tracing.SimpleSpanProcessor(
-                                          new PostHogTraceExporter({
-                                            apiKey: '<ph_project_token>',
-                                            host: '<ph_client_api_host>',
-                                          })
-                                        ),
+                                        new PostHogSpanProcessor({
+                                          apiKey: '<ph_project_token>',
+                                          host: '<ph_client_api_host>',
+                                        }),
                                       ],
                                       instrumentations: [new OpenAIInstrumentation()],
                                     })

--- a/docs/onboarding/llm-analytics/ollama.tsx
+++ b/docs/onboarding/llm-analytics/ollama.tsx
@@ -35,7 +35,7 @@ export const getOllamaSteps = (ctx: OnboardingComponentsContext): StepDefinition
                                 language: 'bash',
                                 file: 'Python',
                                 code: dedent`
-                                    pip install openai opentelemetry-sdk opentelemetry-exporter-otlp-proto-http opentelemetry-instrumentation-openai-v2
+                                    pip install openai opentelemetry-sdk posthog[otel] opentelemetry-instrumentation-openai-v2
                                 `,
                             },
                             {
@@ -68,9 +68,8 @@ export const getOllamaSteps = (ctx: OnboardingComponentsContext): StepDefinition
                                 code: dedent`
                                     from opentelemetry import trace
                                     from opentelemetry.sdk.trace import TracerProvider
-                                    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
                                     from opentelemetry.sdk.resources import Resource, SERVICE_NAME
-                                    from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+                                    from posthog.ai.otel import PostHogSpanProcessor
                                     from opentelemetry.instrumentation.openai_v2 import OpenAIInstrumentor
 
                                     resource = Resource(attributes={
@@ -79,13 +78,13 @@ export const getOllamaSteps = (ctx: OnboardingComponentsContext): StepDefinition
                                         "foo": "bar", # custom properties are passed through
                                     })
 
-                                    exporter = OTLPSpanExporter(
-                                        endpoint="<ph_client_api_host>/i/v0/ai/otel",
-                                        headers={"Authorization": "Bearer <ph_project_token>"},
-                                    )
-
                                     provider = TracerProvider(resource=resource)
-                                    provider.add_span_processor(SimpleSpanProcessor(exporter))
+                                    provider.add_span_processor(
+                                        PostHogSpanProcessor(
+                                            api_key="<ph_project_token>",
+                                            host="<ph_client_api_host>",
+                                        )
+                                    )
                                     trace.set_tracer_provider(provider)
 
                                     OpenAIInstrumentor().instrument()

--- a/docs/onboarding/llm-analytics/openai.tsx
+++ b/docs/onboarding/llm-analytics/openai.tsx
@@ -13,14 +13,17 @@ export const getOpenAISteps = (ctx: OnboardingComponentsContext): StepDefinition
             badge: 'required',
             content: (
                 <>
-                    <CalloutBox type="info" icon="IconInfo" title="Migrating from the SDK wrapper?">
+                    <CalloutBox type="info" icon="IconInfo" title="Full working examples">
                         <Markdown>
-                            These docs now use OpenTelemetry auto-instrumentation, which is the recommended approach.
-                            The previous PostHog SDK wrapper is still available — see the
-                            [Node.js](https://github.com/PostHog/posthog-js/tree/e08ff1be/examples/example-ai-openai)
-                            and
-                            [Python](https://github.com/PostHog/posthog-python/tree/7223c52/examples/example-ai-openai)
-                            wrapper examples.
+                            See the complete
+                            [Node.js](https://github.com/PostHog/posthog-js/tree/main/examples/example-ai-openai) and
+                            [Python](https://github.com/PostHog/posthog-python/tree/master/examples/example-ai-openai)
+                            examples on GitHub. If you're using the PostHog SDK wrapper instead of OpenTelemetry, see
+                            the [Node.js
+                            wrapper](https://github.com/PostHog/posthog-js/tree/e08ff1be/examples/example-ai-openai) and
+                            [Python
+                            wrapper](https://github.com/PostHog/posthog-python/tree/7223c52/examples/example-ai-openai)
+                            examples.
                         </Markdown>
                     </CalloutBox>
 

--- a/docs/onboarding/llm-analytics/openai.tsx
+++ b/docs/onboarding/llm-analytics/openai.tsx
@@ -3,7 +3,7 @@ import { OnboardingComponentsContext, createInstallation } from 'scenes/onboardi
 import { StepDefinition } from '../steps'
 
 export const getOpenAISteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
-    const { CodeBlock, CalloutBox, Markdown, Blockquote, dedent, snippets } = ctx
+    const { CodeBlock, Markdown, Blockquote, dedent, snippets } = ctx
 
     const NotableGenerationProperties = snippets?.NotableGenerationProperties
 
@@ -33,13 +33,6 @@ export const getOpenAISteps = (ctx: OnboardingComponentsContext): StepDefinition
                             },
                         ]}
                     />
-
-                    <CalloutBox type="fyi" icon="IconInfo" title="No proxy">
-                        <Markdown>
-                            These SDKs **do not** proxy your calls. They only send analytics data to PostHog in the
-                            background.
-                        </Markdown>
-                    </CalloutBox>
                 </>
             ),
         },

--- a/docs/onboarding/llm-analytics/openai.tsx
+++ b/docs/onboarding/llm-analytics/openai.tsx
@@ -9,14 +9,11 @@ export const getOpenAISteps = (ctx: OnboardingComponentsContext): StepDefinition
 
     return [
         {
-            title: 'Install the PostHog SDK',
+            title: 'Install dependencies',
             badge: 'required',
             content: (
                 <>
-                    <Markdown>
-                        Setting up analytics starts with installing the PostHog SDK for your language. LLM analytics
-                        works best with our Python and Node SDKs.
-                    </Markdown>
+                    <Markdown>Install the OpenTelemetry SDK, the OpenAI instrumentation, and the OpenAI SDK.</Markdown>
 
                     <CodeBlock
                         blocks={[
@@ -24,60 +21,36 @@ export const getOpenAISteps = (ctx: OnboardingComponentsContext): StepDefinition
                                 language: 'bash',
                                 file: 'Python',
                                 code: dedent`
-                                    pip install posthog
+                                    pip install openai opentelemetry-sdk opentelemetry-exporter-otlp-proto-http opentelemetry-instrumentation-openai-v2
                                 `,
                             },
                             {
                                 language: 'bash',
                                 file: 'Node',
                                 code: dedent`
-                                    npm install @posthog/ai posthog-node
+                                    npm install openai @posthog/ai @opentelemetry/sdk-node @opentelemetry/resources @opentelemetry/instrumentation-openai
                                 `,
                             },
                         ]}
                     />
-                </>
-            ),
-        },
-        {
-            title: 'Install the OpenAI SDK',
-            badge: 'required',
-            content: (
-                <>
-                    <Markdown>
-                        Install the OpenAI SDK. The PostHog SDK instruments your LLM calls by wrapping the OpenAI
-                        client. The PostHog SDK **does not** proxy your calls.
-                    </Markdown>
 
-                    <CodeBlock
-                        blocks={[
-                            {
-                                language: 'bash',
-                                file: 'Python',
-                                code: dedent`
-                                    pip install openai
-                                `,
-                            },
-                            {
-                                language: 'bash',
-                                file: 'Node',
-                                code: dedent`
-                                    npm install openai
-                                `,
-                            },
-                        ]}
-                    />
+                    <CalloutBox type="fyi" icon="IconInfo" title="No proxy">
+                        <Markdown>
+                            These SDKs **do not** proxy your calls. They only send analytics data to PostHog in the
+                            background.
+                        </Markdown>
+                    </CalloutBox>
                 </>
             ),
         },
         {
-            title: 'Initialize PostHog and OpenAI client',
+            title: 'Set up OpenTelemetry tracing',
             badge: 'required',
             content: (
                 <>
                     <Markdown>
-                        Initialize PostHog with your project token and host from [your project
-                        settings](https://app.posthog.com/settings/project), then pass it to our OpenAI wrapper.
+                        Configure OpenTelemetry to auto-instrument OpenAI SDK calls and export traces to PostHog.
+                        PostHog converts `gen_ai.*` spans into `$ai_generation` events automatically.
                     </Markdown>
 
                     <CodeBlock
@@ -86,59 +59,59 @@ export const getOpenAISteps = (ctx: OnboardingComponentsContext): StepDefinition
                                 language: 'python',
                                 file: 'Python',
                                 code: dedent`
-                                    from posthog.ai.openai import OpenAI
-                                    from posthog import Posthog
+                                    from opentelemetry import trace
+                                    from opentelemetry.sdk.trace import TracerProvider
+                                    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+                                    from opentelemetry.sdk.resources import Resource, SERVICE_NAME
+                                    from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+                                    from opentelemetry.instrumentation.openai_v2 import OpenAIInstrumentor
 
-                                    posthog = Posthog(
-                                        "<ph_project_token>",
-                                        host="<ph_client_api_host>"
+                                    resource = Resource(attributes={
+                                        SERVICE_NAME: "my-app",
+                                        "user.id": "user_123", # optional: identifies the user in PostHog
+                                    })
+
+                                    exporter = OTLPSpanExporter(
+                                        endpoint="<ph_client_api_host>/i/v0/ai/otel",
+                                        headers={"Authorization": "Bearer <ph_project_token>"},
                                     )
 
-                                    client = OpenAI(
-                                        api_key="your_openai_api_key",
-                                        posthog_client=posthog # This is an optional parameter. If it is not provided, a default client will be used.
-                                    )
+                                    provider = TracerProvider(resource=resource)
+                                    provider.add_span_processor(SimpleSpanProcessor(exporter))
+                                    trace.set_tracer_provider(provider)
+
+                                    OpenAIInstrumentor().instrument()
                                 `,
                             },
                             {
                                 language: 'typescript',
                                 file: 'Node',
                                 code: dedent`
-                                    import { OpenAI } from '@posthog/ai'
-                                    import { PostHog } from 'posthog-node'
+                                    import { NodeSDK, tracing } from '@opentelemetry/sdk-node'
+                                    import { resourceFromAttributes } from '@opentelemetry/resources'
+                                    import { PostHogTraceExporter } from '@posthog/ai/otel'
+                                    import { OpenAIInstrumentation } from '@opentelemetry/instrumentation-openai'
 
-                                    const phClient = new PostHog(
-                                      '<ph_project_token>',
-                                      { host: '<ph_client_api_host>' }
-                                    );
-
-                                    const openai = new OpenAI({
-                                      apiKey: 'your_openai_api_key',
-                                      posthog: phClient,
-                                    });
-
-                                    // ... your code here ...
-
-                                    // IMPORTANT: Shutdown the client when you're done to ensure all events are sent
-                                    phClient.shutdown()
+                                    const sdk = new NodeSDK({
+                                      resource: resourceFromAttributes({
+                                        'service.name': 'my-app',
+                                        'user.id': 'user_123', // optional: identifies the user in PostHog
+                                      }),
+                                      spanProcessors: [
+                                        new tracing.SimpleSpanProcessor(
+                                          new PostHogTraceExporter({
+                                            apiKey: '<ph_project_token>',
+                                            host: '<ph_client_api_host>',
+                                          })
+                                        ),
+                                      ],
+                                      instrumentations: [new OpenAIInstrumentation()],
+                                    })
+                                    sdk.start()
                                 `,
                             },
                         ]}
                     />
-
-                    <Blockquote>
-                        <Markdown>**Note:** This also works with the `AsyncOpenAI` client.</Markdown>
-                    </Blockquote>
-
-                    <CalloutBox type="fyi" icon="IconInfo" title="Proxy note">
-                        <Markdown>
-                            These SDKs **do not** proxy your calls. They only fire off an async call to PostHog in the
-                            background to send the data. You can also use LLM analytics with other SDKs or our API, but
-                            you will need to capture the data in the right format. See the schema in the [manual capture
-                            section](https://posthog.com/docs/llm-analytics/installation/manual-capture) for more
-                            details.
-                        </Markdown>
-                    </CalloutBox>
                 </>
             ),
         },
@@ -148,9 +121,8 @@ export const getOpenAISteps = (ctx: OnboardingComponentsContext): StepDefinition
             content: (
                 <>
                     <Markdown>
-                        Now, when you use the OpenAI SDK to call LLMs, PostHog automatically captures an
-                        `$ai_generation` event. You can enrich the event with additional data such as the trace ID,
-                        distinct ID, custom properties, groups, and privacy mode options.
+                        Now, when you use the OpenAI SDK to call OpenAI, PostHog automatically captures `$ai_generation`
+                        events via the OpenTelemetry instrumentation.
                     </Markdown>
 
                     <CodeBlock
@@ -159,16 +131,17 @@ export const getOpenAISteps = (ctx: OnboardingComponentsContext): StepDefinition
                                 language: 'python',
                                 file: 'Python',
                                 code: dedent`
+                                    import openai
+
+                                    client = openai.OpenAI(
+                                        api_key="your_openai_api_key",
+                                    )
+
                                     response = client.responses.create(
                                         model="gpt-5-mini",
                                         input=[
                                             {"role": "user", "content": "Tell me a fun fact about hedgehogs"}
                                         ],
-                                        posthog_distinct_id="user_123", # optional
-                                        posthog_trace_id="trace_123", # optional
-                                        posthog_properties={"conversation_id": "abc123", "paid": True}, # optional
-                                        posthog_groups={"company": "company_id_in_your_db"},  # optional
-                                        posthog_privacy_mode=False # optional
                                     )
 
                                     print(response.output_text)
@@ -178,17 +151,18 @@ export const getOpenAISteps = (ctx: OnboardingComponentsContext): StepDefinition
                                 language: 'typescript',
                                 file: 'Node',
                                 code: dedent`
-                                    const completion = await openai.responses.create({
-                                        model: "gpt-5-mini",
-                                        input: [{ role: "user", content: "Tell me a fun fact about hedgehogs" }],
-                                        posthogDistinctId: "user_123", // optional
-                                        posthogTraceId: "trace_123", // optional
-                                        posthogProperties: { conversation_id: "abc123", paid: true }, // optional
-                                        posthogGroups: { company: "company_id_in_your_db" }, // optional
-                                        posthogPrivacyMode: false // optional
-                                    });
+                                    import OpenAI from 'openai'
 
-                                    console.log(completion.output_text)
+                                    const client = new OpenAI({
+                                      apiKey: 'your_openai_api_key',
+                                    })
+
+                                    const response = await client.responses.create({
+                                      model: 'gpt-5-mini',
+                                      input: [{ role: 'user', content: 'Tell me a fun fact about hedgehogs' }],
+                                    })
+
+                                    console.log(response.output_text)
                                 `,
                             },
                         ]}
@@ -196,14 +170,9 @@ export const getOpenAISteps = (ctx: OnboardingComponentsContext): StepDefinition
 
                     <Blockquote>
                         <Markdown>
-                            {dedent`
-                            **Notes:**
-                            - We also support the old \`chat.completions\` API.
-                            - This works with responses where \`stream=True\`.
-                            - If you want to capture LLM events anonymously, **don't** pass a distinct ID to the request.
-
-                            See our docs on [anonymous vs identified events](https://posthog.com/docs/data/anonymous-vs-identified-events) to learn more.
-                            `}
+                            **Note:** If you want to capture LLM events anonymously, omit the `user.id` resource
+                            attribute. See our docs on [anonymous vs identified
+                            events](https://posthog.com/docs/data/anonymous-vs-identified-events) to learn more.
                         </Markdown>
                     </Blockquote>
 
@@ -223,8 +192,8 @@ export const getOpenAISteps = (ctx: OnboardingComponentsContext): StepDefinition
             content: (
                 <>
                     <Markdown>
-                        PostHog can also capture embedding generations as `$ai_embedding` events. Just make sure to use
-                        the same `posthog.ai.openai` client to do so:
+                        PostHog can also capture embedding generations as `$ai_embedding` events. The OpenTelemetry
+                        instrumentation automatically captures these when you use the embeddings API:
                     </Markdown>
 
                     <CodeBlock
@@ -233,11 +202,6 @@ export const getOpenAISteps = (ctx: OnboardingComponentsContext): StepDefinition
                             response = client.embeddings.create(
                                 input="The quick brown fox",
                                 model="text-embedding-3-small",
-                                posthog_distinct_id="user_123", # optional
-                                posthog_trace_id="trace_123",   # optional
-                                posthog_properties={"key": "value"} # optional
-                                posthog_groups={"company": "company_id_in_your_db"}  # optional
-                                posthog_privacy_mode=False # optional
                             )
                         `}
                     />

--- a/docs/onboarding/llm-analytics/openai.tsx
+++ b/docs/onboarding/llm-analytics/openai.tsx
@@ -190,13 +190,28 @@ export const getOpenAISteps = (ctx: OnboardingComponentsContext): StepDefinition
                     </Markdown>
 
                     <CodeBlock
-                        language="python"
-                        code={dedent`
-                            response = client.embeddings.create(
-                                input="The quick brown fox",
-                                model="text-embedding-3-small",
-                            )
-                        `}
+                        blocks={[
+                            {
+                                language: 'python',
+                                file: 'Python',
+                                code: dedent`
+                                    response = client.embeddings.create(
+                                        input="The quick brown fox",
+                                        model="text-embedding-3-small",
+                                    )
+                                `,
+                            },
+                            {
+                                language: 'typescript',
+                                file: 'Node',
+                                code: dedent`
+                                    const response = await client.embeddings.create({
+                                      input: 'The quick brown fox',
+                                      model: 'text-embedding-3-small',
+                                    })
+                                `,
+                            },
+                        ]}
                     />
                 </>
             ),

--- a/docs/onboarding/llm-analytics/openai.tsx
+++ b/docs/onboarding/llm-analytics/openai.tsx
@@ -61,7 +61,8 @@ export const getOpenAISteps = (ctx: OnboardingComponentsContext): StepDefinition
 
                                     resource = Resource(attributes={
                                         SERVICE_NAME: "my-app",
-                                        "user.id": "user_123", # optional: identifies the user in PostHog
+                                        "posthog.distinct_id": "user_123", # optional: identifies the user in PostHog
+                                        "foo": "bar", # custom properties are passed through
                                     })
 
                                     exporter = OTLPSpanExporter(
@@ -88,7 +89,8 @@ export const getOpenAISteps = (ctx: OnboardingComponentsContext): StepDefinition
                                     const sdk = new NodeSDK({
                                       resource: resourceFromAttributes({
                                         'service.name': 'my-app',
-                                        'user.id': 'user_123', // optional: identifies the user in PostHog
+                                        'posthog.distinct_id': 'user_123', // optional: identifies the user in PostHog
+                                        foo: 'bar', // custom properties are passed through
                                       }),
                                       spanProcessors: [
                                         new tracing.SimpleSpanProcessor(
@@ -163,8 +165,8 @@ export const getOpenAISteps = (ctx: OnboardingComponentsContext): StepDefinition
 
                     <Blockquote>
                         <Markdown>
-                            **Note:** If you want to capture LLM events anonymously, omit the `user.id` resource
-                            attribute. See our docs on [anonymous vs identified
+                            **Note:** If you want to capture LLM events anonymously, omit the `posthog.distinct_id`
+                            resource attribute. See our docs on [anonymous vs identified
                             events](https://posthog.com/docs/data/anonymous-vs-identified-events) to learn more.
                         </Markdown>
                     </Blockquote>

--- a/docs/onboarding/llm-analytics/openai.tsx
+++ b/docs/onboarding/llm-analytics/openai.tsx
@@ -3,7 +3,7 @@ import { OnboardingComponentsContext, createInstallation } from 'scenes/onboardi
 import { StepDefinition } from '../steps'
 
 export const getOpenAISteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
-    const { CodeBlock, Markdown, Blockquote, dedent, snippets } = ctx
+    const { CodeBlock, CalloutBox, Markdown, Blockquote, dedent, snippets } = ctx
 
     const NotableGenerationProperties = snippets?.NotableGenerationProperties
 
@@ -13,6 +13,17 @@ export const getOpenAISteps = (ctx: OnboardingComponentsContext): StepDefinition
             badge: 'required',
             content: (
                 <>
+                    <CalloutBox type="info" icon="IconInfo" title="Migrating from the SDK wrapper?">
+                        <Markdown>
+                            These docs now use OpenTelemetry auto-instrumentation, which is the recommended approach.
+                            The previous PostHog SDK wrapper is still available — see the
+                            [Node.js](https://github.com/PostHog/posthog-js/tree/e08ff1be/examples/example-ai-openai)
+                            and
+                            [Python](https://github.com/PostHog/posthog-python/tree/7223c52/examples/example-ai-openai)
+                            wrapper examples.
+                        </Markdown>
+                    </CalloutBox>
+
                     <Markdown>Install the OpenTelemetry SDK, the OpenAI instrumentation, and the OpenAI SDK.</Markdown>
 
                     <CodeBlock

--- a/docs/onboarding/llm-analytics/openai.tsx
+++ b/docs/onboarding/llm-analytics/openai.tsx
@@ -35,7 +35,7 @@ export const getOpenAISteps = (ctx: OnboardingComponentsContext): StepDefinition
                                 language: 'bash',
                                 file: 'Python',
                                 code: dedent`
-                                    pip install openai opentelemetry-sdk opentelemetry-exporter-otlp-proto-http opentelemetry-instrumentation-openai-v2
+                                    pip install openai opentelemetry-sdk posthog[otel] opentelemetry-instrumentation-openai-v2
                                 `,
                             },
                             {
@@ -68,9 +68,8 @@ export const getOpenAISteps = (ctx: OnboardingComponentsContext): StepDefinition
                                 code: dedent`
                                     from opentelemetry import trace
                                     from opentelemetry.sdk.trace import TracerProvider
-                                    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
                                     from opentelemetry.sdk.resources import Resource, SERVICE_NAME
-                                    from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+                                    from posthog.ai.otel import PostHogSpanProcessor
                                     from opentelemetry.instrumentation.openai_v2 import OpenAIInstrumentor
 
                                     resource = Resource(attributes={
@@ -79,13 +78,13 @@ export const getOpenAISteps = (ctx: OnboardingComponentsContext): StepDefinition
                                         "foo": "bar", # custom properties are passed through
                                     })
 
-                                    exporter = OTLPSpanExporter(
-                                        endpoint="<ph_client_api_host>/i/v0/ai/otel",
-                                        headers={"Authorization": "Bearer <ph_project_token>"},
-                                    )
-
                                     provider = TracerProvider(resource=resource)
-                                    provider.add_span_processor(SimpleSpanProcessor(exporter))
+                                    provider.add_span_processor(
+                                        PostHogSpanProcessor(
+                                            api_key="<ph_project_token>",
+                                            host="<ph_client_api_host>",
+                                        )
+                                    )
                                     trace.set_tracer_provider(provider)
 
                                     OpenAIInstrumentor().instrument()

--- a/docs/onboarding/llm-analytics/openai.tsx
+++ b/docs/onboarding/llm-analytics/openai.tsx
@@ -95,9 +95,9 @@ export const getOpenAISteps = (ctx: OnboardingComponentsContext): StepDefinition
                                 language: 'typescript',
                                 file: 'Node',
                                 code: dedent`
-                                    import { NodeSDK, tracing } from '@opentelemetry/sdk-node'
+                                    import { NodeSDK } from '@opentelemetry/sdk-node'
                                     import { resourceFromAttributes } from '@opentelemetry/resources'
-                                    import { PostHogTraceExporter } from '@posthog/ai/otel'
+                                    import { PostHogSpanProcessor } from '@posthog/ai/otel'
                                     import { OpenAIInstrumentation } from '@opentelemetry/instrumentation-openai'
 
                                     const sdk = new NodeSDK({
@@ -107,12 +107,10 @@ export const getOpenAISteps = (ctx: OnboardingComponentsContext): StepDefinition
                                         foo: 'bar', // custom properties are passed through
                                       }),
                                       spanProcessors: [
-                                        new tracing.SimpleSpanProcessor(
-                                          new PostHogTraceExporter({
-                                            apiKey: '<ph_project_token>',
-                                            host: '<ph_client_api_host>',
-                                          })
-                                        ),
+                                        new PostHogSpanProcessor({
+                                          apiKey: '<ph_project_token>',
+                                          host: '<ph_client_api_host>',
+                                        }),
                                       ],
                                       instrumentations: [new OpenAIInstrumentation()],
                                     })

--- a/docs/onboarding/llm-analytics/openrouter.tsx
+++ b/docs/onboarding/llm-analytics/openrouter.tsx
@@ -61,7 +61,8 @@ export const getOpenRouterSteps = (ctx: OnboardingComponentsContext): StepDefini
 
                                     resource = Resource(attributes={
                                         SERVICE_NAME: "my-app",
-                                        "user.id": "user_123", # optional: identifies the user in PostHog
+                                        "posthog.distinct_id": "user_123", # optional: identifies the user in PostHog
+                                        "foo": "bar", # custom properties are passed through
                                     })
 
                                     exporter = OTLPSpanExporter(
@@ -88,7 +89,8 @@ export const getOpenRouterSteps = (ctx: OnboardingComponentsContext): StepDefini
                                     const sdk = new NodeSDK({
                                       resource: resourceFromAttributes({
                                         'service.name': 'my-app',
-                                        'user.id': 'user_123', // optional: identifies the user in PostHog
+                                        'posthog.distinct_id': 'user_123', // optional: identifies the user in PostHog
+                                        foo: 'bar', // custom properties are passed through
                                       }),
                                       spanProcessors: [
                                         new tracing.SimpleSpanProcessor(
@@ -168,7 +170,7 @@ export const getOpenRouterSteps = (ctx: OnboardingComponentsContext): StepDefini
                     <Blockquote>
                         <Markdown>
                             {dedent`
-                            **Note:** If you want to capture LLM events anonymously, omit the \`user.id\` resource attribute. See our docs on [anonymous vs identified events](https://posthog.com/docs/data/anonymous-vs-identified-events) to learn more.
+                            **Note:** If you want to capture LLM events anonymously, omit the \`posthog.distinct_id\` resource attribute. See our docs on [anonymous vs identified events](https://posthog.com/docs/data/anonymous-vs-identified-events) to learn more.
                             `}
                         </Markdown>
                     </Blockquote>

--- a/docs/onboarding/llm-analytics/openrouter.tsx
+++ b/docs/onboarding/llm-analytics/openrouter.tsx
@@ -3,7 +3,7 @@ import { OnboardingComponentsContext, createInstallation } from 'scenes/onboardi
 import { StepDefinition } from '../steps'
 
 export const getOpenRouterSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
-    const { CodeBlock, Markdown, Blockquote, dedent, snippets } = ctx
+    const { CodeBlock, CalloutBox, Markdown, Blockquote, dedent, snippets } = ctx
 
     const NotableGenerationProperties = snippets?.NotableGenerationProperties
 
@@ -13,6 +13,17 @@ export const getOpenRouterSteps = (ctx: OnboardingComponentsContext): StepDefini
             badge: 'required',
             content: (
                 <>
+                    <CalloutBox type="info" icon="IconInfo" title="Migrating from the SDK wrapper?">
+                        <Markdown>
+                            These docs now use OpenTelemetry auto-instrumentation, which is the recommended approach.
+                            The previous PostHog SDK wrapper is still available — see the
+                            [Node.js](https://github.com/PostHog/posthog-js/tree/e08ff1be/examples/example-ai-openrouter)
+                            and
+                            [Python](https://github.com/PostHog/posthog-python/tree/7223c52/examples/example-ai-openrouter)
+                            wrapper examples.
+                        </Markdown>
+                    </CalloutBox>
+
                     <Markdown>Install the OpenTelemetry SDK, the OpenAI instrumentation, and the OpenAI SDK.</Markdown>
 
                     <CodeBlock

--- a/docs/onboarding/llm-analytics/openrouter.tsx
+++ b/docs/onboarding/llm-analytics/openrouter.tsx
@@ -9,87 +9,48 @@ export const getOpenRouterSteps = (ctx: OnboardingComponentsContext): StepDefini
 
     return [
         {
-            title: 'Install the PostHog SDK',
+            title: 'Install dependencies',
             badge: 'required',
             content: (
                 <>
-                    <CalloutBox type="fyi" icon="IconInfo" title="Alternative: OpenRouter Broadcast">
+                    <Markdown>Install the OpenTelemetry SDK, the OpenAI instrumentation, and the OpenAI SDK.</Markdown>
+
+                    <CodeBlock
+                        blocks={[
+                            {
+                                language: 'bash',
+                                file: 'Python',
+                                code: dedent`
+                                    pip install openai opentelemetry-sdk opentelemetry-exporter-otlp-proto-http opentelemetry-instrumentation-openai-v2
+                                `,
+                            },
+                            {
+                                language: 'bash',
+                                file: 'Node',
+                                code: dedent`
+                                    npm install openai @posthog/ai @opentelemetry/sdk-node @opentelemetry/resources @opentelemetry/instrumentation-openai
+                                `,
+                            },
+                        ]}
+                    />
+
+                    <CalloutBox type="fyi" icon="IconInfo" title="No proxy">
                         <Markdown>
-                            OpenRouter also offers a native [Broadcast
-                            feature](https://openrouter.ai/docs/guides/features/broadcast/posthog) that can
-                            automatically send LLM analytics data to PostHog without requiring SDK instrumentation. This
-                            is a simpler option if you don't need the additional customization that our SDK provides.
+                            These SDKs **do not** proxy your calls. They only send analytics data to PostHog in the
+                            background.
                         </Markdown>
                     </CalloutBox>
-
-                    <Markdown>
-                        Setting up analytics starts with installing the PostHog SDK for your language. LLM analytics
-                        works best with our Python and Node SDKs.
-                    </Markdown>
-
-                    <CodeBlock
-                        blocks={[
-                            {
-                                language: 'bash',
-                                file: 'Python',
-                                code: dedent`
-                                    pip install posthog
-                                `,
-                            },
-                            {
-                                language: 'bash',
-                                file: 'Node',
-                                code: dedent`
-                                    npm install @posthog/ai posthog-node
-                                `,
-                            },
-                        ]}
-                    />
                 </>
             ),
         },
         {
-            title: 'Install the OpenAI SDK',
+            title: 'Set up OpenTelemetry tracing',
             badge: 'required',
             content: (
                 <>
                     <Markdown>
-                        Install the OpenAI SDK. The PostHog SDK instruments your LLM calls by wrapping the OpenAI
-                        client. The PostHog SDK **does not** proxy your calls.
-                    </Markdown>
-
-                    <CodeBlock
-                        blocks={[
-                            {
-                                language: 'bash',
-                                file: 'Python',
-                                code: dedent`
-                                    pip install openai
-                                `,
-                            },
-                            {
-                                language: 'bash',
-                                file: 'Node',
-                                code: dedent`
-                                    npm install openai
-                                `,
-                            },
-                        ]}
-                    />
-                </>
-            ),
-        },
-        {
-            title: 'Initialize PostHog and OpenAI client',
-            badge: 'required',
-            content: (
-                <>
-                    <Markdown>
-                        We call OpenRouter through the OpenAI client and generate a response. We'll use PostHog's OpenAI
-                        provider to capture all the details of the call. Initialize PostHog with your PostHog project
-                        token and host from [your project settings](https://app.posthog.com/settings/project), then pass
-                        the PostHog client along with the OpenRouter config (the base URL and API key) to our OpenAI
-                        wrapper.
+                        Configure OpenTelemetry to auto-instrument OpenAI SDK calls and export traces to PostHog.
+                        PostHog converts `gen_ai.*` spans into `$ai_generation` events automatically.
                     </Markdown>
 
                     <CodeBlock
@@ -98,61 +59,59 @@ export const getOpenRouterSteps = (ctx: OnboardingComponentsContext): StepDefini
                                 language: 'python',
                                 file: 'Python',
                                 code: dedent`
-                                    from posthog.ai.openai import OpenAI
-                                    from posthog import Posthog
+                                    from opentelemetry import trace
+                                    from opentelemetry.sdk.trace import TracerProvider
+                                    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+                                    from opentelemetry.sdk.resources import Resource, SERVICE_NAME
+                                    from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+                                    from opentelemetry.instrumentation.openai_v2 import OpenAIInstrumentor
 
-                                    posthog = Posthog(
-                                        "<ph_project_token>",
-                                        host="<ph_client_api_host>"
+                                    resource = Resource(attributes={
+                                        SERVICE_NAME: "my-app",
+                                        "user.id": "user_123", # optional: identifies the user in PostHog
+                                    })
+
+                                    exporter = OTLPSpanExporter(
+                                        endpoint="<ph_client_api_host>/i/v0/ai/otel",
+                                        headers={"Authorization": "Bearer <ph_project_token>"},
                                     )
 
-                                    client = OpenAI(
-                                        base_url="https://openrouter.ai/api/v1",
-                                        api_key="<openrouter_api_key>",
-                                        posthog_client=posthog  # This is an optional parameter. If it is not provided, a default client will be used.
-                                    )
+                                    provider = TracerProvider(resource=resource)
+                                    provider.add_span_processor(SimpleSpanProcessor(exporter))
+                                    trace.set_tracer_provider(provider)
+
+                                    OpenAIInstrumentor().instrument()
                                 `,
                             },
                             {
                                 language: 'typescript',
                                 file: 'Node',
                                 code: dedent`
-                                    import { OpenAI } from '@posthog/ai'
-                                    import { PostHog } from 'posthog-node'
+                                    import { NodeSDK, tracing } from '@opentelemetry/sdk-node'
+                                    import { resourceFromAttributes } from '@opentelemetry/resources'
+                                    import { PostHogTraceExporter } from '@posthog/ai/otel'
+                                    import { OpenAIInstrumentation } from '@opentelemetry/instrumentation-openai'
 
-                                    const phClient = new PostHog(
-                                      '<ph_project_token>',
-                                      { host: '<ph_client_api_host>' }
-                                    );
-
-                                    const openai = new OpenAI({
-                                      baseURL: 'https://openrouter.ai/api/v1',
-                                      apiKey: '<openrouter_api_key>',
-                                      posthog: phClient,
-                                    });
-
-                                    // ... your code here ...
-
-                                    // IMPORTANT: Shutdown the client when you're done to ensure all events are sent
-                                    phClient.shutdown()
+                                    const sdk = new NodeSDK({
+                                      resource: resourceFromAttributes({
+                                        'service.name': 'my-app',
+                                        'user.id': 'user_123', // optional: identifies the user in PostHog
+                                      }),
+                                      spanProcessors: [
+                                        new tracing.SimpleSpanProcessor(
+                                          new PostHogTraceExporter({
+                                            apiKey: '<ph_project_token>',
+                                            host: '<ph_client_api_host>',
+                                          })
+                                        ),
+                                      ],
+                                      instrumentations: [new OpenAIInstrumentation()],
+                                    })
+                                    sdk.start()
                                 `,
                             },
                         ]}
                     />
-
-                    <Blockquote>
-                        <Markdown>**Note:** This also works with the `AsyncOpenAI` client.</Markdown>
-                    </Blockquote>
-
-                    <CalloutBox type="fyi" icon="IconInfo" title="Proxy note">
-                        <Markdown>
-                            These SDKs **do not** proxy your calls. They only fire off an async call to PostHog in the
-                            background to send the data. You can also use LLM analytics with other SDKs or our API, but
-                            you will need to capture the data in the right format. See the schema in the [manual capture
-                            section](https://posthog.com/docs/llm-analytics/installation/manual-capture) for more
-                            details.
-                        </Markdown>
-                    </CalloutBox>
                 </>
             ),
         },
@@ -162,9 +121,8 @@ export const getOpenRouterSteps = (ctx: OnboardingComponentsContext): StepDefini
             content: (
                 <>
                     <Markdown>
-                        Now, when you call OpenRouter with the OpenAI SDK, PostHog automatically captures an
-                        `$ai_generation` event. You can also capture or modify additional properties with the distinct
-                        ID, trace ID, properties, groups, and privacy mode parameters.
+                        Now, when you use the OpenAI SDK to call OpenRouter, PostHog automatically captures
+                        `$ai_generation` events via the OpenTelemetry instrumentation.
                     </Markdown>
 
                     <CodeBlock
@@ -173,16 +131,19 @@ export const getOpenRouterSteps = (ctx: OnboardingComponentsContext): StepDefini
                                 language: 'python',
                                 file: 'Python',
                                 code: dedent`
-                                    response = client.responses.create(
+                                    import openai
+
+                                    client = openai.OpenAI(
+                                        base_url="https://openrouter.ai/api/v1",
+                                        api_key="<openrouter_api_key>",
+                                    )
+
+                                    response = client.chat.completions.create(
                                         model="gpt-5-mini",
-                                        input=[
+                                        max_completion_tokens=1024,
+                                        messages=[
                                             {"role": "user", "content": "Tell me a fun fact about hedgehogs"}
                                         ],
-                                        posthog_distinct_id="user_123", # optional
-                                        posthog_trace_id="trace_123", # optional
-                                        posthog_properties={"conversation_id": "abc123", "paid": True}, # optional
-                                        posthog_groups={"company": "company_id_in_your_db"},  # optional
-                                        posthog_privacy_mode=False # optional
                                     )
 
                                     print(response.choices[0].message.content)
@@ -192,17 +153,20 @@ export const getOpenRouterSteps = (ctx: OnboardingComponentsContext): StepDefini
                                 language: 'typescript',
                                 file: 'Node',
                                 code: dedent`
-                                    const completion = await openai.responses.create({
-                                        model: "gpt-5-mini",
-                                        input: [{ role: "user", content: "Tell me a fun fact about hedgehogs" }],
-                                        posthogDistinctId: "user_123", // optional
-                                        posthogTraceId: "trace_123", // optional
-                                        posthogProperties: { conversation_id: "abc123", paid: true }, // optional
-                                        posthogGroups: { company: "company_id_in_your_db" }, // optional
-                                        posthogPrivacyMode: false // optional
-                                    });
+                                    import OpenAI from 'openai'
 
-                                    console.log(completion.choices[0].message.content)
+                                    const client = new OpenAI({
+                                      baseURL: 'https://openrouter.ai/api/v1',
+                                      apiKey: '<openrouter_api_key>',
+                                    })
+
+                                    const response = await client.chat.completions.create({
+                                      model: 'gpt-5-mini',
+                                      max_completion_tokens: 1024,
+                                      messages: [{ role: 'user', content: 'Tell me a fun fact about hedgehogs' }],
+                                    })
+
+                                    console.log(response.choices[0].message.content)
                                 `,
                             },
                         ]}
@@ -211,12 +175,7 @@ export const getOpenRouterSteps = (ctx: OnboardingComponentsContext): StepDefini
                     <Blockquote>
                         <Markdown>
                             {dedent`
-                            **Notes:**
-                            - We also support the old \`chat.completions\` API.
-                            - This works with responses where \`stream=True\`.
-                            - If you want to capture LLM events anonymously, **don't** pass a distinct ID to the request.
-
-                            See our docs on [anonymous vs identified events](https://posthog.com/docs/data/anonymous-vs-identified-events) to learn more.
+                            **Note:** If you want to capture LLM events anonymously, omit the \`user.id\` resource attribute. See our docs on [anonymous vs identified events](https://posthog.com/docs/data/anonymous-vs-identified-events) to learn more.
                             `}
                         </Markdown>
                     </Blockquote>

--- a/docs/onboarding/llm-analytics/openrouter.tsx
+++ b/docs/onboarding/llm-analytics/openrouter.tsx
@@ -3,7 +3,7 @@ import { OnboardingComponentsContext, createInstallation } from 'scenes/onboardi
 import { StepDefinition } from '../steps'
 
 export const getOpenRouterSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
-    const { CodeBlock, CalloutBox, Markdown, Blockquote, dedent, snippets } = ctx
+    const { CodeBlock, Markdown, Blockquote, dedent, snippets } = ctx
 
     const NotableGenerationProperties = snippets?.NotableGenerationProperties
 
@@ -33,13 +33,6 @@ export const getOpenRouterSteps = (ctx: OnboardingComponentsContext): StepDefini
                             },
                         ]}
                     />
-
-                    <CalloutBox type="fyi" icon="IconInfo" title="No proxy">
-                        <Markdown>
-                            These SDKs **do not** proxy your calls. They only send analytics data to PostHog in the
-                            background.
-                        </Markdown>
-                    </CalloutBox>
                 </>
             ),
         },

--- a/docs/onboarding/llm-analytics/openrouter.tsx
+++ b/docs/onboarding/llm-analytics/openrouter.tsx
@@ -13,14 +13,18 @@ export const getOpenRouterSteps = (ctx: OnboardingComponentsContext): StepDefini
             badge: 'required',
             content: (
                 <>
-                    <CalloutBox type="info" icon="IconInfo" title="Migrating from the SDK wrapper?">
+                    <CalloutBox type="info" icon="IconInfo" title="Full working examples">
                         <Markdown>
-                            These docs now use OpenTelemetry auto-instrumentation, which is the recommended approach.
-                            The previous PostHog SDK wrapper is still available — see the
-                            [Node.js](https://github.com/PostHog/posthog-js/tree/e08ff1be/examples/example-ai-openrouter)
+                            See the complete
+                            [Node.js](https://github.com/PostHog/posthog-js/tree/main/examples/example-ai-openrouter)
                             and
-                            [Python](https://github.com/PostHog/posthog-python/tree/7223c52/examples/example-ai-openrouter)
-                            wrapper examples.
+                            [Python](https://github.com/PostHog/posthog-python/tree/master/examples/example-ai-openrouter)
+                            examples on GitHub. If you're using the PostHog SDK wrapper instead of OpenTelemetry, see
+                            the [Node.js
+                            wrapper](https://github.com/PostHog/posthog-js/tree/e08ff1be/examples/example-ai-openrouter)
+                            and [Python
+                            wrapper](https://github.com/PostHog/posthog-python/tree/7223c52/examples/example-ai-openrouter)
+                            examples.
                         </Markdown>
                     </CalloutBox>
 

--- a/docs/onboarding/llm-analytics/openrouter.tsx
+++ b/docs/onboarding/llm-analytics/openrouter.tsx
@@ -96,9 +96,9 @@ export const getOpenRouterSteps = (ctx: OnboardingComponentsContext): StepDefini
                                 language: 'typescript',
                                 file: 'Node',
                                 code: dedent`
-                                    import { NodeSDK, tracing } from '@opentelemetry/sdk-node'
+                                    import { NodeSDK } from '@opentelemetry/sdk-node'
                                     import { resourceFromAttributes } from '@opentelemetry/resources'
-                                    import { PostHogTraceExporter } from '@posthog/ai/otel'
+                                    import { PostHogSpanProcessor } from '@posthog/ai/otel'
                                     import { OpenAIInstrumentation } from '@opentelemetry/instrumentation-openai'
 
                                     const sdk = new NodeSDK({
@@ -108,12 +108,10 @@ export const getOpenRouterSteps = (ctx: OnboardingComponentsContext): StepDefini
                                         foo: 'bar', // custom properties are passed through
                                       }),
                                       spanProcessors: [
-                                        new tracing.SimpleSpanProcessor(
-                                          new PostHogTraceExporter({
-                                            apiKey: '<ph_project_token>',
-                                            host: '<ph_client_api_host>',
-                                          })
-                                        ),
+                                        new PostHogSpanProcessor({
+                                          apiKey: '<ph_project_token>',
+                                          host: '<ph_client_api_host>',
+                                        }),
                                       ],
                                       instrumentations: [new OpenAIInstrumentation()],
                                     })

--- a/docs/onboarding/llm-analytics/openrouter.tsx
+++ b/docs/onboarding/llm-analytics/openrouter.tsx
@@ -36,7 +36,7 @@ export const getOpenRouterSteps = (ctx: OnboardingComponentsContext): StepDefini
                                 language: 'bash',
                                 file: 'Python',
                                 code: dedent`
-                                    pip install openai opentelemetry-sdk opentelemetry-exporter-otlp-proto-http opentelemetry-instrumentation-openai-v2
+                                    pip install openai opentelemetry-sdk posthog[otel] opentelemetry-instrumentation-openai-v2
                                 `,
                             },
                             {
@@ -69,9 +69,8 @@ export const getOpenRouterSteps = (ctx: OnboardingComponentsContext): StepDefini
                                 code: dedent`
                                     from opentelemetry import trace
                                     from opentelemetry.sdk.trace import TracerProvider
-                                    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
                                     from opentelemetry.sdk.resources import Resource, SERVICE_NAME
-                                    from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+                                    from posthog.ai.otel import PostHogSpanProcessor
                                     from opentelemetry.instrumentation.openai_v2 import OpenAIInstrumentor
 
                                     resource = Resource(attributes={
@@ -80,13 +79,13 @@ export const getOpenRouterSteps = (ctx: OnboardingComponentsContext): StepDefini
                                         "foo": "bar", # custom properties are passed through
                                     })
 
-                                    exporter = OTLPSpanExporter(
-                                        endpoint="<ph_client_api_host>/i/v0/ai/otel",
-                                        headers={"Authorization": "Bearer <ph_project_token>"},
-                                    )
-
                                     provider = TracerProvider(resource=resource)
-                                    provider.add_span_processor(SimpleSpanProcessor(exporter))
+                                    provider.add_span_processor(
+                                        PostHogSpanProcessor(
+                                            api_key="<ph_project_token>",
+                                            host="<ph_client_api_host>",
+                                        )
+                                    )
                                     trace.set_tracer_provider(provider)
 
                                     OpenAIInstrumentor().instrument()

--- a/docs/onboarding/llm-analytics/perplexity.tsx
+++ b/docs/onboarding/llm-analytics/perplexity.tsx
@@ -3,7 +3,7 @@ import { OnboardingComponentsContext, createInstallation } from 'scenes/onboardi
 import { StepDefinition } from '../steps'
 
 export const getPerplexitySteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
-    const { CodeBlock, CalloutBox, Markdown, Blockquote, dedent, snippets } = ctx
+    const { CodeBlock, Markdown, Blockquote, dedent, snippets } = ctx
 
     const NotableGenerationProperties = snippets?.NotableGenerationProperties
 
@@ -33,13 +33,6 @@ export const getPerplexitySteps = (ctx: OnboardingComponentsContext): StepDefini
                             },
                         ]}
                     />
-
-                    <CalloutBox type="fyi" icon="IconInfo" title="No proxy">
-                        <Markdown>
-                            These SDKs **do not** proxy your calls. They only send analytics data to PostHog in the
-                            background.
-                        </Markdown>
-                    </CalloutBox>
                 </>
             ),
         },

--- a/docs/onboarding/llm-analytics/perplexity.tsx
+++ b/docs/onboarding/llm-analytics/perplexity.tsx
@@ -13,14 +13,18 @@ export const getPerplexitySteps = (ctx: OnboardingComponentsContext): StepDefini
             badge: 'required',
             content: (
                 <>
-                    <CalloutBox type="info" icon="IconInfo" title="Migrating from the SDK wrapper?">
+                    <CalloutBox type="info" icon="IconInfo" title="Full working examples">
                         <Markdown>
-                            These docs now use OpenTelemetry auto-instrumentation, which is the recommended approach.
-                            The previous PostHog SDK wrapper is still available — see the
-                            [Node.js](https://github.com/PostHog/posthog-js/tree/e08ff1be/examples/example-ai-perplexity)
+                            See the complete
+                            [Node.js](https://github.com/PostHog/posthog-js/tree/main/examples/example-ai-perplexity)
                             and
-                            [Python](https://github.com/PostHog/posthog-python/tree/7223c52/examples/example-ai-perplexity)
-                            wrapper examples.
+                            [Python](https://github.com/PostHog/posthog-python/tree/master/examples/example-ai-perplexity)
+                            examples on GitHub. If you're using the PostHog SDK wrapper instead of OpenTelemetry, see
+                            the [Node.js
+                            wrapper](https://github.com/PostHog/posthog-js/tree/e08ff1be/examples/example-ai-perplexity)
+                            and [Python
+                            wrapper](https://github.com/PostHog/posthog-python/tree/7223c52/examples/example-ai-perplexity)
+                            examples.
                         </Markdown>
                     </CalloutBox>
 

--- a/docs/onboarding/llm-analytics/perplexity.tsx
+++ b/docs/onboarding/llm-analytics/perplexity.tsx
@@ -3,7 +3,7 @@ import { OnboardingComponentsContext, createInstallation } from 'scenes/onboardi
 import { StepDefinition } from '../steps'
 
 export const getPerplexitySteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
-    const { CodeBlock, Markdown, Blockquote, dedent, snippets } = ctx
+    const { CodeBlock, CalloutBox, Markdown, Blockquote, dedent, snippets } = ctx
 
     const NotableGenerationProperties = snippets?.NotableGenerationProperties
 
@@ -13,6 +13,17 @@ export const getPerplexitySteps = (ctx: OnboardingComponentsContext): StepDefini
             badge: 'required',
             content: (
                 <>
+                    <CalloutBox type="info" icon="IconInfo" title="Migrating from the SDK wrapper?">
+                        <Markdown>
+                            These docs now use OpenTelemetry auto-instrumentation, which is the recommended approach.
+                            The previous PostHog SDK wrapper is still available — see the
+                            [Node.js](https://github.com/PostHog/posthog-js/tree/e08ff1be/examples/example-ai-perplexity)
+                            and
+                            [Python](https://github.com/PostHog/posthog-python/tree/7223c52/examples/example-ai-perplexity)
+                            wrapper examples.
+                        </Markdown>
+                    </CalloutBox>
+
                     <Markdown>Install the OpenTelemetry SDK, the OpenAI instrumentation, and the OpenAI SDK.</Markdown>
 
                     <CodeBlock

--- a/docs/onboarding/llm-analytics/perplexity.tsx
+++ b/docs/onboarding/llm-analytics/perplexity.tsx
@@ -9,14 +9,11 @@ export const getPerplexitySteps = (ctx: OnboardingComponentsContext): StepDefini
 
     return [
         {
-            title: 'Install the PostHog SDK',
+            title: 'Install dependencies',
             badge: 'required',
             content: (
                 <>
-                    <Markdown>
-                        Setting up analytics starts with installing the PostHog SDK for your language. LLM analytics
-                        works best with our Python and Node SDKs.
-                    </Markdown>
+                    <Markdown>Install the OpenTelemetry SDK, the OpenAI instrumentation, and the OpenAI SDK.</Markdown>
 
                     <CodeBlock
                         blocks={[
@@ -24,63 +21,36 @@ export const getPerplexitySteps = (ctx: OnboardingComponentsContext): StepDefini
                                 language: 'bash',
                                 file: 'Python',
                                 code: dedent`
-                                    pip install posthog
+                                    pip install openai opentelemetry-sdk opentelemetry-exporter-otlp-proto-http opentelemetry-instrumentation-openai-v2
                                 `,
                             },
                             {
                                 language: 'bash',
                                 file: 'Node',
                                 code: dedent`
-                                    npm install @posthog/ai posthog-node
+                                    npm install openai @posthog/ai @opentelemetry/sdk-node @opentelemetry/resources @opentelemetry/instrumentation-openai
                                 `,
                             },
                         ]}
                     />
-                </>
-            ),
-        },
-        {
-            title: 'Install the OpenAI SDK',
-            badge: 'required',
-            content: (
-                <>
-                    <Markdown>
-                        Install the OpenAI SDK. The PostHog SDK instruments your LLM calls by wrapping the OpenAI
-                        client. The PostHog SDK **does not** proxy your calls.
-                    </Markdown>
 
-                    <CodeBlock
-                        blocks={[
-                            {
-                                language: 'bash',
-                                file: 'Python',
-                                code: dedent`
-                                    pip install openai
-                                `,
-                            },
-                            {
-                                language: 'bash',
-                                file: 'Node',
-                                code: dedent`
-                                    npm install openai
-                                `,
-                            },
-                        ]}
-                    />
+                    <CalloutBox type="fyi" icon="IconInfo" title="No proxy">
+                        <Markdown>
+                            These SDKs **do not** proxy your calls. They only send analytics data to PostHog in the
+                            background.
+                        </Markdown>
+                    </CalloutBox>
                 </>
             ),
         },
         {
-            title: 'Initialize PostHog and OpenAI client',
+            title: 'Set up OpenTelemetry tracing',
             badge: 'required',
             content: (
                 <>
                     <Markdown>
-                        We call Perplexity through the OpenAI client and generate a response. We'll use PostHog's OpenAI
-                        provider to capture all the details of the call. Initialize PostHog with your PostHog project
-                        token and host from [your project settings](https://app.posthog.com/settings/project), then pass
-                        the PostHog client along with the Perplexity config (the base URL and API key) to our OpenAI
-                        wrapper.
+                        Configure OpenTelemetry to auto-instrument OpenAI SDK calls and export traces to PostHog.
+                        PostHog converts `gen_ai.*` spans into `$ai_generation` events automatically.
                     </Markdown>
 
                     <CodeBlock
@@ -89,61 +59,59 @@ export const getPerplexitySteps = (ctx: OnboardingComponentsContext): StepDefini
                                 language: 'python',
                                 file: 'Python',
                                 code: dedent`
-                                    from posthog.ai.openai import OpenAI
-                                    from posthog import Posthog
+                                    from opentelemetry import trace
+                                    from opentelemetry.sdk.trace import TracerProvider
+                                    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+                                    from opentelemetry.sdk.resources import Resource, SERVICE_NAME
+                                    from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+                                    from opentelemetry.instrumentation.openai_v2 import OpenAIInstrumentor
 
-                                    posthog = Posthog(
-                                        "<ph_project_token>",
-                                        host="<ph_client_api_host>"
+                                    resource = Resource(attributes={
+                                        SERVICE_NAME: "my-app",
+                                        "user.id": "user_123", # optional: identifies the user in PostHog
+                                    })
+
+                                    exporter = OTLPSpanExporter(
+                                        endpoint="<ph_client_api_host>/i/v0/ai/otel",
+                                        headers={"Authorization": "Bearer <ph_project_token>"},
                                     )
 
-                                    client = OpenAI(
-                                        base_url="https://api.perplexity.ai",
-                                        api_key="<perplexity_api_key>",
-                                        posthog_client=posthog
-                                    )
+                                    provider = TracerProvider(resource=resource)
+                                    provider.add_span_processor(SimpleSpanProcessor(exporter))
+                                    trace.set_tracer_provider(provider)
+
+                                    OpenAIInstrumentor().instrument()
                                 `,
                             },
                             {
                                 language: 'typescript',
                                 file: 'Node',
                                 code: dedent`
-                                    import { OpenAI } from '@posthog/ai'
-                                    import { PostHog } from 'posthog-node'
+                                    import { NodeSDK, tracing } from '@opentelemetry/sdk-node'
+                                    import { resourceFromAttributes } from '@opentelemetry/resources'
+                                    import { PostHogTraceExporter } from '@posthog/ai/otel'
+                                    import { OpenAIInstrumentation } from '@opentelemetry/instrumentation-openai'
 
-                                    const phClient = new PostHog(
-                                      '<ph_project_token>',
-                                      { host: '<ph_client_api_host>' }
-                                    );
-
-                                    const openai = new OpenAI({
-                                      baseURL: 'https://api.perplexity.ai',
-                                      apiKey: '<perplexity_api_key>',
-                                      posthog: phClient,
-                                    });
-
-                                    // ... your code here ...
-
-                                    // IMPORTANT: Shutdown the client when you're done to ensure all events are sent
-                                    phClient.shutdown()
+                                    const sdk = new NodeSDK({
+                                      resource: resourceFromAttributes({
+                                        'service.name': 'my-app',
+                                        'user.id': 'user_123', // optional: identifies the user in PostHog
+                                      }),
+                                      spanProcessors: [
+                                        new tracing.SimpleSpanProcessor(
+                                          new PostHogTraceExporter({
+                                            apiKey: '<ph_project_token>',
+                                            host: '<ph_client_api_host>',
+                                          })
+                                        ),
+                                      ],
+                                      instrumentations: [new OpenAIInstrumentation()],
+                                    })
+                                    sdk.start()
                                 `,
                             },
                         ]}
                     />
-
-                    <Blockquote>
-                        <Markdown>**Note:** This also works with the `AsyncOpenAI` client.</Markdown>
-                    </Blockquote>
-
-                    <CalloutBox type="fyi" icon="IconInfo" title="Proxy note">
-                        <Markdown>
-                            These SDKs **do not** proxy your calls. They only fire off an async call to PostHog in the
-                            background to send the data. You can also use LLM analytics with other SDKs or our API, but
-                            you will need to capture the data in the right format. See the schema in the [manual capture
-                            section](https://posthog.com/docs/llm-analytics/installation/manual-capture) for more
-                            details.
-                        </Markdown>
-                    </CalloutBox>
                 </>
             ),
         },
@@ -153,9 +121,8 @@ export const getPerplexitySteps = (ctx: OnboardingComponentsContext): StepDefini
             content: (
                 <>
                     <Markdown>
-                        Now, when you call Perplexity with the OpenAI SDK, PostHog automatically captures an
-                        `$ai_generation` event. You can also capture or modify additional properties with the distinct
-                        ID, trace ID, properties, groups, and privacy mode parameters.
+                        Now, when you use the OpenAI SDK to call Perplexity, PostHog automatically captures
+                        `$ai_generation` events via the OpenTelemetry instrumentation.
                     </Markdown>
 
                     <CodeBlock
@@ -164,16 +131,19 @@ export const getPerplexitySteps = (ctx: OnboardingComponentsContext): StepDefini
                                 language: 'python',
                                 file: 'Python',
                                 code: dedent`
+                                    import openai
+
+                                    client = openai.OpenAI(
+                                        base_url="https://api.perplexity.ai",
+                                        api_key="<perplexity_api_key>",
+                                    )
+
                                     response = client.chat.completions.create(
                                         model="sonar",
+                                        max_completion_tokens=1024,
                                         messages=[
                                             {"role": "user", "content": "Tell me a fun fact about hedgehogs"}
                                         ],
-                                        posthog_distinct_id="user_123", # optional
-                                        posthog_trace_id="trace_123", # optional
-                                        posthog_properties={"conversation_id": "abc123", "paid": True}, # optional
-                                        posthog_groups={"company": "company_id_in_your_db"},  # optional
-                                        posthog_privacy_mode=False # optional
                                     )
 
                                     print(response.choices[0].message.content)
@@ -183,17 +153,20 @@ export const getPerplexitySteps = (ctx: OnboardingComponentsContext): StepDefini
                                 language: 'typescript',
                                 file: 'Node',
                                 code: dedent`
-                                    const completion = await openai.chat.completions.create({
-                                        model: "sonar",
-                                        messages: [{ role: "user", content: "Tell me a fun fact about hedgehogs" }],
-                                        posthogDistinctId: "user_123", // optional
-                                        posthogTraceId: "trace_123", // optional
-                                        posthogProperties: { conversation_id: "abc123", paid: true }, // optional
-                                        posthogGroups: { company: "company_id_in_your_db" }, // optional
-                                        posthogPrivacyMode: false // optional
-                                    });
+                                    import OpenAI from 'openai'
 
-                                    console.log(completion.choices[0].message.content)
+                                    const client = new OpenAI({
+                                      baseURL: 'https://api.perplexity.ai',
+                                      apiKey: '<perplexity_api_key>',
+                                    })
+
+                                    const response = await client.chat.completions.create({
+                                      model: 'sonar',
+                                      max_completion_tokens: 1024,
+                                      messages: [{ role: 'user', content: 'Tell me a fun fact about hedgehogs' }],
+                                    })
+
+                                    console.log(response.choices[0].message.content)
                                 `,
                             },
                         ]}
@@ -202,12 +175,7 @@ export const getPerplexitySteps = (ctx: OnboardingComponentsContext): StepDefini
                     <Blockquote>
                         <Markdown>
                             {dedent`
-                            **Notes:**
-                            - We also support the old \`chat.completions\` API.
-                            - This works with responses where \`stream=True\`.
-                            - If you want to capture LLM events anonymously, **don't** pass a distinct ID to the request.
-
-                            See our docs on [anonymous vs identified events](https://posthog.com/docs/data/anonymous-vs-identified-events) to learn more.
+                            **Note:** If you want to capture LLM events anonymously, omit the \`user.id\` resource attribute. See our docs on [anonymous vs identified events](https://posthog.com/docs/data/anonymous-vs-identified-events) to learn more.
                             `}
                         </Markdown>
                     </Blockquote>

--- a/docs/onboarding/llm-analytics/perplexity.tsx
+++ b/docs/onboarding/llm-analytics/perplexity.tsx
@@ -61,7 +61,8 @@ export const getPerplexitySteps = (ctx: OnboardingComponentsContext): StepDefini
 
                                     resource = Resource(attributes={
                                         SERVICE_NAME: "my-app",
-                                        "user.id": "user_123", # optional: identifies the user in PostHog
+                                        "posthog.distinct_id": "user_123", # optional: identifies the user in PostHog
+                                        "foo": "bar", # custom properties are passed through
                                     })
 
                                     exporter = OTLPSpanExporter(
@@ -88,7 +89,8 @@ export const getPerplexitySteps = (ctx: OnboardingComponentsContext): StepDefini
                                     const sdk = new NodeSDK({
                                       resource: resourceFromAttributes({
                                         'service.name': 'my-app',
-                                        'user.id': 'user_123', // optional: identifies the user in PostHog
+                                        'posthog.distinct_id': 'user_123', // optional: identifies the user in PostHog
+                                        foo: 'bar', // custom properties are passed through
                                       }),
                                       spanProcessors: [
                                         new tracing.SimpleSpanProcessor(
@@ -168,7 +170,7 @@ export const getPerplexitySteps = (ctx: OnboardingComponentsContext): StepDefini
                     <Blockquote>
                         <Markdown>
                             {dedent`
-                            **Note:** If you want to capture LLM events anonymously, omit the \`user.id\` resource attribute. See our docs on [anonymous vs identified events](https://posthog.com/docs/data/anonymous-vs-identified-events) to learn more.
+                            **Note:** If you want to capture LLM events anonymously, omit the \`posthog.distinct_id\` resource attribute. See our docs on [anonymous vs identified events](https://posthog.com/docs/data/anonymous-vs-identified-events) to learn more.
                             `}
                         </Markdown>
                     </Blockquote>

--- a/docs/onboarding/llm-analytics/perplexity.tsx
+++ b/docs/onboarding/llm-analytics/perplexity.tsx
@@ -36,7 +36,7 @@ export const getPerplexitySteps = (ctx: OnboardingComponentsContext): StepDefini
                                 language: 'bash',
                                 file: 'Python',
                                 code: dedent`
-                                    pip install openai opentelemetry-sdk opentelemetry-exporter-otlp-proto-http opentelemetry-instrumentation-openai-v2
+                                    pip install openai opentelemetry-sdk posthog[otel] opentelemetry-instrumentation-openai-v2
                                 `,
                             },
                             {
@@ -69,9 +69,8 @@ export const getPerplexitySteps = (ctx: OnboardingComponentsContext): StepDefini
                                 code: dedent`
                                     from opentelemetry import trace
                                     from opentelemetry.sdk.trace import TracerProvider
-                                    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
                                     from opentelemetry.sdk.resources import Resource, SERVICE_NAME
-                                    from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+                                    from posthog.ai.otel import PostHogSpanProcessor
                                     from opentelemetry.instrumentation.openai_v2 import OpenAIInstrumentor
 
                                     resource = Resource(attributes={
@@ -80,13 +79,13 @@ export const getPerplexitySteps = (ctx: OnboardingComponentsContext): StepDefini
                                         "foo": "bar", # custom properties are passed through
                                     })
 
-                                    exporter = OTLPSpanExporter(
-                                        endpoint="<ph_client_api_host>/i/v0/ai/otel",
-                                        headers={"Authorization": "Bearer <ph_project_token>"},
-                                    )
-
                                     provider = TracerProvider(resource=resource)
-                                    provider.add_span_processor(SimpleSpanProcessor(exporter))
+                                    provider.add_span_processor(
+                                        PostHogSpanProcessor(
+                                            api_key="<ph_project_token>",
+                                            host="<ph_client_api_host>",
+                                        )
+                                    )
                                     trace.set_tracer_provider(provider)
 
                                     OpenAIInstrumentor().instrument()

--- a/docs/onboarding/llm-analytics/perplexity.tsx
+++ b/docs/onboarding/llm-analytics/perplexity.tsx
@@ -96,9 +96,9 @@ export const getPerplexitySteps = (ctx: OnboardingComponentsContext): StepDefini
                                 language: 'typescript',
                                 file: 'Node',
                                 code: dedent`
-                                    import { NodeSDK, tracing } from '@opentelemetry/sdk-node'
+                                    import { NodeSDK } from '@opentelemetry/sdk-node'
                                     import { resourceFromAttributes } from '@opentelemetry/resources'
-                                    import { PostHogTraceExporter } from '@posthog/ai/otel'
+                                    import { PostHogSpanProcessor } from '@posthog/ai/otel'
                                     import { OpenAIInstrumentation } from '@opentelemetry/instrumentation-openai'
 
                                     const sdk = new NodeSDK({
@@ -108,12 +108,10 @@ export const getPerplexitySteps = (ctx: OnboardingComponentsContext): StepDefini
                                         foo: 'bar', // custom properties are passed through
                                       }),
                                       spanProcessors: [
-                                        new tracing.SimpleSpanProcessor(
-                                          new PostHogTraceExporter({
-                                            apiKey: '<ph_project_token>',
-                                            host: '<ph_client_api_host>',
-                                          })
-                                        ),
+                                        new PostHogSpanProcessor({
+                                          apiKey: '<ph_project_token>',
+                                          host: '<ph_client_api_host>',
+                                        }),
                                       ],
                                       instrumentations: [new OpenAIInstrumentation()],
                                     })

--- a/docs/onboarding/llm-analytics/portkey.tsx
+++ b/docs/onboarding/llm-analytics/portkey.tsx
@@ -9,7 +9,7 @@ export const getPortkeySteps = (ctx: OnboardingComponentsContext): StepDefinitio
 
     return [
         {
-            title: 'Install the PostHog SDK',
+            title: 'Install dependencies',
             badge: 'required',
             content: (
                 <>
@@ -21,10 +21,7 @@ export const getPortkeySteps = (ctx: OnboardingComponentsContext): StepDefinitio
                         </Markdown>
                     </CalloutBox>
 
-                    <Markdown>
-                        Setting up analytics starts with installing the PostHog SDK for your language. LLM analytics
-                        works best with our Python and Node SDKs.
-                    </Markdown>
+                    <Markdown>Install the OpenTelemetry SDK, the OpenAI instrumentation, and the OpenAI SDK.</Markdown>
 
                     <CodeBlock
                         blocks={[
@@ -32,61 +29,36 @@ export const getPortkeySteps = (ctx: OnboardingComponentsContext): StepDefinitio
                                 language: 'bash',
                                 file: 'Python',
                                 code: dedent`
-                                    pip install posthog
+                                    pip install openai opentelemetry-sdk opentelemetry-exporter-otlp-proto-http opentelemetry-instrumentation-openai-v2
                                 `,
                             },
                             {
                                 language: 'bash',
                                 file: 'Node',
                                 code: dedent`
-                                    npm install @posthog/ai posthog-node
+                                    npm install openai @posthog/ai @opentelemetry/sdk-node @opentelemetry/resources @opentelemetry/instrumentation-openai
                                 `,
                             },
                         ]}
                     />
-                </>
-            ),
-        },
-        {
-            title: 'Install the OpenAI and Portkey SDKs',
-            badge: 'required',
-            content: (
-                <>
-                    <Markdown>
-                        Install the OpenAI and Portkey SDKs. The PostHog SDK instruments your LLM calls by wrapping the
-                        OpenAI client. The PostHog SDK **does not** proxy your calls.
-                    </Markdown>
 
-                    <CodeBlock
-                        blocks={[
-                            {
-                                language: 'bash',
-                                file: 'Python',
-                                code: dedent`
-                                    pip install openai portkey-ai
-                                `,
-                            },
-                            {
-                                language: 'bash',
-                                file: 'Node',
-                                code: dedent`
-                                    npm install openai portkey-ai
-                                `,
-                            },
-                        ]}
-                    />
+                    <CalloutBox type="fyi" icon="IconInfo" title="No proxy">
+                        <Markdown>
+                            These SDKs **do not** proxy your calls. They only send analytics data to PostHog in the
+                            background.
+                        </Markdown>
+                    </CalloutBox>
                 </>
             ),
         },
         {
-            title: 'Initialize PostHog and Portkey-routed client',
+            title: 'Set up OpenTelemetry tracing',
             badge: 'required',
             content: (
                 <>
                     <Markdown>
-                        Initialize PostHog with your project token and host from [your project
-                        settings](https://app.posthog.com/settings/project), then pass it along with the Portkey gateway
-                        URL and your Portkey API key to our OpenAI wrapper.
+                        Configure OpenTelemetry to auto-instrument OpenAI SDK calls and export traces to PostHog.
+                        PostHog converts `gen_ai.*` spans into `$ai_generation` events automatically.
                     </Markdown>
 
                     <CodeBlock
@@ -95,63 +67,59 @@ export const getPortkeySteps = (ctx: OnboardingComponentsContext): StepDefinitio
                                 language: 'python',
                                 file: 'Python',
                                 code: dedent`
-                                    from posthog.ai.openai import OpenAI
-                                    from posthog import Posthog
-                                    from portkey_ai import PORTKEY_GATEWAY_URL
+                                    from opentelemetry import trace
+                                    from opentelemetry.sdk.trace import TracerProvider
+                                    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+                                    from opentelemetry.sdk.resources import Resource, SERVICE_NAME
+                                    from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+                                    from opentelemetry.instrumentation.openai_v2 import OpenAIInstrumentor
 
-                                    posthog = Posthog(
-                                        "<ph_project_token>",
-                                        host="<ph_client_api_host>"
+                                    resource = Resource(attributes={
+                                        SERVICE_NAME: "my-app",
+                                        "user.id": "user_123", # optional: identifies the user in PostHog
+                                    })
+
+                                    exporter = OTLPSpanExporter(
+                                        endpoint="<ph_client_api_host>/i/v0/ai/otel",
+                                        headers={"Authorization": "Bearer <ph_project_token>"},
                                     )
 
-                                    client = OpenAI(
-                                        base_url=PORTKEY_GATEWAY_URL,
-                                        api_key="<portkey_api_key>",
-                                        posthog_client=posthog
-                                    )
+                                    provider = TracerProvider(resource=resource)
+                                    provider.add_span_processor(SimpleSpanProcessor(exporter))
+                                    trace.set_tracer_provider(provider)
+
+                                    OpenAIInstrumentor().instrument()
                                 `,
                             },
                             {
                                 language: 'typescript',
                                 file: 'Node',
                                 code: dedent`
-                                    import { OpenAI } from '@posthog/ai'
-                                    import { PostHog } from 'posthog-node'
-                                    import { PORTKEY_GATEWAY_URL } from 'portkey-ai'
+                                    import { NodeSDK, tracing } from '@opentelemetry/sdk-node'
+                                    import { resourceFromAttributes } from '@opentelemetry/resources'
+                                    import { PostHogTraceExporter } from '@posthog/ai/otel'
+                                    import { OpenAIInstrumentation } from '@opentelemetry/instrumentation-openai'
 
-                                    const phClient = new PostHog(
-                                      '<ph_project_token>',
-                                      { host: '<ph_client_api_host>' }
-                                    );
-
-                                    const openai = new OpenAI({
-                                      baseURL: PORTKEY_GATEWAY_URL,
-                                      apiKey: '<portkey_api_key>',
-                                      posthog: phClient,
-                                    });
-
-                                    // ... your code here ...
-
-                                    // IMPORTANT: Shutdown the client when you're done to ensure all events are sent
-                                    phClient.shutdown()
+                                    const sdk = new NodeSDK({
+                                      resource: resourceFromAttributes({
+                                        'service.name': 'my-app',
+                                        'user.id': 'user_123', // optional: identifies the user in PostHog
+                                      }),
+                                      spanProcessors: [
+                                        new tracing.SimpleSpanProcessor(
+                                          new PostHogTraceExporter({
+                                            apiKey: '<ph_project_token>',
+                                            host: '<ph_client_api_host>',
+                                          })
+                                        ),
+                                      ],
+                                      instrumentations: [new OpenAIInstrumentation()],
+                                    })
+                                    sdk.start()
                                 `,
                             },
                         ]}
                     />
-
-                    <Blockquote>
-                        <Markdown>**Note:** This also works with the `AsyncOpenAI` client.</Markdown>
-                    </Blockquote>
-
-                    <CalloutBox type="fyi" icon="IconInfo" title="Proxy note">
-                        <Markdown>
-                            These SDKs **do not** proxy your calls. They only fire off an async call to PostHog in the
-                            background to send the data. You can also use LLM analytics with other SDKs or our API, but
-                            you will need to capture the data in the right format. See the schema in the [manual capture
-                            section](https://posthog.com/docs/llm-analytics/installation/manual-capture) for more
-                            details.
-                        </Markdown>
-                    </CalloutBox>
                 </>
             ),
         },
@@ -161,9 +129,8 @@ export const getPortkeySteps = (ctx: OnboardingComponentsContext): StepDefinitio
             content: (
                 <>
                     <Markdown>
-                        Now, when you call Portkey with the OpenAI SDK, PostHog automatically captures an
-                        `$ai_generation` event. You can also capture or modify additional properties with the distinct
-                        ID, trace ID, properties, groups, and privacy mode parameters.
+                        Now, when you call Portkey with the OpenAI SDK, PostHog automatically captures `$ai_generation`
+                        events via the OpenTelemetry instrumentation.
                     </Markdown>
 
                     <CodeBlock
@@ -172,16 +139,19 @@ export const getPortkeySteps = (ctx: OnboardingComponentsContext): StepDefinitio
                                 language: 'python',
                                 file: 'Python',
                                 code: dedent`
+                                    import openai
+                                    from portkey_ai import PORTKEY_GATEWAY_URL
+
+                                    client = openai.OpenAI(
+                                        base_url=PORTKEY_GATEWAY_URL,
+                                        api_key="<portkey_api_key>",
+                                    )
+
                                     response = client.chat.completions.create(
                                         model="@<integration-slug>/gpt-5-mini",
                                         messages=[
                                             {"role": "user", "content": "Tell me a fun fact about hedgehogs"}
                                         ],
-                                        posthog_distinct_id="user_123", # optional
-                                        posthog_trace_id="trace_123", # optional
-                                        posthog_properties={"conversation_id": "abc123", "paid": True}, # optional
-                                        posthog_groups={"company": "company_id_in_your_db"},  # optional
-                                        posthog_privacy_mode=False # optional
                                     )
 
                                     print(response.choices[0].message.content)
@@ -191,17 +161,20 @@ export const getPortkeySteps = (ctx: OnboardingComponentsContext): StepDefinitio
                                 language: 'typescript',
                                 file: 'Node',
                                 code: dedent`
-                                    const completion = await openai.chat.completions.create({
-                                        model: "@<integration-slug>/gpt-5-mini",
-                                        messages: [{ role: "user", content: "Tell me a fun fact about hedgehogs" }],
-                                        posthogDistinctId: "user_123", // optional
-                                        posthogTraceId: "trace_123", // optional
-                                        posthogProperties: { conversation_id: "abc123", paid: true }, // optional
-                                        posthogGroups: { company: "company_id_in_your_db" }, // optional
-                                        posthogPrivacyMode: false // optional
-                                    });
+                                    import OpenAI from 'openai'
+                                    import { PORTKEY_GATEWAY_URL } from 'portkey-ai'
 
-                                    console.log(completion.choices[0].message.content)
+                                    const client = new OpenAI({
+                                      baseURL: PORTKEY_GATEWAY_URL,
+                                      apiKey: '<portkey_api_key>',
+                                    })
+
+                                    const response = await client.chat.completions.create({
+                                      model: '@<integration-slug>/gpt-5-mini',
+                                      messages: [{ role: 'user', content: 'Tell me a fun fact about hedgehogs' }],
+                                    })
+
+                                    console.log(response.choices[0].message.content)
                                 `,
                             },
                         ]}
@@ -209,14 +182,9 @@ export const getPortkeySteps = (ctx: OnboardingComponentsContext): StepDefinitio
 
                     <Blockquote>
                         <Markdown>
-                            {dedent`
-                            **Notes:**
-                            - This works with responses where \`stream=True\`.
-                            - If you want to capture LLM events anonymously, **don't** pass a distinct ID to the request.
-                            - The \`@<integration-slug>\` prefix is the name you chose when setting up the integration in your [Portkey dashboard](https://app.portkey.ai/).
-
-                            See our docs on [anonymous vs identified events](https://posthog.com/docs/data/anonymous-vs-identified-events) to learn more.
-                            `}
+                            **Note:** If you want to capture LLM events anonymously, omit the `user.id` resource
+                            attribute. See our docs on [anonymous vs identified
+                            events](https://posthog.com/docs/data/anonymous-vs-identified-events) to learn more.
                         </Markdown>
                     </Blockquote>
 

--- a/docs/onboarding/llm-analytics/portkey.tsx
+++ b/docs/onboarding/llm-analytics/portkey.tsx
@@ -41,13 +41,6 @@ export const getPortkeySteps = (ctx: OnboardingComponentsContext): StepDefinitio
                             },
                         ]}
                     />
-
-                    <CalloutBox type="fyi" icon="IconInfo" title="No proxy">
-                        <Markdown>
-                            These SDKs **do not** proxy your calls. They only send analytics data to PostHog in the
-                            background.
-                        </Markdown>
-                    </CalloutBox>
                 </>
             ),
         },

--- a/docs/onboarding/llm-analytics/portkey.tsx
+++ b/docs/onboarding/llm-analytics/portkey.tsx
@@ -13,14 +13,17 @@ export const getPortkeySteps = (ctx: OnboardingComponentsContext): StepDefinitio
             badge: 'required',
             content: (
                 <>
-                    <CalloutBox type="info" icon="IconInfo" title="Migrating from the SDK wrapper?">
+                    <CalloutBox type="info" icon="IconInfo" title="Full working examples">
                         <Markdown>
-                            These docs now use OpenTelemetry auto-instrumentation, which is the recommended approach.
-                            The previous PostHog SDK wrapper is still available — see the
-                            [Node.js](https://github.com/PostHog/posthog-js/tree/e08ff1be/examples/example-ai-portkey)
-                            and
-                            [Python](https://github.com/PostHog/posthog-python/tree/7223c52/examples/example-ai-portkey)
-                            wrapper examples.
+                            See the complete
+                            [Node.js](https://github.com/PostHog/posthog-js/tree/main/examples/example-ai-portkey) and
+                            [Python](https://github.com/PostHog/posthog-python/tree/master/examples/example-ai-portkey)
+                            examples on GitHub. If you're using the PostHog SDK wrapper instead of OpenTelemetry, see
+                            the [Node.js
+                            wrapper](https://github.com/PostHog/posthog-js/tree/e08ff1be/examples/example-ai-portkey)
+                            and [Python
+                            wrapper](https://github.com/PostHog/posthog-python/tree/7223c52/examples/example-ai-portkey)
+                            examples.
                         </Markdown>
                     </CalloutBox>
 

--- a/docs/onboarding/llm-analytics/portkey.tsx
+++ b/docs/onboarding/llm-analytics/portkey.tsx
@@ -69,7 +69,8 @@ export const getPortkeySteps = (ctx: OnboardingComponentsContext): StepDefinitio
 
                                     resource = Resource(attributes={
                                         SERVICE_NAME: "my-app",
-                                        "user.id": "user_123", # optional: identifies the user in PostHog
+                                        "posthog.distinct_id": "user_123", # optional: identifies the user in PostHog
+                                        "foo": "bar", # custom properties are passed through
                                     })
 
                                     exporter = OTLPSpanExporter(
@@ -96,7 +97,8 @@ export const getPortkeySteps = (ctx: OnboardingComponentsContext): StepDefinitio
                                     const sdk = new NodeSDK({
                                       resource: resourceFromAttributes({
                                         'service.name': 'my-app',
-                                        'user.id': 'user_123', // optional: identifies the user in PostHog
+                                        'posthog.distinct_id': 'user_123', // optional: identifies the user in PostHog
+                                        foo: 'bar', // custom properties are passed through
                                       }),
                                       spanProcessors: [
                                         new tracing.SimpleSpanProcessor(
@@ -175,8 +177,8 @@ export const getPortkeySteps = (ctx: OnboardingComponentsContext): StepDefinitio
 
                     <Blockquote>
                         <Markdown>
-                            **Note:** If you want to capture LLM events anonymously, omit the `user.id` resource
-                            attribute. See our docs on [anonymous vs identified
+                            **Note:** If you want to capture LLM events anonymously, omit the `posthog.distinct_id`
+                            resource attribute. See our docs on [anonymous vs identified
                             events](https://posthog.com/docs/data/anonymous-vs-identified-events) to learn more.
                         </Markdown>
                     </Blockquote>

--- a/docs/onboarding/llm-analytics/portkey.tsx
+++ b/docs/onboarding/llm-analytics/portkey.tsx
@@ -13,6 +13,17 @@ export const getPortkeySteps = (ctx: OnboardingComponentsContext): StepDefinitio
             badge: 'required',
             content: (
                 <>
+                    <CalloutBox type="info" icon="IconInfo" title="Migrating from the SDK wrapper?">
+                        <Markdown>
+                            These docs now use OpenTelemetry auto-instrumentation, which is the recommended approach.
+                            The previous PostHog SDK wrapper is still available — see the
+                            [Node.js](https://github.com/PostHog/posthog-js/tree/e08ff1be/examples/example-ai-portkey)
+                            and
+                            [Python](https://github.com/PostHog/posthog-python/tree/7223c52/examples/example-ai-portkey)
+                            wrapper examples.
+                        </Markdown>
+                    </CalloutBox>
+
                     <CalloutBox type="fyi" icon="IconInfo" title="About Portkey">
                         <Markdown>
                             Portkey acts as an AI gateway that routes requests to 250+ LLM providers. The model string

--- a/docs/onboarding/llm-analytics/portkey.tsx
+++ b/docs/onboarding/llm-analytics/portkey.tsx
@@ -43,14 +43,14 @@ export const getPortkeySteps = (ctx: OnboardingComponentsContext): StepDefinitio
                                 language: 'bash',
                                 file: 'Python',
                                 code: dedent`
-                                    pip install openai opentelemetry-sdk opentelemetry-exporter-otlp-proto-http opentelemetry-instrumentation-openai-v2
+                                    pip install openai portkey-ai opentelemetry-sdk opentelemetry-exporter-otlp-proto-http opentelemetry-instrumentation-openai-v2
                                 `,
                             },
                             {
                                 language: 'bash',
                                 file: 'Node',
                                 code: dedent`
-                                    npm install openai @posthog/ai @opentelemetry/sdk-node @opentelemetry/resources @opentelemetry/instrumentation-openai
+                                    npm install openai portkey-ai @posthog/ai @opentelemetry/sdk-node @opentelemetry/resources @opentelemetry/instrumentation-openai
                                 `,
                             },
                         ]}

--- a/docs/onboarding/llm-analytics/portkey.tsx
+++ b/docs/onboarding/llm-analytics/portkey.tsx
@@ -43,7 +43,7 @@ export const getPortkeySteps = (ctx: OnboardingComponentsContext): StepDefinitio
                                 language: 'bash',
                                 file: 'Python',
                                 code: dedent`
-                                    pip install openai portkey-ai opentelemetry-sdk opentelemetry-exporter-otlp-proto-http opentelemetry-instrumentation-openai-v2
+                                    pip install openai portkey-ai opentelemetry-sdk posthog[otel] opentelemetry-instrumentation-openai-v2
                                 `,
                             },
                             {
@@ -76,9 +76,8 @@ export const getPortkeySteps = (ctx: OnboardingComponentsContext): StepDefinitio
                                 code: dedent`
                                     from opentelemetry import trace
                                     from opentelemetry.sdk.trace import TracerProvider
-                                    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
                                     from opentelemetry.sdk.resources import Resource, SERVICE_NAME
-                                    from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+                                    from posthog.ai.otel import PostHogSpanProcessor
                                     from opentelemetry.instrumentation.openai_v2 import OpenAIInstrumentor
 
                                     resource = Resource(attributes={
@@ -87,13 +86,13 @@ export const getPortkeySteps = (ctx: OnboardingComponentsContext): StepDefinitio
                                         "foo": "bar", # custom properties are passed through
                                     })
 
-                                    exporter = OTLPSpanExporter(
-                                        endpoint="<ph_client_api_host>/i/v0/ai/otel",
-                                        headers={"Authorization": "Bearer <ph_project_token>"},
-                                    )
-
                                     provider = TracerProvider(resource=resource)
-                                    provider.add_span_processor(SimpleSpanProcessor(exporter))
+                                    provider.add_span_processor(
+                                        PostHogSpanProcessor(
+                                            api_key="<ph_project_token>",
+                                            host="<ph_client_api_host>",
+                                        )
+                                    )
                                     trace.set_tracer_provider(provider)
 
                                     OpenAIInstrumentor().instrument()

--- a/docs/onboarding/llm-analytics/portkey.tsx
+++ b/docs/onboarding/llm-analytics/portkey.tsx
@@ -103,9 +103,9 @@ export const getPortkeySteps = (ctx: OnboardingComponentsContext): StepDefinitio
                                 language: 'typescript',
                                 file: 'Node',
                                 code: dedent`
-                                    import { NodeSDK, tracing } from '@opentelemetry/sdk-node'
+                                    import { NodeSDK } from '@opentelemetry/sdk-node'
                                     import { resourceFromAttributes } from '@opentelemetry/resources'
-                                    import { PostHogTraceExporter } from '@posthog/ai/otel'
+                                    import { PostHogSpanProcessor } from '@posthog/ai/otel'
                                     import { OpenAIInstrumentation } from '@opentelemetry/instrumentation-openai'
 
                                     const sdk = new NodeSDK({
@@ -115,12 +115,10 @@ export const getPortkeySteps = (ctx: OnboardingComponentsContext): StepDefinitio
                                         foo: 'bar', // custom properties are passed through
                                       }),
                                       spanProcessors: [
-                                        new tracing.SimpleSpanProcessor(
-                                          new PostHogTraceExporter({
-                                            apiKey: '<ph_project_token>',
-                                            host: '<ph_client_api_host>',
-                                          })
-                                        ),
+                                        new PostHogSpanProcessor({
+                                          apiKey: '<ph_project_token>',
+                                          host: '<ph_client_api_host>',
+                                        }),
                                       ],
                                       instrumentations: [new OpenAIInstrumentation()],
                                     })

--- a/docs/onboarding/llm-analytics/pydantic-ai.tsx
+++ b/docs/onboarding/llm-analytics/pydantic-ai.tsx
@@ -3,95 +3,77 @@ import { OnboardingComponentsContext, createInstallation } from 'scenes/onboardi
 import { StepDefinition } from '../steps'
 
 export const getPydanticAISteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
-    const { CodeBlock, CalloutBox, Markdown, dedent, snippets } = ctx
+    const { CodeBlock, CalloutBox, Markdown, Blockquote, dedent, snippets } = ctx
 
     const NotableGenerationProperties = snippets?.NotableGenerationProperties
 
     return [
         {
-            title: 'Install the PostHog SDK',
+            title: 'Install dependencies',
             badge: 'required',
             content: (
                 <>
-                    <Markdown>
-                        Setting up analytics starts with installing the PostHog SDK. The Pydantic AI integration uses
-                        PostHog's OpenAI wrapper.
-                    </Markdown>
+                    <CalloutBox type="info" icon="IconInfo" title="Full working examples">
+                        <Markdown>
+                            See the complete [Python
+                            example](https://github.com/PostHog/posthog-python/tree/master/examples/example-ai-pydantic-ai)
+                            on GitHub. If you're using the PostHog SDK wrapper instead of OpenTelemetry, see the [Python
+                            wrapper
+                            example](https://github.com/PostHog/posthog-python/tree/7223c52/examples/example-ai-pydantic-ai).
+                        </Markdown>
+                    </CalloutBox>
+
+                    <Markdown>Install the OpenTelemetry SDK and Pydantic AI.</Markdown>
 
                     <CodeBlock
                         language="bash"
                         code={dedent`
-                            pip install posthog
+                            pip install "pydantic-ai[openai]" opentelemetry-sdk opentelemetry-exporter-otlp-proto-http
                         `}
                     />
                 </>
             ),
         },
         {
-            title: 'Install Pydantic AI',
+            title: 'Set up OpenTelemetry tracing',
             badge: 'required',
             content: (
                 <>
                     <Markdown>
-                        Install Pydantic AI with OpenAI support. PostHog instruments your LLM calls by wrapping the
-                        OpenAI client that Pydantic AI uses.
-                    </Markdown>
-
-                    <CodeBlock
-                        language="bash"
-                        code={dedent`
-                            pip install 'pydantic-ai[openai]'
-                        `}
-                    />
-                </>
-            ),
-        },
-        {
-            title: 'Initialize PostHog and Pydantic AI',
-            badge: 'required',
-            content: (
-                <>
-                    <Markdown>
-                        Initialize PostHog with your project token and host from [your project
-                        settings](https://app.posthog.com/settings/project), then create a PostHog `AsyncOpenAI`
-                        wrapper, pass it to an `OpenAIProvider`, and use that with Pydantic AI's `OpenAIChatModel`.
+                        Configure OpenTelemetry to export traces to PostHog and enable Pydantic AI's built-in OTel
+                        instrumentation. PostHog converts `gen_ai.*` spans into `$ai_generation` events automatically.
                     </Markdown>
 
                     <CodeBlock
                         language="python"
                         code={dedent`
+                            import os
+                            from opentelemetry import trace
+                            from opentelemetry.sdk.trace import TracerProvider
+                            from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+                            from opentelemetry.sdk.resources import Resource, SERVICE_NAME
+                            from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
                             from pydantic_ai import Agent
-                            from pydantic_ai.models.openai import OpenAIChatModel
-                            from pydantic_ai.providers.openai import OpenAIProvider
-                            from posthog.ai.openai import AsyncOpenAI
-                            from posthog import Posthog
 
-                            posthog = Posthog(
-                                "<ph_project_token>",
-                                host="<ph_client_api_host>"
+                            resource = Resource(attributes={
+                                SERVICE_NAME: "my-app",
+                                "posthog.distinct_id": "user_123", # optional: identifies the user in PostHog
+                                "foo": "bar", # custom properties are passed through
+                            })
+
+                            exporter = OTLPSpanExporter(
+                                endpoint="<ph_client_api_host>/i/v0/ai/otel",
+                                headers={"Authorization": "Bearer <ph_project_token>"},
                             )
 
-                            openai_client = AsyncOpenAI(
-                                api_key="your_openai_api_key",
-                                posthog_client=posthog
-                            )
+                            provider = TracerProvider(resource=resource)
+                            provider.add_span_processor(SimpleSpanProcessor(exporter))
+                            trace.set_tracer_provider(provider)
 
-                            provider = OpenAIProvider(openai_client=openai_client)
-
-                            model = OpenAIChatModel(
-                                "gpt-5-mini",
-                                provider=provider
-                            )
+                            # Enable automatic OTel instrumentation for all Pydantic AI agents
+                            Agent.instrument_all()
                         `}
                     />
-
-                    <CalloutBox type="fyi" icon="IconInfo" title="How this works">
-                        <Markdown>
-                            PostHog's `AsyncOpenAI` wrapper is a proper subclass of `openai.AsyncOpenAI`, so it works
-                            directly as the client for Pydantic AI's `OpenAIProvider`. PostHog captures `$ai_generation`
-                            events automatically without proxying your calls.
-                        </Markdown>
-                    </CalloutBox>
                 </>
             ),
         },
@@ -101,26 +83,31 @@ export const getPydanticAISteps = (ctx: OnboardingComponentsContext): StepDefini
             content: (
                 <>
                     <Markdown>
-                        Create a Pydantic AI agent with the model and run it. PostHog automatically captures an
-                        `$ai_generation` event for each LLM call.
+                        Create a Pydantic AI agent and run it. PostHog automatically captures an `$ai_generation` event
+                        for each LLM call via the OTel instrumentation.
                     </Markdown>
 
                     <CodeBlock
                         language="python"
                         code={dedent`
-                            agent = Agent(
-                                model,
-                                system_prompt="You are a helpful assistant.",
-                            )
+                            from pydantic_ai import Agent
+                            from pydantic_ai.models.openai import OpenAIModel
 
-                            result = agent.run_sync(
-                                "Tell me a fun fact about hedgehogs.",
-                                # Pass PostHog metadata via the OpenAI client's extra params
-                            )
+                            model = OpenAIModel("gpt-4o-mini")
+                            agent = Agent(model, system_prompt="You are a helpful assistant.")
 
+                            result = agent.run_sync("Tell me a fun fact about hedgehogs.")
                             print(result.output)
                         `}
                     />
+
+                    <Blockquote>
+                        <Markdown>
+                            **Note:** If you want to capture LLM events anonymously, omit the `posthog.distinct_id`
+                            resource attribute. See our docs on [anonymous vs identified
+                            events](https://posthog.com/docs/data/anonymous-vs-identified-events) to learn more.
+                        </Markdown>
+                    </Blockquote>
 
                     <Markdown>
                         {dedent`

--- a/docs/onboarding/llm-analytics/pydantic-ai.tsx
+++ b/docs/onboarding/llm-analytics/pydantic-ai.tsx
@@ -28,7 +28,7 @@ export const getPydanticAISteps = (ctx: OnboardingComponentsContext): StepDefini
                     <CodeBlock
                         language="bash"
                         code={dedent`
-                            pip install "pydantic-ai[openai]" opentelemetry-sdk opentelemetry-exporter-otlp-proto-http
+                            pip install "pydantic-ai[openai]" opentelemetry-sdk posthog[otel]
                         `}
                     />
                 </>
@@ -50,9 +50,8 @@ export const getPydanticAISteps = (ctx: OnboardingComponentsContext): StepDefini
                             import os
                             from opentelemetry import trace
                             from opentelemetry.sdk.trace import TracerProvider
-                            from opentelemetry.sdk.trace.export import SimpleSpanProcessor
                             from opentelemetry.sdk.resources import Resource, SERVICE_NAME
-                            from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+                            from posthog.ai.otel import PostHogSpanProcessor
                             from pydantic_ai import Agent
 
                             resource = Resource(attributes={
@@ -61,13 +60,13 @@ export const getPydanticAISteps = (ctx: OnboardingComponentsContext): StepDefini
                                 "foo": "bar", # custom properties are passed through
                             })
 
-                            exporter = OTLPSpanExporter(
-                                endpoint="<ph_client_api_host>/i/v0/ai/otel",
-                                headers={"Authorization": "Bearer <ph_project_token>"},
-                            )
-
                             provider = TracerProvider(resource=resource)
-                            provider.add_span_processor(SimpleSpanProcessor(exporter))
+                            provider.add_span_processor(
+                                PostHogSpanProcessor(
+                                    api_key="<ph_project_token>",
+                                    host="<ph_client_api_host>",
+                                )
+                            )
                             trace.set_tracer_provider(provider)
 
                             # Enable automatic OTel instrumentation for all Pydantic AI agents

--- a/docs/onboarding/llm-analytics/semantic-kernel.tsx
+++ b/docs/onboarding/llm-analytics/semantic-kernel.tsx
@@ -3,120 +3,117 @@ import { OnboardingComponentsContext, createInstallation } from 'scenes/onboardi
 import { StepDefinition } from '../steps'
 
 export const getSemanticKernelSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
-    const { CodeBlock, CalloutBox, Markdown, dedent, snippets } = ctx
+    const { CodeBlock, CalloutBox, Markdown, Blockquote, dedent, snippets } = ctx
 
     const NotableGenerationProperties = snippets?.NotableGenerationProperties
 
     return [
         {
-            title: 'Install the PostHog SDK',
+            title: 'Install dependencies',
             badge: 'required',
             content: (
                 <>
-                    <Markdown>
-                        Setting up analytics starts with installing the PostHog SDK. The Semantic Kernel integration
-                        uses PostHog's OpenAI wrapper.
-                    </Markdown>
+                    <CalloutBox type="info" icon="IconInfo" title="Full working examples">
+                        <Markdown>
+                            See the complete [Python
+                            example](https://github.com/PostHog/posthog-python/tree/master/examples/example-ai-semantic-kernel)
+                            on GitHub. If you're using the PostHog SDK wrapper instead of OpenTelemetry, see the [Python
+                            wrapper
+                            example](https://github.com/PostHog/posthog-python/tree/7223c52/examples/example-ai-semantic-kernel).
+                        </Markdown>
+                    </CalloutBox>
+
+                    <Markdown>Install the OpenTelemetry SDK, the OpenAI instrumentation, and Semantic Kernel.</Markdown>
 
                     <CodeBlock
                         language="bash"
                         code={dedent`
-                            pip install posthog
+                            pip install semantic-kernel openai opentelemetry-sdk opentelemetry-exporter-otlp-proto-http opentelemetry-instrumentation-openai-v2
                         `}
                     />
                 </>
             ),
         },
         {
-            title: 'Install Semantic Kernel',
+            title: 'Set up OpenTelemetry tracing',
             badge: 'required',
             content: (
                 <>
                     <Markdown>
-                        Install Semantic Kernel with OpenAI support. PostHog instruments your LLM calls by wrapping the
-                        OpenAI client that Semantic Kernel uses under the hood.
-                    </Markdown>
-
-                    <CodeBlock
-                        language="bash"
-                        code={dedent`
-                            pip install semantic-kernel
-                        `}
-                    />
-                </>
-            ),
-        },
-        {
-            title: 'Initialize PostHog and Semantic Kernel',
-            badge: 'required',
-            content: (
-                <>
-                    <Markdown>
-                        Initialize PostHog with your project token and host from [your project
-                        settings](https://app.posthog.com/settings/project), then create a PostHog `AsyncOpenAI` wrapper
-                        and pass it to Semantic Kernel's `OpenAIChatCompletion` service.
+                        Configure OpenTelemetry to auto-instrument OpenAI SDK calls and export traces to PostHog.
+                        PostHog converts `gen_ai.*` spans into `$ai_generation` events automatically.
                     </Markdown>
 
                     <CodeBlock
                         language="python"
                         code={dedent`
-                            from semantic_kernel import Kernel
-                            from semantic_kernel.connectors.ai.open_ai import OpenAIChatCompletion
-                            from posthog.ai.openai import AsyncOpenAI
-                            from posthog import Posthog
+                            from opentelemetry import trace
+                            from opentelemetry.sdk.trace import TracerProvider
+                            from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+                            from opentelemetry.sdk.resources import Resource, SERVICE_NAME
+                            from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+                            from opentelemetry.instrumentation.openai_v2 import OpenAIInstrumentor
 
-                            posthog = Posthog(
-                                "<ph_project_token>",
-                                host="<ph_client_api_host>"
+                            resource = Resource(attributes={
+                                SERVICE_NAME: "my-app",
+                                "posthog.distinct_id": "user_123", # optional: identifies the user in PostHog
+                                "foo": "bar", # custom properties are passed through
+                            })
+
+                            exporter = OTLPSpanExporter(
+                                endpoint="<ph_client_api_host>/i/v0/ai/otel",
+                                headers={"Authorization": "Bearer <ph_project_token>"},
                             )
 
-                            openai_client = AsyncOpenAI(
-                                api_key="your_openai_api_key",
-                                posthog_client=posthog
-                            )
+                            provider = TracerProvider(resource=resource)
+                            provider.add_span_processor(SimpleSpanProcessor(exporter))
+                            trace.set_tracer_provider(provider)
 
-                            kernel = Kernel()
-                            kernel.add_service(
-                                OpenAIChatCompletion(
-                                    ai_model_id="gpt-5-mini",
-                                    async_client=openai_client,
-                                )
-                            )
+                            OpenAIInstrumentor().instrument()
                         `}
                     />
-
-                    <CalloutBox type="fyi" icon="IconInfo" title="How this works">
-                        <Markdown>
-                            PostHog's `AsyncOpenAI` wrapper is a proper subclass of `openai.AsyncOpenAI`, so it works
-                            directly as the `async_client` parameter in Semantic Kernel's `OpenAIChatCompletion`.
-                            PostHog captures `$ai_generation` events automatically without proxying your calls.
-                        </Markdown>
-                    </CalloutBox>
                 </>
             ),
         },
         {
-            title: 'Run your kernel function',
+            title: 'Run your kernel',
             badge: 'required',
             content: (
                 <>
                     <Markdown>
                         Use Semantic Kernel as normal. PostHog automatically captures an `$ai_generation` event for each
-                        LLM call made through the wrapped client.
+                        LLM call made through the OpenAI SDK that Semantic Kernel uses internally.
                     </Markdown>
 
                     <CodeBlock
                         language="python"
                         code={dedent`
                             import asyncio
+                            from semantic_kernel import Kernel
+                            from semantic_kernel.connectors.ai.open_ai import OpenAIChatCompletion
 
                             async def main():
-                                result = await kernel.invoke_prompt("Tell me a fun fact about hedgehogs.")
+                                kernel = Kernel()
+                                kernel.add_service(
+                                    OpenAIChatCompletion(
+                                        ai_model_id="gpt-4o-mini",
+                                        api_key="your_openai_api_key",
+                                    )
+                                )
+                                result = await kernel.invoke_prompt("Tell me a fun fact about hedgehogs")
                                 print(result)
 
                             asyncio.run(main())
                         `}
                     />
+
+                    <Blockquote>
+                        <Markdown>
+                            **Note:** If you want to capture LLM events anonymously, omit the `posthog.distinct_id`
+                            resource attribute. See our docs on [anonymous vs identified
+                            events](https://posthog.com/docs/data/anonymous-vs-identified-events) to learn more.
+                        </Markdown>
+                    </Blockquote>
 
                     <Markdown>
                         {dedent`

--- a/docs/onboarding/llm-analytics/semantic-kernel.tsx
+++ b/docs/onboarding/llm-analytics/semantic-kernel.tsx
@@ -28,7 +28,7 @@ export const getSemanticKernelSteps = (ctx: OnboardingComponentsContext): StepDe
                     <CodeBlock
                         language="bash"
                         code={dedent`
-                            pip install semantic-kernel openai opentelemetry-sdk opentelemetry-exporter-otlp-proto-http opentelemetry-instrumentation-openai-v2
+                            pip install semantic-kernel openai opentelemetry-sdk posthog[otel] opentelemetry-instrumentation-openai-v2
                         `}
                     />
                 </>
@@ -49,9 +49,8 @@ export const getSemanticKernelSteps = (ctx: OnboardingComponentsContext): StepDe
                         code={dedent`
                             from opentelemetry import trace
                             from opentelemetry.sdk.trace import TracerProvider
-                            from opentelemetry.sdk.trace.export import SimpleSpanProcessor
                             from opentelemetry.sdk.resources import Resource, SERVICE_NAME
-                            from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+                            from posthog.ai.otel import PostHogSpanProcessor
                             from opentelemetry.instrumentation.openai_v2 import OpenAIInstrumentor
 
                             resource = Resource(attributes={
@@ -60,13 +59,13 @@ export const getSemanticKernelSteps = (ctx: OnboardingComponentsContext): StepDe
                                 "foo": "bar", # custom properties are passed through
                             })
 
-                            exporter = OTLPSpanExporter(
-                                endpoint="<ph_client_api_host>/i/v0/ai/otel",
-                                headers={"Authorization": "Bearer <ph_project_token>"},
-                            )
-
                             provider = TracerProvider(resource=resource)
-                            provider.add_span_processor(SimpleSpanProcessor(exporter))
+                            provider.add_span_processor(
+                                PostHogSpanProcessor(
+                                    api_key="<ph_project_token>",
+                                    host="<ph_client_api_host>",
+                                )
+                            )
                             trace.set_tracer_provider(provider)
 
                             OpenAIInstrumentor().instrument()

--- a/docs/onboarding/llm-analytics/smolagents.tsx
+++ b/docs/onboarding/llm-analytics/smolagents.tsx
@@ -3,91 +3,75 @@ import { OnboardingComponentsContext, createInstallation } from 'scenes/onboardi
 import { StepDefinition } from '../steps'
 
 export const getSmolagentsSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
-    const { CodeBlock, CalloutBox, Markdown, dedent, snippets } = ctx
+    const { CodeBlock, CalloutBox, Markdown, Blockquote, dedent, snippets } = ctx
 
     const NotableGenerationProperties = snippets?.NotableGenerationProperties
 
     return [
         {
-            title: 'Install the PostHog SDK',
+            title: 'Install dependencies',
             badge: 'required',
             content: (
                 <>
-                    <Markdown>
-                        Setting up analytics starts with installing the PostHog SDK. The smolagents integration uses
-                        PostHog's OpenAI wrapper.
-                    </Markdown>
+                    <CalloutBox type="info" icon="IconInfo" title="Full working examples">
+                        <Markdown>
+                            See the complete [Python
+                            example](https://github.com/PostHog/posthog-python/tree/master/examples/example-ai-smolagents)
+                            on GitHub. If you're using the PostHog SDK wrapper instead of OpenTelemetry, see the [Python
+                            wrapper
+                            example](https://github.com/PostHog/posthog-python/tree/7223c52/examples/example-ai-smolagents).
+                        </Markdown>
+                    </CalloutBox>
+
+                    <Markdown>Install the OpenTelemetry SDK, the OpenAI instrumentation, and smolagents.</Markdown>
 
                     <CodeBlock
                         language="bash"
                         code={dedent`
-                            pip install posthog
+                            pip install smolagents openai opentelemetry-sdk opentelemetry-exporter-otlp-proto-http opentelemetry-instrumentation-openai-v2
                         `}
                     />
                 </>
             ),
         },
         {
-            title: 'Install smolagents and OpenAI',
+            title: 'Set up OpenTelemetry tracing',
             badge: 'required',
             content: (
                 <>
                     <Markdown>
-                        Install smolagents and the OpenAI SDK. PostHog instruments your LLM calls by wrapping the OpenAI
-                        client, which you can pass to smolagents' `OpenAIServerModel`.
-                    </Markdown>
-
-                    <CodeBlock
-                        language="bash"
-                        code={dedent`
-                            pip install smolagents openai
-                        `}
-                    />
-                </>
-            ),
-        },
-        {
-            title: 'Initialize PostHog and smolagents',
-            badge: 'required',
-            content: (
-                <>
-                    <Markdown>
-                        Initialize PostHog with your project token and host from [your project
-                        settings](https://app.posthog.com/settings/project), then create a PostHog OpenAI wrapper and
-                        pass it to smolagents' `OpenAIServerModel`.
+                        Configure OpenTelemetry to auto-instrument OpenAI SDK calls and export traces to PostHog.
+                        PostHog converts `gen_ai.*` spans into `$ai_generation` events automatically.
                     </Markdown>
 
                     <CodeBlock
                         language="python"
                         code={dedent`
-                            from smolagents import CodeAgent, OpenAIServerModel
-                            from posthog.ai.openai import OpenAI
-                            from posthog import Posthog
+                            from opentelemetry import trace
+                            from opentelemetry.sdk.trace import TracerProvider
+                            from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+                            from opentelemetry.sdk.resources import Resource, SERVICE_NAME
+                            from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+                            from opentelemetry.instrumentation.openai_v2 import OpenAIInstrumentor
 
-                            posthog = Posthog(
-                                "<ph_project_token>",
-                                host="<ph_client_api_host>"
+                            resource = Resource(attributes={
+                                SERVICE_NAME: "my-app",
+                                "posthog.distinct_id": "user_123", # optional: identifies the user in PostHog
+                                "foo": "bar", # custom properties are passed through
+                            })
+
+                            exporter = OTLPSpanExporter(
+                                endpoint="<ph_client_api_host>/i/v0/ai/otel",
+                                headers={"Authorization": "Bearer <ph_project_token>"},
                             )
 
-                            openai_client = OpenAI(
-                                api_key="your_openai_api_key",
-                                posthog_client=posthog
-                            )
+                            provider = TracerProvider(resource=resource)
+                            provider.add_span_processor(SimpleSpanProcessor(exporter))
+                            trace.set_tracer_provider(provider)
 
-                            model = OpenAIServerModel(
-                                model_id="gpt-5-mini",
-                                client=openai_client,
-                            )
+                            OpenAIInstrumentor().instrument()
                         `}
                     />
-
-                    <CalloutBox type="fyi" icon="IconInfo" title="How this works">
-                        <Markdown>
-                            PostHog's `OpenAI` wrapper is a drop-in replacement for `openai.OpenAI`. By passing it as
-                            the `client` to `OpenAIServerModel`, all LLM calls made by smolagents are automatically
-                            captured as `$ai_generation` events.
-                        </Markdown>
-                    </CalloutBox>
                 </>
             ),
         },
@@ -98,24 +82,30 @@ export const getSmolagentsSteps = (ctx: OnboardingComponentsContext): StepDefini
                 <>
                     <Markdown>
                         Use smolagents as normal. PostHog automatically captures an `$ai_generation` event for each LLM
-                        call made through the wrapped OpenAI client.
+                        call made through the OpenAI SDK that smolagents uses internally.
                     </Markdown>
 
                     <CodeBlock
                         language="python"
                         code={dedent`
-                            agent = CodeAgent(
-                                tools=[],
-                                model=model,
-                            )
+                            import os
+                            from smolagents import CodeAgent, LiteLLMModel
 
-                            result = agent.run(
-                                "What is a fun fact about hedgehogs?"
-                            )
+                            model = LiteLLMModel(model_id="gpt-4o-mini", api_key=os.environ["OPENAI_API_KEY"])
+                            agent = CodeAgent(tools=[], model=model)
 
+                            result = agent.run("Tell me a fun fact about hedgehogs")
                             print(result)
                         `}
                     />
+
+                    <Blockquote>
+                        <Markdown>
+                            **Note:** If you want to capture LLM events anonymously, omit the `posthog.distinct_id`
+                            resource attribute. See our docs on [anonymous vs identified
+                            events](https://posthog.com/docs/data/anonymous-vs-identified-events) to learn more.
+                        </Markdown>
+                    </Blockquote>
 
                     <Markdown>
                         {dedent`

--- a/docs/onboarding/llm-analytics/smolagents.tsx
+++ b/docs/onboarding/llm-analytics/smolagents.tsx
@@ -28,7 +28,7 @@ export const getSmolagentsSteps = (ctx: OnboardingComponentsContext): StepDefini
                     <CodeBlock
                         language="bash"
                         code={dedent`
-                            pip install smolagents openai opentelemetry-sdk opentelemetry-exporter-otlp-proto-http opentelemetry-instrumentation-openai-v2
+                            pip install smolagents openai opentelemetry-sdk posthog[otel] opentelemetry-instrumentation-openai-v2
                         `}
                     />
                 </>
@@ -49,9 +49,8 @@ export const getSmolagentsSteps = (ctx: OnboardingComponentsContext): StepDefini
                         code={dedent`
                             from opentelemetry import trace
                             from opentelemetry.sdk.trace import TracerProvider
-                            from opentelemetry.sdk.trace.export import SimpleSpanProcessor
                             from opentelemetry.sdk.resources import Resource, SERVICE_NAME
-                            from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+                            from posthog.ai.otel import PostHogSpanProcessor
                             from opentelemetry.instrumentation.openai_v2 import OpenAIInstrumentor
 
                             resource = Resource(attributes={
@@ -60,13 +59,13 @@ export const getSmolagentsSteps = (ctx: OnboardingComponentsContext): StepDefini
                                 "foo": "bar", # custom properties are passed through
                             })
 
-                            exporter = OTLPSpanExporter(
-                                endpoint="<ph_client_api_host>/i/v0/ai/otel",
-                                headers={"Authorization": "Bearer <ph_project_token>"},
-                            )
-
                             provider = TracerProvider(resource=resource)
-                            provider.add_span_processor(SimpleSpanProcessor(exporter))
+                            provider.add_span_processor(
+                                PostHogSpanProcessor(
+                                    api_key="<ph_project_token>",
+                                    host="<ph_client_api_host>",
+                                )
+                            )
                             trace.set_tracer_provider(provider)
 
                             OpenAIInstrumentor().instrument()

--- a/docs/onboarding/llm-analytics/together-ai.tsx
+++ b/docs/onboarding/llm-analytics/together-ai.tsx
@@ -3,7 +3,7 @@ import { OnboardingComponentsContext, createInstallation } from 'scenes/onboardi
 import { StepDefinition } from '../steps'
 
 export const getTogetherAISteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
-    const { CodeBlock, Markdown, Blockquote, dedent, snippets } = ctx
+    const { CodeBlock, CalloutBox, Markdown, Blockquote, dedent, snippets } = ctx
 
     const NotableGenerationProperties = snippets?.NotableGenerationProperties
 
@@ -13,6 +13,17 @@ export const getTogetherAISteps = (ctx: OnboardingComponentsContext): StepDefini
             badge: 'required',
             content: (
                 <>
+                    <CalloutBox type="info" icon="IconInfo" title="Migrating from the SDK wrapper?">
+                        <Markdown>
+                            These docs now use OpenTelemetry auto-instrumentation, which is the recommended approach.
+                            The previous PostHog SDK wrapper is still available — see the
+                            [Node.js](https://github.com/PostHog/posthog-js/tree/e08ff1be/examples/example-ai-together-ai)
+                            and
+                            [Python](https://github.com/PostHog/posthog-python/tree/7223c52/examples/example-ai-together-ai)
+                            wrapper examples.
+                        </Markdown>
+                    </CalloutBox>
+
                     <Markdown>Install the OpenTelemetry SDK, the OpenAI instrumentation, and the OpenAI SDK.</Markdown>
 
                     <CodeBlock

--- a/docs/onboarding/llm-analytics/together-ai.tsx
+++ b/docs/onboarding/llm-analytics/together-ai.tsx
@@ -13,14 +13,18 @@ export const getTogetherAISteps = (ctx: OnboardingComponentsContext): StepDefini
             badge: 'required',
             content: (
                 <>
-                    <CalloutBox type="info" icon="IconInfo" title="Migrating from the SDK wrapper?">
+                    <CalloutBox type="info" icon="IconInfo" title="Full working examples">
                         <Markdown>
-                            These docs now use OpenTelemetry auto-instrumentation, which is the recommended approach.
-                            The previous PostHog SDK wrapper is still available — see the
-                            [Node.js](https://github.com/PostHog/posthog-js/tree/e08ff1be/examples/example-ai-together-ai)
+                            See the complete
+                            [Node.js](https://github.com/PostHog/posthog-js/tree/main/examples/example-ai-together-ai)
                             and
-                            [Python](https://github.com/PostHog/posthog-python/tree/7223c52/examples/example-ai-together-ai)
-                            wrapper examples.
+                            [Python](https://github.com/PostHog/posthog-python/tree/master/examples/example-ai-together-ai)
+                            examples on GitHub. If you're using the PostHog SDK wrapper instead of OpenTelemetry, see
+                            the [Node.js
+                            wrapper](https://github.com/PostHog/posthog-js/tree/e08ff1be/examples/example-ai-together-ai)
+                            and [Python
+                            wrapper](https://github.com/PostHog/posthog-python/tree/7223c52/examples/example-ai-together-ai)
+                            examples.
                         </Markdown>
                     </CalloutBox>
 

--- a/docs/onboarding/llm-analytics/together-ai.tsx
+++ b/docs/onboarding/llm-analytics/together-ai.tsx
@@ -3,7 +3,7 @@ import { OnboardingComponentsContext, createInstallation } from 'scenes/onboardi
 import { StepDefinition } from '../steps'
 
 export const getTogetherAISteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
-    const { CodeBlock, CalloutBox, Markdown, Blockquote, dedent, snippets } = ctx
+    const { CodeBlock, Markdown, Blockquote, dedent, snippets } = ctx
 
     const NotableGenerationProperties = snippets?.NotableGenerationProperties
 
@@ -33,13 +33,6 @@ export const getTogetherAISteps = (ctx: OnboardingComponentsContext): StepDefini
                             },
                         ]}
                     />
-
-                    <CalloutBox type="fyi" icon="IconInfo" title="No proxy">
-                        <Markdown>
-                            These SDKs **do not** proxy your calls. They only send analytics data to PostHog in the
-                            background.
-                        </Markdown>
-                    </CalloutBox>
                 </>
             ),
         },

--- a/docs/onboarding/llm-analytics/together-ai.tsx
+++ b/docs/onboarding/llm-analytics/together-ai.tsx
@@ -9,14 +9,11 @@ export const getTogetherAISteps = (ctx: OnboardingComponentsContext): StepDefini
 
     return [
         {
-            title: 'Install the PostHog SDK',
+            title: 'Install dependencies',
             badge: 'required',
             content: (
                 <>
-                    <Markdown>
-                        Setting up analytics starts with installing the PostHog SDK for your language. LLM analytics
-                        works best with our Python and Node SDKs.
-                    </Markdown>
+                    <Markdown>Install the OpenTelemetry SDK, the OpenAI instrumentation, and the OpenAI SDK.</Markdown>
 
                     <CodeBlock
                         blocks={[
@@ -24,63 +21,36 @@ export const getTogetherAISteps = (ctx: OnboardingComponentsContext): StepDefini
                                 language: 'bash',
                                 file: 'Python',
                                 code: dedent`
-                                    pip install posthog
+                                    pip install openai opentelemetry-sdk opentelemetry-exporter-otlp-proto-http opentelemetry-instrumentation-openai-v2
                                 `,
                             },
                             {
                                 language: 'bash',
                                 file: 'Node',
                                 code: dedent`
-                                    npm install @posthog/ai posthog-node
+                                    npm install openai @posthog/ai @opentelemetry/sdk-node @opentelemetry/resources @opentelemetry/instrumentation-openai
                                 `,
                             },
                         ]}
                     />
-                </>
-            ),
-        },
-        {
-            title: 'Install the OpenAI SDK',
-            badge: 'required',
-            content: (
-                <>
-                    <Markdown>
-                        Install the OpenAI SDK. The PostHog SDK instruments your LLM calls by wrapping the OpenAI
-                        client. The PostHog SDK **does not** proxy your calls.
-                    </Markdown>
 
-                    <CodeBlock
-                        blocks={[
-                            {
-                                language: 'bash',
-                                file: 'Python',
-                                code: dedent`
-                                    pip install openai
-                                `,
-                            },
-                            {
-                                language: 'bash',
-                                file: 'Node',
-                                code: dedent`
-                                    npm install openai
-                                `,
-                            },
-                        ]}
-                    />
+                    <CalloutBox type="fyi" icon="IconInfo" title="No proxy">
+                        <Markdown>
+                            These SDKs **do not** proxy your calls. They only send analytics data to PostHog in the
+                            background.
+                        </Markdown>
+                    </CalloutBox>
                 </>
             ),
         },
         {
-            title: 'Initialize PostHog and OpenAI client',
+            title: 'Set up OpenTelemetry tracing',
             badge: 'required',
             content: (
                 <>
                     <Markdown>
-                        We call Together AI through the OpenAI client and generate a response. We'll use PostHog's
-                        OpenAI provider to capture all the details of the call. Initialize PostHog with your PostHog
-                        project token and host from [your project settings](https://app.posthog.com/settings/project),
-                        then pass the PostHog client along with the Together AI config (the base URL and API key) to our
-                        OpenAI wrapper.
+                        Configure OpenTelemetry to auto-instrument OpenAI SDK calls and export traces to PostHog.
+                        PostHog converts `gen_ai.*` spans into `$ai_generation` events automatically.
                     </Markdown>
 
                     <CodeBlock
@@ -89,61 +59,59 @@ export const getTogetherAISteps = (ctx: OnboardingComponentsContext): StepDefini
                                 language: 'python',
                                 file: 'Python',
                                 code: dedent`
-                                    from posthog.ai.openai import OpenAI
-                                    from posthog import Posthog
+                                    from opentelemetry import trace
+                                    from opentelemetry.sdk.trace import TracerProvider
+                                    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+                                    from opentelemetry.sdk.resources import Resource, SERVICE_NAME
+                                    from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+                                    from opentelemetry.instrumentation.openai_v2 import OpenAIInstrumentor
 
-                                    posthog = Posthog(
-                                        "<ph_project_token>",
-                                        host="<ph_client_api_host>"
+                                    resource = Resource(attributes={
+                                        SERVICE_NAME: "my-app",
+                                        "user.id": "user_123", # optional: identifies the user in PostHog
+                                    })
+
+                                    exporter = OTLPSpanExporter(
+                                        endpoint="<ph_client_api_host>/i/v0/ai/otel",
+                                        headers={"Authorization": "Bearer <ph_project_token>"},
                                     )
 
-                                    client = OpenAI(
-                                        base_url="https://api.together.xyz/v1",
-                                        api_key="<together_api_key>",
-                                        posthog_client=posthog
-                                    )
+                                    provider = TracerProvider(resource=resource)
+                                    provider.add_span_processor(SimpleSpanProcessor(exporter))
+                                    trace.set_tracer_provider(provider)
+
+                                    OpenAIInstrumentor().instrument()
                                 `,
                             },
                             {
                                 language: 'typescript',
                                 file: 'Node',
                                 code: dedent`
-                                    import { OpenAI } from '@posthog/ai'
-                                    import { PostHog } from 'posthog-node'
+                                    import { NodeSDK, tracing } from '@opentelemetry/sdk-node'
+                                    import { resourceFromAttributes } from '@opentelemetry/resources'
+                                    import { PostHogTraceExporter } from '@posthog/ai/otel'
+                                    import { OpenAIInstrumentation } from '@opentelemetry/instrumentation-openai'
 
-                                    const phClient = new PostHog(
-                                      '<ph_project_token>',
-                                      { host: '<ph_client_api_host>' }
-                                    );
-
-                                    const openai = new OpenAI({
-                                      baseURL: 'https://api.together.xyz/v1',
-                                      apiKey: '<together_api_key>',
-                                      posthog: phClient,
-                                    });
-
-                                    // ... your code here ...
-
-                                    // IMPORTANT: Shutdown the client when you're done to ensure all events are sent
-                                    phClient.shutdown()
+                                    const sdk = new NodeSDK({
+                                      resource: resourceFromAttributes({
+                                        'service.name': 'my-app',
+                                        'user.id': 'user_123', // optional: identifies the user in PostHog
+                                      }),
+                                      spanProcessors: [
+                                        new tracing.SimpleSpanProcessor(
+                                          new PostHogTraceExporter({
+                                            apiKey: '<ph_project_token>',
+                                            host: '<ph_client_api_host>',
+                                          })
+                                        ),
+                                      ],
+                                      instrumentations: [new OpenAIInstrumentation()],
+                                    })
+                                    sdk.start()
                                 `,
                             },
                         ]}
                     />
-
-                    <Blockquote>
-                        <Markdown>**Note:** This also works with the `AsyncOpenAI` client.</Markdown>
-                    </Blockquote>
-
-                    <CalloutBox type="fyi" icon="IconInfo" title="Proxy note">
-                        <Markdown>
-                            These SDKs **do not** proxy your calls. They only fire off an async call to PostHog in the
-                            background to send the data. You can also use LLM analytics with other SDKs or our API, but
-                            you will need to capture the data in the right format. See the schema in the [manual capture
-                            section](https://posthog.com/docs/llm-analytics/installation/manual-capture) for more
-                            details.
-                        </Markdown>
-                    </CalloutBox>
                 </>
             ),
         },
@@ -153,9 +121,8 @@ export const getTogetherAISteps = (ctx: OnboardingComponentsContext): StepDefini
             content: (
                 <>
                     <Markdown>
-                        Now, when you call Together AI with the OpenAI SDK, PostHog automatically captures an
-                        `$ai_generation` event. You can also capture or modify additional properties with the distinct
-                        ID, trace ID, properties, groups, and privacy mode parameters.
+                        Now, when you use the OpenAI SDK to call Together AI, PostHog automatically captures
+                        `$ai_generation` events via the OpenTelemetry instrumentation.
                     </Markdown>
 
                     <CodeBlock
@@ -164,16 +131,19 @@ export const getTogetherAISteps = (ctx: OnboardingComponentsContext): StepDefini
                                 language: 'python',
                                 file: 'Python',
                                 code: dedent`
+                                    import openai
+
+                                    client = openai.OpenAI(
+                                        base_url="https://api.together.xyz/v1",
+                                        api_key="<together_api_key>",
+                                    )
+
                                     response = client.chat.completions.create(
                                         model="meta-llama/Llama-3.3-70B-Instruct-Turbo",
+                                        max_completion_tokens=1024,
                                         messages=[
                                             {"role": "user", "content": "Tell me a fun fact about hedgehogs"}
                                         ],
-                                        posthog_distinct_id="user_123", # optional
-                                        posthog_trace_id="trace_123", # optional
-                                        posthog_properties={"conversation_id": "abc123", "paid": True}, # optional
-                                        posthog_groups={"company": "company_id_in_your_db"},  # optional
-                                        posthog_privacy_mode=False # optional
                                     )
 
                                     print(response.choices[0].message.content)
@@ -183,17 +153,20 @@ export const getTogetherAISteps = (ctx: OnboardingComponentsContext): StepDefini
                                 language: 'typescript',
                                 file: 'Node',
                                 code: dedent`
-                                    const completion = await openai.chat.completions.create({
-                                        model: "meta-llama/Llama-3.3-70B-Instruct-Turbo",
-                                        messages: [{ role: "user", content: "Tell me a fun fact about hedgehogs" }],
-                                        posthogDistinctId: "user_123", // optional
-                                        posthogTraceId: "trace_123", // optional
-                                        posthogProperties: { conversation_id: "abc123", paid: true }, // optional
-                                        posthogGroups: { company: "company_id_in_your_db" }, // optional
-                                        posthogPrivacyMode: false // optional
-                                    });
+                                    import OpenAI from 'openai'
 
-                                    console.log(completion.choices[0].message.content)
+                                    const client = new OpenAI({
+                                      baseURL: 'https://api.together.xyz/v1',
+                                      apiKey: '<together_api_key>',
+                                    })
+
+                                    const response = await client.chat.completions.create({
+                                      model: 'meta-llama/Llama-3.3-70B-Instruct-Turbo',
+                                      max_completion_tokens: 1024,
+                                      messages: [{ role: 'user', content: 'Tell me a fun fact about hedgehogs' }],
+                                    })
+
+                                    console.log(response.choices[0].message.content)
                                 `,
                             },
                         ]}
@@ -202,12 +175,7 @@ export const getTogetherAISteps = (ctx: OnboardingComponentsContext): StepDefini
                     <Blockquote>
                         <Markdown>
                             {dedent`
-                            **Notes:**
-                            - We also support the old \`chat.completions\` API.
-                            - This works with responses where \`stream=True\`.
-                            - If you want to capture LLM events anonymously, **don't** pass a distinct ID to the request.
-
-                            See our docs on [anonymous vs identified events](https://posthog.com/docs/data/anonymous-vs-identified-events) to learn more.
+                            **Note:** If you want to capture LLM events anonymously, omit the \`user.id\` resource attribute. See our docs on [anonymous vs identified events](https://posthog.com/docs/data/anonymous-vs-identified-events) to learn more.
                             `}
                         </Markdown>
                     </Blockquote>

--- a/docs/onboarding/llm-analytics/together-ai.tsx
+++ b/docs/onboarding/llm-analytics/together-ai.tsx
@@ -61,7 +61,8 @@ export const getTogetherAISteps = (ctx: OnboardingComponentsContext): StepDefini
 
                                     resource = Resource(attributes={
                                         SERVICE_NAME: "my-app",
-                                        "user.id": "user_123", # optional: identifies the user in PostHog
+                                        "posthog.distinct_id": "user_123", # optional: identifies the user in PostHog
+                                        "foo": "bar", # custom properties are passed through
                                     })
 
                                     exporter = OTLPSpanExporter(
@@ -88,7 +89,8 @@ export const getTogetherAISteps = (ctx: OnboardingComponentsContext): StepDefini
                                     const sdk = new NodeSDK({
                                       resource: resourceFromAttributes({
                                         'service.name': 'my-app',
-                                        'user.id': 'user_123', // optional: identifies the user in PostHog
+                                        'posthog.distinct_id': 'user_123', // optional: identifies the user in PostHog
+                                        foo: 'bar', // custom properties are passed through
                                       }),
                                       spanProcessors: [
                                         new tracing.SimpleSpanProcessor(
@@ -168,7 +170,7 @@ export const getTogetherAISteps = (ctx: OnboardingComponentsContext): StepDefini
                     <Blockquote>
                         <Markdown>
                             {dedent`
-                            **Note:** If you want to capture LLM events anonymously, omit the \`user.id\` resource attribute. See our docs on [anonymous vs identified events](https://posthog.com/docs/data/anonymous-vs-identified-events) to learn more.
+                            **Note:** If you want to capture LLM events anonymously, omit the \`posthog.distinct_id\` resource attribute. See our docs on [anonymous vs identified events](https://posthog.com/docs/data/anonymous-vs-identified-events) to learn more.
                             `}
                         </Markdown>
                     </Blockquote>

--- a/docs/onboarding/llm-analytics/together-ai.tsx
+++ b/docs/onboarding/llm-analytics/together-ai.tsx
@@ -36,7 +36,7 @@ export const getTogetherAISteps = (ctx: OnboardingComponentsContext): StepDefini
                                 language: 'bash',
                                 file: 'Python',
                                 code: dedent`
-                                    pip install openai opentelemetry-sdk opentelemetry-exporter-otlp-proto-http opentelemetry-instrumentation-openai-v2
+                                    pip install openai opentelemetry-sdk posthog[otel] opentelemetry-instrumentation-openai-v2
                                 `,
                             },
                             {
@@ -69,9 +69,8 @@ export const getTogetherAISteps = (ctx: OnboardingComponentsContext): StepDefini
                                 code: dedent`
                                     from opentelemetry import trace
                                     from opentelemetry.sdk.trace import TracerProvider
-                                    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
                                     from opentelemetry.sdk.resources import Resource, SERVICE_NAME
-                                    from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+                                    from posthog.ai.otel import PostHogSpanProcessor
                                     from opentelemetry.instrumentation.openai_v2 import OpenAIInstrumentor
 
                                     resource = Resource(attributes={
@@ -80,13 +79,13 @@ export const getTogetherAISteps = (ctx: OnboardingComponentsContext): StepDefini
                                         "foo": "bar", # custom properties are passed through
                                     })
 
-                                    exporter = OTLPSpanExporter(
-                                        endpoint="<ph_client_api_host>/i/v0/ai/otel",
-                                        headers={"Authorization": "Bearer <ph_project_token>"},
-                                    )
-
                                     provider = TracerProvider(resource=resource)
-                                    provider.add_span_processor(SimpleSpanProcessor(exporter))
+                                    provider.add_span_processor(
+                                        PostHogSpanProcessor(
+                                            api_key="<ph_project_token>",
+                                            host="<ph_client_api_host>",
+                                        )
+                                    )
                                     trace.set_tracer_provider(provider)
 
                                     OpenAIInstrumentor().instrument()

--- a/docs/onboarding/llm-analytics/together-ai.tsx
+++ b/docs/onboarding/llm-analytics/together-ai.tsx
@@ -96,9 +96,9 @@ export const getTogetherAISteps = (ctx: OnboardingComponentsContext): StepDefini
                                 language: 'typescript',
                                 file: 'Node',
                                 code: dedent`
-                                    import { NodeSDK, tracing } from '@opentelemetry/sdk-node'
+                                    import { NodeSDK } from '@opentelemetry/sdk-node'
                                     import { resourceFromAttributes } from '@opentelemetry/resources'
-                                    import { PostHogTraceExporter } from '@posthog/ai/otel'
+                                    import { PostHogSpanProcessor } from '@posthog/ai/otel'
                                     import { OpenAIInstrumentation } from '@opentelemetry/instrumentation-openai'
 
                                     const sdk = new NodeSDK({
@@ -108,12 +108,10 @@ export const getTogetherAISteps = (ctx: OnboardingComponentsContext): StepDefini
                                         foo: 'bar', // custom properties are passed through
                                       }),
                                       spanProcessors: [
-                                        new tracing.SimpleSpanProcessor(
-                                          new PostHogTraceExporter({
-                                            apiKey: '<ph_project_token>',
-                                            host: '<ph_client_api_host>',
-                                          })
-                                        ),
+                                        new PostHogSpanProcessor({
+                                          apiKey: '<ph_project_token>',
+                                          host: '<ph_client_api_host>',
+                                        }),
                                       ],
                                       instrumentations: [new OpenAIInstrumentation()],
                                     })

--- a/docs/onboarding/llm-analytics/vercel-ai-gateway.tsx
+++ b/docs/onboarding/llm-analytics/vercel-ai-gateway.tsx
@@ -13,14 +13,18 @@ export const getVercelAIGatewaySteps = (ctx: OnboardingComponentsContext): StepD
             badge: 'required',
             content: (
                 <>
-                    <CalloutBox type="info" icon="IconInfo" title="Migrating from the SDK wrapper?">
+                    <CalloutBox type="info" icon="IconInfo" title="Full working examples">
                         <Markdown>
-                            These docs now use OpenTelemetry auto-instrumentation, which is the recommended approach.
-                            The previous PostHog SDK wrapper is still available — see the
-                            [Node.js](https://github.com/PostHog/posthog-js/tree/e08ff1be/examples/example-ai-vercel-ai-gateway)
+                            See the complete
+                            [Node.js](https://github.com/PostHog/posthog-js/tree/main/examples/example-ai-vercel-ai-gateway)
                             and
-                            [Python](https://github.com/PostHog/posthog-python/tree/7223c52/examples/example-ai-vercel-ai-gateway)
-                            wrapper examples.
+                            [Python](https://github.com/PostHog/posthog-python/tree/master/examples/example-ai-vercel-ai-gateway)
+                            examples on GitHub. If you're using the PostHog SDK wrapper instead of OpenTelemetry, see
+                            the [Node.js
+                            wrapper](https://github.com/PostHog/posthog-js/tree/e08ff1be/examples/example-ai-vercel-ai-gateway)
+                            and [Python
+                            wrapper](https://github.com/PostHog/posthog-python/tree/7223c52/examples/example-ai-vercel-ai-gateway)
+                            examples.
                         </Markdown>
                     </CalloutBox>
 

--- a/docs/onboarding/llm-analytics/vercel-ai-gateway.tsx
+++ b/docs/onboarding/llm-analytics/vercel-ai-gateway.tsx
@@ -68,7 +68,8 @@ export const getVercelAIGatewaySteps = (ctx: OnboardingComponentsContext): StepD
 
                                     resource = Resource(attributes={
                                         SERVICE_NAME: "my-app",
-                                        "user.id": "user_123", # optional: identifies the user in PostHog
+                                        "posthog.distinct_id": "user_123", # optional: identifies the user in PostHog
+                                        "foo": "bar", # custom properties are passed through
                                     })
 
                                     exporter = OTLPSpanExporter(
@@ -95,7 +96,8 @@ export const getVercelAIGatewaySteps = (ctx: OnboardingComponentsContext): StepD
                                     const sdk = new NodeSDK({
                                       resource: resourceFromAttributes({
                                         'service.name': 'my-app',
-                                        'user.id': 'user_123', // optional: identifies the user in PostHog
+                                        'posthog.distinct_id': 'user_123', // optional: identifies the user in PostHog
+                                        foo: 'bar', // custom properties are passed through
                                       }),
                                       spanProcessors: [
                                         new tracing.SimpleSpanProcessor(
@@ -172,8 +174,8 @@ export const getVercelAIGatewaySteps = (ctx: OnboardingComponentsContext): StepD
 
                     <Blockquote>
                         <Markdown>
-                            **Note:** If you want to capture LLM events anonymously, omit the `user.id` resource
-                            attribute. See our docs on [anonymous vs identified
+                            **Note:** If you want to capture LLM events anonymously, omit the `posthog.distinct_id`
+                            resource attribute. See our docs on [anonymous vs identified
                             events](https://posthog.com/docs/data/anonymous-vs-identified-events) to learn more.
                         </Markdown>
                     </Blockquote>

--- a/docs/onboarding/llm-analytics/vercel-ai-gateway.tsx
+++ b/docs/onboarding/llm-analytics/vercel-ai-gateway.tsx
@@ -40,13 +40,6 @@ export const getVercelAIGatewaySteps = (ctx: OnboardingComponentsContext): StepD
                             },
                         ]}
                     />
-
-                    <CalloutBox type="fyi" icon="IconInfo" title="No proxy">
-                        <Markdown>
-                            These SDKs **do not** proxy your calls. They only send analytics data to PostHog in the
-                            background.
-                        </Markdown>
-                    </CalloutBox>
                 </>
             ),
         },

--- a/docs/onboarding/llm-analytics/vercel-ai-gateway.tsx
+++ b/docs/onboarding/llm-analytics/vercel-ai-gateway.tsx
@@ -9,7 +9,7 @@ export const getVercelAIGatewaySteps = (ctx: OnboardingComponentsContext): StepD
 
     return [
         {
-            title: 'Install the PostHog SDK',
+            title: 'Install dependencies',
             badge: 'required',
             content: (
                 <>
@@ -20,10 +20,7 @@ export const getVercelAIGatewaySteps = (ctx: OnboardingComponentsContext): StepD
                         </Markdown>
                     </CalloutBox>
 
-                    <Markdown>
-                        Setting up analytics starts with installing the PostHog SDK for your language. LLM analytics
-                        works best with our Python and Node SDKs.
-                    </Markdown>
+                    <Markdown>Install the OpenTelemetry SDK, the OpenAI instrumentation, and the OpenAI SDK.</Markdown>
 
                     <CodeBlock
                         blocks={[
@@ -31,62 +28,36 @@ export const getVercelAIGatewaySteps = (ctx: OnboardingComponentsContext): StepD
                                 language: 'bash',
                                 file: 'Python',
                                 code: dedent`
-                                    pip install posthog
+                                    pip install openai opentelemetry-sdk opentelemetry-exporter-otlp-proto-http opentelemetry-instrumentation-openai-v2
                                 `,
                             },
                             {
                                 language: 'bash',
                                 file: 'Node',
                                 code: dedent`
-                                    npm install @posthog/ai posthog-node
+                                    npm install openai @posthog/ai @opentelemetry/sdk-node @opentelemetry/resources @opentelemetry/instrumentation-openai
                                 `,
                             },
                         ]}
                     />
-                </>
-            ),
-        },
-        {
-            title: 'Install the OpenAI SDK',
-            badge: 'required',
-            content: (
-                <>
-                    <Markdown>
-                        Install the OpenAI SDK. The PostHog SDK instruments your LLM calls by wrapping the OpenAI
-                        client. The PostHog SDK **does not** proxy your calls.
-                    </Markdown>
 
-                    <CodeBlock
-                        blocks={[
-                            {
-                                language: 'bash',
-                                file: 'Python',
-                                code: dedent`
-                                    pip install openai
-                                `,
-                            },
-                            {
-                                language: 'bash',
-                                file: 'Node',
-                                code: dedent`
-                                    npm install openai
-                                `,
-                            },
-                        ]}
-                    />
+                    <CalloutBox type="fyi" icon="IconInfo" title="No proxy">
+                        <Markdown>
+                            These SDKs **do not** proxy your calls. They only send analytics data to PostHog in the
+                            background.
+                        </Markdown>
+                    </CalloutBox>
                 </>
             ),
         },
         {
-            title: 'Initialize PostHog and OpenAI client',
+            title: 'Set up OpenTelemetry tracing',
             badge: 'required',
             content: (
                 <>
                     <Markdown>
-                        We call Vercel AI Gateway through the OpenAI client and generate a response. We'll use PostHog's
-                        OpenAI provider to capture all the details of the call. Initialize PostHog with your PostHog
-                        project token and host from [your project settings](https://app.posthog.com/settings/project),
-                        then pass the PostHog client along with the Vercel AI Gateway base URL to our OpenAI wrapper.
+                        Configure OpenTelemetry to auto-instrument OpenAI SDK calls and export traces to PostHog.
+                        PostHog converts `gen_ai.*` spans into `$ai_generation` events automatically.
                     </Markdown>
 
                     <CodeBlock
@@ -95,61 +66,59 @@ export const getVercelAIGatewaySteps = (ctx: OnboardingComponentsContext): StepD
                                 language: 'python',
                                 file: 'Python',
                                 code: dedent`
-                                    from posthog.ai.openai import OpenAI
-                                    from posthog import Posthog
+                                    from opentelemetry import trace
+                                    from opentelemetry.sdk.trace import TracerProvider
+                                    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+                                    from opentelemetry.sdk.resources import Resource, SERVICE_NAME
+                                    from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+                                    from opentelemetry.instrumentation.openai_v2 import OpenAIInstrumentor
 
-                                    posthog = Posthog(
-                                        "<ph_project_token>",
-                                        host="<ph_client_api_host>"
+                                    resource = Resource(attributes={
+                                        SERVICE_NAME: "my-app",
+                                        "user.id": "user_123", # optional: identifies the user in PostHog
+                                    })
+
+                                    exporter = OTLPSpanExporter(
+                                        endpoint="<ph_client_api_host>/i/v0/ai/otel",
+                                        headers={"Authorization": "Bearer <ph_project_token>"},
                                     )
 
-                                    client = OpenAI(
-                                        base_url="https://ai-gateway.vercel.sh/v1",
-                                        api_key="<your_api_key>",
-                                        posthog_client=posthog
-                                    )
+                                    provider = TracerProvider(resource=resource)
+                                    provider.add_span_processor(SimpleSpanProcessor(exporter))
+                                    trace.set_tracer_provider(provider)
+
+                                    OpenAIInstrumentor().instrument()
                                 `,
                             },
                             {
                                 language: 'typescript',
                                 file: 'Node',
                                 code: dedent`
-                                    import { OpenAI } from '@posthog/ai'
-                                    import { PostHog } from 'posthog-node'
+                                    import { NodeSDK, tracing } from '@opentelemetry/sdk-node'
+                                    import { resourceFromAttributes } from '@opentelemetry/resources'
+                                    import { PostHogTraceExporter } from '@posthog/ai/otel'
+                                    import { OpenAIInstrumentation } from '@opentelemetry/instrumentation-openai'
 
-                                    const phClient = new PostHog(
-                                      '<ph_project_token>',
-                                      { host: '<ph_client_api_host>' }
-                                    );
-
-                                    const openai = new OpenAI({
-                                      baseURL: 'https://ai-gateway.vercel.sh/v1',
-                                      apiKey: '<your_api_key>',
-                                      posthog: phClient,
-                                    });
-
-                                    // ... your code here ...
-
-                                    // IMPORTANT: Shutdown the client when you're done to ensure all events are sent
-                                    phClient.shutdown()
+                                    const sdk = new NodeSDK({
+                                      resource: resourceFromAttributes({
+                                        'service.name': 'my-app',
+                                        'user.id': 'user_123', // optional: identifies the user in PostHog
+                                      }),
+                                      spanProcessors: [
+                                        new tracing.SimpleSpanProcessor(
+                                          new PostHogTraceExporter({
+                                            apiKey: '<ph_project_token>',
+                                            host: '<ph_client_api_host>',
+                                          })
+                                        ),
+                                      ],
+                                      instrumentations: [new OpenAIInstrumentation()],
+                                    })
+                                    sdk.start()
                                 `,
                             },
                         ]}
                     />
-
-                    <Blockquote>
-                        <Markdown>**Note:** This also works with the `AsyncOpenAI` client.</Markdown>
-                    </Blockquote>
-
-                    <CalloutBox type="fyi" icon="IconInfo" title="Proxy note">
-                        <Markdown>
-                            These SDKs **do not** proxy your calls. They only fire off an async call to PostHog in the
-                            background to send the data. You can also use LLM analytics with other SDKs or our API, but
-                            you will need to capture the data in the right format. See the schema in the [manual capture
-                            section](https://posthog.com/docs/llm-analytics/installation/manual-capture) for more
-                            details.
-                        </Markdown>
-                    </CalloutBox>
                 </>
             ),
         },
@@ -159,9 +128,8 @@ export const getVercelAIGatewaySteps = (ctx: OnboardingComponentsContext): StepD
             content: (
                 <>
                     <Markdown>
-                        Now, when you call Vercel AI Gateway with the OpenAI SDK, PostHog automatically captures an
-                        `$ai_generation` event. You can also capture or modify additional properties with the distinct
-                        ID, trace ID, properties, groups, and privacy mode parameters.
+                        Now, when you call Vercel AI Gateway with the OpenAI SDK, PostHog automatically captures
+                        `$ai_generation` events via the OpenTelemetry instrumentation.
                     </Markdown>
 
                     <CodeBlock
@@ -170,16 +138,18 @@ export const getVercelAIGatewaySteps = (ctx: OnboardingComponentsContext): StepD
                                 language: 'python',
                                 file: 'Python',
                                 code: dedent`
+                                    import openai
+
+                                    client = openai.OpenAI(
+                                        base_url="https://ai-gateway.vercel.sh/v1",
+                                        api_key="<your_api_key>",
+                                    )
+
                                     response = client.chat.completions.create(
                                         model="gpt-5-mini",
                                         messages=[
                                             {"role": "user", "content": "Tell me a fun fact about hedgehogs"}
                                         ],
-                                        posthog_distinct_id="user_123", # optional
-                                        posthog_trace_id="trace_123", # optional
-                                        posthog_properties={"conversation_id": "abc123", "paid": True}, # optional
-                                        posthog_groups={"company": "company_id_in_your_db"},  # optional
-                                        posthog_privacy_mode=False # optional
                                     )
 
                                     print(response.choices[0].message.content)
@@ -189,17 +159,19 @@ export const getVercelAIGatewaySteps = (ctx: OnboardingComponentsContext): StepD
                                 language: 'typescript',
                                 file: 'Node',
                                 code: dedent`
-                                    const completion = await openai.chat.completions.create({
-                                        model: "gpt-5-mini",
-                                        messages: [{ role: "user", content: "Tell me a fun fact about hedgehogs" }],
-                                        posthogDistinctId: "user_123", // optional
-                                        posthogTraceId: "trace_123", // optional
-                                        posthogProperties: { conversation_id: "abc123", paid: true }, // optional
-                                        posthogGroups: { company: "company_id_in_your_db" }, // optional
-                                        posthogPrivacyMode: false // optional
-                                    });
+                                    import OpenAI from 'openai'
 
-                                    console.log(completion.choices[0].message.content)
+                                    const client = new OpenAI({
+                                      baseURL: 'https://ai-gateway.vercel.sh/v1',
+                                      apiKey: '<your_api_key>',
+                                    })
+
+                                    const response = await client.chat.completions.create({
+                                      model: 'gpt-5-mini',
+                                      messages: [{ role: 'user', content: 'Tell me a fun fact about hedgehogs' }],
+                                    })
+
+                                    console.log(response.choices[0].message.content)
                                 `,
                             },
                         ]}
@@ -207,14 +179,9 @@ export const getVercelAIGatewaySteps = (ctx: OnboardingComponentsContext): StepD
 
                     <Blockquote>
                         <Markdown>
-                            {dedent`
-                            **Notes:**
-                            - We also support the old \`chat.completions\` API.
-                            - This works with responses where \`stream=True\`.
-                            - If you want to capture LLM events anonymously, **don't** pass a distinct ID to the request.
-
-                            See our docs on [anonymous vs identified events](https://posthog.com/docs/data/anonymous-vs-identified-events) to learn more.
-                            `}
+                            **Note:** If you want to capture LLM events anonymously, omit the `user.id` resource
+                            attribute. See our docs on [anonymous vs identified
+                            events](https://posthog.com/docs/data/anonymous-vs-identified-events) to learn more.
                         </Markdown>
                     </Blockquote>
 

--- a/docs/onboarding/llm-analytics/vercel-ai-gateway.tsx
+++ b/docs/onboarding/llm-analytics/vercel-ai-gateway.tsx
@@ -13,6 +13,17 @@ export const getVercelAIGatewaySteps = (ctx: OnboardingComponentsContext): StepD
             badge: 'required',
             content: (
                 <>
+                    <CalloutBox type="info" icon="IconInfo" title="Migrating from the SDK wrapper?">
+                        <Markdown>
+                            These docs now use OpenTelemetry auto-instrumentation, which is the recommended approach.
+                            The previous PostHog SDK wrapper is still available — see the
+                            [Node.js](https://github.com/PostHog/posthog-js/tree/e08ff1be/examples/example-ai-vercel-ai-gateway)
+                            and
+                            [Python](https://github.com/PostHog/posthog-python/tree/7223c52/examples/example-ai-vercel-ai-gateway)
+                            wrapper examples.
+                        </Markdown>
+                    </CalloutBox>
+
                     <CalloutBox type="fyi" icon="IconInfo" title="About Vercel AI Gateway">
                         <Markdown>
                             Vercel AI Gateway provides a unified OpenAI-compatible API for accessing multiple LLM

--- a/docs/onboarding/llm-analytics/vercel-ai-gateway.tsx
+++ b/docs/onboarding/llm-analytics/vercel-ai-gateway.tsx
@@ -103,9 +103,9 @@ export const getVercelAIGatewaySteps = (ctx: OnboardingComponentsContext): StepD
                                 language: 'typescript',
                                 file: 'Node',
                                 code: dedent`
-                                    import { NodeSDK, tracing } from '@opentelemetry/sdk-node'
+                                    import { NodeSDK } from '@opentelemetry/sdk-node'
                                     import { resourceFromAttributes } from '@opentelemetry/resources'
-                                    import { PostHogTraceExporter } from '@posthog/ai/otel'
+                                    import { PostHogSpanProcessor } from '@posthog/ai/otel'
                                     import { OpenAIInstrumentation } from '@opentelemetry/instrumentation-openai'
 
                                     const sdk = new NodeSDK({
@@ -115,12 +115,10 @@ export const getVercelAIGatewaySteps = (ctx: OnboardingComponentsContext): StepD
                                         foo: 'bar', // custom properties are passed through
                                       }),
                                       spanProcessors: [
-                                        new tracing.SimpleSpanProcessor(
-                                          new PostHogTraceExporter({
-                                            apiKey: '<ph_project_token>',
-                                            host: '<ph_client_api_host>',
-                                          })
-                                        ),
+                                        new PostHogSpanProcessor({
+                                          apiKey: '<ph_project_token>',
+                                          host: '<ph_client_api_host>',
+                                        }),
                                       ],
                                       instrumentations: [new OpenAIInstrumentation()],
                                     })

--- a/docs/onboarding/llm-analytics/vercel-ai-gateway.tsx
+++ b/docs/onboarding/llm-analytics/vercel-ai-gateway.tsx
@@ -43,7 +43,7 @@ export const getVercelAIGatewaySteps = (ctx: OnboardingComponentsContext): StepD
                                 language: 'bash',
                                 file: 'Python',
                                 code: dedent`
-                                    pip install openai opentelemetry-sdk opentelemetry-exporter-otlp-proto-http opentelemetry-instrumentation-openai-v2
+                                    pip install openai opentelemetry-sdk posthog[otel] opentelemetry-instrumentation-openai-v2
                                 `,
                             },
                             {
@@ -76,9 +76,8 @@ export const getVercelAIGatewaySteps = (ctx: OnboardingComponentsContext): StepD
                                 code: dedent`
                                     from opentelemetry import trace
                                     from opentelemetry.sdk.trace import TracerProvider
-                                    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
                                     from opentelemetry.sdk.resources import Resource, SERVICE_NAME
-                                    from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+                                    from posthog.ai.otel import PostHogSpanProcessor
                                     from opentelemetry.instrumentation.openai_v2 import OpenAIInstrumentor
 
                                     resource = Resource(attributes={
@@ -87,13 +86,13 @@ export const getVercelAIGatewaySteps = (ctx: OnboardingComponentsContext): StepD
                                         "foo": "bar", # custom properties are passed through
                                     })
 
-                                    exporter = OTLPSpanExporter(
-                                        endpoint="<ph_client_api_host>/i/v0/ai/otel",
-                                        headers={"Authorization": "Bearer <ph_project_token>"},
-                                    )
-
                                     provider = TracerProvider(resource=resource)
-                                    provider.add_span_processor(SimpleSpanProcessor(exporter))
+                                    provider.add_span_processor(
+                                        PostHogSpanProcessor(
+                                            api_key="<ph_project_token>",
+                                            host="<ph_client_api_host>",
+                                        )
+                                    )
                                     trace.set_tracer_provider(provider)
 
                                     OpenAIInstrumentor().instrument()

--- a/docs/onboarding/llm-analytics/vercel-ai.tsx
+++ b/docs/onboarding/llm-analytics/vercel-ai.tsx
@@ -44,8 +44,7 @@ export const getVercelAISteps = (ctx: OnboardingComponentsContext): StepDefiniti
 
                             const sdk = new NodeSDK({
                               resource: resourceFromAttributes({
-                                'service.name': 'my-ai-app',
-                                'user.id': 'user_123', // optional: identifies the user in PostHog
+                                'service.name': 'my-app',
                               }),
                               spanProcessors: [
                                 new tracing.SimpleSpanProcessor(

--- a/docs/onboarding/llm-analytics/vercel-ai.tsx
+++ b/docs/onboarding/llm-analytics/vercel-ai.tsx
@@ -3,7 +3,7 @@ import { OnboardingComponentsContext, createInstallation } from 'scenes/onboardi
 import { StepDefinition } from '../steps'
 
 export const getVercelAISteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
-    const { CodeBlock, CalloutBox, Markdown, Blockquote, dedent, snippets } = ctx
+    const { CodeBlock, Markdown, Blockquote, dedent, snippets } = ctx
 
     const NotableGenerationProperties = snippets?.NotableGenerationProperties
 
@@ -21,13 +21,6 @@ export const getVercelAISteps = (ctx: OnboardingComponentsContext): StepDefiniti
                             npm install @posthog/ai @ai-sdk/openai ai @opentelemetry/sdk-node @opentelemetry/resources
                         `}
                     />
-
-                    <CalloutBox type="fyi" icon="IconInfo" title="No proxy">
-                        <Markdown>
-                            These SDKs **do not** proxy your calls. They only send analytics data to PostHog in the
-                            background.
-                        </Markdown>
-                    </CalloutBox>
                 </>
             ),
         },

--- a/docs/onboarding/llm-analytics/vercel-ai.tsx
+++ b/docs/onboarding/llm-analytics/vercel-ai.tsx
@@ -45,18 +45,23 @@ export const getVercelAISteps = (ctx: OnboardingComponentsContext): StepDefiniti
                     <CodeBlock
                         language="typescript"
                         code={dedent`
-                            import { NodeSDK } from '@opentelemetry/sdk-node'
+                            import { NodeSDK, tracing } from '@opentelemetry/sdk-node'
                             import { resourceFromAttributes } from '@opentelemetry/resources'
                             import { PostHogTraceExporter } from '@posthog/ai/otel'
 
                             const sdk = new NodeSDK({
                               resource: resourceFromAttributes({
                                 'service.name': 'my-ai-app',
+                                'user.id': 'user_123', // optional: identifies the user in PostHog
                               }),
-                              traceExporter: new PostHogTraceExporter({
-                                apiKey: '<ph_project_token>',
-                                host: '<ph_client_api_host>',
-                              }),
+                              spanProcessors: [
+                                new tracing.SimpleSpanProcessor(
+                                  new PostHogTraceExporter({
+                                    apiKey: '<ph_project_token>',
+                                    host: '<ph_client_api_host>',
+                                  })
+                                ),
+                              ],
                             })
                             sdk.start()
                         `}
@@ -93,8 +98,6 @@ export const getVercelAISteps = (ctx: OnboardingComponentsContext): StepDefiniti
                             })
 
                             console.log(result.text)
-
-                            await sdk.shutdown()
                         `}
                     />
 

--- a/docs/onboarding/llm-analytics/vercel-ai.tsx
+++ b/docs/onboarding/llm-analytics/vercel-ai.tsx
@@ -30,7 +30,7 @@ export const getVercelAISteps = (ctx: OnboardingComponentsContext): StepDefiniti
             content: (
                 <>
                     <Markdown>
-                        Initialize the OpenTelemetry SDK with PostHog's `PostHogTraceExporter`. This sends `gen_ai.*`
+                        Initialize the OpenTelemetry SDK with PostHog's `PostHogSpanProcessor`. This sends `gen_ai.*`
                         spans directly to PostHog's OTLP ingestion endpoint. PostHog converts these into
                         `$ai_generation` events automatically.
                     </Markdown>
@@ -38,21 +38,19 @@ export const getVercelAISteps = (ctx: OnboardingComponentsContext): StepDefiniti
                     <CodeBlock
                         language="typescript"
                         code={dedent`
-                            import { NodeSDK, tracing } from '@opentelemetry/sdk-node'
+                            import { NodeSDK } from '@opentelemetry/sdk-node'
                             import { resourceFromAttributes } from '@opentelemetry/resources'
-                            import { PostHogTraceExporter } from '@posthog/ai/otel'
+                            import { PostHogSpanProcessor } from '@posthog/ai/otel'
 
                             const sdk = new NodeSDK({
                               resource: resourceFromAttributes({
                                 'service.name': 'my-app',
                               }),
                               spanProcessors: [
-                                new tracing.SimpleSpanProcessor(
-                                  new PostHogTraceExporter({
-                                    apiKey: '<ph_project_token>',
-                                    host: '<ph_client_api_host>',
-                                  })
-                                ),
+                                new PostHogSpanProcessor({
+                                  apiKey: '<ph_project_token>',
+                                  host: '<ph_client_api_host>',
+                                }),
                               ],
                             })
                             sdk.start()

--- a/docs/onboarding/llm-analytics/xai.tsx
+++ b/docs/onboarding/llm-analytics/xai.tsx
@@ -13,13 +13,17 @@ export const getXAISteps = (ctx: OnboardingComponentsContext): StepDefinition[] 
             badge: 'required',
             content: (
                 <>
-                    <CalloutBox type="info" icon="IconInfo" title="Migrating from the SDK wrapper?">
+                    <CalloutBox type="info" icon="IconInfo" title="Full working examples">
                         <Markdown>
-                            These docs now use OpenTelemetry auto-instrumentation, which is the recommended approach.
-                            The previous PostHog SDK wrapper is still available — see the
-                            [Node.js](https://github.com/PostHog/posthog-js/tree/e08ff1be/examples/example-ai-xai) and
-                            [Python](https://github.com/PostHog/posthog-python/tree/7223c52/examples/example-ai-xai)
-                            wrapper examples.
+                            See the complete
+                            [Node.js](https://github.com/PostHog/posthog-js/tree/main/examples/example-ai-xai) and
+                            [Python](https://github.com/PostHog/posthog-python/tree/master/examples/example-ai-xai)
+                            examples on GitHub. If you're using the PostHog SDK wrapper instead of OpenTelemetry, see
+                            the [Node.js
+                            wrapper](https://github.com/PostHog/posthog-js/tree/e08ff1be/examples/example-ai-xai) and
+                            [Python
+                            wrapper](https://github.com/PostHog/posthog-python/tree/7223c52/examples/example-ai-xai)
+                            examples.
                         </Markdown>
                     </CalloutBox>
 

--- a/docs/onboarding/llm-analytics/xai.tsx
+++ b/docs/onboarding/llm-analytics/xai.tsx
@@ -3,7 +3,7 @@ import { OnboardingComponentsContext, createInstallation } from 'scenes/onboardi
 import { StepDefinition } from '../steps'
 
 export const getXAISteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
-    const { CodeBlock, CalloutBox, Markdown, Blockquote, dedent, snippets } = ctx
+    const { CodeBlock, Markdown, Blockquote, dedent, snippets } = ctx
 
     const NotableGenerationProperties = snippets?.NotableGenerationProperties
 
@@ -33,13 +33,6 @@ export const getXAISteps = (ctx: OnboardingComponentsContext): StepDefinition[] 
                             },
                         ]}
                     />
-
-                    <CalloutBox type="fyi" icon="IconInfo" title="No proxy">
-                        <Markdown>
-                            These SDKs **do not** proxy your calls. They only send analytics data to PostHog in the
-                            background.
-                        </Markdown>
-                    </CalloutBox>
                 </>
             ),
         },

--- a/docs/onboarding/llm-analytics/xai.tsx
+++ b/docs/onboarding/llm-analytics/xai.tsx
@@ -9,14 +9,11 @@ export const getXAISteps = (ctx: OnboardingComponentsContext): StepDefinition[] 
 
     return [
         {
-            title: 'Install the PostHog SDK',
+            title: 'Install dependencies',
             badge: 'required',
             content: (
                 <>
-                    <Markdown>
-                        Setting up analytics starts with installing the PostHog SDK for your language. LLM analytics
-                        works best with our Python and Node SDKs.
-                    </Markdown>
+                    <Markdown>Install the OpenTelemetry SDK, the OpenAI instrumentation, and the OpenAI SDK.</Markdown>
 
                     <CodeBlock
                         blocks={[
@@ -24,63 +21,36 @@ export const getXAISteps = (ctx: OnboardingComponentsContext): StepDefinition[] 
                                 language: 'bash',
                                 file: 'Python',
                                 code: dedent`
-                                    pip install posthog
+                                    pip install openai opentelemetry-sdk opentelemetry-exporter-otlp-proto-http opentelemetry-instrumentation-openai-v2
                                 `,
                             },
                             {
                                 language: 'bash',
                                 file: 'Node',
                                 code: dedent`
-                                    npm install @posthog/ai posthog-node
+                                    npm install openai @posthog/ai @opentelemetry/sdk-node @opentelemetry/resources @opentelemetry/instrumentation-openai
                                 `,
                             },
                         ]}
                     />
-                </>
-            ),
-        },
-        {
-            title: 'Install the OpenAI SDK',
-            badge: 'required',
-            content: (
-                <>
-                    <Markdown>
-                        Install the OpenAI SDK. The PostHog SDK instruments your LLM calls by wrapping the OpenAI
-                        client. The PostHog SDK **does not** proxy your calls.
-                    </Markdown>
 
-                    <CodeBlock
-                        blocks={[
-                            {
-                                language: 'bash',
-                                file: 'Python',
-                                code: dedent`
-                                    pip install openai
-                                `,
-                            },
-                            {
-                                language: 'bash',
-                                file: 'Node',
-                                code: dedent`
-                                    npm install openai
-                                `,
-                            },
-                        ]}
-                    />
+                    <CalloutBox type="fyi" icon="IconInfo" title="No proxy">
+                        <Markdown>
+                            These SDKs **do not** proxy your calls. They only send analytics data to PostHog in the
+                            background.
+                        </Markdown>
+                    </CalloutBox>
                 </>
             ),
         },
         {
-            title: 'Initialize PostHog and OpenAI client',
+            title: 'Set up OpenTelemetry tracing',
             badge: 'required',
             content: (
                 <>
                     <Markdown>
-                        We call xAI through the OpenAI-compatible API and generate a response. We'll use PostHog's
-                        OpenAI provider to capture all the details of the call. Initialize PostHog with your PostHog
-                        project token and host from [your project settings](https://app.posthog.com/settings/project),
-                        then pass the PostHog client along with the xAI config (the base URL and API key) to our OpenAI
-                        wrapper.
+                        Configure OpenTelemetry to auto-instrument OpenAI SDK calls and export traces to PostHog.
+                        PostHog converts `gen_ai.*` spans into `$ai_generation` events automatically.
                     </Markdown>
 
                     <CodeBlock
@@ -89,61 +59,59 @@ export const getXAISteps = (ctx: OnboardingComponentsContext): StepDefinition[] 
                                 language: 'python',
                                 file: 'Python',
                                 code: dedent`
-                                    from posthog.ai.openai import OpenAI
-                                    from posthog import Posthog
+                                    from opentelemetry import trace
+                                    from opentelemetry.sdk.trace import TracerProvider
+                                    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+                                    from opentelemetry.sdk.resources import Resource, SERVICE_NAME
+                                    from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+                                    from opentelemetry.instrumentation.openai_v2 import OpenAIInstrumentor
 
-                                    posthog = Posthog(
-                                        "<ph_project_token>",
-                                        host="<ph_client_api_host>"
+                                    resource = Resource(attributes={
+                                        SERVICE_NAME: "my-app",
+                                        "user.id": "user_123", # optional: identifies the user in PostHog
+                                    })
+
+                                    exporter = OTLPSpanExporter(
+                                        endpoint="<ph_client_api_host>/i/v0/ai/otel",
+                                        headers={"Authorization": "Bearer <ph_project_token>"},
                                     )
 
-                                    client = OpenAI(
-                                        base_url="https://api.x.ai/v1",
-                                        api_key="<xai_api_key>",
-                                        posthog_client=posthog
-                                    )
+                                    provider = TracerProvider(resource=resource)
+                                    provider.add_span_processor(SimpleSpanProcessor(exporter))
+                                    trace.set_tracer_provider(provider)
+
+                                    OpenAIInstrumentor().instrument()
                                 `,
                             },
                             {
                                 language: 'typescript',
                                 file: 'Node',
                                 code: dedent`
-                                    import { OpenAI } from '@posthog/ai'
-                                    import { PostHog } from 'posthog-node'
+                                    import { NodeSDK, tracing } from '@opentelemetry/sdk-node'
+                                    import { resourceFromAttributes } from '@opentelemetry/resources'
+                                    import { PostHogTraceExporter } from '@posthog/ai/otel'
+                                    import { OpenAIInstrumentation } from '@opentelemetry/instrumentation-openai'
 
-                                    const phClient = new PostHog(
-                                      '<ph_project_token>',
-                                      { host: '<ph_client_api_host>' }
-                                    );
-
-                                    const openai = new OpenAI({
-                                      baseURL: 'https://api.x.ai/v1',
-                                      apiKey: '<xai_api_key>',
-                                      posthog: phClient,
-                                    });
-
-                                    // ... your code here ...
-
-                                    // IMPORTANT: Shutdown the client when you're done to ensure all events are sent
-                                    phClient.shutdown()
+                                    const sdk = new NodeSDK({
+                                      resource: resourceFromAttributes({
+                                        'service.name': 'my-app',
+                                        'user.id': 'user_123', // optional: identifies the user in PostHog
+                                      }),
+                                      spanProcessors: [
+                                        new tracing.SimpleSpanProcessor(
+                                          new PostHogTraceExporter({
+                                            apiKey: '<ph_project_token>',
+                                            host: '<ph_client_api_host>',
+                                          })
+                                        ),
+                                      ],
+                                      instrumentations: [new OpenAIInstrumentation()],
+                                    })
+                                    sdk.start()
                                 `,
                             },
                         ]}
                     />
-
-                    <Blockquote>
-                        <Markdown>**Note:** This also works with the `AsyncOpenAI` client.</Markdown>
-                    </Blockquote>
-
-                    <CalloutBox type="fyi" icon="IconInfo" title="Proxy note">
-                        <Markdown>
-                            These SDKs **do not** proxy your calls. They only fire off an async call to PostHog in the
-                            background to send the data. You can also use LLM analytics with other SDKs or our API, but
-                            you will need to capture the data in the right format. See the schema in the [manual capture
-                            section](https://posthog.com/docs/llm-analytics/installation/manual-capture) for more
-                            details.
-                        </Markdown>
-                    </CalloutBox>
                 </>
             ),
         },
@@ -153,9 +121,8 @@ export const getXAISteps = (ctx: OnboardingComponentsContext): StepDefinition[] 
             content: (
                 <>
                     <Markdown>
-                        Now, when you call xAI with the OpenAI SDK, PostHog automatically captures an `$ai_generation`
-                        event. You can also capture or modify additional properties with the distinct ID, trace ID,
-                        properties, groups, and privacy mode parameters.
+                        Now, when you use the OpenAI SDK to call xAI, PostHog automatically captures `$ai_generation`
+                        events via the OpenTelemetry instrumentation.
                     </Markdown>
 
                     <CodeBlock
@@ -164,16 +131,19 @@ export const getXAISteps = (ctx: OnboardingComponentsContext): StepDefinition[] 
                                 language: 'python',
                                 file: 'Python',
                                 code: dedent`
+                                    import openai
+
+                                    client = openai.OpenAI(
+                                        base_url="https://api.x.ai/v1",
+                                        api_key="<xai_api_key>",
+                                    )
+
                                     response = client.chat.completions.create(
                                         model="grok-3",
+                                        max_completion_tokens=1024,
                                         messages=[
                                             {"role": "user", "content": "Tell me a fun fact about hedgehogs"}
                                         ],
-                                        posthog_distinct_id="user_123", # optional
-                                        posthog_trace_id="trace_123", # optional
-                                        posthog_properties={"conversation_id": "abc123", "paid": True}, # optional
-                                        posthog_groups={"company": "company_id_in_your_db"},  # optional
-                                        posthog_privacy_mode=False # optional
                                     )
 
                                     print(response.choices[0].message.content)
@@ -183,17 +153,20 @@ export const getXAISteps = (ctx: OnboardingComponentsContext): StepDefinition[] 
                                 language: 'typescript',
                                 file: 'Node',
                                 code: dedent`
-                                    const completion = await openai.chat.completions.create({
-                                        model: "grok-3",
-                                        messages: [{ role: "user", content: "Tell me a fun fact about hedgehogs" }],
-                                        posthogDistinctId: "user_123", // optional
-                                        posthogTraceId: "trace_123", // optional
-                                        posthogProperties: { conversation_id: "abc123", paid: true }, // optional
-                                        posthogGroups: { company: "company_id_in_your_db" }, // optional
-                                        posthogPrivacyMode: false // optional
-                                    });
+                                    import OpenAI from 'openai'
 
-                                    console.log(completion.choices[0].message.content)
+                                    const client = new OpenAI({
+                                      baseURL: 'https://api.x.ai/v1',
+                                      apiKey: '<xai_api_key>',
+                                    })
+
+                                    const response = await client.chat.completions.create({
+                                      model: 'grok-3',
+                                      max_completion_tokens: 1024,
+                                      messages: [{ role: 'user', content: 'Tell me a fun fact about hedgehogs' }],
+                                    })
+
+                                    console.log(response.choices[0].message.content)
                                 `,
                             },
                         ]}
@@ -201,14 +174,9 @@ export const getXAISteps = (ctx: OnboardingComponentsContext): StepDefinition[] 
 
                     <Blockquote>
                         <Markdown>
-                            {dedent`
-                            **Notes:**
-                            - We also support the old \`chat.completions\` API.
-                            - This works with responses where \`stream=True\`.
-                            - If you want to capture LLM events anonymously, **don't** pass a distinct ID to the request.
-
-                            See our docs on [anonymous vs identified events](https://posthog.com/docs/data/anonymous-vs-identified-events) to learn more.
-                            `}
+                            **Note:** If you want to capture LLM events anonymously, omit the `user.id` resource
+                            attribute. See our docs on [anonymous vs identified
+                            events](https://posthog.com/docs/data/anonymous-vs-identified-events) to learn more.
                         </Markdown>
                     </Blockquote>
 

--- a/docs/onboarding/llm-analytics/xai.tsx
+++ b/docs/onboarding/llm-analytics/xai.tsx
@@ -61,7 +61,8 @@ export const getXAISteps = (ctx: OnboardingComponentsContext): StepDefinition[] 
 
                                     resource = Resource(attributes={
                                         SERVICE_NAME: "my-app",
-                                        "user.id": "user_123", # optional: identifies the user in PostHog
+                                        "posthog.distinct_id": "user_123", # optional: identifies the user in PostHog
+                                        "foo": "bar", # custom properties are passed through
                                     })
 
                                     exporter = OTLPSpanExporter(
@@ -88,7 +89,8 @@ export const getXAISteps = (ctx: OnboardingComponentsContext): StepDefinition[] 
                                     const sdk = new NodeSDK({
                                       resource: resourceFromAttributes({
                                         'service.name': 'my-app',
-                                        'user.id': 'user_123', // optional: identifies the user in PostHog
+                                        'posthog.distinct_id': 'user_123', // optional: identifies the user in PostHog
+                                        foo: 'bar', // custom properties are passed through
                                       }),
                                       spanProcessors: [
                                         new tracing.SimpleSpanProcessor(
@@ -167,8 +169,8 @@ export const getXAISteps = (ctx: OnboardingComponentsContext): StepDefinition[] 
 
                     <Blockquote>
                         <Markdown>
-                            **Note:** If you want to capture LLM events anonymously, omit the `user.id` resource
-                            attribute. See our docs on [anonymous vs identified
+                            **Note:** If you want to capture LLM events anonymously, omit the `posthog.distinct_id`
+                            resource attribute. See our docs on [anonymous vs identified
                             events](https://posthog.com/docs/data/anonymous-vs-identified-events) to learn more.
                         </Markdown>
                     </Blockquote>

--- a/docs/onboarding/llm-analytics/xai.tsx
+++ b/docs/onboarding/llm-analytics/xai.tsx
@@ -3,7 +3,7 @@ import { OnboardingComponentsContext, createInstallation } from 'scenes/onboardi
 import { StepDefinition } from '../steps'
 
 export const getXAISteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
-    const { CodeBlock, Markdown, Blockquote, dedent, snippets } = ctx
+    const { CodeBlock, CalloutBox, Markdown, Blockquote, dedent, snippets } = ctx
 
     const NotableGenerationProperties = snippets?.NotableGenerationProperties
 
@@ -13,6 +13,16 @@ export const getXAISteps = (ctx: OnboardingComponentsContext): StepDefinition[] 
             badge: 'required',
             content: (
                 <>
+                    <CalloutBox type="info" icon="IconInfo" title="Migrating from the SDK wrapper?">
+                        <Markdown>
+                            These docs now use OpenTelemetry auto-instrumentation, which is the recommended approach.
+                            The previous PostHog SDK wrapper is still available — see the
+                            [Node.js](https://github.com/PostHog/posthog-js/tree/e08ff1be/examples/example-ai-xai) and
+                            [Python](https://github.com/PostHog/posthog-python/tree/7223c52/examples/example-ai-xai)
+                            wrapper examples.
+                        </Markdown>
+                    </CalloutBox>
+
                     <Markdown>Install the OpenTelemetry SDK, the OpenAI instrumentation, and the OpenAI SDK.</Markdown>
 
                     <CodeBlock

--- a/docs/onboarding/llm-analytics/xai.tsx
+++ b/docs/onboarding/llm-analytics/xai.tsx
@@ -95,9 +95,9 @@ export const getXAISteps = (ctx: OnboardingComponentsContext): StepDefinition[] 
                                 language: 'typescript',
                                 file: 'Node',
                                 code: dedent`
-                                    import { NodeSDK, tracing } from '@opentelemetry/sdk-node'
+                                    import { NodeSDK } from '@opentelemetry/sdk-node'
                                     import { resourceFromAttributes } from '@opentelemetry/resources'
-                                    import { PostHogTraceExporter } from '@posthog/ai/otel'
+                                    import { PostHogSpanProcessor } from '@posthog/ai/otel'
                                     import { OpenAIInstrumentation } from '@opentelemetry/instrumentation-openai'
 
                                     const sdk = new NodeSDK({
@@ -107,12 +107,10 @@ export const getXAISteps = (ctx: OnboardingComponentsContext): StepDefinition[] 
                                         foo: 'bar', // custom properties are passed through
                                       }),
                                       spanProcessors: [
-                                        new tracing.SimpleSpanProcessor(
-                                          new PostHogTraceExporter({
-                                            apiKey: '<ph_project_token>',
-                                            host: '<ph_client_api_host>',
-                                          })
-                                        ),
+                                        new PostHogSpanProcessor({
+                                          apiKey: '<ph_project_token>',
+                                          host: '<ph_client_api_host>',
+                                        }),
                                       ],
                                       instrumentations: [new OpenAIInstrumentation()],
                                     })

--- a/docs/onboarding/llm-analytics/xai.tsx
+++ b/docs/onboarding/llm-analytics/xai.tsx
@@ -35,7 +35,7 @@ export const getXAISteps = (ctx: OnboardingComponentsContext): StepDefinition[] 
                                 language: 'bash',
                                 file: 'Python',
                                 code: dedent`
-                                    pip install openai opentelemetry-sdk opentelemetry-exporter-otlp-proto-http opentelemetry-instrumentation-openai-v2
+                                    pip install openai opentelemetry-sdk posthog[otel] opentelemetry-instrumentation-openai-v2
                                 `,
                             },
                             {
@@ -68,9 +68,8 @@ export const getXAISteps = (ctx: OnboardingComponentsContext): StepDefinition[] 
                                 code: dedent`
                                     from opentelemetry import trace
                                     from opentelemetry.sdk.trace import TracerProvider
-                                    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
                                     from opentelemetry.sdk.resources import Resource, SERVICE_NAME
-                                    from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+                                    from posthog.ai.otel import PostHogSpanProcessor
                                     from opentelemetry.instrumentation.openai_v2 import OpenAIInstrumentor
 
                                     resource = Resource(attributes={
@@ -79,13 +78,13 @@ export const getXAISteps = (ctx: OnboardingComponentsContext): StepDefinition[] 
                                         "foo": "bar", # custom properties are passed through
                                     })
 
-                                    exporter = OTLPSpanExporter(
-                                        endpoint="<ph_client_api_host>/i/v0/ai/otel",
-                                        headers={"Authorization": "Bearer <ph_project_token>"},
-                                    )
-
                                     provider = TracerProvider(resource=resource)
-                                    provider.add_span_processor(SimpleSpanProcessor(exporter))
+                                    provider.add_span_processor(
+                                        PostHogSpanProcessor(
+                                            api_key="<ph_project_token>",
+                                            host="<ph_client_api_host>",
+                                        )
+                                    )
                                     trace.set_tracer_provider(provider)
 
                                     OpenAIInstrumentor().instrument()


### PR DESCRIPTION
## Problem

The in-app LLM analytics onboarding docs currently show PostHog SDK wrappers (`posthog.ai.openai`, `@posthog/ai`) as the primary integration method. We're moving toward standard OpenTelemetry auto-instrumentation as the recommended approach, keeping the wrappers available as a last resort for users who need them.

## Changes

Migrates 28 provider onboarding guides from PostHog SDK wrapper approach to OpenTelemetry auto-instrumentation. Each migrated doc follows a consistent 3-step pattern:

1. **Install dependencies** — OTel SDK + provider-specific instrumentation + provider SDK
2. **Set up OpenTelemetry tracing** — `TracerProvider` with `OTLPSpanExporter` (Python) or `PostHogTraceExporter` (Node)
3. **Call the provider** — Native SDK usage, no `posthog_` parameters

User identification uses the `posthog.distinct_id` resource attribute; custom properties like `foo` and `conversation_id` demonstrate the passthrough behavior.

**Providers migrated (21 original + 7 more):**
- OpenAI-compatible: openai, groq, deepseek, mistral, cohere, fireworks-ai, xai, hugging-face, openrouter, together-ai, ollama, cerebras, perplexity
- AI gateways: portkey, helicone, vercel-ai-gateway
- Azure OpenAI, Anthropic
- Frameworks: langchain, langgraph, llamaindex
- Vercel AI (SimpleSpanProcessor update)
- **Newly migrated:** autogen, instructor, mirascope, semantic-kernel, smolagents, pydantic-ai (already OTel-based in examples — docs just hadn't caught up)
- **Mastra** (migrated to `@mastra/posthog` exporter — Mastra's native integration since there's no mature OTel path yet)

**Kept as-is:** google (no Node.js OTel instrumentation for `@google/genai`), aws-bedrock (already OTel), crewai, litellm, dspy, openai-agents, manual

**Migration callout:** Every migrated doc has a callout at the top linking to the full Node.js and Python examples on GitHub (current `main`/`master`), plus legacy wrapper examples pinned to the last commit before the migration. This helps both new users (who see the recommended OTel path) and existing users (who can find the old wrapper examples they're already using).

**Manual capture doc:** Split into multiple steps so it can have a useful table of contents (Capture LLM events manually → Event properties → Verify traces and generations).

**Removed:** "No proxy" callouts from all migrated docs — they made sense when wrapping SDK clients but don't apply to standard OTel tracing.

## How did you test this code?

Agent-authored PR. Manually verified:
- TypeScript compiles (`pnpm --filter=@posthog/frontend format` runs cleanly)
- Each migrated doc follows the same pattern as other OTel docs
- Example code in the docs matches what's in the real example repos (PostHog/posthog-js#3349 and PostHog/posthog-python#482)

No runtime tests since these are in-app onboarding content (static TSX returning step definitions).

## Publish to changelog?

No

## Docs update

This IS the docs update. Companion PR: PostHog/posthog.com#16236 (updates TOC frontmatter in posthog.com).

## 🤖 LLM context

Co-authored with Claude Code. Related PRs:
- PostHog/posthog-js#3349 (Node.js OTel examples)
- PostHog/posthog-python#482 (Python OTel examples)
- PostHog/posthog.com#16236 (docs.posthog.com TOC updates)