### PR TITLE
feat(hogli): add is_posthog_dev telemetry property

### DIFF
--- a/common/hogli/core/cli.py
+++ b/common/hogli/core/cli.py
@@ -11,6 +11,8 @@ import sys
 import time as _time
 import shutil
 import platform
+import functools
+import subprocess
 from collections import defaultdict
 from typing import Any
 
@@ -324,6 +326,22 @@ def _infer_process_manager(command: str | None) -> str | None:
     return None
 
 
+@functools.lru_cache(maxsize=1)
+def _is_posthog_dev() -> bool:
+    """Check if git user.email ends with @posthog.com."""
+    try:
+        result = subprocess.run(
+            ["git", "config", "user.email"],
+            capture_output=True,
+            text=True,
+            timeout=2,
+            cwd=REPO_ROOT,
+        )
+        return result.returncode == 0 and result.stdout.strip().endswith("@posthog.com")
+    except Exception:
+        return False
+
+
 def _env_properties(command: str | None = None) -> dict[str, Any]:
     """Static environment properties shared across telemetry events."""
     ci_env_vars = ("CI", "GITHUB_ACTIONS", "JENKINS_URL", "GITLAB_CI", "CIRCLECI", "BUILDKITE")
@@ -336,6 +354,7 @@ def _env_properties(command: str | None = None) -> dict[str, Any]:
         "has_devenv_config": (REPO_ROOT / ".posthog" / ".generated" / "mprocs.yaml").exists(),
         "in_flox": os.environ.get("FLOX_ENV") is not None,
         "is_worktree": (REPO_ROOT / ".git").is_file(),
+        "is_posthog_dev": _is_posthog_dev(),
         "process_manager": _infer_process_manager(command),
     }
 

--- a/common/hogli/core/cli.py
+++ b/common/hogli/core/cli.py
@@ -11,7 +11,7 @@ import sys
 import time as _time
 import shutil
 import platform
-import functools
+import subprocess
 import configparser
 from collections import defaultdict
 from pathlib import Path
@@ -327,20 +327,76 @@ def _infer_process_manager(command: str | None) -> str | None:
     return None
 
 
-@functools.lru_cache(maxsize=1)
-def _is_posthog_dev() -> bool:
-    """Check if git user.email ends with @posthog.com.
+_POSTHOG_DEV_CACHE_TTL_SECONDS = 30 * 86400  # 30 days
 
-    Reads git config files directly (local then global) to avoid spawning a subprocess.
-    """
+
+def _check_email_domain() -> bool:
+    """Fallback: check if git user.email ends with @posthog.com."""
     parser = configparser.RawConfigParser()
     try:
-        # Local overrides global -- read global first, local second
         parser.read([Path.home() / ".gitconfig", REPO_ROOT / ".git" / "config"])
         email = parser.get("user", "email", fallback="")
         return email.endswith("@posthog.com")
     except Exception:
         return False
+
+
+def _get_github_token() -> str | None:
+    """Resolve a GitHub personal token from env vars or ``gh auth token``."""
+    for var in ("GH_TOKEN", "GITHUB_TOKEN"):
+        token = os.environ.get(var)
+        if token:
+            return token
+    try:
+        result = subprocess.run(["gh", "auth", "token"], capture_output=True, text=True, timeout=5)
+        if result.returncode == 0:
+            return result.stdout.strip() or None
+    except Exception:
+        pass
+    return None
+
+
+def _check_github_org(token: str) -> bool:
+    """Return True if *token* belongs to a PostHog GitHub org member."""
+    import requests
+
+    resp = requests.get(
+        "https://api.github.com/user/memberships/orgs/PostHog",
+        headers={"Authorization": f"Bearer {token}", "Accept": "application/vnd.github+json"},
+        timeout=5,
+    )
+    return resp.status_code == 200
+
+
+def _is_posthog_dev() -> bool:
+    """Check if the user is a PostHog GitHub org member.
+
+    Calls the GitHub ``/user/memberships/orgs/PostHog`` API using a token
+    from ``GH_TOKEN``, ``GITHUB_TOKEN``, or ``gh auth token``.  The boolean
+    result is cached in the telemetry config for 30 days.  Falls back to a
+    git email domain check when no token is available.
+    """
+    from hogli.telemetry import _load_config, _save_config
+
+    config = _load_config()
+    cached = config.get("is_posthog_org_member")
+    checked_at = config.get("org_check_timestamp", 0.0)
+
+    if cached is not None and (_time.time() - checked_at) < _POSTHOG_DEV_CACHE_TTL_SECONDS:
+        return cached
+
+    token = _get_github_token()
+    if token is None:
+        return _check_email_domain()
+
+    try:
+        is_member = _check_github_org(token)
+        config["is_posthog_org_member"] = is_member
+        config["org_check_timestamp"] = _time.time()
+        _save_config(config)
+        return is_member
+    except Exception:
+        return _check_email_domain()
 
 
 def _env_properties(command: str | None = None) -> dict[str, Any]:

