### PR TITLE
chore(cdp): normalize content-type handling in webhook responses

### DIFF
--- a/nodejs/src/cdp/cdp-api.ts
+++ b/nodejs/src/cdp/cdp-api.ts
@@ -44,6 +44,30 @@ import { HogFunctionInvocationGlobals, HogFunctionType, MinimalLogEntry } from '
 import { convertToHogFunctionInvocationGlobals, isNativeHogFunction, isSegmentPluginHogFunction } from './utils'
 import { convertToHogFunctionFilterGlobal } from './utils/hog-function-filtering'
 
+// Allowlist of safe content types for webhook responses to prevent XSS
+const SAFE_CONTENT_TYPES = new Set([
+    'text/plain',
+    'text/csv',
+    'application/json',
+    'application/octet-stream',
+    'application/xml',
+    'image/gif',
+    'image/png',
+    'image/jpeg',
+    'image/webp',
+])
+
+function sanitizeContentType(contentType: string | undefined, fallback: string): string {
+    if (!contentType) {
+        return fallback
+    }
+    const normalized = contentType.toLowerCase().trim().split(';')[0].trim()
+    if (SAFE_CONTENT_TYPES.has(normalized)) {
+        return contentType
+    }
+    return fallback
+}
+
 export type CdpApiConfig = PluginsServerConfig
 export type CdpApiDeps = CdpConsumerBaseDeps
 
@@ -599,18 +623,21 @@ export class CdpApi {
 
             if (typeof result.execResult === 'object' && result.execResult && 'httpResponse' in result.execResult) {
                 const httpResponse = result.execResult.httpResponse as HogFunctionWebhookResult
+
+                // Security headers to prevent XSS via content-type injection
+                res.set('X-Content-Type-Options', 'nosniff')
+                res.set('Content-Security-Policy', "default-src 'none'")
+
                 if (typeof httpResponse.body === 'string') {
+                    const safeContentType = sanitizeContentType(
+                        httpResponse.contentType,
+                        httpResponse.isBase64Encoded ? 'application/octet-stream' : 'text/plain'
+                    )
                     if (httpResponse.isBase64Encoded) {
                         const buffer = Buffer.from(httpResponse.body, 'base64')
-                        return res
-                            .status(httpResponse.status)
-                            .type(httpResponse.contentType ?? 'application/octet-stream')
-                            .send(buffer)
+                        return res.status(httpResponse.status).type(safeContentType).send(buffer)
                     }
-                    return res
-                        .status(httpResponse.status)
-                        .type(httpResponse.contentType ?? 'text/plain')
-                        .send(httpResponse.body)
+                    return res.status(httpResponse.status).type(safeContentType).send(httpResponse.body)
                 } else if (typeof httpResponse.body === 'object') {
                     return res.status(httpResponse.status).json(httpResponse.body)
                 }

--- a/nodejs/src/cdp/cdp-api.ts
+++ b/nodejs/src/cdp/cdp-api.ts
@@ -63,7 +63,7 @@ function sanitizeContentType(contentType: string | undefined, fallback: string):
     }
     const normalized = contentType.toLowerCase().trim().split(';')[0].trim()
     if (SAFE_CONTENT_TYPES.has(normalized)) {
-        return contentType
+        return normalized
     }
     return fallback
 }

--- a/nodejs/src/cdp/consumers/cdp-source-webhooks.consumer.test.ts
+++ b/nodejs/src/cdp/consumers/cdp-source-webhooks.consumer.test.ts
@@ -314,6 +314,8 @@ describe('SourceWebhooksConsumer', () => {
                 const res = await doGetRequest({ webhookId: customBinaryFunction.id })
                 expect(res.status).toEqual(200)
                 expect(res.headers['content-type']).toEqual('image/png')
+                expect(res.headers['x-content-type-options']).toEqual('nosniff')
+                expect(res.headers['content-security-policy']).toEqual("default-src 'none'")
                 expect(Buffer.from(res.body)).toEqual(Buffer.from(base64Png, 'base64'))
             })
 
