### PR TITLE
fix(experiments): improve error handling for the experiment actors query.

### DIFF
--- a/frontend/src/scenes/experiments/charts/funnel/StepBar.tsx
+++ b/frontend/src/scenes/experiments/charts/funnel/StepBar.tsx
@@ -65,22 +65,34 @@ function openExperimentPersonsModalForSeries({
     })
 
     // IMPORTANT: For experiment funnels, the frontend adds an "Experiment exposure" step at index 0
-    // But the backend funnel query doesn't include this - it only has the actual metric events
-    // Frontend: Step 0=Exposure, Step 1=$pageview, Step 2=uploaded_file
-    // Backend:                  Step 1=$pageview, Step 2=uploaded_file
-    // So we subtract 1 to map frontend -> backend step numbers
-    const backendStepNo = stepNo - 1
+    // But the backend actors query funnel doesn't include this - it only has the actual metric events
+    // Frontend: Step 0=Exposure, Step 1=$pageview, Step 2=click
+    // Backend:                  Step 1=$pageview, Step 2=click
+    // So we map frontend step indices to backend step numbers directly (stepIndex = backendStepNo)
+    const backendStepNo = stepIndex
 
-    // Skip if trying to query the "Experiment exposure" step (doesn't exist in backend funnel)
+    // Skip if trying to query the "Experiment exposure" step (stepIndex 0, doesn't exist in backend)
     if (backendStepNo < 1) {
         return
     }
+
+    // Skip drop-off queries for the first metric step (stepIndex 1)
+    // Drop-offs at step 1 would mean "exposed but never entered the funnel",
+    // which can't be queried via the actors funnel (it starts at the first metric event)
+    if (!converted && backendStepNo === 1) {
+        return
+    }
+
+    // For drop-offs, the mapping is straightforward
+    // Frontend step 2 drop-off = "completed step 1 ($pageview) but not step 2 (click)" = backend -2 = -stepIndex
+    // Frontend step 3 drop-off = "completed step 2 (click) but not step 3 (next event)" = backend -3 = -stepIndex
+    const funnelStep = converted ? backendStepNo : -backendStepNo
 
     // Create ExperimentActorsQuery (same pattern as FunnelsActorsQuery)
     const query: ExperimentActorsQuery = {
         kind: NodeKind.ExperimentActorsQuery,
         source: experimentQuery,
-        funnelStep: converted ? backendStepNo : -backendStepNo, // Positive = converted, Negative = dropped off
+        funnelStep,
         funnelStepBreakdown: variantKey, // Filter by variant
         includeRecordings: true,
     }
@@ -176,9 +188,9 @@ export function StepBar({ step, stepIndex }: StepBarProps): JSX.Element {
                         const rect = ref.current.getBoundingClientRect()
                         // Only show "Click to inspect actors" hint when clicking will actually work:
                         // - Step 0 (exposure) with new feature enabled: can't use actors query (returns early), so don't show hint
-                        // - Step 0 with legacy: can use sampled sessions, show hint if sessionData exists
-                        // - Step > 0 with new feature: can use actors query, show hint
-                        // - Step > 0 with legacy: can use sampled sessions, show hint if sessionData exists
+                        // - Step 1 (first metric) drop-offs with new feature: can't query (no exposure in backend funnel), conversions work
+                        // - Step 2+ with new feature: both conversions and drop-offs work
+                        // - Legacy mode: show hint if sessionData exists
                         const hasClickableData = hasActorsQueryFeature ? stepIndex > 0 : !!sessionData
                         showTooltip([rect.x, rect.y, rect.width], stepIndex, step, hasClickableData)
                     }
