### PR TITLE
ci: narrow hobby CI path filter to runtime-relevant `bin/` scripts

### DIFF
--- a/.github/workflows/ci-hobby.yml
+++ b/.github/workflows/ci-hobby.yml
@@ -46,9 +46,24 @@ jobs:
                         - Dockerfile
                         - docker-compose.base.yml
                         - docker-compose.hobby.yml
-                        - 'bin/*'
+                        # Hobby-specific scripts
+                        - 'bin/deploy-hobby'
+                        - 'bin/hobby-ci.py'
+                        - 'bin/upgrade-hobby'
+                        - 'bin/migrate-*-hobby'
+                        # Docker runtime (Dockerfile CMD chain)
+                        - 'bin/docker'
+                        - 'bin/docker-worker'
+                        - 'bin/docker-worker-beat'
+                        - 'bin/docker-worker-celery'
+                        - 'bin/docker-server'
+                        - 'bin/docker-server-unit'
+                        - 'bin/celery-queues.env'
+                        - 'bin/migrate'
+                        - 'bin/migrate-check'
+                        - 'bin/posthog-node'
                         - 'bin/hobby-installer/**'
-                        - 'docker/*'
+                        - 'docker/**'
                         - uv.lock
                         - .github/workflows/ci-hobby.yml
                       installer:


### PR DESCRIPTION
## Problem

The hobby CI workflow (`ci-hobby.yml`) uses `bin/*` as a path filter trigger, which matches all ~79 files in `bin/`. Only ~15 of those are actually used in hobby deployment at runtime. The remaining ~80% are dev-only scripts (CLI tools, build scripts, linters) that trigger an expensive DigitalOcean droplet test (~75 min) unnecessarily.

Additionally, `docker/*` only matches direct children of `docker/`, missing subdirectory files like `docker/clickhouse/config.xml` that are volume-mounted into hobby containers.

## Changes

- Replace `bin/*` glob with explicit paths for the 14 hobby-runtime scripts, traced from the actual docker-compose call chains:
  - Worker service: `bin/docker-worker-celery` -> `bin/docker-worker-beat`, `bin/celery-queues.env`
  - Dockerfile CMD chain: `bin/docker` -> `bin/migrate`, `bin/docker-worker` -> `bin/migrate-check`, `bin/posthog-node`, `bin/docker-server` -> `bin/docker-server-unit`
  - Hobby-specific: `bin/deploy-hobby`, `bin/hobby-ci.py`, `bin/upgrade-hobby`, `bin/migrate-*-hobby`
- Fix `docker/*` to `docker/**` for recursive subdirectory matching

## How did you test this code?

Agent-authored. Verified by tracing the full hobby deployment call chain from `docker-compose.hobby.yml` through `docker-compose.base.yml` to the Dockerfile CMD, confirming which `bin/` scripts are runtime dependencies. No automated tests -- this is a CI configuration change.

Do not publish to changelog

## Docs update

N/A

## LLM context

Agent-authored PR. The path filter was traced by reading docker-compose.hobby.yml, docker-compose.base.yml, and each bin/ script in the call chain to determine the complete set of runtime-relevant scripts.