### PR TITLE
chore(experiments): enrich experiment metric tracking properties

### DIFF
--- a/frontend/src/lib/utils/eventUsageLogic.test.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.test.ts
@@ -1,0 +1,250 @@
+import { NodeKind } from '~/queries/schema/schema-general'
+import type {
+    ExperimentFunnelMetric,
+    ExperimentFunnelsQuery,
+    ExperimentMeanMetric,
+    ExperimentRatioMetric,
+    ExperimentRetentionMetric,
+    ExperimentTrendsQuery,
+} from '~/queries/schema/schema-general'
+import { BaseMathType } from '~/types'
+
+import { getEventPropertiesForMetric } from './eventUsageLogic'
+
+describe('getEventPropertiesForMetric', () => {
+    describe('ExperimentMetric (new format)', () => {
+        it('extracts funnel metric properties', () => {
+            const metric: ExperimentFunnelMetric = {
+                kind: NodeKind.ExperimentMetric,
+                metric_type: 'funnel' as const,
+                series: [
+                    {
+                        kind: NodeKind.EventsNode,
+                        event: 'pageview',
+                        properties: [{ type: 'event', key: 'url', value: '/home' }],
+                    },
+                    { kind: NodeKind.ActionsNode, id: 1 },
+                    {
+                        kind: NodeKind.EventsNode,
+                        event: 'purchase',
+                        properties: [
+                            { type: 'event', key: 'amount', value: '10' },
+                            { type: 'event', key: 'currency', value: 'USD' },
+                        ],
+                    },
+                ],
+                funnel_order_type: 'strict',
+            } as ExperimentFunnelMetric
+
+            const result = getEventPropertiesForMetric(metric) as Record<string, any>
+
+            expect(result.kind).toBe(NodeKind.ExperimentMetric)
+            expect(result.metric_type).toBe('funnel')
+            expect(result.has_breakdown).toBe(false)
+            expect(result.funnel_steps_count).toBe(3)
+            expect(result.funnel_order_type).toBe('strict')
+            expect(result.property_filter_count).toBe(3)
+        })
+
+        it('extracts mean metric properties', () => {
+            const metric: ExperimentMeanMetric = {
+                kind: NodeKind.ExperimentMetric,
+                metric_type: 'mean' as const,
+                source: {
+                    kind: NodeKind.EventsNode,
+                    event: 'purchase',
+                    math: BaseMathType.UniqueUsers,
+                    properties: [{ type: 'event', key: 'amount', value: '10' }],
+                },
+            } as ExperimentMeanMetric
+
+            const result = getEventPropertiesForMetric(metric) as Record<string, any>
+
+            expect(result.kind).toBe(NodeKind.ExperimentMetric)
+            expect(result.metric_type).toBe('mean')
+            expect(result.source_kind).toBe(NodeKind.EventsNode)
+            expect(result.is_data_warehouse).toBe(false)
+            expect(result.property_filter_count).toBe(1)
+            expect(result.math_type).toBe(BaseMathType.UniqueUsers)
+            expect(result.has_math_hogql).toBe(false)
+        })
+
+        it('extracts mean metric with data warehouse source', () => {
+            const metric: ExperimentMeanMetric = {
+                kind: NodeKind.ExperimentMetric,
+                metric_type: 'mean' as const,
+                source: {
+                    kind: NodeKind.ExperimentDataWarehouseNode,
+                    table_name: 'my_table',
+                    timestamp_field: 'ts',
+                    events_join_key: 'id',
+                    data_warehouse_join_key: 'event_id',
+                },
+            } as ExperimentMeanMetric
+
+            const result = getEventPropertiesForMetric(metric) as Record<string, any>
+
+            expect(result.is_data_warehouse).toBe(true)
+            expect(result.source_kind).toBe(NodeKind.ExperimentDataWarehouseNode)
+            expect(result.property_filter_count).toBe(0)
+            expect(result.math_type).toBeUndefined()
+            expect(result.has_math_hogql).toBe(false)
+        })
+
+        it('extracts ratio metric properties from both sources', () => {
+            const metric: ExperimentRatioMetric = {
+                kind: NodeKind.ExperimentMetric,
+                metric_type: 'ratio' as const,
+                numerator: {
+                    kind: NodeKind.EventsNode,
+                    event: 'purchase',
+                    math: BaseMathType.TotalCount,
+                    properties: [{ type: 'event', key: 'a', value: '1' }],
+                },
+                denominator: {
+                    kind: NodeKind.EventsNode,
+                    event: 'pageview',
+                    math_hogql: 'count()',
+                    properties: [
+                        { type: 'event', key: 'b', value: '2' },
+                        { type: 'event', key: 'c', value: '3' },
+                    ],
+                },
+            } as ExperimentRatioMetric
+
+            const result = getEventPropertiesForMetric(metric) as Record<string, any>
+
+            expect(result.metric_type).toBe('ratio')
+            expect(result.numerator_source_kind).toBe(NodeKind.EventsNode)
+            expect(result.denominator_source_kind).toBe(NodeKind.EventsNode)
+            expect(result.is_data_warehouse).toBe(false)
+            expect(result.property_filter_count).toBe(3)
+            expect(result.numerator_math_type).toBe(BaseMathType.TotalCount)
+            expect(result.has_math_hogql).toBe(true)
+        })
+
+        it('extracts retention metric properties', () => {
+            const metric: ExperimentRetentionMetric = {
+                kind: NodeKind.ExperimentMetric,
+                metric_type: 'retention' as const,
+                start_event: { kind: NodeKind.EventsNode, event: 'signup' },
+                completion_event: {
+                    kind: NodeKind.EventsNode,
+                    event: 'purchase',
+                    properties: [{ type: 'event', key: 'x', value: '1' }],
+                },
+                retention_window_start: 1,
+                retention_window_end: 8,
+                retention_window_unit: 'day',
+                start_handling: 'first_seen',
+            } as ExperimentRetentionMetric
+
+            const result = getEventPropertiesForMetric(metric) as Record<string, any>
+
+            expect(result.metric_type).toBe('retention')
+            expect(result.is_data_warehouse).toBe(false)
+            expect(result.property_filter_count).toBe(1)
+        })
+
+        it.each([
+            { unit: 'day', start: 1, end: 8, expected: 7 },
+            { unit: 'week', start: 0, end: 2, expected: 14 },
+            { unit: 'month', start: 0, end: 1, expected: 30 },
+            { unit: 'hour', start: 0, end: 5, expected: undefined },
+        ])('computes retention_window_days for $unit unit', ({ unit, start, end, expected }) => {
+            const metric = {
+                kind: NodeKind.ExperimentMetric,
+                metric_type: 'retention' as const,
+                start_event: { kind: NodeKind.EventsNode, event: 'signup' },
+                completion_event: { kind: NodeKind.EventsNode, event: 'purchase' },
+                retention_window_start: start,
+                retention_window_end: end,
+                retention_window_unit: unit,
+                start_handling: 'first_seen',
+            } as ExperimentRetentionMetric
+
+            const result = getEventPropertiesForMetric(metric) as Record<string, any>
+
+            expect(result.retention_window_days).toBe(expected)
+        })
+
+        it('includes has_breakdown when breakdownFilter is set', () => {
+            const metric: ExperimentMeanMetric = {
+                kind: NodeKind.ExperimentMetric,
+                metric_type: 'mean' as const,
+                source: { kind: NodeKind.EventsNode, event: 'purchase' },
+                breakdownFilter: { breakdown: '$browser', breakdown_type: 'event' },
+            } as ExperimentMeanMetric
+
+            const result = getEventPropertiesForMetric(metric) as Record<string, any>
+
+            expect(result.has_breakdown).toBe(true)
+        })
+
+        it('returns base properties for unknown metric_type', () => {
+            const metric = {
+                kind: NodeKind.ExperimentMetric,
+                metric_type: 'some_future_type',
+            }
+
+            const result = getEventPropertiesForMetric(metric as any) as Record<string, any>
+
+            expect(result).toEqual({
+                kind: NodeKind.ExperimentMetric,
+                metric_type: 'some_future_type',
+                has_breakdown: false,
+            })
+        })
+
+        it('handles empty funnel series', () => {
+            const metric: ExperimentFunnelMetric = {
+                kind: NodeKind.ExperimentMetric,
+                metric_type: 'funnel' as const,
+                series: [],
+            } as ExperimentFunnelMetric
+
+            const result = getEventPropertiesForMetric(metric) as Record<string, any>
+
+            expect(result.funnel_steps_count).toBe(0)
+            expect(result.property_filter_count).toBe(0)
+        })
+    })
+
+    describe('legacy formats', () => {
+        it('extracts ExperimentFunnelsQuery properties', () => {
+            const metric = {
+                kind: NodeKind.ExperimentFunnelsQuery,
+                funnels_query: {
+                    series: [
+                        { kind: NodeKind.EventsNode },
+                        { kind: NodeKind.EventsNode },
+                        { kind: NodeKind.EventsNode },
+                    ],
+                    filterTestAccounts: true,
+                },
+            } as ExperimentFunnelsQuery
+
+            const result = getEventPropertiesForMetric(metric) as Record<string, any>
+
+            expect(result.kind).toBe(NodeKind.ExperimentFunnelsQuery)
+            expect(result.steps_count).toBe(3)
+            expect(result.filter_test_accounts).toBe(true)
+        })
+
+        it('extracts ExperimentTrendsQuery properties', () => {
+            const metric = {
+                kind: NodeKind.ExperimentTrendsQuery,
+                count_query: {
+                    series: [{ kind: NodeKind.ActionsNode, id: 1 }],
+                    filterTestAccounts: false,
+                },
+            } as ExperimentTrendsQuery
+
+            const result = getEventPropertiesForMetric(metric) as Record<string, any>
+
+            expect(result.kind).toBe(NodeKind.ExperimentTrendsQuery)
+            expect(result.series_kind).toBe(NodeKind.ActionsNode)
+            expect(result.filter_test_accounts).toBe(false)
+        })
+    })
+})

