### PR TITLE
fix(sandbox): increase sandbox TTL to 2h

### DIFF
--- a/products/tasks/backend/services/sandbox.py
+++ b/products/tasks/backend/services/sandbox.py
@@ -57,7 +57,7 @@ class ExecutionStream(Protocol):
     def wait(self) -> ExecutionResult: ...
 
 
-SANDBOX_TTL_SECONDS = 60 * 30  # 30 minutes
+SANDBOX_TTL_SECONDS = 60 * 120  # 2 hours (safety net; workflow inactivity timeout handles cleanup)
 
 
 class SandboxConfig(BaseModel):


### PR DESCRIPTION
## Problem

Cloud agent sandboxes are randomly dying mid-work after exactly 30 minutes. The Modal sandbox hard TTL (`SANDBOX_TTL_SECONDS = 60 * 30`) kills the sandbox regardless of whether the agent is actively working. Investigated via task run `f6425b8c-7e2a-46f0-b23a-d57dedd3be75` which died at exactly the 30-minute mark 

## Changes

- increased `SANDBOX_TTL_SECONDS` from 30 minutes to 2 hours