--- a/common/hogli/core/cli.py
+++ b/common/hogli/core/cli.py
@@ -21,6 +21,7 @@ import click
 from hogli import hints, telemetry
 from hogli.core.command_types import BinScriptCommand, CompositeCommand, DirectCommand, HogliCommand
 from hogli.core.manifest import REPO_ROOT, get_category_for_command, load_manifest
+from hogli.telemetry import _load_config, _save_config
 
 BIN_DIR = REPO_ROOT / "bin"
 
@@ -341,43 +342,26 @@ def _check_email_domain() -> bool:
         return False
 
 
-def _get_github_token() -> str | None:
-    """Resolve a GitHub personal token from env vars or ``gh auth token``."""
-    for var in ("GH_TOKEN", "GITHUB_TOKEN"):
-        token = os.environ.get(var)
-        if token:
-            return token
+def _check_github_org_membership() -> bool | None:
+    """Use ``gh api`` to check PostHog org membership. Returns None if gh is unavailable."""
     try:
-        result = subprocess.run(["gh", "auth", "token"], capture_output=True, text=True, timeout=5)
-        if result.returncode == 0:
-            return result.stdout.strip() or None
+        result = subprocess.run(
+            ["gh", "api", "/user/memberships/orgs/PostHog", "--silent"],
+            capture_output=True,
+            timeout=5,
+        )
+        return result.returncode == 0
     except Exception:
-        pass
-    return None
-
-
-def _check_github_org(token: str) -> bool:
-    """Return True if *token* belongs to a PostHog GitHub org member."""
-    import requests
-
-    resp = requests.get(
-        "https://api.github.com/user/memberships/orgs/PostHog",
-        headers={"Authorization": f"Bearer {token}", "Accept": "application/vnd.github+json"},
-        timeout=5,
-    )
-    return resp.status_code == 200
+        return None
 
 
 def _is_posthog_dev() -> bool:
     """Check if the user is a PostHog GitHub org member.
 
-    Calls the GitHub ``/user/memberships/orgs/PostHog`` API using a token
-    from ``GH_TOKEN``, ``GITHUB_TOKEN``, or ``gh auth token``.  The boolean
-    result is cached in the telemetry config for 30 days.  Falls back to a
-    git email domain check when no token is available.
+    Uses ``gh api`` to check org membership, caching the boolean result in
+    the telemetry config for 30 days.  Falls back to a git email domain
+    check when ``gh`` is unavailable or unauthenticated.
     """
-    from hogli.telemetry import _load_config, _save_config
-
     config = _load_config()
     cached = config.get("is_posthog_org_member")
     checked_at = config.get("org_check_timestamp", 0.0)
@@ -385,18 +369,14 @@ def _is_posthog_dev() -> bool:
     if cached is not None and (_time.time() - checked_at) < _POSTHOG_DEV_CACHE_TTL_SECONDS:
         return cached
 
-    token = _get_github_token()
-    if token is None:
+    is_member = _check_github_org_membership()
+    if is_member is None:
         return _check_email_domain()
 
-    try:
-        is_member = _check_github_org(token)
-        config["is_posthog_org_member"] = is_member
-        config["org_check_timestamp"] = _time.time()
-        _save_config(config)
-        return is_member
-    except Exception:
-        return _check_email_domain()
+    config["is_posthog_org_member"] = is_member
+    config["org_check_timestamp"] = _time.time()
+    _save_config(config)
+    return is_member
 
 
 def _env_properties(command: str | None = None) -> dict[str, Any]:

