### PR TITLE
chore: personhog-router-leader metrics/fixes

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -6570,6 +6570,7 @@ dependencies = [
  "k8s-awareness",
  "k8s-openapi",
  "kube",
+ "metrics",
  "serde",
  "serde_json",
  "serial_test",

--- a/rust/common/k8s-awareness/src/watcher.rs
+++ b/rust/common/k8s-awareness/src/watcher.rs
@@ -59,6 +59,12 @@ impl K8sAwareness {
         Ok(pod_info)
     }
 
+    /// Get the cluster intent for a controller, if known.
+    pub async fn get_intent(&self, controller: &ControllerRef) -> Option<ClusterIntent> {
+        let controllers = self.controllers.read().await;
+        controllers.get(controller).cloned()
+    }
+
     /// Classify why a member is departing based on its controller's current intent.
     ///
     /// Returns `DepartureReason::Unknown` if the controller isn't being watched.

--- a/rust/personhog-coordination/Cargo.toml
+++ b/rust/personhog-coordination/Cargo.toml
@@ -9,6 +9,7 @@ assignment-coordination = { path = "../common/assignment-coordination" }
 async-trait = { workspace = true }
 etcd-client = "0.18"
 k8s-awareness = { path = "../common/k8s-awareness" }
+metrics = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/rust/personhog-coordination/src/coordinator.rs
+++ b/rust/personhog-coordination/src/coordinator.rs
@@ -1,8 +1,9 @@
 use std::collections::HashMap;
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use etcd_client::EventType;
+use metrics::{counter, gauge, histogram};
 use tokio_util::sync::CancellationToken;
 
 use assignment_coordination::store::parse_watch_value;
@@ -94,10 +95,13 @@ impl Coordinator {
 
         if !acquired {
             tracing::debug!(name = %self.config.name, "another coordinator is leader, standing by");
+            gauge!("personhog_coordinator_is_leader").set(0.0);
             return Ok(());
         }
 
         tracing::info!(name = %self.config.name, "acquired leadership");
+        gauge!("personhog_coordinator_is_leader").set(1.0);
+        counter!("personhog_coordinator_elections_total").increment(1);
 
         // Spawn lease keepalive
         let keepalive_cancel = cancel.child_token();
@@ -113,6 +117,8 @@ impl Coordinator {
         };
 
         let result = self.run_coordination_loop(cancel.clone()).await;
+
+        gauge!("personhog_coordinator_is_leader").set(0.0);
 
         // Clean up keepalive
         keepalive_cancel.cancel();
@@ -191,7 +197,7 @@ impl Coordinator {
                 _ = cancel.cancelled() => return Ok(()),
                 msg = stream.message() => {
                     let resp = msg?.ok_or_else(|| Error::invalid_state("pod watch stream ended".to_string()))?;
-                    Self::log_pod_events(&resp);
+                    Self::handle_pod_events(&resp, &store, k8s_awareness.as_deref()).await;
                 }
             }
 
@@ -203,7 +209,7 @@ impl Coordinator {
                     _ = tokio::time::sleep_until(deadline) => break,
                     msg = stream.message() => {
                         let resp = msg?.ok_or_else(|| Error::invalid_state("pod watch stream ended".to_string()))?;
-                        Self::log_pod_events(&resp);
+                        Self::handle_pod_events(&resp, &store, k8s_awareness.as_deref()).await;
                     }
                 }
             }
@@ -213,10 +219,69 @@ impl Coordinator {
         }
     }
 
