### PR TITLE
chore(llma): add local dev script for ai_events ClickHouse tables

### DIFF
--- a/bin/clickhouse-ai-events-init
+++ b/bin/clickhouse-ai-events-init
@@ -1,0 +1,40 @@
+#!/usr/bin/env python
+"""Create ai_events ClickHouse tables for local development.
+
+In production these tables live on a dedicated ai_events cluster and are
+applied manually. This script generates the DDL from the Python source of
+truth (posthog/models/ai_events/sql.py) and executes it locally.
+
+Temporary until CH migrations can target the ai_events cluster.
+"""
+
+import os
+import re
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "posthog.settings")
+
+import django
+
+django.setup()
+
+from posthog.clickhouse.client import sync_execute
+from posthog.models.ai_events.sql import (
+    AI_EVENTS_DATA_TABLE_SQL,
+    AI_EVENTS_MV_SQL,
+    DISTRIBUTED_AI_EVENTS_TABLE_SQL,
+    KAFKA_AI_EVENTS_TABLE_SQL,
+    TABLE_BASE_NAME,
+)
+
+# Local dev uses plain MergeTree since there's no replicated cluster.
+data_sql = re.sub(r"ReplicatedMergeTree\([^)]*\)", "MergeTree()", AI_EVENTS_DATA_TABLE_SQL())
+
+sync_execute(data_sql)
+sync_execute(DISTRIBUTED_AI_EVENTS_TABLE_SQL())
+sync_execute(KAFKA_AI_EVENTS_TABLE_SQL())
+sync_execute(AI_EVENTS_MV_SQL(TABLE_BASE_NAME))
+
+print("✅ ai_events tables created")

--- a/common/hogli/manifest.yaml
+++ b/common/hogli/manifest.yaml
@@ -614,6 +614,9 @@ tools:
         cmd: python manage.py print_hog_stl_table
         description: Print HogSQL standard library definitions for reference
         hidden: true
+    clickhouse:ai:init:
+        bin_script: clickhouse-ai-events-init
+        description: Create ai_events ClickHouse tables for local development
     clickhouse:logs:init:
         bin_script: clickhouse-logs-init
         description: 'TODO: add description for clickhouse-logs-init'


### PR DESCRIPTION
## Problem

The ai_events ClickHouse tables live on a dedicated cluster in production and are applied manually — they can't use the normal CH migration system. This means `bin/migrate` and `sync_replicated_schema` don't create them locally, so querying `ai_events` with the `ai-events-table-rollout` feature flag fails.

## Changes

- Add `bin/clickhouse-ai-events-init` Python script that generates DDL from the source of truth (`posthog/models/ai_events/sql.py`) and executes it against local CH
- Register `clickhouse:ai:init` in the hogli manifest

Follows the same pattern as `bin/clickhouse-logs-init`. Temporary until CH migrations can target the ai_events cluster.

## How did you test this code?

- Ran `hogli clickhouse:ai:init` after `hogli nuke` — tables created successfully
- Verified `ai_events` and `sharded_ai_events` appear in CH
- Confirmed TraceQuery works with the `ai-events-table-rollout` feature flag enabled

## Publish to changelog?

no

## Docs update

No docs needed.