### PR TITLE
feat(notebooks): ProseMirror collab plugin and step-based sync

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -358,6 +358,7 @@ export const FEATURE_FLAGS = {
     MAX_SESSION_SUMMARIZATION_VIDEO_AS_BASE: 'max-session-summarization-video-as-base', // owner: #team-signals
     PRODUCT_AUTONOMY: 'product-autonomy', // owner: #team-signals
     MESSAGING_SES: 'messaging-ses', // owner #team-workflows
+    NOTEBOOKS_COLLABORATION: 'notebooks-collaboration', // owner: #team-platform-features
     NOTEBOOKS_COLLAPSIBLE_SECTIONS: 'notebooks-collapsible-sections', // owner: @benjackwhite
     NOTEBOOK_PYTHON: 'notebook-python', // owner: #team-data-tools
     PAGE_REPORTS_AVERAGE_PAGE_VIEW: 'page-reports-average-page-view', // owner: @jordanm-posthog #team-web-analytics

--- a/frontend/src/scenes/notebooks/Notebook/Editor.tsx
+++ b/frontend/src/scenes/notebooks/Notebook/Editor.tsx
@@ -1,9 +1,11 @@
+import { Extension } from '@tiptap/core'
 import ExtensionDocument from '@tiptap/extension-document'
 import { FloatingMenu } from '@tiptap/extension-floating-menu'
 import { TaskItem, TaskList } from '@tiptap/extension-list'
 import { Table, TableCell, TableHeader, TableRow } from '@tiptap/extension-table'
 import TableOfContents, { getHierarchicalIndexes } from '@tiptap/extension-table-of-contents'
 import { Placeholder } from '@tiptap/extensions'
+import { collab } from '@tiptap/pm/collab'
 import StarterKit, { StarterKitOptions } from '@tiptap/starter-kit'
 import { useActions, useValues } from 'kea'
 import { useThrottledCallback } from 'use-debounce'
@@ -59,6 +61,7 @@ import { textContent } from '../utils'
 import { CollapsibleHeading } from './CollapsibleHeading'
 import { DropAndPasteHandlerExtension } from './DropAndPasteHandlerExtension'
 import { InlineMenu } from './InlineMenu'
+import { notebookCollabLogic } from './notebookCollabLogic'
 import { NotebookDefaultBlockOnEnter } from './NotebookDefaultBlockOnEnter'
 import { notebookLogic } from './notebookLogic'
 import { NotebookTrailingParagraph } from './NotebookTrailingParagraph'
@@ -70,10 +73,11 @@ const CustomDocument = ExtensionDocument.extend({
 })
 
 export function Editor(): JSX.Element {
-    const { shortId, mode, isEditable } = useValues(notebookLogic)
+    const { shortId, mode, isEditable, content, collabEnabled, notebook } = useValues(notebookLogic)
     const { setEditor, onEditorUpdate, onEditorSelectionUpdate, setTableOfContents, insertComment } =
         useActions(notebookLogic)
     const hasCollapsibleSections = useFeatureFlag('NOTEBOOKS_COLLAPSIBLE_SECTIONS')
+    const { bindEditor } = useActions(notebookCollabLogic({ shortId }))
 
     const { resetSuggestions, setPreviousNode } = useActions(insertionSuggestionsLogic)
 
@@ -88,6 +92,8 @@ export function Editor(): JSX.Element {
         link: false,
         trailingNode: false,
     }
+
+    const useCollab = collabEnabled && !!notebook
 
     const extensions = [
         mode === 'notebook' ? CustomDocument : ExtensionDocument,
@@ -167,16 +173,29 @@ export function Editor(): JSX.Element {
         NotebookDefaultBlockOnEnter,
     ]
 
+    if (useCollab) {
+        extensions.push(
+            Extension.create({
+                name: 'collaboration',
+                addProseMirrorPlugins() {
+                    return [collab({ version: notebook.version, clientID: uuid() })]
+                },
+            })
+        )
+    }
+
     if (hasCollapsibleSections) {
         extensions.push(CollapsibleHeading.configure())
     }
 
     return (
         <RichContentEditor
-            logicKey={`Notebook.${shortId}`}
+            // Collab suffix forces editor to re-initialize so the collab plugin is present
+            logicKey={`Notebook.${shortId}${useCollab ? '-collab' : ''}`}
             extensions={extensions}
             disabled={!isEditable}
             className="NotebookEditor flex flex-col flex-1"
+            initialContent={content}
             onUpdate={onEditorUpdate}
             onSelectionUpdate={onEditorSelectionUpdate}
             onCreate={(editor) => {
@@ -188,6 +207,10 @@ export function Editor(): JSX.Element {
                 }
 
                 setEditor(notebookEditor)
+
+                if (useCollab) {
+                    bindEditor(editor)
+                }
             }}
         >
             <FloatingSuggestions />

--- a/frontend/src/scenes/notebooks/Notebook/notebookCollabLogic.ts
+++ b/frontend/src/scenes/notebooks/Notebook/notebookCollabLogic.ts
@@ -1,0 +1,60 @@
+import { receiveTransaction } from '@tiptap/pm/collab'
+import { Step } from '@tiptap/pm/transform'
+import { actions, beforeUnmount, kea, key, listeners, path, props, reducers } from 'kea'
+import posthog from 'posthog-js'
+
+import { TTEditor } from 'lib/components/RichContentEditor/types'
+
+import type { notebookCollabLogicType } from './notebookCollabLogicType'
+
+export type NotebookCollabProps = {
+    shortId: string
+}
+
+export const notebookCollabLogic = kea<notebookCollabLogicType>([
+    props({} as NotebookCollabProps),
+    path((key) => ['scenes', 'notebooks', 'Notebook', 'notebookCollabLogic', key]),
+    key(({ shortId }) => shortId),
+
+    actions({
+        bindEditor: (editor: TTEditor) => ({ editor }),
+        unbindEditor: true,
+        rebaseFromSteps: (steps: Record<string, any>[], clientIDs: (string | number)[]) => ({
+            steps,
+            clientIDs,
+        }),
+    }),
+
+    reducers({
+        ttEditor: [
+            null as TTEditor | null,
+            {
+                bindEditor: (_, { editor }) => editor,
+                unbindEditor: () => null,
+            },
+        ],
+    }),
+
+    listeners(({ values }) => ({
+        rebaseFromSteps: ({ steps, clientIDs }) => {
+            const editor = values.ttEditor
+            if (!editor || !steps.length) {
+                return
+            }
+            try {
+                const parsed = steps.map((s) => Step.fromJSON(editor.state.schema, s))
+                const tr = receiveTransaction(editor.state, parsed, clientIDs, {
+                    mapSelectionBackward: true,
+                })
+                editor.view.dispatch(tr)
+            } catch (e) {
+                posthog.captureException(e as Error, { action: 'notebook collab rebase' })
+                throw e
+            }
+        },
+    })),
+
+    beforeUnmount(({ actions }) => {
+        actions.unbindEditor()
+    }),
+])

--- a/frontend/src/scenes/notebooks/Notebook/notebookCollabLogic.ts
+++ b/frontend/src/scenes/notebooks/Notebook/notebookCollabLogic.ts
@@ -3,6 +3,8 @@ import { Step } from '@tiptap/pm/transform'
 import { actions, beforeUnmount, kea, key, listeners, path, props, reducers } from 'kea'
 import posthog from 'posthog-js'
 
+import { lemonToast } from '@posthog/lemon-ui'
+
 import { TTEditor } from 'lib/components/RichContentEditor/types'
 
 import type { notebookCollabLogicType } from './notebookCollabLogicType'
@@ -49,7 +51,7 @@ export const notebookCollabLogic = kea<notebookCollabLogicType>([
                 editor.view.dispatch(tr)
             } catch (e) {
                 posthog.captureException(e as Error, { action: 'notebook collab rebase' })
-                throw e
+                lemonToast.error('Failed to sync notebook changes. Please reload the page.')
             }
         },
     })),

--- a/frontend/src/scenes/notebooks/Notebook/notebookLogic.ts
+++ b/frontend/src/scenes/notebooks/Notebook/notebookLogic.ts
@@ -1,3 +1,4 @@
+import { sendableSteps } from '@tiptap/pm/collab'
 import {
     BuiltLogic,
     actions,
@@ -21,6 +22,8 @@ import { lemonToast } from '@posthog/lemon-ui'
 
 import api from 'lib/api'
 import { EditorRange, JSONContent } from 'lib/components/RichContentEditor/types'
+import { FEATURE_FLAGS } from 'lib/constants'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { base64Decode, base64Encode, downloadFile, slugify } from 'lib/utils'
 import { accessLevelSatisfied } from 'lib/utils/accessControlUtils'
 import { commentsLogic } from 'scenes/comments/commentsLogic'
@@ -66,6 +69,7 @@ import {
 } from '../types'
 import { updateContentHeading } from '../utils'
 import { NOTEBOOKS_VERSION, migrate } from './migrations/migrate'
+import { notebookCollabLogic } from './notebookCollabLogic'
 import { notebookKernelInfoLogic } from './notebookKernelInfoLogic'
 import type { notebookLogicType } from './notebookLogicType'
 import { notebookSettingsLogic } from './notebookSettingsLogic'
@@ -104,6 +108,8 @@ export const notebookLogic = kea<notebookLogicType>([
 
     connect((props: NotebookLogicProps) => ({
         values: [
+            featureFlagLogic,
+            ['featureFlags'],
             notebooksModel,
             ['scratchpadNotebook', 'notebookTemplates'],
             commentsLogic({
@@ -115,6 +121,8 @@ export const notebookLogic = kea<notebookLogicType>([
             ['kernelInfo'],
             notebookSettingsLogic,
             ['showKernelInfo', 'showTableOfContents'],
+            notebookCollabLogic({ shortId: props.shortId }),
+            ['ttEditor'],
         ],
         actions: [
             notebooksModel,
@@ -126,6 +134,8 @@ export const notebookLogic = kea<notebookLogicType>([
                 item_id: props.shortId,
             }),
             ['setItemContext', 'maybeLoadComments'],
+            notebookCollabLogic({ shortId: props.shortId }),
+            ['rebaseFromSteps'],
         ],
     })),
     actions({
@@ -351,6 +361,62 @@ export const notebookLogic = kea<notebookLogicType>([
                         return values.notebook
                     }
 
+                    if (values.collabEnabled && values.ttEditor) {
+                        const sendable = sendableSteps(values.ttEditor.state)
+                        if (!sendable) {
+                            return values.notebook
+                        }
+                        const stepsJson = sendable.steps.map((s) => s.toJSON())
+
+                        try {
+                            const response = await api.create(
+                                `api/projects/@current/notebooks/${values.notebook.short_id}/collab/save/`,
+                                {
+                                    client_id: sendable.clientID,
+                                    version: sendable.version,
+                                    steps: stepsJson,
+                                    content: values.editor?.getJSON(),
+                                    text_content: values.editor?.getText() || '',
+                                    title: notebook.title,
+                                }
+                            )
+                            // Mark sent steps as acknowledged so version update
+                            actions.rebaseFromSteps(
+                                stepsJson,
+                                stepsJson.map(() => sendable.clientID)
+                            )
+                            if (notebook.content === values.localContent) {
+                                actions.clearLocalContent()
+                            }
+                            refreshTreeItem('notebook', String(values.notebook.short_id))
+                            return response
+                        } catch (error: any) {
+                            if (error.status === 409 && error.data?.steps) {
+                                try {
+                                    actions.rebaseFromSteps(error.data.steps, error.data.client_ids)
+                                } catch (rebaseError) {
+                                    // TODO: Temporary path for debugging, remove after confirming this does not occur
+                                    lemonToast.error(`Collab rebase failed: ${rebaseError}`)
+                                    return values.notebook
+                                }
+                                // Retry after rebase
+                                actions.saveNotebook({
+                                    content: values.editor?.getJSON() ?? notebook.content,
+                                    title: notebook.title,
+                                })
+                                return values.notebook
+                            }
+                            if (error.status === 410) {
+                                // Steps expired - gap too large to rebase, must reload
+                                actions.clearLocalContent()
+                                actions.loadNotebook()
+                                return values.notebook
+                            }
+                            throw error
+                        }
+                    }
+
+                    // Legacy path: full-doc PATCH
                     try {
                         const response = await api.notebooks.update(values.notebook.short_id, {
                             version: values.notebook.version,
@@ -464,6 +530,11 @@ export const notebookLogic = kea<notebookLogicType>([
             (props, isTemplate): boolean => {
                 return props.shortId === 'scratchpad' || props.mode === 'canvas' || isTemplate
             },
+        ],
+        collabEnabled: [
+            (s) => [s.featureFlags, s.isLocalOnly],
+            (featureFlags: Record<string, string | boolean>, isLocalOnly: boolean): boolean =>
+                !!featureFlags[FEATURE_FLAGS.NOTEBOOKS_COLLABORATION] && !isLocalOnly,
         ],
         notebookMissing: [
             (s) => [s.notebook, s.notebookLoading, s.mode],
@@ -801,9 +872,7 @@ export const notebookLogic = kea<notebookLogicType>([
                 cache.throttledOnUpdateEditorTimeout = null
             }, 16) // ~60fps throttling
         },
-        setEditor: () => {
-            values.editor?.setContent(values.content)
-        },
+        setEditor: () => {},
 
         saveNotebookSuccess: actions.scheduleNotebookRefresh,
         loadNotebookSuccess: () => {
@@ -855,6 +924,12 @@ export const notebookLogic = kea<notebookLogicType>([
             if (values.mode !== 'notebook') {
                 return
             }
+
+            // When collab is enabled, SSE will handle real-time sync, no polling needed
+            if (values.collabEnabled) {
+                return
+            }
+
             // Remove any existing refresh timeout
             cache.disposables.dispose('refreshTimeout')
 

--- a/frontend/src/scenes/notebooks/Notebook/notebookLogic.ts
+++ b/frontend/src/scenes/notebooks/Notebook/notebookLogic.ts
@@ -392,13 +392,8 @@ export const notebookLogic = kea<notebookLogicType>([
                             return response
                         } catch (error: any) {
                             if (error.status === 409 && error.data?.steps) {
-                                try {
-                                    actions.rebaseFromSteps(error.data.steps, error.data.client_ids)
-                                } catch (rebaseError) {
-                                    // TODO: Temporary path for debugging, remove after confirming this does not occur
-                                    lemonToast.error(`Collab rebase failed: ${rebaseError}`)
-                                    return values.notebook
-                                }
+                                actions.rebaseFromSteps(error.data.steps, error.data.client_ids)
+
                                 // Retry after rebase
                                 actions.saveNotebook({
                                     content: values.editor?.getJSON() ?? notebook.content,


### PR DESCRIPTION
## Problem

Notebooks are currently single-writer. 
This PR is the frontend half of the first collaborative editing implementation, building on the [RFC](https://github.com/PostHog/requests-for-comments-internal/pull/1059). Depends on the backend PR with the collab/save endpoint.

## Changes

- **`notebookCollabLogic`** - new kea logic that owns the Tiptap editor reference and exposes `rebaseFromSteps`, which calls ProseMirror's `receiveTransaction` to apply missed steps from the server and advance the local collab version
- **`notebookLogic` save path** - when collab is enabled, instead of a full-doc PATCH, sends `steps + version` to `collab/save`. 
	- On 409 conflict, applies the returned missed steps via `rebaseFromSteps` and retries. On 410 (steps expired, gap too large), falls back to a full reload
- **`Editor.tsx`** - starts the collab plugin at `notebook.version` with a unique `clientID`. Passes `initialContent` directly to the editor so the collab plugin never sees a `setContent` transaction. Without this, opening a notebook would generate spurious structural steps that break rebase for other clients. 
- **`NOTEBOOKS_COLLAB` flag** - gates all of the above. Falls back to full-doc PATCH with polling. 

## How did you test this code?

- Enable the NOTEBOOKS_COLLAB feature flag
- Open the same notebook in two tabs (each tab gets its own clientID)
- Type something in tab 1, wait for it to save
- Type something in tab 2, he save will conflict, tab 2 will rebase over tab 1's changes and retry
- Both tabs should converge to the same content with all edits merged

https://github.com/user-attachments/assets/c9714e21-67c5-4485-8e38-89f301315b93


## Publish to changelog?
No

## Docs update
No