### PR TITLE
chore(claude-code): install deps in sandboxes

### DIFF
--- a/.claude/hooks/install-tool-versions.sh
+++ b/.claude/hooks/install-tool-versions.sh
@@ -13,14 +13,47 @@ ARCH="$(uname -m)"
 CACHE_DIR="/opt/.tool-version-cache"
 mkdir -p "$CACHE_DIR"
 
-# --- Helper ---
-version_from_file() {
-    local file="$1" pattern="$2"
-    grep -oP "$pattern" "$file" 2>/dev/null | head -1
-}
+# --- Parse versions from config files using Python for reliable TOML/JSON parsing ---
+read -r REQUIRED_UV REQUIRED_PYTHON REQUIRED_PNPM < <(python3 -c "
+import json, re, sys
+try:
+    import tomllib
+except ImportError:
+    try:
+        import tomli as tomllib
+    except ImportError:
+        tomllib = None
+
+uv_ver = python_ver = pnpm_ver = ''
+
+# Parse pyproject.toml
+if tomllib:
+    try:
+        with open('$PROJECT_DIR/pyproject.toml', 'rb') as f:
+            data = tomllib.load(f)
+        # uv required-version: strip specifier prefix (~=, >=, ==, etc.)
+        raw = data.get('tool', {}).get('uv', {}).get('required-version', '')
+        uv_ver = re.sub(r'^[~><=!]+', '', raw)
+        # requires-python: strip specifier prefix
+        raw = data.get('project', {}).get('requires-python', '')
+        python_ver = re.sub(r'^[~><=!]+', '', raw)
+    except Exception:
+        pass
+
+# Parse package.json
+try:
+    with open('$PROJECT_DIR/package.json') as f:
+        pkg = json.load(f)
+    pm = pkg.get('packageManager', '')
+    if '@' in pm:
+        pnpm_ver = pm.split('@', 1)[1]
+except Exception:
+    pass
+
+print(uv_ver, python_ver, pnpm_ver)
+" 2>/dev/null || echo "")
 
 # --- 1. Upgrade uv ---
-REQUIRED_UV=$(version_from_file "$PROJECT_DIR/pyproject.toml" '(?<=required-version = "~=)[0-9.]+')
 CURRENT_UV=$(uv --version 2>/dev/null | grep -oP '[0-9]+\.[0-9]+\.[0-9]+' || echo "0.0.0")
 
 if [ -n "$REQUIRED_UV" ]; then
@@ -57,8 +90,6 @@ if [ -n "$REQUIRED_UV" ]; then
 fi
 
 # --- 2. Install Python via uv ---
-REQUIRED_PYTHON=$(version_from_file "$PROJECT_DIR/pyproject.toml" '(?<=requires-python = "==)[0-9.]+')
-
 if [ -n "$REQUIRED_PYTHON" ]; then
     if ! uv python find "$REQUIRED_PYTHON" >/dev/null 2>&1; then
         echo "Installing Python $REQUIRED_PYTHON via uv..."
@@ -107,8 +138,6 @@ if [ -n "$NODE_VERSION" ]; then
     fi
 
     # --- 4. Install pnpm via npm ---
-    REQUIRED_PNPM=$(version_from_file "$PROJECT_DIR/package.json" '(?<="packageManager": "pnpm@)[0-9.]+')
-
     if [ -n "$REQUIRED_PNPM" ] && [ -x "$NODE_DIR/bin/npm" ]; then
         CURRENT_PNPM=$("$NODE_DIR/bin/pnpm" --version 2>/dev/null || echo "")
         if [ "$CURRENT_PNPM" != "$REQUIRED_PNPM" ]; then

--- a/.claude/hooks/install-tool-versions.sh
+++ b/.claude/hooks/install-tool-versions.sh
@@ -1,0 +1,132 @@
+#!/bin/bash
+# SessionStart hook: install correct tool versions in sandbox Claude Code.
+# Only runs when CLAUDE_CODE_REMOTE=true (cloud/sandbox environment).
+
+if [ "$CLAUDE_CODE_REMOTE" != "true" ]; then
+    exit 0
+fi
+
+set -euo pipefail
+
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(pwd)}"
+ARCH="$(uname -m)"
+CACHE_DIR="/opt/.tool-version-cache"
+mkdir -p "$CACHE_DIR"
+
+# --- Helper ---
+version_from_file() {
+    local file="$1" pattern="$2"
+    grep -oP "$pattern" "$file" 2>/dev/null | head -1
+}
+
+# --- 1. Upgrade uv ---
+REQUIRED_UV=$(version_from_file "$PROJECT_DIR/pyproject.toml" '(?<=required-version = "~=)[0-9.]+')
+CURRENT_UV=$(uv --version 2>/dev/null | grep -oP '[0-9]+\.[0-9]+\.[0-9]+' || echo "0.0.0")
+
+if [ -n "$REQUIRED_UV" ]; then
+    # ~= means compatible release: ~=0.10.2 allows >=0.10.2, <0.11.0
+    REQ_MAJOR_MINOR=$(echo "$REQUIRED_UV" | cut -d. -f1,2)
+    CUR_MAJOR_MINOR=$(echo "$CURRENT_UV" | cut -d. -f1,2)
+    if [ "$CUR_MAJOR_MINOR" != "$REQ_MAJOR_MINOR" ] || [ "$(printf '%s\n' "$REQUIRED_UV" "$CURRENT_UV" | sort -V | head -1)" != "$REQUIRED_UV" ]; then
+        echo "Upgrading uv from $CURRENT_UV (need ~=$REQUIRED_UV)..."
+        # Find latest compatible patch version from GitHub releases
+        TARGET_UV=$(curl -fsSL "https://api.github.com/repos/astral-sh/uv/releases?per_page=30" 2>/dev/null \
+            | grep -oP '"tag_name": "\K[0-9.]+' \
+            | grep "^${REQ_MAJOR_MINOR}\." \
+            | head -1)
+        TARGET_UV="${TARGET_UV:-$REQUIRED_UV}"
+
+        # Download binary directly from GitHub (uv self update doesn't work across major.minor)
+        UV_BIN_DIR=$(dirname "$(command -v uv 2>/dev/null || echo "/root/.local/bin/uv")")
+        case "$ARCH" in
+            x86_64)  UV_ARCH="x86_64-unknown-linux-gnu" ;;
+            aarch64) UV_ARCH="aarch64-unknown-linux-gnu" ;;
+            *)       UV_ARCH="$ARCH-unknown-linux-gnu" ;;
+        esac
+        TMP_UV=$(mktemp -d)
+        if curl -fsSL "https://github.com/astral-sh/uv/releases/download/${TARGET_UV}/uv-${UV_ARCH}.tar.gz" -o "$TMP_UV/uv.tar.gz" 2>/dev/null; then
+            tar -xzf "$TMP_UV/uv.tar.gz" -C "$TMP_UV"
+            cp "$TMP_UV/uv-${UV_ARCH}/uv" "$UV_BIN_DIR/uv"
+            cp "$TMP_UV/uv-${UV_ARCH}/uvx" "$UV_BIN_DIR/uvx" 2>/dev/null || true
+            echo "uv upgraded to $(uv --version 2>/dev/null)"
+        else
+            echo "Warning: Failed to download uv $TARGET_UV" >&2
+        fi
+        rm -rf "$TMP_UV"
+    fi
+fi
+
+# --- 2. Install Python via uv ---
+REQUIRED_PYTHON=$(version_from_file "$PROJECT_DIR/pyproject.toml" '(?<=requires-python = "==)[0-9.]+')
+
+if [ -n "$REQUIRED_PYTHON" ]; then
+    if ! uv python find "$REQUIRED_PYTHON" >/dev/null 2>&1; then
+        echo "Installing Python $REQUIRED_PYTHON via uv..."
+        uv python install "$REQUIRED_PYTHON" 2>/dev/null || true
+    fi
+fi
+
+# --- 3. Install Node ---
+NODE_VERSION=""
+if [ -f "$PROJECT_DIR/.nvmrc" ]; then
+    NODE_VERSION=$(cat "$PROJECT_DIR/.nvmrc" | tr -d '[:space:]')
+    # Strip leading 'v' if present
+    NODE_VERSION="${NODE_VERSION#v}"
+fi
+
+if [ -n "$NODE_VERSION" ]; then
+    NODE_MAJOR=$(echo "$NODE_VERSION" | cut -d. -f1)
+    NODE_DIR="/opt/node${NODE_MAJOR}"
+
+    CURRENT_NODE=$("$NODE_DIR/bin/node" --version 2>/dev/null | tr -d 'v' || echo "")
+
+    if [ "$CURRENT_NODE" != "$NODE_VERSION" ]; then
+        echo "Installing Node v${NODE_VERSION}..."
+
+        # Determine arch for download
+        case "$ARCH" in
+            x86_64)  NODE_ARCH="x64" ;;
+            aarch64) NODE_ARCH="arm64" ;;
+            *)       NODE_ARCH="$ARCH" ;;
+        esac
+
+        TARBALL="node-v${NODE_VERSION}-linux-${NODE_ARCH}.tar.xz"
+        URL="https://nodejs.org/dist/v${NODE_VERSION}/${TARBALL}"
+        TMP_DIR=$(mktemp -d)
+
+        if wget -q -O "$TMP_DIR/$TARBALL" "$URL" 2>/dev/null || curl -fsSL -o "$TMP_DIR/$TARBALL" "$URL" 2>/dev/null; then
+            rm -rf "$NODE_DIR"
+            mkdir -p "$NODE_DIR"
+            tar -xJf "$TMP_DIR/$TARBALL" -C "$NODE_DIR" --strip-components=1
+            echo "Node v${NODE_VERSION} installed to $NODE_DIR"
+        else
+            echo "Warning: Failed to download Node v${NODE_VERSION}" >&2
+        fi
+
+        rm -rf "$TMP_DIR"
+    fi
+
+    # --- 4. Install pnpm via npm ---
+    REQUIRED_PNPM=$(version_from_file "$PROJECT_DIR/package.json" '(?<="packageManager": "pnpm@)[0-9.]+')
+
+    if [ -n "$REQUIRED_PNPM" ] && [ -x "$NODE_DIR/bin/npm" ]; then
+        CURRENT_PNPM=$("$NODE_DIR/bin/pnpm" --version 2>/dev/null || echo "")
+        if [ "$CURRENT_PNPM" != "$REQUIRED_PNPM" ]; then
+            echo "Installing pnpm@${REQUIRED_PNPM}..."
+            "$NODE_DIR/bin/npm" --prefix "$NODE_DIR" install -g "pnpm@${REQUIRED_PNPM}" 2>/dev/null || true
+        fi
+    fi
+
+    # --- 5. Update PATH for this session ---
+    # Prepend the new node dir so it takes precedence over older versions
+    export PATH="$NODE_DIR/bin:$PATH"
+fi
+
+# Write env updates to CLAUDE_ENV_FILE if available (SessionStart only)
+if [ -n "${CLAUDE_ENV_FILE:-}" ]; then
+    {
+        [ -n "$NODE_VERSION" ] && echo "export PATH=\"/opt/node${NODE_MAJOR}/bin:\$PATH\""
+    } >> "$CLAUDE_ENV_FILE"
+fi
+
+exit 0

