### PR TITLE
feat(cohorts): add automatic backfill for person property changes

### DIFF
--- a/posthog/models/cohort/dependencies.py
+++ b/posthog/models/cohort/dependencies.py
@@ -206,15 +206,6 @@ def _person_property_filters_changed(cohort: Cohort) -> bool:
         # Extract current person property filters
         current_filters = _extract_person_property_filters(cohort)
 
-        # Debug logging
-        logger.info(
-            "checking_person_property_filter_changes",
-            cohort_id=cohort.pk,
-            previous_filters=previous_filters,
-            current_filters=current_filters,
-            changed=current_filters != previous_filters,
-        )
-
         # Compare the filters - they changed if they're not equal
         return current_filters != previous_filters
 

--- a/posthog/models/cohort/dependencies.py
+++ b/posthog/models/cohort/dependencies.py
@@ -155,36 +155,7 @@ def _has_person_property_filters(cohort: Cohort) -> bool:
     Check if a cohort has person property filters in its filters.
     Used to determine if backfill should be triggered.
     """
-    if not cohort.filters:
-        return False
-
-    def traverse_filter_tree(node) -> bool:
-        """Recursively traverse the filter tree to find person property filters."""
-        if not isinstance(node, dict):
-            return False
-
-        # Check if this is a group node (AND/OR)
-        node_type = node.get("type")
-        if node_type in ("AND", "OR"):
-            # Check children recursively
-            for child in node.get("values", []):
-                if traverse_filter_tree(child):
-                    return True
-            return False
-
-        # This is a leaf node - check if it's a person property filter with required fields
-        return (
-            node_type == "person"
-            and node.get("conditionHash") is not None
-            and node.get("bytecode") is not None
-            and node.get("key") is not None
-        )
-
-    properties = cohort.filters.get("properties")
-    if not properties:
-        return False
-
-    return traverse_filter_tree(properties)
+    return bool(_extract_person_property_filters(cohort))
 
 
 def _person_property_filters_changed(cohort: Cohort) -> bool:
@@ -274,10 +245,10 @@ def _extract_person_property_filters(cohort: Cohort) -> str:
 def _trigger_cohort_backfill(cohort: Cohort) -> None:
     """
     Trigger backfill for a realtime cohort with person properties.
-    Uses the existing temporal workflow for consistency.
+    Uses Celery to avoid blocking the caller.
     """
     try:
-        from django.core.management import call_command
+        from posthog.tasks.calculate_cohort import trigger_cohort_backfill_task
 
         logger.info(
             "triggering_cohort_backfill_on_conditions_change",
@@ -286,19 +257,8 @@ def _trigger_cohort_backfill(cohort: Cohort) -> None:
             cohort_type=cohort.cohort_type,
         )
 
-        # Use the existing management command to trigger backfill
-        # This will use the Temporal workflow infrastructure
-        call_command(
-            "backfill_precalculated_person_properties",
-            "--team-id",
-            str(cohort.team_id),
-            "--cohort-id",
-            str(cohort.pk),
-            "--batch-size",
-            10_000,
-            "--concurrent-workflows",
-            100,
-        )
+        # Use Celery task to avoid blocking network I/O
+        trigger_cohort_backfill_task.delay(cohort.team_id, cohort.pk)
 
     except Exception as e:
         logger.exception(
@@ -317,14 +277,15 @@ def cohort_pre_save(sender, instance, **kwargs):
     This is needed to compare with the new state in post_save.
     """
     try:
-        if instance.pk:
-            # Get the previous version from database
-            previous_cohort = Cohort.objects.get(pk=instance.pk)
-            # Store the previous person property filters hash on the instance
-            instance._previous_person_property_filters = _extract_person_property_filters(previous_cohort)
-        else:
-            # New cohort, no previous state
+        # Skip non-realtime cohorts to avoid extra DB queries
+        if not instance.pk or instance.cohort_type != CohortType.REALTIME:
             instance._previous_person_property_filters = ""
+            return
+
+        # Get the previous version from database
+        previous_cohort = Cohort.objects.get(pk=instance.pk)
+        # Store the previous person property filters hash on the instance
+        instance._previous_person_property_filters = _extract_person_property_filters(previous_cohort)
     except Cohort.DoesNotExist:
         # Cohort doesn't exist yet (should not happen), treat as new
         instance._previous_person_property_filters = ""

--- a/posthog/models/cohort/dependencies.py
+++ b/posthog/models/cohort/dependencies.py
@@ -321,13 +321,13 @@ def cohort_pre_save(sender, instance, **kwargs):
             # Get the previous version from database
             previous_cohort = Cohort.objects.get(pk=instance.pk)
             # Store the previous person property filters hash on the instance
-            instance._previous_person_property_filters = _extract_person_property_filters(previous_cohort)  # type: ignore
+            instance._previous_person_property_filters = _extract_person_property_filters(previous_cohort)
         else:
             # New cohort, no previous state
-            instance._previous_person_property_filters = ""  # type: ignore
+            instance._previous_person_property_filters = ""
     except Cohort.DoesNotExist:
         # Cohort doesn't exist yet (should not happen), treat as new
-        instance._previous_person_property_filters = ""  # type: ignore
+        instance._previous_person_property_filters = ""
     except Exception as e:
         logger.warning(
             "error_capturing_previous_person_property_filters",
@@ -335,7 +335,7 @@ def cohort_pre_save(sender, instance, **kwargs):
             error=str(e),
         )
         # If we can't capture previous state, mark as None to be safe
-        instance._previous_person_property_filters = None  # type: ignore
+        instance._previous_person_property_filters = None
 
 
 @receiver(post_save, sender=Cohort)

--- a/posthog/models/cohort/dependencies.py
+++ b/posthog/models/cohort/dependencies.py
@@ -1,17 +1,19 @@
 from django.core.cache import cache
 from django.db import transaction
-from django.db.models.signals import post_delete, post_save
+from django.db.models.signals import post_delete, post_save, pre_save
 from django.dispatch import receiver
 
+import posthoganalytics
 from prometheus_client import Counter
 from rest_framework.exceptions import ValidationError
 from structlog import get_logger
 
-from posthog.models.cohort.cohort import Cohort, is_cohort_recalculation_only_save
+from posthog.models.cohort.cohort import Cohort, CohortType, is_cohort_recalculation_only_save
 from posthog.models.team.team import Team
 
 logger = get_logger(__name__)
 DEPENDENCY_CACHE_TIMEOUT = 7 * 24 * 60 * 60  # 1 week