@@ -190,7 +202,7 @@ export function StepBar({ step, stepIndex }: StepBarProps): JSX.Element {
                     onClick={handleDropoffClick}
                     style={{
                         cursor: hasActorsQueryFeature
-                            ? stepIndex > 0
+                            ? stepIndex > 1
                                 ? 'pointer'
                                 : 'default'
                             : sessionData

--- a/posthog/hogql_queries/experiments/experiment_query_runner.py
+++ b/posthog/hogql_queries/experiments/experiment_query_runner.py
@@ -434,6 +434,25 @@ class ExperimentQueryRunner(QueryRunner):
 
         This ensures we get the same behavior as regular funnel actors queries,
         including proper conversion/dropoff filtering and recording support.
+
+        IMPORTANT: Exposure step exclusion
+        --------------------------------------
+        The actors query funnel does NOT include the exposure step, only metric events.
+
+        Main experiment query (calculates conversion rates):
+            - Structure: Exposure (step 0) → Metric 1 (step 1) → Metric 2 (step 2)
+            - Includes exposure to enforce temporal ordering (only count events AFTER exposure)
+            - Returns highest step reached for each exposed user
+
+        Actors query (retrieves individual users):
+            - Structure: Metric 1 (step 1) → Metric 2 (step 2) - NO exposure
+            - Queries WITHIN the already-filtered exposed population
+            - Exposure filtering is inherited through variant breakdown
+
+        Frontend-to-backend step mapping:
+            - Frontend shows: Step 0 (Exposure), Step 1 (Metric 1), Step 2 (Metric 2)
+            - Backend actors query: Step 1 (Metric 1), Step 2 (Metric 2)
+            - Frontend step index maps directly to backend step number (stepIndex = backendStepNo)
         """
         # Ensure actors_query is set (should be set by InsightActorsQueryRunner before calling this)
         if self.actors_query is None:
@@ -442,6 +461,61 @@ class ExperimentQueryRunner(QueryRunner):
         # Only support funnel metrics for now
         if not isinstance(self.metric, ExperimentFunnelMetric):
             raise ValidationError("Actors query only supported for funnel experiment metrics")
+
+        # Validate funnelStep for experiment funnels
+        # Experiment funnels have a unique structure: Exposure → Metric Events
+        # The actors query excludes exposure and only queries metric events
+        funnel_step = self.actors_query.funnelStep
+        if funnel_step is None:
+            raise ValidationError("funnelStep is required for experiment actors query")
+
+        num_metric_steps = len(self.metric.series)
+
+        if funnel_step == -1:
+            # -1 would mean "dropped before first metric step" which is invalid
+            # because we only query exposed users who are already past the exposure checkpoint
+            # Build event names string (handle both EventsNode and ActionsNode)
+            from posthog.schema import EventsNode
+
+            event_names: list[str] = []
+            for step in self.metric.series[:2]:  # Show first 2 for brevity
+                if isinstance(step, EventsNode):
+                    event_names.append(step.event or "All events")
+                else:  # ActionsNode
+                    event_names.append(f"Action {step.id}")
+
+            metric_events_str = " → ".join(event_names)
+            if len(self.metric.series) > 2:
+                metric_events_str += " → ..."
+
+            raise ValidationError(
+                f"Cannot query drop-offs before the first metric step in experiment funnels. "
+                f"Experiment funnel structure: [Exposure → {metric_events_str}]. "
+                f"Drop-offs at funnelStep=-1 would mean 'exposed but never entered the funnel', "
+                f"which cannot be queried through the actors API. "
+                f"Valid drop-off steps: -2 (dropped after first metric step) to -{num_metric_steps + 1}."
+            )
+
+        if funnel_step == 0:
+            raise ValidationError(
+                "Funnel steps are 1-indexed. Step 0 does not exist. "
+                f"Valid conversion steps: 1 (first metric step) to {num_metric_steps}."
+            )
+
+        if funnel_step < -1:
+            # Check if drop-off step is out of range
+            max_drop_off = -(num_metric_steps + 1)
+            if funnel_step < max_drop_off:
+                raise ValidationError(
+                    f"Invalid drop-off step {funnel_step} for experiment with {num_metric_steps} metric steps. "
+                    f"Valid drop-off steps: -2 (dropped after first metric step) to {max_drop_off}."
+                )
+
+        if funnel_step > num_metric_steps:
+            raise ValidationError(
+                f"Invalid conversion step {funnel_step} for experiment with {num_metric_steps} metric steps. "
+                f"Valid conversion steps: 1 (first metric step) to {num_metric_steps}."
+            )
 
         # Import here to avoid circular dependencies
         from posthog.schema import BreakdownFilter, BreakdownType, FunnelsActorsQuery, FunnelsFilter, FunnelsQuery

--- a/posthog/hogql_queries/experiments/test/__snapshots__/test_experiment_actors_query.ambr
+++ b/posthog/hogql_queries/experiments/test/__snapshots__/test_experiment_actors_query.ambr
@@ -1,5 +1,66 @@
 # serializer version: 1
-# name: TestExperimentActorsQuery.test_experiment_funnel_actors_0_conversions_control
+# name: TestExperimentActorsQuery.test_experiment_funnel_actors_0_conversions_step1_control
+  '''
+  SELECT source.id,
+         source.id AS id
+  FROM
+    (SELECT aggregation_target AS actor_id,
+            actor_id AS id
+     FROM
+       (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, arrayMap(x -> ifNull(x, ''), prop_basic), arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1)])))) AS events_array,
+               argMinIf(prop_basic, timestamp, notEmpty(arrayFilter(x -> notEmpty(x), prop_basic))) AS prop,
+               arrayJoin(aggregate_funnel_array(2, 1209600, 'first_touch', 'None', [if(empty(prop), [''], prop)], [], arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                                                    and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                                                    and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                   and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                                                   and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+               af_tuple.1 AS step_reached,
+               plus(af_tuple.1, 1) AS steps,
+               af_tuple.2 AS breakdown,
+               af_tuple.3 AS timings,
+               af_tuple.5 AS steps_bitfield,
+               aggregation_target AS aggregation_target
+        FROM
+          (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                  if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
+                  e.uuid AS uuid,
+                  e.`$session_id` AS `$session_id`,
+                  e.`$window_id` AS `$window_id`,
+                  if(equals(e.event, 'signup'), 1, 0) AS step_0,
+                  if(equals(e.event, 'purchase'), 1, 0) AS step_1,
+                  [ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$feature/test-experiment'), ''), 'null'), '^"|"$', '')), '')] AS prop_basic,
+                  prop_basic AS prop
+           FROM events AS e
+           LEFT OUTER JOIN
+             (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
+                     person_distinct_id_overrides.distinct_id AS distinct_id
+              FROM person_distinct_id_overrides
+              WHERE equals(person_distinct_id_overrides.team_id, 99999)
+              GROUP BY person_distinct_id_overrides.distinct_id
+              HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+           WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('today', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))), in(e.event, tuple('purchase', 'signup'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))
+        GROUP BY aggregation_target
+        HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+     WHERE and(bitTest(steps_bitfield, 0), ifNull(equals(arrayFlatten(array(breakdown)), arrayFlatten(array('control'))), isNull(arrayFlatten(array(breakdown)))
+                                                  and isNull(arrayFlatten(array('control')))))
+     ORDER BY aggregation_target ASC SETTINGS join_algorithm='auto') AS source
+  ORDER BY source.id ASC
+  LIMIT 101
+  OFFSET 0 SETTINGS optimize_aggregation_in_order=1,
+                    join_algorithm='auto',
+                    readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0,
+                    transform_null_in=1,
+                    optimize_min_equality_disjunction_chain_length=4294967295,
+                    allow_experimental_join_condition=1,
+                    use_hive_partitioning=0
+  '''
+# ---
+# name: TestExperimentActorsQuery.test_experiment_funnel_actors_1_conversions_step2_control
   '''
   SELECT source.id,
          source.id AS id
@@ -60,7 +121,7 @@
                     use_hive_partitioning=0
   '''
 # ---
-# name: TestExperimentActorsQuery.test_experiment_funnel_actors_1_dropoffs_control
+# name: TestExperimentActorsQuery.test_experiment_funnel_actors_2_dropoffs_control
   '''
   SELECT source.id,
          source.id AS id
@@ -121,7 +182,68 @@
                     use_hive_partitioning=0
   '''
 # ---
-# name: TestExperimentActorsQuery.test_experiment_funnel_actors_2_conversions_test
+# name: TestExperimentActorsQuery.test_experiment_funnel_actors_3_conversions_step1_test
+  '''
+  SELECT source.id,
+         source.id AS id
+  FROM
+    (SELECT aggregation_target AS actor_id,
+            actor_id AS id
+     FROM
+       (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, arrayMap(x -> ifNull(x, ''), prop_basic), arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1)])))) AS events_array,
+               argMinIf(prop_basic, timestamp, notEmpty(arrayFilter(x -> notEmpty(x), prop_basic))) AS prop,
+               arrayJoin(aggregate_funnel_array(2, 1209600, 'first_touch', 'None', [if(empty(prop), [''], prop)], [], arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                                                    and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                                                    and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                   and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                                                   and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+               af_tuple.1 AS step_reached,
+               plus(af_tuple.1, 1) AS steps,
+               af_tuple.2 AS breakdown,
+               af_tuple.3 AS timings,
+               af_tuple.5 AS steps_bitfield,
+               aggregation_target AS aggregation_target
+        FROM
+          (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                  if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
+                  e.uuid AS uuid,
+                  e.`$session_id` AS `$session_id`,
+                  e.`$window_id` AS `$window_id`,
+                  if(equals(e.event, 'signup'), 1, 0) AS step_0,
+                  if(equals(e.event, 'purchase'), 1, 0) AS step_1,
+                  [ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$feature/test-experiment'), ''), 'null'), '^"|"$', '')), '')] AS prop_basic,
+                  prop_basic AS prop
+           FROM events AS e
+           LEFT OUTER JOIN
+             (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
+                     person_distinct_id_overrides.distinct_id AS distinct_id
+              FROM person_distinct_id_overrides
+              WHERE equals(person_distinct_id_overrides.team_id, 99999)
+              GROUP BY person_distinct_id_overrides.distinct_id
+              HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+           WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('today', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))), in(e.event, tuple('purchase', 'signup'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))
+        GROUP BY aggregation_target
+        HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+     WHERE and(bitTest(steps_bitfield, 0), ifNull(equals(arrayFlatten(array(breakdown)), arrayFlatten(array('test'))), isNull(arrayFlatten(array(breakdown)))
+                                                  and isNull(arrayFlatten(array('test')))))
+     ORDER BY aggregation_target ASC SETTINGS join_algorithm='auto') AS source
+  ORDER BY source.id ASC
+  LIMIT 101
+  OFFSET 0 SETTINGS optimize_aggregation_in_order=1,
+                    join_algorithm='auto',
+                    readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0,
+                    transform_null_in=1,
+                    optimize_min_equality_disjunction_chain_length=4294967295,
+                    allow_experimental_join_condition=1,
+                    use_hive_partitioning=0
+  '''
+# ---
+# name: TestExperimentActorsQuery.test_experiment_funnel_actors_4_conversions_step2_test
   '''
   SELECT source.id,
          source.id AS id
@@ -165,6 +287,67 @@
         HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
      WHERE and(bitTest(steps_bitfield, 1), ifNull(equals(arrayFlatten(array(breakdown)), arrayFlatten(array('test'))), isNull(arrayFlatten(array(breakdown)))
                                                   and isNull(arrayFlatten(array('test')))))
+     ORDER BY aggregation_target ASC SETTINGS join_algorithm='auto') AS source
+  ORDER BY source.id ASC
+  LIMIT 101
+  OFFSET 0 SETTINGS optimize_aggregation_in_order=1,
+                    join_algorithm='auto',
+                    readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0,
+                    transform_null_in=1,
+                    optimize_min_equality_disjunction_chain_length=4294967295,
+                    allow_experimental_join_condition=1,
+                    use_hive_partitioning=0
+  '''
+# ---
+# name: TestExperimentActorsQuery.test_experiment_funnel_actors_5_dropoffs_test
+  '''
+  SELECT source.id,
+         source.id AS id
+  FROM
+    (SELECT aggregation_target AS actor_id,
+            actor_id AS id
+     FROM
+       (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, arrayMap(x -> ifNull(x, ''), prop_basic), arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1)])))) AS events_array,
+               argMinIf(prop_basic, timestamp, notEmpty(arrayFilter(x -> notEmpty(x), prop_basic))) AS prop,
+               arrayJoin(aggregate_funnel_array(2, 1209600, 'first_touch', 'None', [if(empty(prop), [''], prop)], [], arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                                                    and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                                                    and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                   and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                                                   and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+               af_tuple.1 AS step_reached,
+               plus(af_tuple.1, 1) AS steps,
+               af_tuple.2 AS breakdown,
+               af_tuple.3 AS timings,
+               af_tuple.5 AS steps_bitfield,
+               aggregation_target AS aggregation_target
+        FROM
+          (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                  if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
+                  e.uuid AS uuid,
+                  e.`$session_id` AS `$session_id`,
+                  e.`$window_id` AS `$window_id`,
+                  if(equals(e.event, 'signup'), 1, 0) AS step_0,
+                  if(equals(e.event, 'purchase'), 1, 0) AS step_1,
+                  [ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$feature/test-experiment'), ''), 'null'), '^"|"$', '')), '')] AS prop_basic,
+                  prop_basic AS prop
+           FROM events AS e
+           LEFT OUTER JOIN
+             (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
+                     person_distinct_id_overrides.distinct_id AS distinct_id
+              FROM person_distinct_id_overrides
+              WHERE equals(person_distinct_id_overrides.team_id, 99999)
+              GROUP BY person_distinct_id_overrides.distinct_id
+              HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+           WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('today', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))), in(e.event, tuple('purchase', 'signup'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))
+        GROUP BY aggregation_target
+        HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+     WHERE and(bitTest(steps_bitfield, 0), not(bitTest(steps_bitfield, 1)), ifNull(equals(arrayFlatten(array(breakdown)), arrayFlatten(array('test'))), isNull(arrayFlatten(array(breakdown)))
+                                                                                   and isNull(arrayFlatten(array('test')))))
      ORDER BY aggregation_target ASC SETTINGS join_algorithm='auto') AS source
   ORDER BY source.id ASC
   LIMIT 101

--- a/posthog/hogql_queries/experiments/test/test_experiment_actors_query.py
+++ b/posthog/hogql_queries/experiments/test/test_experiment_actors_query.py
@@ -102,9 +102,12 @@ class TestExperimentActorsQuery(ExperimentQueryRunnerBaseTest, ClickhouseTestMix
 
     @parameterized.expand(
         [
-            ("conversions_control", 2, "control", 4),
-            ("dropoffs_control", -2, "control", 2),
-            ("conversions_test", 2, "test", 6),
+            ("conversions_step1_control", 1, "control", 6),  # Step 1 conversions (signup)
+            ("conversions_step2_control", 2, "control", 4),  # Step 2 conversions (purchase)
+            ("dropoffs_control", -2, "control", 2),  # Step 2 drop-offs (signup but no purchase)
+            ("conversions_step1_test", 1, "test", 8),  # Step 1 conversions (signup) - test variant
+            ("conversions_step2_test", 2, "test", 6),  # Step 2 conversions (purchase) - test variant
+            ("dropoffs_test", -2, "test", 2),  # Step 2 drop-offs - test variant
         ]
     )
     @freeze_time("2020-01-01T12:00:00Z")
@@ -213,3 +216,122 @@ class TestExperimentActorsQuery(ExperimentQueryRunnerBaseTest, ClickhouseTestMix
         assert len(response.results[0]) == 3
         # matched_recordings should be a list (may be empty if no actual recordings exist)
         assert isinstance(response.results[0][2], list)
+
+    @freeze_time("2020-01-01T12:00:00Z")
+    def test_experiment_funnel_actors_invalid_steps(self):
+        """
+        Test that invalid funnelStep values are properly rejected with helpful error messages.
+
+        This test verifies that error messages:
+        1. Explain WHY the step is invalid for experiment funnels specifically
+        2. Show the experiment funnel structure (Exposure → Metric events)
+        3. Provide the valid range of steps
+        4. Use clear, actionable language
+
+        Experiment funnels have unique constraints:
+        - Exposure is step 0 in main query but excluded from actors query
+        - funnelStep=-1 is invalid (would mean "exposed but never entered funnel")
+        - funnelStep=0 is invalid (steps are 1-indexed)
+        - Out-of-range steps should be rejected
+        """
+        feature_flag, experiment, experiment_query = self._create_experiment_with_funnel()
+
+        # Test -1: Invalid drop-off (would mean "dropped before first metric step")
+        # Error message should explain the experiment funnel structure and why this is invalid
+        experiment_actors_query = ExperimentActorsQuery(
+            kind="ExperimentActorsQuery",
+            source=experiment_query,
+            funnelStep=-1,
+            funnelStepBreakdown="control",
+            includeRecordings=False,
+        )
+
+        actors_query = ActorsQuery(
+            source=experiment_actors_query,
+            select=["id", "person"],
+        )
+
+        with self.assertRaises(Exception) as context:
+            ActorsQueryRunner(query=actors_query, team=self.team).calculate()
+
+        error_message = str(context.exception)
+        # Verify error message contains all key information
+        self.assertIn("Cannot query drop-offs before the first metric step", error_message)
+        self.assertIn("experiment funnel", error_message.lower())
+        self.assertIn("Exposure", error_message)  # Shows funnel structure
+        self.assertIn("signup", error_message)  # Shows first metric event name
+        self.assertIn("exposed but never entered the funnel", error_message)  # Explains WHY invalid
+        self.assertIn("Valid drop-off steps: -2", error_message)  # Shows valid range
+        self.assertIn("-3", error_message)  # Shows upper bound of valid range
+
+        # Test 0: Invalid step (steps are 1-indexed)
+        # Error message should explain that step 0 doesn't exist and show valid range
+        experiment_actors_query_zero = ExperimentActorsQuery(
+            kind="ExperimentActorsQuery",
+            source=experiment_query,
+            funnelStep=0,
+            funnelStepBreakdown="control",
+            includeRecordings=False,
+        )
+
+        actors_query_zero = ActorsQuery(
+            source=experiment_actors_query_zero,
+            select=["id", "person"],
+        )
+
+        with self.assertRaises(Exception) as context:
+            ActorsQueryRunner(query=actors_query_zero, team=self.team).calculate()
+
+        error_message = str(context.exception)
+        self.assertIn("Funnel steps are 1-indexed", error_message)
+        self.assertIn("Step 0 does not exist", error_message)
+        self.assertIn("Valid conversion steps: 1", error_message)  # Shows start of valid range
+        self.assertIn("2", error_message)  # Shows end of valid range (2 metric steps)
+
+        # Test out-of-range drop-off (2-step funnel, so -3 is last valid, -4 is invalid)
+        # Error message should show the invalid step, number of metric steps, and valid range
+        experiment_actors_query_out_of_range = ExperimentActorsQuery(
+            kind="ExperimentActorsQuery",
+            source=experiment_query,
+            funnelStep=-4,  # Too many steps back for a 2-step funnel
+            funnelStepBreakdown="control",
+            includeRecordings=False,
+        )
+
+        actors_query_out_of_range = ActorsQuery(
+            source=experiment_actors_query_out_of_range,
+            select=["id", "person"],
+        )
+
+        with self.assertRaises(Exception) as context:
+            ActorsQueryRunner(query=actors_query_out_of_range, team=self.team).calculate()
+
+        error_message = str(context.exception)
+        self.assertIn("Invalid drop-off step -4", error_message)  # Shows the invalid value
+        self.assertIn("2 metric steps", error_message)  # Shows context
+        self.assertIn("Valid drop-off steps: -2", error_message)  # Shows valid range start
+        self.assertIn("-3", error_message)  # Shows valid range end
+
+        # Test out-of-range conversion (2-step funnel, so 3 is invalid)
+        # Error message should show the invalid step, number of metric steps, and valid range
+        experiment_actors_query_high_step = ExperimentActorsQuery(
+            kind="ExperimentActorsQuery",
+            source=experiment_query,
+            funnelStep=3,  # Only 2 metric steps exist
+            funnelStepBreakdown="control",
+            includeRecordings=False,
+        )
+
+        actors_query_high_step = ActorsQuery(
+            source=experiment_actors_query_high_step,
+            select=["id", "person"],
+        )
+
+        with self.assertRaises(Exception) as context:
+            ActorsQueryRunner(query=actors_query_high_step, team=self.team).calculate()
+
+        error_message = str(context.exception)
+        self.assertIn("Invalid conversion step 3", error_message)  # Shows the invalid value
+        self.assertIn("2 metric steps", error_message)  # Shows context
+        self.assertIn("Valid conversion steps: 1", error_message)  # Shows valid range start
+        self.assertIn("(first metric step) to 2", error_message)  # Shows valid range end with explanation


### PR DESCRIPTION
## Problem

The experiment actor's query is failing for some edge cases, returning unusable errors.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

We are covering the edge cases, adding tests, and improving the error messages returned by the query.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

```bash
hogli test posthog/hogql_queries/experiments/test/test_experiment_actors_query.py -v
```

![cat-type](https://github.com/user-attachments/assets/2ed168a7-b92c-41b6-b7eb-67b7632f6c65)


<!-- Briefly describe the steps you took, and what steps reviewers must take to get to where changes are, and what is the expected behavior. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

do not publish to changelog

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
