### PR TITLE
feat: Add Bearer token redaction for MCP observability

### DIFF
--- a/services/mcp/src/lib/mcpcat.ts
+++ b/services/mcp/src/lib/mcpcat.ts
@@ -16,6 +16,10 @@ export type McpCatIdentityProvider = {
     getVersion: () => number | undefined
 }
 
+export function redactSensitiveInformation(text: string): string {
+    return text.replace(/Bearer\s?[\w\-.]+/g, '<redacted>')
+}
+
 export async function initMcpCatObservability(server: McpServer, identity: McpCatIdentityProvider): Promise<void> {
     // MCPCat initialization must never block MCP server startup
     // and we don't even need to do anything if the API key or host is not set
@@ -60,6 +64,7 @@ export async function initMcpCatObservability(server: McpServer, identity: McpCa
             identify: async () => identifyResult,
             eventTags: () => eventTags,
             eventProperties: () => eventProperties,
+            redactSensitiveInformation: (text) => Promise.resolve(redactSensitiveInformation(text)),
             exporters: {
                 posthog: {
                     type: 'posthog',

--- a/services/mcp/tests/unit/mcpcat.test.ts
+++ b/services/mcp/tests/unit/mcpcat.test.ts
@@ -3,10 +3,34 @@ import { env } from 'cloudflare:workers'
 import { track } from 'mcpcat'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { initMcpCatObservability, type McpCatIdentityProvider } from '@/lib/mcpcat'
+import { initMcpCatObservability, redactSensitiveInformation, type McpCatIdentityProvider } from '@/lib/mcpcat'
 
 const TEST_API_KEY = 'test-api-key'
 const TEST_HOST = 'https://test.posthog.com'
+
+describe('redactSensitiveInformation', () => {
+    it.each([
+        // PostHog project tokens
+        ['Bearer phc_1a2b3c4d5e6f', '<redacted>'],
+        // PostHog personal API keys
+        ['Bearer phx_9z8y7x6w5v4u', '<redacted>'],
+        // OAuth access and refresh tokens
+        ['Bearer pha_access_token_value', '<redacted>'],
+        ['Bearer phr_refresh_token_value', '<redacted>'],
+        // Inside JSON strings
+        ['"Authorization": "Bearer phc_abc123"', '"Authorization": "<redacted>"'],
+        // Tokens with hyphens and dots (just in case we add them)
+        ['Bearer phc_abc-123.xyz', '<redacted>'],
+        // Multiple tokens
+        ['Bearer phc_token1 and Bearer pha_token2', '<redacted> and <redacted>'],
+        // No space after Bearer
+        ['Bearerphc_no_space', '<redacted>'],
+        // No match
+        ['no sensitive data here', 'no sensitive data here'],
+    ])('redacts %j to %j', (input, expected) => {
+        expect(redactSensitiveInformation(input)).toBe(expected)
+    })
+})
 
 describe('initMcpCatObservability', () => {
     beforeEach(() => {


### PR DESCRIPTION
This pull request adds sensitive information redaction functionality to the MCP observability system. A new `redactSensitiveInformation` function is introduced that uses regex pattern matching to identify and replace Bearer tokens (including PostHog project tokens, personal API keys, and OAuth tokens) with `<redacted>` placeholders. The function is integrated into the MCPCat observability configuration and includes comprehensive test coverage for various token formats, JSON strings, multiple tokens, and edge cases.