### PR TITLE
fix(endpoints): accept hogql breakdown in insight variables

### DIFF
--- a/products/endpoints/backend/api.py
+++ b/products/endpoints/backend/api.py
@@ -43,7 +43,7 @@ from posthog.hogql import ast
 from posthog.hogql.constants import LimitContext
 from posthog.hogql.context import HogQLContext
 from posthog.hogql.errors import ExposedHogQLError, QueryError, ResolutionError
-from posthog.hogql.parser import parse_select
+from posthog.hogql.parser import parse_expr, parse_select
 from posthog.hogql.printer import to_printed_hogql
 from posthog.hogql.printer.base import HogQLPrinter
 from posthog.hogql.printer.utils import print_prepared_ast
@@ -1748,12 +1748,34 @@ class EndpointViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.Model
 
         properties: list[dict] = []
         for prop_name, prop_type in breakdown_infos or []:
-            if prop_name in variables:
-                value = variables[prop_name]
-                # Empty string means "null/unset" — match events where the property is missing.
-                # This keeps inline execution consistent with the materialized path,
-                # where null breakdown values are stored as '' in S3.
+            if prop_name not in variables:
+                continue
+            value = variables[prop_name]
+            # Any failure to build a filter for a breakdown variable must error the
+            # request — silently skipping would return unfiltered data, which is a
+            # data-leak (same principle that gates materialized endpoints on having
+            # all variables present).
+            try:
+                if prop_type == "hogql":
+                    # HogQLPropertyFilter.key is a full HogQL predicate and doesn't accept
+                    # `operator` (HogQLPropertyFilter has extra="forbid"), so build a
+                    # `<expr> = <value>` (or `isNull(<expr>)`) predicate to filter with.
+                    key_expr = parse_expr(prop_name)
+                    predicate_expr: ast.Expr
+                    if value == "":
+                        predicate_expr = ast.Call(name="isNull", args=[key_expr])
+                    else:
+                        predicate_expr = ast.CompareOperation(
+                            left=key_expr,
+                            op=ast.CompareOperationOp.Eq,
+                            right=ast.Constant(value=value),
+                        )
+                    properties.append({"key": predicate_expr.to_hogql(), "type": "hogql"})
+                    continue
                 if value == "":
+                    # Empty string means "null/unset" — match events where the property is missing.
+                    # This keeps inline execution consistent with the materialized path,
+                    # where null breakdown values are stored as '' in S3.
                     properties.append(
                         {
                             "key": prop_name,
@@ -1770,6 +1792,20 @@ class EndpointViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.Model
                             "operator": PropertyOperator.EXACT,
                         }
                     )
+            except Exception as e:
+                capture_exception(
+                    e,
+                    {
+                        "product": Product.ENDPOINTS,
+                        "team_id": self.team_id,
+                        "endpoint_name": self.kwargs.get("name"),
+                        "prop_name": prop_name,
+                        "prop_type": prop_type,
+                    },
+                )
+                raise ValidationError(
+                    {"variables": f"Could not apply filter for breakdown variable '{prop_name}'"}
+                ) from e
 
         if not date_from and not date_to and not properties:
             return None

--- a/products/endpoints/backend/tests/test_endpoint_execution.py
+++ b/products/endpoints/backend/tests/test_endpoint_execution.py
@@ -1404,6 +1404,81 @@ class TestEndpointExecution(ClickhouseTestMixin, APIBaseTest):
                 "OS breakdown property filter should be applied",
             )
 
+    @parameterized.expand(
+        [
+            (
+                "non_empty_value",
+                {
+                    "properties.$browser": "Chrome",
+                    "date_from": "2026-01-05",
+                    "date_to": "2026-01-08",
+                },
+            ),
+            ("empty_value", {"properties.$browser": ""}),
+        ]
+    )
+    def test_non_materialized_insight_endpoint_accepts_hogql_breakdown_variable(self, _name, variables):
+        from posthog.schema import BreakdownFilter, BreakdownType
+
+        # Legacy single-breakdown format with a HogQL expression.
+        endpoint = create_endpoint_with_version(
+            name=f"trends_hogql_breakdown_{_name}",
+            team=self.team,
+            query=TrendsQuery(
+                series=[EventsNode(event="$pageview")],
+                breakdownFilter=BreakdownFilter(
+                    breakdown="properties.$browser",
+                    breakdown_type=BreakdownType.HOGQL,
+                ),
+                dateRange={"date_from": "-30d"},
+            ).model_dump(),
+            created_by=self.user,
+            is_active=True,
+        )
+
+        response = self.client.post(
+            f"/api/environments/{self.team.id}/endpoints/{endpoint.name}/run/",
+            {"variables": variables},
+            format="json",
+        )
+
+        # Before the fix this returned 500 because _variables_to_filters built a
+        # HogQLPropertyFilter dict with `operator` set, which fails pydantic's
+        # extra="forbid" on DashboardFilter.properties.
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
+
+    def test_non_materialized_insight_endpoint_rejects_unbuildable_hogql_breakdown_variable(self):
+        from posthog.schema import BreakdownFilter, BreakdownType
+
+        # An unparseable HogQL expression stored as the breakdown — parse_expr
+        # will raise when _variables_to_filters tries to build a predicate for it.
+        # We must reject with 400 rather than silently skipping the filter, which
+        # would return unfiltered data (same principle that gates materialized
+        # endpoints on having all variables present).
+        endpoint = create_endpoint_with_version(
+            name="trends_hogql_breakdown_unparseable",
+            team=self.team,
+            query=TrendsQuery(
+                series=[EventsNode(event="$pageview")],
+                breakdownFilter=BreakdownFilter(
+                    breakdown=")garbage(",
+                    breakdown_type=BreakdownType.HOGQL,
+                ),
+                dateRange={"date_from": "-30d"},
+            ).model_dump(),
+            created_by=self.user,
+            is_active=True,
+        )
+
+        response = self.client.post(
+            f"/api/environments/{self.team.id}/endpoints/{endpoint.name}/run/",
+            {"variables": {")garbage(": "Chrome"}},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST, response.content)
+        self.assertIn("breakdown variable", response.json().get("detail", ""))
+
     # =========================================================================
     # OFFSET-BASED PAGINATION
     # =========================================================================


### PR DESCRIPTION
## Problem
_variables_to_filters was building a DashboardFilter property dict with type="hogql" and operator=EXACT, which fails HogQLPropertyFilter's extra="forbid" schema and crashes the inline endpoint path with a 500. 

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
Build a HogQL predicate AST (`<expr> = <value>` / `isNull(<expr>)`) and pass it as the property key, matching what property_to_expr expects.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
- added two new tests for this case

<!-- Briefly describe the steps you took, and what steps reviewers must take to get to where changes are, and what is the expected behavior. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
nah
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update
nah
<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
