### PR TITLE
feat(capture v1): v1 analytics event implements Sink event serialization contract

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1718,6 +1718,7 @@ dependencies = [
  "base64 0.22.1",
  "brotli",
  "bytes",
+ "capture",
  "chrono",
  "common-alloc",
  "common-continuous-profiling",

--- a/rust/capture/Cargo.toml
+++ b/rust/capture/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition = "2021"
 publish = false
 
+[features]
+test-utils = []
+
 [lints]
 workspace = true
 
@@ -59,6 +62,7 @@ futures = { workspace = true }
 sha2 = { workspace = true }
 
 [dev-dependencies]
+capture = { path = ".", features = ["test-utils"] }
 assert-json-diff = { workspace = true }
 brotli = "8"
 zstd = "0.13"

--- a/rust/capture/src/v1/analytics/process.rs
+++ b/rust/capture/src/v1/analytics/process.rs
@@ -96,7 +96,7 @@ fn validate_events(context: &Context, batch: Batch) -> Result<HashMap<Uuid, Wrap
                         result: EventResult::Ok,
                         details: None,
                         destination: Destination::default(),
-                        skip_person_processing: false,
+                        force_disable_person_processing: false,
                     },
                 );
             }
@@ -110,7 +110,7 @@ fn validate_events(context: &Context, batch: Batch) -> Result<HashMap<Uuid, Wrap
                         result: EventResult::Drop,
                         details: Some(err.tag()),
                         destination: Destination::default(),
-                        skip_person_processing: false,
+                        force_disable_person_processing: false,
                     },
                 );
             }
@@ -287,7 +287,7 @@ async fn apply_restrictions(
         }
 
         if applied.skip_person_processing() {
-            event.skip_person_processing = true;
+            event.force_disable_person_processing = true;
         }
     }
 }
