### PR TITLE
fix(insights): stop month interval from including events before date_from

### DIFF
--- a/posthog/hogql_queries/insights/trends/test/__snapshots__/test_boxplot_trends_query_runner.ambr
+++ b/posthog/hogql_queries/insights/trends/test/__snapshots__/test_boxplot_trends_query_runner.ambr
@@ -134,7 +134,7 @@
          max(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'revenue'), ''), 'null'), '^"|"$', ''), 'Float64')) AS max_val,
          avg(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'revenue'), ''), 'null'), '^"|"$', ''), 'Float64')) AS mean_val
   FROM events AS e
-  WHERE and(equals(e.team_id, 99999), greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toStartOfInterval(assumeNotNull(toDateTime('2023-10-01 00:00:00', 'UTC')), toIntervalMonth(1))), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-31 23:59:59', 'UTC'))))
+  WHERE and(equals(e.team_id, 99999), greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toStartOfInterval(assumeNotNull(toDateTime('2023-10-01 00:00:00', 'UTC')), toIntervalDay(1))), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-31 23:59:59', 'UTC'))))
   GROUP BY day_start
   ORDER BY day_start ASC
   LIMIT 100 SETTINGS readonly=2,
@@ -266,6 +266,56 @@
                      use_hive_partitioning=0
   '''
 # ---
+# name: TestBoxPlotTrendsQueryRunner.test_multiple_series_returns_data_for_each
+  '''
+  SELECT toStartOfDay(toTimeZone(e.timestamp, 'UTC')) AS day_start,
+         min(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'revenue'), ''), 'null'), '^"|"$', ''), 'Float64')) AS min_val,
+         quantile(0.25)(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'revenue'), ''), 'null'), '^"|"$', ''), 'Float64')) AS p25,
+         quantile(0.5)(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'revenue'), ''), 'null'), '^"|"$', ''), 'Float64')) AS median_val,
+         quantile(0.75)(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'revenue'), ''), 'null'), '^"|"$', ''), 'Float64')) AS p75,
+         max(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'revenue'), ''), 'null'), '^"|"$', ''), 'Float64')) AS max_val,
+         avg(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'revenue'), ''), 'null'), '^"|"$', ''), 'Float64')) AS mean_val
+  FROM events AS e
+  WHERE and(equals(e.team_id, 99999), greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toStartOfInterval(assumeNotNull(toDateTime('2023-12-02 00:00:00', 'UTC')), toIntervalDay(1))), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 23:59:59', 'UTC'))))
+  GROUP BY day_start
+  ORDER BY day_start ASC
+  LIMIT 100 SETTINGS readonly=2,
+                     max_execution_time=60,
+                     allow_experimental_object_type=1,
+                     max_ast_elements=4000000,
+                     max_expanded_ast_elements=4000000,
+                     max_bytes_before_external_group_by=0,
+                     transform_null_in=1,
+                     optimize_min_equality_disjunction_chain_length=4294967295,
+                     allow_experimental_join_condition=1,
+                     use_hive_partitioning=0
+  '''
+# ---
+# name: TestBoxPlotTrendsQueryRunner.test_multiple_series_returns_data_for_each.1
+  '''
+  SELECT toStartOfDay(toTimeZone(e.timestamp, 'UTC')) AS day_start,
+         min(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'other_prop'), ''), 'null'), '^"|"$', ''), 'Float64')) AS min_val,
+         quantile(0.25)(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'other_prop'), ''), 'null'), '^"|"$', ''), 'Float64')) AS p25,
+         quantile(0.5)(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'other_prop'), ''), 'null'), '^"|"$', ''), 'Float64')) AS median_val,
+         quantile(0.75)(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'other_prop'), ''), 'null'), '^"|"$', ''), 'Float64')) AS p75,
+         max(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'other_prop'), ''), 'null'), '^"|"$', ''), 'Float64')) AS max_val,
+         avg(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'other_prop'), ''), 'null'), '^"|"$', ''), 'Float64')) AS mean_val
+  FROM events AS e
+  WHERE and(equals(e.team_id, 99999), greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toStartOfInterval(assumeNotNull(toDateTime('2023-12-02 00:00:00', 'UTC')), toIntervalDay(1))), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 23:59:59', 'UTC'))), equals(e.event, 'other_event'))
+  GROUP BY day_start
+  ORDER BY day_start ASC
+  LIMIT 100 SETTINGS readonly=2,
+                     max_execution_time=60,
+                     allow_experimental_object_type=1,
+                     max_ast_elements=4000000,
+                     max_expanded_ast_elements=4000000,
+                     max_bytes_before_external_group_by=0,
+                     transform_null_in=1,
+                     optimize_min_equality_disjunction_chain_length=4294967295,
+                     allow_experimental_join_condition=1,
+                     use_hive_partitioning=0
+  '''
+# ---
 # name: TestBoxPlotTrendsQueryRunner.test_multiple_users_aggregate_within_same_day
   '''
   SELECT toStartOfDay(toTimeZone(e.timestamp, 'UTC')) AS day_start,
