### PR TITLE
feat(surveys): fix dark theme + redesign closed survey error page

### DIFF
--- a/posthog/templates/surveys/_appearance_helpers.html
+++ b/posthog/templates/surveys/_appearance_helpers.html
@@ -1,0 +1,37 @@
+<script nonce="{{ request.csp_nonce }}">
+    // Shared helpers for survey page appearance adaptation. Included inline via a
+    // Django partial in surveys/public_survey.html and surveys/error.html. Both
+    // pages need to derive contrasting text colors and pick adaptive shadows/pills
+    // based on the customer's background luminance.
+    //
+    // Top-level function declarations so they're hoisted for inline scripts that
+    // come after this include.
+
+    // Computes sRGB luminance (0–1) for a CSS color string. Returns null when the
+    // input can't be parsed — e.g. named colors we don't have a hex for, oklch, etc.
+    // Uncommon in practice since the customer-facing builder emits hex.
+    function getLuminance(color) {
+        if (!color) return null
+        var hex = String(color).trim().toLowerCase()
+        if (hex === 'white') hex = '#ffffff'
+        else if (hex === 'black') hex = '#000000'
+        if (hex[0] !== '#') return null
+        if (hex.length === 4) hex = '#' + hex[1] + hex[1] + hex[2] + hex[2] + hex[3] + hex[3]
+        if (hex.length !== 7) return null
+        var r = parseInt(hex.slice(1, 3), 16) / 255
+        var g = parseInt(hex.slice(3, 5), 16) / 255
+        var b = parseInt(hex.slice(5, 7), 16) / 255
+        // Rec. 709 luma — close enough to perceptual for picking light vs dark.
+        return 0.2126 * r + 0.7152 * g + 0.0722 * b
+    }
+
+    // Picks a contrasting foreground color (dark or light) for a given background.
+    // Matches posthog-js's getContrastingTextColor behavior so page chrome stays
+    // readable on any customer background. Null return means we couldn't parse
+    // the input — caller should fall back to defaults.
+    function getContrastingTextColor(background) {
+        var L = getLuminance(background)
+        if (L === null) return null
+        return L > 0.55 ? '#111111' : '#ffffff'
+    }
+</script>

--- a/posthog/templates/surveys/_appearance_helpers.html
+++ b/posthog/templates/surveys/_appearance_helpers.html
@@ -1,15 +1,4 @@
 <script nonce="{{ request.csp_nonce }}">
-    // Shared helpers for survey page appearance adaptation. Included inline via a
-    // Django partial in surveys/public_survey.html and surveys/error.html. Both
-    // pages need to derive contrasting text colors and pick adaptive shadows/pills
-    // based on the customer's background luminance.
-    //
-    // Top-level function declarations so they're hoisted for inline scripts that
-    // come after this include.
-
-    // Computes sRGB luminance (0–1) for a CSS color string. Returns null when the
-    // input can't be parsed — e.g. named colors we don't have a hex for, oklch, etc.
-    // Uncommon in practice since the customer-facing builder emits hex.
     function getLuminance(color) {
         if (!color) return null
         var hex = String(color).trim().toLowerCase()
@@ -21,14 +10,9 @@
         var r = parseInt(hex.slice(1, 3), 16) / 255
         var g = parseInt(hex.slice(3, 5), 16) / 255
         var b = parseInt(hex.slice(5, 7), 16) / 255
-        // Rec. 709 luma — close enough to perceptual for picking light vs dark.
         return 0.2126 * r + 0.7152 * g + 0.0722 * b
     }
 
