### PR TITLE
fix(mcp): set correct insight url

### DIFF
--- a/services/mcp/src/tools/query-wrapper-factory.ts
+++ b/services/mcp/src/tools/query-wrapper-factory.ts
@@ -46,7 +46,7 @@ export function createQueryWrapper<T extends ZodObjectAny>(config: QueryWrapperC
             const baseUrl = context.api.getProjectBaseUrl(projectId)
             const posthogUrl = config.urlPrefix
                 ? `${baseUrl}${config.urlPrefix}`
-                : `${baseUrl}/insights/new?q=${encodeURIComponent(JSON.stringify(query))}`
+                : `${baseUrl}/insights/new#q=${encodeURIComponent(JSON.stringify({ kind: 'InsightVizNode', source: query }))}`
             return {
                 results: result.formatted_results ?? result.results,
                 _posthogUrl: posthogUrl,

--- a/services/mcp/tests/tools/query-wrappers.integration.test.ts
+++ b/services/mcp/tests/tools/query-wrappers.integration.test.ts
@@ -36,7 +36,7 @@ describe('Query Wrapper Integration Tests', { concurrent: false }, () => {
             expect(result).toHaveProperty('results')
             expect(result).toHaveProperty('_posthogUrl')
             expect(typeof result.results).toBe('string')
-            expect(result._posthogUrl).toMatch(/\/insights\/new\?q=/)
+            expect(result._posthogUrl).toMatch(/\/insights\/new#q=/)
         })
 
         it('should include pipe-separated table in formatted results', async () => {
@@ -129,12 +129,12 @@ describe('Query Wrapper Integration Tests', { concurrent: false }, () => {
                 dateRange: { date_from: '-7d' },
             })) as any
 
-            expect(result._posthogUrl).toContain('/insights/new?q=')
-            const url = new URL(result._posthogUrl)
-            const queryParam = url.searchParams.get('q')
-            expect(queryParam).toBeTruthy()
-            const parsed = JSON.parse(decodeURIComponent(queryParam!))
-            expect(parsed.kind).toBe('StickinessQuery')
+            expect(result._posthogUrl).toContain('/insights/new#q=')
+            const hash = result._posthogUrl.split('#q=')[1]
+            expect(hash).toBeTruthy()
+            const parsed = JSON.parse(decodeURIComponent(hash))
+            expect(parsed.kind).toBe('InsightVizNode')
+            expect(parsed.source.kind).toBe('StickinessQuery')
         })
     })
 
