### PR TITLE
fix(cloud-agent): fix local docker sandbox provider

### DIFF
--- a/products/tasks/backend/services/docker_sandbox.py
+++ b/products/tasks/backend/services/docker_sandbox.py
@@ -147,6 +147,11 @@ class DockerSandbox:
 
         logger.info(f"Building {image_name} image (this may take a few minutes)...")
 
+        # The skills dist directory is populated by CI but won't exist in local
+        # dev checkouts.  The Dockerfile COPYs it unconditionally, so ensure it
+        # exists (install-skills.sh already handles the empty-dir case).
+        os.makedirs(os.path.join(str(settings.BASE_DIR), "products", "posthog_ai", "dist", "skills"), exist_ok=True)
+
         DockerSandbox._run(
             [
                 "docker",
@@ -646,8 +651,11 @@ class DockerSandbox:
             org, repo = repository.lower().split("/")
             repo_path = f"/tmp/workspace/repos/{org}/{repo}"
 
-        if allowed_domains:
-            self._setup_agentsh(WORKING_DIR, allowed_domains)
+        # TODO: Re-enable agentsh egress enforcement in the Docker sandbox once
+        # agentsh works reliably inside local Docker containers.
+        # For now we skip setup and ignore allowed_domains so that callers
+        # (signals, tasks, etc.) don't need to hotfix around Docker failures.
+        allowed_domains = None
 
         mcp_servers_arg = ""
         if mcp_configs:

--- a/products/tasks/backend/services/test_docker_sandbox.py
+++ b/products/tasks/backend/services/test_docker_sandbox.py
@@ -246,7 +246,8 @@ class TestDockerSandboxUnit:
         assert "nohup" in command
         assert "./node_modules/.bin/agent-server" in command
 
-    def test_start_agent_server_passes_allowed_domains(self):
+    def test_start_agent_server_ignores_allowed_domains_in_docker(self):
+        """allowed_domains is intentionally ignored in Docker sandbox until agentsh works reliably."""
         sandbox = DockerSandbox.__new__(DockerSandbox)
         sandbox._container_id = "abc123"
         sandbox.id = "abc123"
@@ -268,11 +269,10 @@ class TestDockerSandboxUnit:
                         allowed_domains=["example.com"],
                     )
 
-        mock_setup_agentsh.assert_called_once_with("/tmp/workspace", ["example.com"])
+        mock_setup_agentsh.assert_not_called()
         command = mock_execute.call_args_list[0][0][0]
-        assert "--allowedDomains" in command
-        assert "agentsh exec" in command
-        assert "env -0 > /tmp/agent-env" in command
+        assert "--allowedDomains" not in command
+        assert "agentsh exec" not in command
 
 
 @pytest.mark.skipif(is_ci() or not docker_available(), reason="Docker sandbox tests only run locally, not in CI")


### PR DESCRIPTION
## Problem

local docker sandbox `agentsh` is not reliable, let's skip so folks locally are not blocked.

## Changes

* unblocked policy enforcements
* fixed missing skill folder (if needed) so we don't fail silently