### PR TITLE
feat(llma): show "View LLM trace" link for all AI events in Activity tab

### DIFF
--- a/frontend/src/queries/nodes/DataTable/EventRowActions.tsx
+++ b/frontend/src/queries/nodes/DataTable/EventRowActions.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import { IconAI, IconWarning } from '@posthog/icons'
+import { IconLlmAnalytics, IconWarning } from '@posthog/icons'
 
 import ViewRecordingButton, { RecordingPlayerType } from 'lib/components/ViewRecordingButton/ViewRecordingButton'
 import { IconLink } from 'lib/lemon-ui/icons'
@@ -74,18 +74,19 @@ function EventRowActionsDropdown({ event }: { event: EventType }): JSX.Element {
                     Visit issue
                 </LemonButton>
             ) : null}
-            {(event.event === '$ai_trace' || event.event === SurveyEventName.SENT) &&
-            '$ai_trace_id' in event.properties ? (
+            {'$ai_trace_id' in event.properties ? (
                 <LemonButton
                     fullWidth
-                    sideIcon={<IconAI />}
+                    sideIcon={<IconLlmAnalytics />}
                     data-attr="events-table-trace-link"
                     to={urls.llmAnalyticsTrace(
                         event.properties.$ai_trace_id,
-                        event.event === '$ai_trace' ? { event: event.id, exception_ts: event.timestamp } : {}
+                        event.event === '$ai_trace'
+                            ? { event: event.id, exception_ts: event.timestamp }
+                            : { event: event.id }
                     )}
                 >
-                    View LLM Trace
+                    View LLM trace
                 </LemonButton>
             ) : null}
             {insightUrl && (

--- a/frontend/src/scenes/activity/explore/EventDetails.tsx
+++ b/frontend/src/scenes/activity/explore/EventDetails.tsx
@@ -1,3 +1,5 @@
+import { IconLlmAnalytics } from '@posthog/icons'
+
 import { ErrorDisplay, idFrom } from 'lib/components/Errors/ErrorDisplay'
 import { ErrorEventType } from 'lib/components/Errors/types'
 import { ErrorPropertyTabEvent, EventPropertyTabs } from 'lib/components/EventPropertyTabs/EventPropertyTabs'
@@ -6,8 +8,10 @@ import { PropertiesTable } from 'lib/components/PropertiesTable'
 import { SurveyResponseDisplay } from 'lib/components/SurveyResponseDisplay/SurveyResponseDisplay'
 import ViewRecordingButton, { RecordingPlayerType } from 'lib/components/ViewRecordingButton/ViewRecordingButton'
 import { LemonBanner } from 'lib/lemon-ui/LemonBanner'
+import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { LemonTableProps } from 'lib/lemon-ui/LemonTable'
 import { Link } from 'lib/lemon-ui/Link'
+import { urls } from 'scenes/urls'
 
 import { KNOWN_PROMOTED_PROPERTY_PARENTS } from '~/taxonomy/taxonomy'
 import { PropertyDefinitionType } from '~/types'
@@ -42,18 +46,34 @@ export function EventDetails({ event, tableProps }: EventDetailsProps): JSX.Elem
                     case 'conversation':
                         return (
                             <div className="mx-3 -mt-2 mb-2 gap-y-2">
-                                {properties.$session_id ? (
+                                {properties.$ai_trace_id || properties.$session_id ? (
                                     <div className="flex flex-row items-center gap-2">
-                                        <ViewRecordingButton
-                                            sessionId={properties.$session_id}
-                                            recordingStatus={properties.$recording_status}
-                                            timestamp={event.timestamp}
-                                            hasRecording={properties.$has_recording as boolean | undefined}
-                                            size="small"
-                                            type="secondary"
-                                            openPlayerIn={RecordingPlayerType.NewTab}
-                                            data-attr="conversation-view-session-recording-button"
-                                        />
+                                        {properties.$ai_trace_id ? (
+                                            <LemonButton
+                                                to={urls.llmAnalyticsTrace(
+                                                    properties.$ai_trace_id,
+                                                    event.event !== '$ai_trace' ? { event: getEventId(event) } : {}
+                                                )}
+                                                size="small"
+                                                type="secondary"
+                                                sideIcon={<IconLlmAnalytics />}
+                                                data-attr="conversation-view-trace-button"
+                                            >
+                                                View LLM trace
+                                            </LemonButton>
+                                        ) : null}
+                                        {properties.$session_id ? (
+                                            <ViewRecordingButton
+                                                sessionId={properties.$session_id}
+                                                recordingStatus={properties.$recording_status}
+                                                timestamp={event.timestamp}
+                                                hasRecording={properties.$has_recording as boolean | undefined}
+                                                size="small"
+                                                type="secondary"
+                                                openPlayerIn={RecordingPlayerType.NewTab}
+                                                data-attr="conversation-view-session-recording-button"
+                                            />
+                                        ) : null}
                                     </div>
                                 ) : null}
                                 <ConversationDisplay eventProperties={properties} eventId={getEventId(event)} />


### PR DESCRIPTION
## Problem

When viewing LLM Analytics events (`$ai_generation`, `$ai_span`, etc.) in the Activity tab, users can navigate to Session Replay via the "View recording" button, but there's no way to navigate to the LLM Analytics trace view. The "View LLM trace" link only appeared for `$ai_trace` and survey events.

## Changes

- **`EventRowActions.tsx`**: Show "View LLM trace" in the row dropdown for **any** event with `$ai_trace_id` (not just `$ai_trace` and survey events). For non-`$ai_trace` events, passes the event ID so the trace view highlights the specific span/generation.
- **`EventDetails.tsx`**: Add a "View LLM trace" button in the expanded Conversation tab alongside the existing "View recording" button.

<img width="589" height="202" alt="Screenshot 2026-04-09 at 09 28 07" src="https://github.com/user-attachments/assets/9549591f-a101-4139-80be-3f8d70f880f6" />


## How did you test this code?

TypeScript type check passes. Manual testing needed: open Activity tab, filter for `$ai_generation` events, verify the trace link appears in both the row dropdown and expanded conversation tab.

## Publish to changelog?

no

## Docs update

N/A

## 🤖 LLM context

Agent-authored PR. Straightforward condition change and button addition following existing patterns from the session recording inspector (`ItemEvent.tsx`).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*