### PR TITLE
feat(notebooks): collab save API with Redis step buffer

### DIFF
--- a/products/notebooks/backend/api/notebook.py
+++ b/products/notebooks/backend/api/notebook.py
@@ -733,6 +733,7 @@ class NotebookViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, ForbidD
 
         return Response(data)
 
+    @extend_schema(request=NotebookCollabSaveSerializer)
     @action(methods=["POST"], url_path="collab/save", detail=True)
     def collab_save(self, request: Request, **kwargs):
         serializer = NotebookCollabSaveSerializer(data=request.data)

--- a/products/notebooks/backend/api/notebook.py
+++ b/products/notebooks/backend/api/notebook.py
@@ -35,6 +35,7 @@ from posthog.renderers import SafeJSONRenderer, ServerSentEventRenderer
 from posthog.settings import SERVER_GATEWAY_INTERFACE
 from posthog.utils import relative_date_parse
 
+from products.notebooks.backend.collab import initialize_collab_session, submit_steps
 from products.notebooks.backend.kernel_runtime import build_notebook_sandbox_config, get_kernel_runtime
 from products.notebooks.backend.models import KernelRuntime, Notebook
 from products.notebooks.backend.python_analysis import analyze_python_globals, annotate_python_nodes
@@ -279,6 +280,18 @@ class NotebookKernelConfigSerializer(serializers.Serializer):
         if not attrs:
             raise serializers.ValidationError("Provide at least one kernel configuration option.")
         return attrs
+
+
+class NotebookCollabSaveSerializer(serializers.Serializer):
+    client_id = serializers.CharField(help_text="Unique identifier for the client session.")
+    version = serializers.IntegerField(help_text="The collab version the client's steps are based on.")
+    steps = serializers.ListField(
+        child=serializers.JSONField(),
+        help_text="List of ProseMirror step JSON objects to apply.",
+    )
+    content = serializers.JSONField(help_text="The resulting ProseMirror document after applying the steps locally.")
+    text_content = serializers.CharField(required=False, default="", help_text="Plain text for search indexing.")
+    title = serializers.CharField(required=False, help_text="Updated notebook title.")
 
 
 def _format_hogql_response_payload(response: Any) -> dict[str, Any]:
@@ -719,6 +732,52 @@ class NotebookViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, ForbidD
             return Response({"detail": "Failed to fetch dataframe data."}, status=503)
 
         return Response(data)
+
+    @action(methods=["POST"], url_path="collab/save", detail=True)
+    def collab_save(self, request: Request, **kwargs):
+        serializer = NotebookCollabSaveSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        data = serializer.validated_data
+
+        notebook = self.get_object()
+
+        initialize_collab_session(str(notebook.short_id), notebook.version)
+
+        result = submit_steps(
+            notebook_id=str(notebook.short_id),
+            client_id=data["client_id"],
+            steps_json=data["steps"],
+            last_seen_version=data["version"],
+        )
+
+        if result.accepted:
+            content = data["content"]
+            Notebook.objects.filter(pk=notebook.pk).update(
+                content=annotate_python_nodes(content) if isinstance(content, dict) else content,
+                text_content=data.get("text_content", ""),
+                title=data.get("title", notebook.title),
+                version=result.version,
+                last_modified_at=now(),
+                last_modified_by=request.user,
+            )
+            notebook.refresh_from_db()
+            return Response(NotebookSerializer(notebook, context=self.get_serializer_context()).data)
+
+        if result.steps_since is None:
+            return Response(
+                {"code": "conflict_stale", "detail": "Reload the notebook."},
+                status=410,
+            )
+
+        return Response(
+            {
+                "code": "conflict",
+                "steps": [e.step for e in result.steps_since],
+                "client_ids": [e.client_id for e in result.steps_since],
+                "version": result.version,
+            },
+            status=409,
+        )
 
     @action(methods=["GET"], detail=False)
     def recording_comments(self, request: Request, **kwargs):

--- a/products/notebooks/backend/api/notebook.py
+++ b/products/notebooks/backend/api/notebook.py
@@ -734,7 +734,7 @@ class NotebookViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, ForbidD
         return Response(data)
 
     @extend_schema(request=NotebookCollabSaveSerializer)
-    @action(methods=["POST"], url_path="collab/save", detail=True)
+    @action(methods=["POST"], url_path="collab/save", detail=True, required_scopes=["notebook:write"])
     def collab_save(self, request: Request, **kwargs):
         serializer = NotebookCollabSaveSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)

