### PR TITLE
fix(cohorts): show between dual input and date picker in cohort filters

### DIFF
--- a/frontend/src/scenes/cohorts/CohortFilters/CohortCriteriaRowBuilder.tsx
+++ b/frontend/src/scenes/cohorts/CohortFilters/CohortCriteriaRowBuilder.tsx
@@ -39,12 +39,15 @@ export function CohortCriteriaRowBuilder({
     const { setCriteria, duplicateFilter, removeFilter } = useActions(cohortEditLogic)
     const rowShape = ROWS[type]
 
+    const cohortFilterLogicKey = `cohort_${groupIndex}_${index}`
+
     const renderFieldComponent = (_field: Field, i: number): JSX.Element => {
         return (
             <div key={_field.fieldKey ?? i}>
                 {renderField[_field.type]({
                     fieldKey: _field.fieldKey,
                     criteria,
+                    cohortFilterLogicKey,
                     ...(_field.type === FilterType.Text ? { value: _field.defaultValue } : {}),
                     ...(_field.groupTypeFieldKey ? { groupTypeFieldKey: _field.groupTypeFieldKey } : {}),
                     onChange: (newCriteria) => setCriteria(newCriteria, groupIndex, index),

--- a/frontend/src/scenes/cohorts/CohortFilters/CohortCriteriaRowBuilder.tsx
+++ b/frontend/src/scenes/cohorts/CohortFilters/CohortCriteriaRowBuilder.tsx
@@ -39,15 +39,12 @@ export function CohortCriteriaRowBuilder({
     const { setCriteria, duplicateFilter, removeFilter } = useActions(cohortEditLogic)
     const rowShape = ROWS[type]
 
-    const cohortFilterLogicKey = `cohort_${groupIndex}_${index}`
-
     const renderFieldComponent = (_field: Field, i: number): JSX.Element => {
         return (
             <div key={_field.fieldKey ?? i}>
                 {renderField[_field.type]({
                     fieldKey: _field.fieldKey,
                     criteria,
-                    cohortFilterLogicKey,
                     ...(_field.type === FilterType.Text ? { value: _field.defaultValue } : {}),
                     ...(_field.groupTypeFieldKey ? { groupTypeFieldKey: _field.groupTypeFieldKey } : {}),
                     onChange: (newCriteria) => setCriteria(newCriteria, groupIndex, index),

--- a/frontend/src/scenes/cohorts/CohortFilters/CohortField.tsx
+++ b/frontend/src/scenes/cohorts/CohortFilters/CohortField.tsx
@@ -167,11 +167,12 @@ export function CohortPersonPropertiesValuesField({
 
     return (
         <PropertyValue
+            key={`${propertyKey}_${operator}`}
             operator={operator || PropertyOperator.Exact}
             propertyKey={propertyKey as string}
             type={PropertyFilterType.Person}
             value={value as PropertyFilterValue}
-            onSet={(newValue: PropertyOperator) => {
+            onSet={(newValue: PropertyFilterValue) => {
                 onChange({ [fieldKey]: newValue })
             }}
             placeholder="Enter value..."

--- a/frontend/src/scenes/cohorts/CohortFilters/CohortField.tsx
+++ b/frontend/src/scenes/cohorts/CohortFilters/CohortField.tsx
@@ -14,7 +14,7 @@ import { dayjs } from 'lib/dayjs'
 import { LemonButton, LemonButtonWithDropdown } from 'lib/lemon-ui/LemonButton'
 import { LemonDivider } from 'lib/lemon-ui/LemonDivider'
 import { LemonInput } from 'lib/lemon-ui/LemonInput/LemonInput'
-import { formatDate, isOperatorDate } from 'lib/utils'
+import { formatDate } from 'lib/utils'
 import { cohortFieldLogic } from 'scenes/cohorts/CohortFilters/cohortFieldLogic'
 import {
     CohortEventFiltersFieldProps,
@@ -116,23 +116,14 @@ export function CohortSelectorField({
  * the selected person property's type. Without this, DateTime properties like
  * "date_of_birth" would show irrelevant operators like "contains" or "maximum".
  *
- * Also auto-resets the operator when switching between DateTime and non-DateTime
- * properties so the user doesn't end up with an invalid operator selection.
+ * The operator auto-reset when switching between DateTime and non-DateTime
+ * properties is handled in cohortEditLogic's setCriteria listener.
  */
 export function CohortMathOperatorField(props: CohortSelectorFieldProps): JSX.Element {
     const { getPropertyDefinition } = useValues(propertyDefinitionsModel)
     const propertyKey = props.criteria?.key
     const propDef = getPropertyDefinition(propertyKey, PropertyDefinitionType.Person)
     const isDateTime = propDef?.property_type === PropertyType.DateTime
-    const currentOperator = props.criteria?.operator as PropertyOperator | undefined
-
-    useEffect(() => {
-        if (isDateTime && (!currentOperator || !isOperatorDate(currentOperator))) {
-            props.onChange?.({ operator: PropertyOperator.IsDateExact })
-        } else if (!isDateTime && currentOperator && isOperatorDate(currentOperator)) {
-            props.onChange?.({ operator: PropertyOperator.Exact })
-        }
-    }, [isDateTime, propertyKey]) // eslint-disable-line react-hooks/exhaustive-deps
 
     const fieldOptionGroupTypes = isDateTime
         ? [FieldOptionsType.SingleFieldDateOperators]

--- a/frontend/src/scenes/cohorts/CohortFilters/CohortField.tsx
+++ b/frontend/src/scenes/cohorts/CohortFilters/CohortField.tsx
@@ -122,7 +122,7 @@ export function CohortSelectorField({
 export function CohortMathOperatorField(props: CohortSelectorFieldProps): JSX.Element {
     const { getPropertyDefinition } = useValues(propertyDefinitionsModel)
     const propertyKey = props.criteria?.key
-    const propDef = getPropertyDefinition(propertyKey, PropertyDefinitionType.Person)
+    const propDef = propertyKey ? getPropertyDefinition(propertyKey, PropertyDefinitionType.Person) : null
     const isDateTime = propDef?.property_type === PropertyType.DateTime
 
     const fieldOptionGroupTypes = isDateTime

--- a/frontend/src/scenes/cohorts/CohortFilters/CohortField.tsx
+++ b/frontend/src/scenes/cohorts/CohortFilters/CohortField.tsx
@@ -25,9 +25,18 @@ import {
     CohortSelectorFieldProps,
     CohortTaxonomicFieldProps,
     CohortTextFieldProps,
+    FieldOptionsType,
 } from 'scenes/cohorts/CohortFilters/types'
 
-import { AnyPropertyFilter, PropertyFilterType, PropertyFilterValue, PropertyOperator } from '~/types'
+import { propertyDefinitionsModel } from '~/models/propertyDefinitionsModel'
+import {
+    AnyPropertyFilter,
+    PropertyDefinitionType,
+    PropertyFilterType,
+    PropertyFilterValue,
+    PropertyOperator,
+    PropertyType,
+} from '~/types'
 
 let uniqueMemoizedIndex = 0
 
@@ -100,6 +109,24 @@ export function CohortSelectorField({
             </span>
         </LemonButtonWithDropdown>
     )
+}
+
+/**
+ * Wraps CohortSelectorField to show date-only or math-only operators based on
+ * the selected person property's type. Without this, DateTime properties like
+ * "date_of_birth" would show irrelevant operators like "contains" or "maximum".
+ */
+export function CohortMathOperatorField(props: CohortSelectorFieldProps): JSX.Element {
+    const { getPropertyDefinition } = useValues(propertyDefinitionsModel)
+    const propertyKey = props.criteria?.key
+    const propDef = getPropertyDefinition(propertyKey, PropertyDefinitionType.Person)
+    const isDateTime = propDef?.property_type === PropertyType.DateTime
+
+    const fieldOptionGroupTypes = isDateTime
+        ? [FieldOptionsType.SingleFieldDateOperators]
+        : [FieldOptionsType.CohortMathOperators]
+
+    return <CohortSelectorField {...props} fieldOptionGroupTypes={fieldOptionGroupTypes} />
 }
 
 export function CohortTaxonomicField({

--- a/frontend/src/scenes/cohorts/CohortFilters/CohortField.tsx
+++ b/frontend/src/scenes/cohorts/CohortFilters/CohortField.tsx
@@ -14,7 +14,7 @@ import { dayjs } from 'lib/dayjs'
 import { LemonButton, LemonButtonWithDropdown } from 'lib/lemon-ui/LemonButton'
 import { LemonDivider } from 'lib/lemon-ui/LemonDivider'
 import { LemonInput } from 'lib/lemon-ui/LemonInput/LemonInput'
-import { formatDate } from 'lib/utils'
+import { formatDate, isOperatorDate } from 'lib/utils'
 import { cohortFieldLogic } from 'scenes/cohorts/CohortFilters/cohortFieldLogic'
 import {
     CohortEventFiltersFieldProps,
@@ -115,12 +115,24 @@ export function CohortSelectorField({
  * Wraps CohortSelectorField to show date-only or math-only operators based on
  * the selected person property's type. Without this, DateTime properties like
  * "date_of_birth" would show irrelevant operators like "contains" or "maximum".
+ *
+ * Also auto-resets the operator when switching between DateTime and non-DateTime
+ * properties so the user doesn't end up with an invalid operator selection.
  */
 export function CohortMathOperatorField(props: CohortSelectorFieldProps): JSX.Element {
     const { getPropertyDefinition } = useValues(propertyDefinitionsModel)
     const propertyKey = props.criteria?.key
     const propDef = getPropertyDefinition(propertyKey, PropertyDefinitionType.Person)
     const isDateTime = propDef?.property_type === PropertyType.DateTime
+    const currentOperator = props.criteria?.operator as PropertyOperator | undefined
+
+    useEffect(() => {
+        if (isDateTime && (!currentOperator || !isOperatorDate(currentOperator))) {
+            props.onChange?.({ operator: PropertyOperator.IsDateExact })
+        } else if (!isDateTime && currentOperator && isOperatorDate(currentOperator)) {
+            props.onChange?.({ operator: PropertyOperator.Exact })
+        }
+    }, [isDateTime, propertyKey]) // eslint-disable-line react-hooks/exhaustive-deps
 
     const fieldOptionGroupTypes = isDateTime
         ? [FieldOptionsType.SingleFieldDateOperators]

--- a/frontend/src/scenes/cohorts/CohortFilters/constants.tsx
+++ b/frontend/src/scenes/cohorts/CohortFilters/constants.tsx
@@ -3,6 +3,7 @@ import { CohortTypeEnum, PROPERTY_MATCH_TYPE } from 'lib/constants'
 import { LemonSelectOptions } from 'lib/lemon-ui/LemonSelect'
 import {
     CohortEventFiltersField,
+    CohortMathOperatorField,
     CohortNumberField,
     CohortPersonPropertiesValuesField,
     CohortRelativeAndExactTimeField,
@@ -932,15 +933,7 @@ export const renderField: Record<FilterType, (props: CohortFieldProps) => JSX.El
         return <CohortSelectorField {...p} fieldOptionGroupTypes={[FieldOptionsType.DateOperators]} />
     },
     [FilterType.MathOperator]: function _renderField(p) {
-        return (
-            <CohortSelectorField
-                {...p}
-                fieldOptionGroupTypes={[
-                    FieldOptionsType.CohortMathOperators,
-                    FieldOptionsType.SingleFieldDateOperators,
-                ]}
-            />
-        )
+        return <CohortMathOperatorField {...p} />
     },
     [FilterType.EventsAndActionsMathOperator]: function _renderField(p) {
         return <CohortSelectorField {...p} fieldOptionGroupTypes={[FieldOptionsType.EventsAndActionsMathOperators]} />

--- a/frontend/src/scenes/cohorts/cohortEditLogic.ts
+++ b/frontend/src/scenes/cohorts/cohortEditLogic.ts
@@ -548,9 +548,11 @@ export const cohortEditLogic = kea<cohortEditLogicType>([
                 return
             }
 
-            const propDef = propertyDefinitionsModel
-                .findMounted()
-                ?.values.getPropertyDefinition(newCriteria.key, PropertyDefinitionType.Person)
+            const propDef = newCriteria.key
+                ? propertyDefinitionsModel
+                      .findMounted()
+                      ?.values.getPropertyDefinition(newCriteria.key, PropertyDefinitionType.Person)
+                : null
             const isDateTime = propDef?.property_type === PropertyType.DateTime
             const currentOperator = criteria.operator as PropertyOperator | undefined
 

--- a/frontend/src/scenes/cohorts/cohortEditLogic.ts
+++ b/frontend/src/scenes/cohorts/cohortEditLogic.ts
@@ -10,8 +10,10 @@ import { SetupTaskId, globalSetupLogic } from 'lib/components/ProductSetup'
 import { ENTITY_MATCH_TYPE } from 'lib/constants'
 import { scrollToFormError } from 'lib/forms/scrollToFormError'
 import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
+import { isOperatorDate } from 'lib/utils'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { NEW_COHORT, NEW_CRITERIA, NEW_CRITERIA_GROUP } from 'scenes/cohorts/CohortFilters/constants'
+import { BehavioralFilterKey } from 'scenes/cohorts/CohortFilters/types'
 import {
     applyAllCriteriaGroup,
     applyAllNestedCriteria,
@@ -26,6 +28,7 @@ import { urls } from 'scenes/urls'
 
 import { refreshTreeItem } from '~/layout/panel-layout/ProjectTree/projectTreeLogic'
 import { cohortsModel, processCohort } from '~/models/cohortsModel'
+import { propertyDefinitionsModel } from '~/models/propertyDefinitionsModel'
 import { dataNodeLogic } from '~/queries/nodes/DataNode/dataNodeLogic'
 import { ActorsQuery, DataTableNode, HogQLQuery, Node, NodeKind } from '~/queries/schema/schema-general'
 import { isDataTableNode } from '~/queries/utils'
@@ -36,7 +39,10 @@ import {
     CohortGroupType,
     CohortType,
     FilterLogicalOperator,
+    PropertyDefinitionType,
     PropertyFilterType,
+    PropertyOperator,
+    PropertyType,
 } from '~/types'
 
 import type { cohortEditLogicType } from './cohortEditLogicType'
@@ -521,6 +527,39 @@ export const cohortEditLogic = kea<cohortEditLogicType>([
         ],
     })),
     listeners(({ actions, values }) => ({
+        setCriteria: ({ newCriteria, groupIndex, criteriaIndex }) => {
+            // When the person property key changes, auto-reset the operator to match the
+            // property type (DateTime → "on the date", non-DateTime → "equals").
+            if (!('key' in newCriteria)) {
+                return
+            }
+
+            const groups = values.cohort.filters.properties.values
+            const group = groups[groupIndex]
+            if (!isCohortCriteriaGroup(group)) {
+                return
+            }
+            const criteria = group.values[criteriaIndex]
+            if (!criteria || isCohortCriteriaGroup(criteria)) {
+                return
+            }
+
+            if (criteria.type !== BehavioralFilterKey.Person) {
+                return
+            }
+
+            const propDef = propertyDefinitionsModel
+                .findMounted()
+                ?.values.getPropertyDefinition(newCriteria.key, PropertyDefinitionType.Person)
+            const isDateTime = propDef?.property_type === PropertyType.DateTime
+            const currentOperator = criteria.operator as PropertyOperator | undefined
+
+            if (isDateTime && (!currentOperator || !isOperatorDate(currentOperator))) {
+                actions.setCriteria({ operator: PropertyOperator.IsDateExact }, groupIndex, criteriaIndex)
+            } else if (!isDateTime && currentOperator && isOperatorDate(currentOperator)) {
+                actions.setCriteria({ operator: PropertyOperator.Exact }, groupIndex, criteriaIndex)
+            }
+        },
         deleteCohort: () => {
             cohortsModel.actions.deleteCohort({ id: values.cohort.id, name: values.cohort.name })
         },

--- a/frontend/src/scenes/cohorts/cohortUtils.tsx
+++ b/frontend/src/scenes/cohorts/cohortUtils.tsx
@@ -479,7 +479,14 @@ export function resolveCohortFieldValue(
     if (fieldKey === 'value') {
         return criteriaToBehavioralFilterType(criteria)
     }
-    return (criteria as Record<string, any>)[fieldKey] ?? null
+    return (
+        (
+            criteria as Record<
+                string,
+                string | number | boolean | null | undefined | AnyPropertyFilter[] | PropertyFilterValue
+            >
+        )[fieldKey] ?? null
+    )
 }
 
 export function applyAllCriteriaGroup(

--- a/frontend/src/scenes/cohorts/cohortUtils.tsx
+++ b/frontend/src/scenes/cohorts/cohortUtils.tsx
@@ -27,6 +27,7 @@ import {
     CohortType,
     FilterLogicalOperator,
     PropertyFilterType,
+    PropertyFilterValue,
     PropertyOperator,
     PropertyType,
     TimeUnitType,
@@ -473,15 +474,12 @@ export function determineFilterType(
 export function resolveCohortFieldValue(
     criteria: AnyCohortCriteriaType,
     fieldKey: string
-): string | number | boolean | null | undefined | AnyPropertyFilter[] {
+): string | number | boolean | null | undefined | AnyPropertyFilter[] | PropertyFilterValue {
     // Resolve correct behavioral filter type
     if (fieldKey === 'value') {
         return criteriaToBehavioralFilterType(criteria)
     }
-    return (
-        (criteria as Record<string, string | number | boolean | null | undefined | AnyPropertyFilter[]>)[fieldKey] ??
-        null
-    )
+    return (criteria as Record<string, any>)[fieldKey] ?? null
 }
 
 export function applyAllCriteriaGroup(

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1569,7 +1569,7 @@ export interface CohortCriteriaType {
     seq_time_value?: number | string | null
     seq_time_interval?: TimeUnitType | null
     negation?: boolean
-    value_property?: string | null // Transformed into 'value' for api calls
+    value_property?: PropertyFilterValue // Transformed into 'value' for api calls
     event_filters?: AnyPropertyFilter[] | null
     sort_key?: string // Client-side only stable id for sorting.
 }


### PR DESCRIPTION
## Problem

Cohort filters with the "between" operator only show a single input field instead of two (min/max), and date properties don't show a date picker when date-specific operators are selected.

Closes #20821

## Changes

Three root causes prevented `PropertyValue` from rendering the correct input variant (`PropertyFilterBetween` for between, `PropertyFilterDatePicker` for date operators):

1. **Missing `cohortFilterLogicKey`** — `renderFieldComponent` in `CohortCriteriaRowBuilder` wasn't passing a unique kea logic key, so all criteria rows across the cohort shared the same logic instance. Added a per-row key: `cohort_${groupIndex}_${index}`.

2. **No React `key` on `PropertyValue`** — `CohortPersonPropertiesValuesField` didn't force a re-mount when the operator changed (e.g. from "exact" to "between"), so `PropertyValue` kept rendering the old input type. Added a `key` prop tied to `${propertyKey}_${operator}`.

3. **Wrong types for between values** — `value_property` was typed as `string | null` but the between operator stores `[min, max]` arrays. Updated to `PropertyFilterValue`, and fixed `resolveCohortFieldValue`'s return type and the `onSet` callback type annotation.

## How did you test this code?

I'm an agent and haven't tested this manually in a browser. The fix is based on code analysis of the rendering pipeline from `CohortCriteriaRowBuilder` → `CohortField` → `PropertyValue`. Existing tests pass. The `PropertyValue` component already has working between/date picker rendering — the issue was that the cohort-specific wrapper wasn't providing the right props for those code paths to activate.

## Publish to changelog?

No

## Docs update

N/A

## 🤖 LLM context

Agent-authored PR fixing a long-standing bug where cohort filter inputs didn't match the selected operator. The fix is surgical — 4 files changed, all in the cohort filter frontend code path.