### PR TITLE
fix(dashboards): handle kea-router auto-parsed query_variables in URL params

### DIFF
--- a/frontend/src/scenes/dashboard/dashboardUtils.test.ts
+++ b/frontend/src/scenes/dashboard/dashboardUtils.test.ts
@@ -1,0 +1,58 @@
+import {
+    parseURLFilters,
+    parseURLVariables,
+    SEARCH_PARAM_FILTERS_KEY,
+    SEARCH_PARAM_QUERY_VARIABLES_KEY,
+} from './dashboardUtils'
+
+describe('parseURLVariables', () => {
+    it('parses a JSON string value from search params', () => {
+        const searchParams = {
+            [SEARCH_PARAM_QUERY_VARIABLES_KEY]: '{"card_name":"Polukranos, Unchained"}',
+        }
+        const result = parseURLVariables(searchParams)
+        expect(result).toEqual({ card_name: 'Polukranos, Unchained' })
+    })
+
+    it('handles an already-parsed object from search params (kea-router auto-parse)', () => {
+        // When the URL has no trailing %20, kea-router auto-parses JSON values into objects
+        const searchParams = {
+            [SEARCH_PARAM_QUERY_VARIABLES_KEY]: { card_name: 'Polukranos, Unchained' },
+        }
+        const result = parseURLVariables(searchParams)
+        expect(result).toEqual({ card_name: 'Polukranos, Unchained' })
+    })
+
+    it('returns empty object when key is missing', () => {
+        expect(parseURLVariables({})).toEqual({})
+    })
+
+    it('returns empty object for invalid JSON string', () => {
+        const searchParams = {
+            [SEARCH_PARAM_QUERY_VARIABLES_KEY]: 'not-json',
+        }
+        expect(parseURLVariables(searchParams)).toEqual({})
+    })
+})
+
+describe('parseURLFilters', () => {
+    it('parses a JSON string value from search params', () => {
+        const searchParams = {
+            [SEARCH_PARAM_FILTERS_KEY]: '{"date_from":"-7d"}',
+        }
+        const result = parseURLFilters(searchParams)
+        expect(result).toEqual({ date_from: '-7d' })
+    })
+
+    it('handles an already-parsed object from search params (kea-router auto-parse)', () => {
+        const searchParams = {
+            [SEARCH_PARAM_FILTERS_KEY]: { date_from: '-7d', date_to: 'now' },
+        }
+        const result = parseURLFilters(searchParams)
+        expect(result).toEqual({ date_from: '-7d', date_to: 'now' })
+    })
+
+    it('returns empty object when key is missing', () => {
+        expect(parseURLFilters({})).toEqual({})
+    })
+})

--- a/frontend/src/scenes/dashboard/dashboardUtils.ts
+++ b/frontend/src/scenes/dashboard/dashboardUtils.ts
@@ -258,9 +258,12 @@ export async function getInsightWithRetry(
 export const parseURLVariables = (searchParams: Record<string, any>): Record<string, Partial<HogQLVariable>> => {
     const variables: Record<string, Partial<HogQLVariable>> = {}
 
-    if (searchParams[SEARCH_PARAM_QUERY_VARIABLES_KEY]) {
+    const raw = searchParams[SEARCH_PARAM_QUERY_VARIABLES_KEY]
+    if (raw) {
         try {
-            const parsedVariables = JSON.parse(searchParams[SEARCH_PARAM_QUERY_VARIABLES_KEY])
+            // kea-router auto-parses JSON-like values from the URL, so the value
+            // may already be an object when the URL doesn't have a trailing space.
+            const parsedVariables = typeof raw === 'string' ? JSON.parse(raw) : raw
             Object.assign(variables, parsedVariables)
         } catch (e) {
             console.error('Failed to parse query_variables from URL:', e)
@@ -283,9 +286,12 @@ export const encodeURLVariables = (variables: Record<string, string>): Record<st
 export const parseURLFilters = (searchParams: Record<string, any>): DashboardFilter => {
     const filters: DashboardFilter = {}
 
-    if (searchParams[SEARCH_PARAM_FILTERS_KEY]) {
+    const raw = searchParams[SEARCH_PARAM_FILTERS_KEY]
+    if (raw) {
         try {
-            const parsedFilters = JSON.parse(searchParams[SEARCH_PARAM_FILTERS_KEY])
+            // kea-router auto-parses JSON-like values from the URL, so the value
+            // may already be an object when the URL doesn't have a trailing space.
+            const parsedFilters = typeof raw === 'string' ? JSON.parse(raw) : raw
             Object.assign(filters, parsedFilters)
         } catch (e) {
             console.error(`Failed to parse ${SEARCH_PARAM_FILTERS_KEY} from URL:`, e)


### PR DESCRIPTION
## Problem

Dashboard `query_variables` URL parameter is silently ignored when manually constructing a URL without a trailing `%20`.

**Works:** `?query_variables={"card_name":"Polukranos, Unchained"}%20`
**Fails:** `?query_variables={"card_name":"Polukranos, Unchained"}`

## Root cause

`kea-router`'s `parseValue()` has two branches for JSON-like strings:
- `{...}` (no trailing space) → auto-parses via `JSON.parse()` → returns an **object**
- `{...} ` (trailing space) → strips the space → returns a **string**

`parseURLVariables()` unconditionally calls `JSON.parse()` on the search param value. When kea-router already parsed it into an object, `JSON.parse(someObject)` stringifies it to `"[object Object]"` and throws a `SyntaxError`, which the catch block swallows — silently dropping all query variables.

The trailing `%20` workaround prevents kea-router from auto-parsing the JSON, so the value stays as a string and `JSON.parse()` succeeds.

## Fix

Check `typeof raw === 'string'` before calling `JSON.parse()`. If the value is already an object (auto-parsed by kea-router), use it directly. Applied the same fix to `parseURLFilters()` which has the same latent bug.

## Changes

- `frontend/src/scenes/dashboard/dashboardUtils.ts` — guard `parseURLVariables` and `parseURLFilters` against pre-parsed object values
- `frontend/src/scenes/dashboard/dashboardUtils.test.ts` — new unit tests covering both string and object inputs

## How I verified

- All 7 new unit tests pass
- All 124 existing dashboard tests pass (`dashboardLogic.test.ts`, `dashboardQuickFiltersDebounce.test.ts`, etc.)

Closes #53788