+
 
 # Prometheus metrics for cache hit/miss tracking
 COHORT_DEPENDENCY_CACHE_COUNTER = Counter(
@@ -148,6 +150,203 @@ def _on_cohort_changed(cohort: Cohort, always_invalidate: bool = False):
     warm_team_cohort_dependency_cache(cohort.team_id)
 
 
+def _has_person_property_filters(cohort: Cohort) -> bool:
+    """
+    Check if a cohort has person property filters in its filters.
+    Used to determine if backfill should be triggered.
+    """
+    if not cohort.filters:
+        return False
+
+    def traverse_filter_tree(node) -> bool:
+        """Recursively traverse the filter tree to find person property filters."""
+        if not isinstance(node, dict):
+            return False
+
+        # Check if this is a group node (AND/OR)
+        node_type = node.get("type")
+        if node_type in ("AND", "OR"):
+            # Check children recursively
+            for child in node.get("values", []):
+                if traverse_filter_tree(child):
+                    return True
+            return False
+
+        # This is a leaf node - check if it's a person property filter with required fields
+        return (
+            node_type == "person"
+            and node.get("conditionHash") is not None
+            and node.get("bytecode") is not None
+            and node.get("key") is not None
+        )
+
+    properties = cohort.filters.get("properties")
+    if not properties:
+        return False
+
+    return traverse_filter_tree(properties)
+
+
+def _person_property_filters_changed(cohort: Cohort) -> bool:
+    """
+    Check if person property filters have changed by comparing current filters
+    with the previous version stored in pre_save.
+    """
+    try:
+        # For new cohorts, always trigger if they have person property filters
+        if not cohort.pk:
+            return True
+
+        # Check if we have the previous state stored from pre_save
+        previous_filters = getattr(cohort, "_previous_person_property_filters", None)
+        if previous_filters is None:
+            # No previous state available, assume changed to be safe
+            return True
+
+        # Extract current person property filters
+        current_filters = _extract_person_property_filters(cohort)
+
+        # Debug logging
+        logger.info(
+            "checking_person_property_filter_changes",
+            cohort_id=cohort.pk,
+            previous_filters=previous_filters,
+            current_filters=current_filters,
+            changed=current_filters != previous_filters,
+        )
+
+        # Compare the filters - they changed if they're not equal
+        return current_filters != previous_filters
+
+    except Exception as e:
+        logger.warning(
+            "error_checking_person_property_filter_changes",
+            cohort_id=cohort.pk,
+            error=str(e),
+        )
+        # If we can't determine if they changed, assume they did to be safe
+        return True
+
+
+def _extract_person_property_filters(cohort: Cohort) -> str:
+    """
+    Extract a normalized representation of person property filters from a cohort.
+    Returns a hash string that can be used for comparison to detect changes.
+    This captures both the individual conditions AND their logical structure.
+    """
+    import json
+    import hashlib
+
+    if not cohort.filters:
+        return ""
+
+    def normalize_filter_tree(node) -> dict | None:
+        """Recursively traverse and normalize the filter tree structure."""
+        if not isinstance(node, dict):
+            return None
+
+        node_type = node.get("type")
+
+        # Check if this is a group node (AND/OR)
+        if node_type in ("AND", "OR"):
+            # Recursively process children and filter out None values
+            children = []
+            for child in node.get("values", []):
+                normalized_child = normalize_filter_tree(child)
+                if normalized_child is not None:
+                    children.append(normalized_child)
+
+            if children:
+                return {"type": node_type, "children": children}
+            return None
+
+        # This is a leaf node - check if it's a person property filter
+        if node_type == "person" and node.get("conditionHash") is not None:
+            # Use conditionHash to represent the condition, preserving structure
+            return {"type": "person", "conditionHash": node.get("conditionHash")}
+
+        return None
+
+    properties = cohort.filters.get("properties")
+    if not properties:
+        return ""
+
+    normalized_tree = normalize_filter_tree(properties)
+    if not normalized_tree:
+        return ""
+
+    # Convert to a stable JSON representation and hash it
+    normalized_json = json.dumps(normalized_tree, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(normalized_json.encode()).hexdigest()
+
+
+def _trigger_cohort_backfill(cohort: Cohort) -> None:
+    """
+    Trigger backfill for a realtime cohort with person properties.
+    Uses the existing temporal workflow for consistency.
+    """
+    try:
+        from django.core.management import call_command
+
+        logger.info(
+            "triggering_cohort_backfill_on_conditions_change",
+            cohort_id=cohort.pk,
+            team_id=cohort.team_id,
+            cohort_type=cohort.cohort_type,
+        )
+
+        # Use the existing management command to trigger backfill
+        # This will use the Temporal workflow infrastructure
+        call_command(
+            "backfill_precalculated_person_properties",
+            "--team-id",
+            str(cohort.team_id),
+            "--cohort-id",
+            str(cohort.pk),
+            "--batch-size",
+            10_000,
+            "--concurrent-workflows",
+            100,
+        )
+
+    except Exception as e:
+        logger.exception(
+            "failed_to_trigger_cohort_backfill",
+            cohort_id=cohort.pk,
+            team_id=cohort.team_id,
+            error=str(e),
+        )
+        # Don't re-raise the exception to avoid breaking the main save operation
+
+
+@receiver(pre_save, sender=Cohort)
+def cohort_pre_save(sender, instance, **kwargs):
+    """
+    Capture the previous state of person property filters before save.
+    This is needed to compare with the new state in post_save.
+    """
+    try:
+        if instance.pk:
+            # Get the previous version from database
+            previous_cohort = Cohort.objects.get(pk=instance.pk)
+            # Store the previous person property filters hash on the instance
+            instance._previous_person_property_filters = _extract_person_property_filters(previous_cohort)  # type: ignore
+        else:
+            # New cohort, no previous state
+            instance._previous_person_property_filters = ""  # type: ignore
+    except Cohort.DoesNotExist:
+        # Cohort doesn't exist yet (should not happen), treat as new
+        instance._previous_person_property_filters = ""  # type: ignore
+    except Exception as e:
+        logger.warning(
+            "error_capturing_previous_person_property_filters",
+            cohort_id=instance.pk,
+            error=str(e),
+        )
+        # If we can't capture previous state, mark as None to be safe
+        instance._previous_person_property_filters = None  # type: ignore
+
+
 @receiver(post_save, sender=Cohort)
 def cohort_changed(sender, instance, **kwargs):
     """
@@ -157,6 +356,54 @@ def cohort_changed(sender, instance, **kwargs):
         return
 
     transaction.on_commit(lambda: _on_cohort_changed(instance))
+
+
+@receiver(post_save, sender=Cohort)
+def cohort_conditions_changed_backfill(sender, instance, **kwargs):
+    """
+    Trigger backfill when realtime cohort person property conditions change.
+    This ensures that person property filters are properly backfilled
+    when cohort filters are modified.
+    """
+    # Skip if this is only a recalculation update
+    if is_cohort_recalculation_only_save(kwargs):
+        return
+
+    # Skip if cohort is not realtime
+    if instance.cohort_type != CohortType.REALTIME:
+        return
+
+    # Skip if cohort is static
+    if instance.is_static:
+        return
+
+    # Skip if cohort is deleted
+    if instance.deleted:
+        return
+
+    # Check if this is a new cohort (created=True) or an update
+    is_new = kwargs.get("created", False)
+
+    if is_new:
+        # For new cohorts, only trigger if they have person property filters
+        if not _has_person_property_filters(instance):
+            return
+    else:
+        # For updates, only trigger if person property filters actually changed
+        if not _person_property_filters_changed(instance):
+            return
+
+    # Check feature flag before triggering backfill
+    if not posthoganalytics.feature_enabled(
+        "cohort-backfill-on-change",
+        str(instance.team_id),
+        groups={"team": str(instance.team_id)},
+        send_feature_flag_events=False,
+    ):
+        return
+
+    # Use transaction.on_commit to ensure backfill runs after the current transaction
+    transaction.on_commit(lambda: _trigger_cohort_backfill(instance))
 
 
 @receiver(post_delete, sender=Cohort)

--- a/posthog/models/cohort/dependencies.py
+++ b/posthog/models/cohort/dependencies.py
@@ -330,6 +330,11 @@ def cohort_conditions_changed_backfill(sender, instance, **kwargs):
     if is_cohort_recalculation_only_save(kwargs):
         return
 
+    # Skip if filters field is not being updated - matches pre_save logic
+    update_fields = kwargs.get("update_fields")
+    if update_fields is not None and "filters" not in update_fields:
+        return
+
     # Skip if cohort is not realtime
     if instance.cohort_type != CohortType.REALTIME:
         return

--- a/posthog/models/cohort/dependencies.py
+++ b/posthog/models/cohort/dependencies.py
@@ -219,6 +219,9 @@ def _extract_person_property_filters(cohort: Cohort) -> str:
                     children.append(normalized_child)
 
             if children:
+                # Sort children by their JSON representation to make order-independent
+                # For AND/OR operations, the order shouldn't matter logically
+                children.sort(key=lambda x: json.dumps(x, sort_keys=True))
                 return {"type": node_type, "children": children}
             return None
 
@@ -279,6 +282,12 @@ def cohort_pre_save(sender, instance, **kwargs):
     try:
         # Skip non-realtime cohorts to avoid extra DB queries
         if not instance.pk or instance.cohort_type != CohortType.REALTIME:
+            instance._previous_person_property_filters = ""
+            return
+
+        # Check if filters field is being updated - if not, skip the expensive DB read
+        update_fields = kwargs.get("update_fields")
+        if update_fields is not None and "filters" not in update_fields:
             instance._previous_person_property_filters = ""
             return
 

--- a/posthog/models/cohort/dependencies.py
+++ b/posthog/models/cohort/dependencies.py
@@ -359,7 +359,6 @@ def cohort_conditions_changed_backfill(sender, instance, **kwargs):
         "cohort-backfill-on-change",
         str(instance.team_id),
         groups={"team": str(instance.team_id)},
-        only_evaluate_locally=True,
         send_feature_flag_events=False,
     ):
         return

--- a/posthog/models/cohort/dependencies.py
+++ b/posthog/models/cohort/dependencies.py
@@ -359,6 +359,7 @@ def cohort_conditions_changed_backfill(sender, instance, **kwargs):
         "cohort-backfill-on-change",
         str(instance.team_id),
         groups={"team": str(instance.team_id)},
+        only_evaluate_locally=True,
         send_feature_flag_events=False,
     ):
         return

--- a/posthog/models/cohort/test/test_dependencies.py
+++ b/posthog/models/cohort/test/test_dependencies.py
@@ -996,7 +996,7 @@ class TestCohortBackfillOnConditionsChanged(BaseTest):
 
         # Simulate pre_save capturing the original state hash
         original_hash = _extract_person_property_filters(original_cohort)
-        modified_cohort._previous_person_property_filters = original_hash  # type: ignore
+        modified_cohort._previous_person_property_filters = original_hash
 
         result = _person_property_filters_changed(modified_cohort)
         self.assertTrue(result)
@@ -1024,7 +1024,7 @@ class TestCohortBackfillOnConditionsChanged(BaseTest):
 
         # Simulate pre_save capturing the same state hash
         current_hash = _extract_person_property_filters(cohort)
-        cohort._previous_person_property_filters = current_hash  # type: ignore
+        cohort._previous_person_property_filters = current_hash
 
         result = _person_property_filters_changed(cohort)
         self.assertFalse(result)
@@ -1107,7 +1107,7 @@ class TestCohortBackfillOnConditionsChanged(BaseTest):
 
         # Simulate pre_save capturing the original structure hash
         original_hash = _extract_person_property_filters(original_cohort)
-        modified_cohort._previous_person_property_filters = original_hash  # type: ignore
+        modified_cohort._previous_person_property_filters = original_hash
 
         result = _person_property_filters_changed(modified_cohort)
         self.assertTrue(result)
@@ -1151,7 +1151,7 @@ class TestCohortBackfillOnConditionsChanged(BaseTest):
 
         # Simulate pre_save capturing the same structure hash
         current_hash = _extract_person_property_filters(cohort)
-        cohort._previous_person_property_filters = current_hash  # type: ignore
+        cohort._previous_person_property_filters = current_hash
 
         result = _person_property_filters_changed(cohort)
         self.assertFalse(result)

--- a/posthog/models/cohort/test/test_dependencies.py
+++ b/posthog/models/cohort/test/test_dependencies.py
@@ -8,9 +8,14 @@ from parameterized import parameterized
 from rest_framework.exceptions import ValidationError
 
 from posthog.models import Cohort
+from posthog.models.cohort.cohort import CohortType
 from posthog.models.cohort.dependencies import (
     COHORT_DEPENDENCY_CACHE_COUNTER,
     DEPENDENCY_CACHE_TIMEOUT,
+    _extract_person_property_filters,
+    _has_person_property_filters,
+    _person_property_filters_changed,
+    _trigger_cohort_backfill,
     extract_cohort_dependencies,
     get_cohort_dependencies,
     get_cohort_dependents,
@@ -429,3 +434,724 @@ class TestCohortDependencies(BaseTest):
             cache_type="dependencies", result="invalid"
         )._value._value
         self.assertEqual(final_invalid, initial_invalid + 1)
+
+
+class TestCohortBackfillOnConditionsChanged(BaseTest):
+    def _create_cohort(self, name: str, **kwargs):
+        return Cohort.objects.create(name=name, team=self.team, **kwargs)
+
+    @fixture(autouse=True)
+    def mock_transaction(self):
+        with mock.patch("django.db.transaction.on_commit", side_effect=lambda func: func()):
+            yield
+
+    def test_has_person_property_filters_with_person_properties(self):
+        """Test that _has_person_property_filters correctly detects person property filters"""
+        cohort = self._create_cohort(
+            name="Test Cohort",
+            filters={
+                "properties": {
+                    "type": "OR",
+                    "values": [
+                        {
+                            "type": "AND",
+                            "values": [
+                                {
+                                    "key": "email",
+                                    "type": "person",
+                                    "value": ["test@example.com"],
+                                    "operator": "exact",
+                                    "conditionHash": "abc123",
+                                    "bytecode": [1, 2, 3],
+                                }
+                            ],
+                        }
+                    ],
+                }
+            },
+        )
+
+        self.assertTrue(_has_person_property_filters(cohort))
+
+    def test_has_person_property_filters_without_required_fields(self):
+        """Test that _has_person_property_filters returns False when required fields are missing"""
+        cohort = self._create_cohort(
+            name="Test Cohort",
+            filters={
+                "properties": {
+                    "type": "OR",
+                    "values": [
+                        {
+                            "type": "AND",
+                            "values": [
+                                {
+                                    "key": "email",
+                                    "type": "person",
+                                    "value": ["test@example.com"],
+                                    "operator": "exact",
+                                    # Missing conditionHash and bytecode
+                                }
+                            ],
+                        }
+                    ],
+                }
+            },
+        )
+
+        self.assertFalse(_has_person_property_filters(cohort))
+
+    def test_has_person_property_filters_with_behavioral_only(self):
+        """Test that _has_person_property_filters returns False for behavioral filters only"""
+        cohort = self._create_cohort(
+            name="Test Cohort",
+            filters={
+                "properties": {
+                    "type": "OR",
+                    "values": [
+                        {
+                            "type": "AND",
+                            "values": [
+                                {
+                                    "key": "pageview",
+                                    "type": "behavioral",
+                                    "value": "performed_event",
+                                    "event_type": "events",
+                                }
+                            ],
+                        }
+                    ],
+                }
+            },
+        )
+
+        self.assertFalse(_has_person_property_filters(cohort))
+
+    def test_has_person_property_filters_no_filters(self):
+        """Test that _has_person_property_filters returns False for cohorts without filters"""
+        cohort = self._create_cohort(name="Test Cohort")
+        self.assertFalse(_has_person_property_filters(cohort))
+
+    @mock.patch("django.core.management.call_command")
+    def test_trigger_cohort_backfill_calls_management_command(self, mock_call_command):
+        """Test that _trigger_cohort_backfill calls the correct management command"""
+        cohort = self._create_cohort(name="Test Cohort", cohort_type=CohortType.REALTIME)
+
+        _trigger_cohort_backfill(cohort)
+
+        mock_call_command.assert_called_once_with(
+            "backfill_precalculated_person_properties",
+            "--team-id",
+            str(cohort.team_id),
+            "--cohort-id",
+            str(cohort.id),
+            "--batch-size",
+            10_000,
+            "--concurrent-workflows",
+            100,
+        )
+
+    @mock.patch("django.core.management.call_command")
+    def test_trigger_cohort_backfill_handles_exceptions(self, mock_call_command):
+        """Test that _trigger_cohort_backfill handles exceptions gracefully"""
+        mock_call_command.side_effect = Exception("Command failed")
+        cohort = self._create_cohort(name="Test Cohort", cohort_type=CohortType.REALTIME)
+
+        # Should not raise an exception
+        _trigger_cohort_backfill(cohort)
+
+    @mock.patch("posthog.models.cohort.dependencies._trigger_cohort_backfill")
+    @mock.patch("posthoganalytics.feature_enabled", return_value=True)
+    def test_backfill_signal_triggered_for_realtime_cohorts(self, mock_feature_enabled, mock_trigger_backfill):
+        """Test that backfill is triggered when a realtime cohort with person properties is saved"""
+        cohort = self._create_cohort(
+            name="Test Cohort",
+            cohort_type=CohortType.REALTIME,
+            filters={
+                "properties": {
+                    "type": "OR",
+                    "values": [
+                        {
+                            "type": "AND",
+                            "values": [
+                                {
+                                    "key": "email",
+                                    "type": "person",
+                                    "value": ["test@example.com"],
+                                    "operator": "exact",
+                                    "conditionHash": "abc123",
+                                    "bytecode": [1, 2, 3],
+                                }
+                            ],
+                        }
+                    ],
+                }
+            },
+        )
+
+        # Reset mock after creation (since creation also triggers the signal)
+        mock_trigger_backfill.reset_mock()
+
+        # Update the cohort filters to trigger the signal again
+        cohort.filters = {
+            "properties": {
+                "type": "OR",
+                "values": [
+                    {
+                        "type": "AND",
+                        "values": [
+                            {
+                                "key": "name",
+                                "type": "person",
+                                "value": ["test user"],
+                                "operator": "exact",
+                                "conditionHash": "xyz789",
+                                "bytecode": [4, 5, 6],
+                            }
+                        ],
+                    }
+                ],
+            }
+        }
+        cohort.save()
+
+        mock_trigger_backfill.assert_called_once_with(cohort)
+
+    @mock.patch("posthog.models.cohort.dependencies._trigger_cohort_backfill")
+    @mock.patch("posthoganalytics.feature_enabled", return_value=True)  # Flag enabled, but cohort type prevents trigger
+    def test_backfill_signal_not_triggered_for_non_realtime_cohorts(self, mock_feature_enabled, mock_trigger_backfill):
+        """Test that backfill is not triggered for non-realtime cohorts"""
+        cohort = self._create_cohort(
+            name="Test Cohort",
+            # cohort_type is None (not realtime)
+            filters={
+                "properties": {
+                    "type": "OR",
+                    "values": [
+                        {
+                            "type": "AND",
+                            "values": [
+                                {
+                                    "key": "email",
+                                    "type": "person",
+                                    "value": ["test@example.com"],
+                                    "operator": "exact",
+                                    "conditionHash": "abc123",
+                                    "bytecode": [1, 2, 3],
+                                }
+                            ],
+                        }
+                    ],
+                }
+            },
+        )
+
+        # Update the cohort to trigger the signal
+        cohort.name = "Updated Test Cohort"
+        cohort.save()
+
+        mock_trigger_backfill.assert_not_called()
+
+    @mock.patch("posthog.models.cohort.dependencies._trigger_cohort_backfill")
+    @mock.patch(
+        "posthoganalytics.feature_enabled", return_value=True
+    )  # Flag enabled, but static cohort prevents trigger
+    def test_backfill_signal_not_triggered_for_static_cohorts(self, mock_feature_enabled, mock_trigger_backfill):
+        """Test that backfill is not triggered for static cohorts"""
+        cohort = self._create_cohort(
+            name="Test Cohort",
+            cohort_type=CohortType.REALTIME,
+            is_static=True,
+            filters={
+                "properties": {
+                    "type": "OR",
+                    "values": [
+                        {
+                            "type": "AND",
+                            "values": [
+                                {
+                                    "key": "email",
+                                    "type": "person",
+                                    "value": ["test@example.com"],
+                                    "operator": "exact",
+                                    "conditionHash": "abc123",
+                                    "bytecode": [1, 2, 3],
+                                }
+                            ],
+                        }
+                    ],
+                }
+            },
+        )
+
+        # Update the cohort to trigger the signal
+        cohort.name = "Updated Test Cohort"
+        cohort.save()
+
+        mock_trigger_backfill.assert_not_called()
+
+    @mock.patch("posthog.models.cohort.dependencies._trigger_cohort_backfill")
+    @mock.patch(
+        "posthoganalytics.feature_enabled", return_value=True
+    )  # Flag enabled, but no person properties prevents trigger
+    def test_backfill_signal_not_triggered_without_person_properties(self, mock_feature_enabled, mock_trigger_backfill):
+        """Test that backfill is not triggered for cohorts without person properties"""
+        cohort = self._create_cohort(
+            name="Test Cohort",
+            cohort_type=CohortType.REALTIME,
+            filters={
+                "properties": {
+                    "type": "OR",
+                    "values": [
+                        {
+                            "type": "AND",
+                            "values": [
+                                {
+                                    "key": "pageview",
+                                    "type": "behavioral",
+                                    "value": "performed_event",
+                                    "event_type": "events",
+                                }
+                            ],
+                        }
+                    ],
+                }
+            },
+        )
+
+        # Update the cohort to trigger the signal
+        cohort.name = "Updated Test Cohort"
+        cohort.save()
+
+        mock_trigger_backfill.assert_not_called()
+
+    @mock.patch("posthog.models.cohort.dependencies._trigger_cohort_backfill")
+    @mock.patch(
+        "posthoganalytics.feature_enabled", return_value=True
+    )  # Flag enabled, but recalculation save prevents trigger
+    def test_backfill_signal_not_triggered_for_recalculation_saves(self, mock_feature_enabled, mock_trigger_backfill):
+        """Test that backfill is not triggered for recalculation-only saves"""
+        # Create cohort first (this will trigger the signal once)
+        cohort = self._create_cohort(
+            name="Test Cohort",
+            cohort_type=CohortType.REALTIME,
+            filters={
+                "properties": {
+                    "type": "OR",
+                    "values": [
+                        {
+                            "type": "AND",
+                            "values": [
+                                {
+                                    "key": "email",
+                                    "type": "person",
+                                    "value": ["test@example.com"],
+                                    "operator": "exact",
+                                    "conditionHash": "abc123",
+                                    "bytecode": [1, 2, 3],
+                                }
+                            ],
+                        }
+                    ],
+                }
+            },
+        )
+
+        # Reset mock after creation
+        mock_trigger_backfill.reset_mock()
+
+        # Save only recalculation fields to simulate recalculation-only update
+        cohort.save(update_fields=["is_calculating", "last_calculation", "count"])
+
+        mock_trigger_backfill.assert_not_called()
+
+    @mock.patch("posthog.models.cohort.dependencies._trigger_cohort_backfill")
+    @mock.patch("posthoganalytics.feature_enabled", return_value=False)
+    def test_backfill_signal_not_triggered_when_feature_flag_disabled(
+        self, mock_feature_enabled, mock_trigger_backfill
+    ):
+        """Test that backfill is not triggered when the feature flag is disabled"""
+        cohort = self._create_cohort(
+            name="Test Cohort",
+            cohort_type=CohortType.REALTIME,
+            filters={
+                "properties": {
+                    "type": "OR",
+                    "values": [
+                        {
+                            "type": "AND",
+                            "values": [
+                                {
+                                    "key": "email",
+                                    "type": "person",
+                                    "value": ["test@example.com"],
+                                    "operator": "exact",
+                                    "conditionHash": "abc123",
+                                    "bytecode": [1, 2, 3],
+                                }
+                            ],
+                        }
+                    ],
+                }
+            },
+        )
+
+        # Reset mock after creation (since creation also triggers the signal)
+        mock_trigger_backfill.reset_mock()
+        mock_feature_enabled.reset_mock()
+
+        # Update the cohort filters to trigger the signal again
+        cohort.filters = {
+            "properties": {
+                "type": "OR",
+                "values": [
+                    {
+                        "type": "AND",
+                        "values": [
+                            {
+                                "key": "name",
+                                "type": "person",
+                                "value": ["test user"],
+                                "operator": "exact",
+                                "conditionHash": "xyz789",
+                                "bytecode": [4, 5, 6],
+                            }
+                        ],
+                    }
+                ],
+            }
+        }
+        cohort.save()
+
+        # Verify the feature flag was checked
+        mock_feature_enabled.assert_called_once_with(
+            "cohort-backfill-on-change",
+            str(cohort.team_id),
+            groups={"team": str(cohort.team_id)},
+            send_feature_flag_events=False,
+        )
+        # Verify backfill was not triggered due to disabled feature flag
+        mock_trigger_backfill.assert_not_called()
+
+    @mock.patch("posthog.models.cohort.dependencies._trigger_cohort_backfill")
+    @mock.patch("posthoganalytics.feature_enabled", return_value=True)
+    def test_backfill_signal_not_triggered_when_person_properties_unchanged(
+        self, mock_feature_enabled, mock_trigger_backfill
+    ):
+        """Test that backfill is not triggered when person property filters haven't changed"""
+        cohort = self._create_cohort(
+            name="Test Cohort",
+            cohort_type=CohortType.REALTIME,
+            filters={
+                "properties": {
+                    "type": "OR",
+                    "values": [
+                        {
+                            "type": "AND",
+                            "values": [
+                                {
+                                    "key": "email",
+                                    "type": "person",
+                                    "value": ["test@example.com"],
+                                    "operator": "exact",
+                                    "conditionHash": "abc123",
+                                    "bytecode": [1, 2, 3],
+                                }
+                            ],
+                        }
+                    ],
+                }
+            },
+        )
+
+        # Reset mock after creation (since creation also triggers the signal)
+        mock_trigger_backfill.reset_mock()
+        mock_feature_enabled.reset_mock()
+
+        # Update the cohort name but not the filters - should not trigger backfill
+        cohort.name = "Updated Test Cohort"
+        cohort.save()
+
+        # Feature flag should not be checked since person properties didn't change
+        mock_feature_enabled.assert_not_called()
+        # Verify backfill was not triggered
+        mock_trigger_backfill.assert_not_called()
+
+    def test_extract_person_property_filters(self):
+        """Test that _extract_person_property_filters correctly extracts and normalizes filters"""
+        cohort = self._create_cohort(
+            name="Test Cohort",
+            filters={
+                "properties": {
+                    "type": "OR",
+                    "values": [
+                        {
+                            "type": "AND",
+                            "values": [
+                                {
+                                    "key": "email",
+                                    "type": "person",
+                                    "value": ["test@example.com"],
+                                    "operator": "exact",
+                                    "conditionHash": "abc123",
+                                    "bytecode": [1, 2, 3],
+                                },
+                                {
+                                    "key": "age",
+                                    "type": "person",
+                                    "value": [25],
+                                    "operator": "gt",
+                                    "conditionHash": "def456",
+                                    "bytecode": [4, 5, 6],
+                                },
+                            ],
+                        }
+                    ],
+                }
+            },
+        )
+
+        filters_hash = _extract_person_property_filters(cohort)
+
+        # Should return a non-empty hash string for filters with person properties
+        self.assertIsInstance(filters_hash, str)
+        self.assertTrue(len(filters_hash) > 0)
+
+    def test_extract_person_property_filters_empty(self):
+        """Test that _extract_person_property_filters returns empty string for no filters"""
+        cohort = self._create_cohort(name="Test Cohort", filters={})
+        filters_hash = _extract_person_property_filters(cohort)
+        self.assertEqual(filters_hash, "")
+
+    def test_extract_person_property_filters_behavioral_only(self):
+        """Test that _extract_person_property_filters ignores behavioral filters"""
+        cohort = self._create_cohort(
+            name="Test Cohort",
+            filters={
+                "properties": {
+                    "type": "OR",
+                    "values": [
+                        {
+                            "key": "$pageview",
+                            "type": "event",
+                            "value": ["performed_event"],
+                            "operator": "exact",
+                        }
+                    ],
+                }
+            },
+        )
+
+        filters_hash = _extract_person_property_filters(cohort)
+        self.assertEqual(filters_hash, "")
+
+    def test_person_property_filters_changed_new_cohort(self):
+        """Test that _person_property_filters_changed returns True for new cohorts"""
+        cohort = self._create_cohort(name="Test Cohort")
+        cohort.pk = None  # Simulate new cohort
+
+        result = _person_property_filters_changed(cohort)
+        self.assertTrue(result)
+
+    def test_person_property_filters_changed_filters_changed(self):
+        """Test that _person_property_filters_changed detects changes"""
+        # Create original cohort with one filter
+        original_cohort = self._create_cohort(
+            name="Test Cohort",
+            filters={
+                "properties": {
+                    "type": "AND",
+                    "values": [
+                        {
+                            "key": "email",
+                            "type": "person",
+                            "value": ["test@example.com"],
+                            "operator": "exact",
+                            "conditionHash": "abc123",
+                            "bytecode": [1, 2, 3],
+                        }
+                    ],
+                }
+            },
+        )
+
+        # Create modified cohort with different filters
+        modified_cohort = self._create_cohort(
+            name="Test Cohort",
+            filters={
+                "properties": {
+                    "type": "AND",
+                    "values": [
+                        {
+                            "key": "age",
+                            "type": "person",
+                            "value": [25],
+                            "operator": "gt",
+                            "conditionHash": "def456",
+                            "bytecode": [4, 5, 6],
+                        }
+                    ],
+                }
+            },
+        )
+
+        # Simulate pre_save capturing the original state hash
+        original_hash = _extract_person_property_filters(original_cohort)
+        modified_cohort._previous_person_property_filters = original_hash  # type: ignore
+
+        result = _person_property_filters_changed(modified_cohort)
+        self.assertTrue(result)
+
+    def test_person_property_filters_changed_no_change(self):
+        """Test that _person_property_filters_changed returns False when filters haven't changed"""
+        # Create cohorts with identical filters
+        filters = {
+            "properties": {
+                "type": "AND",
+                "values": [
+                    {
+                        "key": "email",
+                        "type": "person",
+                        "value": ["test@example.com"],
+                        "operator": "exact",
+                        "conditionHash": "abc123",
+                        "bytecode": [1, 2, 3],
+                    }
+                ],
+            }
+        }
+
+        cohort = self._create_cohort(name="Test Cohort", filters=filters)
+
+        # Simulate pre_save capturing the same state hash
+        current_hash = _extract_person_property_filters(cohort)
+        cohort._previous_person_property_filters = current_hash  # type: ignore
+
+        result = _person_property_filters_changed(cohort)
+        self.assertFalse(result)
+
+    def test_person_property_filters_changed_structural_change(self):
+        """Test that _person_property_filters_changed detects structural changes even with same conditions"""
+        # Original: (A AND B) OR C
+        original_filters = {
+            "properties": {
+                "type": "OR",
+                "values": [
+                    {
+                        "type": "AND",
+                        "values": [
+                            {
+                                "key": "name",
+                                "type": "person",
+                                "value": ["Alice"],
+                                "operator": "exact",
+                                "conditionHash": "hashA",
+                                "bytecode": [1, 2, 3],
+                            },
+                            {
+                                "key": "age",
+                                "type": "person",
+                                "value": [25],
+                                "operator": "gt",
+                                "conditionHash": "hashB",
+                                "bytecode": [4, 5, 6],
+                            },
+                        ],
+                    },
+                    {
+                        "key": "email",
+                        "type": "person",
+                        "value": ["test@example.com"],
+                        "operator": "exact",
+                        "conditionHash": "hashC",
+                        "bytecode": [7, 8, 9],
+                    },
+                ],
+            }
+        }
+
+        # Modified: A OR B OR C (same conditions, different structure)
+        modified_filters = {
+            "properties": {
+                "type": "OR",
+                "values": [
+                    {
+                        "key": "name",
+                        "type": "person",
+                        "value": ["Alice"],
+                        "operator": "exact",
+                        "conditionHash": "hashA",
+                        "bytecode": [1, 2, 3],
+                    },
+                    {
+                        "key": "age",
+                        "type": "person",
+                        "value": [25],
+                        "operator": "gt",
+                        "conditionHash": "hashB",
+                        "bytecode": [4, 5, 6],
+                    },
+                    {
+                        "key": "email",
+                        "type": "person",
+                        "value": ["test@example.com"],
+                        "operator": "exact",
+                        "conditionHash": "hashC",
+                        "bytecode": [7, 8, 9],
+                    },
+                ],
+            }
+        }
+
+        original_cohort = self._create_cohort(name="Test Cohort", filters=original_filters)
+        modified_cohort = self._create_cohort(name="Test Cohort", filters=modified_filters)
+
+        # Simulate pre_save capturing the original structure hash
+        original_hash = _extract_person_property_filters(original_cohort)
+        modified_cohort._previous_person_property_filters = original_hash  # type: ignore
+
+        result = _person_property_filters_changed(modified_cohort)
+        self.assertTrue(result)
+
+    def test_person_property_filters_changed_identical_structure(self):
+        """Test that _person_property_filters_changed returns False for identical structure"""
+        # Both: A OR B OR C (identical structure and conditions)
+        filters = {
+            "properties": {
+                "type": "OR",
+                "values": [
+                    {
+                        "key": "name",
+                        "type": "person",
+                        "value": ["Alice"],
+                        "operator": "exact",
+                        "conditionHash": "hashA",
+                        "bytecode": [1, 2, 3],
+                    },
+                    {
+                        "key": "age",
+                        "type": "person",
+                        "value": [25],
+                        "operator": "gt",
+                        "conditionHash": "hashB",
+                        "bytecode": [4, 5, 6],
+                    },
+                    {
+                        "key": "email",
+                        "type": "person",
+                        "value": ["test@example.com"],
+                        "operator": "exact",
+                        "conditionHash": "hashC",
+                        "bytecode": [7, 8, 9],
+                    },
+                ],
+            }
+        }
+
+        cohort = self._create_cohort(name="Test Cohort", filters=filters)
+
+        # Simulate pre_save capturing the same structure hash
+        current_hash = _extract_person_property_filters(cohort)
+        cohort._previous_person_property_filters = current_hash  # type: ignore
+
+        result = _person_property_filters_changed(cohort)
+        self.assertFalse(result)

--- a/posthog/models/cohort/test/test_dependencies.py
+++ b/posthog/models/cohort/test/test_dependencies.py
@@ -531,29 +531,19 @@ class TestCohortBackfillOnConditionsChanged(BaseTest):
         cohort = self._create_cohort(name="Test Cohort")
         self.assertFalse(_has_person_property_filters(cohort))
 
-    @mock.patch("django.core.management.call_command")
-    def test_trigger_cohort_backfill_calls_management_command(self, mock_call_command):
-        """Test that _trigger_cohort_backfill calls the correct management command"""
+    @mock.patch("posthog.tasks.calculate_cohort.trigger_cohort_backfill_task")
+    def test_trigger_cohort_backfill_calls_celery_task(self, mock_task):
+        """Test that _trigger_cohort_backfill calls the correct Celery task"""
         cohort = self._create_cohort(name="Test Cohort", cohort_type=CohortType.REALTIME)
 
         _trigger_cohort_backfill(cohort)
 
-        mock_call_command.assert_called_once_with(
-            "backfill_precalculated_person_properties",
-            "--team-id",
-            str(cohort.team_id),
-            "--cohort-id",
-            str(cohort.id),
-            "--batch-size",
-            10_000,
-            "--concurrent-workflows",
-            100,
-        )
+        mock_task.delay.assert_called_once_with(cohort.team_id, cohort.pk)
 
-    @mock.patch("django.core.management.call_command")
-    def test_trigger_cohort_backfill_handles_exceptions(self, mock_call_command):
+    @mock.patch("posthog.tasks.calculate_cohort.trigger_cohort_backfill_task")
+    def test_trigger_cohort_backfill_handles_exceptions(self, mock_task):
         """Test that _trigger_cohort_backfill handles exceptions gracefully"""
-        mock_call_command.side_effect = Exception("Command failed")
+        mock_task.delay.side_effect = Exception("Task failed")
         cohort = self._create_cohort(name="Test Cohort", cohort_type=CohortType.REALTIME)
 
         # Should not raise an exception

--- a/posthog/models/cohort/test/test_dependencies.py
+++ b/posthog/models/cohort/test/test_dependencies.py
@@ -934,6 +934,71 @@ class TestCohortBackfillOnConditionsChanged(BaseTest):
         filters_hash = _extract_person_property_filters(cohort)
         self.assertEqual(filters_hash, "")
 
+    def test_extract_person_property_filters_order_independence(self):
+        """Test that _extract_person_property_filters produces same hash regardless of child order"""
+        # Create two cohorts with same conditions but different order
+        cohort_order_1 = self._create_cohort(
+            name="Test Cohort Order 1",
+            filters={
+                "properties": {
+                    "type": "AND",
+                    "values": [
+                        {
+                            "key": "email",
+                            "type": "person",
+                            "value": ["test@example.com"],
+                            "operator": "exact",
+                            "conditionHash": "condition_1",
+                            "bytecode": [1, 2, 3],
+                        },
+                        {
+                            "key": "age",
+                            "type": "person",
+                            "value": [25],
+                            "operator": "gte",
+                            "conditionHash": "condition_2",
+                            "bytecode": [4, 5, 6],
+                        },
+                    ],
+                }
+            },
+        )
+
+        cohort_order_2 = self._create_cohort(
+            name="Test Cohort Order 2",
+            filters={
+                "properties": {
+                    "type": "AND",
+                    "values": [
+                        {
+                            "key": "age",
+                            "type": "person",
+                            "value": [25],
+                            "operator": "gte",
+                            "conditionHash": "condition_2",
+                            "bytecode": [4, 5, 6],
+                        },
+                        {
+                            "key": "email",
+                            "type": "person",
+                            "value": ["test@example.com"],
+                            "operator": "exact",
+                            "conditionHash": "condition_1",
+                            "bytecode": [1, 2, 3],
+                        },
+                    ],
+                }
+            },
+        )
+
+        hash_1 = _extract_person_property_filters(cohort_order_1)
+        hash_2 = _extract_person_property_filters(cohort_order_2)
+
+        # Both hashes should be identical despite different child order
+        self.assertEqual(hash_1, hash_2)
+        # And both should be non-empty since they have person property filters
+        self.assertTrue(len(hash_1) > 0)
+
     def test_person_property_filters_changed_new_cohort(self):
         """Test that _person_property_filters_changed returns True for new cohorts"""
         cohort = self._create_cohort(name="Test Cohort")

--- a/posthog/models/cohort/test/test_dependencies.py
+++ b/posthog/models/cohort/test/test_dependencies.py
@@ -817,6 +817,7 @@ class TestCohortBackfillOnConditionsChanged(BaseTest):
             "cohort-backfill-on-change",
             str(cohort.team_id),
             groups={"team": str(cohort.team_id)},
+            only_evaluate_locally=True,
             send_feature_flag_events=False,
         )
         # Verify backfill was not triggered due to disabled feature flag

--- a/posthog/models/cohort/test/test_dependencies.py
+++ b/posthog/models/cohort/test/test_dependencies.py
@@ -817,7 +817,6 @@ class TestCohortBackfillOnConditionsChanged(BaseTest):
             "cohort-backfill-on-change",
             str(cohort.team_id),
             groups={"team": str(cohort.team_id)},
-            only_evaluate_locally=True,
             send_feature_flag_events=False,
         )
         # Verify backfill was not triggered due to disabled feature flag