--- a/common/hogli/core/cli.py
+++ b/common/hogli/core/cli.py
@@ -12,8 +12,9 @@ import time as _time
 import shutil
 import platform
 import functools
-import subprocess
+import configparser
 from collections import defaultdict
+from pathlib import Path
 from typing import Any
 
 import click
@@ -328,16 +329,16 @@ def _infer_process_manager(command: str | None) -> str | None:
 
 @functools.lru_cache(maxsize=1)
 def _is_posthog_dev() -> bool:
-    """Check if git user.email ends with @posthog.com."""
+    """Check if git user.email ends with @posthog.com.
+
+    Reads git config files directly (local then global) to avoid spawning a subprocess.
+    """
+    parser = configparser.RawConfigParser()
     try:
-        result = subprocess.run(
-            ["git", "config", "user.email"],
-            capture_output=True,
-            text=True,
-            timeout=2,
-            cwd=REPO_ROOT,
-        )
-        return result.returncode == 0 and result.stdout.strip().endswith("@posthog.com")
+        # Local overrides global -- read global first, local second
+        parser.read([Path.home() / ".gitconfig", REPO_ROOT / ".git" / "config"])
+        email = parser.get("user", "email", fallback="")
+        return email.endswith("@posthog.com")
     except Exception:
         return False
 

--- a/common/hogli/core/cli.py
+++ b/common/hogli/core/cli.py
@@ -371,7 +371,7 @@ def _is_posthog_dev() -> bool:
 
     is_member = _check_github_org_membership()
     if is_member is None:
-        return _check_email_domain()
+        is_member = _check_email_domain()
 
     config["is_posthog_org_member"] = is_member
     config["org_check_timestamp"] = _time.time()

--- a/common/hogli/telemetry.py
+++ b/common/hogli/telemetry.py
@@ -39,6 +39,8 @@ class TelemetryConfig(TypedDict, total=False):
     enabled: bool
     anonymous_id: str
     first_run_notice_shown: bool
+    is_posthog_org_member: bool
+    org_check_timestamp: float
 
 
 def get_config_path() -> Path:

--- a/common/hogli/tests/test_cli.py
+++ b/common/hogli/tests/test_cli.py
@@ -9,14 +9,7 @@ import pytest
 from unittest.mock import MagicMock, patch
 
 from click.testing import CliRunner
-from hogli.core.cli import (
-    _POSTHOG_DEV_CACHE_TTL_SECONDS,
-    _check_email_domain,
-    _get_github_token,
-    _infer_process_manager,
-    _is_posthog_dev,
-    cli,
-)
+from hogli.core.cli import _infer_process_manager, _is_posthog_dev, cli
 
 runner = CliRunner()
 
@@ -175,50 +168,6 @@ class TestProcessManagerInference:
         assert _infer_process_manager("start") == "phrocs"
 
 
-class TestCheckEmailDomain:
-    @pytest.fixture()
-    def _fake_home(self, tmp_path, monkeypatch):
-        monkeypatch.setattr("hogli.core.cli.Path.home", staticmethod(lambda: tmp_path))
-        monkeypatch.setattr("hogli.core.cli.REPO_ROOT", tmp_path)
-        return tmp_path
-
-    def test_posthog_email(self, _fake_home):
-        (_fake_home / ".gitconfig").write_text("[user]\n\temail = dev@posthog.com\n")
-        assert _check_email_domain() is True
-
-    def test_non_posthog_email(self, _fake_home):
-        (_fake_home / ".gitconfig").write_text("[user]\n\temail = user@example.com\n")
-        assert _check_email_domain() is False
-
-    def test_no_config_files(self, _fake_home):
-        assert _check_email_domain() is False
-
-
-class TestGetGithubToken:
-    def test_gh_token_env(self, monkeypatch):
-        monkeypatch.setenv("GH_TOKEN", "tok-from-env")
-        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
-        assert _get_github_token() == "tok-from-env"
-
-    def test_github_token_env(self, monkeypatch):
-        monkeypatch.delenv("GH_TOKEN", raising=False)
-        monkeypatch.setenv("GITHUB_TOKEN", "tok-github")
-        assert _get_github_token() == "tok-github"
-
-    @patch("hogli.core.cli.subprocess.run")
-    def test_falls_back_to_gh_auth(self, mock_run, monkeypatch):
-        monkeypatch.delenv("GH_TOKEN", raising=False)
-        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
-        mock_run.return_value = MagicMock(returncode=0, stdout="tok-cli\n")
-        assert _get_github_token() == "tok-cli"
-
-    @patch("hogli.core.cli.subprocess.run", side_effect=FileNotFoundError)
-    def test_no_gh_returns_none(self, _mock_run, monkeypatch):
-        monkeypatch.delenv("GH_TOKEN", raising=False)
-        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
-        assert _get_github_token() is None
-
-
 class TestIsPosthogDev:
     @pytest.fixture()
     def _config_dir(self, tmp_path, monkeypatch):
