### PR TITLE
fix(llma): show reasoning trace content summary/thinking empty

### DIFF
--- a/products/llm_analytics/frontend/utils.test.ts
+++ b/products/llm_analytics/frontend/utils.test.ts
@@ -411,7 +411,7 @@ describe('LLM Analytics utils', () => {
             ])
         })
 
-        it('handles reasoning with no summary', () => {
+        it('handles reasoning with no summary by falling back to raw JSON', () => {
             const message = {
                 type: 'reasoning',
                 id: 'rs_456',
@@ -420,7 +420,7 @@ describe('LLM Analytics utils', () => {
             expect(normalizeMessage(message, 'user')).toEqual([
                 {
                     role: 'assistant (thinking)',
-                    content: '',
+                    content: JSON.stringify(message),
                 },
             ])
         })

--- a/products/llm_analytics/frontend/utils.ts
+++ b/products/llm_analytics/frontend/utils.ts
@@ -907,7 +907,7 @@ export function normalizeMessage(rawMessage: unknown, defaultRole: string): Comp
         return [
             {
                 role: normalizeRole('assistant (thinking)', roleToUse),
-                content: rawMessage.thinking,
+                content: rawMessage.thinking || JSON.stringify(rawMessage),
             },
         ]
     }
@@ -976,7 +976,7 @@ export function normalizeMessage(rawMessage: unknown, defaultRole: string): Comp
         return [
             {
                 role: normalizeRole('assistant (thinking)', roleToUse),
-                content: summaryText,
+                content: summaryText || JSON.stringify(rawMessage),
             },
         ]
     }


### PR DESCRIPTION
## Problem

Users of LLM analytics cannot expand or view reasoning traces ("assistant (thinking)" messages) in the trace Conversation tab. The reasoning data is present in the raw `ai_output_choices`, but the Conversation view shows the role header with no way to expand it.

This affects OpenAI Responses API reasoning items (when `summary` is absent or empty) and Anthropic thinking blocks (when `thinking` is empty), which commonly occurs with gateway-proxied models like Gemini.

The bug was introduced in d06c9a2032 (#52903, Mar 31 2026) which added OpenAI Responses API reasoning support but set content to empty string when no summary was present.

## Changes

When a reasoning/thinking message normalizes to empty content, fall back to `JSON.stringify(rawMessage)` so the raw data is always visible and the expand/collapse button renders.

- `utils.ts`: Added `|| JSON.stringify(rawMessage)` fallback in both the Anthropic thinking and OpenAI Responses reasoning normalization paths
- `utils.test.ts`: Updated the "no summary" test to expect the JSON fallback instead of an empty string

Root cause: empty string `''` is falsy in JavaScript, which causes the expand button condition (`content || ...`) and content render condition (`!!content`) in `ConversationMessagesDisplay.tsx` to evaluate to false, hiding both the toggle and the content.

## How did you test this code?

I haven't tested this manually

## Publish to changelog?

No

## Docs update

No docs update needed.

## 🤖 LLM context

Co-written with Claude Code