### PR TITLE
feat: Add display and chart settings for DataVisualizationNode insights

### DIFF
--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -103,7 +103,7 @@
         }
     },
     "insight-create-from-query": {
-        "description": "Create an insight from a query that you have previously tested with 'query-run'. You should check the query runs, before creating an insight. Do not create an insight before running the query, unless you know already that it is correct (e.g. you are making a minor modification to an existing query you have seen).",
+        "description": "Create an insight from a query that you have previously tested with 'query-run'. You should check the query runs, before creating an insight. Do not create an insight before running the query, unless you know already that it is correct (e.g. you are making a minor modification to an existing query you have seen). IMPORTANT for HogQL insights (DataVisualizationNode): if the user wants a chart (line/bar/area/pie/big number), you MUST set `query.display` (e.g. \"ActionsLineGraph\", \"ActionsBar\", \"ActionsAreaGraph\", \"ActionsPie\", \"BoldNumber\") AND `query.chartSettings` mapping HogQL columns to axes — e.g. `{ xAxis: { column: \"day\" }, yAxis: [{ column: \"signups\" }] }`. Omitting `display` makes a DataVisualizationNode render as a table, which is almost never what the user asked for. InsightVizNode insights (trends/funnels/paths) derive their display from the inner query and do not need these fields.",
         "category": "Insights & analytics",
         "feature": "insights",
         "summary": "Save a query as an insight.",
@@ -191,7 +191,7 @@
         }
     },
     "query-run": {
-        "description": "You should use this to answer questions that a user has about their data and for when you want to create a new insight. You can use 'event-definitions-list' to get events to use in the query, and 'event-properties-list' to get properties for those events. It can run a trend, funnel, paths or HogQL query. Where possible, use a trend, funnel or paths query rather than a HogQL query, unless you know the HogQL is correct (e.g. it came from a previous insight.). Use PathsQuery to visualize user flows and navigation patterns — set includeEventTypes to ['hogql'] with a pathsHogQLExpression for custom path steps.",
+        "description": "You should use this to answer questions that a user has about their data and for when you want to create a new insight. You can use 'event-definitions-list' to get events to use in the query, and 'event-properties-list' to get properties for those events. It can run a trend, funnel, paths or HogQL query. Where possible, use a trend, funnel or paths query rather than a HogQL query, unless you know the HogQL is correct (e.g. it came from a previous insight.). Use PathsQuery to visualize user flows and navigation patterns — set includeEventTypes to ['hogql'] with a pathsHogQLExpression for custom path steps. For HogQL queries that should render as a chart when saved as an insight, wrap the HogQLQuery in a DataVisualizationNode and set `display` (e.g. \"ActionsLineGraph\") and `chartSettings` (e.g. `{ xAxis: { column: \"day\" }, yAxis: [{ column: \"value\" }] }`) — otherwise the resulting insight will render as a table.",
         "category": "Insights & analytics",
         "summary": "Run a trend, funnel, paths or HogQL query.",
         "feature": "insights",

--- a/services/mcp/schema/tool-definitions.json
+++ b/services/mcp/schema/tool-definitions.json
@@ -103,7 +103,7 @@
         }
     },
     "insight-create-from-query": {
-        "description": "Create an insight from a query that you have previously tested with 'query-run'. You should check the query runs, before creating an insight. Do not create an insight before running the query, unless you know already that it is correct (e.g. you are making a minor modification to an existing query you have seen).",
+        "description": "Create an insight from a query that you have previously tested with 'query-run'. You should check the query runs, before creating an insight. Do not create an insight before running the query, unless you know already that it is correct (e.g. you are making a minor modification to an existing query you have seen). IMPORTANT for HogQL insights (DataVisualizationNode): if the user wants a chart (line/bar/area/pie/big number), you MUST set `query.display` (e.g. \"ActionsLineGraph\", \"ActionsBar\", \"ActionsAreaGraph\", \"ActionsPie\", \"BoldNumber\") AND `query.chartSettings` mapping HogQL columns to axes — e.g. `{ xAxis: { column: \"day\" }, yAxis: [{ column: \"signups\" }] }`. Omitting `display` makes a DataVisualizationNode render as a table, which is almost never what the user asked for. InsightVizNode insights (trends/funnels/paths) derive their display from the inner query and do not need these fields.",
         "category": "Insights & analytics",
         "feature": "insights",
         "summary": "Save a query as an insight.",
@@ -191,7 +191,7 @@
         }
     },
     "query-run": {
-        "description": "You should use this to answer questions that a user has about their data and for when you want to create a new insight. You can use 'event-definitions-list' to get events to use in the query, and 'event-properties-list' to get properties for those events. It can run a trend, funnel, paths or HogQL query. Where possible, use a trend, funnel or paths query rather than a HogQL query, unless you know the HogQL is correct (e.g. it came from a previous insight.). Use PathsQuery to visualize user flows and navigation patterns — set includeEventTypes to ['hogql'] with a pathsHogQLExpression for custom path steps.",
+        "description": "You should use this to answer questions that a user has about their data and for when you want to create a new insight. You can use 'event-definitions-list' to get events to use in the query, and 'event-properties-list' to get properties for those events. It can run a trend, funnel, paths or HogQL query. Where possible, use a trend, funnel or paths query rather than a HogQL query, unless you know the HogQL is correct (e.g. it came from a previous insight.). Use PathsQuery to visualize user flows and navigation patterns — set includeEventTypes to ['hogql'] with a pathsHogQLExpression for custom path steps. For HogQL queries that should render as a chart when saved as an insight, wrap the HogQLQuery in a DataVisualizationNode and set `display` (e.g. \"ActionsLineGraph\") and `chartSettings` (e.g. `{ xAxis: { column: \"day\" }, yAxis: [{ column: \"value\" }] }`) — otherwise the resulting insight will render as a table.",
         "category": "Insights & analytics",
         "summary": "Run a trend, funnel, paths or HogQL query.",
         "feature": "insights",

--- a/services/mcp/schema/tool-inputs.json
+++ b/services/mcp/schema/tool-inputs.json
@@ -851,10 +851,31 @@
                                     ]
                                 },
                                 "source": {
-                                    "description": "For new insights, use the query from your successful query-run tool call. For updates, the existing query can optionally be reused."
+                                    "description": "The inner query you validated with `query-run`. For InsightVizNode use a TrendsQuery/FunnelsQuery/PathsQuery; for DataVisualizationNode use a HogQLQuery."
+                                },
+                                "display": {
+                                    "description": "ONLY for DataVisualizationNode (HogQL-backed insights). Sets the visualization type. IMPORTANT: a DataVisualizationNode with no `display` renders as a table — you must set this (e.g. \"ActionsLineGraph\", \"ActionsBar\", \"ActionsAreaGraph\", \"ActionsPie\", \"BoldNumber\") whenever the user asks for a chart. Leave unset on InsightVizNode, which derives its display from the inner query.",
+                                    "type": "string"
+                                },
+                                "chartSettings": {
+                                    "description": "ONLY for DataVisualizationNode when `display` is a chart (line/bar/area/etc.). Maps HogQL columns to chart axes: `{ xAxis: { column: \"day\" }, yAxis: [{ column: \"signups\" }] }`. Without this, line/bar charts will not know which columns to plot.",
+                                    "type": "object",
+                                    "propertyNames": {
+                                        "type": "string"
+                                    },
+                                    "additionalProperties": {}
+                                },
+                                "tableSettings": {
+                                    "description": "ONLY for DataVisualizationNode when `display` is ActionsTable. Optional column pinning, transpose, etc.",
+                                    "type": "object",
+                                    "propertyNames": {
+                                        "type": "string"
+                                    },
+                                    "additionalProperties": {}
                                 }
                             },
