### PR TITLE
fix(ingestion): mv acceptance tests to query CH directly

### DIFF
--- a/posthog/temporal/ingestion_acceptance_test/README.md
+++ b/posthog/temporal/ingestion_acceptance_test/README.md
@@ -1,6 +1,6 @@
 # Ingestion Acceptance Tests
 
-End-to-end tests that verify the PostHog ingestion pipeline is functioning correctly. These tests capture real events via the PostHog SDK and query them back via the HogQL API to ensure the full pipeline works as expected.
+End-to-end tests that verify the PostHog ingestion pipeline is functioning correctly. These tests capture real events via the PostHog SDK and query them back via direct ClickHouse queries to ensure events land in ClickHouse as expected.
 
 ## Goal
 
@@ -28,7 +28,7 @@ Detect ingestion pipeline issues in production before users notice them. The tes
                     ┌───────────────┴───────────────┐
                     ▼                               ▼
            ┌──────────────┐                ┌──────────────┐
-           │ PostHog SDK  │                │  HogQL API   │
+           │ PostHog SDK  │                │  ClickHouse  │
            │  (capture)   │                │   (query)    │
            └──────────────┘                └──────────────┘
                     │                               │
@@ -69,12 +69,12 @@ class TestExample(AcceptanceTest):
 
 **Available client methods:**
 
-- `capture_event(name, distinct_id, properties)` - Send an event
-- `alias(alias, distinct_id)` - Create an alias
-- `merge_dangerously(into_id, from_id)` - Merge two persons
-- `query_event_by_uuid(uuid)` - Poll for an event by UUID
-- `query_person_by_distinct_id(distinct_id)` - Poll for a person
-- `query_events_by_person_id(person_id, expected_event_uuids)` - Poll for events by person
+- `capture_event(name, distinct_id, properties)` - Send an event via SDK
+- `alias(alias, distinct_id)` - Create an alias via SDK
+- `merge_dangerously(into_id, from_id)` - Merge two persons via SDK
+- `query_event_by_uuid(uuid)` - Poll ClickHouse for an event by UUID
+- `query_person_by_distinct_id(distinct_id)` - Poll ClickHouse for a person
+- `query_events_by_person_id(person_id, expected_event_uuids)` - Poll ClickHouse for events by person
 
 **Available assertion methods:**
 
@@ -89,8 +89,7 @@ All configuration is loaded from environment variables with the `INGESTION_ACCEP
 | ----------------------- | -------- | ------- | ------------------------------------------------- |
 | `API_HOST`              | Yes      | -       | PostHog API host (e.g., `https://us.posthog.com`) |
 | `PROJECT_API_KEY`       | Yes      | -       | Project token for capturing events                |
-| `PROJECT_ID`            | Yes      | -       | Project ID for querying events                    |
-| `PERSONAL_API_KEY`      | Yes      | -       | Personal API key for HogQL queries                |
+| `TEAM_ID`               | Yes      | -       | Team ID for ClickHouse queries                    |
 | `EVENT_TIMEOUT_SECONDS` | No       | 90      | Max time to wait for events to appear             |
 | `POLL_INTERVAL_SECONDS` | No       | 10.0    | Interval between query attempts                   |
 | `SLACK_WEBHOOK_URL`     | No       | -       | Slack incoming webhook for failure notifications  |
@@ -101,10 +100,9 @@ All configuration is loaded from environment variables with the `INGESTION_ACCEP
 # Set required environment variables
 export INGESTION_ACCEPTANCE_TEST_API_HOST="https://us.posthog.com"
 export INGESTION_ACCEPTANCE_TEST_PROJECT_API_KEY="phc_xxx"
-export INGESTION_ACCEPTANCE_TEST_PROJECT_ID="12345"
-export INGESTION_ACCEPTANCE_TEST_PERSONAL_API_KEY="phx_xxx"
+export INGESTION_ACCEPTANCE_TEST_TEAM_ID="12345"
 
-# Run directly
+# Run directly (requires ClickHouse connection via Django settings)
 python -m posthog.temporal.ingestion_acceptance_test
 ```
 
@@ -115,7 +113,7 @@ ingestion_acceptance_test/
 ├── __init__.py
 ├── __main__.py              # CLI entry point for local runs
 ├── activities.py            # Temporal activity definition
-├── client.py                # PostHog SDK wrapper with HTTP retry and HogQL queries
+├── client.py                # PostHog SDK wrapper with retry and direct ClickHouse queries
 ├── config.py                # Pydantic settings for environment config
 ├── results.py               # Test result dataclasses
 ├── runner.py                # Test execution engine
@@ -134,15 +132,12 @@ ingestion_acceptance_test/
 
 Unit tests are located at `posthog/temporal/tests/ingestion_acceptance_test/`.
 
-## HTTP Resilience
+## SDK Capture Resilience
 
-The client includes automatic retry for transient HTTP failures:
+The client includes automatic retry for transient SDK capture failures:
 
-- **Timeout:** 30 seconds per request
-- **Retries:** 3 attempts with exponential backoff
-- **Retry on:** 500, 502, 503, 504 (server errors)
-- **Retry on:** Connection errors and read timeouts
-- **No retry on:** 429 (rate limiting) - retrying immediately won't help
+- **Retries:** 5 attempts with exponential backoff
+- **Retry on:** Connection errors and timeouts
 
 ## ClickHouse Query Optimization
 

