### PR TITLE
fix(cohorts): fix cross-DB alias error in static cohort insertion

### DIFF
--- a/posthog/admin/admins/cohort_admin.py
+++ b/posthog/admin/admins/cohort_admin.py
@@ -1,4 +1,4 @@
-from django.contrib import admin
+from django.contrib import admin, messages
 from django.urls import reverse
 from django.utils.html import format_html
 
@@ -10,6 +10,10 @@ class CohortAdmin(admin.ModelAdmin):
         "id",
         "name",
         "team_link",
+        "is_static",
+        "count",
+        "is_calculating",
+        "errors_calculating",
         "created_at",
         "created_by",
     )
@@ -18,6 +22,7 @@ class CohortAdmin(admin.ModelAdmin):
     search_fields = ("id", "name", "team__name", "team__organization__name")
     autocomplete_fields = ("team", "created_by")
     ordering = ("-created_at",)
+    actions = ["resync_static_cohort"]
 
     @admin.display(description="Team")
     def team_link(self, cohort: Cohort):
@@ -26,3 +31,32 @@ class CohortAdmin(admin.ModelAdmin):
             reverse("admin:posthog_team_change", args=[cohort.team.pk]),
             cohort.team.name,
         )
+
+    @admin.action(description="Re-sync static cohort from source query")
+    def resync_static_cohort(self, request, queryset):
+        from posthog.tasks.calculate_cohort import insert_cohort_from_query
+
+        for cohort in queryset:
+            if not cohort.is_static:
+                self.message_user(
+                    request,
+                    f"Cohort {cohort.id} ({cohort.name}) is not static, skipping.",
+                    messages.WARNING,
+                )
+                continue
+
+            if not cohort.query:
+                self.message_user(
+                    request,
+                    f"Cohort {cohort.id} ({cohort.name}) has no source query, skipping.",
+                    messages.WARNING,
+                )
+                continue
+
+            old_count = cohort.count
+            insert_cohort_from_query.delay(cohort.pk, cohort.team_id)
+            self.message_user(
+                request,
+                f"Queued re-sync for cohort {cohort.id} ({cohort.name}), current count: {old_count}.",
+                messages.SUCCESS,
+            )

--- a/posthog/api/test/test_feature_flag.py
+++ b/posthog/api/test/test_feature_flag.py
@@ -8430,7 +8430,7 @@ class TestCohortGenerationForFeatureFlag(APIBaseTest, ClickhouseTestMixin):
         )
 
         # TODO: Ensure server-side cursors are disabled, since in production we use this with pgbouncer
-        with snapshot_postgres_queries_context(self), self.assertNumQueries(18):
+        with snapshot_postgres_queries_context(self), self.assertNumQueries(17):
             get_cohort_actors_for_feature_flag(cohort.pk, "some-feature2", self.team.pk)
 
         cohort.refresh_from_db()
@@ -8488,7 +8488,7 @@ class TestCohortGenerationForFeatureFlag(APIBaseTest, ClickhouseTestMixin):
         )
 
         # Extra queries because each batch adds its own queries
-        with snapshot_postgres_queries_context(self), self.assertNumQueries(25):
+        with snapshot_postgres_queries_context(self), self.assertNumQueries(23):
             get_cohort_actors_for_feature_flag(cohort.pk, "some-feature2", self.team.pk, batchsize=2)
 
         cohort.refresh_from_db()
@@ -8578,7 +8578,7 @@ class TestCohortGenerationForFeatureFlag(APIBaseTest, ClickhouseTestMixin):
             name="some cohort",
         )
 
-        with snapshot_postgres_queries_context(self), self.assertNumQueries(15):
+        with snapshot_postgres_queries_context(self), self.assertNumQueries(14):
             # no queries to evaluate flags, because all evaluated using override properties
             get_cohort_actors_for_feature_flag(cohort.pk, "some-feature2", self.team.pk)
 
@@ -8707,7 +8707,7 @@ class TestCohortGenerationForFeatureFlag(APIBaseTest, ClickhouseTestMixin):
             name="some cohort",
         )
 