-                            "required": ["kind", "source"]
+                            "required": ["kind", "source"],
+                            "description": "The insight query. For HogQL queries wrapped in DataVisualizationNode, remember to set `display` (and `chartSettings.xAxis`/`yAxis` for line/bar/area charts) — otherwise the insight renders as a table even if the user asked for a chart."
                         },
                         "description": {
                             "type": "string"
@@ -972,7 +993,27 @@
                                     ]
                                 },
                                 "source": {
-                                    "description": "For new insights, use the query from your successful query-run tool call. For updates, the existing query can optionally be reused"
+                                    "description": "The inner query (TrendsQuery/FunnelsQuery/PathsQuery for InsightVizNode, HogQLQuery for DataVisualizationNode). On updates the existing query can optionally be reused."
+                                },
+                                "display": {
+                                    "description": "ONLY for DataVisualizationNode. Set to e.g. \"ActionsLineGraph\", \"ActionsBar\", \"ActionsAreaGraph\", \"ActionsPie\", \"BoldNumber\" to render the HogQL result as a chart. Omit (or \"ActionsTable\") for a table. Leave unset on InsightVizNode.",
+                                    "type": "string"
+                                },
+                                "chartSettings": {
+                                    "description": "ONLY for DataVisualizationNode chart displays. Maps HogQL columns to axes, e.g. `{ xAxis: { column: \"day\" }, yAxis: [{ column: \"count\" }] }`.",
+                                    "type": "object",
+                                    "propertyNames": {
+                                        "type": "string"
+                                    },
+                                    "additionalProperties": {}
+                                },
+                                "tableSettings": {
+                                    "description": "ONLY for DataVisualizationNode table displays.",
+                                    "type": "object",
+                                    "propertyNames": {
+                                        "type": "string"
+                                    },
+                                    "additionalProperties": {}
                                 }
                             },
                             "required": ["kind", "source"]