--- a/posthog/temporal/ingestion_acceptance_test/activities.py
+++ b/posthog/temporal/ingestion_acceptance_test/activities.py
@@ -42,7 +42,7 @@ async def run_ingestion_acceptance_tests() -> dict:
     logger.info(
         "Loaded config",
         api_host=config.api_host,
-        project_id=config.project_id,
+        team_id=config.team_id,
     )
 
     posthog_sdk = posthoganalytics.Posthog(

--- a/posthog/temporal/ingestion_acceptance_test/client.py
+++ b/posthog/temporal/ingestion_acceptance_test/client.py
@@ -1,4 +1,4 @@
-"""PostHog client for acceptance tests using the official SDK."""
+"""PostHog client for acceptance tests using the official SDK and direct ClickHouse queries."""
 
 import json
 import time
@@ -10,8 +10,8 @@ from typing import TYPE_CHECKING, Any, TypeVar
 
 import requests
 import structlog
-from requests.adapters import HTTPAdapter
-from urllib3.util.retry import Retry
+
+from posthog.clickhouse.client.execute import sync_execute
 
 from .config import Config
 
@@ -55,18 +55,9 @@ class Person:
 
 
 class PostHogClient:
-    """Client for acceptance tests using the official PostHog SDK.
-
-    Uses the official SDK for event capture and custom code for HogQL queries
-    (since the SDK doesn't support querying).
+    """Client for acceptance tests using the official PostHog SDK for capture
+    and direct ClickHouse queries for verification.
     """
-
-    # HogQL HTTP client configuration
-    HTTP_CONNECT_TIMEOUT_SECONDS = 5
-    HTTP_READ_TIMEOUT_SECONDS = 30
-    HTTP_RETRY_TOTAL = 3
-    HTTP_RETRY_BACKOFF_FACTOR = 0.5
-    HTTP_RETRY_STATUS_FORCELIST = (500, 502, 503, 504)
 
     # SDK capture retry configuration (the SDK's own urllib3 retries don't cover
     # POST read errors because POST is not in urllib3's default allowed_methods)
@@ -77,28 +68,10 @@ class PostHogClient:
     def __init__(self, config: Config, posthog_sdk: "Posthog"):
         self.config = config
         self._posthog = posthog_sdk
-        self._session = self._create_http_session()
         # Store test start date for efficient event queries.
         # ClickHouse ORDER BY uses toDate(timestamp) (day granularity), so filtering by date
         # is sufficient. We subtract 1 day to handle clock skew between test machine and server.
         self._test_start_date = (datetime.now(UTC) - timedelta(days=1)).date()
-
-    def _create_http_session(self) -> requests.Session:
-        """Create an HTTP session with urllib3 retry logic for transient failures."""
-        session = requests.Session()
-        retry_strategy = Retry(
-            total=self.HTTP_RETRY_TOTAL,
-            backoff_factor=self.HTTP_RETRY_BACKOFF_FACTOR,
-            status_forcelist=self.HTTP_RETRY_STATUS_FORCELIST,
-            allowed_methods=["GET", "POST"],
-            raise_on_status=False,  # We handle status codes ourselves
-            connect=self.HTTP_RETRY_TOTAL,
-            read=self.HTTP_RETRY_TOTAL,
-        )
-        adapter = HTTPAdapter(max_retries=retry_strategy)
-        session.mount("https://", adapter)
-        session.mount("http://", adapter)
-        return session
 
     def _retry_on_error(self, fn: Callable[[], T], description: str) -> T:
         """Retry a function on transient errors with exponential backoff.
@@ -264,7 +237,6 @@ class PostHogClient:
     def shutdown(self) -> None:
         """Shutdown the client and flush any pending events."""
         self._posthog.shutdown()
-        self._session.close()
 
     # Polling configuration
     POLL_BACKOFF_FACTOR = 1.5
@@ -278,8 +250,7 @@ class PostHogClient:
         """Poll until fetch_fn returns a non-None result or timeout.
 
         Sleeps before each request with exponential backoff to reduce query pressure
-        and increase likelihood of success on first call. Transient connection errors
-        are caught and logged, allowing polling to continue.
+        and increase likelihood of success on first call.
         """
         start_time = time.time()
         current_interval = self.config.poll_interval_seconds
@@ -297,25 +268,16 @@ class PostHogClient:
                     elapsed_seconds=round(elapsed, 1),
                     next_interval_seconds=round(current_interval, 1),
                 )
