### PR TITLE
fix(insights): avoid crash when hovering suggestion for dwh series

### DIFF
--- a/frontend/src/lib/components/DefinitionPopover/DefinitionPopoverContents.tsx
+++ b/frontend/src/lib/components/DefinitionPopover/DefinitionPopoverContents.tsx
@@ -466,6 +466,10 @@ function DefinitionView({ group }: { group: TaxonomicFilterGroup }): JSX.Element
     }
     if (isDataWarehouse && dataWarehousePopoverFields.length > 0) {
         const _definition = definition as DataWarehouseTableForInsight
+        // early return for pinned/recent meta-items that only have lightweight data, and not the full definition
+        if (!_definition?.fields) {
+            return <></>
+        }
         const columnOptions = Object.values(_definition.fields).map((column) => ({
             label: column.name + ' (' + column.type + ')',
             value: column.name,


### PR DESCRIPTION
## Problem

Trying to select a series from a data warehouse suggested filter results in an error.

![Screenshot 2026-04-08 at 20.40.36.png](https://app.graphite.com/user-attachments/assets/0034b403-3bae-4e62-aeab-f12e0e8ab814.png)

![Screenshot 2026-04-08 at 20.41.24.png](https://app.graphite.com/user-attachments/assets/b524c8e2-5582-4cfe-898b-41b34e51a5b8.png)

## Changes

Avoids the error by not rendering the popover for this suggestion. It would probably be better to re-hydrate the definition or to store the full version in the first place.

## How did you test this code?

Tried locally