### PR TITLE
chore: remove dead findSearchTermInItemName function

### DIFF
--- a/frontend/src/layout/navigation-3000/sidebars/utils.ts
+++ b/frontend/src/layout/navigation-3000/sidebars/utils.ts
@@ -1,26 +1,5 @@
-import { SearchMatch } from '../types'
-
 export interface FuseSearchMatch {
     // kea-typegen has a problem importing Fuse itself, so we have to duplicate this type
     indices: readonly [number, number][]
     key: string
-}
-
-/**
- * Return a search match with instances of the search term highlighted in the string.
- * This provides highlighting for server-side search, which does not return data on how the search term was matched.
- */
-export function findSearchTermInItemName(name: string, searchTerm: string): SearchMatch | null {
-    if (!searchTerm || !name) {
-        return null
-    }
-    const ranges: [number, number][] = []
-    const workingName = name.toLowerCase()
-    const workingSearchTerm = searchTerm.toLowerCase()
-    let index = workingName.indexOf(workingSearchTerm)
-    while (index !== -1) {
-        ranges.push([index, index + searchTerm.length])
-        index = workingName.indexOf(workingSearchTerm, index + 1)
-    }
-    return ranges.length ? { nameHighlightRanges: ranges } : null
 }


### PR DESCRIPTION
## Problem

While investigating `Fuse.match()` adoption during the fuse.js v7 upgrade, found that `findSearchTermInItemName()` in `navigation-3000/sidebars/utils.ts` is dead code — defined but never imported anywhere.

## Changes

Remove the dead `findSearchTermInItemName` function and its unused `SearchMatch` import. The `FuseSearchMatch` interface in the same file is kept — it's actively used by `queryDatabaseLogic.tsx` for match highlighting.

## How did you test this code?

Verified via `grep` that `findSearchTermInItemName` has zero import sites across the entire codebase.

## Publish to changelog?

No

## 🤖 LLM context

Stacked on #53734 (ignoreDiacritics) → #53733 (token search) → #53708 (fuse.js v6 → v7 upgrade).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*