@@ -1724,12 +1765,16 @@
                                                             "type": "string",
                                                             "enum": [
                                                                 "ActionsLineGraph",
-                                                                "ActionsTable",
-                                                                "ActionsPie",
+                                                                "ActionsLineGraphCumulative",
+                                                                "ActionsAreaGraph",
                                                                 "ActionsBar",
+                                                                "ActionsStackedBar",
+                                                                "ActionsUnstackedBar",
                                                                 "ActionsBarValue",
-                                                                "WorldMap",
-                                                                "BoldNumber"
+                                                                "ActionsPie",
+                                                                "ActionsTable",
+                                                                "BoldNumber",
+                                                                "WorldMap"
                                                             ]
                                                         },
                                                         "showLegend": {
@@ -2804,6 +2849,98 @@
                                         }
                                     },
                                     "required": ["kind", "query"]
+                                },
+                                "display": {
+                                    "description": "Visualization type for the HogQL result. Defaults to ActionsTable when omitted — ALWAYS set this when the user asks for a chart (e.g. ActionsLineGraph for a line chart, ActionsBar for a bar chart, ActionsPie for a pie chart, BoldNumber for a single-value big-number card). Pair with `chartSettings.xAxis` / `chartSettings.yAxis` for line/bar/area charts so PostHog knows which HogQL columns to plot.",
+                                    "type": "string",
+                                    "enum": [
+                                        "ActionsLineGraph",
+                                        "ActionsAreaGraph",
+                                        "ActionsBar",
+                                        "ActionsStackedBar",
+                                        "ActionsPie",
+                                        "ActionsTable",
+                                        "BoldNumber"
+                                    ]
+                                },
+                                "chartSettings": {
+                                    "description": "Chart settings for non-table displays. Required in practice for line/bar/area charts so we can map HogQL columns to the X and Y axes.",
+                                    "type": "object",
+                                    "properties": {
+                                        "xAxis": {
+                                            "description": "X axis column — for time-series line/area/bar charts, set this to the date/time column returned by the HogQL query",
+                                            "type": "object",
+                                            "properties": {
+                                                "column": {
+                                                    "type": "string",
+                                                    "description": "Name of the HogQL column (aliased in SELECT) to use for this axis or series"
+                                                }
+                                            },
+                                            "required": ["column"]
+                                        },
+                                        "yAxis": {
+                                            "description": "Y axis series — one entry per numeric column to plot",
+                                            "type": "array",
+                                            "items": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "column": {
+                                                        "type": "string",
+                                                        "description": "Name of the HogQL column (aliased in SELECT) to use for this axis or series"
+                                                    }
+                                                },
+                                                "required": ["column"]
+                                            }
+                                        },
+                                        "seriesBreakdownColumn": {
+                                            "description": "Optional column used to split the data into multiple series (breakdown)",
+                                            "anyOf": [
+                                                {
+                                                    "type": "string"
+                                                },
+                                                {
+                                                    "type": "null"
+                                                }
+                                            ]
+                                        },
+                                        "showLegend": {
+                                            "type": "boolean"
+                                        },
+                                        "showTotalRow": {
+                                            "type": "boolean"
+                                        },
+                                        "stackBars100": {
+                                            "description": "Whether to fill stacked bars to 100% (only for stacked bar charts)",
+                                            "type": "boolean"
+                                        }
+                                    }
+                                },
+                                "tableSettings": {
+                                    "type": "object",
+                                    "properties": {
+                                        "columns": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "column": {
+                                                        "type": "string",
+                                                        "description": "Name of the HogQL column (aliased in SELECT) to use for this axis or series"
+                                                    }
+                                                },
+                                                "required": ["column"]
+                                            }
+                                        },
+                                        "pinnedColumns": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        },
+                                        "transpose": {
+                                            "type": "boolean"
+                                        }
+                                    }
                                 }
                             },
                             "required": ["kind", "source"]