-    // Picks a contrasting foreground color (dark or light) for a given background.
-    // Matches posthog-js's getContrastingTextColor behavior so page chrome stays
-    // readable on any customer background. Null return means we couldn't parse
-    // the input — caller should fall back to defaults.
     function getContrastingTextColor(background) {
         var L = getLuminance(background)
         if (L === null) return null

--- a/posthog/templates/surveys/error.html
+++ b/posthog/templates/surveys/error.html
@@ -126,18 +126,9 @@
     {{ appearance|json_script:"survey-appearance" }}
     {% include "surveys/_appearance_helpers.html" %}
     <script nonce="{{ request.csp_nonce }}">
-        // Apply the customer's survey appearance to the error page so a respondent hitting
-        // a closed survey link still sees the customer's brand (background, text colors,
-        // font). Only fields that affect the page chrome are applied — no card / input /
-        // button styling since the error page has none of those surfaces.
-        //
-        // Text color falls back to contrast-derived when the customer hasn't set an
-        // explicit override. getLuminance and getContrastingTextColor come from
-        // _appearance_helpers.html (included above).
         (function () {
             var appearance = JSON.parse(document.getElementById('survey-appearance').textContent) || {}
             var root = document.documentElement
-            var pageLuminance = getLuminance(appearance.backgroundColor)
 
             if (appearance.backgroundColor) {
                 root.style.setProperty('--ph-survey-page-background', appearance.backgroundColor)
@@ -149,9 +140,8 @@
                 root.style.setProperty('--ph-survey-page-text', explicitText || derivedText)
             }
 
-            // Flip the corner branding pill to a dark translucent fill on dark backgrounds,
-            // matching the hosted page. White pills on dark backgrounds read as glaring badges.
-            if (pageLuminance !== null && pageLuminance < 0.5) {
+            var bgLuminance = getLuminance(appearance.backgroundColor)
+            if (bgLuminance !== null && bgLuminance < 0.5) {
                 root.style.setProperty('--ph-survey-pill-background', 'rgba(17, 17, 17, 0.55)')
             }
 

--- a/posthog/templates/surveys/error.html
+++ b/posthog/templates/surveys/error.html
@@ -4,263 +4,166 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="apple-touch-icon" sizes="180x180" href="/static/icons/apple-touch-icon.png?v=2023-07-07">
+    <link rel="icon" type="image/png" sizes="32x32" href="/static/icons/favicon-32x32.png?v=2023-07-07">
+    <link rel="icon" type="image/png" sizes="16x16" href="/static/icons/favicon-16x16.png?v=2023-07-07">
     <title>{{ error_title }}</title>
     <style>
         :root {
-            --ph-brand-blue: #1D4AFF;
-            --ph-brand-orange: #F54E00;
-            --ph-brand-yellow: #F9BD2B;
-            --ph-brand-black: #000;
-            --ph-brand-white: #fff;
-
-            --ph-bg-primary: #fafaf9;
-            --ph-bg-surface-primary: #fff;
-            --ph-text-primary: #1d1f27;
-            --ph-text-secondary: #6b7280;
-            --ph-text-tertiary: #9ca3af;
-            --ph-border-primary: #e5e7eb;
-            --ph-shadow-lg: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04);
-            --ph-radius: 0.75rem;
-            --ph-radius-lg: 1rem;
-
-            --ph-font-family: -apple-system, BlinkMacSystemFont, 'Inter', 'Segoe UI', 'Roboto', 'Helvetica Neue', helvetica, arial, sans-serif;
-        }
-
-        @media (prefers-color-scheme: dark) {
-            :root {
-                --ph-bg-primary: #1d1f27;
-                --ph-bg-surface-primary: #2d2f3a;
-                --ph-text-primary: #fff;
-                --ph-text-secondary: #d1d5db;
-                --ph-text-tertiary: #9ca3af;
-                --ph-border-primary: #374151;
-                --ph-brand-black: #fff;
-            }
+            --ph-survey-page-background: #ffffff;
+            --ph-survey-page-text: #111111;
+            --ph-survey-page-text-subtle: #6b6b6b;
+            --ph-survey-page-font: -apple-system, BlinkMacSystemFont, "Segoe UI", "Helvetica Neue", Helvetica, Arial, sans-serif;
+            --ph-survey-pill-background: rgba(255, 255, 255, 0.7);
         }
 
         * {
             box-sizing: border-box;
+        }
+
+        html,
+        body {
             margin: 0;
             padding: 0;
+            background: var(--ph-survey-page-background);
+            color: var(--ph-survey-page-text);
+            font-family: var(--ph-survey-page-font);
+            font-size: 16px;
+            line-height: 1.5;
+            -webkit-font-smoothing: antialiased;
+            text-rendering: optimizeLegibility;
         }
 
         body {
-            font-family: var(--ph-font-family);
-            background: var(--ph-bg-primary);
+            min-height: 100vh;
+        }
+
+        .main-container {
             min-height: 100vh;
             display: flex;
-            align-items: center;
-            justify-content: center;
-            padding: 1rem;
-            color: var(--ph-text-primary);
-            line-height: 1.6;
-            -webkit-font-smoothing: antialiased;
-            -moz-osx-font-smoothing: grayscale;
+            flex-direction: column;
+            padding: clamp(1.5rem, 4vw, 2.5rem) clamp(1.25rem, 4vw, 2.5rem);
         }
 
-        .error-container {
-            background: var(--ph-bg-surface-primary);
-            border: 1px solid var(--ph-border-primary);
-            border-radius: var(--ph-radius-lg);
-            box-shadow: var(--ph-shadow-lg);
-            max-width: 600px;
+        .error-stage {
             width: 100%;
-            padding: 3rem 2rem;
-            text-align: center;
-            position: relative;
-            overflow: hidden;
-        }
-
-        .error-container::before {
-            content: '';
-            position: absolute;
-            top: 0;
-            left: 0;
-            right: 0;
-            height: 4px;
-            background: linear-gradient(90deg,
-                    var(--ph-brand-blue) 0%,
-                    var(--ph-brand-orange) 50%,
-                    var(--ph-brand-yellow) 100%);
-        }
-
-        .logo-container {
-            margin-bottom: 2rem;
-        }
-
-        .logo {
-            height: 40px;
-            width: auto;
-        }
-
-        .error-icon {
-            width: 80px;
-            height: 80px;
-            margin: 0 auto 1.5rem;
-            background: var(--ph-brand-orange);
-            border-radius: 50%;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            position: relative;
-        }
-
-        .error-icon::before {
-            content: '!';
-            color: white;
-            font-size: 2rem;
-            font-weight: 700;
-        }
-
-        .error-title {
-            font-size: 1.75rem;
-            font-weight: 700;
-            color: var(--ph-text-primary);
-            margin-bottom: 1rem;
-            line-height: 1.2;
-        }
-
-        .error-message {
-            font-size: 1.125rem;
-            color: var(--ph-text-secondary);
-            margin-bottom: 2rem;
-            line-height: 1.5;
-        }
-
-        .error-actions {
+            max-width: 44rem;
+            margin: auto;
             display: flex;
             flex-direction: column;
             gap: 1rem;
-            align-items: center;
         }
 
-        .btn {
+        .error-title {
+            margin: 0;
+            font-size: clamp(1.5rem, 2.4vw, 1.875rem);
+            font-weight: 600;
+            line-height: 1.25;
+            letter-spacing: -0.015em;
+            color: var(--ph-survey-page-text);
+            text-wrap: balance;
+        }
+
+        .error-message {
+            margin: 0;
+            font-size: 0.975rem;
+            line-height: 1.6;
+            color: var(--ph-survey-page-text-subtle);
+            text-wrap: pretty;
+        }
+
+        .footer-branding {
+            position: fixed;
+            bottom: 1.25rem;
+            right: 1.25rem;
             display: inline-flex;
             align-items: center;
-            justify-content: center;
-            padding: 0.75rem 1.5rem;
-            border-radius: var(--ph-radius);
-            font-weight: 600;
+            gap: 0.35rem;
+            padding: 0.4rem 0.7rem;
+            border-radius: 999px;
+            background: var(--ph-survey-pill-background);
+            backdrop-filter: blur(8px);
+            -webkit-backdrop-filter: blur(8px);
+            box-shadow: 0 1px 2px rgba(17, 17, 17, 0.04), 0 4px 14px rgba(17, 17, 17, 0.06);
+            color: var(--ph-survey-page-text-subtle);
+            font-size: 0.72rem;
+            font-weight: 500;
             text-decoration: none;
-            transition: all 0.15s ease;
-            cursor: pointer;
-            font-size: 0.875rem;
-            min-width: 140px;
+            opacity: 0.75;
+            transition: opacity 140ms ease;
+            z-index: 10;
         }
 
-        .btn-primary {
-            background: var(--ph-brand-orange);
-            color: white;
-            border: none;
-        }
-
-        .btn-primary:hover {
-            background: #e04400;
-            transform: translateY(-1px);
-        }
-
-        .btn-secondary {
-            background: transparent;
-            color: var(--ph-text-secondary);
-            border: 1px solid var(--ph-border-primary);
-        }
-
-        .btn-secondary:hover {
-            background: var(--ph-bg-primary);
-            color: var(--ph-text-primary);
-        }
-
-        .error-code {
-            position: absolute;
-            top: 1rem;
-            right: 1rem;
-            font-size: 0.75rem;
-            color: var(--ph-text-tertiary);
-            font-family: 'SF Mono', Monaco, 'Cascadia Code', 'Roboto Mono', Consolas, 'Courier New', monospace;
-        }
-
-        .decorative-dots {
-            position: absolute;
-            bottom: -20px;
-            right: -20px;
-            width: 120px;
-            height: 120px;
-            opacity: 0.05;
-            background-image: radial-gradient(var(--ph-brand-blue) 2px, transparent 2px);
-            background-size: 20px 20px;
-            border-radius: 50%;
+        .footer-branding:hover {
+            opacity: 1;
         }
 
         @media (max-width: 640px) {
-            .error-container {
-                padding: 2rem 1.5rem;
-                margin: 1rem;
+            .main-container {
+                padding: 1.25rem;
             }
 
-            .error-title {
-                font-size: 1.5rem;
-            }
-
-            .error-message {
-                font-size: 1rem;
-            }
-
-            .logo {
-                height: 32px;
-            }
-
-            .error-icon {
-                width: 64px;
-                height: 64px;
-            }
-
-            .error-icon::before {
-                font-size: 1.5rem;
+            .footer-branding {
+                bottom: 0.75rem;
+                right: 0.75rem;
             }
         }
     </style>
 </head>
 
 <body>
-    <div class="error-container">
-        <div class="error-code">ERROR</div>
-        <div class="decorative-dots"></div>
-
-        <div class="logo-container">
-            <svg class="logo" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 140">
-                <g fill-rule="nonzero" fill="none">
-                    <path
-                        d="M55.383 75.225c-1.874 3.748-7.222 3.748-9.096 0l-4.482-8.963a5.085 5.085 0 0 1 0-4.548l4.482-8.964c1.874-3.748 7.222-3.748 9.096 0l4.482 8.964a5.084 5.084 0 0 1 0 4.548l-4.482 8.963Zm0 50.836c-1.874 3.747-7.222 3.747-9.096 0l-4.482-8.964a5.085 5.085 0 0 1 0-4.548l4.482-8.964c1.874-3.748 7.222-3.748 9.096 0l4.482 8.964a5.084 5.084 0 0 1 0 4.548l-4.482 8.964Z"
-                        fill="var(--ph-brand-blue)" />
-                    <path
-                        d="M0 106.765c0-4.53 5.477-6.8 8.68-3.596l23.307 23.307c3.204 3.204.935 8.68-3.595 8.68H5.085A5.085 5.085 0 0 1 0 130.073v-23.307Zm0-24.55c0 1.35.536 2.643 1.49 3.596l47.856 47.856a5.086 5.086 0 0 0 3.595 1.49h26.286c4.53 0 6.799-5.477 3.595-8.681L8.681 52.334C5.477 49.131 0 51.4 0 55.93v26.286Zm0-50.834c0 1.348.536 2.642 1.49 3.595l98.69 98.691a5.086 5.086 0 0 0 3.596 1.49h26.285c4.53 0 6.8-5.477 3.596-8.681L8.681 1.5C5.477-1.704 0 .565 0 5.095v26.286Zm50.835 0c0 1.348.536 2.642 1.49 3.595l91.5 91.5c3.203 3.204 8.68.935 8.68-3.596V96.595a5.086 5.086 0 0 0-1.49-3.596l-91.5-91.5c-3.203-3.203-8.68-.934-8.68 3.596v26.286ZM110.35 1.5c-3.203-3.204-8.68-.935-8.68 3.595v26.286c0 1.348.536 2.642 1.49 3.595l40.664 40.665c3.204 3.204 8.68.935 8.68-3.596V45.76a5.086 5.086 0 0 0-1.489-3.596L110.35 1.5Z"
-                        fill="var(--ph-brand-yellow)" />
-                    <path
-                        d="m216.24 107.388-47.864-47.863c-3.204-3.204-8.681-.935-8.681 3.595v66.952a5.085 5.085 0 0 0 5.085 5.085h74.142a5.085 5.085 0 0 0 5.085-5.085v-6.097c0-2.809-2.286-5.052-5.07-5.414a39.27 39.27 0 0 1-22.698-11.173Zm-32.145 11.502a8.137 8.137 0 0 1-8.133-8.134 8.137 8.137 0 0 1 8.133-8.134 8.137 8.137 0 0 1 8.134 8.134 8.137 8.137 0 0 1-8.134 8.134Z"
-                        fill="var(--ph-brand-black)" />
-                    <path
-                        d="M0 130.072a5.085 5.085 0 0 0 5.085 5.085h23.307c4.53 0 6.799-5.477 3.595-8.681L8.681 103.169C5.477 99.966 0 102.235 0 106.765v23.307Zm50.835-86.418L8.68 1.5C5.477-1.704 0 .565 0 5.095v26.286c0 1.348.536 2.642 1.49 3.595l49.345 49.346V43.654ZM8.68 52.334C5.477 49.131 0 51.4 0 55.93v26.286c0 1.348.536 2.642 1.49 3.595l49.345 49.346V94.489L8.68 52.334Z"
-                        fill="var(--ph-brand-blue)" />
-                    <path
-                        d="M101.67 45.76a5.083 5.083 0 0 0-1.49-3.596L59.516 1.5c-3.204-3.204-8.681-.935-8.681 3.595v26.286c0 1.348.536 2.642 1.49 3.595l49.345 49.346V45.76Zm-50.835 89.397h28.392c4.53 0 6.799-5.477 3.595-8.681L50.835 94.489v40.668Zm0-91.503v38.562c0 1.348.536 2.642 1.49 3.595l49.345 49.346V96.595a5.084 5.084 0 0 0-1.49-3.596L50.835 43.654Z"
-                        fill="var(--ph-brand-orange)" />
-                    <path
-                        d="M303.32 114.86h20.888V80.22h17.452c19.17 0 31.466-11.37 31.466-28.954 0-17.584-12.295-28.954-31.466-28.954h-38.34v92.547Zm20.888-52.488V40.16h15.337c7.932 0 12.692 4.23 12.692 11.105 0 6.876-4.76 11.106-12.692 11.106h-15.337Zm86.71 53.545c20.36 0 35.167-14.543 35.167-34.375 0-19.831-14.807-34.374-35.167-34.374-20.625 0-35.168 14.543-35.168 34.374 0 19.832 14.543 34.375 35.168 34.375Zm-15.866-34.375c0-10.577 6.346-17.848 15.866-17.848 9.386 0 15.733 7.271 15.733 17.848 0 10.577-6.347 17.849-15.733 17.849-9.52 0-15.866-7.272-15.866-17.849Zm84.462 34.375c15.601 0 26.178-9.784 26.178-21.286 0-26.97-35.829-18.245-35.829-28.822 0-2.908 3.04-4.759 7.404-4.759 4.495 0 9.916 2.776 11.634 8.858l15.601-6.479c-3.04-9.65-14.279-16.261-27.896-16.261-14.676 0-23.798 8.725-23.798 19.17 0 25.252 35.3 18.245 35.3 28.69 0 3.702-3.437 6.214-8.594 6.214-7.403 0-12.56-5.156-14.146-11.37l-15.601 6.081c3.438 10.048 13.486 19.964 29.747 19.964Zm76.43-1.718-1.321-16.791c-2.248 1.19-5.157 1.586-7.536 1.586-4.76 0-7.933-3.437-7.933-9.387V64.355h16.13v-16.13h-16.13V28.923h-19.435v19.302h-10.577v16.13h10.577v27.764c0 16.13 10.974 23.798 25.384 23.798 3.967 0 7.669-.66 10.842-1.718Zm67.764-91.887v35.961h-36.755v-35.96h-20.89v92.546h20.89V76.122h36.755v38.737h21.021V22.312h-21.021Zm67.386 93.605c20.36 0 35.168-14.543 35.168-34.375 0-19.831-14.807-34.374-35.168-34.374-20.625 0-35.168 14.543-35.168 34.374 0 19.832 14.543 34.375 35.168 34.375ZM675.23 81.542c0-10.577 6.346-17.848 15.865-17.848 9.387 0 15.733 7.271 15.733 17.848 0 10.577-6.346 17.849-15.733 17.849-9.519 0-15.865-7.272-15.865-17.849Zm88.545 31.202c7.272 0 13.75-2.512 17.188-6.875v6.346c0 7.404-5.95 12.56-15.072 12.56-6.479 0-12.164-3.173-13.09-8.594l-17.715 2.777c2.38 12.56 15.204 21.022 30.805 21.022 20.492 0 34.11-12.032 34.11-29.88V48.225h-19.17v5.685c-3.57-4.098-9.652-6.742-17.452-6.742-18.51 0-30.144 12.692-30.144 32.788 0 20.096 11.634 32.788 30.54 32.788ZM752.14 79.956c0-9.916 5.817-16.262 14.807-16.262 9.123 0 14.94 6.346 14.94 16.262s-5.817 16.262-14.94 16.262c-8.99 0-14.807-6.346-14.807-16.262Z"
-                        fill="var(--ph-brand-black)" />
-                </g>
-            </svg>
-        </div>
-
-        <div class="error-icon"></div>
-
-        <h1 class="error-title">{{ error_title }}</h1>
-        <p class="error-message">{{ error_message }}</p>
-
-        <div class="error-actions">
-            <a href="javascript:history.back()" class="btn btn-primary">Go Back</a>
-            <a href="javascript:location.reload()" class="btn btn-secondary">Try Again</a>
+    <div class="main-container">
+        <div class="error-stage">
+            <h1 class="error-title">{{ error_title }}</h1>
+            <p class="error-message">{{ error_message }}</p>
         </div>
     </div>
+    <a class="footer-branding" href="https://posthog.com/surveys?utm_source=survey-error" target="_blank" rel="noopener">
+        Survey by PostHog
+    </a>
+
+    {% if appearance %}
+    {{ appearance|json_script:"survey-appearance" }}
+    {% include "surveys/_appearance_helpers.html" %}
+    <script nonce="{{ request.csp_nonce }}">
+        // Apply the customer's survey appearance to the error page so a respondent hitting
+        // a closed survey link still sees the customer's brand (background, text colors,
+        // font). Only fields that affect the page chrome are applied — no card / input /
+        // button styling since the error page has none of those surfaces.
+        //
+        // Text color falls back to contrast-derived when the customer hasn't set an
+        // explicit override. getLuminance and getContrastingTextColor come from
+        // _appearance_helpers.html (included above).
+        (function () {
+            var appearance = JSON.parse(document.getElementById('survey-appearance').textContent) || {}
+            var root = document.documentElement
+            var pageLuminance = getLuminance(appearance.backgroundColor)
+
+            if (appearance.backgroundColor) {
+                root.style.setProperty('--ph-survey-page-background', appearance.backgroundColor)
+            }
+
+            var explicitText = appearance.textColor || appearance.inputTextColor
+            var derivedText = getContrastingTextColor(appearance.backgroundColor)
+            if (explicitText || derivedText) {
+                root.style.setProperty('--ph-survey-page-text', explicitText || derivedText)
+            }
+
+            // Flip the corner branding pill to a dark translucent fill on dark backgrounds,
+            // matching the hosted page. White pills on dark backgrounds read as glaring badges.
+            if (pageLuminance !== null && pageLuminance < 0.5) {
+                root.style.setProperty('--ph-survey-pill-background', 'rgba(17, 17, 17, 0.55)')
+            }
+
+            if (appearance.textSubtleColor) {
+                root.style.setProperty('--ph-survey-page-text-subtle', appearance.textSubtleColor)
+            }
+            if (appearance.fontFamily && appearance.fontFamily !== 'inherit') {
+                root.style.setProperty('--ph-survey-page-font', appearance.fontFamily)
+            }
+        })()
+    </script>
+    {% endif %}
 </body>
 
 </html>

--- a/posthog/templates/surveys/public_survey.html
+++ b/posthog/templates/surveys/public_survey.html
@@ -14,8 +14,6 @@
     <title>{{ name }}</title>
     <meta name="description" content="{{ name }}">
     <style>
-        /* Page-level vars only — survey-card vars are managed by posthog-js (set inline
-           on the survey container based on the merged appearance object). */
         :root {
             --ph-survey-page-background: #ffffff;
             --ph-survey-page-text: #111111;
@@ -24,11 +22,7 @@
             --ph-survey-page-progress-bar: #111111;
             --ph-survey-progress-value: 0%;
             --ph-survey-page-font: -apple-system, BlinkMacSystemFont, "Segoe UI", "Helvetica Neue", Helvetica, Arial, sans-serif;
-            /* Default elevation shadow for light card surfaces. Overridden in JS to a light
-               shadow when the card surface is dark (so cards stay grounded on dark themes). */
             --ph-survey-card-shadow: 0 1px 2px rgba(17, 17, 17, 0.04), 0 2px 8px rgba(17, 17, 17, 0.04);
-            /* Corner branding pill — flipped to a dark translucent fill in JS when the page
-               background is dark, otherwise a white pill reads as a glaring badge. */
             --ph-survey-pill-background: rgba(255, 255, 255, 0.7);
         }
 
@@ -68,17 +62,12 @@
             padding: clamp(1.5rem, 4vw, 2.5rem) clamp(1.25rem, 4vw, 2.5rem);
         }
 
-        /* Progress bar lives at the top of the page, NOT inside the centered content group.
-           It represents progress through the whole survey (page chrome), not the current
-           question's state — so it should stay anchored regardless of how much content sits below. */
         .survey-progress-wrap {
             width: 100%;
             max-width: 44rem;
             margin: 0 auto;
         }
 
-        /* Centers content vertically when it fits, falls back to top-aligned natural scroll
-           when it doesn't (margin: auto collapses to 0 once content exceeds available space). */
         .survey-stage {
             width: 100%;
             max-width: 44rem;
@@ -103,12 +92,6 @@
             transition: width 240ms cubic-bezier(0.22, 1, 0.36, 1);
         }
 
-        /* === Survey rendered by posthog-js into #posthog-survey-container ===
-           When rendered via the API path, posthog-js sets CSS variables inline on
-           this element but does NOT inject its own stylesheet, so we own all the
-           styling. Customer customization flows through via mergeHostedAppearance
-           below — the CSS variable names here MUST match what posthog-js sets. */
-
         #posthog-survey-container {
             display: flex;
             flex-direction: column;
@@ -122,8 +105,6 @@
             gap: 1.5rem;
         }
 
-        /* Thank-you screen is celebratory — center the text. Question screens stay
-           left-aligned because reading left-to-right is faster while answering. */
         #posthog-survey-container .thank-you-message {
             display: flex;
             flex-direction: column;
@@ -201,9 +182,6 @@
             opacity: 0.65;
         }
 
-        /* :focus-visible is enough for text inputs — per spec, mouse-clicking into a text
-           field counts as visible focus (the user might be about to type), so we don't need
-           a separate :focus rule. */
         #posthog-survey-container textarea:focus-visible,
         #posthog-survey-container input[type='text']:focus-visible {
             outline: none;
@@ -241,16 +219,11 @@
             transition: border-color 140ms ease, background-color 140ms ease, transform 140ms ease, box-shadow 140ms ease;
         }
 
-        /* Selected state: dark border + a 1px inset to make it read as a "double-stroke" without
-           a layout-shifting border-width change. No background tint — on gray/dark pages tinting
-           darker makes selected cards appear dimmer than unselected ones, which reads backwards. */
         #posthog-survey-container .multiple-choice-options label:has(input:checked) {
             border-color: var(--ph-survey-rating-active-bg-color, #111);
             box-shadow: inset 0 0 0 1px var(--ph-survey-rating-active-bg-color, #111), var(--ph-survey-card-shadow);
         }
 
-        /* Focus ring on the whole label when its input has keyboard focus, so arrow-key
-           navigation has a clear target instead of just the small native radio dot. */
         #posthog-survey-container .multiple-choice-options label:has(input:focus-visible) {
             outline: none;
             box-shadow: 0 0 0 3px rgba(17, 17, 17, 0.12);
@@ -422,8 +395,6 @@
             box-shadow: 0 0 0 3px rgba(17, 17, 17, 0.12);
         }
 
-        /* Disabled state: outlined treatment instead of a flat gray block, so the unanswered
-           form doesn't feel like it's shouting at the respondent. */
         #posthog-survey-container .form-submit[disabled] {
             background: transparent;
             color: var(--ph-survey-text-subtle-color, #6b6b6b);
@@ -432,9 +403,6 @@
             opacity: 1;
         }
 
-        /* Pin "Survey by PostHog" to the page corner instead of stacking it under the submit button.
-           posthog-js still renders the element (and respects whiteLabel for paid customers); we
-           just relocate it visually. Hidden on small screens to keep the form unobstructed. */
         #posthog-survey-container .footer-branding {
             position: fixed;
             bottom: 1.25rem;
@@ -516,15 +484,13 @@
             border: 0;
         }
 
-        /* Keyboard hint chips. Hidden by default; turned on inside the hover-capable query
-           below. The default-hidden + override pattern means touch devices skip the chips
-           naturally without needing a separate "hide on touch" rule. */
+        /* Hidden by default; shown on hover-capable devices via media query below. */
         #posthog-survey-container .survey-keyhint {
             display: none;
             align-items: center;
             gap: 1rem;
             color: var(--ph-survey-text-subtle-color, #6b6b6b);
-            font-size: 0.78rem;
+            font-size: 0.84rem;
             pointer-events: none;
             user-select: none;
         }
@@ -539,20 +505,25 @@
             display: inline-flex;
             align-items: center;
             justify-content: center;
-            min-width: 1.5rem;
-            height: 1.5rem;
-            padding: 0 0.4rem;
+            min-width: 1.7rem;
+            height: 1.7rem;
+            padding: 0 0.45rem;
             border-radius: 6px;
-            background: rgba(17, 17, 17, 0.05);
+            border: 1px solid var(--ph-survey-border-color, rgba(17, 17, 17, 0.10));
+            background: var(--ph-survey-rating-bg-color, var(--ph-survey-input-background, rgba(17, 17, 17, 0.06)));
             color: var(--ph-survey-text-primary-color, #111);
             font-family: inherit;
-            font-size: 0.78rem;
-            font-weight: 600;
+            font-size: 0.88rem;
+            font-weight: 500;
             line-height: 1;
+            font-variant-numeric: tabular-nums;
+            box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.05), 0 1px 2px rgba(17, 17, 17, 0.12);
         }
 
         #posthog-survey-container .survey-keyhint-label {
-            opacity: 0.7;
+            color: var(--ph-survey-text-subtle-color, #6b6b6b);
+            font-weight: 400;
+            letter-spacing: 0.01em;
         }
 
         @media (hover: hover) and (pointer: fine) {
@@ -683,9 +654,6 @@
             borderRadius: '10px',
             submitButtonColor: '#111111',
             submitButtonTextColor: '#ffffff',
-            // Rating buttons default to the same surface as choice cards and text inputs.
-            // Visual hierarchy should come from selection state, not control type. Customers
-            // can still override ratingButtonColor independently in their appearance settings.
             ratingButtonColor: '#ffffff',
             ratingButtonActiveColor: '#111111',
             inputBackground: '#ffffff',
@@ -696,31 +664,15 @@
             return { ...HOSTED_SURVEY_DEFAULTS, ...(appearance || {}) };
         }
 
-        // getLuminance and getContrastingTextColor are defined in _appearance_helpers.html,
-        // included above. Both return null when a color can't be parsed — callers fall back
-        // to defaults in that case.
-
-        // IMPORTANT: posthog-js's renderSurvey() path does NOT call addSurveyCSSVariablesToElement,
-        // so none of the --ph-survey-* container variables are set by posthog-js on this page.
-        // We have to set them ourselves, replicating what addSurveyCSSVariablesToElement does for
-        // the popup path. Without this, my CSS rules like `var(--ph-survey-input-background, #fff)`
-        // always resolve to the fallback, which means customer appearance customization (input
-        // background, border color, etc.) is silently ignored and dark-theme surveys keep black
-        // text. Set everything on :root so values cascade into the container and its children.
+        // posthog-js doesn't set --ph-survey-* vars on the hosted page path,
+        // so we replicate them on :root from the merged appearance object.
         function applyPageAppearance(appearance) {
             const root = document.documentElement
 
-            // --- Page chrome (progress bar, loading spinner, corner branding) ---
             if (appearance.backgroundColor) {
                 root.style.setProperty('--ph-survey-page-background', appearance.backgroundColor)
             }
-            if (appearance.submitButtonColor) {
-                // Tie progress bar to the primary action color for visual coherence.
-                root.style.setProperty('--ph-survey-page-progress-bar', appearance.submitButtonColor)
-            }
 
-            // --- Survey content variables that posthog-js would normally set itself ---
-            // Card surface (input background). Falls back to backgroundColor if not explicitly set.
             const cardBg = appearance.inputBackground || appearance.backgroundColor
             if (cardBg) {
                 root.style.setProperty('--ph-survey-input-background', cardBg)
@@ -733,10 +685,6 @@
                 root.style.setProperty('--ph-survey-border-radius', appearance.borderRadius)
             }
 
-            // Primary text color. Priority: explicit textColor → explicit inputTextColor →
-            // derived contrast from the card surface → default. Applied to BOTH the container
-            // variable (for question text, choices, etc.) and the page variable (for progress
-            // chrome, loading spinner, corner branding).
             const explicitText = appearance.textColor || appearance.inputTextColor
             const derivedText = cardBg ? getContrastingTextColor(cardBg) : null
             const primaryText = explicitText || derivedText
@@ -751,16 +699,14 @@
                 root.style.setProperty('--ph-survey-page-text-subtle', appearance.textSubtleColor)
             }
 
-            // Submit button. Text color defaults to the contrast of the button fill.
             if (appearance.submitButtonColor) {
                 root.style.setProperty('--ph-survey-submit-button-color', appearance.submitButtonColor)
+                root.style.setProperty('--ph-survey-page-progress-bar', appearance.submitButtonColor)
                 const submitText =
                     appearance.submitButtonTextColor || getContrastingTextColor(appearance.submitButtonColor) || '#ffffff'
                 root.style.setProperty('--ph-survey-submit-button-text-color', submitText)
             }
 
-            // Rating buttons. Default bg follows the card surface; active bg defaults to the
-            // submit button color for visual coherence with the primary action.
             const ratingBg = appearance.ratingButtonColor || cardBg
             if (ratingBg) {
                 root.style.setProperty('--ph-survey-rating-bg-color', ratingBg)
@@ -780,8 +726,6 @@
                 root.style.setProperty('--ph-survey-disabled-button-opacity', appearance.disabledButtonOpacity)
             }
 
-            // Card elevation shadow contrasts with the card surface — dark cards need a light
-            // shadow so elevation doesn't disappear into the background.
             const cardLuminance = getLuminance(cardBg)
             if (cardLuminance !== null && cardLuminance < 0.5) {
                 root.style.setProperty(
@@ -790,9 +734,6 @@
                 )
             }
 
-            // Corner branding pill adapts to the page background. A white translucent pill
-            // on a dark page looks like a glaring badge — flip it to a dark translucent fill
-            // so it recedes into the surface the same way it does on light backgrounds.
             const pageLuminance = getLuminance(appearance.backgroundColor)
             if (pageLuminance !== null && pageLuminance < 0.5) {
                 root.style.setProperty('--ph-survey-pill-background', 'rgba(17, 17, 17, 0.55)')
@@ -800,8 +741,6 @@
         }
 
         function inferCurrentQuestionIndex(container) {
-            // posthog-js exposes the current question index as a data attribute on .survey-box.
-            // Works for every question type (open text, multiple choice, rating, link).
             const surveyBox = container.querySelector('.survey-box[data-question-index]')
             if (surveyBox) {
                 const parsed = Number(surveyBox.getAttribute('data-question-index'))
@@ -810,8 +749,7 @@
                 }
             }
 
-            // Fallback for older posthog-js versions that don't expose the index yet.
-            // Match the displayed question text against survey.questions[].
+            // Fallback: match displayed question text against survey.questions[].
             const displayedQuestion = container.querySelector('.survey-question')?.textContent?.trim()
             if (displayedQuestion && Array.isArray(survey.questions)) {
                 const matchedIndex = survey.questions.findIndex((q) => (q?.question || '').trim() === displayedQuestion)
@@ -832,19 +770,8 @@
             }
         }
 
-        // Single keyboard handler bound once on document.
-        //
-        // Convention (matches iMessage, Linear, Slack, Typeform, ChatGPT):
-        //   - Enter           → submit current question
-        //   - Shift+Enter     → newline inside a textarea (default browser behavior)
-        //   - ↑/↓ or ←/→      → cycle focus through choices and rating buttons
-        //
-        // Bound on DOCUMENT (not the container) because link/announcement questions have
-        // no focusable input — focus stays on <body>, so a container-scoped listener would
-        // never fire. Document-scoped works for every question type uniformly.
-        //
-        // CAPTURE PHASE is required: posthog-js's OpenTextQuestion calls e.stopPropagation()
-        // on every textarea keydown, which kills the bubble phase before our handler can run.
+        // Bound on document (capture phase) because posthog-js stops propagation
+        // on textarea keydown and link questions leave focus on <body>.
         let keyboardShortcutsBound = false
         function bindKeyboardShortcuts(container) {
             if (keyboardShortcutsBound) return
@@ -852,12 +779,7 @@
             document.addEventListener('keydown', (event) => {
                 if (event.metaKey || event.ctrlKey || event.altKey) return
 
-                // Swallow Enter and Escape on the thank-you screen. posthog-js's
-                // ConfirmationMessage binds its own window keydown listener that calls
-                // onClose() on either key — fine inside a popup, but on the hosted page
-                // there's nothing to close, so it unmounts the survey and leaves an empty
-                // container behind. Stopping the event in capture phase prevents posthog-js's
-                // bubble-phase handler from firing.
+                // Prevent posthog-js's ConfirmationMessage from unmounting the survey on Enter/Escape.
                 if ((event.key === 'Enter' || event.key === 'Escape') && container.querySelector('.thank-you-message')) {
                     event.preventDefault()
                     event.stopPropagation()
@@ -873,8 +795,6 @@
                     return
                 }
 
-                // Arrow keys → cycle through focusable options. Skipped while focus is in a
-                // text input or textarea so users can move the cursor through their answer.
                 if (isArrowKey(event.key)) {
                     const target = event.target
                     if (target instanceof HTMLElement) {
@@ -894,9 +814,6 @@
             return key === 'ArrowUp' || key === 'ArrowDown' || key === 'ArrowLeft' || key === 'ArrowRight'
         }
 
-        // Returns the focusable options for the currently displayed question, in DOM order.
-        // Multiple choice → the underlying inputs (radio/checkbox).
-        // Rating          → the rating buttons.
         function getNavigableOptions(container) {
             const choices = container.querySelectorAll('.multiple-choice-options input[type="radio"], .multiple-choice-options input[type="checkbox"]')
             if (choices.length > 0) {
@@ -917,8 +834,6 @@
             const currentIdx = nav.elements.indexOf(active)
             const goingForward = key === 'ArrowDown' || key === 'ArrowRight'
 
-            // If nothing in the group is focused yet, the first arrow press lands on the
-            // first or last option depending on direction. Subsequent presses cycle.
             let nextIdx
             if (currentIdx === -1) {
                 nextIdx = goingForward ? 0 : nav.elements.length - 1
@@ -929,8 +844,6 @@
             const next = nav.elements[nextIdx]
             next.focus()
 
-            // Auto-select on focus for single-select groups (radios + ratings), matching
-            // native radio group behavior. Checkboxes only move focus — Space toggles.
             const shouldAutoSelect = nav.kind === 'rating' || (next.type === 'radio')
             if (shouldAutoSelect) {
                 next.click()
@@ -962,10 +875,6 @@
             updateKeyboardHint(container, currentType)
         }
 
-        // Localized labels for the keyboard hint chips. Covers languages we're confident on;
-        // anything else falls through to English. Region variants fall through to the base
-        // language (pt-BR → pt). Asian and RTL languages need a native-speaker pass before
-        // we add them — for now they'll just see the English fallback.
         const KEYBOARD_HINT_I18N = {
             en: { submit: 'submit', newline: 'new line', select: 'select', toggle: 'toggle' },
             es: { submit: 'enviar', newline: 'nueva línea', select: 'seleccionar', toggle: 'alternar' },
@@ -986,35 +895,10 @@
             return KEYBOARD_HINT_I18N[lang] || KEYBOARD_HINT_I18N.en
         }
 
-        // Renders kbd-style chips next to the submit button explaining the keyboard shortcuts.
-        // Touch devices are handled purely via CSS (`@media (hover: hover)`) — that re-evaluates
-        // when the input device changes, which the JS check wouldn't, and is more accurate on
-        // touchscreen laptops where 'ontouchstart' is true but a real keyboard exists.
-        // Each question type gets only the chips that are actually relevant to it:
-        //   - open                  → ↵ submit  ⇧↵ new line
-        //   - single_choice         → ↵ submit  ↑↓ select
-        //   - multiple_choice       → ↵ submit  ↑↓ select  ␣ toggle
-        //   - rating                → ↵ submit  ←→ select
-        //   - link                  → ↵ submit
-        //   - thank-you / unknown   → no hint
-        function updateKeyboardHint(container, currentType) {
-            const bottomSection = container.querySelector('.bottom-section')
-            const submitButton = bottomSection?.querySelector('.form-submit')
-            if (!bottomSection || !submitButton) return
-
-            let hint = bottomSection.querySelector('.survey-keyhint')
-
-            if (!currentType) {
-                hint?.remove()
-                return
-            }
-
-            if (!hint) {
-                hint = document.createElement('span')
-                hint.className = 'survey-keyhint'
-                bottomSection.appendChild(hint)
-            }
-
+        // Memoized by question type to skip redundant innerHTML writes.
+        const _hintHtmlCache = {}
+        function getHintHtml(currentType) {
+            if (_hintHtmlCache[currentType]) return _hintHtmlCache[currentType]
             const labels = getKeyboardHintLabels()
             const chip = (kbd, label) =>
                 `<span class="survey-keyhint-row"><kbd class="survey-kbd">${kbd}</kbd><span class="survey-keyhint-label">${label}</span></span>`
@@ -1031,7 +915,33 @@
                 chips.push(chip('← →', labels.select))
             }
 
-            hint.innerHTML = chips.join('')
+            _hintHtmlCache[currentType] = chips.join('')
+            return _hintHtmlCache[currentType]
+        }
+
+        function updateKeyboardHint(container, currentType) {
+            const bottomSection = container.querySelector('.bottom-section')
+            const submitButton = bottomSection?.querySelector('.form-submit')
+            if (!bottomSection || !submitButton) return
+
+            let hint = bottomSection.querySelector('.survey-keyhint')
+
+            if (!currentType) {
+                hint?.remove()
+                return
+            }
+
+            const html = getHintHtml(currentType)
+
+            if (!hint) {
+                hint = document.createElement('span')
+                hint.className = 'survey-keyhint'
+                bottomSection.appendChild(hint)
+            }
+
+            if (hint.innerHTML !== html) {
+                hint.innerHTML = html
+            }
         }
 
         function setupSurveyShell() {
@@ -1052,14 +962,11 @@
             new MutationObserver(scheduleRefresh).observe(container, {
                 childList: true,
                 subtree: true,
-                attributes: true,
             })
 
             refreshSurveyState()
         }
 
-        // Merge our hosted-page defaults into the survey appearance before posthog-js renders.
-        // Customer customization (survey.appearance.*) wins; we only fill the gaps.
         survey.appearance = mergeHostedAppearance(survey.appearance);
         applyPageAppearance(survey.appearance);
 

--- a/posthog/templates/surveys/public_survey.html
+++ b/posthog/templates/surveys/public_survey.html
@@ -27,6 +27,9 @@
             /* Default elevation shadow for light card surfaces. Overridden in JS to a light
                shadow when the card surface is dark (so cards stay grounded on dark themes). */
             --ph-survey-card-shadow: 0 1px 2px rgba(17, 17, 17, 0.04), 0 2px 8px rgba(17, 17, 17, 0.04);
+            /* Corner branding pill — flipped to a dark translucent fill in JS when the page
+               background is dark, otherwise a white pill reads as a glaring badge. */
+            --ph-survey-pill-background: rgba(255, 255, 255, 0.7);
         }
 
         * {
@@ -441,11 +444,11 @@
             gap: 0.35rem;
             padding: 0.4rem 0.7rem;
             border-radius: 999px;
-            background: rgba(255, 255, 255, 0.7);
+            background: var(--ph-survey-pill-background);
             backdrop-filter: blur(8px);
             -webkit-backdrop-filter: blur(8px);
             box-shadow: 0 1px 2px rgba(17, 17, 17, 0.04), 0 4px 14px rgba(17, 17, 17, 0.06);
-            color: var(--ph-survey-text-subtle-color, #6b6b6b);
+            color: var(--ph-survey-page-text-subtle, #6b6b6b);
             font-size: 0.72rem;
             font-weight: 500;
             text-decoration: none;
@@ -666,6 +669,7 @@
 
     {{ survey_data|json_script:"survey-data" }}
     {{ project_config|json_script:"project-config" }}
+    {% include "surveys/_appearance_helpers.html" %}
     <script nonce="{{ request.csp_nonce }}">
         const survey = JSON.parse(document.getElementById("survey-data").textContent);
         const projectConfig = JSON.parse(document.getElementById("project-config").textContent);
@@ -692,48 +696,106 @@
             return { ...HOSTED_SURVEY_DEFAULTS, ...(appearance || {}) };
         }
 
-        // Returns sRGB luminance (0–1) for any CSS color string we can parse, or null when we
-        // can't (e.g. named colors we don't have a hex for, oklch, etc — uncommon in customer
-        // appearance settings since the builder UI emits hex). Used to pick a card shadow that
-        // contrasts with the actual surface color, not just the default light theme.
-        function getLuminance(color) {
-            if (!color) return null
-            let hex = color.trim().toLowerCase()
-            if (hex === 'white') hex = '#ffffff'
-            else if (hex === 'black') hex = '#000000'
-            if (hex[0] !== '#') return null
-            if (hex.length === 4) hex = '#' + hex[1] + hex[1] + hex[2] + hex[2] + hex[3] + hex[3]
-            if (hex.length !== 7) return null
-            const r = parseInt(hex.slice(1, 3), 16) / 255
-            const g = parseInt(hex.slice(3, 5), 16) / 255
-            const b = parseInt(hex.slice(5, 7), 16) / 255
-            // Rec. 709 luma — close enough to perceptual for picking light vs dark shadow.
-            return 0.2126 * r + 0.7152 * g + 0.0722 * b
-        }
+        // getLuminance and getContrastingTextColor are defined in _appearance_helpers.html,
+        // included above. Both return null when a color can't be parsed — callers fall back
+        // to defaults in that case.
 
-        // Page background and progress bar follow the survey appearance so the form
-        // feels like a single document rather than a card floating on a contrasting page.
+        // IMPORTANT: posthog-js's renderSurvey() path does NOT call addSurveyCSSVariablesToElement,
+        // so none of the --ph-survey-* container variables are set by posthog-js on this page.
+        // We have to set them ourselves, replicating what addSurveyCSSVariablesToElement does for
+        // the popup path. Without this, my CSS rules like `var(--ph-survey-input-background, #fff)`
+        // always resolve to the fallback, which means customer appearance customization (input
+        // background, border color, etc.) is silently ignored and dark-theme surveys keep black
+        // text. Set everything on :root so values cascade into the container and its children.
         function applyPageAppearance(appearance) {
-            const root = document.documentElement;
+            const root = document.documentElement
+
+            // --- Page chrome (progress bar, loading spinner, corner branding) ---
             if (appearance.backgroundColor) {
-                root.style.setProperty('--ph-survey-page-background', appearance.backgroundColor);
+                root.style.setProperty('--ph-survey-page-background', appearance.backgroundColor)
             }
             if (appearance.submitButtonColor) {
                 // Tie progress bar to the primary action color for visual coherence.
-                root.style.setProperty('--ph-survey-page-progress-bar', appearance.submitButtonColor);
-            }
-            if (appearance.textSubtleColor) {
-                root.style.setProperty('--ph-survey-page-text-subtle', appearance.textSubtleColor);
+                root.style.setProperty('--ph-survey-page-progress-bar', appearance.submitButtonColor)
             }
 
-            // Pick a card elevation shadow that actually contrasts with the card surface.
-            // Dark surfaces need a light shadow (otherwise dark-on-dark = invisible elevation).
-            const cardLuminance = getLuminance(appearance.inputBackground)
+            // --- Survey content variables that posthog-js would normally set itself ---
+            // Card surface (input background). Falls back to backgroundColor if not explicitly set.
+            const cardBg = appearance.inputBackground || appearance.backgroundColor
+            if (cardBg) {
+                root.style.setProperty('--ph-survey-input-background', cardBg)
+                root.style.setProperty('--ph-survey-background-color', cardBg)
+            }
+            if (appearance.borderColor) {
+                root.style.setProperty('--ph-survey-border-color', appearance.borderColor)
+            }
+            if (appearance.borderRadius) {
+                root.style.setProperty('--ph-survey-border-radius', appearance.borderRadius)
+            }
+
+            // Primary text color. Priority: explicit textColor → explicit inputTextColor →
+            // derived contrast from the card surface → default. Applied to BOTH the container
+            // variable (for question text, choices, etc.) and the page variable (for progress
+            // chrome, loading spinner, corner branding).
+            const explicitText = appearance.textColor || appearance.inputTextColor
+            const derivedText = cardBg ? getContrastingTextColor(cardBg) : null
+            const primaryText = explicitText || derivedText
+            if (primaryText) {
+                root.style.setProperty('--ph-survey-text-primary-color', primaryText)
+                root.style.setProperty('--ph-survey-input-text-color', primaryText)
+                root.style.setProperty('--ph-survey-page-text', primaryText)
+            }
+
+            if (appearance.textSubtleColor) {
+                root.style.setProperty('--ph-survey-text-subtle-color', appearance.textSubtleColor)
+                root.style.setProperty('--ph-survey-page-text-subtle', appearance.textSubtleColor)
+            }
+
+            // Submit button. Text color defaults to the contrast of the button fill.
+            if (appearance.submitButtonColor) {
+                root.style.setProperty('--ph-survey-submit-button-color', appearance.submitButtonColor)
+                const submitText =
+                    appearance.submitButtonTextColor || getContrastingTextColor(appearance.submitButtonColor) || '#ffffff'
+                root.style.setProperty('--ph-survey-submit-button-text-color', submitText)
+            }
+
+            // Rating buttons. Default bg follows the card surface; active bg defaults to the
+            // submit button color for visual coherence with the primary action.
+            const ratingBg = appearance.ratingButtonColor || cardBg
+            if (ratingBg) {
+                root.style.setProperty('--ph-survey-rating-bg-color', ratingBg)
+                const ratingText = getContrastingTextColor(ratingBg) || primaryText
+                if (ratingText) {
+                    root.style.setProperty('--ph-survey-rating-text-color', ratingText)
+                }
+            }
+            const ratingActive = appearance.ratingButtonActiveColor || appearance.submitButtonColor
+            if (ratingActive) {
+                root.style.setProperty('--ph-survey-rating-active-bg-color', ratingActive)
+                const ratingActiveText = getContrastingTextColor(ratingActive) || '#ffffff'
+                root.style.setProperty('--ph-survey-rating-active-text-color', ratingActiveText)
+            }
+
+            if (appearance.disabledButtonOpacity) {
+                root.style.setProperty('--ph-survey-disabled-button-opacity', appearance.disabledButtonOpacity)
+            }
+
+            // Card elevation shadow contrasts with the card surface — dark cards need a light
+            // shadow so elevation doesn't disappear into the background.
+            const cardLuminance = getLuminance(cardBg)
             if (cardLuminance !== null && cardLuminance < 0.5) {
                 root.style.setProperty(
                     '--ph-survey-card-shadow',
                     '0 1px 2px rgba(255, 255, 255, 0.04), 0 2px 8px rgba(255, 255, 255, 0.04)'
                 )
+            }
+
+            // Corner branding pill adapts to the page background. A white translucent pill
+            // on a dark page looks like a glaring badge — flip it to a dark translucent fill
+            // so it recedes into the surface the same way it does on light backgrounds.
+            const pageLuminance = getLuminance(appearance.backgroundColor)
+            if (pageLuminance !== null && pageLuminance < 0.5) {
+                root.style.setProperty('--ph-survey-pill-background', 'rgba(17, 17, 17, 0.55)')
             }
         }
 

--- a/products/surveys/backend/api/survey.py
+++ b/products/surveys/backend/api/survey.py
@@ -2792,10 +2792,7 @@ def public_survey_page(request, survey_id: str):
             archived=survey.archived,
             survey_type=survey.type,
         )
-        # Pass survey appearance through so the error page can still wear the customer's
-        # brand (background color, fonts, etc.) even when the survey isn't accepting
-        # responses. A respondent hitting a closed survey link should see the same
-        # visual language they'd have seen if the survey were still live.
+        # Pass appearance so the error page still shows the customer's brand.
         return render(
             request,
             "surveys/error.html",

--- a/products/surveys/backend/api/survey.py
+++ b/products/surveys/backend/api/survey.py
@@ -2792,12 +2792,17 @@ def public_survey_page(request, survey_id: str):
             archived=survey.archived,
             survey_type=survey.type,
         )
+        # Pass survey appearance through so the error page can still wear the customer's
+        # brand (background color, fonts, etc.) even when the survey isn't accepting
+        # responses. A respondent hitting a closed survey link should see the same
+        # visual language they'd have seen if the survey were still live.
         return render(
             request,
             "surveys/error.html",
             {
-                "error_title": "Survey not receiving responses",
-                "error_message": "The requested survey is not receiving responses.",
+                "error_title": "Feels quiet in here",
+                "error_message": "This survey isn't taking responses right now. It might be closed, expired, or not live yet.",
+                "appearance": survey.appearance or {},
             },
             status=404,  # Use 404 instead of 403 to prevent information leakage
         )

--- a/products/surveys/backend/api/test/test_external_surveys.py
+++ b/products/surveys/backend/api/test/test_external_surveys.py
@@ -95,7 +95,7 @@ class TestExternalSurveys(APIBaseTest):
 
         response = self.client.get(f"/external_surveys/{popover_survey.id}/")
         assert response.status_code == 404
-        assert "Survey not receiving responses" in response.content.decode()
+        assert "Feels quiet in here" in response.content.decode()
 
     def test_archived_surveys_not_accessible(self):
         """Test that archived surveys return 404"""
@@ -103,7 +103,7 @@ class TestExternalSurveys(APIBaseTest):
 
         response = self.client.get(f"/external_surveys/{survey.id}/")
         assert response.status_code == 404
-        assert "Survey not receiving responses" in response.content.decode()
+        assert "Feels quiet in here" in response.content.decode()
 
     def test_survey_must_be_running(self):
         """Test survey availability based on start/end dates"""

--- a/products/surveys/backend/api/test/test_external_surveys.py
+++ b/products/surveys/backend/api/test/test_external_surveys.py
@@ -105,12 +105,25 @@ class TestExternalSurveys(APIBaseTest):
         assert response.status_code == 404
         assert "Feels quiet in here" in response.content.decode()
 
+    def test_error_page_includes_survey_appearance(self):
+        survey = self.create_external_survey(
+            archived=True,
+            appearance={"backgroundColor": "#1a1a2e", "textColor": "#e0e0e0"},
+        )
+
+        response = self.client.get(f"/external_surveys/{survey.id}/")
+        assert response.status_code == 404
+        content = response.content.decode()
+        assert "#1a1a2e" in content
+        assert "#e0e0e0" in content
+
     def test_survey_must_be_running(self):
         """Test survey availability based on start/end dates"""
         # Survey not started yet
         future_survey = self.create_external_survey(start_date=datetime.now(UTC) + timedelta(days=1))
         response = self.client.get(f"/external_surveys/{future_survey.id}/")
         assert response.status_code == 404
+        assert "Feels quiet in here" in response.content.decode()
 
         # Survey ended
         ended_survey = self.create_external_survey(
@@ -118,11 +131,13 @@ class TestExternalSurveys(APIBaseTest):
         )
         response = self.client.get(f"/external_surveys/{ended_survey.id}/")
         assert response.status_code == 404
+        assert "Feels quiet in here" in response.content.decode()
 
         # Survey never started
         never_started_survey = self.create_external_survey(start_date=None)
         response = self.client.get(f"/external_surveys/{never_started_survey.id}/")
         assert response.status_code == 404
+        assert "Feels quiet in here" in response.content.decode()
 
     def test_security_headers_present(self):
         """Test that proper security headers are set"""


### PR DESCRIPTION
## Problem

Two real bugs on the hosted survey page + its error sibling looked wrong on dark themes.

## Changes

1. **`renderSurvey()` doesn't call `addSurveyCSSVariablesToElement`** — so none of the `--ph-survey-*` container variables were set by posthog-js on the API path. Customer appearance fields (\`inputBackground\`, \`borderColor\`, text colors, submit button colors, etc.) were silently ignored and dark-theme surveys kept black body text. Replicated the variable-setting logic locally in \`applyPageAppearance\` and set everything on \`:root\` so values cascade into the container.
2. **Corner branding pill** was hardcoded white-translucent, which reads as a glaring badge on dark backgrounds. Now adapts to page luminance and flips to a dark translucent fill on dark themes. Same for the error page pill.
3. **\`surveys/error.html\` rewritten** to match the hosted page aesthetic. Dropped the brand gradient stripe, logo, orange error circle, decorative dots, "Go Back" / "Try Again" buttons (the latter was misleading — reloading doesn't un-archive a survey), and dark mode. Template variables (\`error_title\`, \`error_message\`) untouched. Threads \`survey.appearance\` through when we have the survey object loaded so a respondent hitting a closed survey link still sees the customer's brand.

## How did you test this code?

Authored by Claude in an interactive session with Lucas. Manually exercised on the dev server with a dark-theme customer survey (\`backgroundColor: "#171717"\`, explicit \`textColor\`, custom \`inputBackground\`). Verified that question text, inputs, buttons, borders, and the corner pill all respect the customer theme. **Not** tested on other browsers, real touch devices, or with screen readers.

## Publish to changelog?

No

## 🤖 LLM context

The load-bearing finding: \`posthog-js\`'s \`renderSurvey\` at \`surveys.tsx:377\` only calls \`Preact.render()\` — it does **not** call \`addSurveyCSSVariablesToElement\`. That function is only wired into the automatic popup/widget display path. On the hosted survey page, every \`var(--ph-survey-*, fallback)\` in the template's CSS was silently resolving to the fallback, which is why customer appearance customization was being ignored for everything except \`backgroundColor\` (which we were already setting ourselves). The fix replicates \`addSurveyCSSVariablesToElement\`'s variable mapping locally. Fixing this upstream (have \`renderSurvey\` call the helper) would be a cleaner long-term path but affects every consumer of that API, so doing it here for now.