### PR TITLE
fix: add diagnostic logging for resources_create 401s

### DIFF
--- a/ee/api/agentic_provisioning/authentication.py
+++ b/ee/api/agentic_provisioning/authentication.py
@@ -1,11 +1,14 @@
 from django.conf import settings
 from django.utils import timezone
 
+import structlog
 from rest_framework.authentication import BaseAuthentication
 from rest_framework.exceptions import AuthenticationFailed
 from rest_framework.request import Request
 
 from posthog.models.oauth import find_oauth_access_token
+
+logger = structlog.get_logger(__name__)
 
 BEARER_PREFIX = "Bearer "
 
@@ -22,12 +25,24 @@ class StripeProvisioningBearerAuthentication(BaseAuthentication):
 
         access_token = find_oauth_access_token(token_value)
         if access_token is None:
+            logger.warning("stripe_app.bearer_auth.token_not_found")
             raise AuthenticationFailed("Invalid access token")
 
         if access_token.expires and access_token.expires < timezone.now():
+            logger.warning("stripe_app.bearer_auth.token_expired", token_id=access_token.id)
             raise AuthenticationFailed("Access token expired")
 
         if not _is_stripe_oauth_app(access_token.application):
+            app = access_token.application
+            logger.warning(
+                "stripe_app.bearer_auth.app_mismatch",
+                token_id=access_token.id,
+                has_application=app is not None,
+                app_client_id=app.client_id if app else None,
+                app_name=app.name if app else None,
+                app_id=app.id if app else None,
+                expected_client_id=settings.STRIPE_POSTHOG_OAUTH_CLIENT_ID,
+            )
             raise AuthenticationFailed("Token not issued for Stripe provisioning")
 
         return (access_token.user, access_token)

--- a/mypy-baseline.txt
+++ b/mypy-baseline.txt
@@ -4,6 +4,8 @@ common/hogvm/python/test/test_execute.py:0: error: Value of type "Collection[str
 common/hogvm/stl/compile.py:0: error: Bracketed expression "[...]" is not valid as a type  [valid-type]
 ee/api/authentication.py:0: error: Argument 1 of "get_idp" is incompatible with supertype "social_core.backends.saml.SAMLAuth"; supertype defines the argument type as "str | None"  [override]
 ee/api/authentication.py:0: error: Incompatible return value type (got "Any | None", expected "str")  [return-value]
+ee/api/agentic_provisioning/views.py:0: error: Missing positional argument "spt_token" in call to "_activate_billing_with_spt"  [call-arg]
+ee/api/agentic_provisioning/views.py:0: error: Name "_activate_billing_with_spt" already defined on line 0  [no-redef]
 ee/api/rbac/test/test_access_control.py:0: error: "Organization" has no attribute "available_features"; maybe "get_available_feature" or "available_product_features"?  [attr-defined]
 ee/api/test/base.py:0: error: "setUpTestData" undefined in superclass  [misc]
 ee/api/test/base.py:0: error: Incompatible types in assignment (expression has type "None", variable has type "License")  [assignment]

--- a/mypy-baseline.txt
+++ b/mypy-baseline.txt
@@ -4,8 +4,6 @@ common/hogvm/python/test/test_execute.py:0: error: Value of type "Collection[str
 common/hogvm/stl/compile.py:0: error: Bracketed expression "[...]" is not valid as a type  [valid-type]
 ee/api/authentication.py:0: error: Argument 1 of "get_idp" is incompatible with supertype "social_core.backends.saml.SAMLAuth"; supertype defines the argument type as "str | None"  [override]
 ee/api/authentication.py:0: error: Incompatible return value type (got "Any | None", expected "str")  [return-value]
-ee/api/agentic_provisioning/views.py:0: error: Missing positional argument "spt_token" in call to "_activate_billing_with_spt"  [call-arg]
-ee/api/agentic_provisioning/views.py:0: error: Name "_activate_billing_with_spt" already defined on line 0  [no-redef]
 ee/api/rbac/test/test_access_control.py:0: error: "Organization" has no attribute "available_features"; maybe "get_available_feature" or "available_product_features"?  [attr-defined]
 ee/api/test/base.py:0: error: "setUpTestData" undefined in superclass  [misc]
 ee/api/test/base.py:0: error: Incompatible types in assignment (expression has type "None", variable has type "License")  [assignment]


### PR DESCRIPTION
## Problem

Stripe is reporting intermittent 401s on `resources_create`. We found 17 occurrences over the past week in prod logs, all returning "Authentication failed" - meaning the bearer token exists in the DB but the associated OAuth application doesn't match the Stripe app. The current logging doesn't capture which application the token belongs to, making root cause diagnosis impossible.

## Changes

Adds structured diagnostic logging to `StripeProvisioningBearerAuthentication` in `authentication.py` for three failure cases:

- **Token not found**: logs when `find_oauth_access_token` returns None
- **Token expired**: logs the token's DB primary key
- **App mismatch**: logs the token's application client_id, name, and ID alongside the expected `STRIPE_POSTHOG_OAUTH_CLIENT_ID` - this is the case we're seeing in prod

No sensitive data is logged (no token values or secrets).

## How did you test this code?

This is a logging-only change with no behavioral impact. I'm an agent and have not tested this manually. The structlog calls follow the existing patterns in `views.py`.

## Publish to changelog?

No

## Docs update

N/A - no user-facing changes

## 🤖 LLM context

Investigated Stripe's report of 401s on resources_create. Found 17 occurrences in prod logs (service: posthog-web-django) from 4 AWS IPs, clustered in bursts. All hit the `_is_stripe_oauth_app` check - tokens exist but belong to an unexpected application. This logging will identify which application the tokens actually belong to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)