@@ -352,56 +402,6 @@
          avg(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'revenue'), ''), 'null'), '^"|"$', ''), 'Float64')) AS mean_val
   FROM events AS e
   WHERE and(equals(e.team_id, 99999), greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toStartOfInterval(assumeNotNull(toDateTime('2023-12-02 00:00:00', 'UTC')), toIntervalDay(1))), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 23:59:59', 'UTC'))))
-  GROUP BY day_start
-  ORDER BY day_start ASC
-  LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
-                     allow_experimental_object_type=1,
-                     max_ast_elements=4000000,
-                     max_expanded_ast_elements=4000000,
-                     max_bytes_before_external_group_by=0,
-                     transform_null_in=1,
-                     optimize_min_equality_disjunction_chain_length=4294967295,
-                     allow_experimental_join_condition=1,
-                     use_hive_partitioning=0
-  '''
-# ---
-# name: TestBoxPlotTrendsQueryRunner.test_multiple_series_returns_data_for_each
-  '''
-  SELECT toStartOfDay(toTimeZone(e.timestamp, 'UTC')) AS day_start,
-         min(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'revenue'), ''), 'null'), '^"|"$', ''), 'Float64')) AS min_val,
-         quantile(0.25)(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'revenue'), ''), 'null'), '^"|"$', ''), 'Float64')) AS p25,
-         quantile(0.5)(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'revenue'), ''), 'null'), '^"|"$', ''), 'Float64')) AS median_val,
-         quantile(0.75)(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'revenue'), ''), 'null'), '^"|"$', ''), 'Float64')) AS p75,
-         max(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'revenue'), ''), 'null'), '^"|"$', ''), 'Float64')) AS max_val,
-         avg(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'revenue'), ''), 'null'), '^"|"$', ''), 'Float64')) AS mean_val
-  FROM events AS e
-  WHERE and(equals(e.team_id, 99999), greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toStartOfInterval(assumeNotNull(toDateTime('2023-12-02 00:00:00', 'UTC')), toIntervalDay(1))), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 23:59:59', 'UTC'))))
-  GROUP BY day_start
-  ORDER BY day_start ASC
-  LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
-                     allow_experimental_object_type=1,
-                     max_ast_elements=4000000,
-                     max_expanded_ast_elements=4000000,
-                     max_bytes_before_external_group_by=0,
-                     transform_null_in=1,
-                     optimize_min_equality_disjunction_chain_length=4294967295,
-                     allow_experimental_join_condition=1,
-                     use_hive_partitioning=0
-  '''
-# ---
-# name: TestBoxPlotTrendsQueryRunner.test_multiple_series_returns_data_for_each.1
-  '''
-  SELECT toStartOfDay(toTimeZone(e.timestamp, 'UTC')) AS day_start,
-         min(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'other_prop'), ''), 'null'), '^"|"$', ''), 'Float64')) AS min_val,
-         quantile(0.25)(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'other_prop'), ''), 'null'), '^"|"$', ''), 'Float64')) AS p25,
-         quantile(0.5)(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'other_prop'), ''), 'null'), '^"|"$', ''), 'Float64')) AS median_val,
-         quantile(0.75)(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'other_prop'), ''), 'null'), '^"|"$', ''), 'Float64')) AS p75,
-         max(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'other_prop'), ''), 'null'), '^"|"$', ''), 'Float64')) AS max_val,
-         avg(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'other_prop'), ''), 'null'), '^"|"$', ''), 'Float64')) AS mean_val
-  FROM events AS e
-  WHERE and(equals(e.team_id, 99999), greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toStartOfInterval(assumeNotNull(toDateTime('2023-12-02 00:00:00', 'UTC')), toIntervalDay(1))), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 23:59:59', 'UTC'))), equals(e.event, 'other_event'))
   GROUP BY day_start
   ORDER BY day_start ASC
   LIMIT 100 SETTINGS readonly=2,

--- a/posthog/hogql_queries/insights/trends/test/test_trends.py
+++ b/posthog/hogql_queries/insights/trends/test/test_trends.py
@@ -2505,7 +2505,7 @@ class TestTrends(ClickhouseTestMixin, APIBaseTest):
         self._test_events_with_dates(
             dates=["2020-06-2", "2020-07-30"],
             interval="month",
-            date_from="2020-6-7",  # should round down to 6-1
+            date_from="2020-6-7",  # rounds labels down to 6-1 but only includes events after date_from
             date_to="2020-7-30",
             result=[
                 {
@@ -2522,8 +2522,8 @@ class TestTrends(ClickhouseTestMixin, APIBaseTest):
                         "properties": [],
                     },
                     "label": "event_name",
-                    "count": 2.0,
-                    "data": [1.0, 1.0],
+                    "count": 1.0,
+                    "data": [0.0, 1.0],
                     "labels": ["Jun 2020", "Jul 2020"],
                     "days": ["2020-06-01", "2020-07-01"],
                 }

--- a/posthog/hogql_queries/insights/trends/test/test_trends_query_runner.py
+++ b/posthog/hogql_queries/insights/trends/test/test_trends_query_runner.py
@@ -6438,7 +6438,7 @@ class TestTrendsQueryRunner(ClickhouseTestMixin, APIBaseTest):
             )
         flush_persons_and_events()
 
