### PR TITLE
fix(replay): don't treat captureStopped as error when playback ended naturally

### DIFF
--- a/nodejs/src/session-replay/recording-rasterizer/capture/capture.ts
+++ b/nodejs/src/session-replay/recording-rasterizer/capture/capture.ts
@@ -88,6 +88,11 @@ export async function capturePlayback(
     let captureAborted: Error | null = null
     let captureAbortReject: ((err: Error) => void) | null = null
     const onCaptureStopped = (): void => {
+        if (captureDone || player.isEnded()) {
+            // Playback finished naturally — ffmpeg exiting is expected.
+            log.info({ frames: frameCount }, 'capture stopped after playback ended')
+            return
+        }
         log.error({ stderr: ffmpegStderr.slice(-20), frames: frameCount }, 'capture stopped unexpectedly')
         const err = new RasterizationError('capture stopped unexpectedly', true, 'CAPTURE_ABORTED')
         captureAborted = err
@@ -159,10 +164,15 @@ export async function capturePlayback(
         try {
             await recorder.stop()
         } catch (stopErr) {
-            // recorder.stop() throws the stored _error when capture was
-            // terminated by page close, session disconnect, or ffmpeg crash.
-            // Log it so we can see the actual root cause.
-            log.error({ err: stopErr, frames: frameCount }, 'recorder.stop() error (root cause)')
+            if (stopErr instanceof Error && stopErr.message === 'Capture is not in progress') {
+                // Recorder already stopped (ffmpeg exited before we called stop) — harmless.
+                log.info({ frames: frameCount }, 'recorder already stopped')
+            } else {
+                // recorder.stop() throws the stored _error when capture was
+                // terminated by page close, session disconnect, or ffmpeg crash.
+                // Log it so we can see the actual root cause.
+                log.error({ err: stopErr, frames: frameCount }, 'recorder.stop() error (root cause)')
+            }
         }
     }
 


### PR DESCRIPTION
## Problem

When a recording finishes playing, ffmpeg receives EOF and exits. This triggers puppeteer-capture's `captureStopped` event during the capture loop's `waitForTimeout` await — before the loop checks `player.isEnded()` and breaks. The handler was treating all `captureStopped` events as errors, causing unnecessary retries on ~8% of activities.

Production data from the last 24h shows 134 false `capture stopped unexpectedly` errors across 20 sessions, with 7 sessions that eventually recovered (retry succeeded when the race didn't happen) and wasted activity attempts.

## Changes

- Check `player.isEnded()` in the `captureStopped` handler — when playback finished naturally, ffmpeg exiting is expected, not an error
- Downgrade "Capture is not in progress" from `recorder.stop()` to info level — the recorder already stopped cleanly, this is harmless

## How did you test this code?

- 124 rasterizer unit tests pass
- Diagnosed by querying production Loki logs for the `recording-rasterizer` namespace and correlating `capture stopped unexpectedly` errors with `activity complete` outcomes per session

## Publish to changelog?

No

## 🤖 LLM context

Co-authored with Claude Code. Root cause identified by analyzing production error logs — the `captureStopped` race was a remaining gap from #53394 which fixed the stop-time race but not the loop-time race.