### PR TITLE
docs: Update materialized columns handbook to use Dagster

### DIFF
--- a/docs/published/handbook/engineering/databases/materialized-columns.md
+++ b/docs/published/handbook/engineering/databases/materialized-columns.md
@@ -30,37 +30,34 @@ Note that this cron can often be disabled due to cluster issues or ongoing data 
 
 See [environment variables documentation](https://posthog.com/docs/self-host/configure/environment-variables) + instance settings for toggles which control this.
 
-### Manual materialization
+### Manual materialization via Dagster
 
-`python manage.py materialize_columns` command can be used to manually materialize one or more properties.
+We use Dagster to materialize columns in production. The job is `create_materialized_column` in the `team-clickhouse` location.
 
-Alternatively this can be done over `python manage.py shell_plus`. One example of materializing all properties used by a team can be found here:
+- **EU**: https://dagster.cloud/posthog/prod-eu/locations/team-clickhouse/jobs/create_materialized_column/playground
+- **US**: https://dagster.cloud/posthog/prod-us/locations/team-clickhouse/jobs/create_materialized_column/playground
 
-```python
-from ee.clickhouse.materialized_columns.columns import *
+To materialize columns, go to the playground for the relevant region and configure the `create_materialized_columns_op` with the properties you want to materialize:
 
-pd = PropertyDefinition.objects.filter(team_id=2635)
-used_props = set(p.name for p in pd if "distinct_id" not in p.name and "$" not in p.name)
-
-event_props_to_materialize = used_props - set(get_materialized_columns("events", use_cache=False))
-
-from ee.clickhouse.sql.person import GET_PERSON_PROPERTIES_COUNT
-rows = sync_execute(GET_PERSON_PROPERTIES_COUNT, {"team_id": 2635})
-person_props_to_materialize = set(name for name, _ in rows if "$" not in name) - set(get_materialized_columns("person", use_cache=False))
-
-
-from ee.clickhouse.materialized_columns.analyze import logger, materialize_properties_task
-
-columns_to_materialize = []
-columns_to_materialize += [("events", prop, 0) for prop in event_props_to_materialize]
-columns_to_materialize += [("person", prop, 0) for prop in person_props_to_materialize]
-
-materialize_properties_task(
-    columns_to_materialize=columns_to_materialize,
-    backfill_period_days=90,
-    dry_run=False,
-    maximum=len(columns_to_materialize)
-)
+```yaml
+ops:
+  create_materialized_columns_op:
+    config:
+      backfill_period_days: 90
+      dry_run: false
+      properties:
+      - $browser_language_prefix
+      - $app_namespace
+      table: events
+      table_column: properties
 ```
 
-Note that this snippet might need modification depending on the usecase.
+Config options:
+
+- **`table`**: The ClickHouse table to materialize on (e.g. `events`, `person`)
+- **`table_column`**: The JSON column containing the properties (e.g. `properties`, `person_properties`, `group_properties`)
+- **`properties`**: List of property names to materialize as columns
+- **`backfill_period_days`**: How many days of historical data to backfill (typically `90`)
+- **`dry_run`**: Set to `true` to preview what would be materialized without making changes
+
+Note that backfilling adds extra load to the cluster, so it's best done on a weekend.

--- a/docs/published/handbook/engineering/databases/materialized-columns.md
+++ b/docs/published/handbook/engineering/databases/materialized-columns.md
@@ -46,8 +46,8 @@ ops:
       backfill_period_days: 90
       dry_run: false
       properties:
-      - $browser_language_prefix
-      - $app_namespace
+        - $browser_language_prefix
+        - $app_namespace
       table: events
       table_column: properties
 ```


### PR DESCRIPTION
## Summary
- Replace old `manage.py`/`shell_plus` manual materialization instructions with the Dagster job workflow we use in production
- Add links to EU and US Dagster playgrounds
- Document config options (`table`, `table_column`, `properties`, `backfill_period_days`, `dry_run`)

## Test plan
- [ ] Verify handbook page renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)