### PR TITLE
feat(temporal): extend ingestion-acceptance-tests timeout logging

### DIFF
--- a/posthog/temporal/ingestion_acceptance_test/activities.py
+++ b/posthog/temporal/ingestion_acceptance_test/activities.py
@@ -54,15 +54,18 @@ async def run_ingestion_acceptance_tests() -> dict:
     tests = discover_tests()
     client = PostHogClient(config, posthog_sdk)
     running_tests = RunningTests()
+    executor = ThreadPoolExecutor()
     try:
-        with ThreadPoolExecutor() as executor:
-            result: TestSuiteResult = await asyncio.wait_for(
-                asyncio.to_thread(run_tests, config, tests, client, executor, running_tests),
-                timeout=config.activity_timeout_seconds,
-            )
+        result: TestSuiteResult = await asyncio.wait_for(
+            asyncio.to_thread(run_tests, config, tests, client, executor, running_tests),
+            timeout=config.activity_timeout_seconds,
+        )
     except TimeoutError:
-        send_slack_timeout_notification(config, running_tests=running_tests.snapshot())
+        still_running = running_tests.snapshot_with_polls(client)
+        send_slack_timeout_notification(config, running_tests=still_running)
         raise
+    finally:
+        executor.shutdown(wait=False, cancel_futures=True)
 
     logger.info(
         "Ingestion acceptance tests completed",

--- a/posthog/temporal/ingestion_acceptance_test/client.py
+++ b/posthog/temporal/ingestion_acceptance_test/client.py
@@ -3,6 +3,7 @@
 import json
 import time
 import uuid
+import threading
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
@@ -74,6 +75,8 @@ class PostHogClient:
         # ClickHouse ORDER BY uses toDate(timestamp) (day granularity), so filtering by date
         # is sufficient. We subtract 1 day to handle clock skew between test machine and server.
         self._test_start_date = (datetime.now(UTC) - timedelta(days=1)).date()
+        self._pending_polls: dict[int, str] = {}
+        self._pending_polls_lock = threading.Lock()
 
     def _retry_on_error(self, fn: Callable[[], T], description: str) -> T:
         """Retry a function on transient errors with exponential backoff.
@@ -240,6 +243,11 @@ class PostHogClient:
         """Shutdown the client and flush any pending events."""
         self._posthog.shutdown()
 
+    def pending_polls_snapshot(self) -> dict[int, str]:
+        """Return a snapshot of currently active polls, keyed by thread ID."""
+        with self._pending_polls_lock:
+            return dict(self._pending_polls)
+
     # Polling configuration
     POLL_BACKOFF_FACTOR = 1.5
     POLL_MAX_INTERVAL_SECONDS = 60.0
@@ -252,59 +260,67 @@ class PostHogClient:
         """Poll until fetch_fn returns a non-None result or timeout.
 
         Sleeps before each request with exponential backoff to reduce query pressure
-        and increase likelihood of success on first call.
+        and increase likelihood of success on first call. Transient connection errors
+        are caught and logged, allowing polling to continue.
         """
+        tid = threading.get_ident()
+        with self._pending_polls_lock:
+            self._pending_polls[tid] = description
         start_time = time.time()
         current_interval = self.config.poll_interval_seconds
         attempt = 0
 
-        while time.time() - start_time < self.config.event_timeout_seconds:
-            attempt += 1
-            time.sleep(current_interval)
-            if attempt > 1:
-                elapsed = time.time() - start_time
-                logger.info(
-                    "Polling attempt",
-                    attempt=attempt,
-                    description=description,
-                    elapsed_seconds=round(elapsed, 1),
-                    next_interval_seconds=round(current_interval, 1),
+        try:
+            while time.time() - start_time < self.config.event_timeout_seconds:
+                attempt += 1
+                time.sleep(current_interval)
+                if attempt > 1:
+                    elapsed = time.time() - start_time
+                    logger.info(
+                        "Polling attempt",
+                        attempt=attempt,
+                        description=description,
+                        elapsed_seconds=round(elapsed, 1),
+                        next_interval_seconds=round(current_interval, 1),
+                    )
+                try:
+                    result = fetch_fn()
+                except (InternalCHQueryError, EOFError, ConnectionError, OSError) as e:
+                    if isinstance(e, InternalCHQueryError) and e.code != ErrorCodes.TOO_MANY_SIMULTANEOUS_QUERIES:
+                        raise
+                    logger.warning(
+                        "Transient error during polling, will retry",
+                        error=str(e),
+                        error_type=type(e).__name__,
+                        description=description,
+                        attempt=attempt,
+                    )
+                    result = None
+                if result is not None:
+                    elapsed = time.time() - start_time
+                    logger.info(
+                        "Polling succeeded",
+                        description=description,
+                        attempt=attempt,
+                        elapsed_seconds=round(elapsed, 1),
+                    )
+                    return result
+                current_interval = min(
+                    current_interval * self.POLL_BACKOFF_FACTOR,
+                    self.POLL_MAX_INTERVAL_SECONDS,
+                    self.config.event_timeout_seconds - (time.time() - start_time),
                 )
-            try:
-                result = fetch_fn()
-            except (InternalCHQueryError, EOFError, ConnectionError, OSError) as e:
-                if isinstance(e, InternalCHQueryError) and e.code != ErrorCodes.TOO_MANY_SIMULTANEOUS_QUERIES:
-                    raise
-                logger.warning(
-                    "Transient error during polling, will retry",
-                    error=str(e),
-                    error_type=type(e).__name__,
-                    description=description,
-                    attempt=attempt,
-                )
-                result = None
-            if result is not None:
-                elapsed = time.time() - start_time
-                logger.info(
-                    "Polling succeeded",
-                    description=description,
-                    attempt=attempt,
-                    elapsed_seconds=round(elapsed, 1),
-                )
-                return result
-            current_interval = min(
-                current_interval * self.POLL_BACKOFF_FACTOR,
-                self.POLL_MAX_INTERVAL_SECONDS,
-                self.config.event_timeout_seconds - (time.time() - start_time),
-            )
 
-        logger.warning(
-            "Polling timed out",
-            description=description,
-            timeout_seconds=self.config.event_timeout_seconds,
-            attempts=attempt,
-        )
-        return None
+            logger.warning(
+                "Polling timed out",
+                description=description,
+                timeout_seconds=self.config.event_timeout_seconds,
+                attempts=attempt,
+            )
+            return None
+        finally:
+            with self._pending_polls_lock:
+                self._pending_polls.pop(tid, None)
 
     def _fetch_event_by_uuid(self, event_uuid: str) -> CapturedEvent | None:
         """Fetch an event by UUID via direct ClickHouse query.

--- a/posthog/temporal/ingestion_acceptance_test/runner.py
+++ b/posthog/temporal/ingestion_acceptance_test/runner.py
@@ -17,24 +17,47 @@ from .test_cases_discovery import TestCase
 logger = structlog.get_logger(__name__)
 
 
+@dataclass
+class RunningTestInfo:
+    """Snapshot of a running test with its current pending poll description."""
+
+    name: str
+    pending_poll: str | None
+
+
 class RunningTests:
-    """Thread-safe tracker for currently running tests."""
+    """Thread-safe tracker for currently running tests, keyed by thread ID for
+    correlation with per-thread pending poll state in PostHogClient."""
 
     def __init__(self) -> None:
-        self._tests: set[str] = set()
+        self._tests: dict[int, str] = {}
         self._lock = threading.Lock()
 
     def add(self, test_name: str) -> None:
         with self._lock:
-            self._tests.add(test_name)
+            self._tests[threading.get_ident()] = test_name
 
     def remove(self, test_name: str) -> None:
         with self._lock:
-            self._tests.discard(test_name)
+            self._tests.pop(threading.get_ident(), None)
 
     def snapshot(self) -> list[str]:
         with self._lock:
-            return sorted(self._tests)
+            return sorted(self._tests.values())
+
+    def snapshot_with_polls(self, client: PostHogClient) -> list[RunningTestInfo]:
+        """Snapshot running tests correlated with their pending poll descriptions.
+
+        Joins by thread ID: each test runs in its own thread, and the client
+        tracks which poll description each thread is currently blocked on.
+        """
+        with self._lock:
+            tests_by_tid = dict(self._tests)
+        polls_by_tid = client.pending_polls_snapshot()
+        return [
+            RunningTestInfo(name=name, pending_poll=polls_by_tid.get(tid))
+            for tid, name in sorted(tests_by_tid.items(), key=lambda x: x[1])
+        ]
 
 
 @dataclass

--- a/posthog/temporal/ingestion_acceptance_test/slack.py
+++ b/posthog/temporal/ingestion_acceptance_test/slack.py
@@ -7,6 +7,7 @@ import structlog
 
 from .config import Config
 from .results import TestSuiteResult
+from .runner import RunningTestInfo
 
 logger = structlog.get_logger(__name__)
 
@@ -115,12 +116,13 @@ def _build_context_block(config: Config, result: TestSuiteResult) -> dict[str, A
     }
 
 
-def send_slack_timeout_notification(config: Config, running_tests: list[str] | None = None) -> bool:
+def send_slack_timeout_notification(config: Config, running_tests: list[RunningTestInfo] | None = None) -> bool:
     """Send a timeout notification to Slack via incoming webhook.
 
     Args:
         config: Configuration containing the Slack webhook URL.
-        running_tests: List of test names that were still running when the timeout occurred.
+        running_tests: List of RunningTestInfo with test names and their pending
+            poll descriptions (what each test was waiting for in ClickHouse).
 
     Returns:
         True if notification was sent successfully or skipped, False on send failure.
@@ -145,7 +147,8 @@ def send_slack_timeout_notification(config: Config, running_tests: list[str] | N
                     "text": (
                         f":globe_with_meridians: Env: {config.api_host} | "
                         f":file_folder: Team: {config.team_id} | "
-                        f":stopwatch: Timeout: {config.activity_timeout_seconds}s"
+                        f":stopwatch: Timeout: {config.activity_timeout_seconds}s | "
+                        f":key: Token: `{config.project_api_key[:10]}...`"
                     ),
                 },
             ],
@@ -153,7 +156,13 @@ def send_slack_timeout_notification(config: Config, running_tests: list[str] | N
     ]
 
     if running_tests:
-        test_list = "\n".join(f"• {name}" for name in running_tests)
+        lines = []
+        for info in running_tests:
+            line = f"• {info.name}"
+            if info.pending_poll:
+                line += f" — waiting for: {info.pending_poll}"
+            lines.append(line)
+        test_list = "\n".join(lines)
         blocks.append(
             {
                 "type": "section",

--- a/posthog/temporal/tests/ingestion_acceptance_test/test_runner.py
+++ b/posthog/temporal/tests/ingestion_acceptance_test/test_runner.py
@@ -4,7 +4,13 @@ import pytest
 from unittest.mock import MagicMock, patch
 
 from posthog.temporal.ingestion_acceptance_test.config import Config
-from posthog.temporal.ingestion_acceptance_test.runner import AcceptanceTest, RunningTests, TestContext, run_tests
+from posthog.temporal.ingestion_acceptance_test.runner import (
+    AcceptanceTest,
+    RunningTestInfo,
+    RunningTests,
+    TestContext,
+    run_tests,
+)
 from posthog.temporal.ingestion_acceptance_test.test_cases_discovery import TestCase
 
 
@@ -187,3 +193,40 @@ class TestRunTests:
         run_tests(config, tests, mock_client, mock_executor, running_tests)
 
         assert mock_executor.submit.call_count == 3
+
+
+class TestSnapshotWithPolls:
+    @pytest.mark.parametrize(
+        "tests_by_tid, polls_by_tid, expected",
+        [
+            (
+                {100: "TestA::test_one", 200: "TestB::test_two"},
+                {100: "event UUID 'abc-123'", 200: "person with distinct_id 'xyz-456'"},
+                [
+                    RunningTestInfo("TestA::test_one", "event UUID 'abc-123'"),
+                    RunningTestInfo("TestB::test_two", "person with distinct_id 'xyz-456'"),
+                ],
+            ),
+            (
+                {100: "TestA::test_one", 200: "TestB::test_two"},
+                {100: "event UUID 'abc-123'"},
+                [
+                    RunningTestInfo("TestA::test_one", "event UUID 'abc-123'"),
+                    RunningTestInfo("TestB::test_two", None),
+                ],
+            ),
+            ({}, {}, []),
+        ],
+        ids=["all_polls_matched", "partial_poll_match", "empty"],
+    )
+    def test_snapshot_with_polls(
+        self,
+        tests_by_tid: dict[int, str],
+        polls_by_tid: dict[int, str],
+        expected: list[RunningTestInfo],
+    ) -> None:
+        rt = RunningTests()
+        rt._tests = tests_by_tid
+        mock_client = MagicMock()
+        mock_client.pending_polls_snapshot.return_value = polls_by_tid
+        assert rt.snapshot_with_polls(mock_client) == expected

--- a/posthog/temporal/tests/ingestion_acceptance_test/test_slack.py
+++ b/posthog/temporal/tests/ingestion_acceptance_test/test_slack.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock, patch
 
 from posthog.temporal.ingestion_acceptance_test.config import Config
 from posthog.temporal.ingestion_acceptance_test.results import TestResult, TestSuiteResult
+from posthog.temporal.ingestion_acceptance_test.runner import RunningTestInfo
 from posthog.temporal.ingestion_acceptance_test.slack import send_slack_notification, send_slack_timeout_notification
 
 
@@ -205,7 +206,7 @@ class TestSendSlackTimeoutNotification:
         assert "Timed Out" in header_text
 
     @patch("posthog.temporal.ingestion_acceptance_test.slack.requests.post")
-    def test_payload_contains_environment_and_timeout_info(self, mock_post: MagicMock, config: Config) -> None:
+    def test_payload_contains_environment_timeout_and_token_info(self, mock_post: MagicMock, config: Config) -> None:
         mock_post.return_value.raise_for_status = MagicMock()
 
         send_slack_timeout_notification(config)
@@ -215,6 +216,7 @@ class TestSendSlackTimeoutNotification:
         assert "test.posthog.com" in context_text
         assert "12345" in context_text
         assert "600s" in context_text
+        assert "phc_test_k..." in context_text
 
     @patch("posthog.temporal.ingestion_acceptance_test.slack.requests.post")
     def test_does_nothing_when_no_webhook_url(self, mock_post: MagicMock) -> None:
@@ -229,3 +231,47 @@ class TestSendSlackTimeoutNotification:
 
         assert result is True
         mock_post.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "running_tests, expected_in_text, not_expected_in_text",
+        [
+            (
+                [
+                    RunningTestInfo(name="TestAlias::test_alias", pending_poll="person with distinct_id 'abc-123'"),
+                    RunningTestInfo(name="TestMerge::test_merge", pending_poll="events for person 'person-789'"),
+                ],
+                [
+                    "TestAlias::test_alias",
+                    "person with distinct_id 'abc-123'",
+                    "TestMerge::test_merge",
+                    "Still running (2)",
+                ],
+                [],
+            ),
+            (
+                [RunningTestInfo(name="TestBasic::test_capture", pending_poll=None)],
+                ["TestBasic::test_capture"],
+                ["waiting for"],
+            ),
+        ],
+        ids=["with_poll_descriptions", "without_poll_description"],
+    )
+    @patch("posthog.temporal.ingestion_acceptance_test.slack.requests.post")
+    def test_payload_renders_running_tests(
+        self,
+        mock_post: MagicMock,
+        config: Config,
+        running_tests: list[RunningTestInfo],
+        expected_in_text: list[str],
+        not_expected_in_text: list[str],
+    ) -> None:
+        mock_post.return_value.raise_for_status = MagicMock()
+
+        send_slack_timeout_notification(config, running_tests=running_tests)
+
+        payload = mock_post.call_args[1]["json"]
+        running_text = payload["blocks"][2]["text"]["text"]
+        for expected in expected_in_text:
+            assert expected in running_text
+        for not_expected in not_expected_in_text:
+            assert not_expected not in running_text


### PR DESCRIPTION
## Problem
Fix a small bug that prevents reporting in-flight jobs from snapshot when the job times out awaiting expected events.
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
* Fix shutdown handling bug
* Extend snapshot logging to Slack
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally and in CI (new unit tests too)
<!-- Briefly describe the steps you took, and what steps reviewers must take to get to where changes are, and what is the expected behavior. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
N/A
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update
N/A
<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
