### PR TITLE
feat: enable ignoreDiacritics across all Fuse.js searches

### DIFF
--- a/frontend/src/lib/utils/fuseSearch.ts
+++ b/frontend/src/lib/utils/fuseSearch.ts
@@ -6,6 +6,7 @@ export type { IFuseOptions }
 const FUSE_DEFAULTS = {
     threshold: 0.3,
     useTokenSearch: true,
+    ignoreDiacritics: true,
 }
 
 export function createFuse<T>(items: T[], options: IFuseOptions<T>): FuseClass<T> {


### PR DESCRIPTION
## Problem

Users with accented names (e.g. "José", "François") can't be found without typing the exact accent.

## Changes

One-line change: add `ignoreDiacritics: true` to `FUSE_DEFAULTS` in `lib/utils/fuseSearch`. This applies to all ~30 Fuse search sites automatically thanks to the `createFuse` factory from #53733.

## How did you test this code?

Agent-authored PR. Manual testing recommended — search for accented names in the members list.

## Publish to changelog?

No

## 🤖 LLM context

Stacked on #53733 (createFuse factory). Demonstrates the value of centralized config — what was a 30-file PR is now 1 line.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*