### PR TITLE
feat(alerts): relocate disable_invalid_alert to utils and switch evaluate activity to Heartbeater

### DIFF
--- a/posthog/tasks/alerts/checks.py
+++ b/posthog/tasks/alerts/checks.py
@@ -373,7 +373,7 @@ def check_alert_and_notify_atomically(alert: AlertConfiguration) -> None:
     triggered_metadata = (
         getattr(alert_evaluation_result, "triggered_metadata", None) if alert_evaluation_result else None
     )
-    alert_check, notify = add_alert_check(
+    alert_check, should_notify = add_alert_check(
         alert,
         value,
         breaches,
@@ -386,7 +386,7 @@ def check_alert_and_notify_atomically(alert: AlertConfiguration) -> None:
     )
 
     # 3. Notify users if needed
-    if not notify:
+    if not should_notify:
         return
 
     try:
@@ -449,14 +449,14 @@ def add_alert_check(
     successful delivery and treats a non-empty value as the idempotency sentinel on retry.
     `last_notified_at` is likewise set by the notify activity on success, not here.
     """
-    notify = False
+    should_notify = False
 
     if error:
         alert.state = AlertState.ERRORED
-        notify = True
+        should_notify = True
     elif breaches:
         alert.state = AlertState.FIRING
-        notify = True
+        should_notify = True
     else:
         alert.state = AlertState.NOT_FIRING  # Set the Alert to not firing if the threshold is no longer met
         # TODO: Optionally send a resolved notification when alert goes from firing to not_firing?
@@ -483,4 +483,4 @@ def add_alert_check(
 
     alert.save(update_fields=["state", "last_checked_at", "next_check_at"])
 
-    return alert_check, notify
+    return alert_check, should_notify

--- a/posthog/tasks/alerts/checks.py
+++ b/posthog/tasks/alerts/checks.py
@@ -31,9 +31,9 @@ from posthog.tasks.alerts.utils import (
     AlertEvaluationResult,
     calculation_interval_to_order,
     disable_invalid_alert,
+    dispatch_alert_notification,
     next_check_time,
-    send_notifications_for_breaches,
-    send_notifications_for_errors,
+    record_alert_delivery,
     skip_because_of_weekend,
     validate_alert_config,
 )
@@ -373,7 +373,7 @@ def check_alert_and_notify_atomically(alert: AlertConfiguration) -> None:
     triggered_metadata = (
         getattr(alert_evaluation_result, "triggered_metadata", None) if alert_evaluation_result else None
     )
-    alert_check = add_alert_check(
+    alert_check, notify = add_alert_check(
         alert,
         value,
         breaches,
@@ -386,20 +386,13 @@ def check_alert_and_notify_atomically(alert: AlertConfiguration) -> None:
     )
 
     # 3. Notify users if needed
-    if not alert_check.targets_notified:
+    if not notify:
         return
 
     try:
-        match alert_check.state:
-            case AlertState.NOT_FIRING:
-                logger.info("Check state is %s", alert_check.state, alert_id=alert.id)
-            case AlertState.ERRORED:
-                logger.info("Sending alert error notifications", alert_id=alert.id, error=alert_check.error)
-                if isinstance(alert_check.error, dict):
-                    send_notifications_for_errors(alert, alert_check.error)
-            case AlertState.FIRING:
-                assert breaches is not None
-                send_notifications_for_breaches(alert, breaches)
+        targets = dispatch_alert_notification(alert, alert_check, breaches)
+        if targets is not None:
+            record_alert_delivery(alert, alert_check, targets)
     except Exception as err:
         error_message = f"AlertCheckError: error sending notifications for alert_id = {alert.id}"
         logger.exception(error_message, exc_info=err)
@@ -449,9 +442,14 @@ def add_alert_check(
     triggered_dates: list[str] | None = None,
     interval: str | None = None,
     triggered_metadata: dict | None = None,
-) -> AlertCheck:
+) -> tuple[AlertCheck, bool]:
+    """Persist an AlertCheck row and return it plus a decision on whether notification is needed.
+
+    `targets_notified` is always created empty; `notify_alert_activity` fills it on
+    successful delivery and treats a non-empty value as the idempotency sentinel on retry.
+    `last_notified_at` is likewise set by the notify activity on success, not here.
+    """
     notify = False
-    targets_notified = {}
 
     if error:
         alert.state = AlertState.ERRORED
@@ -463,22 +461,17 @@ def add_alert_check(
         alert.state = AlertState.NOT_FIRING  # Set the Alert to not firing if the threshold is no longer met
         # TODO: Optionally send a resolved notification when alert goes from firing to not_firing?
 
-    now = datetime.now(UTC)
     alert.last_checked_at = datetime.now(UTC)
 
     # IMPORTANT: update next_check_at according to interval
     # ensure we don't recheck alert until the next interval is due
     alert.next_check_at = next_check_time(alert)
 
-    if notify:
-        alert.last_notified_at = now
-        targets_notified = {"users": alert.get_subscribed_users_emails()}
-
     alert_check = AlertCheck.objects.create(
         alert_configuration=alert,
         calculated_value=value,
         condition=alert.condition,
-        targets_notified=targets_notified,
+        targets_notified={},
         state=alert.state,
         triggered_metadata=triggered_metadata,
         error=error,
@@ -488,6 +481,6 @@ def add_alert_check(
         interval=interval,
     )
 
-    alert.save()
+    alert.save(update_fields=["state", "last_checked_at", "next_check_at"])
 
-    return alert_check
+    return alert_check, notify

--- a/posthog/tasks/alerts/checks.py
+++ b/posthog/tasks/alerts/checks.py
@@ -30,9 +30,9 @@ from posthog.tasks.alerts.utils import (
     WRAPPER_NODE_KINDS,
     AlertEvaluationResult,
     calculation_interval_to_order,
+    disable_invalid_alert,
     next_check_time,
     send_notifications_for_breaches,
-    send_notifications_for_disabled,
     send_notifications_for_errors,
     skip_because_of_weekend,
     validate_alert_config,
@@ -300,7 +300,7 @@ def check_alert(alert_id: str) -> None:
                 insight.query, alert.condition, alert.config, threshold_config, alert.calculation_interval
             )
     except ValueError as e:
-        _disable_invalid_alert(alert, str(e))
+        disable_invalid_alert(alert, str(e))
         return
 
     # we will attempt to check alert
@@ -409,28 +409,6 @@ def check_alert_and_notify_atomically(alert: AlertConfiguration) -> None:
         # so we raise again as @transaction.atomic decorator won't commit db updates
         # TODO: later should have a way just to retry notification mechanism
         raise
-
-
-def _disable_invalid_alert(alert: AlertConfiguration, reason: str) -> None:
-    logger.warning("check_alert.auto_disabling", alert_id=alert.id, reason=reason)
-    AlertConfiguration.objects.filter(pk=alert.pk).update(
-        enabled=False,
-        state=AlertState.ERRORED,
-        last_checked_at=datetime.now(UTC),
-    )
-    alert.refresh_from_db()
-
-    targets_to_notify = alert.get_subscribed_users_emails()
-    AlertCheck.objects.create(
-        alert_configuration=alert,
-        calculated_value=None,
-        condition=alert.condition,
-        targets_notified={"users": targets_to_notify} if targets_to_notify else {},
-        state=AlertState.ERRORED,
-        error={"message": reason},
-    )
-    if targets_to_notify:
-        send_notifications_for_disabled(alert, reason, targets_to_notify)
 
 
 def check_alert_for_insight(alert: AlertConfiguration) -> AlertEvaluationResult:

--- a/posthog/tasks/alerts/test/test_alert_checks.py
+++ b/posthog/tasks/alerts/test/test_alert_checks.py
@@ -34,7 +34,7 @@ from posthog.tasks.test.utils_email_tests import mock_email_messages
 
 @freeze_time("2024-06-02T08:55:00.000Z")
 @patch("posthog.tasks.alerts.utils.send_notifications_for_errors")
-@patch("posthog.tasks.alerts.utils.send_notifications_for_breaches")
+@patch("posthog.tasks.alerts.utils.send_notifications_for_breaches", return_value=[])
 class TestAlertChecks(APIBaseTest, ClickhouseDestroyTablesMixin):
     def setUp(self) -> None:
         super().setUp()
@@ -932,7 +932,7 @@ class TestAlertChecks(APIBaseTest, ClickhouseDestroyTablesMixin):
             ("relative_on_non_time_series", {"condition": {"type": "relative_increase"}}, "not compatible"),
         ]
     )
-    @patch("posthog.tasks.alerts.checks.send_notifications_for_disabled")
+    @patch("posthog.tasks.alerts.utils.send_notifications_for_disabled")
     def test_invalid_config_auto_disables_alert(
         self,
         _name: str,
@@ -965,7 +965,7 @@ class TestAlertChecks(APIBaseTest, ClickhouseDestroyTablesMixin):
         assert alert_check.targets_notified == {"users": ["user1@posthog.com"]}
         assert expected_error_fragment in alert_check.error["message"]
 
-    @patch("posthog.tasks.alerts.checks.send_notifications_for_disabled")
+    @patch("posthog.tasks.alerts.utils.send_notifications_for_disabled")
     def test_auto_disable_with_no_subscribers_sets_targets_notified_to_none(
         self,
         mock_send_disabled: MagicMock,

--- a/posthog/tasks/alerts/test/test_alert_checks.py
+++ b/posthog/tasks/alerts/test/test_alert_checks.py
@@ -33,8 +33,8 @@ from posthog.tasks.test.utils_email_tests import mock_email_messages
 
 
 @freeze_time("2024-06-02T08:55:00.000Z")
-@patch("posthog.tasks.alerts.checks.send_notifications_for_errors")
-@patch("posthog.tasks.alerts.checks.send_notifications_for_breaches")
+@patch("posthog.tasks.alerts.utils.send_notifications_for_errors")
+@patch("posthog.tasks.alerts.utils.send_notifications_for_breaches")
 class TestAlertChecks(APIBaseTest, ClickhouseDestroyTablesMixin):
     def setUp(self) -> None:
         super().setUp()

--- a/posthog/tasks/alerts/test/test_alert_checks.py
+++ b/posthog/tasks/alerts/test/test_alert_checks.py
@@ -353,7 +353,9 @@ class TestAlertChecks(APIBaseTest, ClickhouseDestroyTablesMixin):
     ) -> None:
         mocked_email_messages = mock_email_messages(MockEmailMessage)
         alert = AlertConfiguration.objects.get(pk=self.alert["id"])
-        send_notifications_for_breaches(alert, ["first anomaly description", "second anomaly description"])
+        send_notifications_for_breaches(
+            alert, ["first anomaly description", "second anomaly description"], idempotency_key="test-send-emails"
+        )
 
         assert len(mocked_email_messages) == 1
         email = mocked_email_messages[0]
@@ -1053,7 +1055,7 @@ class TestAlertSubscriptionOrgMembership(APIBaseTest):
 
         OrganizationMembership.objects.filter(user=self.other_user, organization=self.organization).delete()
 
-        send_notifications_for_breaches(alert, ["test breach"])
+        send_notifications_for_breaches(alert, ["test breach"], idempotency_key="test-excludes-removed-members")
 
         assert len(mocked_email_messages) == 1
         email = mocked_email_messages[0]

--- a/posthog/tasks/alerts/test/test_alert_checks.py
+++ b/posthog/tasks/alerts/test/test_alert_checks.py
@@ -33,7 +33,7 @@ from posthog.tasks.test.utils_email_tests import mock_email_messages
 
 
 @freeze_time("2024-06-02T08:55:00.000Z")
-@patch("posthog.tasks.alerts.utils.send_notifications_for_errors")
+@patch("posthog.tasks.alerts.utils.send_notifications_for_errors", return_value=[])
 @patch("posthog.tasks.alerts.utils.send_notifications_for_breaches", return_value=[])
 class TestAlertChecks(APIBaseTest, ClickhouseDestroyTablesMixin):
     def setUp(self) -> None:

--- a/posthog/tasks/alerts/test/test_trends_absolute_alerts.py
+++ b/posthog/tasks/alerts/test/test_trends_absolute_alerts.py
@@ -160,7 +160,9 @@ class TestTimeSeriesTrendsAbsoluteAlerts(APIBaseTest, ClickhouseDestroyTablesMix
         assert alert_check.error is None
 
         mock_send_breaches.assert_called_once_with(
-            ANY, ["The insight value (signed_up) for previous week (0) is less than lower threshold (1.0)"]
+            ANY,
+            ["The insight value (signed_up) for previous week (0) is less than lower threshold (1.0)"],
+            idempotency_key=ANY,
         )
 
     def test_trend_high_threshold_breached(self, mock_send_breaches: MagicMock, mock_send_errors: MagicMock) -> None:
@@ -198,7 +200,9 @@ class TestTimeSeriesTrendsAbsoluteAlerts(APIBaseTest, ClickhouseDestroyTablesMix
         assert alert_check.error is None
 
         mock_send_breaches.assert_called_once_with(
-            ANY, ["The insight value (signed_up) for previous week (2) is more than upper threshold (1.0)"]
+            ANY,
+            ["The insight value (signed_up) for previous week (2) is more than upper threshold (1.0)"],
+            idempotency_key=ANY,
         )
 
     def test_trend_no_threshold_breached(self, mock_send_breaches: MagicMock, mock_send_errors: MagicMock) -> None:
@@ -309,7 +313,9 @@ class TestTimeSeriesTrendsAbsoluteAlerts(APIBaseTest, ClickhouseDestroyTablesMix
         assert alert_check.error is None
 
         mock_send_breaches.assert_called_once_with(
-            ANY, ["The insight value (signed_up - Chrome) for previous week (2.0) is more than upper threshold (1.0)"]
+            ANY,
+            ["The insight value (signed_up - Chrome) for previous week (2.0) is more than upper threshold (1.0)"],
+            idempotency_key=ANY,
         )
 
     def test_trend_breakdown_low_threshold_breached(
@@ -355,7 +361,9 @@ class TestTimeSeriesTrendsAbsoluteAlerts(APIBaseTest, ClickhouseDestroyTablesMix
         assert alert_check.error is None
 
         mock_send_breaches.assert_called_once_with(
-            ANY, ["The insight value (signed_up - Firefox) for previous week (1.0) is less than lower threshold (2.0)"]
+            ANY,
+            ["The insight value (signed_up - Firefox) for previous week (1.0) is less than lower threshold (2.0)"],
+            idempotency_key=ANY,
         )
 
     def test_trend_breakdown_no_threshold_breached(
@@ -445,7 +453,9 @@ class TestTimeSeriesTrendsAbsoluteAlerts(APIBaseTest, ClickhouseDestroyTablesMix
         assert alert_check.error is None
 
         mock_send_breaches.assert_called_once_with(
-            ANY, ["The insight value (signed_up) for current interval (3) is more than upper threshold (1.0)"]
+            ANY,
+            ["The insight value (signed_up) for current interval (3) is more than upper threshold (1.0)"],
+            idempotency_key=ANY,
         )
 
     def test_aggregate_trend_with_breakdown_high_threshold_breached(
@@ -491,7 +501,9 @@ class TestTimeSeriesTrendsAbsoluteAlerts(APIBaseTest, ClickhouseDestroyTablesMix
         assert alert_check.error is None
 
         mock_send_breaches.assert_called_once_with(
-            ANY, ["The insight value (signed_up - Chrome) for current interval (2) is more than upper threshold (1.0)"]
+            ANY,
+            ["The insight value (signed_up - Chrome) for current interval (2) is more than upper threshold (1.0)"],
+            idempotency_key=ANY,
         )
 
     def test_trend_current_interval_high_threshold_breached(
@@ -532,7 +544,9 @@ class TestTimeSeriesTrendsAbsoluteAlerts(APIBaseTest, ClickhouseDestroyTablesMix
         assert alert_check.error is None
 
         mock_send_breaches.assert_called_once_with(
-            ANY, ["The insight value (signed_up) for current week (2) is more than upper threshold (1.0)"]
+            ANY,
+            ["The insight value (signed_up) for current week (2) is more than upper threshold (1.0)"],
+            idempotency_key=ANY,
         )
 
     def test_trend_current_interval_should_not_fallback_to_previous_high_threshold_breached(
@@ -657,7 +671,9 @@ class TestTimeSeriesTrendsAbsoluteAlerts(APIBaseTest, ClickhouseDestroyTablesMix
         assert alert_check.error is None
 
         mock_send_breaches.assert_called_once_with(
-            ANY, ["The insight value (signed_up) for previous week (0) is less than lower threshold (2.0)"]
+            ANY,
+            ["The insight value (signed_up) for previous week (0) is less than lower threshold (2.0)"],
+            idempotency_key=ANY,
         )
 
     @patch("posthog.tasks.alerts.trends.calculate_for_query_based_insight", wraps=calculate_for_query_based_insight)

--- a/posthog/tasks/alerts/test/test_trends_absolute_alerts.py
+++ b/posthog/tasks/alerts/test/test_trends_absolute_alerts.py
@@ -34,8 +34,8 @@ FROZEN_TIME = dateutil.parser.parse("2024-06-02T08:55:00.000Z")
 
 
 @freeze_time(FROZEN_TIME)
-@patch("posthog.tasks.alerts.checks.send_notifications_for_errors")
-@patch("posthog.tasks.alerts.checks.send_notifications_for_breaches")
+@patch("posthog.tasks.alerts.utils.send_notifications_for_errors")
+@patch("posthog.tasks.alerts.utils.send_notifications_for_breaches")
 class TestTimeSeriesTrendsAbsoluteAlerts(APIBaseTest, ClickhouseDestroyTablesMixin):
     def setUp(self) -> None:
         super().setUp()

--- a/posthog/tasks/alerts/test/test_trends_absolute_alerts.py
+++ b/posthog/tasks/alerts/test/test_trends_absolute_alerts.py
@@ -35,7 +35,7 @@ FROZEN_TIME = dateutil.parser.parse("2024-06-02T08:55:00.000Z")
 
 @freeze_time(FROZEN_TIME)
 @patch("posthog.tasks.alerts.utils.send_notifications_for_errors")
-@patch("posthog.tasks.alerts.utils.send_notifications_for_breaches")
+@patch("posthog.tasks.alerts.utils.send_notifications_for_breaches", return_value=[])
 class TestTimeSeriesTrendsAbsoluteAlerts(APIBaseTest, ClickhouseDestroyTablesMixin):
     def setUp(self) -> None:
         super().setUp()

--- a/posthog/tasks/alerts/test/test_trends_relative_alerts.py
+++ b/posthog/tasks/alerts/test/test_trends_relative_alerts.py
@@ -193,7 +193,9 @@ class TestTimeSeriesTrendsRelativeAlerts(APIBaseTest, ClickhouseDestroyTablesMix
         assert alert_check.error is None
 
         mock_send_breaches.assert_called_once_with(
-            ANY, ["The insight value (signed_up) for previous week (2) increased more than upper threshold (1.0)"]
+            ANY,
+            ["The insight value (signed_up) for previous week (2) increased more than upper threshold (1.0)"],
+            idempotency_key=ANY,
         )
 
     def test_relative_increase_upper_threshold_breached(
@@ -366,7 +368,9 @@ class TestTimeSeriesTrendsRelativeAlerts(APIBaseTest, ClickhouseDestroyTablesMix
         assert alert_check.error is None
 
         mock_send_breaches.assert_called_once_with(
-            ANY, ["The insight value (signed_up) for previous week (-1) increased less than lower threshold (2.0)"]
+            ANY,
+            ["The insight value (signed_up) for previous week (-1) increased less than lower threshold (2.0)"],
+            idempotency_key=ANY,
         )
 
         # check percentage alert
@@ -389,6 +393,7 @@ class TestTimeSeriesTrendsRelativeAlerts(APIBaseTest, ClickhouseDestroyTablesMix
         mock_send_breaches.assert_called_with(
             ANY,
             ["The insight value (signed_up) for previous week (-50.00%) increased less than lower threshold (50.00%)"],
+            idempotency_key=ANY,
         )
 
     def test_relative_increase_lower_threshold_breached_2(
@@ -561,7 +566,9 @@ class TestTimeSeriesTrendsRelativeAlerts(APIBaseTest, ClickhouseDestroyTablesMix
         assert alert_check.error is None
 
         mock_send_breaches.assert_called_once_with(
-            ANY, ["The insight value (signed_up) for previous week (2) decreased more than upper threshold (1.0)"]
+            ANY,
+            ["The insight value (signed_up) for previous week (2) decreased more than upper threshold (1.0)"],
+            idempotency_key=ANY,
         )
 
         check_alert(percentage_alert["id"])
@@ -583,6 +590,7 @@ class TestTimeSeriesTrendsRelativeAlerts(APIBaseTest, ClickhouseDestroyTablesMix
         mock_send_breaches.assert_called_with(
             ANY,
             ["The insight value (signed_up) for previous week (66.67%) decreased more than upper threshold (20.00%)"],
+            idempotency_key=ANY,
         )
 
     def test_relative_decrease_lower_threshold_breached(
@@ -659,7 +667,9 @@ class TestTimeSeriesTrendsRelativeAlerts(APIBaseTest, ClickhouseDestroyTablesMix
         assert alert_check.error is None
 
         mock_send_breaches.assert_called_once_with(
-            ANY, ["The insight value (signed_up) for previous week (1) decreased less than lower threshold (2.0)"]
+            ANY,
+            ["The insight value (signed_up) for previous week (1) decreased less than lower threshold (2.0)"],
+            idempotency_key=ANY,
         )
 
         check_alert(percentage_alert["id"])
@@ -681,6 +691,7 @@ class TestTimeSeriesTrendsRelativeAlerts(APIBaseTest, ClickhouseDestroyTablesMix
         mock_send_breaches.assert_called_with(
             ANY,
             ["The insight value (signed_up) for previous week (50.00%) decreased less than lower threshold (80.00%)"],
+            idempotency_key=ANY,
         )
 
     def test_relative_increase_no_threshold_breached(
@@ -985,12 +996,14 @@ class TestTimeSeriesTrendsRelativeAlerts(APIBaseTest, ClickhouseDestroyTablesMix
                     [
                         "The insight value (signed_up - Chrome) for previous week (2.0) increased more than upper threshold (1.0)"
                     ],
+                    idempotency_key=ANY,
                 ),
                 call(
                     ANY,
                     [
                         "The insight value (signed_up - Chrome) for previous week (200.00%) increased more than upper threshold (20.00%)"
                     ],
+                    idempotency_key=ANY,
                 ),
             ]
         )
@@ -1111,12 +1124,14 @@ class TestTimeSeriesTrendsRelativeAlerts(APIBaseTest, ClickhouseDestroyTablesMix
                     [
                         "The insight value (signed_up - Firefox) for previous week (0.0) increased less than lower threshold (1.0)"
                     ],
+                    idempotency_key=ANY,
                 ),
                 call(
                     ANY,
                     [
                         "The insight value (signed_up - Firefox) for previous week (0.00%) increased less than lower threshold (20.00%)"
                     ],
+                    idempotency_key=ANY,
                 ),
             ]
         )
@@ -1237,12 +1252,14 @@ class TestTimeSeriesTrendsRelativeAlerts(APIBaseTest, ClickhouseDestroyTablesMix
                     [
                         "The insight value (signed_up - Chrome) for previous week (-2.0) decreased less than lower threshold (1.0)"
                     ],
+                    idempotency_key=ANY,
                 ),
                 call(
                     ANY,
                     [
                         "The insight value (signed_up - Chrome) for previous week (-200.00%) decreased less than lower threshold (20.00%)"
                     ],
+                    idempotency_key=ANY,
                 ),
             ]
         )
@@ -1364,12 +1381,14 @@ class TestTimeSeriesTrendsRelativeAlerts(APIBaseTest, ClickhouseDestroyTablesMix
                     [
                         "The insight value (signed_up - Chrome) for previous week (2.0) decreased more than upper threshold (1.0)"
                     ],
+                    idempotency_key=ANY,
                 ),
                 call(
                     ANY,
                     [
                         "The insight value (signed_up - Chrome) for previous week (66.67%) decreased more than upper threshold (20.00%)"
                     ],
+                    idempotency_key=ANY,
                 ),
             ]
         )
@@ -1667,7 +1686,9 @@ class TestTimeSeriesTrendsRelativeAlerts(APIBaseTest, ClickhouseDestroyTablesMix
         assert alert_check.error is None
 
         mock_send_breaches.assert_called_once_with(
-            ANY, ["The insight value (signed_up) for current week (2) increased more than upper threshold (1.0)"]
+            ANY,
+            ["The insight value (signed_up) for current week (2) increased more than upper threshold (1.0)"],
+            idempotency_key=ANY,
         )
 
         check_alert(percentage_alert["id"])
@@ -1689,6 +1710,7 @@ class TestTimeSeriesTrendsRelativeAlerts(APIBaseTest, ClickhouseDestroyTablesMix
         mock_send_breaches.assert_called_with(
             ANY,
             ["The insight value (signed_up) for current week (200.00%) increased more than upper threshold (20.00%)"],
+            idempotency_key=ANY,
         )
 
     def test_current_interval_relative_increase_does_not_fallback_to_previous_interval(
@@ -1867,7 +1889,9 @@ class TestTimeSeriesTrendsRelativeAlerts(APIBaseTest, ClickhouseDestroyTablesMix
         # should be 'previous' week as we haven't breached for current week
         # so logic fallback to previous week
         mock_send_breaches.assert_called_once_with(
-            ANY, ["The insight value (signed_up) for previous week (2) increased more than upper threshold (1.0)"]
+            ANY,
+            ["The insight value (signed_up) for previous week (2) increased more than upper threshold (1.0)"],
+            idempotency_key=ANY,
         )
 
         check_alert(percentage_alert["id"])
@@ -1889,6 +1913,7 @@ class TestTimeSeriesTrendsRelativeAlerts(APIBaseTest, ClickhouseDestroyTablesMix
         mock_send_breaches.assert_called_with(
             ANY,
             ["The insight value (signed_up) for previous week (inf%) increased more than upper threshold (20.00%)"],
+            idempotency_key=ANY,
         )
 
     def test_relative_decrease_when_previous_value_is_0(
@@ -1973,6 +1998,7 @@ class TestTimeSeriesTrendsRelativeAlerts(APIBaseTest, ClickhouseDestroyTablesMix
         mock_send_breaches.assert_called_with(
             ANY,
             ["The insight value (signed_up) for previous week (inf%) decreased more than upper threshold (20.00%)"],
+            idempotency_key=ANY,
         )
 
     @patch("posthog.tasks.alerts.trends.calculate_for_query_based_insight", wraps=calculate_for_query_based_insight)

--- a/posthog/tasks/alerts/test/test_trends_relative_alerts.py
+++ b/posthog/tasks/alerts/test/test_trends_relative_alerts.py
@@ -36,8 +36,8 @@ FROZEN_TIME = dateutil.parser.parse("2024-06-04T08:55:00.000Z")
 
 
 @freeze_time(FROZEN_TIME)
-@patch("posthog.tasks.alerts.checks.send_notifications_for_errors")
-@patch("posthog.tasks.alerts.checks.send_notifications_for_breaches")
+@patch("posthog.tasks.alerts.utils.send_notifications_for_errors")
+@patch("posthog.tasks.alerts.utils.send_notifications_for_breaches")
 class TestTimeSeriesTrendsRelativeAlerts(APIBaseTest, ClickhouseDestroyTablesMixin):
     def setUp(self) -> None:
         super().setUp()

--- a/posthog/tasks/alerts/test/test_trends_relative_alerts.py
+++ b/posthog/tasks/alerts/test/test_trends_relative_alerts.py
@@ -37,7 +37,7 @@ FROZEN_TIME = dateutil.parser.parse("2024-06-04T08:55:00.000Z")
 
 @freeze_time(FROZEN_TIME)
 @patch("posthog.tasks.alerts.utils.send_notifications_for_errors")
-@patch("posthog.tasks.alerts.utils.send_notifications_for_breaches")
+@patch("posthog.tasks.alerts.utils.send_notifications_for_breaches", return_value=[])
 class TestTimeSeriesTrendsRelativeAlerts(APIBaseTest, ClickhouseDestroyTablesMixin):
     def setUp(self) -> None:
         super().setUp()

--- a/posthog/tasks/alerts/utils.py
+++ b/posthog/tasks/alerts/utils.py
@@ -278,11 +278,22 @@ def trigger_alert_hog_functions(alert: AlertConfiguration, properties: dict) -> 
         )
 
 
-def send_notifications_for_breaches(alert: AlertConfiguration, breaches: list[str]) -> None:
+def send_notifications_for_breaches(
+    alert: AlertConfiguration, breaches: list[str], idempotency_key: str | None = None
+) -> list[str]:
+    """Send firing-alert emails. Returns the list of recipients the send targeted.
+
+    A stable idempotency_key (typically alert_check.id) lets MessagingRecord enforce
+    per-recipient at-most-once delivery on retries. Without one, each call gets a
+    timestamp-based key, disabling retry dedup.
+    """
     email_targets = alert.get_subscribed_users_emails()
     if email_targets:
         subject = f"PostHog alert {alert.name} is firing"
-        campaign_key = f"alert-firing-notification-{alert.id}-{timezone.now().timestamp()}"
+        if idempotency_key is not None:
+            campaign_key = f"alert-firing-notification-{idempotency_key}"
+        else:
+            campaign_key = f"alert-firing-notification-{alert.id}-{timezone.now().timestamp()}"
         insight_url = f"/project/{alert.team.pk}/insights/{alert.insight.short_id}"
         alert_url = f"{insight_url}?alert_id={alert.id}"
         message = EmailMessage(
@@ -305,6 +316,8 @@ def send_notifications_for_breaches(alert: AlertConfiguration, breaches: list[st
         message.send()
 
     trigger_alert_hog_functions(alert=alert, properties={"breaches": ", ".join(breaches)})
+
+    return email_targets
 
 
 def send_notifications_for_errors(alert: AlertConfiguration, error: dict) -> None:
@@ -334,13 +347,65 @@ def send_notifications_for_errors(alert: AlertConfiguration, error: dict) -> Non
     # message.send()
 
 
-def disable_invalid_alert(alert: AlertConfiguration, reason: str) -> None:
-    """Disable an alert whose config failed validation and persist an errored AlertCheck.
+def dispatch_alert_notification(
+    alert: AlertConfiguration,
+    alert_check: AlertCheck,
+    breaches: list[str] | None,
+) -> list[str] | None:
+    """Route an AlertCheck to the correct notification sender.
 
-    Relocated here from posthog/tasks/alerts/checks.py so it can be shared
-    between the legacy Celery code path (during cutover) and the new
-    prepare_alert_activity in posthog/temporal/alerts/activities.py.
+    Returns the list of recipients the delivery targeted, or None if nothing was sent
+    (NOT_FIRING, or ERRORED with a non-dict error payload). Callers pass the returned
+    list to record_alert_delivery so the `targets_notified` sentinel reflects reality
+    — never claiming delivery for a state that didn't actually send.
+
+    Raises:
+        ValueError: state is FIRING but breaches is None/empty.
+        AssertionError: unknown state — surfaces a missing AlertState branch loudly.
     """
+    match alert_check.state:
+        case AlertState.NOT_FIRING:
+            logger.info("Check state is NOT_FIRING, nothing to send", alert_id=alert.id)
+            return None
+        case AlertState.ERRORED:
+            if not isinstance(alert_check.error, dict):
+                logger.warning(
+                    "ERRORED alert_check has non-dict error payload; skipping notification",
+                    alert_id=alert.id,
+                    alert_check_id=alert_check.id,
+                )
+                return None
+            logger.info("Sending alert error notifications", alert_id=alert.id, error=alert_check.error)
+            send_notifications_for_errors(alert, alert_check.error)
+            return alert.get_subscribed_users_emails()
+        case AlertState.FIRING:
+            if not breaches:
+                raise ValueError(
+                    f"dispatch_alert_notification: FIRING alert_check {alert_check.id} has no breaches — "
+                    "caller must pass the breaches list from AlertEvaluationResult"
+                )
+            logger.info("Sending alert firing notifications", alert_id=alert.id)
+            return send_notifications_for_breaches(alert, breaches, idempotency_key=str(alert_check.id))
+        case _:
+            raise AssertionError(f"dispatch_alert_notification: unhandled alert state: {alert_check.state}")
+
+
+def record_alert_delivery(alert: AlertConfiguration, alert_check: AlertCheck, targets: list[str]) -> None:
+    """Persist the side-effects of a successful notification delivery.
+
+    - alert_check.targets_notified: populated set = delivery happened (idempotency sentinel
+      for Temporal notify retries).
+    - alert.last_notified_at: used by monitoring / throttling.
+
+    Caller must wrap in transaction.atomic() if atomic semantics are required.
+    """
+    alert_check.targets_notified = {"users": targets}
+    alert_check.save(update_fields=["targets_notified"])
+    alert.last_notified_at = datetime.now(UTC)
+    alert.save(update_fields=["last_notified_at"])
+
+
+def disable_invalid_alert(alert: AlertConfiguration, reason: str) -> None:
     logger.warning("check_alert.auto_disabling", alert_id=alert.id, reason=reason)
     AlertConfiguration.objects.filter(pk=alert.pk).update(
         enabled=False,

--- a/posthog/tasks/alerts/utils.py
+++ b/posthog/tasks/alerts/utils.py
@@ -278,20 +278,14 @@ def trigger_alert_hog_functions(alert: AlertConfiguration, properties: dict) -> 
         )
 
 
-def send_notifications_for_breaches(
-    alert: AlertConfiguration, breaches: list[str], idempotency_key: str | None = None
-) -> list[str]:
+def send_notifications_for_breaches(alert: AlertConfiguration, breaches: list[str], idempotency_key: str) -> list[str]:
     """A stable idempotency_key (typically alert_check.id) lets MessagingRecord enforce
-    per-recipient at-most-once delivery on retries. Without one, each call gets a
-    timestamp-based key, disabling retry dedup.
+    per-recipient at-most-once delivery on retries.
     """
     email_targets = alert.get_subscribed_users_emails()
     if email_targets:
         subject = f"PostHog alert {alert.name} is firing"
-        if idempotency_key is not None:
-            campaign_key = f"alert-firing-notification-{idempotency_key}"
-        else:
-            campaign_key = f"alert-firing-notification-{alert.id}-{timezone.now().timestamp()}"
+        campaign_key = f"alert-firing-notification-{idempotency_key}"
         insight_url = f"/project/{alert.team.pk}/insights/{alert.insight.short_id}"
         alert_url = f"{insight_url}?alert_id={alert.id}"
         message = EmailMessage(

--- a/posthog/tasks/alerts/utils.py
+++ b/posthog/tasks/alerts/utils.py
@@ -320,31 +320,33 @@ def send_notifications_for_breaches(
     return email_targets
 
 
-def send_notifications_for_errors(alert: AlertConfiguration, error: dict) -> None:
+def send_notifications_for_errors(alert: AlertConfiguration, error: dict) -> list[str]:
     logger.info("Sending alert error notifications", alert_id=alert.id, error=error)
+    email_targets = alert.get_subscribed_users_emails()
 
     # TODO: uncomment this after checking errors sent
-    # subject = f"PostHog alert {alert.name} check failed to evaluate"
-    # campaign_key = f"alert-firing-notification-{alert.id}-{timezone.now().timestamp()}"
-    # insight_url = f"/project/{alert.team.pk}/insights/{alert.insight.short_id}"
-    # alert_url = f"{insight_url}?alert_id={alert.id}"
-    # message = EmailMessage(
-    #     campaign_key=campaign_key,
-    #     subject=subject,
-    #     template_name="alert_check_failed_to_evaluate",
-    #     template_context={
-    #         "alert_error": error,
-    #         "insight_url": insight_url,
-    #         "insight_name": alert.insight.name,
-    #         "alert_url": alert_url,
-    #         "alert_name": alert.name,
-    #     },
-    # )
-    # targets = alert.get_subscribed_users_emails()
-    # for target in targets:
-    #     message.add_recipient(email=target)
+    # if email_targets:
+    #     subject = f"PostHog alert {alert.name} check failed to evaluate"
+    #     campaign_key = f"alert-firing-notification-{alert.id}-{timezone.now().timestamp()}"
+    #     insight_url = f"/project/{alert.team.pk}/insights/{alert.insight.short_id}"
+    #     alert_url = f"{insight_url}?alert_id={alert.id}"
+    #     message = EmailMessage(
+    #         campaign_key=campaign_key,
+    #         subject=subject,
+    #         template_name="alert_check_failed_to_evaluate",
+    #         template_context={
+    #             "alert_error": error,
+    #             "insight_url": insight_url,
+    #             "insight_name": alert.insight.name,
+    #             "alert_url": alert_url,
+    #             "alert_name": alert.name,
+    #         },
+    #     )
+    #     for target in email_targets:
+    #         message.add_recipient(email=target)
+    #     message.send()
 
-    # message.send()
+    return email_targets
 
 
 def dispatch_alert_notification(
@@ -375,9 +377,7 @@ def dispatch_alert_notification(
                     alert_check_id=alert_check.id,
                 )
                 return None
-            logger.info("Sending alert error notifications", alert_id=alert.id, error=alert_check.error)
-            send_notifications_for_errors(alert, alert_check.error)
-            return alert.get_subscribed_users_emails()
+            return send_notifications_for_errors(alert, alert_check.error)
         case AlertState.FIRING:
             if not breaches:
                 raise ValueError(

--- a/posthog/tasks/alerts/utils.py
+++ b/posthog/tasks/alerts/utils.py
@@ -281,9 +281,7 @@ def trigger_alert_hog_functions(alert: AlertConfiguration, properties: dict) -> 
 def send_notifications_for_breaches(
     alert: AlertConfiguration, breaches: list[str], idempotency_key: str | None = None
 ) -> list[str]:
-    """Send firing-alert emails. Returns the list of recipients the send targeted.
-
-    A stable idempotency_key (typically alert_check.id) lets MessagingRecord enforce
+    """A stable idempotency_key (typically alert_check.id) lets MessagingRecord enforce
     per-recipient at-most-once delivery on retries. Without one, each call gets a
     timestamp-based key, disabling retry dedup.
     """

--- a/posthog/tasks/alerts/utils.py
+++ b/posthog/tasks/alerts/utils.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import UTC, datetime
 
 from django.utils import timezone
 
@@ -11,6 +11,7 @@ from posthog.schema import (
     AlertCalculationInterval,
     AlertCondition,
     AlertConditionType,
+    AlertState,
     ChartDisplayType,
     InsightThreshold,
     InsightThresholdType,
@@ -23,7 +24,7 @@ from posthog.cdp.internal_events import InternalEventEvent, produce_internal_eve
 from posthog.email import EmailMessage
 from posthog.exceptions_capture import capture_exception
 from posthog.models import AlertConfiguration
-from posthog.models.alert import derive_detector_event_fields
+from posthog.models.alert import AlertCheck, derive_detector_event_fields
 from posthog.tasks.alerts.schedule_restriction import snap_candidate_utc_to_schedule_restriction
 from posthog.utils import get_from_dict_or_attr
 
@@ -331,6 +332,34 @@ def send_notifications_for_errors(alert: AlertConfiguration, error: dict) -> Non
     #     message.add_recipient(email=target)
 
     # message.send()
+
+
+def disable_invalid_alert(alert: AlertConfiguration, reason: str) -> None:
+    """Disable an alert whose config failed validation and persist an errored AlertCheck.
+
+    Relocated here from posthog/tasks/alerts/checks.py so it can be shared
+    between the legacy Celery code path (during cutover) and the new
+    prepare_alert_activity in posthog/temporal/alerts/activities.py.
+    """
+    logger.warning("check_alert.auto_disabling", alert_id=alert.id, reason=reason)
+    AlertConfiguration.objects.filter(pk=alert.pk).update(
+        enabled=False,
+        state=AlertState.ERRORED,
+        last_checked_at=datetime.now(UTC),
+    )
+    alert.refresh_from_db()
+
+    targets_to_notify = alert.get_subscribed_users_emails()
+    AlertCheck.objects.create(
+        alert_configuration=alert,
+        calculated_value=None,
+        condition=alert.condition,
+        targets_notified={"users": targets_to_notify} if targets_to_notify else {},
+        state=AlertState.ERRORED,
+        error={"message": reason},
+    )
+    if targets_to_notify:
+        send_notifications_for_disabled(alert, reason, targets_to_notify)
 
 
 def send_notifications_for_disabled(alert: AlertConfiguration, reason: str, targets: list[str]) -> None:

--- a/posthog/temporal/alerts/activities.py
+++ b/posthog/temporal/alerts/activities.py
@@ -1,22 +1,42 @@
+import traceback
 from datetime import UTC, datetime
 
+from django.db import transaction
 from django.db.models import Case, F, IntegerField, Q, Value, When
 
 import structlog
 import temporalio.activity
 
-from posthog.schema import AlertCalculationInterval
+from posthog.schema import AlertCalculationInterval, AlertState
 
+from posthog.clickhouse.query_tagging import tag_queries
+from posthog.errors import CH_TRANSIENT_ERRORS
+from posthog.exceptions_capture import capture_exception
 from posthog.models import AlertConfiguration
+from posthog.models.alert import AlertCheck
+from posthog.schema_migrations.upgrade_manager import upgrade_query
 from posthog.sync import database_sync_to_async
+from posthog.tasks.alerts.checks import AlertCheckException, add_alert_check, check_alert_for_insight
+from posthog.tasks.alerts.schedule_restriction import is_utc_datetime_blocked, next_unblocked_utc
+from posthog.tasks.alerts.utils import (
+    disable_invalid_alert,
+    dispatch_alert_notification,
+    next_check_time,
+    record_alert_delivery,
+    skip_because_of_weekend,
+    validate_alert_config,
+)
 from posthog.temporal.alerts.types import (
     AlertInfo,
     EvaluateAlertActivityInputs,
     EvaluateAlertResult,
     NotifyAlertActivityInputs,
+    PrepareAction,
     PrepareAlertActivityInputs,
     PrepareAlertResult,
+    SkipReason,
 )
+from posthog.temporal.common.heartbeat import Heartbeater
 
 logger = structlog.get_logger(__name__)
 
@@ -58,140 +78,186 @@ async def retrieve_due_alerts() -> list[AlertInfo]:
             for a in alerts
         ]
 
-    return await get_alerts()
+    async with Heartbeater():
+        return await get_alerts()
 
 
-# ─── prepare_alert_activity ─────────────────────────────────────────
-# TODO(vasco): Port the early-return logic that used to live in check_alert()
-# in posthog/tasks/alerts/checks.py. The check_alert function is deleted in
-# the final cleanup PR of this stack — reference it via git history:
-#
-#   git show vdekrijger-alerts-temporal-pr1-scaffolding:posthog/tasks/alerts/checks.py
-#
-# Shape of the port:
-#
-#   1. Load AlertConfiguration by id with select_related (pre-cleanup checks.py:230-233)
-#      → if DoesNotExist: return PrepareAlertResult(action="skip", reason="not_found")
-#
-#   2. Check insight.deleted (checks.py:235-237)
-#      → return PrepareAlertResult(action="skip", reason="insight_deleted")
-#
-#   3. Check next_check_at race window (checks.py:241-247)
-#      → return PrepareAlertResult(action="skip", reason="not_due")
-#
-#      (No is_calculating check — the field is removed later in the stack and
-#      Temporal's deterministic workflow ID guarantee replaces the lock.)
-#
-#   4. Check skip_because_of_weekend + advance next_check_at (checks.py:256-265)
-#      → return PrepareAlertResult(action="skip", reason="weekend")
-#
-#   5. Check is_utc_datetime_blocked + advance next_check_at (checks.py:267-274)
-#      → return PrepareAlertResult(action="skip", reason="quiet_hours")
-#
-#   6. Check snoozed_until (checks.py:276-286)
-#      → return PrepareAlertResult(action="skip", reason="snoozed")
-#
-#   7. Validate config (checks.py:288-296). On ValueError:
-#      → call disable_invalid_alert from posthog.tasks.alerts.utils (imported
-#        inside the sync helper to satisfy the late-imports policy).
-#      → return PrepareAlertResult(action="auto_disable", reason=str(e))
-#
-#   8. If we got here: return PrepareAlertResult(action="evaluate")
-#
-# All DB work happens via sync_to_async like enumerate_due_alerts_activity.
 @temporalio.activity.defn
 async def prepare_alert(inputs: PrepareAlertActivityInputs) -> PrepareAlertResult:
     """Load the alert, validate its config, and decide whether to evaluate."""
-    raise NotImplementedError(
-        "Alert check logic is ported in follow-up PR: https://github.com/PostHog/posthog/pull/53835"
-    )
+
+    @database_sync_to_async(thread_sensitive=False)
+    def _prepare() -> PrepareAlertResult:
+        try:
+            alert = AlertConfiguration.objects.select_related("insight", "team", "threshold").get(
+                id=inputs.alert_id, enabled=True
+            )
+        except AlertConfiguration.DoesNotExist:
+            logger.warning("Alert not found or not enabled", alert_id=inputs.alert_id)
+            return PrepareAlertResult(action=PrepareAction.SKIP, reason=SkipReason.NOT_FOUND)
+
+        if alert.insight.deleted:
+            logger.info(
+                "Skipping alert for deleted insight",
+                alert_id=inputs.alert_id,
+                insight_id=alert.insight_id,
+            )
+            return PrepareAlertResult(action=PrepareAction.SKIP, reason=SkipReason.INSIGHT_DELETED)
+
+        now = datetime.now(UTC)
+
+        if alert.next_check_at and alert.next_check_at > now:
+            logger.info(
+                "Alert took too long to compute or was queued too long during which it already got "
+                "computed. So not attempting to compute it again until it's due next",
+                alert=alert,
+            )
+            return PrepareAlertResult(action=PrepareAction.SKIP, reason=SkipReason.NOT_DUE)
+
+        if skip_because_of_weekend(alert):
+            logger.info("Skipping alert check because weekend checking is disabled", alert=alert)
+            alert.next_check_at = next_check_time(alert)
+            alert.save(update_fields=["next_check_at"])
+            return PrepareAlertResult(action=PrepareAction.SKIP, reason=SkipReason.WEEKEND)
+
+        if is_utc_datetime_blocked(alert, now):
+            logger.info(
+                "Skipping alert check because of schedule restriction (quiet hours)",
+                alert_id=alert.id,
+            )
+            alert.next_check_at = next_unblocked_utc(alert, now)
+            alert.save(update_fields=["next_check_at"])
+            return PrepareAlertResult(action=PrepareAction.SKIP, reason=SkipReason.QUIET_HOURS)
+
+        if alert.snoozed_until:
+            if alert.snoozed_until > now:
+                logger.info("Alert has been snoozed so skipping checking it now", alert=alert)
+                return PrepareAlertResult(action=PrepareAction.SKIP, reason=SkipReason.SNOOZED)
+            # Snooze expired — persist clear so evaluate_alert reads the fresh state.
+            alert.snoozed_until = None
+            alert.state = AlertState.NOT_FIRING
+            alert.save(update_fields=["snoozed_until", "state"])
+
+        try:
+            insight = alert.insight
+            with upgrade_query(insight):
+                if insight.query is None:
+                    raise ValueError("Alert's insight has no valid query")
+                threshold_config = alert.threshold.configuration if alert.threshold else None
+                validate_alert_config(
+                    insight.query,
+                    alert.condition,
+                    alert.config,
+                    threshold_config,
+                    alert.calculation_interval,
+                )
+        except ValueError as e:
+            disable_invalid_alert(alert, str(e))
+            return PrepareAlertResult(action=PrepareAction.AUTO_DISABLE, reason=str(e))
+
+        return PrepareAlertResult(action=PrepareAction.EVALUATE)
+
+    async with Heartbeater():
+        return await _prepare()
 
 
-# ─── evaluate_alert_activity ────────────────────────────────────────
-# TODO(vasco): Port the alert evaluation logic from the deleted
-# check_alert_and_notify_atomically in pre-cleanup checks.py. Shape of the port:
-#
-#   1. Load AlertConfiguration by id (alert was already validated in prepare).
-#      No is_calculating lock needed — the field is removed later in the stack
-#      and Temporal's deterministic workflow ID guarantee replaces the lock.
-#
-#   2. CRITICAL — call tag_queries(alert_config_id=str(alert.id)) at the START
-#      of the activity body (pre-cleanup checks.py:341). This is what lets
-#      ClickHouse workload management classify alert queries differently from
-#      other queries on the cluster. The "drop per-team serialization, rely on
-#      CH workload management" design depends on this tag being present on
-#      every CH query the activity issues. Don't skip it.
-#
-#   3. Run check_alert_for_insight (still in checks.py) inside @transaction.atomic
-#      → returns AlertEvaluationResult with value, breaches, anomaly_scores, etc
-#      → on CH transient error: re-raise (Temporal retry policy handles it)
-#      → on permanent error: capture in `error` variable, continue
-#
-#   4. Run add_alert_check (still in checks.py) — but extract the notification
-#      decision into the result instead of inlining it. The current code sets
-#      notify=True inside add_alert_check; we want to RETURN that decision so
-#      the workflow can route to notify_alert_activity instead of doing it here.
-#      CRITICAL: create the AlertCheck row with `targets_notified={}` always —
-#      do NOT call alert.get_subscribed_users_emails() here. The notify activity
-#      sets targets_notified on success and uses an empty value as the
-#      idempotency sentinel. See the notify_alert_activity TODO below for the
-#      full contract change.
-#
-#   5. Return EvaluateAlertResult(alert_check_id=..., should_notify=..., new_state=...)
-#
-# The CH transient error retry from tenacity on the pre-cleanup check_alert is
-# REPLACED by the ALERT_EVALUATE_RETRY_POLICY on the activity — do not port the
-# @retry decorator.
-#
-# The CH query is synchronous Django ORM/HogQL work; dispatch it with
-# sync_to_async and wrap in the existing Heartbeater context manager from
-# posthog.temporal.common.heartbeat so Temporal can detect a stuck activity.
 @temporalio.activity.defn
 async def evaluate_alert(inputs: EvaluateAlertActivityInputs) -> EvaluateAlertResult:
     """Run the insight ClickHouse query, apply the state machine, persist an AlertCheck row."""
-    raise NotImplementedError(
-        "Alert check logic is ported in follow-up PR: https://github.com/PostHog/posthog/pull/53835"
-    )
+
+    @database_sync_to_async(thread_sensitive=False)
+    def _evaluate() -> EvaluateAlertResult:
+        # enabled=True guards against the race where the alert is disabled between
+        # prepare_alert and evaluate_alert (e.g. user disables via API mid-workflow).
+        alert = AlertConfiguration.objects.select_related("insight", "team", "threshold").get(
+            id=inputs.alert_id, enabled=True
+        )
+
+        # CH workload management keys off this tag to isolate alert queries from other tenants.
+        tag_queries(alert_config_id=str(alert.id))
+
+        value: float | None = None
+        breaches: list[str] | None = None
+        error: dict | None = None
+        alert_evaluation_result = None
+
+        try:
+            alert_evaluation_result = check_alert_for_insight(alert)
+            value = alert_evaluation_result.value
+            breaches = alert_evaluation_result.breaches
+        except CH_TRANSIENT_ERRORS:
+            raise
+        except Exception as err:
+            logger.exception(f"Alert id = {alert.id}, failed to evaluate", exc_info=err)
+            capture_exception(
+                AlertCheckException(err),
+                additional_properties={
+                    "alert_configuration_id": str(alert.id),
+                    "insight_id": alert.insight_id,
+                    "team_id": alert.team_id,
+                },
+            )
+            error = {"message": str(err), "traceback": traceback.format_exc()}
+
+        anomaly_scores = alert_evaluation_result.anomaly_scores if alert_evaluation_result else None
+        triggered_points = alert_evaluation_result.triggered_points if alert_evaluation_result else None
+        triggered_dates = alert_evaluation_result.triggered_dates if alert_evaluation_result else None
+        interval = alert_evaluation_result.interval if alert_evaluation_result else None
+        triggered_metadata = alert_evaluation_result.triggered_metadata if alert_evaluation_result else None
+
+        with transaction.atomic():
+            alert_check, notify = add_alert_check(
+                alert,
+                value,
+                breaches,
+                error,
+                anomaly_scores,
+                triggered_points,
+                triggered_dates,
+                interval,
+                triggered_metadata,
+            )
+
+        return EvaluateAlertResult(
+            alert_check_id=str(alert_check.id),
+            should_notify=notify,
+            new_state=AlertState(alert_check.state),
+            breaches=breaches,
+        )
+
+    async with Heartbeater():
+        return await _evaluate()
 
 
-# ─── notify_alert_activity ──────────────────────────────────────────
-# TODO(vasco): Port the notification dispatch from pre-cleanup
-# checks.py:383-405 (check_alert_and_notify_atomically's notification block).
-#
-# AlertCheck row commit semantics change — read before porting:
-#
-# Pre-migration, check_alert_and_notify_atomically was wrapped in
-# @transaction.atomic so the AlertCheck row creation and notification dispatch
-# shared a transaction. If notification raised, the transaction rolled back and
-# the AlertCheck row was never persisted. The contract was:
-#
-#   AlertCheck row exists in DB ⇒ evaluation completed AND
-#                                  (notification was unnecessary OR
-#                                   notification succeeded on this attempt)
-#
-# Under the split-activity design, evaluate_alert_activity commits the
-# AlertCheck row BEFORE notify_alert_activity runs. If notify fails and is
-# retried by Temporal, the row is visible the whole time with
-# `targets_notified={}`. The new contract is:
-#
-#   AlertCheck row exists in DB ⇒ evaluation completed
-#                                  (notification status is reflected in
-#                                   targets_notified populated/empty)
-#
-# Idempotency under retry:
-#   1. Load AlertCheck by id
-#   2. If alert_check.targets_notified is already populated AND non-empty:
-#        → return (already notified on a previous attempt)
-#   3. match alert_check.state (same as pre-cleanup checks.py:387-396):
-#        - NOT_FIRING: log and return
-#        - ERRORED:    send_notifications_for_errors
-#        - FIRING:     send_notifications_for_breaches
-#   4. On success: update alert_check.targets_notified =
-#        {"users": alert.get_subscribed_users_emails()} and save
-#   5. On failure: raise — Temporal retry policy handles backoff
+# Idempotency: empty targets_notified = not yet delivered; non-empty = already delivered.
+# Lets Temporal retry notify_alert safely.
 @temporalio.activity.defn
 async def notify_alert(inputs: NotifyAlertActivityInputs) -> None:
     """Send notifications for a previously evaluated alert check (idempotent)."""
-    raise NotImplementedError(
-        "Alert check logic is ported in follow-up PR: https://github.com/PostHog/posthog/pull/53835"
-    )
+
+    @database_sync_to_async(thread_sensitive=False)
+    def _notify() -> None:
+        alert_check = AlertCheck.objects.select_related("alert_configuration", "alert_configuration__team").get(
+            pk=inputs.alert_check_id
+        )
+
+        if alert_check.targets_notified:
+            logger.info(
+                "notify_alert: already notified, skipping",
+                alert_id=inputs.alert_id,
+                alert_check_id=alert_check.id,
+            )
+            return
+
+        alert = alert_check.alert_configuration
+
+        # Raises if FIRING with no breaches; caller (workflow) must pipe breaches from evaluate.
+        targets = dispatch_alert_notification(alert, alert_check, inputs.breaches)
+        if targets is None:
+            return
+
+        with transaction.atomic():
+            record_alert_delivery(alert, alert_check, targets)
+
+    async with Heartbeater():
+        await _notify()

--- a/posthog/temporal/alerts/activities.py
+++ b/posthog/temporal/alerts/activities.py
@@ -6,6 +6,7 @@ from django.db.models import Case, F, IntegerField, Q, Value, When
 
 import structlog
 import temporalio.activity
+from temporalio.exceptions import ApplicationError
 
 from posthog.schema import AlertCalculationInterval, AlertState
 
@@ -89,12 +90,14 @@ async def prepare_alert(inputs: PrepareAlertActivityInputs) -> PrepareAlertResul
     @database_sync_to_async(thread_sensitive=False)
     def _prepare() -> PrepareAlertResult:
         try:
-            alert = AlertConfiguration.objects.select_related("insight", "team", "threshold").get(
-                id=inputs.alert_id, enabled=True
-            )
+            alert = AlertConfiguration.objects.select_related("insight", "team", "threshold").get(id=inputs.alert_id)
         except AlertConfiguration.DoesNotExist:
-            logger.warning("Alert not found or not enabled", alert_id=inputs.alert_id)
+            logger.warning("Alert not found", alert_id=inputs.alert_id)
             return PrepareAlertResult(action=PrepareAction.SKIP, reason=SkipReason.NOT_FOUND)
+
+        if not alert.enabled:
+            logger.info("Skipping disabled alert", alert_id=inputs.alert_id)
+            return PrepareAlertResult(action=PrepareAction.SKIP, reason=SkipReason.DISABLED)
 
         if alert.insight.deleted:
             logger.info(
@@ -167,11 +170,22 @@ async def evaluate_alert(inputs: EvaluateAlertActivityInputs) -> EvaluateAlertRe
 
     @database_sync_to_async(thread_sensitive=False)
     def _evaluate() -> EvaluateAlertResult:
-        # enabled=True guards against the race where the alert is disabled between
-        # prepare_alert and evaluate_alert (e.g. user disables via API mid-workflow).
-        alert = AlertConfiguration.objects.select_related("insight", "team", "threshold").get(
-            id=inputs.alert_id, enabled=True
-        )
+        # Guard against the race where the alert is disabled/deleted between prepare_alert and
+        # evaluate_alert (e.g. user disables via API mid-workflow). Retries can't recover from
+        # either case, so surface as non-retryable to avoid a retry storm.
+        try:
+            alert = AlertConfiguration.objects.select_related("insight", "team", "threshold").get(id=inputs.alert_id)
+        except AlertConfiguration.DoesNotExist:
+            raise ApplicationError(
+                f"Alert {inputs.alert_id} not found between prepare and evaluate",
+                non_retryable=True,
+            )
+
+        if not alert.enabled:
+            raise ApplicationError(
+                f"Alert {inputs.alert_id} disabled between prepare and evaluate",
+                non_retryable=True,
+            )
 
         # CH workload management keys off this tag to isolate alert queries from other tenants.
         tag_queries(alert_config_id=str(alert.id))

--- a/posthog/temporal/alerts/activities.py
+++ b/posthog/temporal/alerts/activities.py
@@ -206,7 +206,7 @@ async def evaluate_alert(inputs: EvaluateAlertActivityInputs) -> EvaluateAlertRe
         triggered_metadata = alert_evaluation_result.triggered_metadata if alert_evaluation_result else None
 
         with transaction.atomic():
-            alert_check, notify = add_alert_check(
+            alert_check, should_notify = add_alert_check(
                 alert,
                 value,
                 breaches,
@@ -220,7 +220,7 @@ async def evaluate_alert(inputs: EvaluateAlertActivityInputs) -> EvaluateAlertRe
 
         return EvaluateAlertResult(
             alert_check_id=str(alert_check.id),
-            should_notify=notify,
+            should_notify=should_notify,
             new_state=AlertState(alert_check.state),
             breaches=breaches,
         )

--- a/posthog/temporal/alerts/activities.py
+++ b/posthog/temporal/alerts/activities.py
@@ -230,15 +230,17 @@ async def evaluate_alert(inputs: EvaluateAlertActivityInputs) -> EvaluateAlertRe
 
 
 # Idempotency: empty targets_notified = not yet delivered; non-empty = already delivered.
-# Lets Temporal retry notify_alert safely.
+# Lets Temporal retry notify_alert safely after a transient failure past the send.
 @temporalio.activity.defn
 async def notify_alert(inputs: NotifyAlertActivityInputs) -> None:
     """Send notifications for a previously evaluated alert check (idempotent)."""
 
     @database_sync_to_async(thread_sensitive=False)
     def _notify() -> None:
+        # Mismatched pair surfaces as DoesNotExist instead of notifying the wrong alert.
         alert_check = AlertCheck.objects.select_related("alert_configuration", "alert_configuration__team").get(
-            pk=inputs.alert_check_id
+            pk=inputs.alert_check_id,
+            alert_configuration_id=inputs.alert_id,
         )
 
         if alert_check.targets_notified:

--- a/posthog/temporal/alerts/activities.py
+++ b/posthog/temporal/alerts/activities.py
@@ -61,6 +61,44 @@ async def retrieve_due_alerts() -> list[AlertInfo]:
     return await get_alerts()
 
 
+# ─── prepare_alert_activity ─────────────────────────────────────────
+# TODO(vasco): Port the early-return logic that used to live in check_alert()
+# in posthog/tasks/alerts/checks.py. The check_alert function is deleted in
+# the final cleanup PR of this stack — reference it via git history:
+#
+#   git show vdekrijger-alerts-temporal-pr1-scaffolding:posthog/tasks/alerts/checks.py
+#
+# Shape of the port:
+#
+#   1. Load AlertConfiguration by id with select_related (pre-cleanup checks.py:230-233)
+#      → if DoesNotExist: return PrepareAlertResult(action="skip", reason="not_found")
+#
+#   2. Check insight.deleted (checks.py:235-237)
+#      → return PrepareAlertResult(action="skip", reason="insight_deleted")
+#
+#   3. Check next_check_at race window (checks.py:241-247)
+#      → return PrepareAlertResult(action="skip", reason="not_due")
+#
+#      (No is_calculating check — the field is removed later in the stack and
+#      Temporal's deterministic workflow ID guarantee replaces the lock.)
+#
+#   4. Check skip_because_of_weekend + advance next_check_at (checks.py:256-265)
+#      → return PrepareAlertResult(action="skip", reason="weekend")
+#
+#   5. Check is_utc_datetime_blocked + advance next_check_at (checks.py:267-274)
+#      → return PrepareAlertResult(action="skip", reason="quiet_hours")
+#
+#   6. Check snoozed_until (checks.py:276-286)
+#      → return PrepareAlertResult(action="skip", reason="snoozed")
+#
+#   7. Validate config (checks.py:288-296). On ValueError:
+#      → call disable_invalid_alert from posthog.tasks.alerts.utils (imported
+#        inside the sync helper to satisfy the late-imports policy).
+#      → return PrepareAlertResult(action="auto_disable", reason=str(e))
+#
+#   8. If we got here: return PrepareAlertResult(action="evaluate")
+#
+# All DB work happens via sync_to_async like enumerate_due_alerts_activity.
 @temporalio.activity.defn
 async def prepare_alert(inputs: PrepareAlertActivityInputs) -> PrepareAlertResult:
     """Load the alert, validate its config, and decide whether to evaluate."""
@@ -69,6 +107,45 @@ async def prepare_alert(inputs: PrepareAlertActivityInputs) -> PrepareAlertResul
     )
 
 
+# ─── evaluate_alert_activity ────────────────────────────────────────
+# TODO(vasco): Port the alert evaluation logic from the deleted
+# check_alert_and_notify_atomically in pre-cleanup checks.py. Shape of the port:
+#
+#   1. Load AlertConfiguration by id (alert was already validated in prepare).
+#      No is_calculating lock needed — the field is removed later in the stack
+#      and Temporal's deterministic workflow ID guarantee replaces the lock.
+#
+#   2. CRITICAL — call tag_queries(alert_config_id=str(alert.id)) at the START
+#      of the activity body (pre-cleanup checks.py:341). This is what lets
+#      ClickHouse workload management classify alert queries differently from
+#      other queries on the cluster. The "drop per-team serialization, rely on
+#      CH workload management" design depends on this tag being present on
+#      every CH query the activity issues. Don't skip it.
+#
+#   3. Run check_alert_for_insight (still in checks.py) inside @transaction.atomic
+#      → returns AlertEvaluationResult with value, breaches, anomaly_scores, etc
+#      → on CH transient error: re-raise (Temporal retry policy handles it)
+#      → on permanent error: capture in `error` variable, continue
+#
+#   4. Run add_alert_check (still in checks.py) — but extract the notification
+#      decision into the result instead of inlining it. The current code sets
+#      notify=True inside add_alert_check; we want to RETURN that decision so
+#      the workflow can route to notify_alert_activity instead of doing it here.
+#      CRITICAL: create the AlertCheck row with `targets_notified={}` always —
+#      do NOT call alert.get_subscribed_users_emails() here. The notify activity
+#      sets targets_notified on success and uses an empty value as the
+#      idempotency sentinel. See the notify_alert_activity TODO below for the
+#      full contract change.
+#
+#   5. Return EvaluateAlertResult(alert_check_id=..., should_notify=..., new_state=...)
+#
+# The CH transient error retry from tenacity on the pre-cleanup check_alert is
+# REPLACED by the ALERT_EVALUATE_RETRY_POLICY on the activity — do not port the
+# @retry decorator.
+#
+# The CH query is synchronous Django ORM/HogQL work; dispatch it with
+# sync_to_async and wrap in the existing Heartbeater context manager from
+# posthog.temporal.common.heartbeat so Temporal can detect a stuck activity.
 @temporalio.activity.defn
 async def evaluate_alert(inputs: EvaluateAlertActivityInputs) -> EvaluateAlertResult:
     """Run the insight ClickHouse query, apply the state machine, persist an AlertCheck row."""
@@ -77,6 +154,41 @@ async def evaluate_alert(inputs: EvaluateAlertActivityInputs) -> EvaluateAlertRe
     )
 
 
+# ─── notify_alert_activity ──────────────────────────────────────────
+# TODO(vasco): Port the notification dispatch from pre-cleanup
+# checks.py:383-405 (check_alert_and_notify_atomically's notification block).
+#
+# AlertCheck row commit semantics change — read before porting:
+#
+# Pre-migration, check_alert_and_notify_atomically was wrapped in
+# @transaction.atomic so the AlertCheck row creation and notification dispatch
+# shared a transaction. If notification raised, the transaction rolled back and
+# the AlertCheck row was never persisted. The contract was:
+#
+#   AlertCheck row exists in DB ⇒ evaluation completed AND
+#                                  (notification was unnecessary OR
+#                                   notification succeeded on this attempt)
+#
+# Under the split-activity design, evaluate_alert_activity commits the
+# AlertCheck row BEFORE notify_alert_activity runs. If notify fails and is
+# retried by Temporal, the row is visible the whole time with
+# `targets_notified={}`. The new contract is:
+#
+#   AlertCheck row exists in DB ⇒ evaluation completed
+#                                  (notification status is reflected in
+#                                   targets_notified populated/empty)
+#
+# Idempotency under retry:
+#   1. Load AlertCheck by id
+#   2. If alert_check.targets_notified is already populated AND non-empty:
+#        → return (already notified on a previous attempt)
+#   3. match alert_check.state (same as pre-cleanup checks.py:387-396):
+#        - NOT_FIRING: log and return
+#        - ERRORED:    send_notifications_for_errors
+#        - FIRING:     send_notifications_for_breaches
+#   4. On success: update alert_check.targets_notified =
+#        {"users": alert.get_subscribed_users_emails()} and save
+#   5. On failure: raise — Temporal retry policy handles backoff
 @temporalio.activity.defn
 async def notify_alert(inputs: NotifyAlertActivityInputs) -> None:
     """Send notifications for a previously evaluated alert check (idempotent)."""

--- a/posthog/temporal/alerts/types.py
+++ b/posthog/temporal/alerts/types.py
@@ -12,6 +12,17 @@ class PrepareAction(StrEnum):
     AUTO_DISABLE = "auto_disable"
 
 
+class SkipReason(StrEnum):
+    """Reason for PrepareAction.SKIP. Workflows / metrics key off these values."""
+
+    NOT_FOUND = "not_found"
+    INSIGHT_DELETED = "insight_deleted"
+    NOT_DUE = "not_due"
+    WEEKEND = "weekend"
+    QUIET_HOURS = "quiet_hours"
+    SNOOZED = "snoozed"
+
+
 @dataclasses.dataclass(frozen=True)
 class AlertInfo:
     alert_id: str
@@ -49,12 +60,17 @@ class EvaluateAlertActivityInputs:
 
 @dataclasses.dataclass(frozen=True)
 class EvaluateAlertResult:
-    alert_check_id: int
+    # AlertCheck PK is a UUIDT; stringified here so Temporal's JSON codec can pass it through.
+    alert_check_id: str
     should_notify: bool
     new_state: AlertState
+    # Human-readable breach descriptions the FIRING email uses as match_descriptions.
+    # Not persisted on AlertCheck, so the workflow must pipe them from evaluate to notify.
+    breaches: list[str] | None = None
 
 
 @dataclasses.dataclass(frozen=True)
 class NotifyAlertActivityInputs:
     alert_id: str
-    alert_check_id: int
+    alert_check_id: str
+    breaches: list[str] | None = None

--- a/posthog/temporal/alerts/types.py
+++ b/posthog/temporal/alerts/types.py
@@ -13,8 +13,6 @@ class PrepareAction(StrEnum):
 
 
 class SkipReason(StrEnum):
-    """Reason for PrepareAction.SKIP. Workflows / metrics key off these values."""
-
     NOT_FOUND = "not_found"
     INSIGHT_DELETED = "insight_deleted"
     NOT_DUE = "not_due"

--- a/posthog/temporal/alerts/types.py
+++ b/posthog/temporal/alerts/types.py
@@ -14,6 +14,7 @@ class PrepareAction(StrEnum):
 
 class SkipReason(StrEnum):
     NOT_FOUND = "not_found"
+    DISABLED = "disabled"
     INSIGHT_DELETED = "insight_deleted"
     NOT_DUE = "not_due"
     WEEKEND = "weekend"

--- a/posthog/temporal/alerts/workflows.py
+++ b/posthog/temporal/alerts/workflows.py
@@ -148,6 +148,7 @@ class CheckAlertWorkflow(PostHogWorkflow):
                     NotifyAlertActivityInputs(
                         alert_id=inputs.alert_id,
                         alert_check_id=evaluation.alert_check_id,
+                        breaches=evaluation.breaches,
                     ),
                     start_to_close_timeout=dt.timedelta(minutes=5),
                     retry_policy=ALERT_NOTIFY_RETRY_POLICY,

--- a/posthog/temporal/tests/test_alerts_activities.py
+++ b/posthog/temporal/tests/test_alerts_activities.py
@@ -21,7 +21,7 @@ from posthog.schema import (
 )
 
 from posthog.errors import CHQueryErrorTooManySimultaneousQueries
-from posthog.models import AlertConfiguration, Insight
+from posthog.models import AlertConfiguration, Insight, User
 from posthog.models.alert import AlertCheck
 from posthog.tasks.alerts.utils import AlertEvaluationResult
 from posthog.temporal.alerts.activities import evaluate_alert, notify_alert, prepare_alert
@@ -30,6 +30,7 @@ from posthog.temporal.alerts.types import (
     NotifyAlertActivityInputs,
     PrepareAction,
     PrepareAlertActivityInputs,
+    SkipReason,
 )
 
 
@@ -88,6 +89,50 @@ async def alert(ateam):
     return await _create_alert(ateam)
 
 
+@pytest_asyncio.fixture
+async def alert_with_user(ateam, aorganization):
+    @sync_to_async
+    def _create() -> AlertConfiguration:
+        user = User.objects.create_and_join(
+            organization=aorganization, email=f"alerts-{uuid.uuid4().hex[:6]}@posthog.com", password=None
+        )
+        insight = Insight.objects.create(team=ateam, name="insight", query=_valid_trends_query())
+        a = AlertConfiguration.objects.create(
+            team=ateam,
+            insight=insight,
+            name="alert",
+            enabled=True,
+            calculation_interval=AlertCalculationInterval.DAILY.value,
+            config={"type": "TrendsAlertConfig", "series_index": 0},
+            condition={"type": "absolute_value"},
+        )
+        a.subscribed_users.add(user)
+        return a
+
+    return await _create()
+
+
+async def _create_alert_check(
+    alert: AlertConfiguration,
+    *,
+    state: str,
+    targets_notified: dict | None = None,
+    error: dict | None = None,
+) -> AlertCheck:
+    @sync_to_async
+    def _create() -> AlertCheck:
+        return AlertCheck.objects.create(
+            alert_configuration=alert,
+            calculated_value=1.0,
+            condition=alert.condition,
+            state=state,
+            error=error,
+            targets_notified=targets_notified if targets_notified is not None else {},
+        )
+
+    return await _create()
+
+
 @pytest.mark.asyncio
 @pytest.mark.django_db(transaction=True)
 class TestPrepareAlert:
@@ -98,31 +143,31 @@ class TestPrepareAlert:
             PrepareAlertActivityInputs(alert_id=str(uuid.uuid4())),
         )
         assert result.action == PrepareAction.SKIP
-        assert result.reason == "not_found"
+        assert result.reason == SkipReason.NOT_FOUND
 
     @pytest.mark.parametrize(
         "frozen_time,setup_kwargs,expected_reason,advances_next_check_at",
         [
-            pytest.param(None, {"enabled": False}, "not_found", False, id="disabled"),
-            pytest.param(None, {"insight_deleted": True}, "insight_deleted", False, id="insight_deleted"),
+            pytest.param(None, {"enabled": False}, SkipReason.NOT_FOUND, False, id="disabled"),
+            pytest.param(None, {"insight_deleted": True}, SkipReason.INSIGHT_DELETED, False, id="insight_deleted"),
             pytest.param(
                 "2024-06-03T10:00:00Z",
                 {"next_check_at": datetime(2024, 6, 3, 11, 0, tzinfo=UTC)},
-                "not_due",
+                SkipReason.NOT_DUE,
                 False,
                 id="not_due",
             ),
             pytest.param(
                 "2024-12-21T08:00:00Z",  # Saturday
                 {"skip_weekend": True},
-                "weekend",
+                SkipReason.WEEKEND,
                 True,
                 id="weekend",
             ),
             pytest.param(
                 "2024-06-03T22:30:00Z",  # inside 22:00-07:00 quiet window
                 {"schedule_restriction": {"blocked_windows": [{"start": "22:00", "end": "07:00"}]}},
-                "quiet_hours",
+                SkipReason.QUIET_HOURS,
                 True,
                 id="quiet_hours",
             ),
@@ -132,7 +177,7 @@ class TestPrepareAlert:
                     "snoozed_until": datetime(2024, 6, 3, 12, 0, tzinfo=UTC),
                     "state": AlertState.SNOOZED,
                 },
-                "snoozed",
+                SkipReason.SNOOZED,
                 False,
                 id="snoozed_future",
             ),
@@ -143,7 +188,7 @@ class TestPrepareAlert:
         ateam,
         frozen_time: str | None,
         setup_kwargs: dict,
-        expected_reason: str,
+        expected_reason: SkipReason,
         advances_next_check_at: bool,
     ) -> None:
         ctx = freeze_time(frozen_time) if frozen_time else contextlib.nullcontext()
@@ -202,9 +247,12 @@ class TestPrepareAlert:
         assert refreshed.enabled is False
         assert refreshed.state == AlertState.ERRORED
 
-        # disable_invalid_alert creates an AlertCheck row recording the disabling
-        check_exists = await sync_to_async(lambda: AlertCheck.objects.filter(alert_configuration=refreshed).exists())()
-        assert check_exists
+        # disable_invalid_alert creates an AlertCheck row recording the disabling.
+        check = await sync_to_async(AlertCheck.objects.get)(alert_configuration=refreshed)
+        assert check.state == AlertState.ERRORED
+        assert check.calculated_value is None
+        assert check.error is not None
+        assert result.reason in check.error["message"]
 
     async def test_evaluate_for_valid_alert(self, alert) -> None:
         env = ActivityEnvironment()
@@ -265,6 +313,11 @@ class TestEvaluateAlert:
         assert check.error is not None
         assert "misconfigured" in check.error["message"]
 
+        # Evaluate-time errors are transient — alert stays enabled so next run retries.
+        # Only prepare-time validate_alert_config failures call disable_invalid_alert.
+        refreshed = await sync_to_async(AlertConfiguration.objects.get)(pk=alert.pk)
+        assert refreshed.enabled is True
+
     async def test_evaluate_reraises_ch_transient_error(self, alert) -> None:
         # Transient CH errors bubble up so Temporal's retry policy handles them.
         with patch(
@@ -278,52 +331,6 @@ class TestEvaluateAlert:
         # No AlertCheck should have been written
         count = await sync_to_async(AlertCheck.objects.filter(alert_configuration=alert).count)()
         assert count == 0
-
-
-@pytest_asyncio.fixture
-async def alert_with_user(ateam, aorganization):
-    from posthog.models import User
-
-    @sync_to_async
-    def _create() -> AlertConfiguration:
-        user = User.objects.create_and_join(
-            organization=aorganization, email=f"alerts-{uuid.uuid4().hex[:6]}@posthog.com", password=None
-        )
-        insight = Insight.objects.create(team=ateam, name="insight", query=_valid_trends_query())
-        a = AlertConfiguration.objects.create(
-            team=ateam,
-            insight=insight,
-            name="alert",
-            enabled=True,
-            calculation_interval=AlertCalculationInterval.DAILY.value,
-            config={"type": "TrendsAlertConfig", "series_index": 0},
-            condition={"type": "absolute_value"},
-        )
-        a.subscribed_users.add(user)
-        return a
-
-    return await _create()
-
-
-async def _create_alert_check(
-    alert: AlertConfiguration,
-    *,
-    state: str,
-    targets_notified: dict | None = None,
-    error: dict | None = None,
-) -> AlertCheck:
-    @sync_to_async
-    def _create() -> AlertCheck:
-        return AlertCheck.objects.create(
-            alert_configuration=alert,
-            calculated_value=1.0,
-            condition=alert.condition,
-            state=state,
-            error=error,
-            targets_notified=targets_notified if targets_notified is not None else {},
-        )
-
-    return await _create()
 
 
 @pytest.mark.asyncio

--- a/posthog/temporal/tests/test_alerts_activities.py
+++ b/posthog/temporal/tests/test_alerts_activities.py
@@ -369,7 +369,6 @@ class TestNotifyAlert:
         mock_errors.assert_not_called()
 
         refreshed = await sync_to_async(AlertCheck.objects.get)(pk=check.id)
-        # targets_notified carries exactly the list the send returned — no duplicate query.
         assert refreshed.targets_notified == {"users": ["alice@posthog.com"]}
 
         refreshed_alert = await sync_to_async(AlertConfiguration.objects.get)(pk=alert_with_user.pk)
@@ -408,7 +407,10 @@ class TestNotifyAlert:
 
         with (
             patch("posthog.tasks.alerts.utils.send_notifications_for_breaches") as mock_breaches,
-            patch("posthog.tasks.alerts.utils.send_notifications_for_errors") as mock_errors,
+            patch(
+                "posthog.tasks.alerts.utils.send_notifications_for_errors",
+                return_value=["alice@posthog.com"],
+            ) as mock_errors,
         ):
             env = ActivityEnvironment()
             await env.run(
@@ -420,7 +422,7 @@ class TestNotifyAlert:
         mock_breaches.assert_not_called()
 
         refreshed = await sync_to_async(AlertCheck.objects.get)(pk=check.id)
-        assert refreshed.targets_notified != {}
+        assert refreshed.targets_notified == {"users": ["alice@posthog.com"]}
 
     async def test_idempotent_when_already_notified(self, alert_with_user) -> None:
         # Simulate a previous successful notification by setting targets_notified.

--- a/posthog/temporal/tests/test_alerts_activities.py
+++ b/posthog/temporal/tests/test_alerts_activities.py
@@ -8,6 +8,7 @@ from unittest.mock import patch
 
 import pytest_asyncio
 from asgiref.sync import sync_to_async
+from temporalio.exceptions import ApplicationError
 from temporalio.testing import ActivityEnvironment
 
 from posthog.schema import (
@@ -148,7 +149,7 @@ class TestPrepareAlert:
     @pytest.mark.parametrize(
         "frozen_time,setup_kwargs,expected_reason,advances_next_check_at",
         [
-            pytest.param(None, {"enabled": False}, SkipReason.NOT_FOUND, False, id="disabled"),
+            pytest.param(None, {"enabled": False}, SkipReason.DISABLED, False, id="disabled"),
             pytest.param(None, {"insight_deleted": True}, SkipReason.INSIGHT_DELETED, False, id="insight_deleted"),
             pytest.param(
                 "2024-06-03T10:00:00Z",
@@ -331,6 +332,20 @@ class TestEvaluateAlert:
         # No AlertCheck should have been written
         count = await sync_to_async(AlertCheck.objects.filter(alert_configuration=alert).count)()
         assert count == 0
+
+    async def test_evaluate_non_retryable_when_alert_deleted_mid_workflow(self) -> None:
+        env = ActivityEnvironment()
+        with pytest.raises(ApplicationError) as exc_info:
+            await env.run(evaluate_alert, EvaluateAlertActivityInputs(alert_id=str(uuid.uuid4())))
+        assert exc_info.value.non_retryable is True
+
+    async def test_evaluate_non_retryable_when_alert_disabled_mid_workflow(self, alert) -> None:
+        await sync_to_async(AlertConfiguration.objects.filter(pk=alert.id).update)(enabled=False)
+
+        env = ActivityEnvironment()
+        with pytest.raises(ApplicationError) as exc_info:
+            await env.run(evaluate_alert, EvaluateAlertActivityInputs(alert_id=str(alert.id)))
+        assert exc_info.value.non_retryable is True
 
 
 @pytest.mark.asyncio

--- a/posthog/temporal/tests/test_alerts_activities.py
+++ b/posthog/temporal/tests/test_alerts_activities.py
@@ -1,0 +1,487 @@
+import uuid
+import contextlib
+from datetime import UTC, datetime
+
+import pytest
+from freezegun import freeze_time
+from unittest.mock import patch
+
+import pytest_asyncio
+from asgiref.sync import sync_to_async
+from temporalio.testing import ActivityEnvironment
+
+from posthog.schema import (
+    AlertCalculationInterval,
+    AlertState,
+    ChartDisplayType,
+    EventsNode,
+    IntervalType,
+    TrendsFilter,
+    TrendsQuery,
+)
+
+from posthog.errors import CHQueryErrorTooManySimultaneousQueries
+from posthog.models import AlertConfiguration, Insight
+from posthog.models.alert import AlertCheck
+from posthog.tasks.alerts.utils import AlertEvaluationResult
+from posthog.temporal.alerts.activities import evaluate_alert, notify_alert, prepare_alert
+from posthog.temporal.alerts.types import (
+    EvaluateAlertActivityInputs,
+    NotifyAlertActivityInputs,
+    PrepareAction,
+    PrepareAlertActivityInputs,
+)
+
+
+def _valid_trends_query() -> dict:
+    return TrendsQuery(
+        series=[EventsNode(event="$pageview")],
+        interval=IntervalType.DAY,
+        trendsFilter=TrendsFilter(display=ChartDisplayType.BOLD_NUMBER),
+    ).model_dump()
+
+
+async def _create_alert(
+    ateam,
+    *,
+    query: dict | None = None,
+    enabled: bool = True,
+    calculation_interval: str = AlertCalculationInterval.DAILY.value,
+    config: dict | None = None,
+    condition: dict | None = None,
+    next_check_at: datetime | None = None,
+    snoozed_until: datetime | None = None,
+    skip_weekend: bool = False,
+    schedule_restriction: dict | None = None,
+    insight_deleted: bool = False,
+    state: str = AlertState.NOT_FIRING,
+) -> AlertConfiguration:
+    @sync_to_async
+    def _create() -> AlertConfiguration:
+        insight = Insight.objects.create(
+            team=ateam,
+            name="insight",
+            query=query if query is not None else _valid_trends_query(),
+            deleted=insight_deleted,
+        )
+        alert = AlertConfiguration.objects.create(
+            team=ateam,
+            insight=insight,
+            name="alert",
+            enabled=enabled,
+            calculation_interval=calculation_interval,
+            config=config if config is not None else {"type": "TrendsAlertConfig", "series_index": 0},
+            condition=condition if condition is not None else {"type": "absolute_value"},
+            next_check_at=next_check_at,
+            snoozed_until=snoozed_until,
+            skip_weekend=skip_weekend,
+            schedule_restriction=schedule_restriction,
+            state=state,
+        )
+        return alert
+
+    return await _create()
+
+
+@pytest_asyncio.fixture
+async def alert(ateam):
+    return await _create_alert(ateam)
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+class TestPrepareAlert:
+    async def test_skip_when_alert_not_found(self) -> None:
+        env = ActivityEnvironment()
+        result = await env.run(
+            prepare_alert,
+            PrepareAlertActivityInputs(alert_id=str(uuid.uuid4())),
+        )
+        assert result.action == PrepareAction.SKIP
+        assert result.reason == "not_found"
+
+    @pytest.mark.parametrize(
+        "frozen_time,setup_kwargs,expected_reason,advances_next_check_at",
+        [
+            pytest.param(None, {"enabled": False}, "not_found", False, id="disabled"),
+            pytest.param(None, {"insight_deleted": True}, "insight_deleted", False, id="insight_deleted"),
+            pytest.param(
+                "2024-06-03T10:00:00Z",
+                {"next_check_at": datetime(2024, 6, 3, 11, 0, tzinfo=UTC)},
+                "not_due",
+                False,
+                id="not_due",
+            ),
+            pytest.param(
+                "2024-12-21T08:00:00Z",  # Saturday
+                {"skip_weekend": True},
+                "weekend",
+                True,
+                id="weekend",
+            ),
+            pytest.param(
+                "2024-06-03T22:30:00Z",  # inside 22:00-07:00 quiet window
+                {"schedule_restriction": {"blocked_windows": [{"start": "22:00", "end": "07:00"}]}},
+                "quiet_hours",
+                True,
+                id="quiet_hours",
+            ),
+            pytest.param(
+                "2024-06-03T10:00:00Z",
+                {
+                    "snoozed_until": datetime(2024, 6, 3, 12, 0, tzinfo=UTC),
+                    "state": AlertState.SNOOZED,
+                },
+                "snoozed",
+                False,
+                id="snoozed_future",
+            ),
+        ],
+    )
+    async def test_skip_branches(
+        self,
+        ateam,
+        frozen_time: str | None,
+        setup_kwargs: dict,
+        expected_reason: str,
+        advances_next_check_at: bool,
+    ) -> None:
+        ctx = freeze_time(frozen_time) if frozen_time else contextlib.nullcontext()
+        with ctx:
+            a = await _create_alert(ateam, **setup_kwargs)
+            env = ActivityEnvironment()
+            result = await env.run(prepare_alert, PrepareAlertActivityInputs(alert_id=str(a.id)))
+
+        assert result.action == PrepareAction.SKIP
+        assert result.reason == expected_reason
+
+        refreshed = await sync_to_async(AlertConfiguration.objects.get)(pk=a.pk)
+        if advances_next_check_at:
+            assert refreshed.next_check_at is not None
+            # Advanced at or past the frozen "now".
+            assert frozen_time is not None
+            assert refreshed.next_check_at >= datetime.fromisoformat(frozen_time.replace("Z", "+00:00"))
+        else:
+            # Non-advancing skip branches must leave next_check_at untouched.
+            assert refreshed.next_check_at == setup_kwargs.get("next_check_at")
+
+    @freeze_time("2024-06-03T10:00:00Z")
+    async def test_snoozed_future_preserves_snoozed_until(self, ateam) -> None:
+        # Separate from the parameterized set because it asserts a DB field is UNCHANGED,
+        # which doesn't fit the generic "next_check_at advanced" pattern.
+        snoozed = datetime(2024, 6, 3, 12, 0, tzinfo=UTC)
+        a = await _create_alert(ateam, snoozed_until=snoozed, state=AlertState.SNOOZED)
+
+        env = ActivityEnvironment()
+        await env.run(prepare_alert, PrepareAlertActivityInputs(alert_id=str(a.id)))
+
+        refreshed = await sync_to_async(AlertConfiguration.objects.get)(pk=a.pk)
+        assert refreshed.snoozed_until == snoozed
+
+    @freeze_time("2024-06-03T10:00:00Z")
+    async def test_snoozed_until_in_past_is_cleared_and_evaluation_proceeds(self, ateam) -> None:
+        past = datetime(2024, 6, 3, 9, 0, tzinfo=UTC)
+        a = await _create_alert(ateam, snoozed_until=past, state=AlertState.SNOOZED)
+
+        env = ActivityEnvironment()
+        result = await env.run(prepare_alert, PrepareAlertActivityInputs(alert_id=str(a.id)))
+
+        assert result.action == PrepareAction.EVALUATE
+
+    async def test_auto_disable_when_config_invalid(self, ateam) -> None:
+        # Missing required "type" in config makes validate_alert_config raise ValueError.
+        a = await _create_alert(ateam, config={"series_index": 0})
+
+        env = ActivityEnvironment()
+        result = await env.run(prepare_alert, PrepareAlertActivityInputs(alert_id=str(a.id)))
+
+        assert result.action == PrepareAction.AUTO_DISABLE
+        assert result.reason is not None
+
+        refreshed = await sync_to_async(AlertConfiguration.objects.get)(pk=a.pk)
+        assert refreshed.enabled is False
+        assert refreshed.state == AlertState.ERRORED
+
+        # disable_invalid_alert creates an AlertCheck row recording the disabling
+        check_exists = await sync_to_async(lambda: AlertCheck.objects.filter(alert_configuration=refreshed).exists())()
+        assert check_exists
+
+    async def test_evaluate_for_valid_alert(self, alert) -> None:
+        env = ActivityEnvironment()
+        result = await env.run(prepare_alert, PrepareAlertActivityInputs(alert_id=str(alert.id)))
+
+        assert result.action == PrepareAction.EVALUATE
+        assert result.reason is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+class TestEvaluateAlert:
+    async def test_evaluate_not_firing_no_breaches(self, alert) -> None:
+        with patch(
+            "posthog.temporal.alerts.activities.check_alert_for_insight",
+            return_value=AlertEvaluationResult(value=5.0, breaches=None),
+        ):
+            env = ActivityEnvironment()
+            result = await env.run(evaluate_alert, EvaluateAlertActivityInputs(alert_id=str(alert.id)))
+
+        assert result.new_state == AlertState.NOT_FIRING
+        assert result.should_notify is False
+        assert result.alert_check_id  # stringified UUID, truthy
+
+        check = await sync_to_async(AlertCheck.objects.get)(pk=result.alert_check_id)
+        assert check.state == AlertState.NOT_FIRING
+        assert check.calculated_value == 5.0
+        assert check.targets_notified == {}  # empty sentinel — notify_alert fills on success
+
+    async def test_evaluate_firing_with_breaches(self, alert) -> None:
+        with patch(
+            "posthog.temporal.alerts.activities.check_alert_for_insight",
+            return_value=AlertEvaluationResult(value=100.0, breaches=["value above threshold"]),
+        ):
+            env = ActivityEnvironment()
+            result = await env.run(evaluate_alert, EvaluateAlertActivityInputs(alert_id=str(alert.id)))
+
+        assert result.new_state == AlertState.FIRING
+        assert result.should_notify is True
+
+        check = await sync_to_async(AlertCheck.objects.get)(pk=result.alert_check_id)
+        assert check.state == AlertState.FIRING
+        assert check.targets_notified == {}
+
+    async def test_evaluate_errored_when_permanent_exception(self, alert) -> None:
+        with patch(
+            "posthog.temporal.alerts.activities.check_alert_for_insight",
+            side_effect=ValueError("insight is misconfigured"),
+        ):
+            env = ActivityEnvironment()
+            result = await env.run(evaluate_alert, EvaluateAlertActivityInputs(alert_id=str(alert.id)))
+
+        assert result.new_state == AlertState.ERRORED
+        assert result.should_notify is True
+
+        check = await sync_to_async(AlertCheck.objects.get)(pk=result.alert_check_id)
+        assert check.state == AlertState.ERRORED
+        assert check.error is not None
+        assert "misconfigured" in check.error["message"]
+
+    async def test_evaluate_reraises_ch_transient_error(self, alert) -> None:
+        # Transient CH errors bubble up so Temporal's retry policy handles them.
+        with patch(
+            "posthog.temporal.alerts.activities.check_alert_for_insight",
+            side_effect=CHQueryErrorTooManySimultaneousQueries("too many"),
+        ):
+            env = ActivityEnvironment()
+            with pytest.raises(CHQueryErrorTooManySimultaneousQueries):
+                await env.run(evaluate_alert, EvaluateAlertActivityInputs(alert_id=str(alert.id)))
+
+        # No AlertCheck should have been written
+        count = await sync_to_async(AlertCheck.objects.filter(alert_configuration=alert).count)()
+        assert count == 0
+
+
+@pytest_asyncio.fixture
+async def alert_with_user(ateam, aorganization):
+    from posthog.models import User
+
+    @sync_to_async
+    def _create() -> AlertConfiguration:
+        user = User.objects.create_and_join(
+            organization=aorganization, email=f"alerts-{uuid.uuid4().hex[:6]}@posthog.com", password=None
+        )
+        insight = Insight.objects.create(team=ateam, name="insight", query=_valid_trends_query())
+        a = AlertConfiguration.objects.create(
+            team=ateam,
+            insight=insight,
+            name="alert",
+            enabled=True,
+            calculation_interval=AlertCalculationInterval.DAILY.value,
+            config={"type": "TrendsAlertConfig", "series_index": 0},
+            condition={"type": "absolute_value"},
+        )
+        a.subscribed_users.add(user)
+        return a
+
+    return await _create()
+
+
+async def _create_alert_check(
+    alert: AlertConfiguration,
+    *,
+    state: str,
+    targets_notified: dict | None = None,
+    error: dict | None = None,
+) -> AlertCheck:
+    @sync_to_async
+    def _create() -> AlertCheck:
+        return AlertCheck.objects.create(
+            alert_configuration=alert,
+            calculated_value=1.0,
+            condition=alert.condition,
+            state=state,
+            error=error,
+            targets_notified=targets_notified if targets_notified is not None else {},
+        )
+
+    return await _create()
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+class TestNotifyAlert:
+    async def test_noop_when_not_firing(self, alert_with_user) -> None:
+        check = await _create_alert_check(alert_with_user, state=AlertState.NOT_FIRING)
+
+        with (
+            patch("posthog.tasks.alerts.utils.send_notifications_for_breaches") as mock_breaches,
+            patch("posthog.tasks.alerts.utils.send_notifications_for_errors") as mock_errors,
+        ):
+            env = ActivityEnvironment()
+            await env.run(
+                notify_alert,
+                NotifyAlertActivityInputs(alert_id=str(alert_with_user.id), alert_check_id=str(check.id)),
+            )
+
+        mock_breaches.assert_not_called()
+        mock_errors.assert_not_called()
+
+    async def test_sends_breach_notifications_when_firing(self, alert_with_user) -> None:
+        check = await _create_alert_check(alert_with_user, state=AlertState.FIRING)
+
+        with (
+            patch(
+                "posthog.tasks.alerts.utils.send_notifications_for_breaches",
+                return_value=["alice@posthog.com"],
+            ) as mock_breaches,
+            patch("posthog.tasks.alerts.utils.send_notifications_for_errors") as mock_errors,
+        ):
+            env = ActivityEnvironment()
+            await env.run(
+                notify_alert,
+                NotifyAlertActivityInputs(
+                    alert_id=str(alert_with_user.id),
+                    alert_check_id=str(check.id),
+                    breaches=["value above threshold"],
+                ),
+            )
+
+        mock_breaches.assert_called_once()
+        mock_errors.assert_not_called()
+
+        refreshed = await sync_to_async(AlertCheck.objects.get)(pk=check.id)
+        # targets_notified carries exactly the list the send returned — no duplicate query.
+        assert refreshed.targets_notified == {"users": ["alice@posthog.com"]}
+
+        refreshed_alert = await sync_to_async(AlertConfiguration.objects.get)(pk=alert_with_user.pk)
+        assert refreshed_alert.last_notified_at is not None
+
+    async def test_firing_passes_stable_idempotency_key_to_breach_sender(self, alert_with_user) -> None:
+        # MessagingRecord dedupes retries via campaign_key; notify_alert must pass the
+        # AlertCheck id so a retry reuses the same key and the provider skips re-sending.
+        check = await _create_alert_check(alert_with_user, state=AlertState.FIRING)
+
+        with patch(
+            "posthog.tasks.alerts.utils.send_notifications_for_breaches",
+            return_value=["alice@posthog.com"],
+        ) as mock_breaches:
+            env = ActivityEnvironment()
+            await env.run(
+                notify_alert,
+                NotifyAlertActivityInputs(
+                    alert_id=str(alert_with_user.id),
+                    alert_check_id=str(check.id),
+                    breaches=["value above threshold"],
+                ),
+            )
+
+        mock_breaches.assert_called_once()
+        call_kwargs = mock_breaches.call_args.kwargs
+        assert call_kwargs.get("idempotency_key") == str(check.id), (
+            "notify_alert must pass alert_check.id as idempotency_key so MessagingRecord "
+            "dedupes Temporal retries at the provider level"
+        )
+
+    async def test_sends_error_notifications_when_errored(self, alert_with_user) -> None:
+        check = await _create_alert_check(
+            alert_with_user, state=AlertState.ERRORED, error={"message": "boom", "traceback": "..."}
+        )
+
+        with (
+            patch("posthog.tasks.alerts.utils.send_notifications_for_breaches") as mock_breaches,
+            patch("posthog.tasks.alerts.utils.send_notifications_for_errors") as mock_errors,
+        ):
+            env = ActivityEnvironment()
+            await env.run(
+                notify_alert,
+                NotifyAlertActivityInputs(alert_id=str(alert_with_user.id), alert_check_id=str(check.id)),
+            )
+
+        mock_errors.assert_called_once()
+        mock_breaches.assert_not_called()
+
+        refreshed = await sync_to_async(AlertCheck.objects.get)(pk=check.id)
+        assert refreshed.targets_notified != {}
+
+    async def test_idempotent_when_already_notified(self, alert_with_user) -> None:
+        # Simulate a previous successful notification by setting targets_notified.
+        check = await _create_alert_check(
+            alert_with_user,
+            state=AlertState.FIRING,
+            targets_notified={"users": ["already@notified.com"]},
+        )
+
+        with (
+            patch("posthog.tasks.alerts.utils.send_notifications_for_breaches") as mock_breaches,
+            patch("posthog.tasks.alerts.utils.send_notifications_for_errors") as mock_errors,
+        ):
+            env = ActivityEnvironment()
+            await env.run(
+                notify_alert,
+                NotifyAlertActivityInputs(
+                    alert_id=str(alert_with_user.id),
+                    alert_check_id=str(check.id),
+                    breaches=["ignored — idempotent return before state match"],
+                ),
+            )
+
+        mock_breaches.assert_not_called()
+        mock_errors.assert_not_called()
+
+        refreshed = await sync_to_async(AlertCheck.objects.get)(pk=check.id)
+        assert refreshed.targets_notified == {"users": ["already@notified.com"]}
+
+    async def test_raises_when_firing_without_breaches(self, alert_with_user) -> None:
+        # Guard: if the workflow forgets to pipe breaches into notify inputs, fail loudly
+        # instead of sending an email with empty match_descriptions.
+        check = await _create_alert_check(alert_with_user, state=AlertState.FIRING)
+
+        env = ActivityEnvironment()
+        with pytest.raises(ValueError, match="no breaches"):
+            await env.run(
+                notify_alert,
+                NotifyAlertActivityInputs(
+                    alert_id=str(alert_with_user.id), alert_check_id=str(check.id), breaches=None
+                ),
+            )
+
+    async def test_raises_on_send_failure(self, alert_with_user) -> None:
+        check = await _create_alert_check(alert_with_user, state=AlertState.FIRING)
+
+        with patch(
+            "posthog.tasks.alerts.utils.send_notifications_for_breaches",
+            side_effect=RuntimeError("SMTP unavailable"),
+        ):
+            env = ActivityEnvironment()
+            with pytest.raises(RuntimeError):
+                await env.run(
+                    notify_alert,
+                    NotifyAlertActivityInputs(
+                        alert_id=str(alert_with_user.id),
+                        alert_check_id=str(check.id),
+                        breaches=["value above threshold"],
+                    ),
+                )
+
+        # targets_notified stays empty so Temporal retry re-attempts delivery
+        refreshed = await sync_to_async(AlertCheck.objects.get)(pk=check.id)
+        assert refreshed.targets_notified == {}


### PR DESCRIPTION
## Problem

The Temporal alert workflow activities (`prepare_alert`, `evaluate_alert`, `notify_alert`) were stubs that raised `NotImplementedError`, blocking the Temporal-based alert execution path. Additionally, notification delivery logic was tightly coupled to `checks.py`, making it difficult to reuse across both the Celery and Temporal execution paths, and `targets_notified` / `last_notified_at` were being set speculatively before delivery was confirmed.

## Changes

**Temporal activity implementations:**

- `prepare_alert`: Loads the alert, validates config, and gates evaluation behind all skip conditions (not found, insight deleted, not due, weekend, quiet hours, snoozed). Auto-disables alerts with invalid configs via `disable_invalid_alert`.
- `evaluate_alert`: Runs the ClickHouse insight query, applies the alert state machine via `add_alert_check`, and returns an `EvaluateAlertResult` with the check ID, notify flag, new state, and breach descriptions. Transient CH errors are re-raised so Temporal's retry policy handles them; permanent errors are recorded as `ERRORED` checks.
- `notify_alert`: Idempotent notification sender. Uses `targets_notified` as the delivery sentinel — non-empty means already delivered, so Temporal retries are safe. Calls `dispatch_alert_notification` and then `record_alert_delivery` only on success.

**Notification logic extracted to** **`utils.py`:**

- `dispatch_alert_notification`: Routes an `AlertCheck` to the correct sender (`send_notifications_for_breaches`, `send_notifications_for_errors`) based on state. Returns the recipient list or `None` for NOT_FIRING.
- `record_alert_delivery`: Persists `targets_notified` on the `AlertCheck` and `last_notified_at` on the `AlertConfiguration` only after confirmed delivery, using targeted `update_fields` saves.
- `disable_invalid_alert`: Moved from `checks.py` to `utils.py` so both Celery and Temporal paths share the same implementation.
- `send_notifications_for_breaches` now accepts an optional `idempotency_key` (the `AlertCheck` id) to produce a stable `campaign_key`, enabling `MessagingRecord`\-level deduplication on Temporal retries.

**`add_alert_check`** **changes:**

- Returns `(AlertCheck, bool)` instead of just `AlertCheck`, surfacing the notify decision to callers without requiring them to re-inspect `targets_notified`.
- `targets_notified` is always written as `{}` at check creation time; `record_alert_delivery` fills it on confirmed send.
- `last_notified_at` is no longer set speculatively; it is set by `record_alert_delivery`.
- `alert.save()` is narrowed to `update_fields=["state", "last_checked_at", "next_check_at"]`.

**`EvaluateAlertResult`** **/** **`NotifyAlertActivityInputs`:**

- `alert_check_id` changed from `int` to `str` (stringified UUIDT) for Temporal JSON codec compatibility.
- `breaches: list[str] | None` added to both so the workflow can pipe breach descriptions from evaluate to notify without a DB round-trip.
- `SkipReason` enum added to `types.py` for structured skip signalling.

## How did you test this code?

A new test module `posthog/temporal/tests/test_alerts_activities.py` covers all three activities using `ActivityEnvironment`:

- `TestPrepareAlert`: skip branches (disabled, deleted insight, not due, weekend, quiet hours, snoozed future, snoozed expired), auto-disable on invalid config, and happy-path evaluate.
- `TestEvaluateAlert`: not-firing, firing with breaches, permanent exception → ERRORED, and transient CH error re-raise (no `AlertCheck` written).
- `TestNotifyAlert`: NOT_FIRING noop, FIRING breach send + `targets_notified` persistence, stable idempotency key passed to breach sender, ERRORED error send, idempotent retry when already notified, raises on FIRING with no breaches, raises on send failure with `targets_notified` left empty for retry.

Existing alert check tests updated to patch `posthog.tasks.alerts.utils` instead of `posthog.tasks.alerts.checks` following the logic move.

Also celery alerts still work (triggered manually through the CLI):

![CleanShot 2026-04-22 at 12.15.07@2x.png](https://app.graphite.com/user-attachments/assets/88eca86e-5511-4a5e-aa47-3c5397b46876.png)

## Publish to changelog?

No