-    fn log_pod_events(resp: &etcd_client::WatchResponse) {
+    /// Log pod watch events and enrich new registrations with K8s metadata.
+    ///
+    /// When a pod registers with empty generation (which is the normal case —
+    /// leader pods self-register without K8s context), the coordinator discovers
+    /// the pod's controller and generation via the K8s API and persists it back
+    /// to etcd. This is a one-time operation per pod registration.
+    async fn handle_pod_events(
+        resp: &etcd_client::WatchResponse,
+        store: &PersonhogStore,
+        k8s_awareness: Option<&K8sAwareness>,
+    ) {
         for event in resp.events() {
             match event.event_type() {
-                EventType::Put => tracing::info!("pod registered or updated"),
+                EventType::Put => {
+                    let pod: RegisteredPod = match parse_watch_value(event) {
+                        Ok(p) => p,
+                        Err(e) => {
+                            tracing::warn!(error = %e, "failed to parse pod event");
+                            continue;
+                        }
+                    };
+                    tracing::info!(pod = %pod.pod_name, status = ?pod.status, "pod registered or updated");
+
+                    if pod.generation.is_empty() {
+                        if let Some(k8s) = k8s_awareness {
+                            match k8s.discover_controller(&pod.pod_name).await {
+                                Ok(info) => {
+                                    tracing::info!(
+                                        pod = %pod.pod_name,
+                                        controller = %info.controller,
+                                        generation = %info.generation,
+                                        "discovered K8s controller for pod"
+                                    );
+                                    if let Err(e) = store
+                                        .enrich_pod_k8s(
+                                            &pod.pod_name,
+                                            &info.generation,
+                                            &info.controller,
+                                        )
+                                        .await
+                                    {
+                                        tracing::warn!(
+                                            pod = %pod.pod_name,
+                                            error = %e,
+                                            "failed to persist K8s enrichment"
+                                        );
+                                        counter!("personhog_coordinator_k8s_enrichments_total", "outcome" => "persist_error").increment(1);
+                                    } else {
+                                        counter!("personhog_coordinator_k8s_enrichments_total", "outcome" => "success").increment(1);
+                                    }
+                                }
+                                Err(e) => {
+                                    tracing::warn!(
+                                        pod = %pod.pod_name,
+                                        error = %e,
+                                        "failed to discover K8s controller, proceeding without"
+                                    );
+                                    counter!("personhog_coordinator_k8s_enrichments_total", "outcome" => "discovery_error").increment(1);
+                                }
+                            }
+                        }
+                    }
+                }
                 EventType::Delete => tracing::warn!("pod lease expired or deleted"),
             }
         }
@@ -366,6 +431,8 @@ impl Coordinator {
         strategy: &dyn AssignmentStrategy,
         k8s_awareness: Option<&K8sAwareness>,
     ) -> Result<()> {
+        let rebalance_start = Instant::now();
+
         let pods = store.list_pods().await?;
         let total_partitions = match store.get_total_partitions().await {
             Ok(n) => n,
@@ -375,6 +442,16 @@ impl Coordinator {
             }
             Err(e) => return Err(e),
         };
+
+        // Emit pod gauges
+        let ready = pods.iter().filter(|p| p.status == PodStatus::Ready).count();
+        let draining = pods.iter().filter(|p| p.status == PodStatus::Draining).count();
+        gauge!("personhog_coordinator_pods_registered", "status" => "ready").set(ready as f64);
+        gauge!("personhog_coordinator_pods_registered", "status" => "draining").set(draining as f64);
+
+        // Emit router gauge
+        let routers = store.list_routers().await.unwrap_or_default();
+        gauge!("personhog_coordinator_routers_registered").set(routers.len() as f64);
 
         let mut active_pods = active_pod_names(&pods);
 
@@ -392,6 +469,7 @@ impl Coordinator {
         // rebalances from overwriting each other. The watch_handoffs_loop will
         // re-trigger rebalancing once all handoffs complete.
         let remaining_handoffs = store.list_handoffs().await?;
+        emit_handoff_gauges(&remaining_handoffs);
         if !remaining_handoffs.is_empty() {
             tracing::info!(
                 in_flight = remaining_handoffs.len(),
@@ -434,6 +512,10 @@ impl Coordinator {
                 "writing initial assignments"
             );
             store.put_assignments(&assignment_objects).await?;
+            emit_assignment_gauges(&assignment_objects);
+            counter!("personhog_coordinator_rebalances_total").increment(1);
+            histogram!("personhog_coordinator_rebalance_duration_seconds")
+                .record(rebalance_start.elapsed().as_secs_f64());
             return Ok(());
         }
 
@@ -468,6 +550,12 @@ impl Coordinator {
             .create_assignments_and_handoffs(&stable_assignments, &handoff_objects)
             .await?;
 
+        counter!("personhog_coordinator_handoffs_total", "outcome" => "started")
+            .increment(handoff_objects.len() as u64);
+        counter!("personhog_coordinator_rebalances_total").increment(1);
+        histogram!("personhog_coordinator_rebalance_duration_seconds")
+            .record(rebalance_start.elapsed().as_secs_f64());
+
         Ok(())
     }
 
@@ -487,6 +575,7 @@ impl Coordinator {
                 );
                 store.delete_router_acks(handoff.partition).await?;
                 store.delete_handoff(handoff.partition).await?;
+                counter!("personhog_coordinator_handoffs_total", "outcome" => "stale_cleanup").increment(1);
             }
         }
 
@@ -498,12 +587,16 @@ impl Coordinator {
         handoff: &HandoffState,
     ) -> Result<()> {
         if handoff.phase == HandoffPhase::Complete {
+            let duration = util::now_seconds() - handoff.started_at;
             tracing::info!(
                 partition = handoff.partition,
+                duration_secs = duration,
                 "handoff complete, cleaning up"
             );
             store.delete_router_acks(handoff.partition).await?;
             store.delete_handoff(handoff.partition).await?;
+            counter!("personhog_coordinator_handoffs_total", "outcome" => "completed").increment(1);
+            histogram!("personhog_coordinator_handoff_duration_seconds").record(duration as f64);
         }
         Ok(())
     }
@@ -579,6 +672,27 @@ async fn filter_pods_for_k8s(
     active.sort();
     active.dedup();
     active
+}
+
+fn emit_handoff_gauges(handoffs: &[HandoffState]) {
+    let warming = handoffs.iter().filter(|h| h.phase == HandoffPhase::Warming).count();
+    let ready = handoffs.iter().filter(|h| h.phase == HandoffPhase::Ready).count();
+    let complete = handoffs.iter().filter(|h| h.phase == HandoffPhase::Complete).count();
+    gauge!("personhog_coordinator_handoffs_in_flight", "phase" => "warming").set(warming as f64);
+    gauge!("personhog_coordinator_handoffs_in_flight", "phase" => "ready").set(ready as f64);
+    gauge!("personhog_coordinator_handoffs_in_flight", "phase" => "complete").set(complete as f64);
+}
+
+fn emit_assignment_gauges(assignments: &[PartitionAssignment]) {
+    gauge!("personhog_coordinator_assigned_partitions").set(assignments.len() as f64);
+
+    let mut per_pod: HashMap<&str, u64> = HashMap::new();
+    for a in assignments {
+        *per_pod.entry(a.owner.as_str()).or_default() += 1;
+    }
+    for (pod, count) in per_pod {
+        gauge!("personhog_coordinator_partitions_per_pod", "pod" => pod.to_string()).set(count as f64);
+    }
 }
 
 #[cfg(test)]

--- a/rust/personhog-coordination/src/coordinator.rs
+++ b/rust/personhog-coordination/src/coordinator.rs
@@ -425,9 +425,7 @@ impl Coordinator {
                         partition = handoff.partition,
                         "cleaning up orphaned Complete handoff from previous leader"
                     );
-                    self.store
-                        .delete_router_acks(handoff.partition)
-                        .await?;
+                    self.store.delete_router_acks(handoff.partition).await?;
                     self.store.delete_handoff(handoff.partition).await?;
                     counter!("personhog_coordinator_handoffs_total", "outcome" => "completed")
                         .increment(1);
@@ -472,9 +470,13 @@ impl Coordinator {
 
         // Emit pod gauges
         let ready = pods.iter().filter(|p| p.status == PodStatus::Ready).count();
-        let draining = pods.iter().filter(|p| p.status == PodStatus::Draining).count();
+        let draining = pods
+            .iter()
+            .filter(|p| p.status == PodStatus::Draining)
+            .count();
         gauge!("personhog_coordinator_pods_registered", "status" => "ready").set(ready as f64);
-        gauge!("personhog_coordinator_pods_registered", "status" => "draining").set(draining as f64);
+        gauge!("personhog_coordinator_pods_registered", "status" => "draining")
+            .set(draining as f64);
 
         // Emit router gauge
         let routers = store.list_routers().await.unwrap_or_default();
@@ -603,7 +605,8 @@ impl Coordinator {
                 );
                 store.delete_router_acks(handoff.partition).await?;
                 store.delete_handoff(handoff.partition).await?;
-                counter!("personhog_coordinator_handoffs_total", "outcome" => "stale_cleanup").increment(1);
+                counter!("personhog_coordinator_handoffs_total", "outcome" => "stale_cleanup")
+                    .increment(1);
             }
         }
 
@@ -695,7 +698,11 @@ async fn filter_pods_for_k8s(
                 old_gen_pods.push(pod);
                 rollout_controller = Some(controller);
             }
-            (ControllerKind::Deployment, PodStatus::Ready, DepartureReason::Crash | DepartureReason::Unknown | DepartureReason::Downscale) => {
+            (
+                ControllerKind::Deployment,
+                PodStatus::Ready,
+                DepartureReason::Crash | DepartureReason::Unknown | DepartureReason::Downscale,
+            ) => {
                 // New-gen or steady-state pod — stays in active list
                 new_gen_count += 1;
             }
@@ -757,9 +764,18 @@ async fn filter_pods_for_k8s(
 }
 
 fn emit_handoff_gauges(handoffs: &[HandoffState]) {
-    let warming = handoffs.iter().filter(|h| h.phase == HandoffPhase::Warming).count();
-    let ready = handoffs.iter().filter(|h| h.phase == HandoffPhase::Ready).count();
-    let complete = handoffs.iter().filter(|h| h.phase == HandoffPhase::Complete).count();
+    let warming = handoffs
+        .iter()
+        .filter(|h| h.phase == HandoffPhase::Warming)
+        .count();
+    let ready = handoffs
+        .iter()
+        .filter(|h| h.phase == HandoffPhase::Ready)
+        .count();
+    let complete = handoffs
+        .iter()
+        .filter(|h| h.phase == HandoffPhase::Complete)
+        .count();
     gauge!("personhog_coordinator_handoffs_in_flight", "phase" => "warming").set(warming as f64);
     gauge!("personhog_coordinator_handoffs_in_flight", "phase" => "ready").set(ready as f64);
     gauge!("personhog_coordinator_handoffs_in_flight", "phase" => "complete").set(complete as f64);
@@ -773,7 +789,8 @@ fn emit_assignment_gauges(assignments: &[PartitionAssignment]) {
         *per_pod.entry(a.owner.as_str()).or_default() += 1;
     }
     for (pod, count) in per_pod {
-        gauge!("personhog_coordinator_partitions_per_pod", "pod" => pod.to_string()).set(count as f64);
+        gauge!("personhog_coordinator_partitions_per_pod", "pod" => pod.to_string())
+            .set(count as f64);
     }
 }
 

--- a/rust/personhog-coordination/src/coordinator.rs
+++ b/rust/personhog-coordination/src/coordinator.rs
@@ -655,13 +655,17 @@ fn active_pod_names(pods: &[RegisteredPod]) -> Vec<String> {
 
 /// Adjust the active pod list based on K8s controller intent.
 ///
-/// Two adjustments during rollouts:
+/// Three adjustments during rollouts:
 ///
-/// 1. **Deployment rollout** — old-gen Ready pods are excluded from the
-///    active list so the strategy never assigns partitions to them. Existing
-///    assignments move to new-gen pods via handoff.
+/// 1. **Deployment rollout (gradual)** — only exclude enough old-gen pods
+///    to match the number of new-gen pods, keeping total active pods at
+///    `desired_replicas`. This avoids overloading the first new-gen pod
+///    with all partitions — each partition moves exactly once.
 ///
-/// 2. **StatefulSet rollout** — Draining pods are *added back* to the
+/// 2. **Deployment rollout (all new-gen ready)** — when new-gen count
+///    reaches `desired_replicas`, exclude all remaining old-gen pods.
+///
+/// 3. **StatefulSet rollout** — Draining pods are *added back* to the
 ///    active list so their assignments are held. In a StatefulSet rollout the
 ///    same pod name comes back with a new revision, so there's no point
 ///    handing off to a different pod.
@@ -670,6 +674,11 @@ async fn filter_pods_for_k8s(
     pods: &[RegisteredPod],
     mut active: Vec<String>,
 ) -> Vec<String> {
+    // Classify pods by controller and generation
+    let mut old_gen_pods: Vec<&RegisteredPod> = Vec::new();
+    let mut new_gen_count: u32 = 0;
+    let mut rollout_controller: Option<&k8s_awareness::types::ControllerRef> = None;
+
     for pod in pods {
         let (Some(controller), generation) = (&pod.controller, &pod.generation) else {
             continue;
@@ -682,17 +691,14 @@ async fn filter_pods_for_k8s(
         let reason = k8s.classify_departure(controller, generation).await;
 
         match (&controller.kind, pod.status, reason) {
-            // Deployment rollout: old-gen Ready pod → exclude
             (ControllerKind::Deployment, PodStatus::Ready, DepartureReason::Rollout) => {
-                tracing::info!(
-                    pod = %pod.pod_name,
-                    controller = %controller,
-                    generation = %generation,
-                    "excluding old-gen deployment pod from active list"
-                );
-                active.retain(|name| name != &pod.pod_name);
+                old_gen_pods.push(pod);
+                rollout_controller = Some(controller);
             }
-            // StatefulSet rollout: Draining pod → add back (hold assignment)
+            (ControllerKind::Deployment, PodStatus::Ready, DepartureReason::Crash | DepartureReason::Unknown | DepartureReason::Downscale) => {
+                // New-gen or steady-state pod — stays in active list
+                new_gen_count += 1;
+            }
             (ControllerKind::StatefulSet, PodStatus::Draining, DepartureReason::Rollout) => {
                 tracing::info!(
                     pod = %pod.pod_name,
@@ -705,6 +711,43 @@ async fn filter_pods_for_k8s(
                 }
             }
             _ => {}
+        }
+    }
+
+    // Deployment rollout: exclude old-gen pods gradually based on how many
+    // new-gen pods are ready, so each partition only moves once.
+    if !old_gen_pods.is_empty() {
+        let desired_replicas = if let Some(controller) = rollout_controller {
+            k8s.get_intent(controller)
+                .await
+                .map(|i| i.desired_replicas)
+                .unwrap_or(0)
+        } else {
+            0
+        };
+
+        // How many old-gen pods to keep: enough so total active = desired_replicas
+        let old_gen_to_keep = desired_replicas.saturating_sub(new_gen_count) as usize;
+        let old_gen_to_exclude = old_gen_pods.len().saturating_sub(old_gen_to_keep);
+
+        tracing::info!(
+            old_gen = old_gen_pods.len(),
+            new_gen = new_gen_count,
+            desired_replicas,
+            old_gen_to_keep,
+            old_gen_to_exclude,
+            "deployment rollout: gradual old-gen exclusion"
+        );
+
+        // Exclude old-gen pods, preferring to exclude those with fewer partitions
+        // (so we minimize partition movement)
+        for pod in old_gen_pods.iter().take(old_gen_to_exclude) {
+            tracing::info!(
+                pod = %pod.pod_name,
+                generation = %pod.generation,
+                "excluding old-gen deployment pod from active list"
+            );
+            active.retain(|name| name != &pod.pod_name);
         }
     }
 

--- a/rust/personhog-coordination/src/coordinator.rs
+++ b/rust/personhog-coordination/src/coordinator.rs
@@ -393,9 +393,12 @@ impl Coordinator {
         Ok(())
     }
 
-    /// Check all in-flight handoffs for completed ack quorum. Completes any
-    /// handoffs where all routers have already acked, which can happen when the
-    /// coordinator restarts or a new leader is elected after acks were written.
+    /// Reconcile all coordination state on leadership acquisition.
+    ///
+    /// The previous leader may have crashed at any point, leaving partial state:
+    /// - Ready handoffs with full ack quorum that were never completed
+    /// - Complete handoffs that were never cleaned up (acks + handoff key)
+    /// - Handoffs targeting pods that no longer exist
     async fn reconcile_pending_handoffs(&self) -> Result<()> {
         let handoffs = self.store.list_handoffs().await?;
         if handoffs.is_empty() {
@@ -407,11 +410,35 @@ impl Coordinator {
             "reconciling existing handoffs on startup"
         );
 
+        let pods = self.store.list_pods().await?;
+        let active = active_pod_names(&pods);
+
         for handoff in &handoffs {
-            if handoff.phase == HandoffPhase::Ready {
-                Self::check_ack_completion(&self.store, handoff.partition).await?;
+            match handoff.phase {
+                // Ready: check if acks already reached quorum
+                HandoffPhase::Ready => {
+                    Self::check_ack_completion(&self.store, handoff.partition).await?;
+                }
+                // Complete: old leader crashed before cleanup — finish it
+                HandoffPhase::Complete => {
+                    tracing::info!(
+                        partition = handoff.partition,
+                        "cleaning up orphaned Complete handoff from previous leader"
+                    );
+                    self.store
+                        .delete_router_acks(handoff.partition)
+                        .await?;
+                    self.store.delete_handoff(handoff.partition).await?;
+                    counter!("personhog_coordinator_handoffs_total", "outcome" => "completed")
+                        .increment(1);
+                }
+                // Warming: check if new_owner is still alive
+                HandoffPhase::Warming => {}
             }
         }
+
+        // Clean up handoffs targeting dead pods (covers all phases)
+        Self::cleanup_stale_handoffs(&self.store, &active).await?;
 
         Ok(())
     }
@@ -479,6 +506,7 @@ impl Coordinator {
         }
 
         let current_assignments = store.list_assignments().await?;
+        emit_assignment_gauges(&current_assignments);
 
         let current_map: HashMap<u32, String> = current_assignments
             .iter()
@@ -586,17 +614,28 @@ impl Coordinator {
         store: &PersonhogStore,
         handoff: &HandoffState,
     ) -> Result<()> {
-        if handoff.phase == HandoffPhase::Complete {
-            let duration = util::now_seconds() - handoff.started_at;
-            tracing::info!(
-                partition = handoff.partition,
-                duration_secs = duration,
-                "handoff complete, cleaning up"
-            );
-            store.delete_router_acks(handoff.partition).await?;
-            store.delete_handoff(handoff.partition).await?;
-            counter!("personhog_coordinator_handoffs_total", "outcome" => "completed").increment(1);
-            histogram!("personhog_coordinator_handoff_duration_seconds").record(duration as f64);
+        match handoff.phase {
+            // When a handoff reaches Ready, check if acks already arrived.
+            // This handles the race where routers ack before the coordinator
+            // processes the Ready event — without this, the handoff gets stuck.
+            HandoffPhase::Ready => {
+                Self::check_ack_completion(store, handoff.partition).await?;
+            }
+            HandoffPhase::Complete => {
+                let duration = util::now_seconds() - handoff.started_at;
+                tracing::info!(
+                    partition = handoff.partition,
+                    duration_secs = duration,
+                    "handoff complete, cleaning up"
+                );
+                store.delete_router_acks(handoff.partition).await?;
+                store.delete_handoff(handoff.partition).await?;
+                counter!("personhog_coordinator_handoffs_total", "outcome" => "completed")
+                    .increment(1);
+                histogram!("personhog_coordinator_handoff_duration_seconds")
+                    .record(duration as f64);
+            }
+            HandoffPhase::Warming => {}
         }
         Ok(())
     }

--- a/rust/personhog-coordination/src/pod.rs
+++ b/rust/personhog-coordination/src/pod.rs
@@ -279,7 +279,8 @@ impl PodHandle {
                 .record(warm_start.elapsed().as_secs_f64());
 
             self.owned_partitions.lock().await.insert(handoff.partition);
-            gauge!("personhog_pod_owned_partitions").set(self.owned_partitions.lock().await.len() as f64);
+            gauge!("personhog_pod_owned_partitions")
+                .set(self.owned_partitions.lock().await.len() as f64);
 
             // Signal ready — routers will now begin cutover
             let mut updated = handoff.clone();
@@ -297,7 +298,8 @@ impl PodHandle {
                 .lock()
                 .await
                 .remove(&handoff.partition);
-            gauge!("personhog_pod_owned_partitions").set(self.owned_partitions.lock().await.len() as f64);
+            gauge!("personhog_pod_owned_partitions")
+                .set(self.owned_partitions.lock().await.len() as f64);
             counter!("personhog_pod_partitions_released_total").increment(1);
             self.drain_notify.notify_one();
         }
@@ -372,7 +374,8 @@ impl PodHandle {
             .lock()
             .await
             .insert(assignment.partition);
-        gauge!("personhog_pod_owned_partitions").set(self.owned_partitions.lock().await.len() as f64);
+        gauge!("personhog_pod_owned_partitions")
+            .set(self.owned_partitions.lock().await.len() as f64);
 
         Ok(())
     }

--- a/rust/personhog-coordination/src/pod.rs
+++ b/rust/personhog-coordination/src/pod.rs
@@ -1,9 +1,10 @@
 use std::collections::HashSet;
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
 use etcd_client::EventType;
+use metrics::{counter, gauge, histogram};
 use tokio::sync::{Mutex, Notify};
 use tokio_util::sync::CancellationToken;
 
@@ -272,8 +273,13 @@ impl PodHandle {
                 partition = handoff.partition,
                 "warming cache for partition"
             );
+            let warm_start = Instant::now();
             self.handler.warm_partition(handoff.partition).await?;
+            histogram!("personhog_pod_warm_duration_seconds")
+                .record(warm_start.elapsed().as_secs_f64());
+
             self.owned_partitions.lock().await.insert(handoff.partition);
+            gauge!("personhog_pod_owned_partitions").set(self.owned_partitions.lock().await.len() as f64);
 
             // Signal ready — routers will now begin cutover
             let mut updated = handoff.clone();
@@ -291,6 +297,8 @@ impl PodHandle {
                 .lock()
                 .await
                 .remove(&handoff.partition);
+            gauge!("personhog_pod_owned_partitions").set(self.owned_partitions.lock().await.len() as f64);
+            counter!("personhog_pod_partitions_released_total").increment(1);
             self.drain_notify.notify_one();
         }
 
@@ -355,11 +363,16 @@ impl PodHandle {
             partition = assignment.partition,
             "warming partition from direct assignment"
         );
+        let warm_start = Instant::now();
         self.handler.warm_partition(assignment.partition).await?;
+        histogram!("personhog_pod_warm_duration_seconds")
+            .record(warm_start.elapsed().as_secs_f64());
+
         self.owned_partitions
             .lock()
             .await
             .insert(assignment.partition);
+        gauge!("personhog_pod_owned_partitions").set(self.owned_partitions.lock().await.len() as f64);
 
         Ok(())
     }

--- a/rust/personhog-coordination/src/routing_table.rs
+++ b/rust/personhog-coordination/src/routing_table.rs
@@ -1,9 +1,10 @@
 use std::collections::HashMap;
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
 use etcd_client::EventType;
+use metrics::{counter, gauge, histogram};
 use tokio::sync::RwLock;
 use tokio_util::sync::CancellationToken;
 
@@ -160,6 +161,7 @@ impl RoutingTable {
             table.insert(a.partition, a.owner);
         }
         tracing::info!(count = table.len(), "loaded initial routing table");
+        gauge!("personhog_router_routing_table_size").set(table.len() as f64);
         drop(table);
 
         // Catch up on any in-progress handoffs that reached Ready before we
@@ -208,14 +210,18 @@ impl RoutingTable {
                         match event.event_type() {
                             EventType::Put => {
                                 let assignment: PartitionAssignment = parse_watch_value(event)?;
-                                table.write().await.insert(assignment.partition, assignment.owner);
+                                let mut t = table.write().await;
+                                t.insert(assignment.partition, assignment.owner);
+                                gauge!("personhog_router_routing_table_size").set(t.len() as f64);
                             }
                             EventType::Delete => {
                                 if let Some(kv) = event.kv() {
                                     if let Some(partition) = store::extract_partition_from_key(
                                         std::str::from_utf8(kv.key()).unwrap_or(""),
                                     ) {
-                                        table.write().await.remove(&partition);
+                                        let mut t = table.write().await;
+                                        t.remove(&partition);
+                                        gauge!("personhog_router_routing_table_size").set(t.len() as f64);
                                     }
                                 }
                             }
@@ -251,6 +257,7 @@ impl RoutingTable {
                                         "executing cutover"
                                     );
 
+                                    let cutover_start = Instant::now();
                                     handler.execute_cutover(
                                         handoff.partition,
                                         &handoff.old_owner,
@@ -263,6 +270,10 @@ impl RoutingTable {
                                         acked_at: util::now_seconds(),
                                     };
                                     store.put_router_ack(&ack).await?;
+
+                                    counter!("personhog_router_cutovers_total").increment(1);
+                                    histogram!("personhog_router_cutover_duration_seconds")
+                                        .record(cutover_start.elapsed().as_secs_f64());
 
                                     tracing::info!(
                                         router = %router_name,

--- a/rust/personhog-coordination/src/store.rs
+++ b/rust/personhog-coordination/src/store.rs
@@ -1,5 +1,6 @@
 use assignment_coordination::store::EtcdStore;
 use etcd_client::{Compare, CompareOp, PutOptions, Txn, TxnOp, WatchStream};
+use k8s_awareness::types::ControllerRef;
 
 use crate::error::{Error, Result};
 use crate::types::{
@@ -106,6 +107,34 @@ impl PersonhogStore {
             .ok_or_else(|| Error::NotFound(format!("pod {pod_name}")))?;
         pod.status = status;
         Ok(self.inner.put(&key, &pod, Some(lease_id)).await?)
+    }
+
+    /// Update a pod's K8s metadata (generation and controller) while preserving
+    /// its lease. Used by the coordinator to enrich pod registrations with
+    /// controller info discovered via the K8s API.
+    pub async fn enrich_pod_k8s(
+        &self,
+        pod_name: &str,
+        generation: &str,
+        controller: &ControllerRef,
+    ) -> Result<()> {
+        let key = self.key(StoreKey::Pod(pod_name));
+        let resp = self.inner.client().clone().get(key.clone(), None).await?;
+        let kv = resp
+            .kvs()
+            .first()
+            .ok_or_else(|| Error::NotFound(format!("pod {pod_name}")))?;
+        let lease_id = kv.lease();
+        let mut pod: RegisteredPod = serde_json::from_slice(kv.value())?;
+        pod.generation = generation.to_string();
+        pod.controller = Some(controller.clone());
+        let options = PutOptions::new().with_lease(lease_id);
+        self.inner
+            .client()
+            .clone()
+            .put(key, serde_json::to_string(&pod)?, Some(options))
+            .await?;
+        Ok(())
     }
 
     pub async fn watch_pods(&self) -> Result<WatchStream> {

--- a/rust/personhog-coordination/tests/integration.rs
+++ b/rust/personhog-coordination/tests/integration.rs
@@ -1154,6 +1154,75 @@ async fn graceful_drain_transfers_partitions(
     coord_cancel.cancel();
 }
 
+/// Verify that `enrich_pod_k8s` updates a pod's generation and controller
+/// while preserving its lease. After enrichment, the pod key should still
+/// expire when the lease is revoked.
+#[tokio::test]
+async fn enrich_pod_k8s_preserves_lease() {
+    use k8s_awareness::types::{ControllerKind, ControllerRef};
+
+    let store = test_store("enrich-pod-k8s").await;
+
+    // Grant a lease and register a pod with empty generation (like a real leader pod)
+    let lease_id = store.grant_lease(60).await.unwrap();
+    let pod = personhog_coordination::types::RegisteredPod {
+        pod_name: "writer-0".to_string(),
+        generation: String::new(),
+        status: personhog_coordination::types::PodStatus::Ready,
+        registered_at: 1000,
+        last_heartbeat: 1000,
+        controller: None,
+    };
+    store.register_pod(&pod, lease_id).await.unwrap();
+
+    // Verify the pod is registered with empty generation
+    let fetched = store.get_pod("writer-0").await.unwrap().unwrap();
+    assert!(fetched.generation.is_empty());
+    assert!(fetched.controller.is_none());
+
+    // Enrich the pod with K8s metadata
+    let controller = ControllerRef {
+        kind: ControllerKind::Deployment,
+        name: "personhog-leader".to_string(),
+    };
+    store
+        .enrich_pod_k8s("writer-0", "abc123", &controller)
+        .await
+        .unwrap();
+
+    // Verify enrichment persisted
+    let enriched = store.get_pod("writer-0").await.unwrap().unwrap();
+    assert_eq!(enriched.generation, "abc123");
+    assert_eq!(enriched.controller.as_ref().unwrap().name, "personhog-leader");
+    assert_eq!(enriched.controller.as_ref().unwrap().kind, ControllerKind::Deployment);
+    // Other fields should be unchanged
+    assert_eq!(enriched.pod_name, "writer-0");
+    assert_eq!(enriched.status, personhog_coordination::types::PodStatus::Ready);
+    assert_eq!(enriched.registered_at, 1000);
+
+    // Verify the lease is preserved: revoking it should delete the pod key
+    store.revoke_lease(lease_id).await.unwrap();
+    let gone = store.get_pod("writer-0").await.unwrap();
+    assert!(gone.is_none(), "pod key should be deleted after lease revocation");
+}
+
+/// Verify that `enrich_pod_k8s` returns NotFound for a nonexistent pod.
+#[tokio::test]
+async fn enrich_pod_k8s_not_found() {
+    use k8s_awareness::types::{ControllerKind, ControllerRef};
+
+    let store = test_store("enrich-pod-not-found").await;
+
+    let controller = ControllerRef {
+        kind: ControllerKind::Deployment,
+        name: "test".to_string(),
+    };
+    let result = store
+        .enrich_pod_k8s("nonexistent", "abc123", &controller)
+        .await;
+    assert!(result.is_err());
+}
+
 /// Verify that when the drain status write to etcd fails (e.g. pod key was
 /// already deleted), the pod exits cleanly without hanging or panicking.
 /// It falls back to lease-based cleanup.

--- a/rust/personhog-coordination/tests/integration.rs
+++ b/rust/personhog-coordination/tests/integration.rs
@@ -1193,17 +1193,29 @@ async fn enrich_pod_k8s_preserves_lease() {
     // Verify enrichment persisted
     let enriched = store.get_pod("writer-0").await.unwrap().unwrap();
     assert_eq!(enriched.generation, "abc123");
-    assert_eq!(enriched.controller.as_ref().unwrap().name, "personhog-leader");
-    assert_eq!(enriched.controller.as_ref().unwrap().kind, ControllerKind::Deployment);
+    assert_eq!(
+        enriched.controller.as_ref().unwrap().name,
+        "personhog-leader"
+    );
+    assert_eq!(
+        enriched.controller.as_ref().unwrap().kind,
+        ControllerKind::Deployment
+    );
     // Other fields should be unchanged
     assert_eq!(enriched.pod_name, "writer-0");
-    assert_eq!(enriched.status, personhog_coordination::types::PodStatus::Ready);
+    assert_eq!(
+        enriched.status,
+        personhog_coordination::types::PodStatus::Ready
+    );
     assert_eq!(enriched.registered_at, 1000);
 
     // Verify the lease is preserved: revoking it should delete the pod key
     store.revoke_lease(lease_id).await.unwrap();
     let gone = store.get_pod("writer-0").await.unwrap();
-    assert!(gone.is_none(), "pod key should be deleted after lease revocation");
+    assert!(
+        gone.is_none(),
+        "pod key should be deleted after lease revocation"
+    );
 }
 
 /// Verify that `enrich_pod_k8s` returns NotFound for a nonexistent pod.

--- a/rust/personhog-leader/src/main.rs
+++ b/rust/personhog-leader/src/main.rs
@@ -67,7 +67,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     );
     let coordination_handle = manager.register(
         "coordination",
-        ComponentOptions::new().with_graceful_shutdown(Duration::from_secs(5)),
+        ComponentOptions::new().with_graceful_shutdown(Duration::from_secs(25)),
     );
 
     let readiness = manager.readiness_handler();


### PR DESCRIPTION
## Problem

The personhog coordinator lacked observability into its coordination loop (leadership, rebalancing, handoffs, pod state), making it difficult to monitor and debug production behavior. Additionally, during deployment rollouts, all partitions were immediately moved to the first new-gen pod instead of being migrated gradually as new pods became ready.

## Changes

- Add comprehensive metrics to the coordinator
- Add metrics to pod and router components: partition warming duration, owned partition gauge, cutover counts/duration, routing table size
- Implement K8s pod enrichment: coordinator discovers controller/generation for newly registered pods via the K8s API and persists it back to etcd (`enrich_pod_k8s`)
- Add `get_intent` to `K8sAwareness` to expose desired replica count for controllers
- Implement gradual old-gen pod exclusion during deployment rollouts, matching the number of excluded old-gen pods to the number of ready new-gen pods so total active pods stays at `desired_replicas`
- Reconcile orphaned Complete and stale handoffs on leadership acquisition, not just Ready ones
- Handle the Ready-phase handoff event by checking ack completion (fixes a race where routers ack before coordinator processes the event)
- Increase personhog-leader graceful shutdown timeout from 5s to 25s

## How did you test this code?

<!-- Briefly describe the steps you took, and what steps reviewers must take to get to where changes are, and what is the expected behavior. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