@@ -308,7 +308,7 @@ async fn apply_token_distinct_id_limits(
             GlobalRateLimitKey::TokenDistinctId(&context.api_token, &event.event.distinct_id)
                 .to_cache_key();
         if limiter.is_limited(&cache_key, 1).await.is_some() {
-            event.skip_person_processing = true;
+            event.force_disable_person_processing = true;
             event.details = Some(DETAIL_RATE_LIMITED_TOKEN_DISTINCT_ID);
             limited_distinct_ids.insert(event.event.distinct_id.as_str());
         } else {
@@ -826,7 +826,7 @@ mod tests {
         let ev = find_by_did(&events, "user-1");
         assert_eq!(ev.result, EventResult::Ok);
         assert_eq!(ev.destination, Destination::AnalyticsMain);
-        assert!(!ev.skip_person_processing);
+        assert!(!ev.force_disable_person_processing);
     }
 
     #[tokio::test]
@@ -954,7 +954,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn restrictions_skip_person_processing() {
+    async fn restrictions_force_disable_person_processing() {
         let service = restriction_service(
             "phc_token",
             vec![Restriction {
@@ -973,7 +973,7 @@ mod tests {
         let ev = find_by_did(&events, "user-1");
         assert_eq!(ev.result, EventResult::Ok);
         assert_eq!(ev.destination, Destination::AnalyticsMain);
-        assert!(ev.skip_person_processing);
+        assert!(ev.force_disable_person_processing);
     }
 
     #[tokio::test]
@@ -1135,7 +1135,7 @@ mod tests {
         let limited_ev = find_by_did(&events, "user-2");
         assert_eq!(limited_ev.result, EventResult::Ok);
         assert_eq!(limited_ev.destination, Destination::AnalyticsMain);
-        assert!(limited_ev.skip_person_processing);
+        assert!(limited_ev.force_disable_person_processing);
         assert_eq!(
             limited_ev.details,
             Some(DETAIL_RATE_LIMITED_TOKEN_DISTINCT_ID)
@@ -1175,7 +1175,10 @@ mod tests {
                 Destination::AnalyticsMain,
                 "should stay on main topic"
             );
-            assert!(ev.skip_person_processing, "should skip person processing");
+            assert!(
+                ev.force_disable_person_processing,
+                "should skip person processing"
+            );
             assert_eq!(
                 ev.details,
                 Some(DETAIL_RATE_LIMITED_TOKEN_DISTINCT_ID),
@@ -1189,7 +1192,7 @@ mod tests {
         let limiter = mock_limiter(vec!["phc_tok:user-2"]);
         let ctx = td_context();
         let pre_drop = wrapped_event("$pageview", "user-1");
-        let pre_drop_uuid = Uuid::parse_str(pre_drop.event.uuid()).unwrap();
+        let pre_drop_uuid = pre_drop.uuid;
         let mut events = events_map(vec![pre_drop, wrapped_event("$identify", "user-2")]);
         // Simulate event already dropped by restrictions
         events.get_mut(&pre_drop_uuid).unwrap().result = EventResult::Drop;
@@ -1205,7 +1208,7 @@ mod tests {
         let limited = find_by_did(&events, "user-2");
         assert_eq!(limited.result, EventResult::Ok);
         assert_eq!(limited.destination, Destination::AnalyticsMain);
-        assert!(limited.skip_person_processing);
+        assert!(limited.force_disable_person_processing);
         assert_eq!(limited.details, Some(DETAIL_RATE_LIMITED_TOKEN_DISTINCT_ID));
     }
 
@@ -1273,14 +1276,14 @@ mod tests {
         let mut ctx = test_utils::test_context();
         ctx.historical_migration = true;
         let ev = wrapped_event("$pageview", "user-1");
-        let uuid = Uuid::parse_str(ev.event.uuid()).unwrap();
+        let ev_uuid = ev.uuid;
         let mut events = events_map(vec![ev]);
-        events.get_mut(&uuid).unwrap().destination = Destination::Overflow;
+        events.get_mut(&ev_uuid).unwrap().destination = Destination::Overflow;
 
         apply_historical_rerouting(&cfg, &ctx, &mut events);
 
         assert_eq!(
-            events.get(&uuid).unwrap().destination,
+            events.get(&ev_uuid).unwrap().destination,
             Destination::Overflow
         );
     }
@@ -1291,15 +1294,15 @@ mod tests {
         let mut ctx = test_utils::test_context();
         ctx.historical_migration = true;
         let ev = wrapped_event("$pageview", "user-1");
-        let uuid = Uuid::parse_str(ev.event.uuid()).unwrap();
+        let ev_uuid = ev.uuid;
         let mut events = events_map(vec![ev]);
-        let e = events.get_mut(&uuid).unwrap();
+        let e = events.get_mut(&ev_uuid).unwrap();
         e.result = EventResult::Drop;
         e.destination = Destination::Drop;
 
         apply_historical_rerouting(&cfg, &ctx, &mut events);
 
-        assert_eq!(events.get(&uuid).unwrap().destination, Destination::Drop);
+        assert_eq!(events.get(&ev_uuid).unwrap().destination, Destination::Drop);
     }
 
     #[test]
@@ -1321,7 +1324,7 @@ mod tests {
         let mut ctx = test_utils::test_context();
         ctx.historical_migration = true;
         let dlq_ev = wrapped_event("$identify", "user-2");
-        let dlq_uuid = Uuid::parse_str(dlq_ev.event.uuid()).unwrap();
+        let dlq_uuid = dlq_ev.uuid;
         let mut events = events_map(vec![wrapped_event("$pageview", "user-1"), dlq_ev]);
         events.get_mut(&dlq_uuid).unwrap().destination = Destination::Dlq;
 

--- a/rust/capture/src/v1/analytics/types.rs
+++ b/rust/capture/src/v1/analytics/types.rs
@@ -202,9 +202,9 @@ impl SinkEvent for WrappedEvent {
         } else {
             ctx.client_ip.to_string()
         };
-        let timestamp = self
-            .adjusted_timestamp
-            .ok_or_else(|| anyhow::anyhow!("serialize_into called on event without adjusted_timestamp"))?;
+        let timestamp = self.adjusted_timestamp.ok_or_else(|| {
+            anyhow::anyhow!("serialize_into called on event without adjusted_timestamp")
+        })?;
         let ie = IngestionEvent {
             uuid: self.uuid,
             distinct_id: self.event.distinct_id.clone(),
@@ -820,7 +820,9 @@ mod tests {
         let ctx = test_utils::test_context();
         let ev = ok_wrapped("$pageview", "user-1");
         let h = ev.headers(&ctx);
-        let now = h.now.expect("now should be set from ctx.server_received_at");
+        let now = h
+            .now
+            .expect("now should be set from ctx.server_received_at");
         assert_eq!(
             now,
             ctx.server_received_at

--- a/rust/capture/src/v1/analytics/types.rs
+++ b/rust/capture/src/v1/analytics/types.rs
@@ -173,9 +173,7 @@ impl SinkEvent for WrappedEvent {
         }
     }
 
-    // Accepts a buffer that is reset by the caller in the event publish
-    // inner loop. This spares us a lot of string allocations.
-    fn write_partition_key(&self, ctx: &Context, buf: &mut String) {
+    fn partition_key<'buf>(&self, ctx: &Context, buf: &'buf mut String) -> Option<&'buf str> {
         use std::fmt::Write;
         // v0 parity: only drop partition key for main/overflow analytics.
         // DLQ, Historical, and Custom destinations always retain their key
@@ -186,7 +184,7 @@ impl SinkEvent for WrappedEvent {
                 Destination::AnalyticsMain | Destination::Overflow
             )
         {
-            return;
+            return None;
         }
         match (
             self.event.options.cookieless_mode == Some(true),
@@ -202,6 +200,7 @@ impl SinkEvent for WrappedEvent {
                 let _ = write!(buf, "{}:{}", ctx.api_token, self.event.distinct_id);
             }
         }
+        Some(buf.as_str())
     }
 
     fn serialize_into(&self, ctx: &Context, buf: &mut String) -> anyhow::Result<()> {
@@ -877,10 +876,9 @@ mod tests {
         assert!(h.historical_migration.is_none());
     }
 
-    fn partition_key(ev: &WrappedEvent, ctx: &Context) -> String {
+    fn partition_key_str(ev: &WrappedEvent, ctx: &Context) -> Option<String> {
         let mut buf = String::new();
-        ev.write_partition_key(ctx, &mut buf);
-        buf
+        ev.partition_key(ctx, &mut buf).map(String::from)
     }
 
     #[test]
@@ -888,8 +886,8 @@ mod tests {
         let ctx = test_utils::test_context();
         let ev = ok_wrapped("$pageview", "user-42");
         assert_eq!(
-            partition_key(&ev, &ctx),
-            format!("{}:user-42", ctx.api_token)
+            partition_key_str(&ev, &ctx),
+            Some(format!("{}:user-42", ctx.api_token))
         );
     }
 
@@ -899,8 +897,8 @@ mod tests {
         let mut ev = ok_wrapped("$pageview", "user-42");
         ev.event.options.cookieless_mode = Some(true);
         assert_eq!(
-            partition_key(&ev, &ctx),
-            format!("{}:{}", ctx.api_token, ctx.client_ip)
+            partition_key_str(&ev, &ctx),
+            Some(format!("{}:{}", ctx.api_token, ctx.client_ip))
         );
     }
 
@@ -911,8 +909,8 @@ mod tests {
         let mut ev = ok_wrapped("$pageview", "user-42");
         ev.event.options.cookieless_mode = Some(true);
         assert_eq!(
-            partition_key(&ev, &ctx),
-            format!("{}:127.0.0.1", ctx.api_token)
+            partition_key_str(&ev, &ctx),
+            Some(format!("{}:127.0.0.1", ctx.api_token))
         );
     }
 
@@ -931,7 +929,7 @@ mod tests {
         let mut ev = ok_wrapped("$pageview", "user-42");
         ev.force_disable_person_processing = true;
         ev.destination = Destination::AnalyticsMain;
-        assert_eq!(partition_key(&ev, &ctx), "");
+        assert_eq!(partition_key_str(&ev, &ctx), None);
     }
 
     #[test]
@@ -940,7 +938,7 @@ mod tests {
         let mut ev = ok_wrapped("$pageview", "user-42");
         ev.force_disable_person_processing = true;
         ev.destination = Destination::Overflow;
-        assert_eq!(partition_key(&ev, &ctx), "");
+        assert_eq!(partition_key_str(&ev, &ctx), None);
     }
 
     #[test]
@@ -950,8 +948,8 @@ mod tests {
         ev.force_disable_person_processing = true;
         ev.destination = Destination::Dlq;
         assert_eq!(
-            partition_key(&ev, &ctx),
-            format!("{}:user-42", ctx.api_token)
+            partition_key_str(&ev, &ctx),
+            Some(format!("{}:user-42", ctx.api_token))
         );
     }
 
@@ -962,8 +960,8 @@ mod tests {
         ev.force_disable_person_processing = true;
         ev.destination = Destination::AnalyticsHistorical;
         assert_eq!(
-            partition_key(&ev, &ctx),
-            format!("{}:user-42", ctx.api_token)
+            partition_key_str(&ev, &ctx),
+            Some(format!("{}:user-42", ctx.api_token))
         );
     }
 
@@ -974,8 +972,8 @@ mod tests {
         ev.force_disable_person_processing = true;
         ev.destination = Destination::Custom("my_topic".into());
         assert_eq!(
-            partition_key(&ev, &ctx),
-            format!("{}:user-42", ctx.api_token)
+            partition_key_str(&ev, &ctx),
+            Some(format!("{}:user-42", ctx.api_token))
         );
     }
 
@@ -987,8 +985,8 @@ mod tests {
         ev.destination = Destination::Dlq;
         ev.event.options.cookieless_mode = Some(true);
         assert_eq!(
-            partition_key(&ev, &ctx),
-            format!("{}:{}", ctx.api_token, ctx.client_ip)
+            partition_key_str(&ev, &ctx),
+            Some(format!("{}:{}", ctx.api_token, ctx.client_ip))
         );
     }
 

--- a/rust/capture/src/v1/analytics/types.rs
+++ b/rust/capture/src/v1/analytics/types.rs
@@ -149,11 +149,20 @@ impl SinkEvent for WrappedEvent {
 
     fn write_partition_key(&self, ctx: &Context, buf: &mut String) {
         use std::fmt::Write;
-        if self.force_disable_person_processing {
-            // buffer remains empty as sentinel for "no partition key set"
-            // this signals Kafka producer to supply no key, causing
-            // round-robin or random partition production depending on
-            // the producer's configuration.
+        // v0 parity: only drop partition key for main/overflow analytics.
+        // DLQ, Historical, and Custom destinations always retain their key
+        // even when person processing is disabled via event restrictions.
+        //
+        // TODO: when v1 adds overflow limiting, a separate signal
+        // (e.g. `drop_partition_key: bool`) is needed for the
+        // `Limited + !preserve_locality` case that drops key WITHOUT
+        // setting the person processing header.
+        if self.force_disable_person_processing
+            && matches!(
+                self.destination,
+                Destination::AnalyticsMain | Destination::Overflow
+            )
+        {
             return;
         }
         if self.event.options.cookieless_mode == Some(true) {
@@ -872,6 +881,75 @@ mod tests {
         let mut ev = ok_wrapped("$pageview", "user-1");
         ev.destination = Destination::Overflow;
         assert_eq!(*ev.destination(), Destination::Overflow);
+    }
+
+    // --- partition key + force_disable_person_processing × destination ---
+
+    #[test]
+    fn partition_key_force_disable_analytics_main() {
+        let ctx = test_utils::test_context();
+        let mut ev = ok_wrapped("$pageview", "user-42");
+        ev.force_disable_person_processing = true;
+        ev.destination = Destination::AnalyticsMain;
+        assert_eq!(partition_key(&ev, &ctx), "");
+    }
+
+    #[test]
+    fn partition_key_force_disable_overflow() {
+        let ctx = test_utils::test_context();
+        let mut ev = ok_wrapped("$pageview", "user-42");
+        ev.force_disable_person_processing = true;
+        ev.destination = Destination::Overflow;
+        assert_eq!(partition_key(&ev, &ctx), "");
+    }
+
+    #[test]
+    fn partition_key_force_disable_dlq() {
+        let ctx = test_utils::test_context();
+        let mut ev = ok_wrapped("$pageview", "user-42");
+        ev.force_disable_person_processing = true;
+        ev.destination = Destination::Dlq;
+        assert_eq!(
+            partition_key(&ev, &ctx),
+            format!("{}:user-42", ctx.api_token)
+        );
+    }
+
+    #[test]
+    fn partition_key_force_disable_historical() {
+        let ctx = test_utils::test_context();
+        let mut ev = ok_wrapped("$pageview", "user-42");
+        ev.force_disable_person_processing = true;
+        ev.destination = Destination::AnalyticsHistorical;
+        assert_eq!(
+            partition_key(&ev, &ctx),
+            format!("{}:user-42", ctx.api_token)
+        );
+    }
+
+    #[test]
+    fn partition_key_force_disable_custom() {
+        let ctx = test_utils::test_context();
+        let mut ev = ok_wrapped("$pageview", "user-42");
+        ev.force_disable_person_processing = true;
+        ev.destination = Destination::Custom("my_topic".into());
+        assert_eq!(
+            partition_key(&ev, &ctx),
+            format!("{}:user-42", ctx.api_token)
+        );
+    }
+
+    #[test]
+    fn partition_key_force_disable_cookieless_dlq() {
+        let ctx = test_utils::test_context();
+        let mut ev = ok_wrapped("$pageview", "user-42");
+        ev.force_disable_person_processing = true;
+        ev.destination = Destination::Dlq;
+        ev.event.options.cookieless_mode = Some(true);
+        assert_eq!(
+            partition_key(&ev, &ctx),
+            format!("{}:{}", ctx.api_token, ctx.client_ip)
+        );
     }
 
     // --- HasEventName impl for WrappedEvent ---

--- a/rust/capture/src/v1/analytics/types.rs
+++ b/rust/capture/src/v1/analytics/types.rs
@@ -1,3 +1,5 @@
+use std::ops::Not;
+
 use chrono::{DateTime, SecondsFormat, Utc};
 use common_types::{CapturedEventHeaders, HasEventName};
 use serde::{Deserialize, Serialize};
@@ -72,14 +74,14 @@ impl Event {
 #[derive(Debug)]
 pub struct WrappedEvent {
     pub event: Event,
-    /// Pre-parsed UUID for result correlation. Copy, zero alloc.
+    /// Pre-parsed UUID from Event.uuid, set once during validate_events.
     pub uuid: Uuid,
     // Post-skew-adjustment timestamp for Kafka export, None if event is malformed
     pub adjusted_timestamp: Option<DateTime<Utc>>,
     pub result: EventResult,
     pub details: Option<&'static str>,
     pub destination: Destination,
-    pub skip_person_processing: bool,
+    pub force_disable_person_processing: bool,
 }
 
 impl SinkEvent for WrappedEvent {
@@ -97,10 +99,10 @@ impl SinkEvent for WrappedEvent {
 
     fn headers(&self, ctx: &Context) -> CapturedEventHeaders {
         // v0 compat: downstream consumers key on "force_disable_person_processing".
-        // v1 decouples overflow routing from person-processing skip (unlike v0 where
+        // v1 decouples overflow routing from person-processing (unlike v0 where
         // overflow ForceLimited unconditionally sets this); operators configure
-        // SkipPersonProcessing alongside ForceOverflow when needed.
-        let force_disable_person_processing = if self.skip_person_processing {
+        // this flag alongside ForceOverflow when needed.
+        let force_disable_person_processing = if self.force_disable_person_processing {
             Some(true)
         } else {
             None
@@ -147,7 +149,7 @@ impl SinkEvent for WrappedEvent {
 
     fn write_partition_key(&self, ctx: &Context, buf: &mut String) {
         use std::fmt::Write;
-        if self.skip_person_processing {
+        if self.force_disable_person_processing {
             // buffer remains empty as sentinel for "no partition key set"
             // this signals Kafka producer to supply no key, causing
             // round-robin or random partition production depending on
@@ -168,10 +170,120 @@ impl SinkEvent for WrappedEvent {
         }
     }
 
-    fn serialize_into(&self, _ctx: &Context, _buf: &mut String) -> anyhow::Result<()> {
-        // TODO: builds IngestionEvent from self + Context, applies $-prefix
-        // remapping, IP redaction, property merging. Tackled separately.
-        unimplemented!("WrappedEvent::serialize_into")
+    fn serialize_into(&self, ctx: &Context, buf: &mut String) -> anyhow::Result<()> {
+        let ingestion_data = self.build_ingestion_data()?;
+        let data = serde_json::to_string(&ingestion_data)
+            .map_err(|e| anyhow::anyhow!("serializing IngestionData: {e:#}"))?;
+        let ip = if ctx.capture_internal {
+            "127.0.0.1".to_string()
+        } else {
+            ctx.client_ip.to_string()
+        };
+        let timestamp = self
+            .adjusted_timestamp
+            .ok_or_else(|| anyhow::anyhow!("serialize_into called on event without adjusted_timestamp"))?;
+        let ie = IngestionEvent {
+            uuid: self.uuid,
+            distinct_id: self.event.distinct_id.clone(),
+            ip,
+            data,
+            now: ctx
+                .server_received_at
+                .to_rfc3339_opts(chrono::SecondsFormat::AutoSi, true),
+            sent_at: Some(ctx.client_timestamp),
+            token: ctx.api_token.clone(),
+            event: self.event.event.clone(),
+            timestamp,
+            is_cookieless_mode: self.event.options.cookieless_mode.unwrap_or(false),
+            historical_migration: ctx.historical_migration,
+        };
+
+        serde_json::to_string(&ie)
+            .map(|s| buf.push_str(&s))
+            .map_err(|e| anyhow::anyhow!("serializing IngestionEvent: {e:#}"))
+    }
+}
+
+impl WrappedEvent {
+    #[allow(unused_assignments)]
+    fn build_property_injections(&self) -> anyhow::Result<String> {
+        let mut buf = String::with_capacity(256);
+        let mut first = true;
+
+        macro_rules! inject {
+            ($buf:expr, $first:expr, $key:expr, $val:expr) => {{
+                if !$first {
+                    $buf.push(',');
+                }
+                $first = false;
+                $buf.push('"');
+                $buf.push_str($key);
+                $buf.push_str("\":");
+                // SAFETY: serde_json::to_writer only emits valid UTF-8 (JSON spec
+                // mandates UTF-8), so writing into String's backing Vec<u8> cannot
+                // produce invalid UTF-8.
+                serde_json::to_writer(unsafe { $buf.as_mut_vec() }, $val)
+                    .map_err(|e| anyhow::anyhow!("injecting {}: {e:#}", $key))?;
+            }};
+        }
+
+        if let Some(ref sid) = self.event.session_id {
+            inject!(buf, first, "$session_id", sid);
+        }
+        if let Some(ref wid) = self.event.window_id {
+            inject!(buf, first, "$window_id", wid);
+        }
+        if let Some(cm) = self.event.options.cookieless_mode {
+            inject!(buf, first, "$cookieless_mode", &cm);
+        }
+        if let Some(dsa) = self.event.options.disable_skew_adjustment {
+            inject!(buf, first, "$ignore_sent_at", &dsa);
+        }
+        if let Some(ref pti) = self.event.options.product_tour_id {
+            inject!(buf, first, "$product_tour_id", pti);
+        }
+        if let Some(ppp) = self.event.options.process_person_profile {
+            inject!(buf, first, "$process_person_profile", &ppp);
+        }
+
+        Ok(buf)
+    }
+
+    fn build_ingestion_data(&self) -> anyhow::Result<IngestionData> {
+        let injection = self.build_property_injections()?;
+        let raw = self.event.properties.get();
+
+        let properties = if injection.is_empty() {
+            self.event.properties.clone()
+        } else {
+            if raw.len() < 2 {
+                return Err(anyhow::anyhow!(
+                    "properties too short ({} bytes) for JSON object",
+                    raw.len()
+                ));
+            }
+            let prefix = &raw[..raw.len() - 1];
+            let has_existing = raw.len() > 2;
+
+            let mut buf = String::with_capacity(raw.len() + injection.len() + 2);
+            buf.push_str(prefix);
+            if has_existing {
+                buf.push(',');
+            }
+            buf.push_str(&injection);
+            buf.push('}');
+
+            RawValue::from_string(buf)
+                .map_err(|e| anyhow::anyhow!("property surgery produced invalid JSON: {e:#}"))?
+        };
+
+        Ok(IngestionData {
+            event: self.event.event.clone(),
+            distinct_id: Some(self.event.distinct_id.clone()),
+            uuid: Some(self.uuid),
+            properties,
+            timestamp: Some(self.event.timestamp.clone()),
+        })
     }
 }
 
@@ -194,53 +306,48 @@ impl HasEventName for WrappedEvent {
     }
 }
 
-/// The Kafka-ready event produced by the v1 analytics pipeline.
-/// Replaces legacy `CapturedEvent` from `common_types`.
+/// The Kafka payload produced by `WrappedEvent::serialize_into`.
 ///
-/// Constructed from a valid `WrappedEvent` + request `Context` in a future
-/// transformation step within `process_batch`, before being handed to a
-/// `v1::Sink` for publishing. The sink should not perform any enrichment
-/// or property inspection -- all transformations happen at construction time.
-///
-/// Checks needed at construction time (from legacy parity):
-/// - `Context.capture_internal`: if true, redact `ip` to "127.0.0.1"
-///   AND force the Kafka partition key to `token:127.0.0.1` to match
-///   the IP redaction (otherwise the key references a real IP while the
-///   payload carries a redacted one). See `CapturedEvent::key()` in
-///   `common_types/event.rs` for the v0 key derivation pattern.
-/// - `Options.cookieless_mode`: controls Kafka partition key selection
-///   (true -> partition by token:ip, false -> token:distinct_id).
-///   Non-boolean values are rejected at deserialization by serde.
-///
-/// Will implement the upcoming `v1::Sink` trait to abstract serialization
-/// and partition key derivation.
-// TODO(v1::Sink): when publishing to Kafka, re-apply `$` prefixes to these
-// fields for legacy consumer compatibility:
-//   Event: session_id -> $session_id, window_id -> $window_id
-//   Options: cookieless_mode -> $cookieless_mode,
-//            disable_skew_adjustment -> $disable_skew_adjustment,
-//            product_tour_id -> $product_tour_id,
-//            process_person_profile -> $process_person_profile
+/// Field order matches `CapturedEvent` from `common_types` so that serde's
+/// derived `Serialize` emits JSON keys in the same order as v0. Serde
+/// annotations (`skip_serializing_if`) also match CapturedEvent exactly.
 #[derive(Debug, Serialize)]
 pub struct IngestionEvent {
-    pub uuid: String,
+    pub uuid: Uuid,
     pub distinct_id: String,
     pub ip: String,
-    pub event: String,
-    pub timestamp: DateTime<Utc>,
-    pub token: String,
-    pub is_cookieless_mode: bool,
-    // TODO: custom build this serialized JSON from Event's raw payload
-    // and inject event.options including legacy $-prefixes
     pub data: String,
     pub now: String,
-    #[serde(skip)]
-    pub destination: Destination,
-    #[serde(skip)]
-    pub skip_person_processing: bool,
-    /// Maps back to the originating WrappedEvent via HashMap key for result tracking.
-    #[serde(skip)]
-    pub uuid_key: Uuid,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sent_at: Option<DateTime<Utc>>,
+    pub token: String,
+    pub event: String,
+    pub timestamp: DateTime<Utc>,
+    #[serde(skip_serializing_if = "<&bool>::not", default)]
+    pub is_cookieless_mode: bool,
+    #[serde(skip_serializing_if = "<&bool>::not", default)]
+    pub historical_migration: bool,
+}
+
+/// The inner `data` payload: a simplified RawEvent-shaped struct for
+/// constructing the double-encoded JSON in `IngestionEvent.data`.
+///
+/// Omitted vs RawEvent:
+/// - `token`: v1 uses Authorization header; downstream handles absence
+/// - `offset`: dead field; Node.js ingestion parses but never reads it
+/// - `$set`/`$set_once` at top level: legacy Python SDK cruft; v1 schema
+///   does not support these at top level (clients send them inside
+///   `properties`, where they pass through the opaque blob as-is)
+#[derive(Debug, Serialize)]
+pub struct IngestionData {
+    pub event: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub distinct_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub uuid: Option<Uuid>,
+    pub properties: Box<RawValue>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub timestamp: Option<String>,
 }
 
 #[cfg(test)]
@@ -631,7 +738,7 @@ mod tests {
     fn headers_include_force_disable_person_processing() {
         let ctx = test_utils::test_context();
         let mut ev = ok_wrapped("$pageview", "user-1");
-        ev.skip_person_processing = true;
+        ev.force_disable_person_processing = true;
         let h = ev.headers(&ctx);
         assert_eq!(h.force_disable_person_processing, Some(true));
     }
@@ -640,7 +747,7 @@ mod tests {
     fn headers_omit_force_disable_person_processing_when_false() {
         let ctx = test_utils::test_context();
         let ev = ok_wrapped("$pageview", "user-1");
-        assert!(!ev.skip_person_processing);
+        assert!(!ev.force_disable_person_processing);
         let h = ev.headers(&ctx);
         assert!(h.force_disable_person_processing.is_none());
     }
@@ -792,5 +899,464 @@ mod tests {
     fn has_property_unknown_key() {
         let ev = ok_wrapped("$pageview", "user-1");
         assert!(!ev.has_property("unknown_key"));
+    }
+
+    // --- serialize_into ---
+
+    use std::net::{IpAddr, Ipv4Addr};
+
+    use common_types::{CapturedEvent, RawEvent};
+    use serde_json::Value;
+
+    fn raw_obj(s: &str) -> Box<RawValue> {
+        RawValue::from_string(s.to_owned()).unwrap()
+    }
+
+    fn dt(s: &str) -> DateTime<Utc> {
+        DateTime::parse_from_rfc3339(s).unwrap().with_timezone(&Utc)
+    }
+
+    fn serialize_ctx() -> crate::v1::context::Context {
+        let mut ctx = test_utils::test_context();
+        ctx.api_token = "phc_project_abc123".to_string();
+        ctx.client_ip = IpAddr::V4(Ipv4Addr::new(203, 0, 113, 42));
+        ctx.client_timestamp = dt("2026-03-19T14:30:01.500Z");
+        ctx.server_received_at = dt("2026-03-19T14:30:00.000Z");
+        ctx.capture_internal = false;
+        ctx.historical_migration = false;
+        ctx
+    }
+
+    fn pageview_event() -> WrappedEvent {
+        let uuid = Uuid::new_v4();
+        WrappedEvent {
+            event: Event {
+                event: "$pageview".to_string(),
+                uuid: uuid.to_string(),
+                distinct_id: "user-42".to_string(),
+                timestamp: "2026-03-19T14:29:58.123Z".to_string(),
+                session_id: Some("sess-01jq9abc".to_string()),
+                window_id: Some("win-xyz789".to_string()),
+                options: Options {
+                    cookieless_mode: Some(false),
+                    disable_skew_adjustment: None,
+                    product_tour_id: None,
+                    process_person_profile: Some(true),
+                },
+                properties: raw_obj(
+                    r#"{"$current_url":"https://app.example.com/dashboard","$browser":"Chrome","custom_prop":42}"#,
+                ),
+            },
+            uuid,
+            adjusted_timestamp: Some(dt("2026-03-19T14:29:53.123Z")),
+            result: EventResult::Ok,
+            details: None,
+            destination: Destination::AnalyticsMain,
+            force_disable_person_processing: false,
+        }
+    }
+
+    fn serialize_and_parse(
+        wrapped: &WrappedEvent,
+        ctx: &crate::v1::context::Context,
+    ) -> (CapturedEvent, RawEvent) {
+        let mut buf = String::new();
+        wrapped
+            .serialize_into(ctx, &mut buf)
+            .expect("serialize_into failed");
+        let captured: CapturedEvent =
+            serde_json::from_str(&buf).expect("v1 output must deserialize as CapturedEvent");
+        let data: RawEvent =
+            serde_json::from_str(&captured.data).expect("data field must deserialize as RawEvent");
+        (captured, data)
+    }
+
+    #[test]
+    fn serialize_round_trip_basic() {
+        let wrapped = pageview_event();
+        let ctx = serialize_ctx();
+        let (captured, data) = serialize_and_parse(&wrapped, &ctx);
+
+        assert_eq!(captured.uuid, wrapped.uuid);
+        assert_eq!(captured.distinct_id, "user-42");
+        assert_eq!(captured.ip, "203.0.113.42");
+        assert_eq!(captured.token, "phc_project_abc123");
+        assert_eq!(captured.event, "$pageview");
+        assert_eq!(captured.timestamp, wrapped.adjusted_timestamp.unwrap());
+        assert!(!captured.is_cookieless_mode);
+        assert!(!captured.historical_migration);
+
+        assert_eq!(data.event, "$pageview");
+        assert_eq!(data.distinct_id, Some(Value::String("user-42".to_string())));
+        assert_eq!(data.timestamp.as_deref(), Some("2026-03-19T14:29:58.123Z"));
+
+        let props = &data.properties;
+        assert_eq!(props["$current_url"], "https://app.example.com/dashboard");
+        assert_eq!(props["$browser"], "Chrome");
+        assert_eq!(props["custom_prop"], 42);
+        assert_eq!(props["$session_id"], "sess-01jq9abc");
+        assert_eq!(props["$window_id"], "win-xyz789");
+        assert_eq!(props["$cookieless_mode"], false);
+        assert_eq!(props["$process_person_profile"], true);
+    }
+
+    #[test]
+    fn serialize_ip_redaction_capture_internal() {
+        let wrapped = pageview_event();
+        let mut ctx = serialize_ctx();
+        ctx.capture_internal = true;
+        let (captured, _) = serialize_and_parse(&wrapped, &ctx);
+        assert_eq!(captured.ip, "127.0.0.1");
+    }
+
+    #[test]
+    fn serialize_ip_normal() {
+        let wrapped = pageview_event();
+        let ctx = serialize_ctx();
+        let (captured, _) = serialize_and_parse(&wrapped, &ctx);
+        assert_eq!(captured.ip, "203.0.113.42");
+    }
+
+    #[test]
+    fn serialize_all_options_injected() {
+        let uuid = Uuid::new_v4();
+        let wrapped = WrappedEvent {
+            event: Event {
+                event: "$pageview".to_string(),
+                uuid: uuid.to_string(),
+                distinct_id: "user-42".to_string(),
+                timestamp: "2026-03-19T14:29:58.123Z".to_string(),
+                session_id: Some("sess-01jq9abc".to_string()),
+                window_id: Some("win-xyz789".to_string()),
+                options: Options {
+                    cookieless_mode: Some(true),
+                    disable_skew_adjustment: Some(true),
+                    product_tour_id: Some("tour-onboarding-v2".to_string()),
+                    process_person_profile: Some(false),
+                },
+                properties: raw_obj(r#"{"existing":"value"}"#),
+            },
+            uuid,
+            adjusted_timestamp: Some(dt("2026-03-19T14:29:53.123Z")),
+            result: EventResult::Ok,
+            details: None,
+            destination: Destination::AnalyticsMain,
+            force_disable_person_processing: false,
+        };
+
+        let ctx = serialize_ctx();
+        let (_, data) = serialize_and_parse(&wrapped, &ctx);
+        let props = &data.properties;
+
+        assert_eq!(props["existing"], "value");
+        assert_eq!(props["$session_id"], "sess-01jq9abc");
+        assert_eq!(props["$window_id"], "win-xyz789");
+        assert_eq!(props["$cookieless_mode"], true);
+        assert_eq!(props["$ignore_sent_at"], true);
+        assert_eq!(props["$product_tour_id"], "tour-onboarding-v2");
+        assert_eq!(props["$process_person_profile"], false);
+    }
+
+    #[test]
+    fn serialize_partial_options() {
+        let uuid = Uuid::new_v4();
+        let wrapped = WrappedEvent {
+            event: Event {
+                event: "$pageview".to_string(),
+                uuid: uuid.to_string(),
+                distinct_id: "user-42".to_string(),
+                timestamp: "2026-03-19T14:29:58.123Z".to_string(),
+                session_id: Some("sess-abc".to_string()),
+                window_id: None,
+                options: Options {
+                    cookieless_mode: Some(false),
+                    disable_skew_adjustment: None,
+                    product_tour_id: None,
+                    process_person_profile: None,
+                },
+                properties: raw_obj(r#"{"x":1}"#),
+            },
+            uuid,
+            adjusted_timestamp: Some(dt("2026-03-19T14:29:53.123Z")),
+            result: EventResult::Ok,
+            details: None,
+            destination: Destination::AnalyticsMain,
+            force_disable_person_processing: false,
+        };
+
+        let ctx = serialize_ctx();
+        let (_, data) = serialize_and_parse(&wrapped, &ctx);
+        let props = &data.properties;
+
+        assert_eq!(props["$session_id"], "sess-abc");
+        assert_eq!(props["$cookieless_mode"], false);
+        assert!(!props.contains_key("$window_id"));
+        assert!(!props.contains_key("$ignore_sent_at"));
+        assert!(!props.contains_key("$product_tour_id"));
+        assert!(!props.contains_key("$process_person_profile"));
+    }
+
+    #[test]
+    fn serialize_empty_properties_no_options() {
+        let uuid = Uuid::new_v4();
+        let wrapped = WrappedEvent {
+            event: Event {
+                event: "$pageview".to_string(),
+                uuid: uuid.to_string(),
+                distinct_id: "user-42".to_string(),
+                timestamp: "2026-03-19T14:29:58.123Z".to_string(),
+                session_id: None,
+                window_id: None,
+                options: Options {
+                    cookieless_mode: None,
+                    disable_skew_adjustment: None,
+                    product_tour_id: None,
+                    process_person_profile: None,
+                },
+                properties: raw_obj("{}"),
+            },
+            uuid,
+            adjusted_timestamp: Some(dt("2026-03-19T14:29:53.123Z")),
+            result: EventResult::Ok,
+            details: None,
+            destination: Destination::AnalyticsMain,
+            force_disable_person_processing: false,
+        };
+
+        let ctx = serialize_ctx();
+        let (_, data) = serialize_and_parse(&wrapped, &ctx);
+        assert!(data.properties.is_empty());
+    }
+
+    #[test]
+    fn serialize_empty_properties_with_options() {
+        let uuid = Uuid::new_v4();
+        let wrapped = WrappedEvent {
+            event: Event {
+                event: "$pageview".to_string(),
+                uuid: uuid.to_string(),
+                distinct_id: "user-42".to_string(),
+                timestamp: "2026-03-19T14:29:58.123Z".to_string(),
+                session_id: Some("sess-abc".to_string()),
+                window_id: None,
+                options: Options {
+                    cookieless_mode: Some(true),
+                    disable_skew_adjustment: None,
+                    product_tour_id: None,
+                    process_person_profile: None,
+                },
+                properties: raw_obj("{}"),
+            },
+            uuid,
+            adjusted_timestamp: Some(dt("2026-03-19T14:29:53.123Z")),
+            result: EventResult::Ok,
+            details: None,
+            destination: Destination::AnalyticsMain,
+            force_disable_person_processing: false,
+        };
+
+        let ctx = serialize_ctx();
+        let (_, data) = serialize_and_parse(&wrapped, &ctx);
+        let props = &data.properties;
+        assert_eq!(props["$session_id"], "sess-abc");
+        assert_eq!(props["$cookieless_mode"], true);
+        assert_eq!(props.len(), 2);
+    }
+
+    #[test]
+    fn serialize_existing_properties_preserved() {
+        let uuid = Uuid::new_v4();
+        let wrapped = WrappedEvent {
+            event: Event {
+                event: "$pageview".to_string(),
+                uuid: uuid.to_string(),
+                distinct_id: "user-42".to_string(),
+                timestamp: "2026-03-19T14:29:58.123Z".to_string(),
+                session_id: Some("sess-abc".to_string()),
+                window_id: None,
+                options: Options {
+                    cookieless_mode: None,
+                    disable_skew_adjustment: None,
+                    product_tour_id: None,
+                    process_person_profile: None,
+                },
+                properties: raw_obj(
+                    r#"{"$lib":"posthog-js","$lib_version":"1.150.0","$referrer":"https://google.com"}"#,
+                ),
+            },
+            uuid,
+            adjusted_timestamp: Some(dt("2026-03-19T14:29:53.123Z")),
+            result: EventResult::Ok,
+            details: None,
+            destination: Destination::AnalyticsMain,
+            force_disable_person_processing: false,
+        };
+
+        let ctx = serialize_ctx();
+        let (_, data) = serialize_and_parse(&wrapped, &ctx);
+        let props = &data.properties;
+        assert_eq!(props["$lib"], "posthog-js");
+        assert_eq!(props["$lib_version"], "1.150.0");
+        assert_eq!(props["$referrer"], "https://google.com");
+        assert_eq!(props["$session_id"], "sess-abc");
+    }
+
+    #[test]
+    fn serialize_is_cookieless_mode_true() {
+        let mut wrapped = pageview_event();
+        wrapped.event.options.cookieless_mode = Some(true);
+        let ctx = serialize_ctx();
+        let (captured, data) = serialize_and_parse(&wrapped, &ctx);
+        assert!(captured.is_cookieless_mode);
+        assert_eq!(data.properties["$cookieless_mode"], true);
+    }
+
+    #[test]
+    fn serialize_is_cookieless_mode_false_skipped() {
+        let wrapped = pageview_event();
+        assert_eq!(wrapped.event.options.cookieless_mode, Some(false));
+        let ctx = serialize_ctx();
+        let mut buf = String::new();
+        wrapped.serialize_into(&ctx, &mut buf).unwrap();
+        let val: Value = serde_json::from_str(&buf).unwrap();
+        assert!(
+            val.get("is_cookieless_mode").is_none(),
+            "is_cookieless_mode should be absent when false"
+        );
+    }
+
+    #[test]
+    fn serialize_historical_migration_true() {
+        let wrapped = pageview_event();
+        let mut ctx = serialize_ctx();
+        ctx.historical_migration = true;
+        let (captured, _) = serialize_and_parse(&wrapped, &ctx);
+        assert!(captured.historical_migration);
+    }
+
+    #[test]
+    fn serialize_historical_migration_false_skipped() {
+        let wrapped = pageview_event();
+        let ctx = serialize_ctx();
+        let mut buf = String::new();
+        wrapped.serialize_into(&ctx, &mut buf).unwrap();
+        let val: Value = serde_json::from_str(&buf).unwrap();
+        assert!(
+            val.get("historical_migration").is_none(),
+            "historical_migration should be absent when false"
+        );
+    }
+
+    #[test]
+    fn serialize_sent_at_present() {
+        let wrapped = pageview_event();
+        let ctx = serialize_ctx();
+        let (captured, _) = serialize_and_parse(&wrapped, &ctx);
+        assert!(captured.sent_at.is_some());
+    }
+
+    #[test]
+    fn serialize_data_timestamp_is_original_not_adjusted() {
+        let wrapped = pageview_event();
+        let ctx = serialize_ctx();
+        let (captured, data) = serialize_and_parse(&wrapped, &ctx);
+        assert_eq!(
+            data.timestamp.as_deref(),
+            Some("2026-03-19T14:29:58.123Z"),
+            "data.timestamp should be the original client timestamp"
+        );
+        assert_eq!(
+            captured.timestamp,
+            dt("2026-03-19T14:29:53.123Z"),
+            "captured.timestamp should be the adjusted timestamp"
+        );
+    }
+
+    #[test]
+    fn serialize_process_person_profile_in_properties() {
+        let mut wrapped = pageview_event();
+        wrapped.event.options.process_person_profile = Some(false);
+        wrapped.force_disable_person_processing = false;
+        let ctx = serialize_ctx();
+        let (_, data) = serialize_and_parse(&wrapped, &ctx);
+        assert_eq!(data.properties["$process_person_profile"], false);
+    }
+
+    #[test]
+    fn serialize_force_disable_does_not_affect_data() {
+        let uuid = Uuid::new_v4();
+        let wrapped = WrappedEvent {
+            event: Event {
+                event: "$pageview".to_string(),
+                uuid: uuid.to_string(),
+                distinct_id: "user-42".to_string(),
+                timestamp: "2026-03-19T14:29:58.123Z".to_string(),
+                session_id: None,
+                window_id: None,
+                options: Options {
+                    cookieless_mode: None,
+                    disable_skew_adjustment: None,
+                    product_tour_id: None,
+                    process_person_profile: None,
+                },
+                properties: raw_obj(r#"{"x":1}"#),
+            },
+            uuid,
+            adjusted_timestamp: Some(dt("2026-03-19T14:29:53.123Z")),
+            result: EventResult::Ok,
+            details: None,
+            destination: Destination::AnalyticsMain,
+            force_disable_person_processing: true,
+        };
+
+        let ctx = serialize_ctx();
+        let (_, data) = serialize_and_parse(&wrapped, &ctx);
+        assert!(
+            !data
+                .properties
+                .contains_key("force_disable_person_processing"),
+            "force_disable_person_processing must not appear in properties"
+        );
+        assert!(
+            !data.properties.contains_key("$process_person_profile"),
+            "$process_person_profile must not appear when options.process_person_profile is None"
+        );
+    }
+
+    #[test]
+    fn serialize_identify_event() {
+        let uuid = Uuid::new_v4();
+        let wrapped = WrappedEvent {
+            event: Event {
+                event: "$identify".to_string(),
+                uuid: uuid.to_string(),
+                distinct_id: "user-99".to_string(),
+                timestamp: "2026-03-19T14:30:00.000Z".to_string(),
+                session_id: None,
+                window_id: None,
+                options: Options {
+                    cookieless_mode: None,
+                    disable_skew_adjustment: None,
+                    product_tour_id: None,
+                    process_person_profile: Some(true),
+                },
+                properties: raw_obj(r#"{"$browser":"Safari","$os":"macOS"}"#),
+            },
+            uuid,
+            adjusted_timestamp: Some(dt("2026-03-19T14:29:55.000Z")),
+            result: EventResult::Ok,
+            details: None,
+            destination: Destination::AnalyticsMain,
+            force_disable_person_processing: false,
+        };
+
+        let ctx = serialize_ctx();
+        let (captured, data) = serialize_and_parse(&wrapped, &ctx);
+        assert_eq!(captured.event, "$identify");
+        assert_eq!(captured.uuid, uuid);
+        assert_eq!(data.event, "$identify");
+        assert_eq!(data.properties["$browser"], "Safari");
+        assert_eq!(data.properties["$os"], "macOS");
+        assert_eq!(data.properties["$process_person_profile"], true);
     }
 }

--- a/rust/capture/src/v1/analytics/types.rs
+++ b/rust/capture/src/v1/analytics/types.rs
@@ -1,4 +1,4 @@
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, SecondsFormat, Utc};
 use common_types::{CapturedEventHeaders, HasEventName};
 use serde::{Deserialize, Serialize};
 use serde_json::value::RawValue;
@@ -95,29 +95,65 @@ impl SinkEvent for WrappedEvent {
         &self.destination
     }
 
-    fn headers(&self, _ctx: &Context) -> CapturedEventHeaders {
+    fn headers(&self, ctx: &Context) -> CapturedEventHeaders {
+        // v0 compat: downstream consumers key on "force_disable_person_processing".
+        // v1 decouples overflow routing from person-processing skip (unlike v0 where
+        // overflow ForceLimited unconditionally sets this); operators configure
+        // SkipPersonProcessing alongside ForceOverflow when needed.
+        let force_disable_person_processing = if self.skip_person_processing {
+            Some(true)
+        } else {
+            None
+        };
+
+        // historical_migration header follows legacy CapturedEvent::to_headers()
+        // convention: emitted only when enabled for the batch.
+        let historical_migration = if ctx.historical_migration {
+            Some(true)
+        } else {
+            None
+        };
+
+        let (dlq_reason, dlq_step, dlq_timestamp) = if self.destination == Destination::Dlq {
+            (
+                Some("event_restriction".to_string()),
+                Some("capture".to_string()),
+                Some(Utc::now().to_rfc3339_opts(SecondsFormat::Millis, true)),
+            )
+        } else {
+            (None, None, None)
+        };
+
         CapturedEventHeaders {
-            token: None,
-            distinct_id: None,
-            session_id: None,
-            timestamp: None,
-            event: None,
-            uuid: None,
-            now: None,
-            force_disable_person_processing: if self.skip_person_processing {
-                Some(true)
-            } else {
-                None
-            },
-            historical_migration: None,
-            dlq_reason: None,
-            dlq_step: None,
-            dlq_timestamp: None,
+            token: Some(ctx.api_token.clone()),
+            distinct_id: Some(self.event.distinct_id.clone()),
+            session_id: self.event.session_id.clone(),
+            timestamp: self
+                .adjusted_timestamp
+                .map(|ts| ts.timestamp_millis().to_string()),
+            event: Some(self.event.event.clone()),
+            uuid: Some(self.event.uuid().to_owned()),
+            now: Some(
+                ctx.server_received_at
+                    .to_rfc3339_opts(SecondsFormat::AutoSi, true),
+            ),
+            force_disable_person_processing,
+            historical_migration,
+            dlq_reason,
+            dlq_step,
+            dlq_timestamp,
         }
     }
 
     fn write_partition_key(&self, ctx: &Context, buf: &mut String) {
         use std::fmt::Write;
+        if self.skip_person_processing {
+            // buffer remains empty as sentinel for "no partition key set"
+            // this signals Kafka producer to supply no key, causing
+            // round-robin or random partition production depending on
+            // the producer's configuration.
+            return;
+        }
         if self.event.options.cookieless_mode == Some(true) {
             let ip = if ctx.capture_internal {
                 "127.0.0.1"
@@ -541,47 +577,148 @@ mod tests {
     }
 
     #[test]
-    fn headers_empty_when_no_skip_person() {
+    fn headers_base_fields_always_present() {
         let ctx = test_utils::test_context();
         let ev = ok_wrapped("$pageview", "user-1");
         let h = ev.headers(&ctx);
-        // No skip → the only field this WIP impl writes to stays None, and
-        // every other field remains None as well (nothing populated yet at
-        // this PR tip).
+        assert_eq!(h.distinct_id.as_deref(), Some("user-1"));
+        assert_eq!(h.event.as_deref(), Some("$pageview"));
+        assert!(h.uuid.is_some());
+        assert!(h.timestamp.is_some());
         assert!(h.force_disable_person_processing.is_none());
-        assert!(h.token.is_none());
-        assert!(h.distinct_id.is_none());
         assert!(h.session_id.is_none());
+        assert!(h.dlq_reason.is_none());
+    }
+
+    #[test]
+    fn headers_timestamp_is_millis_epoch() {
+        let ctx = test_utils::test_context();
+        let ev = ok_wrapped("$pageview", "user-1");
+        let h = ev.headers(&ctx);
+        let ts_str = h.timestamp.expect("timestamp should be set");
+        let ts_millis: i64 = ts_str.parse().expect("timestamp should be numeric millis");
+        assert_eq!(ts_millis, ev.adjusted_timestamp.unwrap().timestamp_millis());
+    }
+
+    #[test]
+    fn headers_omit_timestamp_when_none() {
+        let ctx = test_utils::test_context();
+        let mut ev = ok_wrapped("$pageview", "user-1");
+        ev.adjusted_timestamp = None;
+        let h = ev.headers(&ctx);
         assert!(h.timestamp.is_none());
-        assert!(h.event.is_none());
-        assert!(h.uuid.is_none());
-        assert!(h.now.is_none());
-        assert!(h.historical_migration.is_none());
+    }
+
+    #[test]
+    fn headers_include_session_id_when_present() {
+        let ctx = test_utils::test_context();
+        let mut ev = ok_wrapped("$pageview", "user-1");
+        ev.event.session_id = Some("sess-abc".to_string());
+        let h = ev.headers(&ctx);
+        assert_eq!(h.session_id.as_deref(), Some("sess-abc"));
+    }
+
+    #[test]
+    fn headers_omit_session_id_when_none() {
+        let ctx = test_utils::test_context();
+        let ev = ok_wrapped("$pageview", "user-1");
+        assert!(ev.event.session_id.is_none());
+        let h = ev.headers(&ctx);
+        assert!(h.session_id.is_none());
+    }
+
+    #[test]
+    fn headers_include_force_disable_person_processing() {
+        let ctx = test_utils::test_context();
+        let mut ev = ok_wrapped("$pageview", "user-1");
+        ev.skip_person_processing = true;
+        let h = ev.headers(&ctx);
+        assert_eq!(h.force_disable_person_processing, Some(true));
+    }
+
+    #[test]
+    fn headers_omit_force_disable_person_processing_when_false() {
+        let ctx = test_utils::test_context();
+        let ev = ok_wrapped("$pageview", "user-1");
+        assert!(!ev.skip_person_processing);
+        let h = ev.headers(&ctx);
+        assert!(h.force_disable_person_processing.is_none());
+    }
+
+    #[test]
+    fn headers_include_dlq_headers_when_destination_dlq() {
+        let ctx = test_utils::test_context();
+        let mut ev = ok_wrapped("$pageview", "user-1");
+        ev.destination = Destination::Dlq;
+        let h = ev.headers(&ctx);
+        assert_eq!(h.dlq_reason.as_deref(), Some("event_restriction"));
+        assert_eq!(h.dlq_step.as_deref(), Some("capture"));
+        let dlq_ts = h.dlq_timestamp.expect("dlq_timestamp should be set");
+        assert!(
+            chrono::DateTime::parse_from_rfc3339(&dlq_ts).is_ok(),
+            "dlq_timestamp should be valid RFC3339: {dlq_ts}"
+        );
+    }
+
+    #[test]
+    fn headers_omit_dlq_headers_when_not_dlq() {
+        let ctx = test_utils::test_context();
+        let ev = ok_wrapped("$pageview", "user-1");
+        assert_ne!(ev.destination, Destination::Dlq);
+        let h = ev.headers(&ctx);
         assert!(h.dlq_reason.is_none());
         assert!(h.dlq_step.is_none());
         assert!(h.dlq_timestamp.is_none());
     }
 
     #[test]
-    fn headers_include_skip_person_processing() {
+    fn headers_include_token_from_ctx() {
+        // Absorbs coverage from the removed build_context_headers token test:
+        // the api_token on the batch context must flow verbatim onto every
+        // event's typed headers.
         let ctx = test_utils::test_context();
-        let mut ev = ok_wrapped("$pageview", "user-1");
-        ev.skip_person_processing = true;
+        let ev = ok_wrapped("$pageview", "user-1");
         let h = ev.headers(&ctx);
-        assert_eq!(h.force_disable_person_processing, Some(true));
-        // WIP impl populates only this one field; every other field stays
-        // None. PR-5a will extend the impl and this assertion set.
-        assert!(h.token.is_none());
-        assert!(h.distinct_id.is_none());
-        assert!(h.session_id.is_none());
-        assert!(h.timestamp.is_none());
-        assert!(h.event.is_none());
-        assert!(h.uuid.is_none());
-        assert!(h.now.is_none());
+        assert_eq!(h.token, Some(ctx.api_token.clone()));
+    }
+
+    #[test]
+    fn headers_now_uses_server_received_at_autosi_rfc3339() {
+        // Absorbs coverage from the removed build_context_headers now test,
+        // and asserts the legacy-aligned format upgrade (SecondsFormat::AutoSi,
+        // matches IngestionEvent.now and legacy CapturedEvent::to_headers()).
+        let ctx = test_utils::test_context();
+        let ev = ok_wrapped("$pageview", "user-1");
+        let h = ev.headers(&ctx);
+        let now = h.now.expect("now should be set from ctx.server_received_at");
+        assert_eq!(
+            now,
+            ctx.server_received_at
+                .to_rfc3339_opts(chrono::SecondsFormat::AutoSi, true)
+        );
+        // Double-check the value is a valid RFC3339 timestamp regardless of
+        // how the format is spelled out.
+        assert!(
+            chrono::DateTime::parse_from_rfc3339(&now).is_ok(),
+            "now should be valid RFC3339: {now}"
+        );
+    }
+
+    #[test]
+    fn headers_historical_migration_from_ctx() {
+        // Absorbs coverage from the removed build_context_headers
+        // historical_migration tests (set → Some(true); unset → None),
+        // matching legacy CapturedEvent::to_headers() convention.
+        let ev = ok_wrapped("$pageview", "user-1");
+
+        let mut ctx = test_utils::test_context();
+        ctx.historical_migration = true;
+        let h = ev.headers(&ctx);
+        assert_eq!(h.historical_migration, Some(true));
+
+        ctx.historical_migration = false;
+        let h = ev.headers(&ctx);
         assert!(h.historical_migration.is_none());
-        assert!(h.dlq_reason.is_none());
-        assert!(h.dlq_step.is_none());
-        assert!(h.dlq_timestamp.is_none());
     }
 
     fn partition_key(ev: &WrappedEvent, ctx: &Context) -> String {

--- a/rust/capture/src/v1/analytics/types.rs
+++ b/rust/capture/src/v1/analytics/types.rs
@@ -85,18 +85,30 @@ pub struct WrappedEvent {
 }
 
 impl SinkEvent for WrappedEvent {
+    // Pre-parsed UUID for result correlation. By the Sink stage,
+    // we know ALL well-formed incoming events have a valid UUID.
     fn uuid(&self) -> Uuid {
         self.uuid
     }
 
+    // Helps the Sink implementations filter events that were marked
+    // as ineligible for publishing in the request preprocessing step.
     fn should_publish(&self) -> bool {
         self.result == EventResult::Ok && self.destination != Destination::Drop
     }
 
+    // Resolve the storage-agnostic Destination scope for this event.
+    // The config for each Sink implementation knows how to resolve
+    // these to topics (etc.) depending on the sink type
     fn destination(&self) -> &Destination {
         &self.destination
     }
 
+    // Returns the full typed header set for this event, combining per-request
+    // context fields (token, now, historical_migration) with event-owned
+    // fields. Sinks convert the returned CapturedEventHeaders to their
+    // backend-specific format (e.g. OwnedHeaders for Kafka) via the From impl
+    // in common_types — same conversion legacy capture uses.
     fn headers(&self, ctx: &Context) -> CapturedEventHeaders {
         // v0 compat: downstream consumers key on "force_disable_person_processing".
         // v1 decouples overflow routing from person-processing (unlike v0 where
@@ -147,6 +159,8 @@ impl SinkEvent for WrappedEvent {
         }
     }
 
+    // Accepts a buffer that is reset by the caller in the event publish
+    // inner loop. This spares us a lot of string allocations.
     fn write_partition_key(&self, ctx: &Context, buf: &mut String) {
         use std::fmt::Write;
         // v0 parity: only drop partition key for main/overflow analytics.

--- a/rust/capture/src/v1/analytics/types.rs
+++ b/rust/capture/src/v1/analytics/types.rs
@@ -205,28 +205,40 @@ impl SinkEvent for WrappedEvent {
     }
 
     fn serialize_into(&self, ctx: &Context, buf: &mut String) -> anyhow::Result<()> {
-        let ingestion_data = self.build_ingestion_data()?;
+        let spliced = self.build_spliced_properties()?;
+        let properties: &RawValue = spliced.as_deref().unwrap_or(&self.event.properties);
+        let ingestion_data = IngestionData {
+            event: &self.event.event,
+            distinct_id: Some(&self.event.distinct_id),
+            uuid: Some(self.uuid),
+            properties,
+            timestamp: Some(&self.event.timestamp),
+        };
         let data = serde_json::to_string(&ingestion_data)
             .map_err(|e| anyhow::anyhow!("serializing IngestionData: {e:#}"))?;
-        let ip = if ctx.capture_internal {
-            "127.0.0.1".to_string()
+
+        let ip;
+        let ip_ref: &str = if ctx.capture_internal {
+            "127.0.0.1"
         } else {
-            ctx.client_ip.to_string()
+            ip = ctx.client_ip.to_string();
+            &ip
         };
         let timestamp = self.adjusted_timestamp.ok_or_else(|| {
             anyhow::anyhow!("serialize_into called on event without adjusted_timestamp")
         })?;
+        let now = ctx
+            .server_received_at
+            .to_rfc3339_opts(chrono::SecondsFormat::AutoSi, true);
         let ie = IngestionEvent {
             uuid: self.uuid,
-            distinct_id: self.event.distinct_id.clone(),
-            ip,
-            data,
-            now: ctx
-                .server_received_at
-                .to_rfc3339_opts(chrono::SecondsFormat::AutoSi, true),
+            distinct_id: &self.event.distinct_id,
+            ip: ip_ref,
+            data: &data,
+            now: &now,
             sent_at: Some(ctx.client_timestamp),
-            token: ctx.api_token.clone(),
-            event: self.event.event.clone(),
+            token: &ctx.api_token,
+            event: &self.event.event,
             timestamp,
             is_cookieless_mode: self.event.options.cookieless_mode.unwrap_or(false),
             historical_migration: ctx.historical_migration,
@@ -280,47 +292,41 @@ impl WrappedEvent {
         Ok(buf)
     }
 
-    fn build_ingestion_data(&self) -> anyhow::Result<IngestionData> {
+    /// Build spliced properties if injection is needed, or return None
+    /// to signal the caller should borrow `self.event.properties` directly.
+    fn build_spliced_properties(&self) -> anyhow::Result<Option<Box<RawValue>>> {
         let injection = self.build_property_injections()?;
+        if injection.is_empty() {
+            return Ok(None);
+        }
+
         let raw = self.event.properties.get();
+        if !raw.starts_with('{') {
+            return Err(anyhow::anyhow!(
+                "properties must be a JSON object for injection, got: {:.32}",
+                raw,
+            ));
+        }
+        if raw.len() < 2 {
+            return Err(anyhow::anyhow!(
+                "properties too short ({} bytes) for JSON object",
+                raw.len()
+            ));
+        }
+        let prefix = &raw[..raw.len() - 1];
+        let has_existing = !raw[1..].trim_start().starts_with('}');
 
-        let properties = if injection.is_empty() {
-            self.event.properties.clone()
-        } else {
-            if !raw.starts_with('{') {
-                return Err(anyhow::anyhow!(
-                    "properties must be a JSON object for injection, got: {:.32}",
-                    raw,
-                ));
-            }
-            if raw.len() < 2 {
-                return Err(anyhow::anyhow!(
-                    "properties too short ({} bytes) for JSON object",
-                    raw.len()
-                ));
-            }
-            let prefix = &raw[..raw.len() - 1];
-            let has_existing = !raw[1..].trim_start().starts_with('}');
+        let mut buf = String::with_capacity(raw.len() + injection.len() + 2);
+        buf.push_str(prefix);
+        if has_existing {
+            buf.push(',');
+        }
+        buf.push_str(&injection);
+        buf.push('}');
 
-            let mut buf = String::with_capacity(raw.len() + injection.len() + 2);
-            buf.push_str(prefix);
-            if has_existing {
-                buf.push(',');
-            }
-            buf.push_str(&injection);
-            buf.push('}');
-
-            RawValue::from_string(buf)
-                .map_err(|e| anyhow::anyhow!("property surgery produced invalid JSON: {e:#}"))?
-        };
-
-        Ok(IngestionData {
-            event: self.event.event.clone(),
-            distinct_id: Some(self.event.distinct_id.clone()),
-            uuid: Some(self.uuid),
-            properties,
-            timestamp: Some(self.event.timestamp.clone()),
-        })
+        RawValue::from_string(buf)
+            .map(Some)
+            .map_err(|e| anyhow::anyhow!("property surgery produced invalid JSON: {e:#}"))
     }
 }
 
@@ -348,17 +354,21 @@ impl HasEventName for WrappedEvent {
 /// Field order matches `CapturedEvent` from `common_types` so that serde's
 /// derived `Serialize` emits JSON keys in the same order as v0. Serde
 /// annotations (`skip_serializing_if`) also match CapturedEvent exactly.
+///
+/// Borrows from `WrappedEvent` and `Context` to avoid per-event heap
+/// allocations -- the struct is created, serialized, and dropped within
+/// a single `serialize_into` call.
 #[derive(Debug, Serialize)]
-pub struct IngestionEvent {
+pub struct IngestionEvent<'a> {
     pub uuid: Uuid,
-    pub distinct_id: String,
-    pub ip: String,
-    pub data: String,
-    pub now: String,
+    pub distinct_id: &'a str,
+    pub ip: &'a str,
+    pub data: &'a str,
+    pub now: &'a str,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub sent_at: Option<DateTime<Utc>>,
-    pub token: String,
-    pub event: String,
+    pub token: &'a str,
+    pub event: &'a str,
     pub timestamp: DateTime<Utc>,
     #[serde(skip_serializing_if = "<&bool>::not", default)]
     pub is_cookieless_mode: bool,
@@ -376,15 +386,15 @@ pub struct IngestionEvent {
 ///   does not support these at top level (clients send them inside
 ///   `properties`, where they pass through the opaque blob as-is)
 #[derive(Debug, Serialize)]
-pub struct IngestionData {
-    pub event: String,
+pub struct IngestionData<'a> {
+    pub event: &'a str,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub distinct_id: Option<String>,
+    pub distinct_id: Option<&'a str>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub uuid: Option<Uuid>,
-    pub properties: Box<RawValue>,
+    pub properties: &'a RawValue,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub timestamp: Option<String>,
+    pub timestamp: Option<&'a str>,
 }
 
 #[cfg(test)]

--- a/rust/capture/src/v1/analytics/types.rs
+++ b/rust/capture/src/v1/analytics/types.rs
@@ -1,3 +1,4 @@
+use std::io;
 use std::ops::Not;
 
 use chrono::{DateTime, SecondsFormat, Utc};
@@ -5,6 +6,21 @@ use common_types::{CapturedEventHeaders, HasEventName};
 use serde::{Deserialize, Serialize};
 use serde_json::value::RawValue;
 use uuid::Uuid;
+
+/// Safe adapter for writing serde_json output into a `String` buffer.
+/// `from_utf8` on serde_json output is essentially free (JSON mandates UTF-8).
+struct StringWriter<'a>(&'a mut String);
+
+impl io::Write for StringWriter<'_> {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        let s = std::str::from_utf8(buf).map_err(io::Error::other)?;
+        self.0.push_str(s);
+        Ok(buf.len())
+    }
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
 
 use crate::v1::context::Context;
 use crate::v1::sinks::event::Event as SinkEvent;
@@ -31,7 +47,7 @@ pub struct Batch {
     pub created_at: String,
     #[serde(default)]
     pub historical_migration: bool,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
     pub capture_internal: Option<bool>,
     pub batch: Vec<Event>,
 }
@@ -54,9 +70,7 @@ pub struct Event {
     pub uuid: String,
     pub distinct_id: String,
     pub timestamp: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub session_id: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub window_id: Option<String>,
     pub options: Options,
     #[serde(default = "empty_raw_object")]
@@ -166,11 +180,6 @@ impl SinkEvent for WrappedEvent {
         // v0 parity: only drop partition key for main/overflow analytics.
         // DLQ, Historical, and Custom destinations always retain their key
         // even when person processing is disabled via event restrictions.
-        //
-        // TODO: when v1 adds overflow limiting, a separate signal
-        // (e.g. `drop_partition_key: bool`) is needed for the
-        // `Limited + !preserve_locality` case that drops key WITHOUT
-        // setting the person processing header.
         if self.force_disable_person_processing
             && matches!(
                 self.destination,
@@ -179,17 +188,19 @@ impl SinkEvent for WrappedEvent {
         {
             return;
         }
-        if self.event.options.cookieless_mode == Some(true) {
-            let ip = if ctx.capture_internal {
-                "127.0.0.1"
-            } else {
-                // client_ip.to_string() allocates; write! into the buffer avoids that
+        match (
+            self.event.options.cookieless_mode == Some(true),
+            ctx.capture_internal,
+        ) {
+            (true, true) => {
+                let _ = write!(buf, "{}:127.0.0.1", ctx.api_token);
+            }
+            (true, false) => {
                 let _ = write!(buf, "{}:{}", ctx.api_token, ctx.client_ip);
-                return;
-            };
-            let _ = write!(buf, "{}:{}", ctx.api_token, ip);
-        } else {
-            let _ = write!(buf, "{}:{}", ctx.api_token, self.event.distinct_id);
+            }
+            (false, _) => {
+                let _ = write!(buf, "{}:{}", ctx.api_token, self.event.distinct_id);
+            }
         }
     }
 
@@ -242,10 +253,7 @@ impl WrappedEvent {
                 $buf.push('"');
                 $buf.push_str($key);
                 $buf.push_str("\":");
-                // SAFETY: serde_json::to_writer only emits valid UTF-8 (JSON spec
-                // mandates UTF-8), so writing into String's backing Vec<u8> cannot
-                // produce invalid UTF-8.
-                serde_json::to_writer(unsafe { $buf.as_mut_vec() }, $val)
+                serde_json::to_writer(StringWriter(&mut $buf), $val)
                     .map_err(|e| anyhow::anyhow!("injecting {}: {e:#}", $key))?;
             }};
         }
@@ -279,6 +287,12 @@ impl WrappedEvent {
         let properties = if injection.is_empty() {
             self.event.properties.clone()
         } else {
+            if !raw.starts_with('{') {
+                return Err(anyhow::anyhow!(
+                    "properties must be a JSON object for injection, got: {:.32}",
+                    raw,
+                ));
+            }
             if raw.len() < 2 {
                 return Err(anyhow::anyhow!(
                     "properties too short ({} bytes) for JSON object",
@@ -286,7 +300,7 @@ impl WrappedEvent {
                 ));
             }
             let prefix = &raw[..raw.len() - 1];
-            let has_existing = raw.len() > 2;
+            let has_existing = !raw[1..].trim_start().starts_with('}');
 
             let mut buf = String::with_capacity(raw.len() + injection.len() + 2);
             buf.push_str(prefix);
@@ -1452,5 +1466,76 @@ mod tests {
         assert_eq!(data.properties["$browser"], "Safari");
         assert_eq!(data.properties["$os"], "macOS");
         assert_eq!(data.properties["$process_person_profile"], true);
+    }
+
+    // --- A3: property injection safety ---
+
+    #[test]
+    fn serialize_array_properties_rejected() {
+        let uuid = Uuid::new_v4();
+        let wrapped = WrappedEvent {
+            event: Event {
+                event: "$pageview".to_string(),
+                uuid: uuid.to_string(),
+                distinct_id: "user-42".to_string(),
+                timestamp: "2026-03-19T14:29:58.123Z".to_string(),
+                session_id: Some("sess-abc".to_string()),
+                window_id: None,
+                options: Options {
+                    cookieless_mode: None,
+                    disable_skew_adjustment: None,
+                    product_tour_id: None,
+                    process_person_profile: None,
+                },
+                properties: raw_obj("[1,2,3]"),
+            },
+            uuid,
+            adjusted_timestamp: Some(dt("2026-03-19T14:29:53.123Z")),
+            result: EventResult::Ok,
+            details: None,
+            destination: Destination::AnalyticsMain,
+            force_disable_person_processing: false,
+        };
+
+        let ctx = serialize_ctx();
+        let mut buf = String::new();
+        let err = wrapped.serialize_into(&ctx, &mut buf).unwrap_err();
+        assert!(
+            err.to_string().contains("must be a JSON object"),
+            "expected object guard, got: {err}"
+        );
+    }
+
+    #[test]
+    fn serialize_whitespace_padded_empty_object() {
+        let uuid = Uuid::new_v4();
+        let wrapped = WrappedEvent {
+            event: Event {
+                event: "$pageview".to_string(),
+                uuid: uuid.to_string(),
+                distinct_id: "user-42".to_string(),
+                timestamp: "2026-03-19T14:29:58.123Z".to_string(),
+                session_id: Some("sess-abc".to_string()),
+                window_id: None,
+                options: Options {
+                    cookieless_mode: None,
+                    disable_skew_adjustment: None,
+                    product_tour_id: None,
+                    process_person_profile: None,
+                },
+                properties: raw_obj("{   }"),
+            },
+            uuid,
+            adjusted_timestamp: Some(dt("2026-03-19T14:29:53.123Z")),
+            result: EventResult::Ok,
+            details: None,
+            destination: Destination::AnalyticsMain,
+            force_disable_person_processing: false,
+        };
+
+        let ctx = serialize_ctx();
+        let (_, data) = serialize_and_parse(&wrapped, &ctx);
+        assert_eq!(data.properties["$session_id"], "sess-abc");
+        assert_eq!(data.properties.len(), 1);
     }
 }

--- a/rust/capture/src/v1/mod.rs
+++ b/rust/capture/src/v1/mod.rs
@@ -4,8 +4,8 @@ pub mod context;
 pub mod error;
 pub mod quota_limiter_shim;
 pub mod sinks;
-#[cfg(test)]
-pub(crate) mod test_utils;
+#[cfg(any(test, feature = "test-utils"))]
+pub mod test_utils;
 pub mod util;
 
 pub use error::Error;

--- a/rust/capture/src/v1/quota_limiter_shim.rs
+++ b/rust/capture/src/v1/quota_limiter_shim.rs
@@ -295,7 +295,7 @@ mod tests {
             result: EventResult::Ok,
             details: None,
             destination: Destination::AnalyticsMain,
-            skip_person_processing: false,
+            force_disable_person_processing: false,
         }
     }
 
@@ -369,7 +369,7 @@ mod tests {
     async fn global_limit_preserves_all_event_states() {
         let limiter = build_limiter("tok", true, &[]).await;
         let bad = make_event("bad_event", None);
-        let bad_uuid = Uuid::parse_str(bad.event.uuid()).unwrap();
+        let bad_uuid = bad.uuid;
         let mut events = events_map(vec![make_event("$pageview", None), bad]);
         // Pre-mark one event as Drop (e.g. from validation)
         let bad_ev = events.get_mut(&bad_uuid).unwrap();
@@ -477,7 +477,7 @@ mod tests {
     async fn survey_limit_excludes_product_tour_events() {
         let limiter = build_limiter("tok", false, &[QuotaResource::Surveys]).await;
         let tour_ev = make_event("survey sent", Some("tour-123"));
-        let tour_uuid = Uuid::parse_str(tour_ev.event.uuid()).unwrap();
+        let tour_uuid = tour_ev.uuid;
         let mut events = events_map(vec![make_event("survey sent", None), tour_ev]);
 
         let result = apply_quota_limits(&limiter, "tok", &mut events).await;
@@ -627,7 +627,7 @@ mod tests {
         // No global limit, but exceptions limited
         let limiter = build_limiter("tok", false, &[QuotaResource::Exceptions]).await;
         let pv = make_event("$pageview", None);
-        let pv_uuid = Uuid::parse_str(pv.event.uuid()).unwrap();
+        let pv_uuid = pv.uuid;
         let mut events = events_map(vec![make_event("$exception", None), pv]);
         // Pre-mark pageview as Drop from a prior validation step
         let pv_ev = events.get_mut(&pv_uuid).unwrap();
@@ -643,7 +643,7 @@ mod tests {
     async fn mixed_pre_existing_and_scoped_still_ok_if_some_remain() {
         let limiter = build_limiter("tok", false, &[QuotaResource::Exceptions]).await;
         let pv = make_event("$pageview", None);
-        let pv_uuid = Uuid::parse_str(pv.event.uuid()).unwrap();
+        let pv_uuid = pv.uuid;
         let mut events = events_map(vec![
             make_event("$exception", None),
             pv,

--- a/rust/capture/src/v1/sinks/event.rs
+++ b/rust/capture/src/v1/sinks/event.rs
@@ -27,10 +27,10 @@ pub trait Event: Send + Sync {
     /// `common_types`).
     fn headers(&self, ctx: &Context) -> CapturedEventHeaders;
 
-    /// Resolve the partition key for this message, and write
-    /// to the supplied buffer. Called by Sinks that write to
-    /// event streams (Kafka, WarpStream etc.)
-    fn write_partition_key(&self, ctx: &Context, buf: &mut String);
+    /// Resolve the partition key for this message into the supplied buffer.
+    /// Returns `Some(key)` for consistent routing, `None` to let the
+    /// transport decide (e.g. round-robin across partitions).
+    fn partition_key<'buf>(&self, ctx: &Context, buf: &'buf mut String) -> Option<&'buf str>;
 
     /// Serialize the event payload into a caller-provided buffer.
     fn serialize_into(&self, ctx: &Context, buf: &mut String) -> anyhow::Result<()>;

--- a/rust/capture/src/v1/sinks/kafka/config.rs
+++ b/rust/capture/src/v1/sinks/kafka/config.rs
@@ -57,6 +57,23 @@ pub struct Config {
     #[envconfig(default = "10000")]
     pub statistics_interval_ms: u32,
 
+    // -- v0 parity settings (defaults from production charts/argocd/capture) --
+    /// Partitioning strategy. Must be murmur2_random for v0 parity
+    /// (python-kafka compat). librdkafka default varies by version.
+    #[envconfig(default = "murmur2_random")]
+    pub partitioner: String,
+    /// Max retry attempts per message. Production default: 4 (tuned for
+    /// MSK failover with socket_timeout_ms=5000, message_timeout_ms=30000).
+    #[envconfig(default = "4")]
+    pub max_retries: u32,
+    #[envconfig(default = "1000000")]
+    pub max_in_flight_requests: u32,
+    /// How long (ms) the producer sticks to a random partition for keyless
+    /// messages before switching. Affects distribution of events with
+    /// force_disable_person_processing (no partition key).
+    #[envconfig(default = "10")]
+    pub sticky_partitioning_linger_ms: u32,
+
     // -- QueueFull backpressure --
     /// Max enqueue retry attempts when rdkafka returns QueueFull.
     /// 0 = no retries (immediate failure, pre-backpressure behavior).
@@ -170,6 +187,10 @@ mod tests {
         env.insert("STATISTICS_INTERVAL_MS".into(), "5000".into());
         env.insert("ENQUEUE_RETRY_MAX".into(), "5".into());
         env.insert("ENQUEUE_POLL_MS".into(), "50".into());
+        env.insert("PARTITIONER".into(), "consistent_random".into());
+        env.insert("MAX_RETRIES".into(), "6".into());
+        env.insert("MAX_IN_FLIGHT_REQUESTS".into(), "500000".into());
+        env.insert("STICKY_PARTITIONING_LINGER_MS".into(), "20".into());
 
         let cfg = Config::init_from_hashmap(&env).unwrap();
         assert_eq!(cfg.hosts, "localhost:9092");
@@ -190,6 +211,10 @@ mod tests {
         assert_eq!(cfg.statistics_interval_ms, 5000);
         assert_eq!(cfg.enqueue_retry_max, 5);
         assert_eq!(cfg.enqueue_poll_ms, 50);
+        assert_eq!(cfg.partitioner, "consistent_random");
+        assert_eq!(cfg.max_retries, 6);
+        assert_eq!(cfg.max_in_flight_requests, 500000);
+        assert_eq!(cfg.sticky_partitioning_linger_ms, 20);
         assert_eq!(cfg.topic_main, "events_main");
     }
 
@@ -214,6 +239,10 @@ mod tests {
         assert_eq!(cfg.statistics_interval_ms, 10000);
         assert_eq!(cfg.enqueue_retry_max, 3);
         assert_eq!(cfg.enqueue_poll_ms, 33);
+        assert_eq!(cfg.partitioner, "murmur2_random");
+        assert_eq!(cfg.max_retries, 4);
+        assert_eq!(cfg.max_in_flight_requests, 1000000);
+        assert_eq!(cfg.sticky_partitioning_linger_ms, 10);
     }
 
     #[test]

--- a/rust/capture/src/v1/sinks/kafka/config.rs
+++ b/rust/capture/src/v1/sinks/kafka/config.rs
@@ -74,6 +74,26 @@ pub struct Config {
     #[envconfig(default = "10")]
     pub sticky_partitioning_linger_ms: u32,
 
+    /// IP family for broker connections. Empty = let librdkafka decide (default);
+    /// "v4" / "v6" / "any" force-select. Matches legacy KAFKA_BROKER_ADDRESS_FAMILY.
+    #[envconfig(default = "")]
+    pub broker_address_family: String,
+    /// Log broker connection close events. librdkafka default = true.
+    #[envconfig(default = "true")]
+    pub log_connection_close: bool,
+    /// Max messages buffered in the producer queue. librdkafka default = 100_000.
+    #[envconfig(default = "100000")]
+    pub queue_buffering_max_messages: u32,
+    /// Upper bound on exponential retry backoff (ms). librdkafka default = 1000.
+    #[envconfig(default = "1000")]
+    pub retry_backoff_max_ms: u32,
+    /// TCP socket send buffer size in bytes. 0 = use OS default. librdkafka default = 0.
+    #[envconfig(default = "0")]
+    pub socket_send_buffer_bytes: u32,
+    /// TCP socket receive buffer size in bytes. 0 = use OS default. librdkafka default = 0.
+    #[envconfig(default = "0")]
+    pub socket_receive_buffer_bytes: u32,
+
     // -- QueueFull backpressure --
     /// Max enqueue retry attempts when rdkafka returns QueueFull.
     /// 0 = no retries (immediate failure, pre-backpressure behavior).
@@ -191,6 +211,12 @@ mod tests {
         env.insert("MAX_RETRIES".into(), "6".into());
         env.insert("MAX_IN_FLIGHT_REQUESTS".into(), "500000".into());
         env.insert("STICKY_PARTITIONING_LINGER_MS".into(), "20".into());
+        env.insert("BROKER_ADDRESS_FAMILY".into(), "v4".into());
+        env.insert("LOG_CONNECTION_CLOSE".into(), "false".into());
+        env.insert("QUEUE_BUFFERING_MAX_MESSAGES".into(), "250000".into());
+        env.insert("RETRY_BACKOFF_MAX_MS".into(), "2000".into());
+        env.insert("SOCKET_SEND_BUFFER_BYTES".into(), "65536".into());
+        env.insert("SOCKET_RECEIVE_BUFFER_BYTES".into(), "65536".into());
 
         let cfg = Config::init_from_hashmap(&env).unwrap();
         assert_eq!(cfg.hosts, "localhost:9092");
@@ -215,6 +241,12 @@ mod tests {
         assert_eq!(cfg.max_retries, 6);
         assert_eq!(cfg.max_in_flight_requests, 500000);
         assert_eq!(cfg.sticky_partitioning_linger_ms, 20);
+        assert_eq!(cfg.broker_address_family, "v4");
+        assert!(!cfg.log_connection_close);
+        assert_eq!(cfg.queue_buffering_max_messages, 250000);
+        assert_eq!(cfg.retry_backoff_max_ms, 2000);
+        assert_eq!(cfg.socket_send_buffer_bytes, 65536);
+        assert_eq!(cfg.socket_receive_buffer_bytes, 65536);
         assert_eq!(cfg.topic_main, "events_main");
     }
 
@@ -243,6 +275,12 @@ mod tests {
         assert_eq!(cfg.max_retries, 4);
         assert_eq!(cfg.max_in_flight_requests, 1000000);
         assert_eq!(cfg.sticky_partitioning_linger_ms, 10);
+        assert_eq!(cfg.broker_address_family, "");
+        assert!(cfg.log_connection_close);
+        assert_eq!(cfg.queue_buffering_max_messages, 100000);
+        assert_eq!(cfg.retry_backoff_max_ms, 1000);
+        assert_eq!(cfg.socket_send_buffer_bytes, 0);
+        assert_eq!(cfg.socket_receive_buffer_bytes, 0);
     }
 
     #[test]

--- a/rust/capture/src/v1/sinks/kafka/producer.rs
+++ b/rust/capture/src/v1/sinks/kafka/producer.rs
@@ -156,7 +156,10 @@ impl KafkaProducer {
                 "sticky.partitioning.linger.ms",
                 config.sticky_partitioning_linger_ms.to_string(),
             )
-            .set("log.connection.close", config.log_connection_close.to_string())
+            .set(
+                "log.connection.close",
+                config.log_connection_close.to_string(),
+            )
             .set(
                 "queue.buffering.max.messages",
                 config.queue_buffering_max_messages.to_string(),

--- a/rust/capture/src/v1/sinks/kafka/producer.rs
+++ b/rust/capture/src/v1/sinks/kafka/producer.rs
@@ -155,8 +155,28 @@ impl KafkaProducer {
             .set(
                 "sticky.partitioning.linger.ms",
                 config.sticky_partitioning_linger_ms.to_string(),
+            )
+            .set("log.connection.close", config.log_connection_close.to_string())
+            .set(
+                "queue.buffering.max.messages",
+                config.queue_buffering_max_messages.to_string(),
+            )
+            .set(
+                "retry.backoff.max.ms",
+                config.retry_backoff_max_ms.to_string(),
+            )
+            .set(
+                "socket.send.buffer.bytes",
+                config.socket_send_buffer_bytes.to_string(),
+            )
+            .set(
+                "socket.receive.buffer.bytes",
+                config.socket_receive_buffer_bytes.to_string(),
             );
 
+        if !config.broker_address_family.is_empty() {
+            client_config.set("broker.address.family", &config.broker_address_family);
+        }
         if !config.client_id.is_empty() {
             client_config.set("client.id", &config.client_id);
         }

--- a/rust/capture/src/v1/sinks/kafka/producer.rs
+++ b/rust/capture/src/v1/sinks/kafka/producer.rs
@@ -145,7 +145,17 @@ impl KafkaProducer {
                 "metadata.max.age.ms",
                 config.metadata_max_age_ms.to_string(),
             )
-            .set("socket.timeout.ms", config.socket_timeout_ms.to_string());
+            .set("socket.timeout.ms", config.socket_timeout_ms.to_string())
+            .set("partitioner", &config.partitioner)
+            .set("message.send.max.retries", config.max_retries.to_string())
+            .set(
+                "max.in.flight.requests.per.connection",
+                config.max_in_flight_requests.to_string(),
+            )
+            .set(
+                "sticky.partitioning.linger.ms",
+                config.sticky_partitioning_linger_ms.to_string(),
+            );
 
         if !config.client_id.is_empty() {
             client_config.set("client.id", &config.client_id);

--- a/rust/capture/src/v1/sinks/kafka/sink.rs
+++ b/rust/capture/src/v1/sinks/kafka/sink.rs
@@ -161,17 +161,7 @@ impl<P: KafkaProducerTrait + 'static> KafkaSink<P> {
             let headers: rdkafka::message::OwnedHeaders = event.headers(ctx).into();
 
             key_buf.clear();
-            event.write_partition_key(ctx, &mut key_buf);
-
-            // Empty buffer = event requested no partition key (e.g.
-            // force_disable_person_processing on AnalyticsMain). Pass None so
-            // librdkafka round-robins; Some("") would hash to a single
-            // deterministic partition via murmur2, creating a hot partition.
-            let key = if key_buf.is_empty() {
-                None
-            } else {
-                Some(key_buf.as_str())
-            };
+            let key = event.partition_key(ctx, &mut key_buf);
 
             let mut record = ProduceRecord {
                 topic,

--- a/rust/capture/src/v1/sinks/kafka/sink.rs
+++ b/rust/capture/src/v1/sinks/kafka/sink.rs
@@ -137,7 +137,7 @@ impl<P: KafkaProducerTrait + 'static> KafkaSink<P> {
                     Level::ERROR,
                     ctx,
                     sink = sink_str,
-                    uuid_key = %uuid,
+                    event_uuid = %uuid,
                     error = %e,
                     "event serialization failed, dropping event"
                 );

--- a/rust/capture/src/v1/sinks/kafka/sink.rs
+++ b/rust/capture/src/v1/sinks/kafka/sink.rs
@@ -133,6 +133,14 @@ impl<P: KafkaProducerTrait + 'static> KafkaSink<P> {
 
             payload_buf.clear();
             if let Err(e) = event.serialize_into(ctx, &mut payload_buf) {
+                crate::ctx_log!(
+                    Level::ERROR,
+                    ctx,
+                    sink = sink_str,
+                    uuid_key = %uuid_key,
+                    error = %e,
+                    "event serialization failed, dropping event"
+                );
                 counter!(
                     "capture_v1_kafka_publish_total",
                     "mode" => labels.mode,

--- a/rust/capture/src/v1/sinks/kafka/sink.rs
+++ b/rust/capture/src/v1/sinks/kafka/sink.rs
@@ -163,9 +163,19 @@ impl<P: KafkaProducerTrait + 'static> KafkaSink<P> {
             key_buf.clear();
             event.write_partition_key(ctx, &mut key_buf);
 
+            // Empty buffer = event requested no partition key (e.g.
+            // force_disable_person_processing on AnalyticsMain). Pass None so
+            // librdkafka round-robins; Some("") would hash to a single
+            // deterministic partition via murmur2, creating a hot partition.
+            let key = if key_buf.is_empty() {
+                None
+            } else {
+                Some(key_buf.as_str())
+            };
+
             let mut record = ProduceRecord {
                 topic,
-                key: Some(&key_buf),
+                key,
                 payload: &payload_buf,
                 headers,
             };

--- a/rust/capture/src/v1/sinks/kafka/sink.rs
+++ b/rust/capture/src/v1/sinks/kafka/sink.rs
@@ -137,7 +137,7 @@ impl<P: KafkaProducerTrait + 'static> KafkaSink<P> {
                     Level::ERROR,
                     ctx,
                     sink = sink_str,
-                    uuid_key = %uuid_key,
+                    uuid_key = %uuid,
                     error = %e,
                     "event serialization failed, dropping event"
                 );

--- a/rust/capture/src/v1/sinks/kafka/sink.rs
+++ b/rust/capture/src/v1/sinks/kafka/sink.rs
@@ -136,7 +136,7 @@ impl<P: KafkaProducerTrait + 'static> KafkaSink<P> {
                 crate::ctx_log!(
                     Level::ERROR,
                     ctx,
-                    sink = sink_str,
+                    sink = labels.sink,
                     event_uuid = %uuid,
                     error = %e,
                     "event serialization failed, dropping event"

--- a/rust/capture/src/v1/sinks/kafka/sink_tests.rs
+++ b/rust/capture/src/v1/sinks/kafka/sink_tests.rs
@@ -1015,3 +1015,117 @@ async fn realistic_dropped_event_not_published() {
     assert!(results.is_empty());
     assert_eq!(h.producer.record_count(), 0);
 }
+
+// ===========================================================================
+// Coverage gap fills (C5)
+// ===========================================================================
+
+// ---------------------------------------------------------------------------
+// Mixed send error + ack error in one batch: first event fails at send,
+// remaining events fail at ack. Verifies both error types are reported.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn mixed_send_error_and_ack_error_in_batch() {
+    let h = TestHarness::builder()
+        .send_error(|| ProduceError::Kafka {
+            code: RDKafkaErrorCode::QueueFull,
+        })
+        .send_error_count(1)
+        .enqueue_retry_max(0)
+        .ack_error(|| ProduceError::DeliveryCancelled)
+        .build();
+    let e1 = FakeEvent::ok("evt-1");
+    let e2 = FakeEvent::ok("evt-2");
+    let e3 = FakeEvent::ok("evt-3");
+    let events: Vec<&(dyn Event + Send + Sync)> = vec![&e1, &e2, &e3];
+
+    let results = h.sink.publish_batch(&h.ctx, &events).await;
+
+    assert_eq!(results.len(), 3);
+    let by_key: HashMap<Uuid, _> = results.iter().map(|r| (r.key(), r)).collect();
+
+    // evt-1: send error (queue_full)
+    assert_eq!(by_key[&e1.parsed_uuid].outcome(), Outcome::RetriableError);
+    assert_eq!(by_key[&e1.parsed_uuid].cause(), Some("queue_full"));
+
+    // evt-2 and evt-3: enqueued successfully, but ack error (delivery_cancelled)
+    assert_eq!(by_key[&e2.parsed_uuid].outcome(), Outcome::RetriableError);
+    assert_eq!(
+        by_key[&e2.parsed_uuid].cause(),
+        Some("delivery_cancelled")
+    );
+    assert_eq!(by_key[&e3.parsed_uuid].outcome(), Outcome::RetriableError);
+    assert_eq!(
+        by_key[&e3.parsed_uuid].cause(),
+        Some("delivery_cancelled")
+    );
+
+    // Only evt-2 and evt-3 were enqueued (evt-1 failed at send)
+    assert_eq!(h.producer.record_count(), 2);
+}
+
+// ---------------------------------------------------------------------------
+// Partial timeout: first event fails at send (immediate), remaining time out.
+// Verifies mixed Outcome::RetriableError and Outcome::Timeout in one batch.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn partial_timeout_with_send_error() {
+    let h = TestHarness::builder()
+        .send_error(|| ProduceError::Kafka {
+            code: RDKafkaErrorCode::QueueFull,
+        })
+        .send_error_count(1)
+        .enqueue_retry_max(0)
+        .ack_delay(Duration::from_secs(60))
+        .produce_timeout(Duration::from_millis(50))
+        .build();
+    let e1 = FakeEvent::ok("evt-1");
+    let e2 = FakeEvent::ok("evt-2");
+    let events: Vec<&(dyn Event + Send + Sync)> = vec![&e1, &e2];
+
+    let results = h.sink.publish_batch(&h.ctx, &events).await;
+
+    assert_eq!(results.len(), 2);
+    let by_key: HashMap<Uuid, _> = results.iter().map(|r| (r.key(), r)).collect();
+
+    // evt-1: immediate send error
+    assert_eq!(by_key[&e1.parsed_uuid].outcome(), Outcome::RetriableError);
+    assert_eq!(by_key[&e1.parsed_uuid].cause(), Some("queue_full"));
+
+    // evt-2: enqueued successfully, but ack times out
+    assert_eq!(by_key[&e2.parsed_uuid].outcome(), Outcome::Timeout);
+    assert_eq!(by_key[&e2.parsed_uuid].cause(), Some("timeout"));
+}
+
+// ---------------------------------------------------------------------------
+// Partial timeout: serialization failure + timeout in one batch.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn partial_timeout_with_serialization_error() {
+    let h = TestHarness::builder()
+        .ack_delay(Duration::from_secs(60))
+        .produce_timeout(Duration::from_millis(50))
+        .build();
+    let e1 = FakeEvent::ok("evt-1").with_payload(Err("bad".into()));
+    let e2 = FakeEvent::ok("evt-2");
+    let events: Vec<&(dyn Event + Send + Sync)> = vec![&e1, &e2];
+
+    let results = h.sink.publish_batch(&h.ctx, &events).await;
+
+    assert_eq!(results.len(), 2);
+    let by_key: HashMap<Uuid, _> = results.iter().map(|r| (r.key(), r)).collect();
+
+    // evt-1: serialization failure (immediate, fatal)
+    assert_eq!(by_key[&e1.parsed_uuid].outcome(), Outcome::FatalError);
+    assert_eq!(
+        by_key[&e1.parsed_uuid].cause(),
+        Some("serialization_failed")
+    );
+
+    // evt-2: enqueued, times out
+    assert_eq!(by_key[&e2.parsed_uuid].outcome(), Outcome::Timeout);
+    assert_eq!(by_key[&e2.parsed_uuid].cause(), Some("timeout"));
+}

--- a/rust/capture/src/v1/sinks/kafka/sink_tests.rs
+++ b/rust/capture/src/v1/sinks/kafka/sink_tests.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 
-use common_types::CapturedEventHeaders;
+use common_types::{CapturedEvent, CapturedEventHeaders, RawEvent};
 use rdkafka::error::RDKafkaErrorCode;
 use rstest::rstest;
 use uuid::Uuid;
@@ -13,6 +13,7 @@ use crate::v1::sinks::event::Event;
 use crate::v1::sinks::sink::Sink;
 use crate::v1::sinks::types::{BatchSummary, Outcome};
 use crate::v1::sinks::{Config, Destination, SinkName};
+use crate::v1::test_utils::{self, WrappedEventMut};
 
 use super::mock::MockProducer;
 use super::producer::ProduceError;
@@ -907,4 +908,110 @@ async fn nonempty_partition_key_propagates_as_some() {
     h.producer.with_records(|records| {
         assert_eq!(records[0].key.as_deref(), Some("phc_test:user-1"));
     });
+}
+
+// ===========================================================================
+// Realistic WrappedEvent round-trip tests
+//
+// These use production-shaped fixtures from test_utils and verify the
+// MockProducer payload deserializes as CapturedEvent + RawEvent.
+// ===========================================================================
+
+#[tokio::test]
+async fn realistic_single_pageview_round_trip() {
+    let h = TestHarness::new();
+    let wrapped = test_utils::realistic_pageview("user-42");
+    let events: Vec<&(dyn Event + Send + Sync)> = vec![&wrapped];
+
+    let results = h.sink.publish_batch(&h.ctx, &events).await;
+
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].key(), wrapped.uuid);
+    assert_eq!(results[0].outcome(), Outcome::Success);
+
+    h.producer.with_records(|records| {
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].topic, "events_main");
+
+        let captured: CapturedEvent =
+            serde_json::from_str(&records[0].payload).expect("must deserialize as CapturedEvent");
+        assert_eq!(captured.uuid, wrapped.uuid);
+        assert_eq!(captured.distinct_id, "user-42");
+        assert_eq!(captured.event, "$pageview");
+
+        let data: RawEvent =
+            serde_json::from_str(&captured.data).expect("data must deserialize as RawEvent");
+        assert_eq!(data.event, "$pageview");
+        assert_eq!(data.properties["$browser"], "Chrome");
+        assert_eq!(data.properties["$session_id"], "01jq9abc-def0-1234-5678-9abcdef01234");
+        assert_eq!(data.properties["$process_person_profile"], true);
+    });
+}
+
+#[tokio::test]
+async fn realistic_batch_round_trip() {
+    let h = TestHarness::new();
+    let batch = test_utils::realistic_batch();
+    let events: Vec<&(dyn Event + Send + Sync)> = vec![&batch[0], &batch[1], &batch[2]];
+
+    let results = h.sink.publish_batch(&h.ctx, &events).await;
+
+    assert_eq!(results.len(), 3);
+    for r in &results {
+        assert_eq!(r.outcome(), Outcome::Success);
+    }
+
+    h.producer.with_records(|records| {
+        assert_eq!(records.len(), 3);
+        for record in records {
+            let captured: CapturedEvent =
+                serde_json::from_str(&record.payload).expect("must deserialize as CapturedEvent");
+            let _data: RawEvent =
+                serde_json::from_str(&captured.data).expect("data must deserialize as RawEvent");
+        }
+
+        let names: Vec<&str> = records
+            .iter()
+            .map(|r| {
+                let c: CapturedEvent = serde_json::from_str(&r.payload).unwrap();
+                match c.event.as_str() {
+                    "$pageview" => "$pageview",
+                    "$identify" => "$identify",
+                    _ => "custom",
+                }
+            })
+            .collect();
+        assert_eq!(names, vec!["$pageview", "$identify", "custom"]);
+    });
+}
+
+#[tokio::test]
+async fn realistic_event_with_destination_mutation() {
+    let h = TestHarness::new();
+    let wrapped = test_utils::realistic_pageview("user-42")
+        .with_destination(Destination::AnalyticsHistorical);
+    let events: Vec<&(dyn Event + Send + Sync)> = vec![&wrapped];
+
+    let results = h.sink.publish_batch(&h.ctx, &events).await;
+
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].outcome(), Outcome::Success);
+    h.producer.with_records(|records| {
+        assert_eq!(records[0].topic, "events_hist");
+    });
+}
+
+#[tokio::test]
+async fn realistic_dropped_event_not_published() {
+    use crate::v1::analytics::types::EventResult;
+
+    let h = TestHarness::new();
+    let wrapped = test_utils::realistic_pageview("user-42")
+        .with_result(EventResult::Drop, Some("rate_limited"));
+    let events: Vec<&(dyn Event + Send + Sync)> = vec![&wrapped];
+
+    let results = h.sink.publish_batch(&h.ctx, &events).await;
+
+    assert!(results.is_empty());
+    assert_eq!(h.producer.record_count(), 0);
 }

--- a/rust/capture/src/v1/sinks/kafka/sink_tests.rs
+++ b/rust/capture/src/v1/sinks/kafka/sink_tests.rs
@@ -77,6 +77,11 @@ impl FakeEvent {
         self.payload = p;
         self
     }
+
+    fn with_partition_key(mut self, k: &str) -> Self {
+        self.partition_key = k.to_string();
+        self
+    }
 }
 
 impl Event for FakeEvent {
@@ -114,20 +119,6 @@ impl Event for FakeEvent {
 // ---------------------------------------------------------------------------
 // TestHarness
 // ---------------------------------------------------------------------------
-
-fn test_kafka_config() -> super::config::Config {
-    let env: HashMap<String, String> = [
-        ("HOSTS", "localhost:9092"),
-        ("TOPIC_MAIN", "events_main"),
-        ("TOPIC_HISTORICAL", "events_hist"),
-        ("TOPIC_OVERFLOW", "events_overflow"),
-        ("TOPIC_DLQ", "events_dlq"),
-    ]
-    .into_iter()
-    .map(|(k, v)| (k.to_string(), v.to_string()))
-    .collect();
-    envconfig::Envconfig::init_from_hashmap(&env).unwrap()
-}
 
 struct TestHarness {
     sink: KafkaSink<MockProducer>,
@@ -254,7 +245,7 @@ impl HarnessBuilder {
 
         let producer = Arc::new(mock);
 
-        let mut kafka_config = test_kafka_config();
+        let mut kafka_config = crate::v1::test_utils::test_kafka_config();
         if let Some(n) = self.enqueue_retry_max {
             kafka_config.enqueue_retry_max = n;
         }
@@ -879,4 +870,41 @@ async fn health_refreshed_on_partial_success() {
         h.handle.is_healthy(),
         "handle should stay healthy when at least one event succeeded"
     );
+}
+
+// ---------------------------------------------------------------------------
+// Empty partition key propagates as None (not Some(""))
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn empty_partition_key_propagates_as_none() {
+    let h = TestHarness::new();
+    let event = FakeEvent::ok("evt-1").with_partition_key("");
+    let events: Vec<&(dyn Event + Send + Sync)> = vec![&event];
+
+    let results = h.sink.publish_batch(&h.ctx, &events).await;
+
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].outcome(), Outcome::Success);
+    h.producer.with_records(|records| {
+        assert_eq!(
+            records[0].key, None,
+            "empty partition key must become None, not Some(\"\")"
+        );
+    });
+}
+
+#[tokio::test]
+async fn nonempty_partition_key_propagates_as_some() {
+    let h = TestHarness::new();
+    let event = FakeEvent::ok("evt-1").with_partition_key("phc_test:user-1");
+    let events: Vec<&(dyn Event + Send + Sync)> = vec![&event];
+
+    let results = h.sink.publish_batch(&h.ctx, &events).await;
+
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].outcome(), Outcome::Success);
+    h.producer.with_records(|records| {
+        assert_eq!(records[0].key.as_deref(), Some("phc_test:user-1"));
+    });
 }

--- a/rust/capture/src/v1/sinks/kafka/sink_tests.rs
+++ b/rust/capture/src/v1/sinks/kafka/sink_tests.rs
@@ -47,7 +47,7 @@ struct FakeEvent {
     parsed_uuid: Uuid,
     publish: bool,
     destination: Destination,
-    partition_key: String,
+    partition_key: Option<String>,
     payload: Result<String, String>,
     event_headers: CapturedEventHeaders,
 }
@@ -58,7 +58,7 @@ impl FakeEvent {
             parsed_uuid: Uuid::new_v4(),
             publish: true,
             destination: Destination::AnalyticsMain,
-            partition_key: format!("phc_test:{uuid}"),
+            partition_key: Some(format!("phc_test:{uuid}")),
             payload: Ok(r#"{"event":"test"}"#.to_string()),
             event_headers: empty_captured_headers(),
         }
@@ -79,8 +79,8 @@ impl FakeEvent {
         self
     }
 
-    fn with_partition_key(mut self, k: &str) -> Self {
-        self.partition_key = k.to_string();
+    fn with_partition_key(mut self, k: Option<&str>) -> Self {
+        self.partition_key = k.map(String::from);
         self
     }
 }
@@ -102,8 +102,14 @@ impl Event for FakeEvent {
         self.event_headers.clone()
     }
 
-    fn write_partition_key(&self, _ctx: &Context, buf: &mut String) {
-        buf.push_str(&self.partition_key);
+    fn partition_key<'buf>(&self, _ctx: &Context, buf: &'buf mut String) -> Option<&'buf str> {
+        match &self.partition_key {
+            Some(k) => {
+                buf.push_str(k);
+                Some(buf.as_str())
+            }
+            None => None,
+        }
     }
 
     fn serialize_into(&self, _ctx: &Context, buf: &mut String) -> anyhow::Result<()> {
@@ -874,13 +880,13 @@ async fn health_refreshed_on_partial_success() {
 }
 
 // ---------------------------------------------------------------------------
-// Empty partition key propagates as None (not Some(""))
+// Partition key: None vs Some
 // ---------------------------------------------------------------------------
 
 #[tokio::test]
-async fn empty_partition_key_propagates_as_none() {
+async fn none_partition_key_propagates_as_none() {
     let h = TestHarness::new();
-    let event = FakeEvent::ok("evt-1").with_partition_key("");
+    let event = FakeEvent::ok("evt-1").with_partition_key(None);
     let events: Vec<&(dyn Event + Send + Sync)> = vec![&event];
 
     let results = h.sink.publish_batch(&h.ctx, &events).await;
@@ -890,15 +896,15 @@ async fn empty_partition_key_propagates_as_none() {
     h.producer.with_records(|records| {
         assert_eq!(
             records[0].key, None,
-            "empty partition key must become None, not Some(\"\")"
+            "None partition key must propagate as None"
         );
     });
 }
 
 #[tokio::test]
-async fn nonempty_partition_key_propagates_as_some() {
+async fn some_partition_key_propagates_as_some() {
     let h = TestHarness::new();
-    let event = FakeEvent::ok("evt-1").with_partition_key("phc_test:user-1");
+    let event = FakeEvent::ok("evt-1").with_partition_key(Some("phc_test:user-1"));
     let events: Vec<&(dyn Event + Send + Sync)> = vec![&event];
 
     let results = h.sink.publish_batch(&h.ctx, &events).await;
@@ -943,7 +949,10 @@ async fn realistic_single_pageview_round_trip() {
             serde_json::from_str(&captured.data).expect("data must deserialize as RawEvent");
         assert_eq!(data.event, "$pageview");
         assert_eq!(data.properties["$browser"], "Chrome");
-        assert_eq!(data.properties["$session_id"], "01jq9abc-def0-1234-5678-9abcdef01234");
+        assert_eq!(
+            data.properties["$session_id"],
+            "01jq9abc-def0-1234-5678-9abcdef01234"
+        );
         assert_eq!(data.properties["$process_person_profile"], true);
     });
 }
@@ -1051,15 +1060,9 @@ async fn mixed_send_error_and_ack_error_in_batch() {
 
     // evt-2 and evt-3: enqueued successfully, but ack error (delivery_cancelled)
     assert_eq!(by_key[&e2.parsed_uuid].outcome(), Outcome::RetriableError);
-    assert_eq!(
-        by_key[&e2.parsed_uuid].cause(),
-        Some("delivery_cancelled")
-    );
+    assert_eq!(by_key[&e2.parsed_uuid].cause(), Some("delivery_cancelled"));
     assert_eq!(by_key[&e3.parsed_uuid].outcome(), Outcome::RetriableError);
-    assert_eq!(
-        by_key[&e3.parsed_uuid].cause(),
-        Some("delivery_cancelled")
-    );
+    assert_eq!(by_key[&e3.parsed_uuid].cause(), Some("delivery_cancelled"));
 
     // Only evt-2 and evt-3 were enqueued (evt-1 failed at send)
     assert_eq!(h.producer.record_count(), 2);

--- a/rust/capture/src/v1/sinks/router.rs
+++ b/rust/capture/src/v1/sinks/router.rs
@@ -186,25 +186,11 @@ mod tests {
         }
     }
 
-    fn test_kafka_config() -> crate::v1::sinks::kafka::config::Config {
-        let env: HashMap<String, String> = [
-            ("HOSTS", "localhost:9092"),
-            ("TOPIC_MAIN", "events_main"),
-            ("TOPIC_HISTORICAL", "events_hist"),
-            ("TOPIC_OVERFLOW", "events_overflow"),
-            ("TOPIC_DLQ", "events_dlq"),
-        ]
-        .into_iter()
-        .map(|(k, v)| (k.to_string(), v.to_string()))
-        .collect();
-        envconfig::Envconfig::init_from_hashmap(&env).unwrap()
-    }
-
     fn build_sink(name: SinkName, handle: lifecycle::Handle) -> Box<dyn Sink> {
         let producer = Arc::new(MockProducer::new(name, handle.clone()));
         let config = Config {
             produce_timeout: Duration::from_secs(30),
-            kafka: test_kafka_config(),
+            kafka: crate::v1::test_utils::test_kafka_config(),
         };
         Box::new(KafkaSink::new(
             name,

--- a/rust/capture/src/v1/sinks/router.rs
+++ b/rust/capture/src/v1/sinks/router.rs
@@ -177,8 +177,10 @@ mod tests {
                 dlq_timestamp: None,
             }
         }
-        fn write_partition_key(&self, _ctx: &Context, buf: &mut String) {
-            buf.push_str(&format!("key:{}", self.uuid()));
+        fn partition_key<'buf>(&self, _ctx: &Context, buf: &'buf mut String) -> Option<&'buf str> {
+            use std::fmt::Write;
+            let _ = write!(buf, "key:{}", self.uuid());
+            Some(buf.as_str())
         }
         fn serialize_into(&self, _ctx: &Context, buf: &mut String) -> anyhow::Result<()> {
             buf.push_str(r#"{"event":"test"}"#);

--- a/rust/capture/src/v1/test_utils.rs
+++ b/rust/capture/src/v1/test_utils.rs
@@ -145,3 +145,17 @@ pub fn find_by_did<'a>(
         .find(|e| e.event.distinct_id == distinct_id)
         .unwrap()
 }
+
+pub fn test_kafka_config() -> crate::v1::sinks::kafka::config::Config {
+    let env: std::collections::HashMap<String, String> = [
+        ("HOSTS", "localhost:9092"),
+        ("TOPIC_MAIN", "events_main"),
+        ("TOPIC_HISTORICAL", "events_hist"),
+        ("TOPIC_OVERFLOW", "events_overflow"),
+        ("TOPIC_DLQ", "events_dlq"),
+    ]
+    .into_iter()
+    .map(|(k, v)| (k.to_string(), v.to_string()))
+    .collect();
+    envconfig::Envconfig::init_from_hashmap(&env).unwrap()
+}

--- a/rust/capture/src/v1/test_utils.rs
+++ b/rust/capture/src/v1/test_utils.rs
@@ -84,7 +84,7 @@ pub fn wrapped_event(event_name: &str, distinct_id: &str) -> WrappedEvent {
         result: EventResult::Ok,
         details: None,
         destination: Destination::default(),
-        skip_person_processing: false,
+        force_disable_person_processing: false,
     }
 }
 
@@ -106,7 +106,7 @@ pub fn wrapped_event_at(timestamp: DateTime<Utc>) -> WrappedEvent {
         result: EventResult::Ok,
         details: None,
         destination: Destination::default(),
-        skip_person_processing: false,
+        force_disable_person_processing: false,
     }
 }
 
@@ -128,7 +128,7 @@ pub fn malformed_wrapped_event() -> WrappedEvent {
         result: EventResult::Drop,
         details: Some("missing_event_name"),
         destination: Destination::default(),
-        skip_person_processing: false,
+        force_disable_person_processing: false,
     }
 }
 

--- a/rust/capture/src/v1/test_utils.rs
+++ b/rust/capture/src/v1/test_utils.rs
@@ -1,5 +1,3 @@
-// Some helpers here are only consumed by process.rs tests (PR 1 / sinks-1).
-// Remove this allow once that branch has landed on master.
 #![allow(dead_code)]
 
 use std::collections::HashMap;
@@ -158,4 +156,174 @@ pub fn test_kafka_config() -> crate::v1::sinks::kafka::config::Config {
     .map(|(k, v)| (k.to_string(), v.to_string()))
     .collect();
     envconfig::Envconfig::init_from_hashmap(&env).unwrap()
+}
+
+// ---------------------------------------------------------------------------
+// Realistic fixture builders
+// ---------------------------------------------------------------------------
+
+/// A realistic $pageview event with typical posthog-js properties.
+pub fn realistic_pageview(distinct_id: &str) -> WrappedEvent {
+    let uuid = Uuid::new_v4();
+    WrappedEvent {
+        event: Event {
+            event: "$pageview".to_string(),
+            uuid: uuid.to_string(),
+            distinct_id: distinct_id.to_string(),
+            timestamp: "2026-03-19T14:29:58.123Z".to_string(),
+            session_id: Some("01jq9abc-def0-1234-5678-9abcdef01234".to_string()),
+            window_id: Some("01jq9xyz-0000-4321-8765-fedcba987654".to_string()),
+            options: Options {
+                cookieless_mode: Some(false),
+                disable_skew_adjustment: None,
+                product_tour_id: None,
+                process_person_profile: Some(true),
+            },
+            properties: raw_obj(
+                r#"{"$current_url":"https://app.example.com/dashboard","$referrer":"https://google.com","$browser":"Chrome","$browser_version":"120.0","$os":"Mac OS X","$lib":"posthog-js","$lib_version":"1.150.0","custom_prop":42}"#,
+            ),
+        },
+        uuid,
+        adjusted_timestamp: Some(
+            DateTime::parse_from_rfc3339("2026-03-19T14:29:53.123Z")
+                .unwrap()
+                .with_timezone(&Utc),
+        ),
+        result: EventResult::Ok,
+        details: None,
+        destination: Destination::AnalyticsMain,
+        force_disable_person_processing: false,
+    }
+}
+
+/// A realistic $identify event.
+pub fn realistic_identify(distinct_id: &str) -> WrappedEvent {
+    let uuid = Uuid::new_v4();
+    WrappedEvent {
+        event: Event {
+            event: "$identify".to_string(),
+            uuid: uuid.to_string(),
+            distinct_id: distinct_id.to_string(),
+            timestamp: "2026-03-19T14:30:01.000Z".to_string(),
+            session_id: Some("01jq9abc-def0-1234-5678-9abcdef01234".to_string()),
+            window_id: None,
+            options: Options {
+                cookieless_mode: None,
+                disable_skew_adjustment: None,
+                product_tour_id: None,
+                process_person_profile: Some(true),
+            },
+            properties: raw_obj(
+                r#"{"$set":{"email":"user@example.com","name":"Test User"},"$set_once":{"created_at":"2026-01-01"},"$browser":"Safari","$os":"iOS"}"#,
+            ),
+        },
+        uuid,
+        adjusted_timestamp: Some(
+            DateTime::parse_from_rfc3339("2026-03-19T14:29:56.000Z")
+                .unwrap()
+                .with_timezone(&Utc),
+        ),
+        result: EventResult::Ok,
+        details: None,
+        destination: Destination::AnalyticsMain,
+        force_disable_person_processing: false,
+    }
+}
+
+/// A realistic custom event.
+pub fn realistic_custom(distinct_id: &str, event_name: &str) -> WrappedEvent {
+    let uuid = Uuid::new_v4();
+    WrappedEvent {
+        event: Event {
+            event: event_name.to_string(),
+            uuid: uuid.to_string(),
+            distinct_id: distinct_id.to_string(),
+            timestamp: "2026-03-19T14:30:05.500Z".to_string(),
+            session_id: Some("01jq9abc-def0-1234-5678-9abcdef01234".to_string()),
+            window_id: Some("01jq9xyz-0000-4321-8765-fedcba987654".to_string()),
+            options: Options {
+                cookieless_mode: None,
+                disable_skew_adjustment: None,
+                product_tour_id: None,
+                process_person_profile: Some(true),
+            },
+            properties: raw_obj(
+                r#"{"button_id":"cta-signup","$current_url":"https://app.example.com/pricing"}"#,
+            ),
+        },
+        uuid,
+        adjusted_timestamp: Some(
+            DateTime::parse_from_rfc3339("2026-03-19T14:30:00.500Z")
+                .unwrap()
+                .with_timezone(&Utc),
+        ),
+        result: EventResult::Ok,
+        details: None,
+        destination: Destination::AnalyticsMain,
+        force_disable_person_processing: false,
+    }
+}
+
+/// A realistic 3-event batch for round-trip tests.
+pub fn realistic_batch() -> Vec<WrappedEvent> {
+    vec![
+        realistic_pageview("user-42"),
+        realistic_identify("user-42"),
+        realistic_custom("user-42", "button_clicked"),
+    ]
+}
+
+/// Builder for mutating a WrappedEvent after creation.
+pub trait WrappedEventMut {
+    fn with_destination(self, d: Destination) -> Self;
+    fn with_force_disable_person_processing(self, v: bool) -> Self;
+    fn with_result(self, r: EventResult, details: Option<&'static str>) -> Self;
+    fn with_properties(self, raw: &str) -> Self;
+}
+
+impl WrappedEventMut for WrappedEvent {
+    fn with_destination(mut self, d: Destination) -> Self {
+        self.destination = d;
+        self
+    }
+
+    fn with_force_disable_person_processing(mut self, v: bool) -> Self {
+        self.force_disable_person_processing = v;
+        self
+    }
+
+    fn with_result(mut self, r: EventResult, details: Option<&'static str>) -> Self {
+        self.result = r;
+        self.details = details;
+        self
+    }
+
+    fn with_properties(mut self, raw: &str) -> Self {
+        self.event.properties = raw_obj(raw);
+        self
+    }
+}
+
+/// Assert that a serialized WrappedEvent round-trips through CapturedEvent
+/// and its inner data field round-trips through RawEvent.
+pub fn assert_round_trip(
+    wrapped: &WrappedEvent,
+    ctx: &Context,
+) -> (common_types::CapturedEvent, common_types::RawEvent) {
+    use crate::v1::sinks::event::Event as SinkEvent;
+
+    let mut buf = String::new();
+    wrapped
+        .serialize_into(ctx, &mut buf)
+        .expect("serialize_into failed");
+    let captured: common_types::CapturedEvent =
+        serde_json::from_str(&buf).expect("v1 output must deserialize as CapturedEvent");
+    let data: common_types::RawEvent =
+        serde_json::from_str(&captured.data).expect("data field must deserialize as RawEvent");
+
+    assert_eq!(captured.uuid, wrapped.uuid);
+    assert_eq!(captured.distinct_id, wrapped.event.distinct_id);
+    assert_eq!(captured.event, wrapped.event.event);
+
+    (captured, data)
 }

--- a/rust/capture/tests/v1_sink_integration.rs
+++ b/rust/capture/tests/v1_sink_integration.rs
@@ -160,7 +160,10 @@ async fn v1_batch_round_trip() -> Result<()> {
     }
 
     event_names.sort();
-    assert_eq!(event_names, vec!["$identify", "$pageview", "button_clicked"]);
+    assert_eq!(
+        event_names,
+        vec!["$identify", "$pageview", "button_clicked"]
+    );
 
     topic.assert_empty();
     Ok(())
@@ -193,12 +196,9 @@ async fn v1_kafka_headers_round_trip() -> Result<()> {
         headers.get("distinct_id").map(|s| s.as_str()),
         Some("integ-user-headers")
     );
-    assert_eq!(
-        headers.get("event").map(|s| s.as_str()),
-        Some("$pageview")
-    );
-    assert!(headers.get("uuid").is_some());
-    assert!(headers.get("timestamp").is_some());
+    assert_eq!(headers.get("event").map(|s| s.as_str()), Some("$pageview"));
+    assert!(headers.contains_key("uuid"));
+    assert!(headers.contains_key("timestamp"));
 
     Ok(())
 }
@@ -240,11 +240,10 @@ async fn v1_dropped_event_not_published() -> Result<()> {
     let (sink, _monitor) = build_v1_sink(topic.topic_name()).await;
     let ctx = v1_test_context();
 
-    let wrapped = test_utils::realistic_pageview("integ-user-dropped")
-        .with_result(
-            capture::v1::analytics::types::EventResult::Drop,
-            Some("rate_limited"),
-        );
+    let wrapped = test_utils::realistic_pageview("integ-user-dropped").with_result(
+        capture::v1::analytics::types::EventResult::Drop,
+        Some("rate_limited"),
+    );
     let events: Vec<&(dyn Event + Send + Sync)> = vec![&wrapped];
 
     let results = sink.publish_batch(&ctx, &events).await;

--- a/rust/capture/tests/v1_sink_integration.rs
+++ b/rust/capture/tests/v1_sink_integration.rs
@@ -1,0 +1,255 @@
+//! Sink-level integration tests for the v1 analytics pipeline.
+//!
+//! These tests verify the end-to-end path:
+//!   WrappedEvent -> KafkaSink.publish_batch() -> real Kafka -> consumer -> CapturedEvent
+//!
+//! Requires Docker Kafka (same rig as legacy integration tests).
+//!
+//! TODO(v1): add HTTP-level integration tests (ServerHandle + POST /i/v1/general/events)
+//! and process_batch orchestration tests once the v1 HTTP router is merged into the
+//! main application and process_batch is fully implemented (currently a stub).
+
+#[path = "common/utils.rs"]
+mod utils;
+use utils::*;
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::Result;
+use common_types::{CapturedEvent, RawEvent};
+
+use capture::config::CaptureMode;
+use capture::v1::context::Context;
+use capture::v1::sinks::event::Event;
+use capture::v1::sinks::kafka::producer::KafkaProducer;
+use capture::v1::sinks::kafka::KafkaSink;
+use capture::v1::sinks::sink::Sink;
+use capture::v1::sinks::types::Outcome;
+use capture::v1::sinks::{Config, SinkName};
+use capture::v1::test_utils::{self, WrappedEventMut};
+
+fn v1_kafka_config(topic: &str) -> capture::v1::sinks::kafka::config::Config {
+    let env: std::collections::HashMap<String, String> = [
+        ("HOSTS", "kafka:9092"),
+        ("TOPIC_MAIN", topic),
+        ("TOPIC_HISTORICAL", topic),
+        ("TOPIC_OVERFLOW", topic),
+        ("TOPIC_DLQ", topic),
+        ("LINGER_MS", "0"),
+        ("COMPRESSION_CODEC", "none"),
+        ("MESSAGE_TIMEOUT_MS", "10000"),
+        ("QUEUE_MIB", "10"),
+    ]
+    .into_iter()
+    .map(|(k, v)| (k.to_string(), v.to_string()))
+    .collect();
+    envconfig::Envconfig::init_from_hashmap(&env).unwrap()
+}
+
+fn v1_test_context() -> Context {
+    let mut ctx = test_utils::test_context();
+    ctx.api_token = "phc_integration_test_token".to_string();
+    ctx
+}
+
+async fn build_v1_sink(topic: &str) -> (KafkaSink<KafkaProducer>, lifecycle::MonitorGuard) {
+    let mut manager = lifecycle::Manager::builder("v1-sink-integration-test")
+        .with_trap_signals(false)
+        .with_prestop_check(false)
+        .build();
+    let handle = manager.register("v1_kafka", lifecycle::ComponentOptions::new());
+    handle.report_healthy();
+    let monitor = manager.monitor_background();
+
+    let kafka_config = v1_kafka_config(topic);
+    let producer = KafkaProducer::new(
+        SinkName::Msk,
+        &kafka_config,
+        handle.clone(),
+        CaptureMode::Events.as_tag(),
+    )
+    .expect("failed to create v1 KafkaProducer");
+
+    let config = Config {
+        produce_timeout: Duration::from_secs(10),
+        kafka: kafka_config,
+    };
+
+    let sink = KafkaSink::new(
+        SinkName::Msk,
+        Arc::new(producer),
+        config,
+        CaptureMode::Events,
+        handle,
+    );
+
+    (sink, monitor)
+}
+
+// ---------------------------------------------------------------------------
+// Single realistic pageview round-trip
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn v1_single_pageview_round_trip() -> Result<()> {
+    setup_tracing();
+    let topic = EphemeralTopic::new().await;
+    let (sink, _monitor) = build_v1_sink(topic.topic_name()).await;
+    let ctx = v1_test_context();
+
+    let wrapped = test_utils::realistic_pageview("integ-user-1");
+    let events: Vec<&(dyn Event + Send + Sync)> = vec![&wrapped];
+
+    let results = sink.publish_batch(&ctx, &events).await;
+
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].key(), wrapped.uuid);
+    assert_eq!(results[0].outcome(), Outcome::Success);
+
+    let event_json = topic.next_event()?;
+    let captured: CapturedEvent = serde_json::from_value(event_json)?;
+    assert_eq!(captured.uuid, wrapped.uuid);
+    assert_eq!(captured.distinct_id, "integ-user-1");
+    assert_eq!(captured.event, "$pageview");
+    assert_eq!(captured.token, "phc_integration_test_token");
+
+    let data: RawEvent = serde_json::from_str(&captured.data)?;
+    assert_eq!(data.event, "$pageview");
+    assert_eq!(data.properties["$browser"], "Chrome");
+    assert_eq!(
+        data.properties["$session_id"],
+        "01jq9abc-def0-1234-5678-9abcdef01234"
+    );
+    assert_eq!(data.properties["$process_person_profile"], true);
+    assert_eq!(data.properties["custom_prop"], 42);
+
+    topic.assert_empty();
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// 3-event realistic batch round-trip
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn v1_batch_round_trip() -> Result<()> {
+    setup_tracing();
+    let topic = EphemeralTopic::new().await;
+    let (sink, _monitor) = build_v1_sink(topic.topic_name()).await;
+    let ctx = v1_test_context();
+
+    let batch = test_utils::realistic_batch();
+    let events: Vec<&(dyn Event + Send + Sync)> = vec![&batch[0], &batch[1], &batch[2]];
+
+    let results = sink.publish_batch(&ctx, &events).await;
+
+    assert_eq!(results.len(), 3);
+    for r in &results {
+        assert_eq!(r.outcome(), Outcome::Success);
+    }
+
+    let mut event_names = Vec::new();
+    for _ in 0..3 {
+        let json = topic.next_event()?;
+        let captured: CapturedEvent = serde_json::from_value(json)?;
+        let data: RawEvent = serde_json::from_str(&captured.data)?;
+        assert_eq!(captured.distinct_id, "user-42");
+        assert_eq!(captured.token, "phc_integration_test_token");
+        event_names.push(data.event.clone());
+    }
+
+    event_names.sort();
+    assert_eq!(event_names, vec!["$identify", "$pageview", "button_clicked"]);
+
+    topic.assert_empty();
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Verify Kafka headers round-trip
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn v1_kafka_headers_round_trip() -> Result<()> {
+    setup_tracing();
+    let topic = EphemeralTopic::new().await;
+    let (sink, _monitor) = build_v1_sink(topic.topic_name()).await;
+    let ctx = v1_test_context();
+
+    let wrapped = test_utils::realistic_pageview("integ-user-headers");
+    let events: Vec<&(dyn Event + Send + Sync)> = vec![&wrapped];
+
+    let results = sink.publish_batch(&ctx, &events).await;
+    assert_eq!(results[0].outcome(), Outcome::Success);
+
+    let (_event_json, headers) = topic.next_message_with_headers()?;
+
+    assert_eq!(
+        headers.get("token").map(|s| s.as_str()),
+        Some("phc_integration_test_token")
+    );
+    assert_eq!(
+        headers.get("distinct_id").map(|s| s.as_str()),
+        Some("integ-user-headers")
+    );
+    assert_eq!(
+        headers.get("event").map(|s| s.as_str()),
+        Some("$pageview")
+    );
+    assert!(headers.get("uuid").is_some());
+    assert!(headers.get("timestamp").is_some());
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Partition key verification
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn v1_partition_key_round_trip() -> Result<()> {
+    setup_tracing();
+    let topic = EphemeralTopic::new().await;
+    let (sink, _monitor) = build_v1_sink(topic.topic_name()).await;
+    let ctx = v1_test_context();
+
+    let wrapped = test_utils::realistic_pageview("integ-user-pkey");
+    let events: Vec<&(dyn Event + Send + Sync)> = vec![&wrapped];
+
+    let results = sink.publish_batch(&ctx, &events).await;
+    assert_eq!(results[0].outcome(), Outcome::Success);
+
+    let key = topic.next_message_key()?;
+    assert_eq!(
+        key.as_deref(),
+        Some("phc_integration_test_token:integ-user-pkey")
+    );
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Dropped event not published
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn v1_dropped_event_not_published() -> Result<()> {
+    setup_tracing();
+    let topic = EphemeralTopic::new().await;
+    let (sink, _monitor) = build_v1_sink(topic.topic_name()).await;
+    let ctx = v1_test_context();
+
+    let wrapped = test_utils::realistic_pageview("integ-user-dropped")
+        .with_result(
+            capture::v1::analytics::types::EventResult::Drop,
+            Some("rate_limited"),
+        );
+    let events: Vec<&(dyn Event + Send + Sync)> = vec![&wrapped];
+
+    let results = sink.publish_batch(&ctx, &events).await;
+    assert!(results.is_empty());
+
+    topic.assert_empty();
+    Ok(())
+}


### PR DESCRIPTION
## Problem
Stacked PR, based on [this parent PR](https://github.com/PostHog/posthog/pull/53649) this is 6th in Sinks series.

Implements the new `v1::sinks::Event` serialization contract for the v1 analytics event types (request's `v1::Context`, `v1::analytics::WrappedEvent` and friends) to produce the new `v1::analytics::IngestionEvent` which is in parity with legacy `CapturedEvent` shape for ingestion backend compatibility, as verified by the new test suite.

This step includes some DIY `event.properties` surgery:

At this stage, to avoid changing the downstream schema contract, we're injecting (with legacy prop renames!) the new `v1::analytics::Event`'s  `event.option` props, if present, into the legacy `event.properties` map as ingestion workers expect. This is a bit hacky but well tested, and shouldn't cause trouble at this step. The incoming v1 events are well validated by this step.

This PR includes a couple of other loose ends this unit of work surfaced:
* Address some corner cases in partition key resolution on `WrappedEvent`
* Expose a few more Kafka producer configs that will be handy to have; set prod defaults where practical to avoid mismatches
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
* Implement SinkEvent serialization contract for v1 analytics events
* Full validation test suite to match output parity with `CapturedEvent`
* Handle a few partition key resolution corner cases
* Expose a few missing Kafka produce config values 
* Small spot fixes for previous oversights, footguns
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally and in CI. Integration test suite coming in a follow on after this series lands (too big to include here)
<!-- Briefly describe the steps you took, and what steps reviewers must take to get to where changes are, and what is the expected behavior. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
N/A
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update
N/A
<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