--- a/products/notebooks/backend/api/notebook.py
+++ b/products/notebooks/backend/api/notebook.py
@@ -742,9 +742,10 @@ class NotebookViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, ForbidD
 
         notebook = self.get_object()
 
-        initialize_collab_session(str(notebook.short_id), notebook.version)
+        initialize_collab_session(notebook.team_id, str(notebook.short_id), notebook.version)
 
         result = submit_steps(
+            team_id=notebook.team_id,
             notebook_id=str(notebook.short_id),
             client_id=data["client_id"],
             steps_json=data["steps"],

--- a/products/notebooks/backend/collab.py
+++ b/products/notebooks/backend/collab.py
@@ -13,7 +13,7 @@ STEPS_KEY = "notebook:collab:{id}:steps"
 
 # Atomic operation: append steps only if the last_seen_version matches the current version in Redis.
 # Each step is stored individually in a sorted set (score=version), for example:
-#   score=3  {"step": {"stepType": "replace", "from": 0, "to": 0}, "client_id": "uuid1"}
+#   score=3  {"step": {"stepType": "replace", "from": 0, "to": 0}, "client_id": "uuid1", "v": 3}
 # Returns {-1, 0} if not initialized, {0, current} if mismatch, {1, new} if accepted.
 _APPEND_STEPS_LUA = """
 local version_key, steps_key = KEYS[1], KEYS[2]
@@ -42,6 +42,7 @@ return {1, next_version}
 class StepEntry:
     step: dict
     client_id: str
+    v: int  # ensures ZADD doesn't dedup identical steps across versions
 
 
 @dataclass
@@ -72,7 +73,10 @@ def submit_steps(
     version_key = VERSION_KEY.format(id=notebook_id)
     steps_key = STEPS_KEY.format(id=notebook_id)
 
-    step_entries = [json.dumps({"step": s, "client_id": client_id}) for s in steps_json]
+    step_entries = [
+        json.dumps({"step": s, "client_id": client_id, "v": last_seen_version + i + 1})
+        for i, s in enumerate(steps_json)
+    ]
 
     accepted, version = client.eval(
         _APPEND_STEPS_LUA,

--- a/products/notebooks/backend/collab.py
+++ b/products/notebooks/backend/collab.py
@@ -1,0 +1,103 @@
+"""
+Collaboration service for notebooks using Redis as the step buffer.
+"""
+
+import json
+from dataclasses import dataclass
+
+from posthog import redis
+
+TTL_SECONDS = 60 * 60 * 24  # 1 day
+VERSION_KEY = "notebook:collab:{id}:version"
+STEPS_KEY = "notebook:collab:{id}:steps"
+
+# Atomic operation: append steps only if the last_seen_version matches the current version in Redis.
+# Each step is stored individually in a sorted set (score=version), for example:
+#   score=3  {"step": {"stepType": "replace", "from": 0, "to": 0}, "client_id": "uuid1"}
+# Returns {-1, 0} if not initialized, {0, current} if mismatch, {1, new} if accepted.
+_APPEND_STEPS_LUA = """
+local version_key, steps_key = KEYS[1], KEYS[2]
+local last_seen_version, ttl_seconds = tonumber(ARGV[1]), ARGV[2]
+
+local current_version = redis.call('GET', version_key)
+if not current_version then return {-1, 0} end
+
+if tonumber(current_version) ~= last_seen_version then
+    return {0, tonumber(current_version)}
+end
+
+local next_version = tonumber(current_version)
+for i = 3, #ARGV do
+    next_version = next_version + 1
+    redis.call('ZADD', steps_key, next_version, ARGV[i])
+end
+
+redis.call('SET', version_key, next_version, 'EX', ttl_seconds)
+redis.call('EXPIRE', steps_key, ttl_seconds)
+return {1, next_version}
+"""
+
+
+@dataclass
+class StepEntry:
+    step: dict
+    client_id: str
+
+
+@dataclass
+class SubmitResult:
+    accepted: bool
+    version: int
+    steps_since: list[StepEntry] | None = None
+
+
+def initialize_collab_session(notebook_id: str, version: int) -> None:
+    """Seed the Redis version from Postgres if not already present."""
+    client = redis.get_client()
+    version_key = VERSION_KEY.format(id=notebook_id)
+    client.set(version_key, str(version), ex=TTL_SECONDS, nx=True)
+
+
+def submit_steps(
+    notebook_id: str,
+    client_id: str,
+    steps_json: list[dict],
+    last_seen_version: int,
+) -> SubmitResult:
+    """Try to submit steps at last_seen_version.
+    Version increments by len(steps), matching Prosemirror's per-step versioning.
+    If rejected, steps_since contains missed StepEntry items for rebase.
+    """
+    client = redis.get_client()
+    version_key = VERSION_KEY.format(id=notebook_id)
+    steps_key = STEPS_KEY.format(id=notebook_id)
+
+    step_entries = [json.dumps({"step": s, "client_id": client_id}) for s in steps_json]
+
+    accepted, version = client.eval(
+        _APPEND_STEPS_LUA,
+        2,  # number of KEYS
+        version_key,  # KEYS[1]
+        steps_key,  # KEYS[2]
+        last_seen_version,  # ARGV[1]
+        TTL_SECONDS,  # ARGV[2]
+        *step_entries,  # ARGV[3..]
+    )
+
+    if accepted == -1:
+        return SubmitResult(accepted=False, version=0)
+
+    if accepted == 1:
+        return SubmitResult(accepted=True, version=version)
+
+    # Rejected - fetch steps the client missed
+    raw = client.zrangebyscore(steps_key, f"({last_seen_version}", version)
+
+    if len(raw) < version - last_seen_version:
+        return SubmitResult(accepted=False, version=version, steps_since=None)
+
+    return SubmitResult(
+        accepted=False,
+        version=version,
+        steps_since=[StepEntry(**json.loads(r)) for r in raw],
+    )

--- a/products/notebooks/backend/collab.py
+++ b/products/notebooks/backend/collab.py
@@ -8,8 +8,8 @@ from dataclasses import dataclass
 from posthog import redis
 
 TTL_SECONDS = 60 * 60 * 24  # 1 day
-VERSION_KEY = "notebook:collab:{id}:version"
-STEPS_KEY = "notebook:collab:{id}:steps"
+VERSION_KEY = "notebook:collab:{team_id}:{notebook_id}:version"
+STEPS_KEY = "notebook:collab:{team_id}:{notebook_id}:steps"
 
 # Atomic operation: append steps only if the last_seen_version matches the current version in Redis.
 # Each step is stored individually in a sorted set (score=version), for example:
@@ -52,14 +52,15 @@ class SubmitResult:
     steps_since: list[StepEntry] | None = None
 
 
-def initialize_collab_session(notebook_id: str, version: int) -> None:
+def initialize_collab_session(team_id: int, notebook_id: str, version: int) -> None:
     """Seed the Redis version from Postgres if not already present."""
     client = redis.get_client()
-    version_key = VERSION_KEY.format(id=notebook_id)
+    version_key = VERSION_KEY.format(team_id=team_id, notebook_id=notebook_id)
     client.set(version_key, str(version), ex=TTL_SECONDS, nx=True)
 
 
 def submit_steps(
+    team_id: int,
     notebook_id: str,
     client_id: str,
     steps_json: list[dict],
@@ -70,8 +71,8 @@ def submit_steps(
     If rejected, steps_since contains missed StepEntry items for rebase.
     """
     client = redis.get_client()
-    version_key = VERSION_KEY.format(id=notebook_id)
-    steps_key = STEPS_KEY.format(id=notebook_id)
+    version_key = VERSION_KEY.format(team_id=team_id, notebook_id=notebook_id)
+    steps_key = STEPS_KEY.format(team_id=team_id, notebook_id=notebook_id)
 
     step_entries = [
         json.dumps({"step": s, "client_id": client_id, "v": last_seen_version + i + 1})

--- a/products/notebooks/backend/collab.py
+++ b/products/notebooks/backend/collab.py
@@ -78,14 +78,10 @@ def submit_steps(
         for i, s in enumerate(steps_json)
     ]
 
-    accepted, version = client.eval(
-        _APPEND_STEPS_LUA,
-        2,  # number of KEYS
-        version_key,  # KEYS[1]
-        steps_key,  # KEYS[2]
-        last_seen_version,  # ARGV[1]
-        TTL_SECONDS,  # ARGV[2]
-        *step_entries,  # ARGV[3..]
+    script = client.register_script(_APPEND_STEPS_LUA)
+    accepted, version = script(
+        keys=[version_key, steps_key],
+        args=[last_seen_version, TTL_SECONDS, *step_entries],
     )
 
     if accepted == -1:

--- a/products/notebooks/backend/test/test_collab.py
+++ b/products/notebooks/backend/test/test_collab.py
@@ -38,7 +38,7 @@ class TestNotebookCollab(BaseTest):
         assert result.accepted is False
         assert result.version == 1
         assert result.steps_since == [
-            StepEntry(step={"stepType": "replace", "from": 0, "to": 0}, client_id="client1"),
+            StepEntry(step={"stepType": "replace", "from": 0, "to": 0}, client_id="client1", v=1),
         ]
 
     def test_submit_multiple_steps_as_batch(self):

--- a/products/notebooks/backend/test/test_collab.py
+++ b/products/notebooks/backend/test/test_collab.py
@@ -1,0 +1,95 @@
+from posthog.test.base import BaseTest
+
+from parameterized import parameterized
+
+from posthog import redis
+
+from products.notebooks.backend.collab import STEPS_KEY, StepEntry, initialize_collab_session, submit_steps
+
+
+class TestNotebookCollab(BaseTest):
+    def test_initialize_collab_session_sets_version(self):
+        initialize_collab_session("nb1", 5)
+        result = submit_steps("nb1", "client1", [{"stepType": "replace", "from": 0, "to": 0}], 5)
+        assert result.accepted is True
+        assert result.version == 6
+
+    def test_initialize_collab_session_does_not_overwrite(self):
+        initialize_collab_session("nb2", 5)
+        submit_steps("nb2", "client1", [{"stepType": "replace", "from": 0, "to": 0}], 5)
+        # Re-initializing must not reset the version back to 5
+        initialize_collab_session("nb2", 5)
+        result = submit_steps("nb2", "client2", [{"stepType": "replace", "from": 0, "to": 0}], 6)
+        assert result.accepted is True
+        assert result.version == 7
+
+    def test_submit_steps_accepted(self):
+        initialize_collab_session("nb3", 0)
+        result = submit_steps("nb3", "client1", [{"stepType": "replace", "from": 0, "to": 0}], 0)
+        assert result.accepted is True
+        assert result.version == 1
+
+    def test_submit_steps_rejected_on_version_mismatch(self):
+        initialize_collab_session("nb4", 0)
+        # First client advances the version
+        submit_steps("nb4", "client1", [{"stepType": "replace", "from": 0, "to": 0}], 0)
+        # Second client tries with stale version
+        result = submit_steps("nb4", "client2", [{"stepType": "replace", "from": 1, "to": 1}], 0)
+        assert result.accepted is False
+        assert result.version == 1
+        assert result.steps_since == [
+            StepEntry(step={"stepType": "replace", "from": 0, "to": 0}, client_id="client1"),
+        ]
+
+    def test_submit_multiple_steps_as_batch(self):
+        initialize_collab_session("nb5", 0)
+        steps = [
+            {"stepType": "replace", "from": 0, "to": 0},
+            {"stepType": "replace", "from": 1, "to": 1},
+            {"stepType": "replace", "from": 2, "to": 2},
+        ]
+        result = submit_steps("nb5", "client1", steps, 0)
+        assert result.accepted is True
+        assert result.version == 3
+
+    def test_submit_to_uninitialized_session(self):
+        result = submit_steps("uninitialized", "client1", [{"stepType": "replace"}], 0)
+        assert result.accepted is False
+        assert result.version == 0
+
+    @parameterized.expand(
+        [
+            ("two_clients_sequential", 2),
+            ("three_clients_sequential", 3),
+        ]
+    )
+    def test_multiple_clients_sequential(self, _name, num_clients):
+        initialize_collab_session("nb_multi", 0)
+        expected_version = 0
+        for i in range(num_clients):
+            result = submit_steps(
+                "nb_multi",
+                f"client{i}",
+                [{"stepType": "replace", "from": i, "to": i}],
+                expected_version,
+            )
+            assert result.accepted is True
+            expected_version += 1
+
+        assert expected_version == num_clients
+
+    def test_submit_steps_returns_none_when_steps_expired(self):
+        initialize_collab_session("nb_expired", 0)
+        # Advance version by submitting steps
+        submit_steps("nb_expired", "client1", [{"stepType": "replace", "from": 0, "to": 0}], 0)
+        submit_steps("nb_expired", "client1", [{"stepType": "replace", "from": 1, "to": 1}], 1)
+
+        # Simulate Redis expiry by deleting the steps key
+        client = redis.get_client()
+        client.delete(STEPS_KEY.format(id="nb_expired"))
+
+        # Submit with stale version - version key still exists but steps are gone
+        result = submit_steps("nb_expired", "client2", [{"stepType": "replace", "from": 2, "to": 2}], 0)
+        assert result.accepted is False
+        assert result.version == 2
+        assert result.steps_since is None

--- a/products/notebooks/backend/test/test_collab.py
+++ b/products/notebooks/backend/test/test_collab.py
@@ -9,32 +9,32 @@ from products.notebooks.backend.collab import STEPS_KEY, StepEntry, initialize_c
 
 class TestNotebookCollab(BaseTest):
     def test_initialize_collab_session_sets_version(self):
-        initialize_collab_session("nb1", 5)
-        result = submit_steps("nb1", "client1", [{"stepType": "replace", "from": 0, "to": 0}], 5)
+        initialize_collab_session(self.team.pk, "nb1", 5)
+        result = submit_steps(self.team.pk, "nb1", "client1", [{"stepType": "replace", "from": 0, "to": 0}], 5)
         assert result.accepted is True
         assert result.version == 6
 
     def test_initialize_collab_session_does_not_overwrite(self):
-        initialize_collab_session("nb2", 5)
-        submit_steps("nb2", "client1", [{"stepType": "replace", "from": 0, "to": 0}], 5)
+        initialize_collab_session(self.team.pk, "nb2", 5)
+        submit_steps(self.team.pk, "nb2", "client1", [{"stepType": "replace", "from": 0, "to": 0}], 5)
         # Re-initializing must not reset the version back to 5
-        initialize_collab_session("nb2", 5)
-        result = submit_steps("nb2", "client2", [{"stepType": "replace", "from": 0, "to": 0}], 6)
+        initialize_collab_session(self.team.pk, "nb2", 5)
+        result = submit_steps(self.team.pk, "nb2", "client2", [{"stepType": "replace", "from": 0, "to": 0}], 6)
         assert result.accepted is True
         assert result.version == 7
 
     def test_submit_steps_accepted(self):
-        initialize_collab_session("nb3", 0)
-        result = submit_steps("nb3", "client1", [{"stepType": "replace", "from": 0, "to": 0}], 0)
+        initialize_collab_session(self.team.pk, "nb3", 0)
+        result = submit_steps(self.team.pk, "nb3", "client1", [{"stepType": "replace", "from": 0, "to": 0}], 0)
         assert result.accepted is True
         assert result.version == 1
 
     def test_submit_steps_rejected_on_version_mismatch(self):
-        initialize_collab_session("nb4", 0)
+        initialize_collab_session(self.team.pk, "nb4", 0)
         # First client advances the version
-        submit_steps("nb4", "client1", [{"stepType": "replace", "from": 0, "to": 0}], 0)
+        submit_steps(self.team.pk, "nb4", "client1", [{"stepType": "replace", "from": 0, "to": 0}], 0)
         # Second client tries with stale version
-        result = submit_steps("nb4", "client2", [{"stepType": "replace", "from": 1, "to": 1}], 0)
+        result = submit_steps(self.team.pk, "nb4", "client2", [{"stepType": "replace", "from": 1, "to": 1}], 0)
         assert result.accepted is False
         assert result.version == 1
         assert result.steps_since == [
@@ -42,33 +42,34 @@ class TestNotebookCollab(BaseTest):
         ]
 
     def test_submit_multiple_steps_as_batch(self):
-        initialize_collab_session("nb5", 0)
+        initialize_collab_session(self.team.pk, "nb5", 0)
         steps = [
             {"stepType": "replace", "from": 0, "to": 0},
             {"stepType": "replace", "from": 1, "to": 1},
             {"stepType": "replace", "from": 2, "to": 2},
         ]
-        result = submit_steps("nb5", "client1", steps, 0)
+        result = submit_steps(self.team.pk, "nb5", "client1", steps, 0)
         assert result.accepted is True
         assert result.version == 3
 
     def test_submit_to_uninitialized_session(self):
-        result = submit_steps("uninitialized", "client1", [{"stepType": "replace"}], 0)
+        result = submit_steps(self.team.pk, "uninitialized", "client1", [{"stepType": "replace"}], 0)
         assert result.accepted is False
         assert result.version == 0
 
     @parameterized.expand(
         [
-            ("two_clients_sequential", 2),
-            ("three_clients_sequential", 3),
+            ("two_clients_sequential", "nb_multi_2", 2),
+            ("three_clients_sequential", "nb_multi_3", 3),
         ]
     )
-    def test_multiple_clients_sequential(self, _name, num_clients):
-        initialize_collab_session("nb_multi", 0)
+    def test_multiple_clients_sequential(self, _name, notebook_id, num_clients):
+        initialize_collab_session(self.team.pk, notebook_id, 0)
         expected_version = 0
         for i in range(num_clients):
             result = submit_steps(
-                "nb_multi",
+                self.team.pk,
+                notebook_id,
                 f"client{i}",
                 [{"stepType": "replace", "from": i, "to": i}],
                 expected_version,
@@ -79,17 +80,17 @@ class TestNotebookCollab(BaseTest):
         assert expected_version == num_clients
 
     def test_submit_steps_returns_none_when_steps_expired(self):
-        initialize_collab_session("nb_expired", 0)
+        initialize_collab_session(self.team.pk, "nb_expired", 0)
         # Advance version by submitting steps
-        submit_steps("nb_expired", "client1", [{"stepType": "replace", "from": 0, "to": 0}], 0)
-        submit_steps("nb_expired", "client1", [{"stepType": "replace", "from": 1, "to": 1}], 1)
+        submit_steps(self.team.pk, "nb_expired", "client1", [{"stepType": "replace", "from": 0, "to": 0}], 0)
+        submit_steps(self.team.pk, "nb_expired", "client1", [{"stepType": "replace", "from": 1, "to": 1}], 1)
 
         # Simulate Redis expiry by deleting the steps key
         client = redis.get_client()
-        client.delete(STEPS_KEY.format(id="nb_expired"))
+        client.delete(STEPS_KEY.format(team_id=self.team.pk, notebook_id="nb_expired"))
 
         # Submit with stale version - version key still exists but steps are gone
-        result = submit_steps("nb_expired", "client2", [{"stepType": "replace", "from": 2, "to": 2}], 0)
+        result = submit_steps(self.team.pk, "nb_expired", "client2", [{"stepType": "replace", "from": 2, "to": 2}], 0)
         assert result.accepted is False
         assert result.version == 2
         assert result.steps_since is None

--- a/products/notebooks/backend/test/test_collab_api.py
+++ b/products/notebooks/backend/test/test_collab_api.py
@@ -1,0 +1,166 @@
+from posthog.test.base import APIBaseTest
+from unittest.mock import patch
+
+from rest_framework import status
+
+from products.notebooks.backend.collab import SubmitResult, initialize_collab_session
+from products.notebooks.backend.models import Notebook
+
+SAMPLE_DOC = {"type": "doc", "content": [{"type": "heading", "content": [{"type": "text", "text": "Test"}]}]}
+UPDATED_DOC = {"type": "doc", "content": [{"type": "heading", "content": [{"type": "text", "text": "Updated"}]}]}
+
+
+class TestNotebookCollabSaveAPI(APIBaseTest):
+    def _create_notebook(self, content=None):
+        data = {}
+        if content:
+            data["content"] = content
+        response = self.client.post(f"/api/projects/{self.team.id}/notebooks/", data=data, format="json")
+        assert response.status_code == status.HTTP_201_CREATED
+        return response.json()
+
+    def _collab_save(self, notebook, *, version, steps, content=None, text_content=None, client_id="test-client"):
+        payload = {
+            "client_id": client_id,
+            "version": version,
+            "steps": steps,
+            "content": content or UPDATED_DOC,
+        }
+        if text_content is not None:
+            payload["text_content"] = text_content
+        return self.client.post(
+            f"/api/projects/{self.team.id}/notebooks/{notebook['short_id']}/collab/save/",
+            data=payload,
+            format="json",
+        )
+
+    def _init_collab(self, notebook) -> int:
+        initialize_collab_session(notebook["short_id"], notebook["version"])
+        return notebook["version"]
+
+    def test_collab_save_accepted(self):
+        notebook = self._create_notebook(SAMPLE_DOC)
+        version = self._init_collab(notebook)
+
+        response = self._collab_save(
+            notebook,
+            version=version,
+            steps=[{"stepType": "replace", "from": 0, "to": 0}],
+            content=UPDATED_DOC,
+        )
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data["version"] == version + 1
+        assert data["content"] == UPDATED_DOC
+
+    def test_collab_save_persists_to_postgres(self):
+        notebook = self._create_notebook(SAMPLE_DOC)
+        version = self._init_collab(notebook)
+
+        self._collab_save(
+            notebook,
+            version=version,
+            steps=[{"stepType": "replace", "from": 0, "to": 0}],
+            content=UPDATED_DOC,
+            text_content="Updated",
+        )
+
+        nb = Notebook.objects.get(short_id=notebook["short_id"])
+        assert nb.version == version + 1
+        assert nb.content == UPDATED_DOC
+        assert nb.text_content == "Updated"
+
+    def test_collab_save_updates_title(self):
+        notebook = self._create_notebook(SAMPLE_DOC)
+        version = self._init_collab(notebook)
+
+        self._collab_save(
+            notebook,
+            version=version,
+            steps=[{"stepType": "replace", "from": 0, "to": 0}],
+            content=UPDATED_DOC,
+        )
+
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/notebooks/{notebook['short_id']}/collab/save/",
+            data={
+                "client_id": "test-client",
+                "version": version + 1,
+                "steps": [{"stepType": "replace", "from": 0, "to": 0}],
+                "content": UPDATED_DOC,
+                "title": "New Title",
+            },
+            format="json",
+        )
+        assert response.status_code == status.HTTP_200_OK
+        nb = Notebook.objects.get(short_id=notebook["short_id"])
+        assert nb.title == "New Title"
+
+    def test_collab_save_rejected_stale_version(self):
+        notebook = self._create_notebook(SAMPLE_DOC)
+        version = self._init_collab(notebook)
+
+        # First client advances the version
+        self._collab_save(
+            notebook,
+            version=version,
+            steps=[{"stepType": "replace", "from": 0, "to": 0}],
+            client_id="client-1",
+        )
+
+        # Second client submits with stale version - gets 409 with missed steps
+        response = self._collab_save(
+            notebook,
+            version=version,
+            steps=[{"stepType": "replace", "from": 1, "to": 1}],
+            client_id="client-2",
+        )
+        assert response.status_code == status.HTTP_409_CONFLICT
+        data = response.json()
+        assert data["code"] == "conflict"
+        assert data["steps"] == [{"stepType": "replace", "from": 0, "to": 0}]
+        assert data["client_ids"] == ["client-1"]
+        assert "version" in data
+
+    def test_collab_save_returns_full_notebook_on_success(self):
+        notebook = self._create_notebook(SAMPLE_DOC)
+        version = self._init_collab(notebook)
+
+        response = self._collab_save(
+            notebook,
+            version=version,
+            steps=[{"stepType": "replace", "from": 0, "to": 0}],
+            content=UPDATED_DOC,
+        )
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert "short_id" in data
+        assert "id" in data
+        assert "content" in data
+        assert "version" in data
+
+    def test_collab_save_missing_required_fields(self):
+        notebook = self._create_notebook(SAMPLE_DOC)
+
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/notebooks/{notebook['short_id']}/collab/save/",
+            data={},
+            format="json",
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    @patch("products.notebooks.backend.api.notebook.submit_steps")
+    def test_collab_save_returns_410_when_steps_expired(self, mock_submit):
+        notebook = self._create_notebook(SAMPLE_DOC)
+        self._init_collab(notebook)
+
+        mock_submit.return_value = SubmitResult(accepted=False, version=5, steps_since=None)
+
+        response = self._collab_save(
+            notebook,
+            version=0,
+            steps=[{"stepType": "replace", "from": 0, "to": 0}],
+        )
+        assert response.status_code == status.HTTP_410_GONE
+        data = response.json()
+        assert data["code"] == "conflict_stale"

--- a/products/notebooks/backend/test/test_collab_api.py
+++ b/products/notebooks/backend/test/test_collab_api.py
@@ -35,7 +35,7 @@ class TestNotebookCollabSaveAPI(APIBaseTest):
         )
 
     def _init_collab(self, notebook) -> int:
-        initialize_collab_session(notebook["short_id"], notebook["version"])
+        initialize_collab_session(self.team.pk, notebook["short_id"], notebook["version"])
         return notebook["version"]
 
     def test_collab_save_accepted(self):

--- a/products/notebooks/frontend/generated/api.schemas.ts
+++ b/products/notebooks/frontend/generated/api.schemas.ts
@@ -175,6 +175,21 @@ export interface PatchedNotebookApi {
     _create_in_folder?: string
 }
 
+export interface NotebookCollabSaveApi {
+    /** Unique identifier for the client session. */
+    client_id: string
+    /** The collab version the client's steps are based on. */
+    version: number
+    /** List of ProseMirror step JSON objects to apply. */
+    steps: unknown[]
+    /** The resulting ProseMirror document after applying the steps locally. */
+    content: unknown
+    /** Plain text for search indexing. */
+    text_content?: string
+    /** Updated notebook title. */
+    title?: string
+}
+
 export type NotebooksListParams = {
     /**
  * Filter for notebooks that match a provided filter.

--- a/products/notebooks/frontend/generated/api.ts
+++ b/products/notebooks/frontend/generated/api.ts
@@ -177,6 +177,27 @@ export const notebooksActivityRetrieve2 = async (
 /**
  * The API for interacting with Notebooks. This feature is in early access and the API can have breaking changes without announcement.
  */
+export const getNotebooksCollabSaveCreateUrl = (projectId: string, shortId: string) => {
+    return `/api/projects/${projectId}/notebooks/${shortId}/collab/save/`
+}
+
+export const notebooksCollabSaveCreate = async (
+    projectId: string,
+    shortId: string,
+    notebookApi: NonReadonly<NotebookApi>,
+    options?: RequestInit
+): Promise<void> => {
+    return apiMutator<void>(getNotebooksCollabSaveCreateUrl(projectId, shortId), {
+        ...options,
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(notebookApi),
+    })
+}
+
+/**
+ * The API for interacting with Notebooks. This feature is in early access and the API can have breaking changes without announcement.
+ */
 export const getNotebooksHogqlExecuteCreateUrl = (projectId: string, shortId: string) => {
     return `/api/projects/${projectId}/notebooks/${shortId}/hogql/execute/`
 }

--- a/products/notebooks/frontend/generated/api.ts
+++ b/products/notebooks/frontend/generated/api.ts
@@ -10,6 +10,7 @@ import { apiMutator } from '../../../../frontend/src/lib/api-orval-mutator'
  */
 import type {
     NotebookApi,
+    NotebookCollabSaveApi,
     NotebooksListParams,
     PaginatedNotebookMinimalListApi,
     PatchedNotebookApi,
@@ -184,14 +185,14 @@ export const getNotebooksCollabSaveCreateUrl = (projectId: string, shortId: stri
 export const notebooksCollabSaveCreate = async (
     projectId: string,
     shortId: string,
-    notebookApi: NonReadonly<NotebookApi>,
+    notebookCollabSaveApi: NotebookCollabSaveApi,
     options?: RequestInit
 ): Promise<void> => {
     return apiMutator<void>(getNotebooksCollabSaveCreateUrl(projectId, shortId), {
         ...options,
         method: 'POST',
         headers: { 'Content-Type': 'application/json', ...options?.headers },
-        body: JSON.stringify(notebookApi),
+        body: JSON.stringify(notebookCollabSaveApi),
     })
 }
 

--- a/products/notebooks/mcp/tools.yaml
+++ b/products/notebooks/mcp/tools.yaml
@@ -122,3 +122,6 @@ tools:
     notebooks-recording-comments-retrieve:
         operation: notebooks_recording_comments_retrieve
         enabled: false
+    notebooks-collab-save-create:
+        operation: notebooks_collab_save_create
+        enabled: false

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -19744,6 +19744,21 @@ export namespace Schemas {
       _create_in_folder?: string;
     }
 
+    export interface NotebookCollabSave {
+      /** Unique identifier for the client session. */
+      client_id: string;
+      /** The collab version the client's steps are based on. */
+      version: number;
+      /** List of ProseMirror step JSON objects to apply. */
+      steps: unknown[];
+      /** The resulting ProseMirror document after applying the steps locally. */
+      content: unknown;
+      /** Plain text for search indexing. */
+      text_content?: string;
+      /** Updated notebook title. */
+      title?: string;
+    }
+
     export interface NotebookMinimal {
       /** UUID of the notebook. */
       readonly id: string;


### PR DESCRIPTION
## Problem

Notebooks are currently single-writer. 
This PR is the first implementation of collaborative editing based on the [RFC](https://github.com/PostHog/requests-for-comments-internal/pull/1059), using `prosemirror-collab` and client-side rebase.

## Changes

- New `collab/save` endpoint that accepts steps (what changed since the last known version) alongside the full content snapshot to persist in Postgres
- If the server version (tracked in Redis) has advanced beyond what the client knows, the save is rejected with a 409, and the missed steps are returned. The client rebases its local unconfirmed steps on top of them and retries at the new version.
	- ProseMirror increments the version by the number of steps, not by 1 per save - e.g. typing "aaa" at version 0 persists as version 3
- Steps and version counter are stored in Redis. Version updates and step appends are done atomically via a Lua script to prevent race conditions. Without atomicity, two clients submitting at the same version simultaneously could both pass the version check and corrupt the step history.
- A sorted set stores transient steps, enabling efficient range queries (ZRANGEBYSCORE). Steps from the same client can't be identical (positions change with each edit), sorted set deduplication guarantees it. 

## How did you test this code?
Better to test it together with the frontend (PR: https://github.com/PostHog/posthog/pull/53673)

https://github.com/user-attachments/assets/c9714e21-67c5-4485-8e38-89f301315b93


## Publish to changelog?

Not yet, this is an early version under a feature flag. Will be released only internally. 

## Docs update

No