--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -17,7 +17,13 @@ import {
     Breakdown,
     ExperimentFunnelsQuery,
     ExperimentMetric,
+    ExperimentMetricSource,
+    ExperimentRetentionMetric,
     ExperimentTrendsQuery,
+    isExperimentFunnelMetric,
+    isExperimentMeanMetric,
+    isExperimentRatioMetric,
+    isExperimentRetentionMetric,
     Node,
     NodeKind,
 } from '~/queries/schema/schema-general'
@@ -106,14 +112,85 @@ export enum GraphSeriesAddedSource {
     Duplicate = 'duplicate',
 }
 
+function retentionWindowDays(metric: ExperimentRetentionMetric): number | undefined {
+    const unitToDays: Record<string, number> = { day: 1, week: 7, month: 30 }
+    const multiplier = unitToDays[metric.retention_window_unit]
+    return multiplier ? (metric.retention_window_end - metric.retention_window_start) * multiplier : undefined
+}
+
+function getSourceProperties(source: ExperimentMetricSource): {
+    source_kind: string
+    is_data_warehouse: boolean
+    property_filter_count: number
+    math_type: string | undefined
+    has_math_hogql: boolean
+} {
+    return {
+        source_kind: source.kind,
+        is_data_warehouse: source.kind === NodeKind.ExperimentDataWarehouseNode,
+        property_filter_count: (source.properties?.length ?? 0) + (source.fixedProperties?.length ?? 0),
+        math_type: source.math,
+        has_math_hogql: !!source.math_hogql,
+    }
+}
+
 export function getEventPropertiesForMetric(
     metric: ExperimentMetric | ExperimentTrendsQuery | ExperimentFunnelsQuery
 ): object {
     if (metric.kind === NodeKind.ExperimentMetric) {
-        return {
+        const base = {
             kind: NodeKind.ExperimentMetric,
             metric_type: metric.metric_type,
+            has_breakdown: !!metric.breakdownFilter,
         }
+
+        if (isExperimentFunnelMetric(metric)) {
+            const totalFilterCount = metric.series.reduce(
+                (sum, step) => sum + (step.properties?.length ?? 0) + (step.fixedProperties?.length ?? 0),
+                0
+            )
+            return {
+                ...base,
+                funnel_steps_count: metric.series.length,
+                funnel_order_type: metric.funnel_order_type,
+                property_filter_count: totalFilterCount,
+            }
+        }
+
+        if (isExperimentMeanMetric(metric)) {
+            return {
+                ...base,
+                ...getSourceProperties(metric.source),
+            }
+        }
+
+        if (isExperimentRatioMetric(metric)) {
+            const numeratorProps = getSourceProperties(metric.numerator)
+            const denominatorProps = getSourceProperties(metric.denominator)
+            return {
+                ...base,
+                numerator_source_kind: numeratorProps.source_kind,
+                denominator_source_kind: denominatorProps.source_kind,
+                is_data_warehouse: numeratorProps.is_data_warehouse || denominatorProps.is_data_warehouse,
+                property_filter_count: numeratorProps.property_filter_count + denominatorProps.property_filter_count,
+                numerator_math_type: numeratorProps.math_type,
+                denominator_math_type: denominatorProps.math_type,
+                has_math_hogql: numeratorProps.has_math_hogql || denominatorProps.has_math_hogql,
+            }
+        }
+
+        if (isExperimentRetentionMetric(metric)) {
+            const startProps = getSourceProperties(metric.start_event)
+            const completionProps = getSourceProperties(metric.completion_event)
+            return {
+                ...base,
+                is_data_warehouse: startProps.is_data_warehouse || completionProps.is_data_warehouse,
+                property_filter_count: startProps.property_filter_count + completionProps.property_filter_count,
+                retention_window_days: retentionWindowDays(metric),
+            }
+        }
+
+        return base
     } else if (metric.kind === NodeKind.ExperimentFunnelsQuery) {
         return {
             kind: NodeKind.ExperimentFunnelsQuery,


### PR DESCRIPTION
## Problem

We're investigating what makes experiment metrics slow, but our current tracking (`getEventPropertiesForMetric`) only captures `metric_type` for new-format metrics — nothing about the metric's composition (breakdowns, property filters, math types, data warehouse sources). This means we can't answer questions like "are metrics with breakdowns slower?" or "do data warehouse sources cause timeouts?" from our [experiment metric performance dashboard](https://us.posthog.com/project/2/dashboard/1441600).

For example, Insight 6 on that dashboard shows experiments with 3-5 metrics sometimes taking longer than 6+ metrics — but without composition data, we can't determine whether that's driven by funnel-heavy configs, high property filter counts, or specific aggregation types.

## Changes

Enriches `getEventPropertiesForMetric` to extract detailed, low-cardinality properties from each metric type:

| Metric type | New properties |
|---|---|
| **All types** | `has_breakdown` |
| **Funnel** | `funnel_steps_count`, `funnel_order_type`, `property_filter_count` |
| **Mean** | `source_kind`, `is_data_warehouse`, `property_filter_count`, `math_type`, `has_math_hogql` |
| **Ratio** | `numerator_source_kind`, `denominator_source_kind`, `is_data_warehouse`, `property_filter_count`, `numerator_math_type`, `denominator_math_type`, `has_math_hogql` |
| **Retention** | `is_data_warehouse`, `property_filter_count`, `retention_window_days` |

Adds a `getSourceProperties` helper to deduplicate property extraction across mean/ratio/retention branches. Legacy formats (`ExperimentTrendsQuery`, `ExperimentFunnelsQuery`) are unchanged.

No high-cardinality properties (event names, breakdown values, property keys) are included — only enums, booleans, and small integers.

## How did you test this code?

- 11 unit tests covering all metric types, edge cases (empty funnel series, unknown future metric_type fallthrough, data warehouse sources with no optional fields), and legacy format backward compatibility.
- `pnpm typescript:check` passes with no new errors.

No manual testing — this is an agent-authored tracking change with no UI impact.

## Publish to changelog?

No

## Docs update

N/A

## 🤖 LLM context

Co-authored with Claude Code. The changes were informed by analysis of the [experiment metric performance dashboard](https://us.posthog.com/project/2/dashboard/1441600), which revealed that metric count alone doesn't explain slowness — metric composition matters more. We ran a HogQL query joining `experiment metric finished` with `experiment results refresh completed` by `experiment_id` to confirm that funnel and retention metrics are the slowest types regardless of count bucket, and that the 3-5 vs 6+ anomaly in Insight 6 is likely sample noise rather than a real signal.

The gap analysis in the baseline insights doc identified that `getEventPropertiesForMetric` was the bottleneck — the metric objects have rich composition data available, but the function was barely extracting any of it. This PR fills that gap so future analysis can correlate slowness with specific metric configurations.