### PR TITLE
fix(experiments): use correct indexes when building actors query.

### DIFF
--- a/frontend/src/scenes/experiments/charts/funnel/StepBar.tsx
+++ b/frontend/src/scenes/experiments/charts/funnel/StepBar.tsx
@@ -38,14 +38,16 @@ interface StepBarCSSProperties extends React.CSSProperties {
  */
 function openExperimentPersonsModalForSeries({
     step,
+    stepIndex,
     converted,
     experimentQuery,
 }: {
     step: FunnelStepWithConversionMetrics
+    stepIndex: number
     converted: boolean
     experimentQuery: ExperimentQuery
 }): void {
-    const stepNo = step.order + 1
+    const stepNo = stepIndex + 1
     const variantKey = step.breakdown_value as string
 
     // This should only be called for funnel metrics
@@ -133,6 +135,7 @@ export function StepBar({ step, stepIndex }: StepBarProps): JSX.Element {
         if (hasActorsQueryFeature && experimentQuery) {
             openExperimentPersonsModalForSeries({
                 step: step,
+                stepIndex: stepIndex,
                 converted: false, // Dropoffs
                 experimentQuery,
             })
@@ -146,6 +149,7 @@ export function StepBar({ step, stepIndex }: StepBarProps): JSX.Element {
         if (hasActorsQueryFeature && experimentQuery) {
             openExperimentPersonsModalForSeries({
                 step: step,
+                stepIndex: stepIndex,
                 converted: true, // Conversions
                 experimentQuery,
             })


### PR DESCRIPTION
## Problem

We were using the wrong indexes when building the doppped off actors query for experiment funnelo metrics.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Use the base zero `stepIndex` consistently.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

![cat-type](https://github.com/user-attachments/assets/15878f09-6605-46a7-9598-2b8f0de2b07e)

<!-- Briefly describe the steps you took, and what steps reviewers must take to get to where changes are, and what is the expected behavior. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

do not publish to changelog

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