@@ -151,7 +151,7 @@ describe('Query Wrapper Integration Tests', { concurrent: false }, () => {
 
             expect(result).toHaveProperty('results')
             expect(result).toHaveProperty('_posthogUrl')
-            expect(result._posthogUrl).toMatch(/\/insights\/new\?q=/)
+            expect(result._posthogUrl).toMatch(/\/insights\/new#q=/)
         })
 
         it('should execute a paths query with start point', async () => {
@@ -238,20 +238,19 @@ describe('Query Wrapper Integration Tests', { concurrent: false }, () => {
     })
 
     describe('factory behavior', () => {
-        it('should generate a valid PostHog URL with kind', async () => {
+        it('should wrap query in InsightVizNode in the URL', async () => {
             const tool = getToolByName(GENERATED_TOOLS as Record<string, () => ToolBase<ZodObjectAny>>, 'query-trends')
             const result = (await tool.handler(context, {
                 series: [{ kind: 'EventsNode', event: '$pageview' }],
                 dateRange: { date_from: '-7d' },
             })) as any
 
-            expect(result._posthogUrl).toContain('/insights/new?q=')
-            // URL-encoded query should be parseable
-            const url = new URL(result._posthogUrl)
-            const queryParam = url.searchParams.get('q')
-            expect(queryParam).toBeTruthy()
-            const parsed = JSON.parse(decodeURIComponent(queryParam!))
-            expect(parsed.kind).toBe('TrendsQuery')
+            expect(result._posthogUrl).toContain('/insights/new#q=')
+            const hash = result._posthogUrl.split('#q=')[1]
+            expect(hash).toBeTruthy()
+            const parsed = JSON.parse(decodeURIComponent(hash))
+            expect(parsed.kind).toBe('InsightVizNode')
+            expect(parsed.source.kind).toBe('TrendsQuery')
         })
     })
 })

--- a/services/mcp/tests/unit/query-wrapper-factory.test.ts
+++ b/services/mcp/tests/unit/query-wrapper-factory.test.ts
@@ -1,7 +1,8 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { z } from 'zod'
 
 import { createQueryWrapper } from '@/tools/query-wrapper-factory'
+import type { Context } from '@/tools/types'
 
 describe('createQueryWrapper _meta', () => {
     const schema = z.object({ kind: z.string() })
@@ -31,5 +32,89 @@ describe('createQueryWrapper _meta', () => {
             ui: { resourceUri: 'ui://posthog/test.html' },
             responseFormat: 'json',
         })
+    })
+})
+
+describe('createQueryWrapper _posthogUrl', () => {
+    const schema = z.object({
+        series: z.array(z.object({ kind: z.string(), event: z.string() })),
+    })
+
+    function createMockContext(projectId = '1', baseUrl = 'http://localhost:8010'): Context {
+        return {
+            api: {
+                request: vi.fn().mockResolvedValue({ results: [] }),
+                getProjectBaseUrl: vi.fn().mockReturnValue(`${baseUrl}/project/${projectId}`),
+            },
+            stateManager: {
+                getProjectId: vi.fn().mockResolvedValue(projectId),
+            },
+        } as unknown as Context
+    }
+
+    it.each(['TrendsQuery', 'FunnelsQuery', 'RetentionQuery', 'StickinessQuery', 'PathsQuery', 'LifecycleQuery'])(
+        'wraps %s in InsightVizNode in the URL',
+        async (kind) => {
+            const context = createMockContext()
+            const factory = createQueryWrapper({ name: 'test', schema, kind })
+            const tool = factory()
+
+            const result = (await tool.handler(context, {
+                series: [{ kind: 'EventsNode', event: '$pageview' }],
+            })) as any
+
+            const hash = result._posthogUrl.split('#q=')[1]
+            expect(hash).toBeTruthy()
+            const parsed = JSON.parse(decodeURIComponent(hash))
+            expect(parsed.kind).toBe('InsightVizNode')
+            expect(parsed.source.kind).toBe(kind)
+        }
+    )
+
+    it('uses hash param not query param', async () => {
+        const context = createMockContext()
+        const factory = createQueryWrapper({ name: 'test', schema, kind: 'TrendsQuery' })
+        const tool = factory()
+
+        const result = (await tool.handler(context, {
+            series: [{ kind: 'EventsNode', event: '$pageview' }],
+        })) as any
+
+        expect(result._posthogUrl).toContain('/insights/new#q=')
+        expect(result._posthogUrl).not.toContain('/insights/new?q=')
+    })
+
+    it('preserves inner query fields in InsightVizNode source', async () => {
+        const context = createMockContext()
+        const factory = createQueryWrapper({ name: 'test', schema, kind: 'FunnelsQuery' })
+        const tool = factory()
+
+        const result = (await tool.handler(context, {
+            series: [{ kind: 'EventsNode', event: '$pageview' }],
+        })) as any
+
+        const hash = result._posthogUrl.split('#q=')[1]
+        const parsed = JSON.parse(decodeURIComponent(hash))
+        expect(parsed.kind).toBe('InsightVizNode')
+        expect(parsed.source.kind).toBe('FunnelsQuery')
+        expect(parsed.source.series).toEqual([{ kind: 'EventsNode', event: '$pageview' }])
+    })
+
+    it('uses urlPrefix directly without InsightVizNode wrapping', async () => {
+        const context = createMockContext()
+        const factory = createQueryWrapper({
+            name: 'test',
+            schema,
+            kind: 'ErrorTrackingQuery',
+            urlPrefix: '/error_tracking',
+        })
+        const tool = factory()
+
+        const result = (await tool.handler(context, {
+            series: [{ kind: 'EventsNode', event: '$pageview' }],
+        })) as any
+
+        expect(result._posthogUrl).toBe('http://localhost:8010/project/1/error_tracking')
+        expect(result._posthogUrl).not.toContain('InsightVizNode')
     })
 })


### PR DESCRIPTION
## Problem

Using MCP to create insights, I saw that we're not rendering the UI app correctly. 
Tried to open the link in PostHog, but it still does not render the right insight.

https://github.com/user-attachments/assets/d6f69273-50fc-4501-9b6f-1c85b08be4ef


Seems like we have a fix for the UI app: https://github.com/PostHog/posthog/pull/53499
Here's the fix for the PostHog URL

## Changes

1. Set `InsightVizNode` in the URL
2. Use `#` instead of `?` for the query params

## How did you test this code?

Manually + Added tests

## Publish to changelog?

No