@@ -230,48 +179,17 @@ class TestIsPosthogDev:
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text(json.dumps(kwargs))
 
-    def test_fresh_cache_returns_cached_true(self, _config_dir):
+    def test_fresh_cache_skips_api(self, _config_dir):
         self._write_config(_config_dir, is_posthog_org_member=True, org_check_timestamp=time.time())
         assert _is_posthog_dev() is True
 
-    def test_fresh_cache_returns_cached_false(self, _config_dir):
-        self._write_config(_config_dir, is_posthog_org_member=False, org_check_timestamp=time.time())
-        assert _is_posthog_dev() is False
-
-    @patch("hogli.core.cli._check_github_org", return_value=True)
-    @patch("hogli.core.cli._get_github_token", return_value="tok")
-    def test_stale_cache_triggers_api_check(self, _mock_tok, _mock_org, _config_dir):
-        stale_ts = time.time() - _POSTHOG_DEV_CACHE_TTL_SECONDS - 1
-        self._write_config(_config_dir, is_posthog_org_member=False, org_check_timestamp=stale_ts)
-
+    @patch("hogli.core.cli._check_github_org_membership", return_value=True)
+    def test_cache_miss_calls_gh_and_persists(self, _mock_gh, _config_dir):
         assert _is_posthog_dev() is True
-
-    @patch("hogli.core.cli._check_github_org", return_value=True)
-    @patch("hogli.core.cli._get_github_token", return_value="tok")
-    def test_api_member_caches_true(self, _mock_tok, _mock_org, _config_dir):
-        assert _is_posthog_dev() is True
-
-        config = json.loads(_config_dir.read_text())
-        assert config["is_posthog_org_member"] is True
-        assert config["org_check_timestamp"] > 0
-
-    @patch("hogli.core.cli._check_github_org", return_value=False)
-    @patch("hogli.core.cli._get_github_token", return_value="tok")
-    def test_api_non_member_caches_false(self, _mock_tok, _mock_org, _config_dir):
-        assert _is_posthog_dev() is False
-
-        config = json.loads(_config_dir.read_text())
-        assert config["is_posthog_org_member"] is False
+        assert json.loads(_config_dir.read_text())["is_posthog_org_member"] is True
 
     @patch("hogli.core.cli._check_email_domain", return_value=True)
-    @patch("hogli.core.cli._get_github_token", return_value=None)
-    def test_no_token_falls_back_to_email(self, _mock_tok, mock_email, _config_dir):
+    @patch("hogli.core.cli._check_github_org_membership", return_value=None)
+    def test_gh_unavailable_falls_back_to_email(self, _mock_gh, mock_email, _config_dir):
         assert _is_posthog_dev() is True
-        mock_email.assert_called_once()
-
-    @patch("hogli.core.cli._check_email_domain", return_value=False)
-    @patch("hogli.core.cli._check_github_org", side_effect=Exception("network error"))
-    @patch("hogli.core.cli._get_github_token", return_value="tok")
-    def test_api_error_falls_back_to_email(self, _mock_tok, _mock_org, mock_email, _config_dir):
-        assert _is_posthog_dev() is False
         mock_email.assert_called_once()

--- a/common/hogli/tests/test_cli.py
+++ b/common/hogli/tests/test_cli.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import subprocess
-
 import pytest
 from unittest.mock import MagicMock, patch
 