-        # Test 1: Without explicitDate, filtering last 7 days with monthly interval includes entire month
+        # Test 1: Without explicitDate, filtering last 7 days with monthly interval only includes events within range
         with freeze_time("2020-01-31 23:59:59"):
             response_default = TrendsQueryRunner(
                 query=TrendsQuery(
@@ -6451,9 +6451,9 @@ class TestTrendsQueryRunner(ClickhouseTestMixin, APIBaseTest):
 
         self.assertEqual(1, len(response_default.results))
         self.assertEqual(
-            31,
+            8,
             response_default.results[0]["count"],
-            "Without explicitDate, includes entire month due to interval boundary adjustment",
+            "Without explicitDate, only includes events within the date range, not the entire month",
         )
 
         # Test 2: With explicitDate=True and explicit dates, STILL has issues (gets 6 instead of 7)

--- a/posthog/hogql_queries/utils/query_date_range.py
+++ b/posthog/hogql_queries/utils/query_date_range.py
@@ -332,15 +332,16 @@ class QueryDateRange:
         return self.date_to_start_of_interval_hogql(self.date_from_as_hogql())
 
     def date_from_with_adjusted_start_of_interval_hogql(self) -> ast.Call:
-        if self.interval_name == "week":
-            # in `where` queries with week intervals, we need to return the date_from instead of the start of the week
-            # this ensures that we only fetch records after the date_from
+        if self.interval_name in ("week", "month"):
+            # in `where` queries with week/month intervals, we need to return the date_from instead of the
+            # start of the week/month — this ensures that we only fetch records after the date_from,
+            # not from the beginning of the interval period
             return ast.Call(
                 name="toStartOfInterval",
                 args=[
                     self.date_from_as_hogql(),
                     ast.Call(
-                        name=f"toIntervalDay",
+                        name="toIntervalDay",
                         args=[ast.Constant(value=1)],
                     ),
                 ],

--- a/posthog/hogql_queries/utils/query_date_range.py
+++ b/posthog/hogql_queries/utils/query_date_range.py
@@ -332,7 +332,7 @@ class QueryDateRange:
         return self.date_to_start_of_interval_hogql(self.date_from_as_hogql())
 
     def date_from_with_adjusted_start_of_interval_hogql(self) -> ast.Call:
-        if self.interval_name in ("week", "month", "year"):
+        if self.interval_name in ("week", "month"):
             # in `where` queries with week/month intervals, we need to return the date_from instead of the
             # start of the week/month — this ensures that we only fetch records after the date_from,
             # not from the beginning of the interval period

--- a/posthog/hogql_queries/utils/query_date_range.py
+++ b/posthog/hogql_queries/utils/query_date_range.py
@@ -332,7 +332,7 @@ class QueryDateRange:
         return self.date_to_start_of_interval_hogql(self.date_from_as_hogql())
 
     def date_from_with_adjusted_start_of_interval_hogql(self) -> ast.Call:
-        if self.interval_name in ("week", "month"):
+        if self.interval_name in ("week", "month", "year"):
             # in `where` queries with week/month intervals, we need to return the date_from instead of the
             # start of the week/month — this ensures that we only fetch records after the date_from,
             # not from the beginning of the interval period


### PR DESCRIPTION
## Problem

When filtering an insight to "last 12 months" grouped by month, events before the actual `date_from` were included. For example, selecting "last 12 months" on April 8 would show the date range starting April 8, but events from April 1-7 were still counted because the WHERE clause rounded `date_from` back to the 1st of the month. Same issue existed for year intervals.

## Changes

- Extended the existing week-interval guard in `date_from_with_adjusted_start_of_interval_hogql` to also cover month and year intervals
- The WHERE clause now truncates to start-of-day (like weeks already do) instead of start-of-month/year
- Updated two existing tests that asserted the old buggy behavior

## How did you test this code?

Comparing 5 months vs 6 months ago with test data. First week of month 5 months ago is not included anymore. 

<img width="1296" height="677" alt="Screenshot 2026-04-08 at 15 33 37" src="https://github.com/user-attachments/assets/3d5fe4ae-7818-412f-87d1-ece12a8db8d2" />
<img width="1290" height="682" alt="Screenshot 2026-04-08 at 15 33 25" src="https://github.com/user-attachments/assets/667ddd17-6a9e-46ab-9058-81352638d835" />


## Publish to changelog?

no

## 🤖 LLM context

Authored by Claude Code. The fix mirrors the existing week-interval behavior — weeks already had this same fix applied, months and years were just missing it.