### PR TITLE
refactor(insights): rename and split property math selector components

### DIFF
--- a/frontend/src/scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow.tsx
+++ b/frontend/src/scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow.tsx
@@ -45,9 +45,10 @@ import {
 
 import { ActionFilterRowMenu } from './ActionFilterRowMenu'
 import { getValue, taxonomicFilterGroupTypeToEntityType } from './actionFilterRowUtils'
+import { BoxPlotPropertySelector } from './BoxPlotPropertySelector'
 import { HogQLMathEditorDropdown } from './HogQLMathEditor'
 import { MathSelector } from './MathSelector'
-import { BoxPlotPropertySelector, PropertyValueMathSelector } from './PropertyMathSelector'
+import { PropertyValueMathSelector } from './PropertyValueMathSelector'
 import type { ActionFilterRowProps } from './types'
 import { MathAvailability } from './types'
 

--- a/frontend/src/scenes/insights/filters/ActionFilter/ActionFilterRow/BoxPlotPropertySelector.tsx
+++ b/frontend/src/scenes/insights/filters/ActionFilter/ActionFilterRow/BoxPlotPropertySelector.tsx
@@ -1,0 +1,50 @@
+import { PropertyKeyInfo } from 'lib/components/PropertyKeyInfo'
+import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
+import { TaxonomicStringPopover } from 'lib/components/TaxonomicPopover/TaxonomicPopover'
+
+interface BoxPlotPropertySelectorProps {
+    /** The currently selected taxonomic group for the box plot property, e.g. session or person properties. */
+    mathPropertyType: TaxonomicFilterGroupType | null | undefined
+    /** The currently selected numeric property key for the box plot calculation. */
+    mathProperty: string | null | undefined
+    /** The row index used when reporting selection changes back to the parent filter list. */
+    index: number
+    /** Called when the user selects a property and its taxonomic group. */
+    onMathPropertySelect: (index: number, value: string, groupType: TaxonomicFilterGroupType) => void
+    /** The event or action name used to scope property suggestions shown in the picker. */
+    mathName: string | null | undefined
+}
+
+export function BoxPlotPropertySelector({
+    mathPropertyType,
+    mathProperty,
+    index,
+    onMathPropertySelect,
+    mathName,
+}: BoxPlotPropertySelectorProps): JSX.Element {
+    return (
+        <div className="flex-auto min-w-0">
+            <TaxonomicStringPopover
+                groupType={mathPropertyType || TaxonomicFilterGroupType.NumericalEventProperties}
+                groupTypes={[
+                    TaxonomicFilterGroupType.NumericalEventProperties,
+                    TaxonomicFilterGroupType.SessionProperties,
+                    TaxonomicFilterGroupType.PersonProperties,
+                ]}
+                value={mathProperty || undefined}
+                onChange={(currentValue, groupType) => onMathPropertySelect(index, currentValue, groupType)}
+                eventNames={mathName ? [mathName] : []}
+                placeholder="Select numeric property"
+                data-attr="box-plot-property-select"
+                showNumericalPropsOnly
+                renderValue={(currentValue) => (
+                    <PropertyKeyInfo
+                        value={currentValue}
+                        disablePopover
+                        type={TaxonomicFilterGroupType.EventProperties}
+                    />
+                )}
+            />
+        </div>
+    )
+}

--- a/frontend/src/scenes/insights/filters/ActionFilter/ActionFilterRow/PropertyValueMathSelector.tsx
+++ b/frontend/src/scenes/insights/filters/ActionFilter/ActionFilterRow/PropertyValueMathSelector.tsx
@@ -5,46 +5,7 @@ import { Tooltip } from 'lib/lemon-ui/Tooltip'
 
 import { DatabaseSchemaField } from '~/queries/schema/schema-general'
 
-type BoxPlotPropertySelectorProps = Pick<
-    PropertyMathSelectorProps,
-    'mathPropertyType' | 'mathProperty' | 'index' | 'onMathPropertySelect' | 'mathName'
->
-
-export function BoxPlotPropertySelector({
-    mathPropertyType,
-    mathProperty,
-    index,
-    onMathPropertySelect,
-    mathName,
-}: BoxPlotPropertySelectorProps): JSX.Element {
-    return (
-        <div className="flex-auto min-w-0">
-            <TaxonomicStringPopover
-                groupType={mathPropertyType || TaxonomicFilterGroupType.NumericalEventProperties}
-                groupTypes={[
-                    TaxonomicFilterGroupType.NumericalEventProperties,
-                    TaxonomicFilterGroupType.SessionProperties,
-                    TaxonomicFilterGroupType.PersonProperties,
-                ]}
-                value={mathProperty || undefined}
-                onChange={(currentValue, groupType) => onMathPropertySelect(index, currentValue, groupType)}
-                eventNames={mathName ? [mathName] : []}
-                placeholder="Select numeric property"
-                data-attr="box-plot-property-select"
-                showNumericalPropsOnly
-                renderValue={(currentValue) => (
-                    <PropertyKeyInfo
-                        value={currentValue}
-                        disablePopover
-                        type={TaxonomicFilterGroupType.EventProperties}
-                    />
-                )}
-            />
-        </div>
-    )
-}
-
-interface PropertyMathSelectorProps {
+interface PropertyValueMathSelectorProps {
     /** The currently selected taxonomic group for the math property, e.g. session or person properties. */
     mathPropertyType: TaxonomicFilterGroupType | null | undefined
     /** The set of taxonomic groups the picker should allow the user to choose math properties from. */
@@ -53,7 +14,9 @@ interface PropertyMathSelectorProps {
     mathProperty: string | null | undefined
     /** The event or action name used to scope property suggestions shown in the picker. */
     mathName: string | null | undefined
+    /** The row index used when reporting selection changes back to the parent filter list. */
     index: number
+    /** Called when the user selects a property and its taxonomic group. */
     onMathPropertySelect: (index: number, value: string, groupType: TaxonomicFilterGroupType) => void
     showNumericalPropsOnly?: boolean
     /** Available schema fields for data warehouse property suggestions when the picker is scoped to a table. */
@@ -72,7 +35,7 @@ export function PropertyValueMathSelector({
     showNumericalPropsOnly,
     schemaColumns,
     mathDisplayName,
-}: PropertyMathSelectorProps): JSX.Element {
+}: PropertyValueMathSelectorProps): JSX.Element {
     return (
         <div className="flex-auto min-w-0">
             <TaxonomicStringPopover


### PR DESCRIPTION
## Problem

Two components in one file + filename didn't match component.

## Changes

Fixes this.

## How did you test this code?

n/a