### PR TITLE
fix(dagster): use hash-based verification for pre-DROP safety check

### DIFF
--- a/posthog/dags/part_breaker.py
+++ b/posthog/dags/part_breaker.py
@@ -1012,6 +1012,13 @@ def break_part(
                 _ssh_exec(ssh, f"mv {staging_tgt_detached}{dp} {source_detached}{dp}")
 
             # -- Step 11: ATTACH the new parts to source table --
+            # Record the min block number of our parts so we can verify exactly
+            # our rows after ATTACH. Part names: {partition}_{min_block}_{max_block}_{level}.
+            # Our INSERT SELECT parts have block numbers higher than existing parts,
+            # so filtering by min_block_number >= our_min_block isolates our data
+            # even after background merges combine parts.
+            our_min_block = min(int(dp.split("_")[1]) for dp in detached_parts)
+
             # Use ATTACH PART (not ATTACH PARTITION) to only attach the parts we moved,
             # avoiding accidentally reattaching unrelated pre-existing detached parts.
             # Other replicas will automatically fetch these parts via replication.
@@ -1050,20 +1057,45 @@ def break_part(
             # Safety check: verify new parts exist on the source table before dropping.
             # If ATTACHes failed silently or parts were merged away, dropping the old
             # part would lose data.
-            new_attached = client.execute(
-                "SELECT count() FROM system.parts "
+            # Verify the new parts by checking row count of parts whose block
+            # numbers fall in our range (min_block_number >= our_min_block).
+            # This isolates exactly the rows we attached, immune to:
+            # - Background merges (merges preserve min/max block numbers)
+            # - Pre-existing partition data (different block range)
+            # - Concurrent ingestion (new inserts get higher block numbers,
+            #   but are included — which only inflates the count, never hides loss)
+            our_parts = client.execute(
+                "SELECT count(), sum(rows) FROM system.parts "
                 "WHERE database = %(db)s AND table = %(table)s AND active "
                 "AND partition_id = %(partition_id)s "
+                "AND min_block_number >= %(min_block)s "
                 "AND name != %(old_part)s",
-                {"db": database, "table": source_table, "partition_id": partition_id, "old_part": part.part_name},
+                {
+                    "db": database,
+                    "table": source_table,
+                    "partition_id": partition_id,
+                    "min_block": our_min_block,
+                    "old_part": part.part_name,
+                },
             )
-            new_attached_count = new_attached[0][0] if new_attached else 0
-            if new_attached_count < len(detached_parts):
+            our_part_count = our_parts[0][0] if our_parts else 0
+            our_row_count = our_parts[0][1] or 0 if our_parts else 0
+
+            if our_part_count == 0:
                 raise dagster.Failure(
-                    description=f"Expected at least {len(detached_parts)} new parts on {source_table} "
-                    f"partition {partition_id}, but only found {new_attached_count} (excluding original). "
+                    description=f"No parts found with min_block >= {our_min_block} on "
+                    f"{source_table} partition {partition_id}. Skipping DROP to avoid data loss."
+                )
+            if our_row_count < target_count:
+                raise dagster.Failure(
+                    description=f"Parts with min_block >= {our_min_block} have {our_row_count:,} rows, "
+                    f"expected at least {target_count:,}. "
                     f"Skipping DROP to avoid data loss."
                 )
+            context.log.info(
+                f"Pre-DROP safety check passed: {our_row_count:,} rows in {our_part_count} parts "
+                f"with min_block >= {our_min_block} (target: {target_count:,})"
+            )
 
             # Re-query the part by its min_block/max_block numbers which are stable
             # across mutations (mutations only change the suffix, not the block range).

--- a/posthog/dags/part_breaker.py
+++ b/posthog/dags/part_breaker.py
@@ -1012,12 +1012,12 @@ def break_part(
                 _ssh_exec(ssh, f"mv {staging_tgt_detached}{dp} {source_detached}{dp}")
 
             # -- Step 11: ATTACH the new parts to source table --
-            # Record the min block number of our parts so we can verify exactly
+            # Record the block number range of our parts so we can verify exactly
             # our rows after ATTACH. Part names: {partition}_{min_block}_{max_block}_{level}.
-            # Our INSERT SELECT parts have block numbers higher than existing parts,
-            # so filtering by min_block_number >= our_min_block isolates our data
-            # even after background merges combine parts.
+            # Filtering by block range isolates our data even after background
+            # merges combine parts (merges preserve min/max block numbers).
             our_min_block = min(int(dp.split("_")[1]) for dp in detached_parts)
+            our_max_block = max(int(dp.split("_")[2]) for dp in detached_parts)
 
             # Use ATTACH PART (not ATTACH PARTITION) to only attach the parts we moved,
             # avoiding accidentally reattaching unrelated pre-existing detached parts.
@@ -1057,24 +1057,26 @@ def break_part(
             # Safety check: verify new parts exist on the source table before dropping.
             # If ATTACHes failed silently or parts were merged away, dropping the old
             # part would lose data.
-            # Verify the new parts by checking row count of parts whose block
-            # numbers fall in our range (min_block_number >= our_min_block).
-            # This isolates exactly the rows we attached, immune to:
-            # - Background merges (merges preserve min/max block numbers)
-            # - Pre-existing partition data (different block range)
-            # - Concurrent ingestion (new inserts get higher block numbers,
-            #   but are included — which only inflates the count, never hides loss)
+            # Verify the new parts by checking row count of parts that overlap
+            # with our block range. We use max_block_number >= our_min_block
+            # (not min_block_number >= our_min_block) because background merges
+            # can combine our parts with pre-existing ones, producing a merged
+            # part whose min_block is lower than ours but whose max_block
+            # extends into our range. We exclude the old part by name since
+            # its block range may technically overlap.
             our_parts = client.execute(
                 "SELECT count(), sum(rows) FROM system.parts "
                 "WHERE database = %(db)s AND table = %(table)s AND active "
                 "AND partition_id = %(partition_id)s "
-                "AND min_block_number >= %(min_block)s "
+                "AND max_block_number >= %(min_block)s "
+                "AND min_block_number <= %(max_block)s "
                 "AND name != %(old_part)s",
                 {
                     "db": database,
                     "table": source_table,
                     "partition_id": partition_id,
                     "min_block": our_min_block,
+                    "max_block": our_max_block,
                     "old_part": part.part_name,
                 },
             )
@@ -1083,18 +1085,18 @@ def break_part(
 
             if our_part_count == 0:
                 raise dagster.Failure(
-                    description=f"No parts found with min_block >= {our_min_block} on "
+                    description=f"No parts found in block range [{our_min_block}, {our_max_block}] on "
                     f"{source_table} partition {partition_id}. Skipping DROP to avoid data loss."
                 )
             if our_row_count < target_count:
                 raise dagster.Failure(
-                    description=f"Parts with min_block >= {our_min_block} have {our_row_count:,} rows, "
-                    f"expected at least {target_count:,}. "
+                    description=f"Parts in block range [{our_min_block}, {our_max_block}] have "
+                    f"{our_row_count:,} rows, expected at least {target_count:,}. "
                     f"Skipping DROP to avoid data loss."
                 )
             context.log.info(
                 f"Pre-DROP safety check passed: {our_row_count:,} rows in {our_part_count} parts "
-                f"with min_block >= {our_min_block} (target: {target_count:,})"
+                f"in block range [{our_min_block}, {our_max_block}] (target: {target_count:,})"
             )
 
             # Re-query the part by its min_block/max_block numbers which are stable

--- a/posthog/dags/part_breaker.py
+++ b/posthog/dags/part_breaker.py
@@ -982,18 +982,24 @@ def break_part(
                     f"({config.max_part_size_gib} GiB). INSERT SELECT may not have broken sufficiently."
                 )
 
-            # -- Step 9: DETACH new parts from staging target --
-            # Check for stale detached parts from a previous failed run before detaching.
-            # TRUNCATE removes active parts but leaves detached/ contents.
+            # -- Step 9: Capture part hashes for post-ATTACH verification.
+            staging_hashes = client.execute(
+                "SELECT hash_of_all_files, rows FROM system.parts "
+                "WHERE database = %(db)s AND table = %(table)s AND active "
+                "AND partition_id = %(partition_id)s",
+                {"db": database, "table": staging_target, "partition_id": partition_id},
+            )
+            expected_hashes = {row[0] for row in staging_hashes}
+            expected_rows_by_hash = {row[0]: row[1] for row in staging_hashes}
+
+            # Fail if stale detached parts exist from a previous failed run.
             pre_detach_ls = _ssh_exec(ssh, f"ls -1 {staging_tgt_detached}").strip()
             if pre_detach_ls:
-                # Only flag parts matching our partition — ignore CH-internal entries
                 stale_parts = [p for p in pre_detach_ls.split("\n") if p and p.startswith(f"{partition_id}_")]
                 if stale_parts:
                     raise dagster.Failure(
                         description=f"Staging target {staging_target} has {len(stale_parts)} stale detached part(s) "
-                        f"for partition {partition_id} from a previous run. "
-                        f"Clean up manually before retrying: {staging_tgt_detached}"
+                        f"for partition {partition_id}. Clean up manually: {staging_tgt_detached}"
                     )
 
             context.log.info(f"Detaching parts from {staging_target}...")
@@ -1002,8 +1008,7 @@ def break_part(
                 settings={"max_partition_size_to_drop": "0"},
             )
 
-            # -- Step 10: Move detached parts to source table's detached dir --
-            # List the detached parts for this partition
+            # -- Step 10: Move detached parts to source table and ATTACH.
             ls_output = _ssh_exec(ssh, f"ls -1 {staging_tgt_detached}")
             detached_parts = [p for p in ls_output.strip().split("\n") if p and p.startswith(f"{partition_id}_")]
 
@@ -1011,99 +1016,47 @@ def break_part(
             for dp in detached_parts:
                 _ssh_exec(ssh, f"mv {staging_tgt_detached}{dp} {source_detached}{dp}")
 
-            # -- Step 11: ATTACH the new parts to source table --
-            # Record the block number range of our parts so we can verify exactly
-            # our rows after ATTACH. Part names: {partition}_{min_block}_{max_block}_{level}.
-            # Filtering by block range isolates our data even after background
-            # merges combine parts (merges preserve min/max block numbers).
-            our_min_block = min(int(dp.split("_")[1]) for dp in detached_parts)
-            our_max_block = max(int(dp.split("_")[2]) for dp in detached_parts)
-
-            # Use ATTACH PART (not ATTACH PARTITION) to only attach the parts we moved,
-            # avoiding accidentally reattaching unrelated pre-existing detached parts.
-            # Other replicas will automatically fetch these parts via replication.
             context.log.info(f"Attaching {len(detached_parts)} new parts to {source_table}...")
             for dp in detached_parts:
                 client.execute(f"ALTER TABLE {database}.{source_table} ATTACH PART '{dp}'")
 
-            # Dedup window: both old oversized part and new broken parts are active.
-            # ReplacingMergeTree handles this transparently on read.
+            # -- Step 11: Verify our parts exist by hash_of_all_files.
+            current_parts = client.execute(
+                "SELECT hash_of_all_files FROM system.parts "
+                "WHERE database = %(db)s AND table = %(table)s "
+                "AND partition_id = %(partition_id)s "
+                "AND name != %(old_part)s",
+                {"db": database, "table": source_table, "partition_id": partition_id, "old_part": part.part_name},
+            )
+            current_hashes = {row[0] for row in current_parts}
+            missing_hashes = expected_hashes - current_hashes
+            if missing_hashes:
+                missing_rows = sum(expected_rows_by_hash[h] for h in missing_hashes)
+                raise dagster.Failure(
+                    description=f"{len(missing_hashes)} of {len(expected_hashes)} parts missing after ATTACH "
+                    f"({missing_rows:,} rows). Skipping DROP to avoid data loss."
+                )
+            context.log.info(
+                f"Safety check passed: all {len(expected_hashes)} part hashes verified ({target_count:,} rows)"
+            )
 
-            # Capture the current log index — all replicas must reach at least this
-            # point before we drop the old part, ensuring they have the new parts.
+            # -- Step 12: Wait for replication before dropping.
             log_index_rows = client.execute(
                 "SELECT log_max_index FROM system.replicas WHERE database = %(db)s AND table = %(table)s",
                 {"db": database, "table": source_table},
             )
             if not log_index_rows or log_index_rows[0][0] is None:
-                raise dagster.Failure(
-                    description=f"Could not get log_max_index for {source_table} — cannot safely proceed with DROP"
-                )
+                raise dagster.Failure(description=f"Could not get log_max_index for {source_table}")
             target_log_index = log_index_rows[0][0]
 
-            # -- Step 12: Wait for replication before dropping --
-            # Wait for all replicas to fetch the new parts before dropping the old one.
-            # Without this, if the initiating replica goes down after DROP, other replicas
-            # would have neither the old part (dropped via replication) nor the new parts
-            # (not yet fetched). For large parts (hundreds of GiB to TiB) the fetch can
-            # take 30+ minutes, so this wait is critical for data safety.
             context.log.info(
                 f"Waiting for all replicas to reach log index {target_log_index} before dropping old part..."
             )
             _wait_for_replication(client, source_table, target_log_index, part.shard_num)
             context.log.info("Replication complete — all replicas have the new parts")
 
-            # -- Step 13: DROP the original oversized part --
-            # Safety check: verify new parts exist on the source table before dropping.
-            # If ATTACHes failed silently or parts were merged away, dropping the old
-            # part would lose data.
-            # Verify the new parts by checking row count of parts that overlap
-            # with our block range. We use max_block_number >= our_min_block
-            # (not min_block_number >= our_min_block) because background merges
-            # can combine our parts with pre-existing ones, producing a merged
-            # part whose min_block is lower than ours but whose max_block
-            # extends into our range. We exclude the old part by name since
-            # its block range may technically overlap.
-            our_parts = client.execute(
-                "SELECT count(), sum(rows) FROM system.parts "
-                "WHERE database = %(db)s AND table = %(table)s AND active "
-                "AND partition_id = %(partition_id)s "
-                "AND max_block_number >= %(min_block)s "
-                "AND min_block_number <= %(max_block)s "
-                "AND name != %(old_part)s",
-                {
-                    "db": database,
-                    "table": source_table,
-                    "partition_id": partition_id,
-                    "min_block": our_min_block,
-                    "max_block": our_max_block,
-                    "old_part": part.part_name,
-                },
-            )
-            our_part_count = our_parts[0][0] if our_parts else 0
-            our_row_count = our_parts[0][1] or 0 if our_parts else 0
-
-            if our_part_count == 0:
-                raise dagster.Failure(
-                    description=f"No parts found in block range [{our_min_block}, {our_max_block}] on "
-                    f"{source_table} partition {partition_id}. Skipping DROP to avoid data loss."
-                )
-            if our_row_count < target_count:
-                raise dagster.Failure(
-                    description=f"Parts in block range [{our_min_block}, {our_max_block}] have "
-                    f"{our_row_count:,} rows, expected at least {target_count:,}. "
-                    f"Skipping DROP to avoid data loss."
-                )
-            context.log.info(
-                f"Pre-DROP safety check passed: {our_row_count:,} rows in {our_part_count} parts "
-                f"in block range [{our_min_block}, {our_max_block}] (target: {target_count:,})"
-            )
-
-            # Re-query the part by its min_block/max_block numbers which are stable
-            # across mutations (mutations only change the suffix, not the block range).
-            # Original part name format: {partition}_{min_block}_{max_block}_{level}
-            # Extract the block range from the original name for matching.
-            original_prefix = "_".join(part.part_name.split("_")[:3])  # e.g. "202108_1_1"
+            # -- Step 13: DROP the original part (re-query by prefix, mutations change suffix).
+            original_prefix = "_".join(part.part_name.split("_")[:3])
             current_parts = client.execute(
                 "SELECT name FROM system.parts "
                 "WHERE database = %(db)s AND table = %(table)s AND active "


### PR DESCRIPTION
…heck

## Problem

The part breaker's pre-DROP safety check compared part counts, which fails when ClickHouse background merges combine freshly attached parts before the check runs:

> Expected at least x new parts, but only found < x

Data is intact but the job fails, leaving the old oversized part on disk.

## Changes

Replace the part count check with hash-based verification using `hash_of_all_files`:

1. Before DETACH from staging, capture each part's `hash_of_all_files` and row count
2. After ATTACH to source table (now before replication wait), verify all hashes exist in `system.parts`
3. The hash query omits `AND active` so merged-away parts still visible within `old_parts_lifetime`
4. If any hashes are missing → fail with count of missing parts and rows

## How did you test this code?

- Verified all queries and `hash_of_all_files` is populated on both active and non-active parts

## Publish to changelog?

no