@@ -174,21 +172,26 @@ class TestIsPosthogDev:
         yield
         _is_posthog_dev.cache_clear()
 
-    def test_posthog_email(self):
-        with patch("hogli.core.cli.subprocess.run") as mock_run:
-            mock_run.return_value = subprocess.CompletedProcess(args=[], returncode=0, stdout="dev@posthog.com\n")
-            assert _is_posthog_dev() is True
+    @pytest.fixture()
+    def _fake_home(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("hogli.core.cli.Path.home", staticmethod(lambda: tmp_path))
+        monkeypatch.setattr("hogli.core.cli.REPO_ROOT", tmp_path)
+        return tmp_path
 
-    def test_non_posthog_email(self):
-        with patch("hogli.core.cli.subprocess.run") as mock_run:
-            mock_run.return_value = subprocess.CompletedProcess(args=[], returncode=0, stdout="user@example.com\n")
-            assert _is_posthog_dev() is False
+    def test_posthog_email(self, _fake_home):
+        (_fake_home / ".gitconfig").write_text("[user]\n\temail = dev@posthog.com\n")
+        assert _is_posthog_dev() is True
 
-    def test_git_config_fails(self):
-        with patch("hogli.core.cli.subprocess.run") as mock_run:
-            mock_run.return_value = subprocess.CompletedProcess(args=[], returncode=1, stdout="")
-            assert _is_posthog_dev() is False
+    def test_non_posthog_email(self, _fake_home):
+        (_fake_home / ".gitconfig").write_text("[user]\n\temail = user@example.com\n")
+        assert _is_posthog_dev() is False
 
-    def test_subprocess_exception(self):
-        with patch("hogli.core.cli.subprocess.run", side_effect=OSError("no git")):
-            assert _is_posthog_dev() is False
+    def test_local_config_overrides_global(self, _fake_home):
+        (_fake_home / ".gitconfig").write_text("[user]\n\temail = user@example.com\n")
+        git_dir = _fake_home / ".git"
+        git_dir.mkdir()
+        (git_dir / "config").write_text("[user]\n\temail = dev@posthog.com\n")
+        assert _is_posthog_dev() is True
+
+    def test_no_config_files(self, _fake_home):
+        assert _is_posthog_dev() is False

--- a/common/hogli/tests/test_cli.py
+++ b/common/hogli/tests/test_cli.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+import subprocess
+
+import pytest
 from unittest.mock import MagicMock, patch
 
 from click.testing import CliRunner
-from hogli.core.cli import _infer_process_manager, cli
+from hogli.core.cli import _infer_process_manager, _is_posthog_dev, cli
 
 runner = CliRunner()
 
@@ -162,3 +165,30 @@ class TestProcessManagerInference:
         monkeypatch.setattr("sys.argv", ["hogli", "start", "--mprocs"])
 
         assert _infer_process_manager("start") == "phrocs"
+
+
+class TestIsPosthogDev:
+    @pytest.fixture(autouse=True)
+    def _clear_cache(self):
+        _is_posthog_dev.cache_clear()
+        yield
+        _is_posthog_dev.cache_clear()
+
+    def test_posthog_email(self):
+        with patch("hogli.core.cli.subprocess.run") as mock_run:
+            mock_run.return_value = subprocess.CompletedProcess(args=[], returncode=0, stdout="dev@posthog.com\n")
+            assert _is_posthog_dev() is True
+
+    def test_non_posthog_email(self):
+        with patch("hogli.core.cli.subprocess.run") as mock_run:
+            mock_run.return_value = subprocess.CompletedProcess(args=[], returncode=0, stdout="user@example.com\n")
+            assert _is_posthog_dev() is False
+
+    def test_git_config_fails(self):
+        with patch("hogli.core.cli.subprocess.run") as mock_run:
+            mock_run.return_value = subprocess.CompletedProcess(args=[], returncode=1, stdout="")
+            assert _is_posthog_dev() is False
+
+    def test_subprocess_exception(self):
+        with patch("hogli.core.cli.subprocess.run", side_effect=OSError("no git")):
+            assert _is_posthog_dev() is False

--- a/common/hogli/tests/test_cli.py
+++ b/common/hogli/tests/test_cli.py
@@ -2,11 +2,21 @@
 
 from __future__ import annotations
 
+import json
+import time
+
 import pytest
 from unittest.mock import MagicMock, patch
 
 from click.testing import CliRunner
-from hogli.core.cli import _infer_process_manager, _is_posthog_dev, cli
+from hogli.core.cli import (
+    _POSTHOG_DEV_CACHE_TTL_SECONDS,
+    _check_email_domain,
+    _get_github_token,
+    _infer_process_manager,
+    _is_posthog_dev,
+    cli,
+)
 
 runner = CliRunner()
 
@@ -165,13 +175,7 @@ class TestProcessManagerInference:
         assert _infer_process_manager("start") == "phrocs"
 
 
-class TestIsPosthogDev:
-    @pytest.fixture(autouse=True)
-    def _clear_cache(self):
-        _is_posthog_dev.cache_clear()
-        yield
-        _is_posthog_dev.cache_clear()
-
+class TestCheckEmailDomain:
     @pytest.fixture()
     def _fake_home(self, tmp_path, monkeypatch):
         monkeypatch.setattr("hogli.core.cli.Path.home", staticmethod(lambda: tmp_path))
@@ -180,18 +184,94 @@ class TestIsPosthogDev:
 
     def test_posthog_email(self, _fake_home):
         (_fake_home / ".gitconfig").write_text("[user]\n\temail = dev@posthog.com\n")
-        assert _is_posthog_dev() is True
+        assert _check_email_domain() is True
 
     def test_non_posthog_email(self, _fake_home):
         (_fake_home / ".gitconfig").write_text("[user]\n\temail = user@example.com\n")
-        assert _is_posthog_dev() is False
-
-    def test_local_config_overrides_global(self, _fake_home):
-        (_fake_home / ".gitconfig").write_text("[user]\n\temail = user@example.com\n")
-        git_dir = _fake_home / ".git"
-        git_dir.mkdir()
-        (git_dir / "config").write_text("[user]\n\temail = dev@posthog.com\n")
-        assert _is_posthog_dev() is True
+        assert _check_email_domain() is False
 
     def test_no_config_files(self, _fake_home):
+        assert _check_email_domain() is False
+
+
+class TestGetGithubToken:
+    def test_gh_token_env(self, monkeypatch):
+        monkeypatch.setenv("GH_TOKEN", "tok-from-env")
+        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+        assert _get_github_token() == "tok-from-env"
+
+    def test_github_token_env(self, monkeypatch):
+        monkeypatch.delenv("GH_TOKEN", raising=False)
+        monkeypatch.setenv("GITHUB_TOKEN", "tok-github")
+        assert _get_github_token() == "tok-github"
+
+    @patch("hogli.core.cli.subprocess.run")
+    def test_falls_back_to_gh_auth(self, mock_run, monkeypatch):
+        monkeypatch.delenv("GH_TOKEN", raising=False)
+        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+        mock_run.return_value = MagicMock(returncode=0, stdout="tok-cli\n")
+        assert _get_github_token() == "tok-cli"
+
+    @patch("hogli.core.cli.subprocess.run", side_effect=FileNotFoundError)
+    def test_no_gh_returns_none(self, _mock_run, monkeypatch):
+        monkeypatch.delenv("GH_TOKEN", raising=False)
+        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+        assert _get_github_token() is None
+
+
+class TestIsPosthogDev:
+    @pytest.fixture()
+    def _config_dir(self, tmp_path, monkeypatch):
+        config_file = tmp_path / "hogli_telemetry.json"
+        monkeypatch.setattr("hogli.telemetry.get_config_path", lambda: config_file)
+        return config_file
+
+    def _write_config(self, path, **kwargs):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(kwargs))
+
+    def test_fresh_cache_returns_cached_true(self, _config_dir):
+        self._write_config(_config_dir, is_posthog_org_member=True, org_check_timestamp=time.time())
+        assert _is_posthog_dev() is True
+
+    def test_fresh_cache_returns_cached_false(self, _config_dir):
+        self._write_config(_config_dir, is_posthog_org_member=False, org_check_timestamp=time.time())
         assert _is_posthog_dev() is False
