### PR TITLE
chore(dashboards): lowercase template_name in template chooser analytics

### DIFF
--- a/frontend/src/scenes/dashboard/dashboards/templates/dashboardTemplateChooserLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboards/templates/dashboardTemplateChooserLogic.tsx
@@ -67,7 +67,7 @@ export const dashboardTemplateChooserLogic = kea<dashboardTemplateChooserLogicTy
                 selection_type: 'template',
                 tile_location: tileLocation,
                 template_id: template.id,
-                template_name: template.template_name,
+                template_name: template.template_name.toLowerCase(),
                 is_featured: template.is_featured === true,
                 $feature_flag: FEATURE_FLAGS.DASHBOARD_TEMPLATE_CHOOSER_EXPERIMENT,
                 $feature_flag_response: props.experimentVariant,


### PR DESCRIPTION
## Problem

Template click events used `template.template_name` verbatim, so the same logical template could appear as multiple breakdown rows when casing differed (for example "Product analytics" vs "Product Analytics").

## Changes

Lowercase `template_name` in the `dashboard template chooser template clicked` event payload so HogQL breakdowns and insights group on a normalized key.

## How did you test this code?

No automated tests were added; change is a single property transform. No manual browser verification.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

do not publish to changelog

## Docs update

N/A (internal analytics property behavior only).

## LLM context

Co-authored by Cursor agent. One-file change: `frontend/src/scenes/dashboard/dashboards/templates/dashboardTemplateChooserLogic.tsx` — `template_name` now uses `toLowerCase()` for the capture payload only; UI is unchanged. Branch already had commit `chore(dashboard template): normalize event name`.

Made with [Cursor](https://cursor.com)