### PR TITLE
fix(signup): skip email verification for invite signups

### DIFF
--- a/posthog/api/signup.py
+++ b/posthog/api/signup.py
@@ -459,11 +459,14 @@ class InviteSignupSerializer(serializers.Serializer):
                     if passkey_credential and session_user_uuid:
                         extra_fields["uuid"] = uuid_module.UUID(session_user_uuid)
 
+                    # Trust that the user owns `target_email`: the invite link was emailed
+                    # to that address, so clicking it already proves ownership. Open share
+                    # links (no target_email) still require verification.
                     user = User.objects.create_user(
                         invite.target_email,
                         password,
                         first_name,
-                        is_email_verified=False,
+                        is_email_verified=bool(invite.target_email),
                         role_at_organization=role_at_organization,
                         **extra_fields,
                     )

--- a/posthog/api/test/test_signup.py
+++ b/posthog/api/test/test_signup.py
@@ -1782,7 +1782,7 @@ class TestInviteSignupAPI(APIBaseTest):
                 "first_name": "Alice",
                 "email": "test+99@posthog.com",
                 "redirect_url": "/",
-                "is_email_verified": False,
+                "is_email_verified": True,
                 "hedgehog_config": None,
                 "role_at_organization": "Engineering",
             },
@@ -1995,9 +1995,9 @@ class TestInviteSignupAPI(APIBaseTest):
 
         member_join_emails = [m for m in mail.outbox if "joined you on PostHog" in m.subject]
         self.assertEqual(len(member_join_emails), 0)
-        # Verify invite signup still sends verification email to the new user.
-        self.assertEqual(len(mail.outbox), 1)
-        self.assertListEqual(mail.outbox[0].to, ['"Alice" <test+100@posthog.com>'])
+        # Invite signup does not send a verification email — clicking the invite link
+        # (emailed to target_email) already proves ownership of the address.
+        self.assertEqual(len(mail.outbox), 0)
 
     def test_api_invite_sign_up_member_joined_email_is_sent_for_next_members(self):
         with override_instance_config("EMAIL_HOST", "localhost"):
@@ -2018,11 +2018,10 @@ class TestInviteSignupAPI(APIBaseTest):
 
             self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
-            self.assertEqual(len(mail.outbox), 2)
-            # Someone joined email is sent to the initial user
+            # Only the "someone joined" email to the existing member is sent; the new
+            # user is not asked to re-verify the email they just clicked.
+            self.assertEqual(len(mail.outbox), 1)
             self.assertListEqual(mail.outbox[0].to, [initial_user.email])
-            # Verify email is sent to the new user (formatted with name)
-            self.assertListEqual(mail.outbox[1].to, ['"Alice" <test+100@posthog.com>'])
 
     def test_api_invite_sign_up_member_joined_email_is_not_sent_if_disabled(self):
         initial_user = User.objects.create_and_join(self.organization, "test+420@posthog.com", None)
@@ -2052,6 +2051,38 @@ class TestInviteSignupAPI(APIBaseTest):
 
         member_join_emails = [m for m in mail.outbox if "joined you on PostHog" in m.subject]
         self.assertEqual(len(member_join_emails), 0)
+
+    def test_api_invite_sign_up_marks_user_verified_and_logs_in(self):
+        # The invite link is emailed to target_email, so clicking it already proves
+        # ownership. The new user should be auto-verified, logged in, and sent to "/"
+        # rather than the verify-email page — even with email verification enabled.
+        invite: OrganizationInvite = OrganizationInvite.objects.create(
+            target_email="invited@posthog.com", organization=self.organization
+        )
+
+        with override_instance_config("EMAIL_HOST", "localhost"):
+            with self.settings(EMAIL_ENABLED=True, SITE_URL="http://test.posthog.com"):
+                response = self.client.post(
+                    f"/api/signup/{invite.id}/",
+                    {"first_name": "Alice", "password": VALID_TEST_PASSWORD},
+                )
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        body = response.json()
+        self.assertTrue(body["is_email_verified"])
+        self.assertEqual(body["redirect_url"], "/")
+
+        user = cast(User, User.objects.get(email="invited@posthog.com"))
+        self.assertTrue(user.is_email_verified)
+
+        # User is logged in — the verify-email page is not in the way.
+        me_response = self.client.get("/api/users/@me/")
+        self.assertEqual(me_response.status_code, status.HTTP_200_OK)
+        self.assertEqual(me_response.json()["email"], "invited@posthog.com")
+
+        # No verification email was sent.
+        verification_emails = [m for m in mail.outbox if "verify" in m.subject.lower()]
+        self.assertEqual(verification_emails, [])
 
     @patch("posthoganalytics.capture")
     @patch("ee.billing.billing_manager.BillingManager.update_billing_organization_users")


### PR DESCRIPTION
## Problem

When a user accepts an org invitation via the link in their invite email, PostHog currently asks them to verify their email address before letting them in.
But the invite link is delivered to the target email (`send_invite` in `posthog/tasks/email.py` emails it to `invite.target_email`), so clicking it is already proof of ownership.
The extra verification step is redundant — users end up stuck on `/verify_email/<uuid>` after accepting an invitation, waiting for a second email that adds nothing.

## Changes

- `InviteSignupSerializer.create` (`posthog/api/signup.py`) now creates the invited user with `is_email_verified=bool(invite.target_email)` instead of a hardcoded `False`.
  - When the invite has a specific `target_email` (the normal case), the user is auto-verified and logged in directly.
  - Open share links with no `target_email` still require verification, preserving the current security posture for that edge case.
- Mirrors the pattern already used by social invite signup (`process_social_invite_signup`) and JIT provisioning, which both trust the email and mark it verified.
- Flows through `verify_email_or_login` → hits the `login()` branch → `get_redirect_url` returns `/` (or `next_url`) instead of `/verify_email/<uuid>`.

### Tests

- `test_api_invite_sign_up`: updated expected `is_email_verified` → `True`.
- `test_api_invite_sign_up_member_joined_email_is_not_sent_for_initial_member`: updated to assert no verification email is sent (previous assertion codified the bug).
- `test_api_invite_sign_up_member_joined_email_is_sent_for_next_members`: updated — only the "member joined" email to existing members is sent.
- Added `test_api_invite_sign_up_marks_user_verified_and_logs_in`: explicit coverage with `EMAIL_ENABLED=True` asserting the invited user is auto-verified, logged in, redirected to `/`, and no verification email is sent.

## How did you test this code?

Automated only. Ran `hogli test posthog/api/test/test_signup.py::TestInviteSignupAPI` — all 29 tests pass, including the new one.

I'm an agent and have not manually tested this end-to-end in a running PostHog instance. Reviewer should sanity-check the UX flow (invite → click link → signup → land directly on home/onboarding).

The 12 pre-existing `TestSignupAPI::test_api_*_social_*` failures in the file are unrelated (missing `index.html` frontend template in the test env) and reproduce on `master` without this change.

## Publish to changelog?

no

## 🤖 LLM context

Authored by Claude (Opus 4.6) via Claude Code. Investigation traced the invite flow from `send_invite` → `InviteSignupViewset` → `InviteSignupSerializer.create` → `verify_email_or_login` → `get_redirect_url`. The bug is a one-line hardcoded `is_email_verified=False` that was out of step with the social-auth and JIT paths in the same file.