+
+    @patch("hogli.core.cli._check_github_org", return_value=True)
+    @patch("hogli.core.cli._get_github_token", return_value="tok")
+    def test_stale_cache_triggers_api_check(self, _mock_tok, _mock_org, _config_dir):
+        stale_ts = time.time() - _POSTHOG_DEV_CACHE_TTL_SECONDS - 1
+        self._write_config(_config_dir, is_posthog_org_member=False, org_check_timestamp=stale_ts)
+
+        assert _is_posthog_dev() is True
+
+    @patch("hogli.core.cli._check_github_org", return_value=True)
+    @patch("hogli.core.cli._get_github_token", return_value="tok")
+    def test_api_member_caches_true(self, _mock_tok, _mock_org, _config_dir):
+        assert _is_posthog_dev() is True
+
+        config = json.loads(_config_dir.read_text())
+        assert config["is_posthog_org_member"] is True
+        assert config["org_check_timestamp"] > 0
+
+    @patch("hogli.core.cli._check_github_org", return_value=False)
+    @patch("hogli.core.cli._get_github_token", return_value="tok")
+    def test_api_non_member_caches_false(self, _mock_tok, _mock_org, _config_dir):
+        assert _is_posthog_dev() is False
+
+        config = json.loads(_config_dir.read_text())
+        assert config["is_posthog_org_member"] is False
+
+    @patch("hogli.core.cli._check_email_domain", return_value=True)
+    @patch("hogli.core.cli._get_github_token", return_value=None)
+    def test_no_token_falls_back_to_email(self, _mock_tok, mock_email, _config_dir):
+        assert _is_posthog_dev() is True
+        mock_email.assert_called_once()
+
+    @patch("hogli.core.cli._check_email_domain", return_value=False)
+    @patch("hogli.core.cli._check_github_org", side_effect=Exception("network error"))
+    @patch("hogli.core.cli._get_github_token", return_value="tok")
+    def test_api_error_falls_back_to_email(self, _mock_tok, _mock_org, mock_email, _config_dir):
+        assert _is_posthog_dev() is False
+        mock_email.assert_called_once()