@@ -329,7 +331,65 @@ describe('SourceWebhooksConsumer', () => {
                 const res = await doGetRequest({ webhookId: customTextFunction.id })
                 expect(res.status).toEqual(200)
                 expect(res.headers['content-type']).toContain('text/plain')
+                expect(res.headers['x-content-type-options']).toEqual('nosniff')
+                expect(res.headers['content-security-policy']).toEqual("default-src 'none'")
                 expect(res.text).toEqual('Hello, world!')
+            })
+
+            it.each([
+                ['text/html', '<script>alert(document.cookie)</script>'],
+                ['image/svg+xml', '<svg onload="alert(1)"></svg>'],
+                ['application/javascript', 'alert(1)'],
+                ['text/javascript', 'alert(1)'],
+                ['application/xhtml+xml', '<html></html>'],
+            ])(
+                'should reject dangerous content type %s and fall back to text/plain',
+                async (dangerousType, payload) => {
+                    const fn = await insertHogFunction(hub.postgres, team.id, {
+                        type: 'source_webhook',
+                        hog: `return { 'httpResponse': { 'status': 200, 'body': '${payload}', 'contentType': '${dangerousType}' } }`,
+                        bytecode: await compileHog(
+                            `return { 'httpResponse': { 'status': 200, 'body': '${payload}', 'contentType': '${dangerousType}' } }`
+                        ),
+                        inputs: {},
+                    })
+                    const res = await doGetRequest({ webhookId: fn.id })
+                    expect(res.status).toEqual(200)
+                    expect(res.headers['content-type']).toContain('text/plain')
+                    expect(res.headers['content-type']).not.toContain(dangerousType)
+                    expect(res.headers['x-content-type-options']).toEqual('nosniff')
+                    expect(res.headers['content-security-policy']).toEqual("default-src 'none'")
+                    expect(res.text).toEqual(payload)
+                }
+            )
+
+            it('should reject unknown content types not on the allowlist', async () => {
+                const fn = await insertHogFunction(hub.postgres, team.id, {
+                    type: 'source_webhook',
+                    hog: `return { 'httpResponse': { 'status': 200, 'body': 'data', 'contentType': 'application/x-custom' } }`,
+                    bytecode: await compileHog(
+                        `return { 'httpResponse': { 'status': 200, 'body': 'data', 'contentType': 'application/x-custom' } }`
+                    ),
+                    inputs: {},
+                })
+                const res = await doGetRequest({ webhookId: fn.id })
+                expect(res.status).toEqual(200)
+                expect(res.headers['content-type']).toContain('text/plain')
+            })
+
+            it('should reject dangerous content type with charset parameter', async () => {
+                const fn = await insertHogFunction(hub.postgres, team.id, {
+                    type: 'source_webhook',
+                    hog: `return { 'httpResponse': { 'status': 200, 'body': '<script>alert(1)</script>', 'contentType': 'text/html; charset=utf-8' } }`,
+                    bytecode: await compileHog(
+                        `return { 'httpResponse': { 'status': 200, 'body': '<script>alert(1)</script>', 'contentType': 'text/html; charset=utf-8' } }`
+                    ),
+                    inputs: {},
+                })
+                const res = await doGetRequest({ webhookId: fn.id })
+                expect(res.status).toEqual(200)
+                expect(res.headers['content-type']).toContain('text/plain')
+                expect(res.headers['content-type']).not.toContain('text/html')
             })
 
             it('should default to application/octet-stream when isBase64Encoded is true but no contentType', async () => {

--- a/nodejs/src/cdp/consumers/cdp-source-webhooks.consumer.test.ts
+++ b/nodejs/src/cdp/consumers/cdp-source-webhooks.consumer.test.ts
@@ -392,6 +392,21 @@ describe('SourceWebhooksConsumer', () => {
                 expect(res.headers['content-type']).not.toContain('text/html')
             })
 
+            it('should strip parameters from allowlisted content types', async () => {
+                const fn = await insertHogFunction(hub.postgres, team.id, {
+                    type: 'source_webhook',
+                    hog: `return { 'httpResponse': { 'status': 200, 'body': 'hello', 'contentType': 'text/plain; charset=utf-7' } }`,
+                    bytecode: await compileHog(
+                        `return { 'httpResponse': { 'status': 200, 'body': 'hello', 'contentType': 'text/plain; charset=utf-7' } }`
+                    ),
+                    inputs: {},
+                })
+                const res = await doGetRequest({ webhookId: fn.id })
+                expect(res.status).toEqual(200)
+                expect(res.headers['content-type']).toContain('text/plain')
+                expect(res.headers['content-type']).not.toContain('utf-7')
+            })
+
             it('should default to application/octet-stream when isBase64Encoded is true but no contentType', async () => {
                 const base64Data = 'AQIDBA=='
                 const customBinaryFunction = await insertHogFunction(hub.postgres, team.id, {


### PR DESCRIPTION
Consolidate content-type resolution for webhook responses behind a shared helper and add standard response headers.