--- a/.claude/hooks/install-tool-versions.sh
+++ b/.claude/hooks/install-tool-versions.sh
@@ -10,8 +10,6 @@ set -euo pipefail
 
 PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(pwd)}"
 ARCH="$(uname -m)"
-CACHE_DIR="/opt/.tool-version-cache"
-mkdir -p "$CACHE_DIR"
 
 # --- Parse versions from config files using Python for reliable TOML/JSON parsing ---
 read -r REQUIRED_UV REQUIRED_PYTHON REQUIRED_PNPM < <(python3 -c "

--- a/.claude/hooks/setup-cloud.sh
+++ b/.claude/hooks/setup-cloud.sh
@@ -6,8 +6,19 @@ fi
 
 cd "$CLAUDE_PROJECT_DIR"
 
-# hogli needs click, bin/ruff.sh needs ruff (no flox in sandbox)
-python3 -m pip install click ruff 2>/dev/null
+# Install correct tool versions (uv, Python, Node, pnpm) if needed
+if [ -x .claude/hooks/install-tool-versions.sh ]; then
+    .claude/hooks/install-tool-versions.sh
+fi
+
+# Pick up the correct Node version
+NODE_MAJOR=$(cat .nvmrc 2>/dev/null | tr -d 'v[:space:]' | cut -d. -f1)
+if [ -n "$NODE_MAJOR" ] && [ -d "/opt/node${NODE_MAJOR}/bin" ]; then
+    export PATH="/opt/node${NODE_MAJOR}/bin:$PATH"
+fi
+
+# Sync Python dependencies (installs click, ruff, etc. from pyproject.toml)
+uv sync 2>/dev/null
 # Root-only install: linting tools + husky, skips full workspace
 pnpm install --frozen-lockfile --filter=. 2>/dev/null
 

--- a/.claude/hooks/setup-cloud.sh
+++ b/.claude/hooks/setup-cloud.sh
@@ -11,7 +11,8 @@ if [ -x .claude/hooks/install-tool-versions.sh ]; then
     .claude/hooks/install-tool-versions.sh
 fi
 
-# Pick up the correct Node version
+# install-tool-versions.sh runs in a subprocess so its PATH export doesn't propagate here;
+# re-apply it explicitly so pnpm below sees the right node.
 NODE_MAJOR=$(cat .nvmrc 2>/dev/null | tr -d 'v[:space:]' | cut -d. -f1)
 if [ -n "$NODE_MAJOR" ] && [ -d "/opt/node${NODE_MAJOR}/bin" ]; then
     export PATH="/opt/node${NODE_MAJOR}/bin:$PATH"


### PR DESCRIPTION
## Problem

When Claude Code runs in a cloud/sandbox environment, it needs to ensure the correct versions of development tools (uv, Python, Node, pnpm) are installed to match the project's requirements. Previously, the setup only installed basic dependencies via pip, which didn't account for version-specific requirements defined in project configuration files.

Deps:

<img width="727" height="661" alt="Screenshot 2026-04-08 at 13 37 19" src="https://github.com/user-attachments/assets/6c6f7e2f-e367-41d0-bedc-ad7b5c670eb2" />

Oxfmt:

<img width="735" height="318" alt="Screenshot 2026-04-08 at 13 50 26" src="https://github.com/user-attachments/assets/87660d46-4cce-4064-9fe6-6f6b4923a38c" />

Ruff:

<img width="726" height="451" alt="Screenshot 2026-04-08 at 13 50 20" src="https://github.com/user-attachments/assets/a1f3b22d-be15-4a96-bf72-83894213d551" />


## Changes

Added a new `install-tool-versions.sh` hook that:
- Parses version requirements from `pyproject.toml` (uv, Python) and `package.json` (pnpm) using Python for reliable TOML/JSON parsing
- Upgrades uv to the required version by downloading the correct binary from GitHub releases
- Installs the required Python version via uv
- Installs the required Node version from nodejs.org based on `.nvmrc`
- Installs the required pnpm version via npm
- Updates the session PATH to use the newly installed Node version

Updated `setup-cloud.sh` to:
- Call the new `install-tool-versions.sh` hook during SessionStart
- Use `uv sync` instead of raw pip install to properly install Python dependencies from `pyproject.toml`
- Ensure the correct Node version is in PATH before running pnpm

The hook only runs when `CLAUDE_CODE_REMOTE=true` (cloud environment) and gracefully handles missing configuration files or download failures.

## How did you test this code?

This is a new hook for the cloud sandbox environment. The implementation:
- Uses standard shell scripting with proper error handling (`set -euo pipefail`)
- Follows existing patterns in the codebase for tool installation
- Gracefully degrades if downloads fail or config files are missing
- Only activates in cloud environments via the `CLAUDE_CODE_REMOTE` guard

The changes are straightforward tool installation logic that will be validated by actual usage in the cloud environment.

## Publish to changelog?

No

https://claude.ai/code/session_019dRJKZBnNPgi797dnxpBeN