### PR TITLE
fix(mcp): override $ai_session_id for LLM analytics grouping

### DIFF
--- a/services/mcp/src/lib/mcpcat.ts
+++ b/services/mcp/src/lib/mcpcat.ts
@@ -41,13 +41,16 @@ export async function initMcpCatObservability(server: McpServer, identity: McpCa
         mcp_region: identity.getRegion(),
     }
 
-    // For tags, we need to override MCPcat's default $session_id with our own PostHog session UUID.
+    // For tags, we need to override MCPcat's default $session_id and $ai_session_id with our own
+    // PostHog session UUID. $session_id drives Session Replay; $ai_session_id is what LLM Analytics
+    // groups traces by — without overriding it, MCPcat's exporter falls back to `mcpcat_<ksuid>`.
     // We can't just do this with a single object because the type returned must be `Record<string, string>`,
     // so we need some shenanigans here.
     const sessionUuid = await identity.getSessionUuid()
     const eventTags: Record<string, string> = {}
     if (sessionUuid) {
         eventTags.$session_id = sessionUuid
+        eventTags.$ai_session_id = sessionUuid
     }
 
     // Compute the distinct ID only once and include with every single event

--- a/services/mcp/tests/unit/mcpcat.test.ts
+++ b/services/mcp/tests/unit/mcpcat.test.ts
@@ -129,14 +129,17 @@ describe('initMcpCatObservability', () => {
         expect(result).toEqual({ userId: 'user-123' })
     })
 
-    it('eventTags callback returns session_id when available', async () => {
+    it('eventTags callback returns $session_id and $ai_session_id when available', async () => {
         const server = new McpServer({ name: 'test', version: '1.0.0' })
         const identity = createMockIdentity()
 
         await initMcpCatObservability(server, identity)
 
         const result = await getEventTagsCallback()()
-        expect(result).toEqual({ $session_id: 'session-uuid-456' })
+        expect(result).toEqual({
+            $session_id: 'session-uuid-456',
+            $ai_session_id: 'session-uuid-456',
+        })
     })
 
     it('eventTags callback returns empty when session uuid is undefined', async () => {


### PR DESCRIPTION
## Problem

Hey folks — MCPcat dev here. Y'all flagged that sessions in your PostHog + MCPcat LLM analytics integration were showing up with `mcpcat_…`-looking IDs instead of your own PostHog session UUIDs. We took a look from our side — the MCPcat exporter is doing the right thing, your integration just needs to override one extra key. Quick fix below to unblock you.

The mismatch is that PostHog's LLM analytics product groups traces by the event property `$ai_session_id` (see `products/llm_analytics/frontend/llmAnalyticsSessionLogic.ts:89` and `nodejs/src/ingestion/ai/process-ai-event.ts:82`) — **not** `$session_id`, which is the general PostHog/Session Replay session and a separate property entirely.

On the MCPcat side, our PostHog exporter's `buildAISpanEvent` sets a default `$ai_session_id` derived from the MCPcat session, which consumers are expected to override via `eventTags` / `eventProperties` when they have their own session source. `services/mcp/src/lib/mcpcat.ts` was already overriding `$session_id` from the identity provider, but not `$ai_session_id`, so Session Replay grouping was correct while LLM analytics was stuck on the MCPcat-side default.

## Changes

- Also set `eventTags.$ai_session_id = sessionUuid` in `initMcpCatObservability`. Because `eventTags` is spread *after* the defaults inside MCPcat's exporter, this cleanly overrides them. The key is 14 chars and matches MCPcat's tag-key validation regex, and the UUID value fits the ≤200-char value limit, so it passes client-side validation.
- Updated the comment to explain *why* both `$session_id` and `$ai_session_id` need to be overridden (Session Replay vs. LLM analytics use different keys).

## How did you test this code?

Code-only change. Traced the value flow against the MCPcat TypeScript SDK source to confirm `eventTags` lands at the right place inside `buildAISpanEvent` and overrides the default. No automated tests added — this file has no existing test coverage and the change is a one-line config override. After deploy, the easy verification is: open any `$ai_span` event in PostHog and confirm `$ai_session_id` is now the PostHog session UUID rather than a `mcpcat_…` string.

## Publish to changelog?

no