### PR TITLE
fix(recordings): prevent player getting stuck when ?t= param exceeds recording duration

### DIFF
--- a/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.test.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.test.ts
@@ -325,6 +325,110 @@ describe('sessionRecordingPlayerLogic', () => {
             logic.unmount()
             expect(logic.cache.hasInitialized).toBeFalsy()
         })
+
+        // This tests the stale-segment refresh in syncSnapshotsWithPlayer.
+        // In production there's a race: initializePlayerFromStart runs from
+        // loadRecordingMetaSuccess before snapshots are processed. At that
+        // moment segments[0] is a synthetic buffer (no windowId). The player
+        // captures it as currentSegment, and without a refresh step nothing
+        // updates it when real segments arrive — leaving tryInitReplayer
+        // unable to find a valid windowId until manual user interaction.
+        // We can't reproduce the race naturally because test mocks resolve
+        // synchronously, so we inject the stale state manually and then
+        // trigger the sync to verify the refresh logic.
+        it('syncSnapshotsWithPlayer refreshes stale buffer currentSegment', async () => {
+            // Let the logic fully initialize with real segments first.
+            await expectLogic(logic)
+                .toDispatchActions([
+                    sessionRecordingDataCoordinatorLogic({ sessionRecordingId: '2' }).actionTypes
+                        .loadRecordingMetaSuccess,
+                    'initializePlayerFromStart',
+                ])
+                .toFinishAllListeners()
+
+            // Inject a stale buffer currentSegment. The setCurrentSegment
+            // listener triggers a seekToTimestamp that would refresh it
+            // immediately, so we wait for all listeners to drain first,
+            // then inject directly via a freshly-dispatched action and
+            // immediately trigger the sync before the chain can recover.
+            const start = logic.values.sessionPlayerData.start?.valueOf() ?? 0
+            const end = logic.values.sessionPlayerData.end?.valueOf() ?? 0
+            const staleBuffer: RecordingSegment = {
+                kind: 'buffer',
+                startTimestamp: start,
+                endTimestamp: end,
+                isActive: false,
+                durationMs: end - start,
+                windowId: undefined,
+            }
+
+            // Stub the setCurrentSegment listener-triggered seek away so it
+            // doesn't immediately overwrite our injected stale segment.
+            const originalSeek = logic.actions.seekToTimestamp
+            logic.actions.seekToTimestamp = jest.fn() as any
+
+            try {
+                logic.actions.setCurrentSegment(staleBuffer)
+                expect(logic.values.currentSegment?.windowId).toBeUndefined()
+                expect(logic.values.currentSegment?.kind).toBe('buffer')
+            } finally {
+                logic.actions.seekToTimestamp = originalSeek
+            }
+
+            // Now trigger the sync. The fix should detect the stale buffer
+            // and refresh currentSegment to a real window segment.
+            await expectLogic(logic, () => {
+                logic.actions.syncSnapshotsWithPlayer()
+            }).toFinishAllListeners()
+
+            expect(logic.values.currentSegment?.kind).not.toBe('buffer')
+            expect(logic.values.currentSegment?.windowId).not.toBeUndefined()
+        })
+
+        // The mock recording is 11 seconds long.
+        // We test loading with `?t=999` (999 seconds, ~16x the recording length).
+        // The player should recover gracefully — leave the player in a state
+        // where tryInitReplayer can succeed (valid currentSegment with windowId,
+        // and not stuck in endReached) so the rrweb wrapper can render.
+        it('handles out-of-range t parameter without leaving player in endReached state', async () => {
+            logic.unmount()
+            router.actions.push('/replay/2', { t: '999' })
+
+            logic = sessionRecordingPlayerLogic({
+                sessionRecordingId: '2',
+                playerKey: 'test',
+                blobV2PollingDisabled: true,
+            })
+            logic.mount()
+
+            await expectLogic(logic)
+                .toDispatchActions([
+                    sessionRecordingDataCoordinatorLogic({ sessionRecordingId: '2' }).actionTypes
+                        .loadRecordingMetaSuccess,
+                    'initializePlayerFromStart',
+                ])
+                .toFinishAllListeners()
+
+            // The current segment must have a valid windowId so tryInitReplayer
+            // can find snapshots and create the rrweb Replayer.
+            expect(logic.values.currentSegment).not.toBeNull()
+            expect(logic.values.currentSegment?.windowId).not.toBeUndefined()
+
+            // currentTimestamp must be set (not undefined) so the player has a
+            // position to render from, and it must be within the recording's
+            // valid range — not past the end (which would put us into the
+            // endReached state and prevent the replayer from auto-initializing).
+            expect(logic.values.currentTimestamp).not.toBeUndefined()
+            const start = logic.values.sessionPlayerData.start?.valueOf() ?? 0
+            const end = logic.values.sessionPlayerData.end?.valueOf() ?? 0
+            expect(logic.values.currentTimestamp).toBeGreaterThanOrEqual(start)
+            expect(logic.values.currentTimestamp).toBeLessThan(end)
+
+            // After init with an out-of-range t param, the player should NOT be
+            // stuck in endReached state — that prevents tryInitReplayer from
+            // creating the rrweb wrapper without manual user interaction.
+            expect(logic.values.endReached).toBe(false)
+        })
     })
 
     describe('delete session recording', () => {

--- a/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.test.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.test.ts
@@ -326,75 +326,13 @@ describe('sessionRecordingPlayerLogic', () => {
             expect(logic.cache.hasInitialized).toBeFalsy()
         })
 
-        // This tests the stale-segment refresh in syncSnapshotsWithPlayer.
-        // In production there's a race: initializePlayerFromStart runs from
-        // loadRecordingMetaSuccess before snapshots are processed. At that
-        // moment segments[0] is a synthetic buffer (no windowId). The player
-        // captures it as currentSegment, and without a refresh step nothing
-        // updates it when real segments arrive — leaving tryInitReplayer
-        // unable to find a valid windowId until manual user interaction.
-        // We can't reproduce the race naturally because test mocks resolve
-        // synchronously, so we inject the stale state manually and then
-        // trigger the sync to verify the refresh logic.
-        it('syncSnapshotsWithPlayer refreshes stale buffer currentSegment', async () => {
-            // Let the logic fully initialize with real segments first.
-            await expectLogic(logic)
-                .toDispatchActions([
-                    sessionRecordingDataCoordinatorLogic({ sessionRecordingId: '2' }).actionTypes
-                        .loadRecordingMetaSuccess,
-                    'initializePlayerFromStart',
-                ])
-                .toFinishAllListeners()
-
-            // Inject a stale buffer currentSegment. The setCurrentSegment
-            // listener triggers a seekToTimestamp that would refresh it
-            // immediately, so we wait for all listeners to drain first,
-            // then inject directly via a freshly-dispatched action and
-            // immediately trigger the sync before the chain can recover.
-            const start = logic.values.sessionPlayerData.start?.valueOf() ?? 0
-            const end = logic.values.sessionPlayerData.end?.valueOf() ?? 0
-            const staleBuffer: RecordingSegment = {
-                kind: 'buffer',
-                startTimestamp: start,
-                endTimestamp: end,
-                isActive: false,
-                durationMs: end - start,
-                windowId: undefined,
-            }
-
-            // Stub the setCurrentSegment listener-triggered seek away so it
-            // doesn't immediately overwrite our injected stale segment.
-            const originalSeek = logic.actions.seekToTimestamp
-            logic.actions.seekToTimestamp = jest.fn() as any
-
-            try {
-                logic.actions.setCurrentSegment(staleBuffer)
-                expect(logic.values.currentSegment?.windowId).toBeUndefined()
-                expect(logic.values.currentSegment?.kind).toBe('buffer')
-            } finally {
-                logic.actions.seekToTimestamp = originalSeek
-            }
-
-            // Now trigger the sync. The fix should detect the stale buffer
-            // and refresh currentSegment to a real window segment.
-            await expectLogic(logic, () => {
-                logic.actions.syncSnapshotsWithPlayer()
-            }).toFinishAllListeners()
-
-            expect(logic.values.currentSegment?.kind).not.toBe('buffer')
-            expect(logic.values.currentSegment?.windowId).not.toBeUndefined()
-        })
-
-        // The mock recording is 11 seconds long. We cover both boundary cases:
-        // `t=11` (exactly at recording end — triggers endReached via `>= end`)
-        // and `t=999` (far past end — stale shared URL). The player should
-        // recover gracefully in both cases so the rrweb wrapper can render.
-        it.each([
-            { t: '11', label: 'exactly at recording end' },
-            { t: '999', label: 'far past recording end' },
-        ])('handles out-of-range t=$t ($label) without leaving player in endReached state', async ({ t }) => {
+        // `t=999` against the ~12s mock recording lands seekToTime's clamp
+        // on exactly `end`, which previously tripped the `>= end` check in
+        // seekToTimestamp and fired endReached before tryInitReplayer could
+        // run. See the isPastEnd comment in sessionRecordingPlayerLogic.ts.
+        it('handles out-of-range ?t= parameter without leaving player in endReached state', async () => {
             logic.unmount()
-            router.actions.push('/replay/2', { t })
+            router.actions.push('/replay/2', { t: '999' })
 
             logic = sessionRecordingPlayerLogic({
                 sessionRecordingId: '2',
@@ -411,24 +349,21 @@ describe('sessionRecordingPlayerLogic', () => {
                 ])
                 .toFinishAllListeners()
 
-            // The current segment must have a valid windowId so tryInitReplayer
-            // can find snapshots and create the rrweb Replayer.
-            expect(logic.values.currentSegment).not.toBeNull()
+            // A window segment (not buffer/gap) is required for tryInitReplayer
+            // to find snapshots and create the rrweb Replayer.
+            expect(logic.values.currentSegment?.kind).toBe('window')
             expect(logic.values.currentSegment?.windowId).not.toBeUndefined()
 
-            // currentTimestamp must be set (not undefined) so the player has a
-            // position to render from, and it must be within the recording's
-            // valid range — not past the end (which would put us into the
-            // endReached state and prevent the replayer from auto-initializing).
-            expect(logic.values.currentTimestamp).not.toBeUndefined()
+            // seekToTime clamps to [start, end] inclusive, so landing exactly
+            // on `end` is expected and valid.
             const start = logic.values.sessionPlayerData.start?.valueOf() ?? 0
             const end = logic.values.sessionPlayerData.end?.valueOf() ?? 0
             expect(logic.values.currentTimestamp).toBeGreaterThanOrEqual(start)
-            expect(logic.values.currentTimestamp).toBeLessThan(end)
+            expect(logic.values.currentTimestamp).toBeLessThanOrEqual(end)
 
-            // After init with an out-of-range t param, the player should NOT be
-            // stuck in endReached state — that prevents tryInitReplayer from
-            // creating the rrweb wrapper without manual user interaction.
+            // With isPastEnd using `> end`, landing on exactly `end` must NOT
+            // trip endReached — otherwise the player pauses before the rrweb
+            // wrapper is created and only appears after manual interaction.
             expect(logic.values.endReached).toBe(false)
         })
     })

--- a/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.test.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.test.ts
@@ -385,14 +385,16 @@ describe('sessionRecordingPlayerLogic', () => {
             expect(logic.values.currentSegment?.windowId).not.toBeUndefined()
         })
 
-        // The mock recording is 11 seconds long.
-        // We test loading with `?t=999` (999 seconds, ~16x the recording length).
-        // The player should recover gracefully — leave the player in a state
-        // where tryInitReplayer can succeed (valid currentSegment with windowId,
-        // and not stuck in endReached) so the rrweb wrapper can render.
-        it('handles out-of-range t parameter without leaving player in endReached state', async () => {
+        // The mock recording is 11 seconds long. We cover both boundary cases:
+        // `t=11` (exactly at recording end — triggers endReached via `>= end`)
+        // and `t=999` (far past end — stale shared URL). The player should
+        // recover gracefully in both cases so the rrweb wrapper can render.
+        it.each([
+            { t: '11', label: 'exactly at recording end' },
+            { t: '999', label: 'far past recording end' },
+        ])('handles out-of-range t=$t ($label) without leaving player in endReached state', async ({ t }) => {
             logic.unmount()
-            router.actions.push('/replay/2', { t: '999' })
+            router.actions.push('/replay/2', { t })
 
             logic = sessionRecordingPlayerLogic({
                 sessionRecordingId: '2',

--- a/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
@@ -1545,12 +1545,8 @@ export const sessionRecordingPlayerLogic = kea<sessionRecordingPlayerLogicType>(
                         const desiredStartTime = Number(searchParams.timestamp)
                         actions.seekToTimestamp(desiredStartTime, true)
                     } else if (searchParams.t) {
-                        // Landing exactly on durationMs fires endReached in seekToTimestamp,
-                        // which blocks auto-init of the rrweb replayer — keep strictly below.
                         const desiredStartTime = Number(searchParams.t) * 1000
-                        const durationMs = values.sessionPlayerData?.durationMs ?? 0
-                        const maxTime = Math.max(0, durationMs - 1)
-                        actions.seekToTime(clamp(desiredStartTime, 0, maxTime))
+                        actions.seekToTime(desiredStartTime)
                     } else {
                         actions.setSkipToFirstMatchingEvent(true)
                     }
@@ -1596,14 +1592,6 @@ export const sessionRecordingPlayerLogic = kea<sessionRecordingPlayerLogicType>(
 
             if (!values.currentTimestamp) {
                 actions.initializePlayerFromStart()
-            } else if (values.currentSegment?.kind === 'buffer') {
-                // initializePlayerFromStart can capture a synthetic buffer segment
-                // before snapshots load; refresh it now that real segments exist
-                // so tryInitReplayer can find a valid windowId.
-                const refreshedSegment = values.segmentForTimestamp(values.currentTimestamp)
-                if (refreshedSegment && refreshedSegment.windowId !== undefined) {
-                    actions.setCurrentSegment(refreshedSegment)
-                }
             }
             actions.checkBufferingCompleted()
 
@@ -1734,7 +1722,14 @@ export const sessionRecordingPlayerLogic = kea<sessionRecordingPlayerLogicType>(
             // findSegmentForTimestamp can safely return a real segment for
             // past-end timestamps (needed for the image exporter to boot the
             // rrweb replayer). See #49364 and #53550.
-            const isPastEnd = values.sessionPlayerData.end && timestamp >= values.sessionPlayerData.end.valueOf()
+            //
+            // Strictly > (not >=): landing exactly on `end` is a valid
+            // "show the last frame" seek (e.g. from a stale ?t= URL that
+            // got clamped by seekToTime). Firing endReached here would
+            // pause the player before tryInitReplayer has created the
+            // rrweb wrapper. Natural playback progression still triggers
+            // endReached via updateAnimation.
+            const isPastEnd = values.sessionPlayerData.end && timestamp > values.sessionPlayerData.end.valueOf()
             if (isPastEnd) {
                 actions.setEndReached(true)
             } else if (segment && !objectsEqual(segment, values.currentSegment)) {

--- a/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
@@ -1548,7 +1548,8 @@ export const sessionRecordingPlayerLogic = kea<sessionRecordingPlayerLogicType>(
                         // Landing exactly on durationMs fires endReached in seekToTimestamp,
                         // which blocks auto-init of the rrweb replayer — keep strictly below.
                         const desiredStartTime = Number(searchParams.t) * 1000
-                        const maxTime = (values.sessionPlayerData?.durationMs ?? Infinity) - 1
+                        const durationMs = values.sessionPlayerData?.durationMs ?? 0
+                        const maxTime = Math.max(0, durationMs - 1)
                         actions.seekToTime(clamp(desiredStartTime, 0, maxTime))
                     } else {
                         actions.setSkipToFirstMatchingEvent(true)

--- a/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
@@ -1545,8 +1545,11 @@ export const sessionRecordingPlayerLogic = kea<sessionRecordingPlayerLogicType>(
                         const desiredStartTime = Number(searchParams.timestamp)
                         actions.seekToTimestamp(desiredStartTime, true)
                     } else if (searchParams.t) {
+                        // Landing exactly on durationMs fires endReached in seekToTimestamp,
+                        // which blocks auto-init of the rrweb replayer — keep strictly below.
                         const desiredStartTime = Number(searchParams.t) * 1000
-                        actions.seekToTime(desiredStartTime)
+                        const maxTime = (values.sessionPlayerData?.durationMs ?? Infinity) - 1
+                        actions.seekToTime(clamp(desiredStartTime, 0, maxTime))
                     } else {
                         actions.setSkipToFirstMatchingEvent(true)
                     }
@@ -1592,6 +1595,14 @@ export const sessionRecordingPlayerLogic = kea<sessionRecordingPlayerLogicType>(
 
             if (!values.currentTimestamp) {
                 actions.initializePlayerFromStart()
+            } else if (values.currentSegment?.kind === 'buffer') {
+                // initializePlayerFromStart can capture a synthetic buffer segment
+                // before snapshots load; refresh it now that real segments exist
+                // so tryInitReplayer can find a valid windowId.
+                const refreshedSegment = values.segmentForTimestamp(values.currentTimestamp)
+                if (refreshedSegment && refreshedSegment.windowId !== undefined) {
+                    actions.setCurrentSegment(refreshedSegment)
+                }
             }
             actions.checkBufferingCompleted()
 


### PR DESCRIPTION
## Problem

Recording exports (and shared recording URLs) were getting stuck on a blank frame — the `.replayer-wrapper` DOM element never appeared until a user manually clicked play.

When a shared URL pointed past the end of the recording (e.g. a stale URL from a trimmed recording, or our image exporter querying with `?t=999`), `seekToTime`'s internal clamp lands the target on exactly `sessionPlayerData.end.valueOf()`. That satisfied the `timestamp >= end` check in `seekToTimestamp`, which fired `setEndReached(true)` and paused the player before `tryInitReplayer` could create the rrweb wrapper. The wrapper then only appeared after manual user interaction.

This primarily affected the screenshot/image exporter for recordings but also surfaced for users landing on stale shareable URLs.

Follow-up to #53550, which narrowed the scope of this code path but didn't catch this specific edge case.

## Changes

One-character root-cause fix in `sessionRecordingPlayerLogic.ts`: change the `isPastEnd` check in the `seekToTimestamp` listener from `timestamp >= end` to `timestamp > end`.

**Why strict** **`>`** **is correct:**

- Natural playback progression has its own end-of-recording detection in `updateAnimation` (which already uses `>`), so nothing is lost by tightening this check.
- Seeks that land exactly on `end` are a valid "show me the last frame" operation — e.g. the image exporter wanting the final frame, or a user scrubbing to the end. Firing `endReached` there is actively wrong because it pauses the player before the rrweb wrapper exists.
- Seeks that are genuinely past the end (`timestamp > end`) still trigger `endReached` exactly as before.
- The only call site that seeks to a raw `end` value is the recording's `end.valueOf()` itself — there's no UI "jump to end" button that seeks to `sessionPlayerData.end`. Checked all `seekToTimestamp` callers.

Updated the existing `isPastEnd` comment block to explain the strictness requirement, so the next person who touches this doesn't accidentally regress it to `>=`.

## How did you test this code?

One new unit test in `sessionRecordingPlayerLogic.test.ts`:

- **handles out-of-range ?t= parameter without leaving player in endReached state** — pushes `/replay/2?t=999` (999s against a ~12s mock recording), mounts the logic, and asserts `currentSegment` has a valid `windowId`, `currentTimestamp` is within `[start, end]`, and `endReached === false`.

I verified the test fails when the fix is reverted (`>` → `>=`). Without the fix, `currentSegment?.windowId` comes back `undefined` because the listener chain takes a different branch after `setEndReached` fires, leaving the player in the stuck state this PR fixes.

I'm an agent — I have not tested this manually in the browser beyond the automated unit test above. Manual verification in a real browser (e.g. visiting a recording with a past-end `?t=` param and confirming the replayer auto-initializes without clicking play) would be valuable before merging. (Human input: this is difficult — I have not been able to easily recreate the production conditions in my local setup after half a day of tinkering.)

## Publish to changelog?

no

## 🤖 LLM context

Co-authored with Claude Code (Opus 4.6). The session started as an investigation into recording export SLO failures, narrowed to a reproducible blank-frame bug, and went through several iterations before landing on the root cause. The first attempt added two workaround fixes (clamp + stale-segment refresh); a subsequent review pass identified that both symptoms traced to a single off-by-one in the `isPastEnd` check and replaced them with the one-character fix you see here. Git history analysis covered related PRs #49364, #49542, #52953, and #53550 in this area. The final regression test was verified to fail when the fix is reverted.