--- a/posthog/tasks/calculate_cohort.py
+++ b/posthog/tasks/calculate_cohort.py
@@ -686,3 +686,43 @@ def collect_cohort_query_stats(
             error=str(e),
         )
         raise
+
+
+@shared_task(ignore_result=True, max_retries=3)
+def trigger_cohort_backfill_task(team_id: int, cohort_id: int):
+    """
+    Trigger backfill for a realtime cohort with person properties.
+    Uses the existing temporal workflow for consistency.
+    """
+    from django.core.management import call_command
+
+    logger = structlog.get_logger(__name__)
+
+    try:
+        logger.info(
+            "triggering_cohort_backfill_task",
+            cohort_id=cohort_id,
+            team_id=team_id,
+        )
+
+        # Use the existing management command to trigger backfill
+        call_command(
+            "backfill_precalculated_person_properties",
+            "--team-id",
+            str(team_id),
+            "--cohort-id",
+            str(cohort_id),
+            "--batch-size",
+            10_000,
+            "--concurrent-workflows",
+            100,
+        )
+
+    except Exception as e:
+        logger.exception(
+            "failed_to_trigger_cohort_backfill_task",
+            cohort_id=cohort_id,
+            team_id=team_id,
+            error=str(e),
+        )
+        raise

--- a/posthog/tasks/calculate_cohort.py
+++ b/posthog/tasks/calculate_cohort.py
@@ -689,7 +689,7 @@ def collect_cohort_query_stats(
 
 
 @shared_task(ignore_result=True, max_retries=3)
-def trigger_cohort_backfill_task(team_id: int, cohort_id: int):
+def trigger_cohort_backfill_task(team_id: int, cohort_id: int) -> None:
     """
     Trigger backfill for a realtime cohort with person properties.
     Uses the existing temporal workflow for consistency.

--- a/posthog/tasks/calculate_cohort.py
+++ b/posthog/tasks/calculate_cohort.py
@@ -693,6 +693,11 @@ def trigger_cohort_backfill_task(team_id: int, cohort_id: int) -> None:
     """
     Trigger backfill for a realtime cohort with person properties.
     Uses the existing temporal workflow for consistency.
+
+    TODO: Extract the core logic from backfill_precalculated_person_properties
+    into a standalone function (e.g. posthog.cohorts.backfill.run_backfill)
+    so this task, the management command, and the admin view can all call it
+    directly instead of going through call_command/argparse.
     """
     from django.core.management import call_command
 

--- a/posthog/tasks/test/__snapshots__/test_task_registration.ambr
+++ b/posthog/tasks/test/__snapshots__/test_task_registration.ambr
@@ -22,6 +22,7 @@
     'posthog.tasks.calculate_cohort.collect_cohort_query_stats',
     'posthog.tasks.calculate_cohort.insert_cohort_from_feature_flag',
     'posthog.tasks.calculate_cohort.insert_cohort_from_query',
+    'posthog.tasks.calculate_cohort.trigger_cohort_backfill_task',
     'posthog.tasks.demo_create_data.create_data_for_demo_team',
     'posthog.tasks.early_access_feature.send_events_for_early_access_feature_stage_change',
     'posthog.tasks.email.login_from_new_device_notification',


### PR DESCRIPTION
## Problem

When realtime cohorts with person property filters are updated, the person property data isn't automatically backfilled. This can lead to inconsistent data until backfill is manually triggered.

## Changes

- Added automatic backfill triggering for realtime cohorts when person property conditions change

## How did you test this code?

- Added 21 new test cases covering all backfill scenarios
- Tests verify proper triggering conditions (realtime cohorts, person properties, feature flag)
- Tests verify proper skipping conditions (static cohorts, non-realtime, disabled flag)
- Tests verify structural change detection with identical conditions but different logical structure
- All 44 dependency tests pass