### PR TITLE
fix(audit-logs): show loading state on filter value dropdowns

### DIFF
--- a/frontend/src/scenes/audit-logs/BasicFiltersTab.tsx
+++ b/frontend/src/scenes/audit-logs/BasicFiltersTab.tsx
@@ -14,7 +14,7 @@ import { advancedActivityLogsLogic } from './advancedActivityLogsLogic'
 import { DetailFilters } from './DetailFilters'
 
 export const BasicFiltersTab = (): JSX.Element => {
-    const { filters, availableFilters, showMoreFilters, activeAdvancedFiltersCount } =
+    const { filters, availableFilters, availableFiltersLoading, showMoreFilters, activeAdvancedFiltersCount } =
         useValues(advancedActivityLogsLogic)
     const { setFilters, setShowMoreFilters } = useActions(advancedActivityLogsLogic)
 
@@ -49,6 +49,7 @@ export const BasicFiltersTab = (): JSX.Element => {
                                 label: u.label,
                             })) || []
                         }
+                        loading={availableFiltersLoading}
                         placeholder="All users"
                         allowCustomValues={false}
                         data-attr="audit-logs-user-filter"
@@ -73,6 +74,7 @@ export const BasicFiltersTab = (): JSX.Element => {
                                 }))
                                 .sort((a, b) => a.label.localeCompare(b.label)) || []
                         }
+                        loading={availableFiltersLoading}
                         placeholder="All scopes"
                         allowCustomValues={false}
                         data-attr="audit-logs-scope-filter"
@@ -97,6 +99,7 @@ export const BasicFiltersTab = (): JSX.Element => {
                                 }))
                                 .sort((a, b) => a.label.localeCompare(b.label)) || []
                         }
+                        loading={availableFiltersLoading}
                         placeholder="All activities"
                         allowCustomValues={false}
                         data-attr="audit-logs-action-filter"


### PR DESCRIPTION
## Problem

The User, Scope, and Activity dropdowns in the audit log filters fetch their options asynchronously but gave no feedback while loading — users saw "No options matching" and assumed the filter was broken instead of waiting.

## Changes

- Wire `availableFiltersLoading` from the kea loader into the User, Scope, and Activity `LemonInputSelect`s so they render the built-in skeleton state while options are in flight

## How did you test this code?

No automated tests added. Manually verified the skeleton renders on initial load of the audit logs scene before options arrive.

## Publish to changelog?

no