### PR TITLE
feat(ux): add inline pinning feature and option to remove definition popovers

### DIFF
--- a/frontend/src/lib/components/DefinitionPopover/DefinitionPopoverContents.tsx
+++ b/frontend/src/lib/components/DefinitionPopover/DefinitionPopoverContents.tsx
@@ -727,7 +727,11 @@ export function ControlledDefinitionPopover({
         group.type === TaxonomicFilterGroupType.DataWarehouse && !!definitionPopoverRenderer
 
     const defaultView = <DefinitionView group={group} />
-    const customView = definitionPopoverRenderer?.({ item, group, defaultView }) ?? defaultView
+    const customView = definitionPopoverRenderer ? definitionPopoverRenderer({ item, group, defaultView }) : defaultView
+
+    if (customView === null) {
+        return null
+    }
 
     return (
         <Popover

--- a/frontend/src/lib/components/TaxonomicFilter/InfiniteList.scss
+++ b/frontend/src/lib/components/TaxonomicFilter/InfiniteList.scss
@@ -76,7 +76,8 @@
             justify-content: center;
             width: 1rem;
             margin-left: 0.5rem;
-            pointer-events: none;
+            cursor: pointer;
+            transition: opacity 100ms ease;
         }
 
         &.hover,

--- a/frontend/src/lib/components/TaxonomicFilter/InfiniteList.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/InfiniteList.tsx
@@ -794,7 +794,11 @@ export function InfiniteList({
                                               selectedItem.name,
                                               selectedItemGroup?.type
                                           )
-                                          label = coreDef?.label ?? selectedItem.name ?? 'Unknown'
+                                          label =
+                                              coreDef?.label ||
+                                              selectedItemGroup?.getName?.(selectedItem) ||
+                                              selectedItem.name ||
+                                              ''
                                       }
                                       return (
                                           <>

--- a/frontend/src/lib/components/TaxonomicFilter/InfiniteList.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/InfiniteList.tsx
@@ -1,4 +1,3 @@
-import '../../lemon-ui/Popover/Popover.scss'
 import './InfiniteList.scss'
 
 import clsx from 'clsx'
@@ -16,16 +15,21 @@ import { formatPropertyLabel } from 'lib/components/PropertyFilters/utils'
 import { PropertyKeyInfo } from 'lib/components/PropertyKeyInfo'
 import { hasRecentContext } from 'lib/components/TaxonomicFilter/recentTaxonomicFiltersLogic'
 import { taxonomicFilterLogic } from 'lib/components/TaxonomicFilter/taxonomicFilterLogic'
-import { hasPinnedContext } from 'lib/components/TaxonomicFilter/taxonomicFilterPinnedPropertiesLogic'
+import {
+    hasPinnedContext,
+    taxonomicFilterPinnedPropertiesLogic,
+} from 'lib/components/TaxonomicFilter/taxonomicFilterPinnedPropertiesLogic'
 import {
     DataWarehousePopoverField,
     DefinitionPopoverRenderer,
     isSkeletonItem,
+    META_GROUP_TYPES,
     SkeletonItem,
     TaxonomicDefinitionTypes,
     TaxonomicFilterGroup,
     TaxonomicFilterGroupType,
     TaxonomicFilterGroupValueMap,
+    TaxonomicFilterValue,
 } from 'lib/components/TaxonomicFilter/types'
 import { dayjs } from 'lib/dayjs'
 import { LemonRow } from 'lib/lemon-ui/LemonRow'
@@ -44,6 +48,8 @@ import { NO_ITEM_SELECTED, infiniteListLogic } from './infiniteListLogic'
 export interface InfiniteListProps {
     popupAnchorElement: HTMLDivElement | null
     definitionPopoverRenderer?: DefinitionPopoverRenderer
+    /** Show inline pin/unpin buttons on hover for each row (default: false). */
+    inlinePinning?: boolean
 }
 
 function hasLocalListContext(item: unknown): boolean {
@@ -274,6 +280,14 @@ interface InfiniteListRowProps {
     setIndex: (index: number) => void
     pinnedRowIndex: number | null
     onToggleRowPin: (rowIndex: number) => void
+    isItemPinned: (groupType: TaxonomicFilterGroupType, value: TaxonomicFilterValue) => boolean
+    onToggleItemPin: (
+        groupType: TaxonomicFilterGroupType,
+        groupName: string,
+        value: TaxonomicFilterValue,
+        item: TaxonomicDefinitionTypes
+    ) => void
+    inlinePinning: boolean
     expand: () => void
     selectItem: (
         group: TaxonomicFilterGroup,
@@ -339,6 +353,9 @@ export const InfiniteListRow = ({
     setIndex,
     pinnedRowIndex,
     onToggleRowPin,
+    isItemPinned,
+    onToggleItemPin,
+    inlinePinning,
     expand,
     selectItem,
     setHighlightedItemElement,
@@ -449,18 +466,11 @@ export const InfiniteListRow = ({
 
     if (item && itemGroup) {
         const isDisabledItem = itemGroup?.getIsDisabled?.(item) ?? false
-        const isPinnable = !canSelectItem(listGroupType, dataWarehousePopoverFields) && !isDisabledItem
         const isCrossGroupItem = !!group.isLocalOnly && itemGroup.type !== listGroupType
         const localListLabel = getLocalListLabel(item)
         const localListGroup = hasLocalListContext(item)
             ? taxonomicGroups.find((g) => g.type === listGroupType)
             : undefined
-        const shouldShowPinIcon = isPinnable && (isHighlighted || isCurrentRowPinned)
-        const pinIcon = isCurrentRowPinned ? (
-            <IconPinFilled className="size-4 text-warning" />
-        ) : (
-            <IconPin className="size-4 text-secondary" />
-        )
 
         const { listGroupType: resolvedListGroupType, itemGroup: resolvedItemGroup } = resolveItemRendering({
             item,
@@ -471,10 +481,21 @@ export const InfiniteListRow = ({
             fallbackGroup: group,
         })
 
+        // Pin button: determine the source group for pinning
+        const pinGroupType = getSourceGroupType(item) ?? resolvedListGroupType
+        const pinGroupName = taxonomicGroups.find((g) => g.type === pinGroupType)?.name ?? resolvedItemGroup.name ?? ''
+        const pinValue = item.name ?? null
+        const canPin = inlinePinning && !isDisabledItem && !META_GROUP_TYPES.has(pinGroupType) && pinValue !== null
+        const pinned = canPin && isItemPinned(pinGroupType, pinValue)
+
         return (
             <div
                 {...commonDivProps}
-                className={clsx(commonDivProps.className, isDisabledItem && 'cursor-not-allowed opacity-60')}
+                className={clsx(
+                    commonDivProps.className,
+                    isDisabledItem && 'cursor-not-allowed opacity-60',
+                    'group/row'
+                )}
                 data-attr={`prop-filter-${listGroupType}-${rowIndex}`}
                 data-ph-capture-attribute-taxonomic-group={resolvedListGroupType}
                 data-ph-capture-attribute-taxonomic-group-name={resolvedItemGroup.name}
@@ -505,13 +526,22 @@ export const InfiniteListRow = ({
                         {localListLabel ? `${itemGroup.name} - ${localListLabel}` : itemGroup.name}
                     </LemonTag>
                 )}
-                {isPinnable && (
+                {canPin && (
                     <div
-                        className="taxonomic-list-row-pin"
+                        className={clsx('taxonomic-list-row-pin', !pinned && 'opacity-0 group-hover/row:opacity-100')}
                         data-attr={`pin-row-${listGroupType}-${rowIndex}`}
-                        aria-hidden="true"
+                        onClick={(event) => {
+                            event.stopPropagation()
+                            onToggleItemPin(pinGroupType, pinGroupName, pinValue, item)
+                        }}
+                        role="button"
+                        aria-label={pinned ? 'Unpin' : 'Pin'}
                     >
-                        {shouldShowPinIcon ? pinIcon : null}
+                        {pinned ? (
+                            <IconPinFilled className="size-4 text-warning" />
+                        ) : (
+                            <IconPin className="size-4 text-secondary hover:text-primary" />
+                        )}
                     </div>
                 )}
             </div>
@@ -600,7 +630,11 @@ function InfiniteListEmptyState(): JSX.Element {
     )
 }
 
-export function InfiniteList({ popupAnchorElement, definitionPopoverRenderer }: InfiniteListProps): JSX.Element {
+export function InfiniteList({
+    popupAnchorElement,
+    definitionPopoverRenderer,
+    inlinePinning = false,
+}: InfiniteListProps): JSX.Element {
     const {
         mouseInteractionsEnabled,
         eventNames,
@@ -637,6 +671,8 @@ export function InfiniteList({ popupAnchorElement, definitionPopoverRenderer }: 
         showSuggestedFiltersEmptyState,
     } = useValues(infiniteListLogic)
     const { onRowsRendered, setIndex, togglePinnedRow, expand, updateRemoteItem } = useActions(infiniteListLogic)
+    const { isPinned: isItemPinned } = useValues(taxonomicFilterPinnedPropertiesLogic)
+    const { togglePin: onToggleItemPin } = useActions(taxonomicFilterPinnedPropertiesLogic)
     const [highlightedItemElement, setHighlightedItemElement] = useState<HTMLDivElement | null>(null)
     const listRef = useListRef(null)
 
@@ -702,6 +738,9 @@ export function InfiniteList({ popupAnchorElement, definitionPopoverRenderer }: 
                                     setIndex,
                                     pinnedRowIndex,
                                     onToggleRowPin: togglePinnedRow,
+                                    isItemPinned,
+                                    onToggleItemPin,
+                                    inlinePinning,
                                     expand,
                                     selectItem,
                                     setHighlightedItemElement,
@@ -741,6 +780,9 @@ export function InfiniteList({ popupAnchorElement, definitionPopoverRenderer }: 
                                       const recentRenderer = definitionPopoverRenderer
                                           ? definitionPopoverRenderer({ item, group, defaultView })
                                           : defaultView
+                                      if (recentRenderer === null) {
+                                          return null
+                                      }
                                       let label: string
                                       if (
                                           hasRecentContext(selectedItem) &&
@@ -752,11 +794,7 @@ export function InfiniteList({ popupAnchorElement, definitionPopoverRenderer }: 
                                               selectedItem.name,
                                               selectedItemGroup?.type
                                           )
-                                          label =
-                                              coreDef?.label ||
-                                              selectedItemGroup?.getName?.(selectedItem) ||
-                                              selectedItem.name ||
-                                              ''
+                                          label = coreDef?.label ?? selectedItem.name ?? 'Unknown'
                                       }
                                       return (
                                           <>

--- a/frontend/src/lib/components/TaxonomicFilter/InfiniteSelectResults.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/InfiniteSelectResults.tsx
@@ -21,6 +21,8 @@ export interface InfiniteSelectResultsProps {
     taxonomicFilterLogicProps: TaxonomicFilterLogicProps
     popupAnchorElement: HTMLDivElement | null
     definitionPopoverRenderer?: DefinitionPopoverRenderer
+    /** Show inline pin/unpin buttons on hover for each row (default: false). */
+    inlinePinning?: boolean
 }
 
 // CategoryPillContent uses useValues(infiniteListLogic) without props, relying on BindLogic context
@@ -121,6 +123,7 @@ export function InfiniteSelectResults({
     taxonomicFilterLogicProps,
     popupAnchorElement,
     definitionPopoverRenderer,
+    inlinePinning = false,
 }: InfiniteSelectResultsProps): JSX.Element {
     const { activeTab, taxonomicGroups, taxonomicGroupTypes, activeTaxonomicGroup, value } =
         useValues(taxonomicFilterLogic)
@@ -155,6 +158,7 @@ export function InfiniteSelectResults({
             <InfiniteList
                 popupAnchorElement={popupAnchorElement}
                 definitionPopoverRenderer={definitionPopoverRenderer}
+                inlinePinning={inlinePinning}
             />
         </>
     )

--- a/frontend/src/lib/components/TaxonomicFilter/TaxonomicFilter.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/TaxonomicFilter.tsx
@@ -49,6 +49,7 @@ export function TaxonomicFilter({
     hogQLGlobals,
     definitionPopoverRenderer,
     minSearchQueryLength,
+    inlinePinning = false,
 }: TaxonomicFilterProps): JSX.Element {
     // Generate a unique key for each unique TaxonomicFilter that's rendered
     const taxonomicFilterLogicKey = useMemo(
@@ -131,6 +132,7 @@ export function TaxonomicFilter({
                         taxonomicFilterLogicProps={taxonomicFilterLogicProps}
                         popupAnchorElement={taxonomicFilterRef.current}
                         definitionPopoverRenderer={definitionPopoverRenderer}
+                        inlinePinning={inlinePinning}
                     />
                 )}
             </div>

--- a/frontend/src/lib/components/TaxonomicFilter/TaxonomicFilterPinning.test.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/TaxonomicFilterPinning.test.tsx
@@ -112,10 +112,11 @@ describe('TaxonomicFilter pinning', () => {
         expect(pinnedTab.textContent).toContain('0')
     })
 
-    it('shows pin button in definition popover on hover', async () => {
+    it('shows inline pin button on row hover', async () => {
         renderFilter({
             taxonomicGroupTypes: [TaxonomicFilterGroupType.EventProperties],
             popoverEnabled: true,
+            inlinePinning: true,
         })
 
         await waitFor(() => {

--- a/frontend/src/lib/components/TaxonomicFilter/TaxonomicFilterPinning.test.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/TaxonomicFilterPinning.test.tsx
@@ -112,11 +112,10 @@ describe('TaxonomicFilter pinning', () => {
         expect(pinnedTab.textContent).toContain('0')
     })
 
-    it('shows inline pin button on row hover', async () => {
+    it('shows pin button in definition popover on hover', async () => {
         renderFilter({
             taxonomicGroupTypes: [TaxonomicFilterGroupType.EventProperties],
             popoverEnabled: true,
-            inlinePinning: true,
         })
 
         await waitFor(() => {

--- a/frontend/src/lib/components/TaxonomicFilter/types.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/types.ts
@@ -99,6 +99,8 @@ export interface TaxonomicFilterProps {
     definitionPopoverRenderer?: DefinitionPopoverRenderer
     /** Override the group-level minSearchQueryLength for all groups in this instance. */
     minSearchQueryLength?: number
+    /** Show inline pin/unpin buttons on hover for each row (default: false). */
+    inlinePinning?: boolean
 }
 
 export interface DataWarehousePopoverField {

--- a/frontend/src/lib/components/TaxonomicPopover/TaxonomicPopover.tsx
+++ b/frontend/src/lib/components/TaxonomicPopover/TaxonomicPopover.tsx
@@ -49,6 +49,8 @@ export interface TaxonomicPopoverProps<ValueType extends TaxonomicFilterValue = 
     allowNonCapturedEvents?: boolean
     sideIcon?: React.ReactElement | null
     definitionPopoverRenderer?: DefinitionPopoverRenderer
+    /** Show inline pin/unpin buttons on hover for each row (default: false). */
+    inlinePinning?: boolean
 }
 
 /** Like TaxonomicPopover, but convenient when you know you will only use string values */
@@ -88,6 +90,7 @@ export const TaxonomicPopover = forwardRef(function TaxonomicPopover_<
         maxContextOptions,
         allowNonCapturedEvents,
         definitionPopoverRenderer,
+        inlinePinning,
         width,
         placement,
         sideIcon,
@@ -144,6 +147,7 @@ export const TaxonomicPopover = forwardRef(function TaxonomicPopover_<
                     maxContextOptions={maxContextOptions}
                     allowNonCapturedEvents={allowNonCapturedEvents}
                     definitionPopoverRenderer={definitionPopoverRenderer}
+                    inlinePinning={inlinePinning}
                     width={width}
                 />
             }

--- a/products/logs/frontend/components/LogsAlerting/LogsAlertForm.tsx
+++ b/products/logs/frontend/components/LogsAlerting/LogsAlertForm.tsx
@@ -353,6 +353,8 @@ function AlertFilterSearch(): JSX.Element {
                             focusInput={() => searchInputRef.current?.focus()}
                             taxonomicFilterLogicProps={taxonomicFilterLogicProps}
                             popupAnchorElement={floatingRef.current}
+                            inlinePinning
+                            definitionPopoverRenderer={() => null}
                         />
                     </div>
                 }

--- a/products/logs/frontend/components/LogsViewer/Filters/FilterGroup.tsx
+++ b/products/logs/frontend/components/LogsViewer/Filters/FilterGroup.tsx
@@ -108,6 +108,8 @@ const UniversalSearch = (): JSX.Element => {
                             focusInput={() => searchInputRef.current?.focus()}
                             taxonomicFilterLogicProps={taxonomicFilterLogicProps}
                             popupAnchorElement={floatingRef.current}
+                            inlinePinning
+                            definitionPopoverRenderer={() => null}
                         />
                     </div>
                 }

--- a/products/logs/frontend/components/LogsViewer/Filters/LogsFilterBar/LogsFilterBar.tsx
+++ b/products/logs/frontend/components/LogsViewer/Filters/LogsFilterBar/LogsFilterBar.tsx
@@ -204,6 +204,8 @@ const LogsFilterSearch = (): JSX.Element => {
                             focusInput={() => searchInputRef.current?.focus()}
                             taxonomicFilterLogicProps={taxonomicFilterLogicProps}
                             popupAnchorElement={floatingRef.current}
+                            inlinePinning
+                            definitionPopoverRenderer={() => null}
                         />
                     </div>
                 }

--- a/products/tracing/frontend/TracingFilterBar.tsx
+++ b/products/tracing/frontend/TracingFilterBar.tsx
@@ -245,6 +245,8 @@ function TracingFilterSearch(): JSX.Element {
                             focusInput={() => searchInputRef.current?.focus()}
                             taxonomicFilterLogicProps={taxonomicFilterLogicProps}
                             popupAnchorElement={floatingRef.current}
+                            inlinePinning
+                            definitionPopoverRenderer={() => null}
                         />
                     </div>
                 }


### PR DESCRIPTION

## Problem

definition popovers are noisy and e.g. in logs/tracing often covers critical UI elements

make the popovers options and add inline pinning instead

https://github.com/user-attachments/assets/73d48c50-8519-459f-925f-176ce2607dc9


## Changes

- add inlinePinning prop to property filters UI
- make definition popover renderer able to return null to not render a popup
- changes only applied to logs and tracing UI (for now)

<img width="731" height="301" alt="image" src="https://github.com/user-attachments/assets/bcde3f0c-6166-4858-981f-75e89f6ce301" />


## How did you test this code?
locally for now
<!-- Briefly describe the steps you took, and what steps reviewers must take to get to where changes are, and what is the expected behavior. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
no
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