--- a/common/hogli/tests/test_cli.py
+++ b/common/hogli/tests/test_cli.py
@@ -190,6 +190,7 @@ class TestIsPosthogDev:
 
     @patch("hogli.core.cli._check_email_domain", return_value=True)
     @patch("hogli.core.cli._check_github_org_membership", return_value=None)
-    def test_gh_unavailable_falls_back_to_email(self, _mock_gh, mock_email, _config_dir):
+    def test_gh_unavailable_falls_back_to_email_and_caches(self, _mock_gh, mock_email, _config_dir):
         assert _is_posthog_dev() is True
         mock_email.assert_called_once()
+        assert json.loads(_config_dir.read_text())["is_posthog_org_member"] is True


### PR DESCRIPTION
## Problem

The hogli DevEx dashboard mixes PostHog engineer usage with external contributor usage. There's no way to filter by audience, making it hard to understand internal adoption vs community usage.

The naive approach (checking `git config user.email` for `@posthog.com`) has a ~50% false-negative rate (checked against latest 30 `master` commits) since many PostHog engineers use personal or GitHub noreply emails for commits.

## Changes

Adds a boolean `is_posthog_dev` event property to all hogli telemetry events.

Detection strategy (in order):
1. **Persistent cache** -- checks `~/.config/posthog/hogli_telemetry.json` for a cached org membership result (30-day TTL)
2. **GitHub org membership** -- runs `gh api /user/memberships/orgs/PostHog` to check if the authenticated user belongs to the PostHog org, then caches the boolean result
3. **Email domain fallback** -- if `gh` is unavailable, checks `git config user.email` for `@posthog.com`

The actual email and GitHub username are never sent -- just a boolean. The `gh` API call only happens on cache miss (~once/month).

## How did you test this code?

- Unit tests covering: cache hit, cache miss with gh API, gh unavailable falling back to email
- Full test suite passes (20 tests)

No manual testing beyond unit tests -- this was agent-authored.

No changelog, no docs update.

## LLM context

Agent-authored PR. Claude Code session.