-            try:
-                result = fetch_fn()
-                if result is not None:
-                    elapsed = time.time() - start_time
-                    logger.info(
-                        "Polling succeeded",
-                        description=description,
-                        attempt=attempt,
-                        elapsed_seconds=round(elapsed, 1),
-                    )
-                    return result
-            except requests.exceptions.RequestException as e:
-                logger.warning(
-                    "Transient error during polling, will retry",
-                    error=str(e),
-                    error_type=type(e).__name__,
+            result = fetch_fn()
+            if result is not None:
+                elapsed = time.time() - start_time
+                logger.info(
+                    "Polling succeeded",
                     description=description,
                     attempt=attempt,
+                    elapsed_seconds=round(elapsed, 1),
                 )
+                return result
             current_interval = min(
                 current_interval * self.POLL_BACKOFF_FACTOR,
                 self.POLL_MAX_INTERVAL_SECONDS,
@@ -330,46 +292,8 @@ class PostHogClient:
         )
         return None
 
-    def _execute_hogql_query(self, query: str, values: dict[str, Any]) -> dict[str, Any] | None:
-        """Execute a HogQL query and return the first row as a dict, or None if no results."""
-        rows = self._execute_hogql_query_all(query, values)
-        if not rows:
-            return None
-        return rows[0]
-
-    def _execute_hogql_query_all(self, query: str, values: dict[str, Any]) -> list[dict[str, Any]]:
-        """Execute a HogQL query and return all rows as a list of dicts.
-
-        Uses a session with urllib3 retry on transient HTTP errors (5xx, connection, read).
-        """
-        url = f"{self.config.api_host}/api/projects/{self.config.project_id}/query/"
-
-        response = self._session.post(
-            url,
-            json={
-                "query": {
-                    "kind": "HogQLQuery",
-                    "query": query,
-                    "values": values,
-                },
-                "refresh": "force_blocking",
-            },
-            headers={"Authorization": f"Bearer {self.config.personal_api_key}"},
-            timeout=(self.HTTP_CONNECT_TIMEOUT_SECONDS, self.HTTP_READ_TIMEOUT_SECONDS),
-        )
-
-        if response.status_code == 404:
-            return []
-
-        response.raise_for_status()
-        data = response.json()
-
-        results = data.get("results", [])
-        columns = data.get("columns", [])
-        return [dict(zip(columns, row, strict=True)) for row in results]
-
     def _fetch_event_by_uuid(self, event_uuid: str) -> CapturedEvent | None:
-        """Fetch an event by UUID.
+        """Fetch an event by UUID via direct ClickHouse query.
 
         Includes a timestamp filter to benefit from ClickHouse's table partitioning
         (PARTITION BY toYYYYMM(timestamp)) and ordering (ORDER BY includes toDate(timestamp)).
@@ -377,55 +301,67 @@ class PostHogClient:
         query = """
             SELECT uuid, event, distinct_id, properties, timestamp
             FROM events
-            WHERE uuid = {event_uuid}
-              AND timestamp >= {min_timestamp}
+            WHERE team_id = %(team_id)s
+              AND uuid = %(event_uuid)s
+              AND timestamp >= %(min_timestamp)s
             LIMIT 1
         """
 
-        row = self._execute_hogql_query(
+        rows = sync_execute(
             query,
             {
+                "team_id": self.config.team_id,
                 "event_uuid": event_uuid,
                 "min_timestamp": self._test_start_date.isoformat(),
             },
+            team_id=self.config.team_id,
         )
-        if not row:
+        if not rows:
             return None
 
-        properties = row.get("properties", {})
+        row = rows[0]
+        properties = row[3]
         if isinstance(properties, str):
             properties = json.loads(properties)
 
         return CapturedEvent(
-            uuid=row.get("uuid", ""),
-            event=row.get("event", ""),
-            distinct_id=row.get("distinct_id", ""),
+            uuid=str(row[0]),
+            event=row[1],
+            distinct_id=row[2],
             properties=properties,
-            timestamp=row.get("timestamp", ""),
+            timestamp=str(row[4]),
         )
 
     def _fetch_person_by_distinct_id(self, distinct_id: str) -> Person | None:
-        """Fetch a person by distinct_id."""
+        """Fetch a person by distinct_id via direct ClickHouse query."""
         query = """
             SELECT p.id, p.properties, p.created_at
-            FROM persons p
-            JOIN person_distinct_ids pdi ON p.id = pdi.person_id
-            WHERE pdi.distinct_id = {distinct_id}
+            FROM person p
+            JOIN person_distinct_id2 pdi ON p.id = pdi.person_id AND pdi.team_id = %(team_id)s
+            WHERE p.team_id = %(team_id)s
+              AND pdi.distinct_id = %(distinct_id)s
+              AND pdi.is_deleted = 0
+            ORDER BY p.version DESC
             LIMIT 1
         """
 
-        row = self._execute_hogql_query(query, {"distinct_id": distinct_id})
-        if not row:
+        rows = sync_execute(
+            query,
+            {"team_id": self.config.team_id, "distinct_id": distinct_id},
+            team_id=self.config.team_id,
+        )
+        if not rows:
             return None
 
-        properties = row.get("properties", {})
+        row = rows[0]
+        properties = row[1]
         if isinstance(properties, str):
             properties = json.loads(properties)
 
         return Person(
-            id=row.get("id", ""),
+            id=str(row[0]),
             properties=properties,
-            created_at=row.get("created_at", ""),
+            created_at=str(row[2]),
         )
 
     def _fetch_events_by_person_id(self, person_id: str, expected_event_uuids: set[str]) -> list[CapturedEvent] | None:
@@ -437,34 +373,37 @@ class PostHogClient:
         query = """
             SELECT uuid, event, distinct_id, properties, timestamp
             FROM events
-            WHERE person_id = {person_id}
-              AND timestamp >= {min_timestamp}
+            WHERE team_id = %(team_id)s
+              AND person_id = %(person_id)s
+              AND timestamp >= %(min_timestamp)s
             ORDER BY timestamp ASC
         """
 
-        rows = self._execute_hogql_query_all(
+        rows = sync_execute(
             query,
             {
+                "team_id": self.config.team_id,
                 "person_id": person_id,
                 "min_timestamp": self._test_start_date.isoformat(),
             },
+            team_id=self.config.team_id,
         )
-        found_uuids = {row.get("uuid", "") for row in rows}
+        found_uuids = {str(row[0]) for row in rows}
         if not expected_event_uuids.issubset(found_uuids):
             return None
 
         events = []
         for row in rows:
-            properties = row.get("properties", {})
+            properties = row[3]
             if isinstance(properties, str):
                 properties = json.loads(properties)
             events.append(
                 CapturedEvent(
-                    uuid=row.get("uuid", ""),
-                    event=row.get("event", ""),
-                    distinct_id=row.get("distinct_id", ""),
+                    uuid=str(row[0]),
+                    event=row[1],
+                    distinct_id=row[2],
                     properties=properties,
-                    timestamp=row.get("timestamp", ""),
+                    timestamp=str(row[4]),
                 )
             )
         return events

--- a/posthog/temporal/ingestion_acceptance_test/client.py
+++ b/posthog/temporal/ingestion_acceptance_test/client.py
@@ -12,6 +12,7 @@ import requests
 import structlog
 
 from posthog.clickhouse.client.execute import sync_execute
+from posthog.errors import InternalCHQueryError
 
 from .config import Config
 
@@ -268,7 +269,17 @@ class PostHogClient:
                     elapsed_seconds=round(elapsed, 1),
                     next_interval_seconds=round(current_interval, 1),
                 )
-            result = fetch_fn()
+            try:
+                result = fetch_fn()
+            except (InternalCHQueryError, EOFError, ConnectionError, OSError) as e:
+                logger.warning(
+                    "Transient error during polling, will retry",
+                    error=str(e),
+                    error_type=type(e).__name__,
+                    description=description,
+                    attempt=attempt,
+                )
+                result = None
             if result is not None:
                 elapsed = time.time() - start_time
                 logger.info(
@@ -341,6 +352,7 @@ class PostHogClient:
             WHERE p.team_id = %(team_id)s
               AND pdi.distinct_id = %(distinct_id)s
               AND pdi.is_deleted = 0
+              AND p.is_deleted = 0
             ORDER BY p.version DESC
             LIMIT 1
         """

--- a/posthog/temporal/ingestion_acceptance_test/config.py
+++ b/posthog/temporal/ingestion_acceptance_test/config.py
@@ -17,8 +17,7 @@ class Config(BaseSettings):
 
     api_host: str
     project_api_key: str
-    project_id: str
-    personal_api_key: str
+    team_id: int
     event_timeout_seconds: int = Field(default=3600)
     poll_interval_seconds: float = Field(default=10.0)
     activity_timeout_seconds: int = Field(default=3600)
@@ -33,7 +32,7 @@ class Config(BaseSettings):
         """Return configuration as a dictionary with sensitive values redacted."""
         return {
             "api_host": self.api_host,
-            "project_id": self.project_id,
+            "team_id": str(self.team_id),
             "event_timeout_seconds": str(self.event_timeout_seconds),
             "poll_interval_seconds": str(self.poll_interval_seconds),
             "activity_timeout_seconds": str(self.activity_timeout_seconds),

--- a/posthog/temporal/ingestion_acceptance_test/slack.py
+++ b/posthog/temporal/ingestion_acceptance_test/slack.py
@@ -101,7 +101,7 @@ def _build_summary_block(result: TestSuiteResult) -> dict[str, Any]:
 def _build_context_block(config: Config, result: TestSuiteResult) -> dict[str, Any]:
     text = (
         f":globe_with_meridians: Env: {config.api_host} | "
-        f":file_folder: Project: {config.project_id} | "
+        f":file_folder: Team: {config.team_id} | "
         f":hourglass: Duration: {result.total_duration_seconds:.2f}s"
     )
     return {
@@ -144,7 +144,7 @@ def send_slack_timeout_notification(config: Config, running_tests: list[str] | N
                     "type": "mrkdwn",
                     "text": (
                         f":globe_with_meridians: Env: {config.api_host} | "
-                        f":file_folder: Project: {config.project_id} | "
+                        f":file_folder: Team: {config.team_id} | "
                         f":stopwatch: Timeout: {config.activity_timeout_seconds}s"
                     ),
                 },

--- a/posthog/temporal/ingestion_acceptance_test/terminal_report.py
+++ b/posthog/temporal/ingestion_acceptance_test/terminal_report.py
@@ -24,7 +24,7 @@ def _format_header(result: TestSuiteResult) -> str:
 def _format_environment(result: TestSuiteResult) -> str:
     return (
         f"Environment: {result.environment.get('api_host', 'unknown')}\n"
-        f"Project ID:  {result.environment.get('project_id', 'unknown')}\n"
+        f"Team ID:     {result.environment.get('team_id', 'unknown')}\n"
         f"Timestamp:   {result.timestamp}\n"
     )
 

--- a/posthog/temporal/ingestion_acceptance_test/tests/acceptance_test_basic_capture.py
+++ b/posthog/temporal/ingestion_acceptance_test/tests/acceptance_test_basic_capture.py
@@ -13,7 +13,7 @@ class TestBasicCapture(AcceptanceTest):
     """Test basic event capture and retrieval flow."""
 
     def test_capture_event(self) -> None:
-        """Capture a basic event and verify it appears in HogQL queries."""
+        """Capture a basic event and verify it appears in ClickHouse."""
         event_name = "$test_basic_capture"
         distinct_id = str(uuid.uuid4())
 

--- a/posthog/temporal/tests/ingestion_acceptance_test/test_activities.py
+++ b/posthog/temporal/tests/ingestion_acceptance_test/test_activities.py
@@ -12,8 +12,7 @@ def config() -> Config:
     return Config(
         api_host="https://test.posthog.com",
         project_api_key="phc_test_key",
-        project_id="12345",
-        personal_api_key="phx_personal_key",
+        team_id=12345,
         slack_webhook_url="https://hooks.slack.com/services/T00/B00/XXX",
         activity_timeout_seconds=1,
     )

--- a/posthog/temporal/tests/ingestion_acceptance_test/test_client.py
+++ b/posthog/temporal/tests/ingestion_acceptance_test/test_client.py
@@ -1,9 +1,6 @@
-import json
-import threading
+import uuid
 from collections.abc import Generator
 from datetime import UTC, datetime, timedelta
-from http.server import BaseHTTPRequestHandler, HTTPServer
-from typing import Any
 
 import pytest
 from unittest.mock import MagicMock, patch
@@ -17,8 +14,7 @@ def config() -> Config:
     return Config(
         api_host="https://test.posthog.com",
         project_api_key="phc_test_key",
-        project_id="12345",
-        personal_api_key="phx_personal_key",
+        team_id=12345,
         event_timeout_seconds=5,
         poll_interval_seconds=0.1,
     )
@@ -61,293 +57,156 @@ class TestCaptureEvent:
 
 
 class TestFetchEventByUuid:
-    def test_sends_correct_hogql_query(self, client: PostHogClient) -> None:
-        with patch.object(client._session, "post") as mock_post:
-            mock_post.return_value.status_code = 200
-            mock_post.return_value.json.return_value = {"results": [], "columns": []}
+    @patch("posthog.temporal.ingestion_acceptance_test.client.sync_execute")
+    def test_sends_correct_clickhouse_query(self, mock_sync_execute: MagicMock, client: PostHogClient) -> None:
+        mock_sync_execute.return_value = []
 
-            client._fetch_event_by_uuid("test-uuid-123")
+        client._fetch_event_by_uuid("test-uuid-123")
 
-            mock_post.assert_called_once()
-            call_kwargs = mock_post.call_args[1]
+        mock_sync_execute.assert_called_once()
+        query = mock_sync_execute.call_args[0][0]
+        params = mock_sync_execute.call_args[0][1]
 
-            assert call_kwargs["headers"] == {"Authorization": "Bearer phx_personal_key"}
-            assert call_kwargs["timeout"] == (
-                PostHogClient.HTTP_CONNECT_TIMEOUT_SECONDS,
-                PostHogClient.HTTP_READ_TIMEOUT_SECONDS,
+        assert "WHERE team_id = %(team_id)s" in query
+        assert "uuid = %(event_uuid)s" in query
+        assert "timestamp >= %(min_timestamp)s" in query
+        assert params["team_id"] == 12345
+        assert params["event_uuid"] == "test-uuid-123"
+        assert params["min_timestamp"] == client._test_start_date.isoformat()
+        assert mock_sync_execute.call_args[1]["team_id"] == 12345
+
+    @patch("posthog.temporal.ingestion_acceptance_test.client.sync_execute")
+    def test_returns_captured_event_when_found(self, mock_sync_execute: MagicMock, client: PostHogClient) -> None:
+        mock_sync_execute.return_value = [
+            (
+                uuid.UUID("00000000-0000-0000-0000-000000000123"),
+                "test_event",
+                "user_456",
+                {"key": "value"},
+                datetime(2024, 1, 1),
             )
+        ]
 
-            request_body = call_kwargs["json"]
-            assert request_body["query"]["kind"] == "HogQLQuery"
-            assert "WHERE uuid = {event_uuid}" in request_body["query"]["query"]
-            assert "timestamp >= {min_timestamp}" in request_body["query"]["query"]
-            assert request_body["query"]["values"]["event_uuid"] == "test-uuid-123"
-            assert "min_timestamp" in request_body["query"]["values"]
-            assert request_body["refresh"] == "force_blocking"
+        result = client._fetch_event_by_uuid("uuid-123")
 
-    def test_posts_to_correct_url(self, client: PostHogClient) -> None:
-        with patch.object(client._session, "post") as mock_post:
-            mock_post.return_value.status_code = 200
-            mock_post.return_value.json.return_value = {"results": [], "columns": []}
+        assert result is not None
+        assert isinstance(result, CapturedEvent)
+        assert result.uuid == "00000000-0000-0000-0000-000000000123"
+        assert result.event == "test_event"
+        assert result.distinct_id == "user_456"
+        assert result.properties == {"key": "value"}
 
-            client._fetch_event_by_uuid("test-uuid")
+    @patch("posthog.temporal.ingestion_acceptance_test.client.sync_execute")
+    def test_returns_none_when_not_found(self, mock_sync_execute: MagicMock, client: PostHogClient) -> None:
+        mock_sync_execute.return_value = []
 
-            url = mock_post.call_args[0][0]
-            assert url == "https://test.posthog.com/api/projects/12345/query/"
+        result = client._fetch_event_by_uuid("nonexistent-uuid")
 
-    def test_returns_captured_event_when_found(self, client: PostHogClient) -> None:
-        with patch.object(client._session, "post") as mock_post:
-            mock_post.return_value.status_code = 200
-            mock_post.return_value.json.return_value = {
-                "results": [["uuid-123", "test_event", "user_456", '{"key": "value"}', "2024-01-01T00:00:00Z"]],
-                "columns": ["uuid", "event", "distinct_id", "properties", "timestamp"],
-            }
+        assert result is None
 
-            result = client._fetch_event_by_uuid("uuid-123")
+    @patch("posthog.temporal.ingestion_acceptance_test.client.sync_execute")
+    def test_parses_json_string_properties(self, mock_sync_execute: MagicMock, client: PostHogClient) -> None:
+        mock_sync_execute.return_value = [
+            (
+                uuid.UUID("00000000-0000-0000-0000-000000000123"),
+                "test_event",
+                "user_456",
+                '{"key": "value"}',
+                datetime(2024, 1, 1),
+            )
+        ]
 
-            assert result is not None
-            assert isinstance(result, CapturedEvent)
-            assert result.uuid == "uuid-123"
-            assert result.event == "test_event"
-            assert result.distinct_id == "user_456"
-            assert result.properties == {"key": "value"}
-            assert result.timestamp == "2024-01-01T00:00:00Z"
+        result = client._fetch_event_by_uuid("uuid-123")
 
-    def test_returns_none_when_not_found(self, client: PostHogClient) -> None:
-        with patch.object(client._session, "post") as mock_post:
-            mock_post.return_value.status_code = 200
-            mock_post.return_value.json.return_value = {"results": [], "columns": []}
-
-            result = client._fetch_event_by_uuid("nonexistent-uuid")
-
-            assert result is None
+        assert result is not None
+        assert result.properties == {"key": "value"}
 
 
 class TestFetchPersonByDistinctId:
-    def test_sends_correct_hogql_query_with_join(self, client: PostHogClient) -> None:
-        with patch.object(client._session, "post") as mock_post:
-            mock_post.return_value.status_code = 200
-            mock_post.return_value.json.return_value = {"results": [], "columns": []}
+    @patch("posthog.temporal.ingestion_acceptance_test.client.sync_execute")
+    def test_sends_correct_clickhouse_query(self, mock_sync_execute: MagicMock, client: PostHogClient) -> None:
+        mock_sync_execute.return_value = []
 
-            client._fetch_person_by_distinct_id("user_123")
+        client._fetch_person_by_distinct_id("user_123")
 
-            mock_post.assert_called_once()
-            call_kwargs = mock_post.call_args[1]
+        mock_sync_execute.assert_called_once()
+        query = mock_sync_execute.call_args[0][0]
+        params = mock_sync_execute.call_args[0][1]
 
-            request_body = call_kwargs["json"]
-            query = request_body["query"]["query"]
+        assert "FROM person p" in query
+        assert "JOIN person_distinct_id2 pdi" in query
+        assert "pdi.distinct_id = %(distinct_id)s" in query
+        assert "pdi.is_deleted = 0" in query
+        assert params["team_id"] == 12345
+        assert params["distinct_id"] == "user_123"
 
-            assert "FROM persons p" in query
-            assert "JOIN person_distinct_ids pdi ON p.id = pdi.person_id" in query
-            assert "WHERE pdi.distinct_id = {distinct_id}" in query
-            assert request_body["query"]["values"] == {"distinct_id": "user_123"}
-
-    def test_returns_person_when_found(self, client: PostHogClient) -> None:
-        with patch.object(client._session, "post") as mock_post:
-            mock_post.return_value.status_code = 200
-            mock_post.return_value.json.return_value = {
-                "results": [["person-id-123", '{"email": "test@example.com", "name": "Test"}', "2024-01-01T00:00:00Z"]],
-                "columns": ["id", "properties", "created_at"],
-            }
-
-            result = client._fetch_person_by_distinct_id("user_123")
-
-            assert result is not None
-            assert isinstance(result, Person)
-            assert result.id == "person-id-123"
-            assert result.properties == {"email": "test@example.com", "name": "Test"}
-            assert result.created_at == "2024-01-01T00:00:00Z"
-
-    def test_returns_none_when_not_found(self, client: PostHogClient) -> None:
-        with patch.object(client._session, "post") as mock_post:
-            mock_post.return_value.status_code = 200
-            mock_post.return_value.json.return_value = {"results": [], "columns": []}
-
-            result = client._fetch_person_by_distinct_id("nonexistent-user")
-
-            assert result is None
-
-
-class MockHttpHandler(BaseHTTPRequestHandler):
-    """HTTP handler that returns configurable responses for testing retry behavior."""
-
-    # Use HTTP/1.0 to avoid keep-alive connection issues in tests
-    protocol_version = "HTTP/1.0"
-
-    queued_responses: list[dict[str, Any]] = []
-    call_count: int = 0
-
-    def do_POST(self) -> None:
-        MockHttpHandler.call_count += 1
-
-        if MockHttpHandler.queued_responses:
-            resp = MockHttpHandler.queued_responses.pop(0)
-            status_code = resp.get("status_code", 200)
-            body = resp.get("json", {"results": [], "columns": []})
-        else:
-            status_code = 200
-            body = {"results": [], "columns": []}
-
-        body_bytes = json.dumps(body).encode()
-        self.send_response(status_code)
-        self.send_header("Content-Type", "application/json")
-        self.send_header("Content-Length", str(len(body_bytes)))
-        self.end_headers()
-        self.wfile.write(body_bytes)
-
-    def log_message(self, format: str, *args: Any) -> None:
-        pass  # Suppress logging
-
-
-@pytest.fixture
-def mock_server() -> Generator[HTTPServer, None, None]:
-    """Create a test HTTP server on a random available port."""
-    MockHttpHandler.queued_responses = []
-    MockHttpHandler.call_count = 0
-
-    server = HTTPServer(("127.0.0.1", 0), MockHttpHandler)
-    thread = threading.Thread(target=server.serve_forever)
-    thread.daemon = True
-    thread.start()
-
-    yield server
-
-    server.shutdown()
-
-
-class TestHttpRetryBehavior:
-    """Test HTTP retry behavior using a real test server."""
-
-    def test_retries_on_500_error_then_succeeds(self, mock_server: HTTPServer, mock_posthog_sdk: MagicMock) -> None:
-        port = mock_server.server_address[1]
-        config = Config(
-            api_host=f"http://127.0.0.1:{port}",
-            project_api_key="phc_test_key",
-            project_id="12345",
-            personal_api_key="phx_personal_key",
-            event_timeout_seconds=5,
-            poll_interval_seconds=0.1,
-        )
-
-        MockHttpHandler.queued_responses = [
-            {"status_code": 500},
-            {"status_code": 500},
-            {"json": {"results": [], "columns": []}, "status_code": 200},
+    @patch("posthog.temporal.ingestion_acceptance_test.client.sync_execute")
+    def test_returns_person_when_found(self, mock_sync_execute: MagicMock, client: PostHogClient) -> None:
+        mock_sync_execute.return_value = [
+            (
+                uuid.UUID("00000000-0000-0000-0000-000000000abc"),
+                {"email": "test@example.com", "name": "Test"},
+                datetime(2024, 1, 1),
+            )
         ]
 
-        client = PostHogClient(config, mock_posthog_sdk)
-        result = client._execute_hogql_query_all("SELECT 1", {})
-        client.shutdown()
+        result = client._fetch_person_by_distinct_id("user_123")
 
-        assert result == []
-        assert MockHttpHandler.call_count == 3
+        assert result is not None
+        assert isinstance(result, Person)
+        assert result.id == "00000000-0000-0000-0000-000000000abc"
+        assert result.properties == {"email": "test@example.com", "name": "Test"}
 
-    def test_retries_on_502_503_504_errors(self, mock_server: HTTPServer, mock_posthog_sdk: MagicMock) -> None:
-        port = mock_server.server_address[1]
-        config = Config(
-            api_host=f"http://127.0.0.1:{port}",
-            project_api_key="phc_test_key",
-            project_id="12345",
-            personal_api_key="phx_personal_key",
-            event_timeout_seconds=5,
-            poll_interval_seconds=0.1,
-        )
+    @patch("posthog.temporal.ingestion_acceptance_test.client.sync_execute")
+    def test_returns_none_when_not_found(self, mock_sync_execute: MagicMock, client: PostHogClient) -> None:
+        mock_sync_execute.return_value = []
 
-        MockHttpHandler.queued_responses = [
-            {"status_code": 502},
-            {"status_code": 503},
-            {"status_code": 504},
-            {"json": {"results": [], "columns": []}, "status_code": 200},
+        result = client._fetch_person_by_distinct_id("nonexistent-user")
+
+        assert result is None
+
+
+class TestFetchEventsByPersonId:
+    @patch("posthog.temporal.ingestion_acceptance_test.client.sync_execute")
+    def test_includes_timestamp_filter(self, mock_sync_execute: MagicMock, client: PostHogClient) -> None:
+        mock_sync_execute.return_value = []
+
+        client._fetch_events_by_person_id("test-person-id", expected_event_uuids={"some-uuid"})
+
+        mock_sync_execute.assert_called_once()
+        query = mock_sync_execute.call_args[0][0]
+        params = mock_sync_execute.call_args[0][1]
+
+        assert "timestamp >= %(min_timestamp)s" in query
+        assert params["min_timestamp"] == client._test_start_date.isoformat()
+
+    @patch("posthog.temporal.ingestion_acceptance_test.client.sync_execute")
+    def test_returns_none_when_not_all_uuids_found(self, mock_sync_execute: MagicMock, client: PostHogClient) -> None:
+        mock_sync_execute.return_value = [
+            (uuid.UUID("00000000-0000-0000-0000-000000000001"), "ev", "u", {}, datetime(2024, 1, 1))
         ]
 
-        client = PostHogClient(config, mock_posthog_sdk)
-        result = client._execute_hogql_query_all("SELECT 1", {})
-        client.shutdown()
-
-        assert result == []
-        assert MockHttpHandler.call_count == 4
-
-    def test_does_not_retry_on_400_error(self, mock_server: HTTPServer, mock_posthog_sdk: MagicMock) -> None:
-        port = mock_server.server_address[1]
-        config = Config(
-            api_host=f"http://127.0.0.1:{port}",
-            project_api_key="phc_test_key",
-            project_id="12345",
-            personal_api_key="phx_personal_key",
-            event_timeout_seconds=5,
-            poll_interval_seconds=0.1,
+        result = client._fetch_events_by_person_id(
+            "person-1", expected_event_uuids={"00000000-0000-0000-0000-000000000001", "missing-uuid"}
         )
 
-        MockHttpHandler.queued_responses = [{"status_code": 400, "json": {"error": "Bad request"}}]
+        assert result is None
 
-        client = PostHogClient(config, mock_posthog_sdk)
-        with pytest.raises(Exception):
-            client._execute_hogql_query_all("SELECT 1", {})
-        client.shutdown()
+    @patch("posthog.temporal.ingestion_acceptance_test.client.sync_execute")
+    def test_returns_events_when_all_uuids_found(self, mock_sync_execute: MagicMock, client: PostHogClient) -> None:
+        uuid1 = uuid.UUID("00000000-0000-0000-0000-000000000001")
+        uuid2 = uuid.UUID("00000000-0000-0000-0000-000000000002")
+        mock_sync_execute.return_value = [
+            (uuid1, "ev1", "u1", {"k": "v1"}, datetime(2024, 1, 1)),
+            (uuid2, "ev2", "u2", {"k": "v2"}, datetime(2024, 1, 2)),
+        ]
 
-        assert MockHttpHandler.call_count == 1
+        result = client._fetch_events_by_person_id("person-1", expected_event_uuids={str(uuid1), str(uuid2)})
 
-    def test_does_not_retry_on_429_rate_limit(self, mock_server: HTTPServer, mock_posthog_sdk: MagicMock) -> None:
-        port = mock_server.server_address[1]
-        config = Config(
-            api_host=f"http://127.0.0.1:{port}",
-            project_api_key="phc_test_key",
-            project_id="12345",
-            personal_api_key="phx_personal_key",
-            event_timeout_seconds=5,
-            poll_interval_seconds=0.1,
-        )
-
-        MockHttpHandler.queued_responses = [{"status_code": 429, "json": {"error": "Rate limited"}}]
-
-        client = PostHogClient(config, mock_posthog_sdk)
-        with pytest.raises(Exception):
-            client._execute_hogql_query_all("SELECT 1", {})
-        client.shutdown()
-
-        assert MockHttpHandler.call_count == 1
-
-    def test_returns_empty_list_on_404(self, mock_server: HTTPServer, mock_posthog_sdk: MagicMock) -> None:
-        port = mock_server.server_address[1]
-        config = Config(
-            api_host=f"http://127.0.0.1:{port}",
-            project_api_key="phc_test_key",
-            project_id="12345",
-            personal_api_key="phx_personal_key",
-            event_timeout_seconds=5,
-            poll_interval_seconds=0.1,
-        )
-
-        MockHttpHandler.queued_responses = [{"status_code": 404}]
-
-        client = PostHogClient(config, mock_posthog_sdk)
-        result = client._execute_hogql_query_all("SELECT 1", {})
-        client.shutdown()
-
-        assert result == []
-        assert MockHttpHandler.call_count == 1
-
-    def test_succeeds_on_first_try_when_server_healthy(
-        self, mock_server: HTTPServer, mock_posthog_sdk: MagicMock
-    ) -> None:
-        port = mock_server.server_address[1]
-        config = Config(
-            api_host=f"http://127.0.0.1:{port}",
-            project_api_key="phc_test_key",
-            project_id="12345",
-            personal_api_key="phx_personal_key",
-            event_timeout_seconds=5,
-            poll_interval_seconds=0.1,
-        )
-
-        MockHttpHandler.queued_responses = [{"json": {"results": [["value"]], "columns": ["col"]}, "status_code": 200}]
-
-        client = PostHogClient(config, mock_posthog_sdk)
-        result = client._execute_hogql_query_all("SELECT 1", {})
-        client.shutdown()
-
-        assert result == [{"col": "value"}]
-        assert MockHttpHandler.call_count == 1
+        assert result is not None
+        assert len(result) == 2
+        assert result[0].uuid == str(uuid1)
+        assert result[1].uuid == str(uuid2)
 
 
 class TestTimestampFiltering:
@@ -356,18 +215,3 @@ class TestTimestampFiltering:
         yesterday = today - timedelta(days=1)
 
         assert client._test_start_date == yesterday
-
-    def test_fetch_events_by_person_id_includes_timestamp_filter(self, client: PostHogClient) -> None:
-        with patch.object(client._session, "post") as mock_post:
-            mock_post.return_value.status_code = 200
-            mock_post.return_value.json.return_value = {"results": [], "columns": []}
-
-            client._fetch_events_by_person_id("test-person-id", expected_event_uuids={"some-uuid"})
-
-            mock_post.assert_called_once()
-            call_kwargs = mock_post.call_args[1]
-            request_body = call_kwargs["json"]
-
-            assert "timestamp >= {min_timestamp}" in request_body["query"]["query"]
-            assert "min_timestamp" in request_body["query"]["values"]
-            assert request_body["query"]["values"]["min_timestamp"] == client._test_start_date.isoformat()

--- a/posthog/temporal/tests/ingestion_acceptance_test/test_client.py
+++ b/posthog/temporal/tests/ingestion_acceptance_test/test_client.py
@@ -137,6 +137,7 @@ class TestFetchPersonByDistinctId:
         assert "JOIN person_distinct_id2 pdi" in query
         assert "pdi.distinct_id = %(distinct_id)s" in query
         assert "pdi.is_deleted = 0" in query
+        assert "p.is_deleted = 0" in query
         assert params["team_id"] == 12345
         assert params["distinct_id"] == "user_123"
 
@@ -164,6 +165,23 @@ class TestFetchPersonByDistinctId:
         result = client._fetch_person_by_distinct_id("nonexistent-user")
 
         assert result is None
+
+    @patch("posthog.temporal.ingestion_acceptance_test.client.sync_execute")
+    def test_filters_out_deleted_persons_and_distinct_ids(
+        self, mock_sync_execute: MagicMock, client: PostHogClient
+    ) -> None:
+        """Verify the query includes is_deleted = 0 filters for both person and person_distinct_id2.
+
+        Both tables are ReplacingMergeTree — without these filters, soft-deleted rows
+        can be returned before ClickHouse merges parts.
+        """
+        mock_sync_execute.return_value = []
+
+        client._fetch_person_by_distinct_id("user_123")
+
+        query = mock_sync_execute.call_args[0][0]
+        assert "p.is_deleted = 0" in query, "Missing is_deleted filter on person table"
+        assert "pdi.is_deleted = 0" in query, "Missing is_deleted filter on person_distinct_id2 table"
 
 
 class TestFetchEventsByPersonId:

--- a/posthog/temporal/tests/ingestion_acceptance_test/test_runner.py
+++ b/posthog/temporal/tests/ingestion_acceptance_test/test_runner.py
@@ -13,8 +13,7 @@ def config() -> Config:
     return Config(
         api_host="https://test.posthog.com",
         project_api_key="phc_test_key",
-        project_id="12345",
-        personal_api_key="phx_personal_key",
+        team_id=12345,
     )
 
 
@@ -154,7 +153,7 @@ class TestRunTests:
         result = run_tests(config, tests, mock_client, executor, running_tests)
 
         assert result.environment["api_host"] == "https://test.posthog.com"
-        assert result.environment["project_id"] == "12345"
+        assert result.environment["team_id"] == "12345"
 
     @patch("posthog.temporal.ingestion_acceptance_test.runner.as_completed")
     def test_submits_all_tests_to_executor(

--- a/posthog/temporal/tests/ingestion_acceptance_test/test_slack.py
+++ b/posthog/temporal/tests/ingestion_acceptance_test/test_slack.py
@@ -11,8 +11,7 @@ def config() -> Config:
     return Config(
         api_host="https://test.posthog.com",
         project_api_key="phc_test_key",
-        project_id="12345",
-        personal_api_key="phx_personal_key",
+        team_id=12345,
         slack_webhook_url="https://hooks.slack.com/services/T00/B00/XXX",
     )
 
@@ -37,7 +36,7 @@ def passing_result() -> TestSuiteResult:
             ),
         ],
         total_duration_seconds=3.5,
-        environment={"api_host": "https://test.posthog.com", "project_id": "12345"},
+        environment={"api_host": "https://test.posthog.com", "team_id": "12345"},
         timestamp="2024-01-01T00:00:00Z",
     )
 
@@ -63,7 +62,7 @@ def failing_result() -> TestSuiteResult:
             ),
         ],
         total_duration_seconds=3.0,
-        environment={"api_host": "https://test.posthog.com", "project_id": "12345"},
+        environment={"api_host": "https://test.posthog.com", "team_id": "12345"},
         timestamp="2024-01-01T00:00:00Z",
     )
 
@@ -174,8 +173,7 @@ class TestSendSlackNotification:
         config_no_webhook = Config(
             api_host="https://test.posthog.com",
             project_api_key="phc_test_key",
-            project_id="12345",
-            personal_api_key="phx_personal_key",
+            team_id=12345,
             slack_webhook_url=None,
         )
 
@@ -223,8 +221,7 @@ class TestSendSlackTimeoutNotification:
         config_no_webhook = Config(
             api_host="https://test.posthog.com",
             project_api_key="phc_test_key",
-            project_id="12345",
-            personal_api_key="phx_personal_key",
+            team_id=12345,
             slack_webhook_url=None,
         )
 


### PR DESCRIPTION
## Problem

The ingestion acceptance tests (a Temporal scheduled workflow that runs every 10 minutes) query ClickHouse via the PostHog HogQL API, authenticated with a personal API key. This adds an unnecessary dependency on the web tier being healthy and requires managing a `PERSONAL_API_KEY` credential. Since the only goal of these tests is to verify that events land in ClickHouse, we can query ClickHouse directly from the Temporal worker, which already has ClickHouse credentials via Django settings.

## Changes

- **`config.py`**: Removed `personal_api_key` and `project_id` fields, added `team_id: int` (env var: `INGESTION_ACCEPTANCE_TEST_TEAM_ID`)
- **`client.py`**: Replaced HTTP session + HogQL API queries with `sync_execute` from `posthog.clickhouse.client.execute`. Queries now go directly to ClickHouse using real table names (`events`, `person`, `person_distinct_id2`) with `team_id` filtering. Removed all HTTP query infrastructure (`_create_http_session`, `_execute_hogql_query`, `_execute_hogql_query_all`, HTTP retry/resilience config)
- **`activities.py`**, **`__main__.py`**, **`slack.py`**, **`terminal_report.py`**: Updated references from `project_id` to `team_id`
- **`README.md`**: Updated architecture diagram, configuration table, and descriptions to reflect direct ClickHouse queries
- **Unit tests**: Rewrote client query tests to mock `sync_execute` instead of HTTP responses, updated all `Config` fixtures to use `team_id` instead of `project_id`/`personal_api_key`

**Deployment note**: Env var changes required:
- Remove: `INGESTION_ACCEPTANCE_TEST_PERSONAL_API_KEY`, `INGESTION_ACCEPTANCE_TEST_PROJECT_ID`
- Add: `INGESTION_ACCEPTANCE_TEST_TEAM_ID`

## How did you test this code?

All 36 unit tests pass (`pytest posthog/temporal/tests/ingestion_acceptance_test/ -v`). Linting passes with `ruff check` and `ruff format --check`.