--- a/services/mcp/src/schema/insights.ts
+++ b/services/mcp/src/schema/insights.ts
@@ -44,14 +44,36 @@ export type Insight = Omit<
 
 export const CreateInsightInputSchema = z.object({
     name: z.string(),
-    query: z.object({
-        kind: z.union([z.literal('InsightVizNode'), z.literal('DataVisualizationNode')]),
-        source: z
-            .any()
-            .describe(
-                'For new insights, use the query from your successful query-run tool call. For updates, the existing query can optionally be reused.'
-            ), // NOTE: This is intentionally z.any() to avoid populating the context with the complicated query schema, but we prompt the LLM to use 'query-run' to check queries, before creating insights.
-    }),
+    query: z
+        .object({
+            kind: z.union([z.literal('InsightVizNode'), z.literal('DataVisualizationNode')]),
+            source: z
+                .any()
+                .describe(
+                    'The inner query you validated with `query-run`. For InsightVizNode use a TrendsQuery/FunnelsQuery/PathsQuery; for DataVisualizationNode use a HogQLQuery.'
+                ), // NOTE: This is intentionally z.any() to avoid populating the context with the complicated query schema, but we prompt the LLM to use 'query-run' to check queries, before creating insights.
+            display: z
+                .string()
+                .optional()
+                .describe(
+                    'ONLY for DataVisualizationNode (HogQL-backed insights). Sets the visualization type. IMPORTANT: a DataVisualizationNode with no `display` renders as a table — you must set this (e.g. "ActionsLineGraph", "ActionsBar", "ActionsAreaGraph", "ActionsPie", "BoldNumber") whenever the user asks for a chart. Leave unset on InsightVizNode, which derives its display from the inner query.'
+                ),
+            chartSettings: z
+                .record(z.string(), z.any())
+                .optional()
+                .describe(
+                    'ONLY for DataVisualizationNode when `display` is a chart (line/bar/area/etc.). Maps HogQL columns to chart axes: `{ xAxis: { column: "day" }, yAxis: [{ column: "signups" }] }`. Without this, line/bar charts will not know which columns to plot.'
+                ),
+            tableSettings: z
+                .record(z.string(), z.any())
+                .optional()
+                .describe(
+                    'ONLY for DataVisualizationNode when `display` is ActionsTable. Optional column pinning, transpose, etc.'
+                ),
+        })
+        .describe(
+            'The insight query. For HogQL queries wrapped in DataVisualizationNode, remember to set `display` (and `chartSettings.xAxis`/`yAxis` for line/bar/area charts) — otherwise the insight renders as a table even if the user asked for a chart.'
+        ),
     description: z.string().optional(),
     favorited: z.boolean(),
     tags: z.array(z.string()).optional(),
@@ -67,8 +89,24 @@ export const UpdateInsightInputSchema = z.object({
             source: z
                 .any()
                 .describe(
-                    'For new insights, use the query from your successful query-run tool call. For updates, the existing query can optionally be reused'
+                    'The inner query (TrendsQuery/FunnelsQuery/PathsQuery for InsightVizNode, HogQLQuery for DataVisualizationNode). On updates the existing query can optionally be reused.'
                 ), // NOTE: This is intentionally z.any() to avoid populating the context with the complicated query schema, and to allow the LLM to make a change to an existing insight whose schema we do not support in our simplified subset of the full insight schema.
+            display: z
+                .string()
+                .optional()
+                .describe(
+                    'ONLY for DataVisualizationNode. Set to e.g. "ActionsLineGraph", "ActionsBar", "ActionsAreaGraph", "ActionsPie", "BoldNumber" to render the HogQL result as a chart. Omit (or "ActionsTable") for a table. Leave unset on InsightVizNode.'
+                ),
+            chartSettings: z
+                .record(z.string(), z.any())
+                .optional()
+                .describe(
+                    'ONLY for DataVisualizationNode chart displays. Maps HogQL columns to axes, e.g. `{ xAxis: { column: "day" }, yAxis: [{ column: "count" }] }`.'
+                ),
+            tableSettings: z
+                .record(z.string(), z.any())
+                .optional()
+                .describe('ONLY for DataVisualizationNode table displays.'),
         })
         .optional(),
     favorited: z.boolean().optional(),

--- a/services/mcp/src/schema/query.ts
+++ b/services/mcp/src/schema/query.ts
@@ -7,11 +7,29 @@ const IntervalType = z.enum(['hour', 'day', 'week', 'month'])
 
 const ChartDisplayType = z.enum([
     'ActionsLineGraph',
-    'ActionsTable',
-    'ActionsPie',
+    'ActionsLineGraphCumulative',
+    'ActionsAreaGraph',
     'ActionsBar',
+    'ActionsStackedBar',
+    'ActionsUnstackedBar',
     'ActionsBarValue',
+    'ActionsPie',
+    'ActionsTable',
+    'BoldNumber',
     'WorldMap',
+])
+
+// Chart display type for DataVisualizationNode (HogQL-backed charts).
+// Mirrors the subset of ChartDisplayType that the DataVisualization renderer supports.
+// If omitted, the DataVisualizationNode renders as a table — always set this when
+// you want a HogQL insight to render as a chart.
+const DataVisualizationDisplayType = z.enum([
+    'ActionsLineGraph',
+    'ActionsAreaGraph',
+    'ActionsBar',
+    'ActionsStackedBar',
+    'ActionsPie',
+    'ActionsTable',
     'BoldNumber',
 ])
 
@@ -227,9 +245,46 @@ const InsightVizNodeSchema = z.object({
     source: z.discriminatedUnion('kind', [TrendsQuerySchema, FunnelsQuerySchema, PathsQuerySchema]),
 })
 
+// Axis/series configuration for HogQL-backed charts. `column` must reference a
+// column returned by the HogQL query (e.g. the alias used in SELECT).
+const ChartAxisSchema = z.object({
+    column: z.string().describe('Name of the HogQL column (aliased in SELECT) to use for this axis or series'),
+})
+
+// Chart settings for DataVisualizationNode. For line/bar/area charts, `xAxis`
+// should be a time/category column and `yAxis` should be the numeric series.
+const ChartSettingsSchema = z.object({
+    xAxis: ChartAxisSchema.optional().describe(
+        'X axis column — for time-series line/area/bar charts, set this to the date/time column returned by the HogQL query'
+    ),
+    yAxis: z.array(ChartAxisSchema).optional().describe('Y axis series — one entry per numeric column to plot'),
+    seriesBreakdownColumn: z
+        .string()
+        .nullable()
+        .optional()
+        .describe('Optional column used to split the data into multiple series (breakdown)'),
+    showLegend: z.boolean().optional(),
+    showTotalRow: z.boolean().optional(),
+    stackBars100: z.boolean().optional().describe('Whether to fill stacked bars to 100% (only for stacked bar charts)'),
+})
+
+// Optional table-view settings (only applies when `display` is ActionsTable).
+const TableSettingsSchema = z.object({
+    columns: z.array(ChartAxisSchema).optional(),
+    pinnedColumns: z.array(z.string()).optional(),
+    transpose: z.boolean().optional(),
+})
+
 const DataVisualizationNodeSchema = z.object({
     kind: z.literal('DataVisualizationNode'),
     source: HogQLQuerySchema,
+    display: DataVisualizationDisplayType.optional().describe(
+        'Visualization type for the HogQL result. Defaults to ActionsTable when omitted — ALWAYS set this when the user asks for a chart (e.g. ActionsLineGraph for a line chart, ActionsBar for a bar chart, ActionsPie for a pie chart, BoldNumber for a single-value big-number card). Pair with `chartSettings.xAxis` / `chartSettings.yAxis` for line/bar/area charts so PostHog knows which HogQL columns to plot.'
+    ),
+    chartSettings: ChartSettingsSchema.optional().describe(
+        'Chart settings for non-table displays. Required in practice for line/bar/area charts so we can map HogQL columns to the X and Y axes.'
+    ),
+    tableSettings: TableSettingsSchema.optional(),
 })
 
 // Any insight query
@@ -241,6 +296,7 @@ export {
     NodeKind,
     IntervalType,
     ChartDisplayType,
+    DataVisualizationDisplayType,
     BreakdownType,
     FunnelVizType,
     FunnelOrderType,
@@ -266,6 +322,10 @@ export {
     TrendsFilter,
     FunnelsFilter,
     PathsFilter,
+    // Data visualization settings
+    ChartAxisSchema,
+    ChartSettingsSchema,
+    TableSettingsSchema,
     // HogQL types
     HogQLVariable,
     HogQLFilters,

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/insight-create-from-query.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/insight-create-from-query.json
@@ -13,7 +13,20 @@
                     "type": "string"
                 },
                 "query": {
+                    "description": "The insight query. For HogQL queries wrapped in DataVisualizationNode, remember to set `display` (and `chartSettings.xAxis`/`yAxis` for line/bar/area charts) — otherwise the insight renders as a table even if the user asked for a chart.",
                     "properties": {
+                        "chartSettings": {
+                            "additionalProperties": {},
+                            "description": "ONLY for DataVisualizationNode when `display` is a chart (line/bar/area/etc.). Maps HogQL columns to chart axes: `{ xAxis: { column: \"day\" }, yAxis: [{ column: \"signups\" }] }`. Without this, line/bar charts will not know which columns to plot.",
+                            "propertyNames": {
+                                "type": "string"
+                            },
+                            "type": "object"
+                        },
+                        "display": {
+                            "description": "ONLY for DataVisualizationNode (HogQL-backed insights). Sets the visualization type. IMPORTANT: a DataVisualizationNode with no `display` renders as a table — you must set this (e.g. \"ActionsLineGraph\", \"ActionsBar\", \"ActionsAreaGraph\", \"ActionsPie\", \"BoldNumber\") whenever the user asks for a chart. Leave unset on InsightVizNode, which derives its display from the inner query.",
+                            "type": "string"
+                        },
                         "kind": {
                             "anyOf": [
                                 {
@@ -27,7 +40,15 @@
                             ]
                         },
                         "source": {
-                            "description": "For new insights, use the query from your successful query-run tool call. For updates, the existing query can optionally be reused."
+                            "description": "The inner query you validated with `query-run`. For InsightVizNode use a TrendsQuery/FunnelsQuery/PathsQuery; for DataVisualizationNode use a HogQLQuery."
+                        },
+                        "tableSettings": {
+                            "additionalProperties": {},
+                            "description": "ONLY for DataVisualizationNode when `display` is ActionsTable. Optional column pinning, transpose, etc.",
+                            "propertyNames": {
+                                "type": "string"
+                            },
+                            "type": "object"
                         }
                     },
                     "required": ["kind", "source"],

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/insight-update.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/insight-update.json
@@ -28,6 +28,18 @@
                 },
                 "query": {
                     "properties": {
+                        "chartSettings": {
+                            "additionalProperties": {},
+                            "description": "ONLY for DataVisualizationNode chart displays. Maps HogQL columns to axes, e.g. `{ xAxis: { column: \"day\" }, yAxis: [{ column: \"count\" }] }`.",
+                            "propertyNames": {
+                                "type": "string"
+                            },
+                            "type": "object"
+                        },
+                        "display": {
+                            "description": "ONLY for DataVisualizationNode. Set to e.g. \"ActionsLineGraph\", \"ActionsBar\", \"ActionsAreaGraph\", \"ActionsPie\", \"BoldNumber\" to render the HogQL result as a chart. Omit (or \"ActionsTable\") for a table. Leave unset on InsightVizNode.",
+                            "type": "string"
+                        },
                         "kind": {
                             "anyOf": [
                                 {
@@ -41,7 +53,15 @@
                             ]
                         },
                         "source": {
-                            "description": "For new insights, use the query from your successful query-run tool call. For updates, the existing query can optionally be reused"
+                            "description": "The inner query (TrendsQuery/FunnelsQuery/PathsQuery for InsightVizNode, HogQLQuery for DataVisualizationNode). On updates the existing query can optionally be reused."
+                        },
+                        "tableSettings": {
+                            "additionalProperties": {},
+                            "description": "ONLY for DataVisualizationNode table displays.",
+                            "propertyNames": {
+                                "type": "string"
+                            },
+                            "type": "object"
                         }
                     },
                     "required": ["kind", "source"],

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/v1/query-run.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/v1/query-run.json
@@ -525,12 +525,16 @@
                                                     "default": "ActionsLineGraph",
                                                     "enum": [
                                                         "ActionsLineGraph",
-                                                        "ActionsTable",
-                                                        "ActionsPie",
+                                                        "ActionsLineGraphCumulative",
+                                                        "ActionsAreaGraph",
                                                         "ActionsBar",
+                                                        "ActionsStackedBar",
+                                                        "ActionsUnstackedBar",
                                                         "ActionsBarValue",
-                                                        "WorldMap",
-                                                        "BoldNumber"
+                                                        "ActionsPie",
+                                                        "ActionsTable",
+                                                        "BoldNumber",
+                                                        "WorldMap"
                                                     ],
                                                     "type": "string"
                                                 },
@@ -1373,6 +1377,71 @@
                 },
                 {
                     "properties": {
+                        "chartSettings": {
+                            "description": "Chart settings for non-table displays. Required in practice for line/bar/area charts so we can map HogQL columns to the X and Y axes.",
+                            "properties": {
+                                "seriesBreakdownColumn": {
+                                    "anyOf": [
+                                        {
+                                            "type": "string"
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "description": "Optional column used to split the data into multiple series (breakdown)"
+                                },
+                                "showLegend": {
+                                    "type": "boolean"
+                                },
+                                "showTotalRow": {
+                                    "type": "boolean"
+                                },
+                                "stackBars100": {
+                                    "description": "Whether to fill stacked bars to 100% (only for stacked bar charts)",
+                                    "type": "boolean"
+                                },
+                                "xAxis": {
+                                    "description": "X axis column — for time-series line/area/bar charts, set this to the date/time column returned by the HogQL query",
+                                    "properties": {
+                                        "column": {
+                                            "description": "Name of the HogQL column (aliased in SELECT) to use for this axis or series",
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": ["column"],
+                                    "type": "object"
+                                },
+                                "yAxis": {
+                                    "description": "Y axis series — one entry per numeric column to plot",
+                                    "items": {
+                                        "properties": {
+                                            "column": {
+                                                "description": "Name of the HogQL column (aliased in SELECT) to use for this axis or series",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": ["column"],
+                                        "type": "object"
+                                    },
+                                    "type": "array"
+                                }
+                            },
+                            "type": "object"
+                        },
+                        "display": {
+                            "description": "Visualization type for the HogQL result. Defaults to ActionsTable when omitted — ALWAYS set this when the user asks for a chart (e.g. ActionsLineGraph for a line chart, ActionsBar for a bar chart, ActionsPie for a pie chart, BoldNumber for a single-value big-number card). Pair with `chartSettings.xAxis` / `chartSettings.yAxis` for line/bar/area charts so PostHog knows which HogQL columns to plot.",
+                            "enum": [
+                                "ActionsLineGraph",
+                                "ActionsAreaGraph",
+                                "ActionsBar",
+                                "ActionsStackedBar",
+                                "ActionsPie",
+                                "ActionsTable",
+                                "BoldNumber"
+                            ],
+                            "type": "string"
+                        },
                         "kind": {
                             "const": "DataVisualizationNode",
                             "type": "string"
@@ -1532,6 +1601,33 @@
                                 }
                             },
                             "required": ["kind", "query"],
+                            "type": "object"
+                        },
+                        "tableSettings": {
+                            "properties": {
+                                "columns": {
+                                    "items": {
+                                        "properties": {
+                                            "column": {
+                                                "description": "Name of the HogQL column (aliased in SELECT) to use for this axis or series",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": ["column"],
+                                        "type": "object"
+                                    },
+                                    "type": "array"
+                                },
+                                "pinnedColumns": {
+                                    "items": {
+                                        "type": "string"
+                                    },
+                                    "type": "array"
+                                },
+                                "transpose": {
+                                    "type": "boolean"
+                                }
+                            },
                             "type": "object"
                         }
                     },


### PR DESCRIPTION
## Problem

DataVisualizationNode (HogQL-backed insights) lacked proper configuration options for visualization type and chart axis mapping. Without these fields, HogQL queries would always render as tables even when users requested charts, and there was no way to specify which columns should map to chart axes.

## Changes

Added comprehensive visualization configuration support for DataVisualizationNode:

1. **New `display` field**: Specifies the visualization type (e.g., "ActionsLineGraph", "ActionsBar", "ActionsPie", "BoldNumber"). Defaults to table when omitted.

2. **New `chartSettings` field**: Maps HogQL result columns to chart axes:
   - `xAxis`: Specifies the X-axis column (typically time/category)
   - `yAxis`: Array of numeric columns to plot as series
   - `seriesBreakdownColumn`: Optional column for series breakdown
   - `showLegend`, `showTotalRow`, `stackBars100`: Display options

3. **New `tableSettings` field**: Optional table-specific configuration:
   - `columns`: Column selection
   - `pinnedColumns`: Columns to pin
   - `transpose`: Whether to transpose the table

4. **Updated chart display types**: Expanded enum to include additional chart types (ActionsLineGraphCumulative, ActionsAreaGraph, ActionsStackedBar, ActionsUnstackedBar) and created a separate `DataVisualizationDisplayType` enum for the subset supported by DataVisualizationNode.

5. **Enhanced documentation**: Added clear descriptions emphasizing that `display` must be set when users request charts, and that `chartSettings.xAxis`/`yAxis` are required for line/bar/area charts.

Updated schemas in:
- `services/mcp/src/schema/query.ts`: Added ChartAxisSchema, ChartSettingsSchema, TableSettingsSchema, and DataVisualizationDisplayType
- `services/mcp/src/schema/insights.ts`: Added display, chartSettings, and tableSettings to CreateInsightInputSchema and UpdateInsightInputSchema
- `services/mcp/schema/tool-inputs.json`: Updated tool input definitions
- Test snapshots: Updated to reflect new schema structure

## How did you test this code?

Schema changes are validated through TypeScript compilation and existing unit tests. The snapshot tests in `services/mcp/tests/unit/__snapshots__/` have been updated to reflect the new schema structure and will verify the generated tool schemas match expectations.

## Publish to changelog?

No

https://claude.ai/code/session_01VPBfjBDr9gGD9Nb5z1LQLv