### PR TITLE
fix: rename duplicate _activate_billing_with_spt function

### DIFF
--- a/ee/api/agentic_provisioning/views.py
+++ b/ee/api/agentic_provisioning/views.py
@@ -935,7 +935,7 @@ def provisioning_update_service(request: Request, resource_id: str) -> Response:
     if payment_credentials:
         spt = payment_credentials.get("stripe_payment_token")
         if spt:
-            _activate_billing_with_spt(team, spt)
+            _activate_billing_with_spt_direct(team, spt)
 
     cache.set(f"{RESOURCE_SERVICE_CACHE_PREFIX}{team_id}", service_id, timeout=None)
 
@@ -961,7 +961,7 @@ def provisioning_update_service(request: Request, resource_id: str) -> Response:
     )
 
 
-def _activate_billing_with_spt(team: Team, spt: str) -> None:
+def _activate_billing_with_spt_direct(team: Team, spt: str) -> None:
     """Forward a Stripe Payment Token to the billing service to activate a paid subscription."""
     try:
         res = requests.post(


### PR DESCRIPTION
## Problem

#53349 introduced a second `_activate_billing_with_spt` function (line 964) that shadows the existing one (line 660). This causes a mypy `no-redef` error and a `call-arg` error since the call site passes 2 args but the first definition expects 3.

## Changes

- Renamed the second definition to `_activate_billing_with_spt_direct` to avoid shadowing
- Updated the call site in `update_service` to use the renamed function

## How did you test this code?

mypy and ruff pass on the file.