-        with snapshot_postgres_queries_context(self), self.assertNumQueries(32):
+        with snapshot_postgres_queries_context(self), self.assertNumQueries(31):
             # forced to evaluate flags by going to db, because cohorts need db query to evaluate
             get_cohort_actors_for_feature_flag(cohort.pk, "some-feature-new", self.team.pk)
 

--- a/posthog/models/cohort/cohort.py
+++ b/posthog/models/cohort/cohort.py
@@ -731,6 +731,7 @@ class Cohort(FileSystemSyncMixin, RootTeamMixin, models.Model):
                     LEFT JOIN "{cohort_people_table}" AS cp
                         ON cp."person_id" = p."id" AND cp."cohort_id" = {self.pk}
                     WHERE cp."person_id" IS NULL
+                    ON CONFLICT DO NOTHING
                 """
                 cursor.execute(query, params)
 

--- a/posthog/models/cohort/cohort.py
+++ b/posthog/models/cohort/cohort.py
@@ -63,12 +63,6 @@ DELETE_QUERY = """
 DELETE FROM "posthog_cohortpeople" WHERE "cohort_id" = {cohort_id}
 """
 
-UPDATE_QUERY = """
-INSERT INTO "posthog_cohortpeople" ("person_id", "cohort_id", "version")
-{values_query}
-ON CONFLICT DO NOTHING
-"""
-
 DEFAULT_COHORT_INSERT_BATCH_SIZE = 1000
 
 
@@ -699,37 +693,45 @@ class Cohort(FileSystemSyncMixin, RootTeamMixin, models.Model):
             db_read = router.db_for_read(Person) or "default"
             persons_connection = connections[db_write]
             cursor = persons_connection.cursor()
+            cohort_people_table = CohortPeople._meta.db_table
             for batch_index, batch in batch_iterator:
                 current_batch_index = batch_index
-                # Get persons already in this cohort to exclude them
-                # Can't use .exclude(cohort__id=self.id) because Cohort is in default DB
-                # and Person/CohortPeople are in persons DB - cross-DB joins don't work
-                existing_person_ids = set(
-                    CohortPeople.objects.using(db_write).filter(cohort_id=self.id).values_list("person_id", flat=True)
-                )
 
-                persons_query = (
-                    Person.objects.db_manager(db_read)
-                    .filter(team_id=team_id)
-                    .filter(uuid__in=batch)
-                    .exclude(id__in=existing_person_ids)
-                )
+                persons_query = Person.objects.db_manager(db_read).filter(team_id=team_id).filter(uuid__in=batch)
                 if insert_in_clickhouse:
+                    # Both querysets must use db_write so Django can merge the
+                    # .exclude() into a single NOT IN subquery. Using db_read
+                    # for Person + db_write for CohortPeople causes a
+                    # "Subqueries aren't allowed across different databases"
+                    # ValueError when the aliases differ (production config).
+                    insert_uuids_query = (
+                        Person.objects.using(db_write)
+                        .filter(team_id=team_id, uuid__in=batch)
+                        .exclude(
+                            id__in=CohortPeople.objects.using(db_write)
+                            .filter(cohort_id=self.id)
+                            .values_list("person_id", flat=True)
+                        )
+                    )
                     insert_static_cohort(
-                        list(persons_query.values_list("uuid", flat=True)),
+                        list(insert_uuids_query.values_list("uuid", flat=True)),
                         self.pk,
                         team_id=team_id,
                     )
+
+                # Dedup via LEFT JOIN so the exclusion stays entirely in SQL,
+                # avoiding the O(cohort_size) memory cost of loading all
+                # existing member IDs into Python. Both tables live on the
+                # persons DB so the join works on the db_write cursor.
                 sql, params = persons_query.distinct("pk").only("pk").query.sql_with_params()
-                person_table = Person._meta.db_table
-                query = UPDATE_QUERY.format(
-                    cohort_id=self.pk,
-                    values_query=sql.replace(
-                        f'FROM "{person_table}"',
-                        f', {self.pk}, {self.version or "NULL"} FROM "{person_table}"',
-                        1,
-                    ),
-                )
+                query = f"""
+                    INSERT INTO "{cohort_people_table}" ("person_id", "cohort_id", "version")
+                    SELECT p."id", {self.pk}, {self.version or "NULL"}
+                    FROM ({sql}) AS p
+                    LEFT JOIN "{cohort_people_table}" AS cp
+                        ON cp."person_id" = p."id" AND cp."cohort_id" = {self.pk}
+                    WHERE cp."person_id" IS NULL
+                """
                 cursor.execute(query, params)
 
         except Exception as err:

--- a/posthog/test/test_cohort_model.py
+++ b/posthog/test/test_cohort_model.py
@@ -377,6 +377,26 @@ class TestCohort(BaseTest):
         # Verify the cohort is not in calculating state
         self.assertFalse(cohort.is_calculating)
 
+    def test_insert_users_list_by_uuid_with_different_db_aliases(self):
+        from unittest.mock import patch
+
+        person = Person.objects.create(team=self.team, distinct_ids=["cross-db-test"])
+        cohort = Cohort.objects.create(team=self.team, groups=[], is_static=True)
+
+        # Simulate production config where db_for_read returns a different
+        # alias than db_for_write. Both "default" and "persons_db_writer"
+        # resolve to the same test database, but Django treats them as
+        # different DBs and rejects cross-DB subqueries.
+        with patch("django.db.router.db_for_read", return_value="default"):
+            cohort.insert_users_list_by_uuid(
+                items=[str(person.uuid)],
+                team_id=self.team.id,
+            )
+
+        cohort.refresh_from_db()
+        assert cohort.people.count() == 1
+        assert str(cohort.people.first().uuid) == str(person.uuid)
+
     @parameterized.expand(
         [
             # operator, filter_value, excluded_ages, included_ages


### PR DESCRIPTION
## Problem

#52819 fixed static cohort duplication truncation but was reverted (#53670) because it broke adding users to static cohorts in production.

The root cause: the ClickHouse dedup path mixed `db_read` (`persons_db_reader`) and `db_write` (`persons_db_writer`) Django database aliases in a single queryset with `.exclude()`. Django rejects cross-alias subqueries — even when both aliases point to the same physical database — raising:

```
ValueError: Subqueries aren't allowed across different databases.
```

This error was silently swallowed by the `except` block in `_insert_users_list_with_batching`, so API calls returned 200 but cohort membership was never updated. Tests passed because `db_read == db_write` in the test config.

## Changes

- **CH dedup path**: Use `db_write` for both `Person` and `CohortPeople` querysets so Django can merge the `.exclude()` into a single `NOT IN` subquery. No cross-DB error, no memory explosion.
- **PG insert path**: Replace the string-replacement hack (`UPDATE_QUERY.format(sql.replace(...))`) with a `LEFT JOIN` via raw SQL on the `db_write` cursor. Dedup stays entirely in SQL, avoiding the O(cohort_size) memory cost of loading all existing member IDs into Python.
- Remove unused `UPDATE_QUERY` constant.
- Re-apply admin improvements from #52819 (resync action, list fields).
- Add regression test that simulates production's split DB aliases.

## How did you test this code?

- All 40 static cohort API tests pass
- All 4 feature flag cohort generation tests pass (with updated query counts)
- All 5 cohort model insertion tests pass
- Regression test validates the fix: passes with `db_write` for both querysets, fails with `db_read` + `db_write` mix (reproduces the production `ValueError`)

## Publish to changelog?

No

## Docs update

N/A

## LLM context

Re-land of #52819 with the cross-DB alias bug fixed. The key insight is that Django checks database *aliases*, not physical databases, when validating subqueries. Production uses separate `persons_db_reader`/`persons_db_writer` aliases, but tests use a single alias for both, which is why the original PR's tests passed.