### PR TITLE
feat(alerts): cutover alert checks from Celery to Temporal schedule

### DIFF
--- a/posthog/tasks/scheduled.py
+++ b/posthog/tasks/scheduled.py
@@ -486,12 +486,6 @@ def setup_periodic_tasks(sender: Celery, **kwargs: Any) -> None:
         name="update survey's sampling feature flag rollout  based on date",
     )
 
-    # check_alerts_task is no longer registered here — alert checks run via the
-    # ScheduleDueAlertChecksWorkflow Temporal schedule (every 2 minutes on
-    # ANALYTICS_PLATFORM_TASK_QUEUE). See posthog/temporal/alerts/schedule.py
-    # and posthog/temporal/schedule.py. The Celery task function itself is
-    # removed in PR4 of the stack.
-
     sender.add_periodic_task(
         crontab(hour="*", minute="*/12"),
         alerts_backlog_task.s(),

--- a/posthog/tasks/scheduled.py
+++ b/posthog/tasks/scheduled.py
@@ -487,7 +487,7 @@ def setup_periodic_tasks(sender: Celery, **kwargs: Any) -> None:
     )
 
     # check_alerts_task is no longer registered here — alert checks run via the
-    # ScheduleAllAlertChecksWorkflow Temporal schedule (every 2 minutes on
+    # ScheduleDueAlertChecksWorkflow Temporal schedule (every 2 minutes on
     # ANALYTICS_PLATFORM_TASK_QUEUE). See posthog/temporal/alerts/schedule.py
     # and posthog/temporal/schedule.py. The Celery task function itself is
     # removed in PR4 of the stack.

--- a/posthog/tasks/scheduled.py
+++ b/posthog/tasks/scheduled.py
@@ -10,12 +10,7 @@ from celery.schedules import crontab
 from posthog.approvals.tasks import expire_old_change_requests, validate_pending_change_requests
 from posthog.caching.warming import schedule_warming_for_teams_task
 from posthog.clickhouse.client.execute_async import QueryStatusManager
-from posthog.tasks.alerts.checks import (
-    alerts_backlog_task,
-    check_alerts_task,
-    checks_cleanup_task,
-    reset_stuck_alerts_task,
-)
+from posthog.tasks.alerts.checks import alerts_backlog_task, checks_cleanup_task, reset_stuck_alerts_task
 from posthog.tasks.auth_token_cache_verification import verify_and_fix_auth_token_cache_task
 from posthog.tasks.email import (
     send_error_tracking_weekly_digest,
@@ -491,11 +486,11 @@ def setup_periodic_tasks(sender: Celery, **kwargs: Any) -> None:
         name="update survey's sampling feature flag rollout  based on date",
     )
 
-    sender.add_periodic_task(
-        crontab(hour="*", minute="*/2"),
-        check_alerts_task.s(),
-        name="check_alerts_task",
-    )
+    # check_alerts_task is no longer registered here — alert checks run via the
+    # ScheduleAllAlertChecksWorkflow Temporal schedule (every 2 minutes on
+    # ANALYTICS_PLATFORM_TASK_QUEUE). See posthog/temporal/alerts/schedule.py
+    # and posthog/temporal/schedule.py. The Celery task function itself is
+    # removed in PR4 of the stack.
 
     sender.add_periodic_task(
         crontab(hour="*", minute="*/12"),

--- a/posthog/temporal/alerts/workflows.py
+++ b/posthog/temporal/alerts/workflows.py
@@ -148,8 +148,6 @@ class CheckAlertWorkflow(PostHogWorkflow):
                     NotifyAlertActivityInputs(
                         alert_id=inputs.alert_id,
                         alert_check_id=evaluation.alert_check_id,
-                        # breaches aren't persisted on AlertCheck; notify_alert raises on FIRING
-                        # without them, so the wiring bug would surface immediately.
                         breaches=evaluation.breaches,
                     ),
                     start_to_close_timeout=dt.timedelta(minutes=5),

--- a/posthog/temporal/alerts/workflows.py
+++ b/posthog/temporal/alerts/workflows.py
@@ -148,6 +148,8 @@ class CheckAlertWorkflow(PostHogWorkflow):
                     NotifyAlertActivityInputs(
                         alert_id=inputs.alert_id,
                         alert_check_id=evaluation.alert_check_id,
+                        # breaches aren't persisted on AlertCheck; notify_alert raises on FIRING
+                        # without them, so the wiring bug would surface immediately.
                         breaches=evaluation.breaches,
                     ),
                     start_to_close_timeout=dt.timedelta(minutes=5),

--- a/posthog/temporal/schedule.py
+++ b/posthog/temporal/schedule.py
@@ -23,7 +23,7 @@ from temporalio.client import (
 from posthog.hogql_queries.ai.vector_search_query_runner import LATEST_ACTIONS_EMBEDDING_VERSION
 from posthog.temporal.ai import SyncVectorsInputs
 from posthog.temporal.ai.sync_vectors import EmbeddingVersion
-from posthog.temporal.alerts.schedule import create_schedule_all_alert_checks_schedule
+from posthog.temporal.alerts.schedule import create_schedule_due_alert_checks_schedule
 from posthog.temporal.common.client import async_connect
 from posthog.temporal.common.schedule import a_create_schedule, a_delete_schedule, a_schedule_exists, a_update_schedule
 from posthog.temporal.data_imports.signals.conversations_schedule import (
@@ -553,7 +553,7 @@ schedules = [
     create_conversations_signals_coordinator_schedule,
     create_wa_weekly_digest_schedule,
     create_logs_alert_check_schedule,
-    create_schedule_all_alert_checks_schedule,
+    create_schedule_due_alert_checks_schedule,
 ]
 
 if settings.EE_AVAILABLE:

--- a/posthog/temporal/schedule.py
+++ b/posthog/temporal/schedule.py
@@ -23,6 +23,7 @@ from temporalio.client import (
 from posthog.hogql_queries.ai.vector_search_query_runner import LATEST_ACTIONS_EMBEDDING_VERSION
 from posthog.temporal.ai import SyncVectorsInputs
 from posthog.temporal.ai.sync_vectors import EmbeddingVersion
+from posthog.temporal.alerts.schedule import create_schedule_all_alert_checks_schedule
 from posthog.temporal.common.client import async_connect
 from posthog.temporal.common.schedule import a_create_schedule, a_delete_schedule, a_schedule_exists, a_update_schedule
 from posthog.temporal.data_imports.signals.conversations_schedule import (
@@ -552,6 +553,7 @@ schedules = [
     create_conversations_signals_coordinator_schedule,
     create_wa_weekly_digest_schedule,
     create_logs_alert_check_schedule,
+    create_schedule_all_alert_checks_schedule,
 ]
 
 if settings.EE_AVAILABLE:

--- a/posthog/temporal/tests/test_alerts_workflows.py
+++ b/posthog/temporal/tests/test_alerts_workflows.py
@@ -1,16 +1,14 @@
 import uuid
-import datetime as dt
 from collections.abc import Callable
 from typing import Any
 
 import pytest
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 from django.conf import settings
 
 import pytest_asyncio
 from asgiref.sync import sync_to_async
-from temporalio.client import Schedule, ScheduleActionStartWorkflow, ScheduleOverlapPolicy, ScheduleSpec
 from temporalio.testing import WorkflowEnvironment
 from temporalio.worker import UnsandboxedWorkflowRunner, Worker
 
@@ -34,55 +32,13 @@ from posthog.temporal.alerts.types import CheckAlertWorkflowInputs, SkipReason
 from posthog.temporal.alerts.workflows import CheckAlertWorkflow
 from posthog.temporal.common.slo_interceptor import SloInterceptor
 
+CHECK_ALERT_ACTIVITIES: list[Callable[..., Any]] = [prepare_alert, evaluate_alert, notify_alert]
+
 
 def test_schedule_is_registered_in_init_schedules():
     from posthog.temporal.schedule import schedules
 
     assert create_schedule_due_alert_checks_schedule in schedules
-
-
-@pytest.mark.parametrize(
-    "schedule_exists,expect_create,expect_update",
-    [
-        pytest.param(False, True, False, id="creates_when_absent"),
-        pytest.param(True, False, True, id="updates_when_present"),
-    ],
-)
-@pytest.mark.asyncio
-async def test_create_schedule_routes_by_existence(
-    schedule_exists: bool, expect_create: bool, expect_update: bool
-) -> None:
-    mock_client = AsyncMock()
-    with (
-        patch(
-            "posthog.temporal.alerts.schedule.a_schedule_exists",
-            new=AsyncMock(return_value=schedule_exists),
-        ),
-        patch("posthog.temporal.alerts.schedule.a_create_schedule", new=AsyncMock()) as mock_create,
-        patch("posthog.temporal.alerts.schedule.a_update_schedule", new=AsyncMock()) as mock_update,
-    ):
-        await create_schedule_due_alert_checks_schedule(mock_client)
-
-    assert mock_create.await_count == (1 if expect_create else 0)
-    assert mock_update.await_count == (1 if expect_update else 0)
-
-    # Same Schedule shape must be registered on both paths — a stale config
-    # passed to a_update_schedule would silently ship otherwise.
-    invoked = mock_create if expect_create else mock_update
-    assert invoked.await_args is not None
-    schedule_arg = invoked.await_args.args[2]
-    assert isinstance(schedule_arg, Schedule)
-    assert isinstance(schedule_arg.spec, ScheduleSpec)
-    assert schedule_arg.spec.cron_expressions == ["*/2 * * * *"]
-    assert schedule_arg.policy.overlap == ScheduleOverlapPolicy.ALLOW_ALL
-    assert isinstance(schedule_arg.action, ScheduleActionStartWorkflow)
-    assert schedule_arg.action.execution_timeout == dt.timedelta(minutes=10)
-
-    if expect_create:
-        assert mock_create.await_args.kwargs.get("trigger_immediately") is False
-
-
-CHECK_ALERT_ACTIVITIES: list[Callable[..., Any]] = [prepare_alert, evaluate_alert, notify_alert]
 
 
 def _valid_trends_query() -> dict:
@@ -93,7 +49,13 @@ def _valid_trends_query() -> dict:
     ).model_dump()
 
 
-def _build_alert(ateam, *, insight_deleted: bool = False, enabled: bool = True) -> AlertConfiguration:
+def _build_alert(
+    ateam,
+    *,
+    insight_deleted: bool = False,
+    enabled: bool = True,
+    config: dict | None = None,
+) -> AlertConfiguration:
     insight = Insight.objects.create(team=ateam, name="insight", query=_valid_trends_query(), deleted=insight_deleted)
     return AlertConfiguration.objects.create(
         team=ateam,
@@ -101,14 +63,20 @@ def _build_alert(ateam, *, insight_deleted: bool = False, enabled: bool = True) 
         name="wf-test-alert",
         enabled=enabled,
         calculation_interval=AlertCalculationInterval.DAILY.value,
-        config={"type": "TrendsAlertConfig", "series_index": 0},
+        config=config if config is not None else {"type": "TrendsAlertConfig", "series_index": 0},
         condition={"type": "absolute_value"},
     )
 
 
 @sync_to_async
-def _create_alert(ateam, *, insight_deleted: bool = False, enabled: bool = True) -> AlertConfiguration:
-    return _build_alert(ateam, insight_deleted=insight_deleted, enabled=enabled)
+def _create_alert(
+    ateam,
+    *,
+    insight_deleted: bool = False,
+    enabled: bool = True,
+    config: dict | None = None,
+) -> AlertConfiguration:
+    return _build_alert(ateam, insight_deleted=insight_deleted, enabled=enabled, config=config)
 
 
 @pytest_asyncio.fixture
@@ -303,9 +271,55 @@ async def test_check_alert_workflow_records_errored_check_on_permanent_evaluatio
     assert check.error is not None
     assert "insight query broken" in check.error["message"]
 
+    # Evaluate-time errors are transient — alert stays enabled so next run retries.
+    # Only prepare-time validate_alert_config failures call disable_invalid_alert.
+    refreshed = await sync_to_async(AlertConfiguration.objects.get)(pk=alert_with_subscriber.pk)
+    assert refreshed.enabled is True
+
     mock_send_errors.assert_called_once()
 
     completed_props = _completed_slo_props(mock_slo_analytics)
     # Errored evaluation = degraded alert, not a workflow failure → SLO stays SUCCESS.
     assert completed_props["outcome"] == SloOutcome.SUCCESS
     assert completed_props["alert_state"] == AlertState.ERRORED
+
+
+@patch("posthog.slo.events.posthoganalytics")
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_check_alert_workflow_auto_disables_alert_with_invalid_config(
+    mock_slo_analytics: MagicMock,
+    ateam,
+) -> None:
+    # Missing required "type" in config → validate_alert_config raises ValueError at prepare
+    # → disable_invalid_alert flips enabled=False and writes an ERRORED AlertCheck row.
+    alert = await _create_alert(ateam, config={"series_index": 0})
+
+    with (
+        patch("posthog.temporal.alerts.activities.check_alert_for_insight") as mock_ch_query,
+        patch("posthog.tasks.alerts.utils.send_notifications_for_breaches") as mock_send_breaches,
+    ):
+        await _run_check_alert_workflow(
+            alert_id=str(alert.id),
+            slo=_slo_config(alert),
+            team_id=alert.team_id,
+            insight_id=alert.insight_id,
+        )
+
+    refreshed = await sync_to_async(AlertConfiguration.objects.get)(pk=alert.pk)
+    assert refreshed.enabled is False
+    assert refreshed.state == AlertState.ERRORED
+
+    check = await sync_to_async(AlertCheck.objects.get)(alert_configuration=refreshed)
+    assert check.state == AlertState.ERRORED
+    assert check.calculated_value is None
+    assert check.error is not None
+
+    # Disable short-circuits before evaluate / notify.
+    mock_ch_query.assert_not_called()
+    mock_send_breaches.assert_not_called()
+
+    completed_props = _completed_slo_props(mock_slo_analytics)
+    assert completed_props["outcome"] == SloOutcome.SUCCESS
+    assert completed_props.get("skip_reason") is not None
+    assert "alert_state" not in completed_props

--- a/posthog/temporal/tests/test_alerts_workflows.py
+++ b/posthog/temporal/tests/test_alerts_workflows.py
@@ -1,6 +1,7 @@
 import uuid
 import datetime as dt
-from concurrent.futures import ThreadPoolExecutor
+from collections.abc import Callable
+from typing import Any
 
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -9,7 +10,7 @@ from django.conf import settings
 
 import pytest_asyncio
 from asgiref.sync import sync_to_async
-from temporalio.client import Client, Schedule, ScheduleActionStartWorkflow, ScheduleOverlapPolicy, ScheduleSpec
+from temporalio.client import Schedule, ScheduleActionStartWorkflow, ScheduleOverlapPolicy, ScheduleSpec
 from temporalio.testing import WorkflowEnvironment
 from temporalio.worker import UnsandboxedWorkflowRunner, Worker
 
@@ -40,71 +41,45 @@ def test_schedule_is_registered_in_init_schedules():
     assert create_schedule_due_alert_checks_schedule in schedules
 
 
+@pytest.mark.parametrize(
+    "schedule_exists,expect_create,expect_update",
+    [
+        pytest.param(False, True, False, id="creates_when_absent"),
+        pytest.param(True, False, True, id="updates_when_present"),
+    ],
+)
 @pytest.mark.asyncio
-async def test_create_schedule_creates_when_absent():
+async def test_create_schedule_routes_by_existence(
+    schedule_exists: bool, expect_create: bool, expect_update: bool
+) -> None:
     mock_client = AsyncMock()
     with (
         patch(
             "posthog.temporal.alerts.schedule.a_schedule_exists",
-            new=AsyncMock(return_value=False),
+            new=AsyncMock(return_value=schedule_exists),
         ),
-        patch(
-            "posthog.temporal.alerts.schedule.a_create_schedule",
-            new=AsyncMock(),
-        ) as mock_create,
-        patch(
-            "posthog.temporal.alerts.schedule.a_update_schedule",
-            new=AsyncMock(),
-        ) as mock_update,
+        patch("posthog.temporal.alerts.schedule.a_create_schedule", new=AsyncMock()) as mock_create,
+        patch("posthog.temporal.alerts.schedule.a_update_schedule", new=AsyncMock()) as mock_update,
     ):
         await create_schedule_due_alert_checks_schedule(mock_client)
 
-    mock_create.assert_awaited_once()
-    mock_update.assert_not_awaited()
+    assert mock_create.await_count == (1 if expect_create else 0)
+    assert mock_update.await_count == (1 if expect_update else 0)
 
-    call_args = mock_create.await_args
-    assert call_args is not None
-    schedule_arg = call_args.args[2]
-    assert isinstance(schedule_arg, Schedule)
-    assert isinstance(schedule_arg.spec, ScheduleSpec)
-    assert schedule_arg.spec.cron_expressions == ["*/2 * * * *"]
-    assert schedule_arg.policy.overlap == ScheduleOverlapPolicy.ALLOW_ALL
-    assert isinstance(schedule_arg.action, ScheduleActionStartWorkflow)
-    assert schedule_arg.action.execution_timeout == dt.timedelta(minutes=10)
-    assert call_args.kwargs.get("trigger_immediately") is False
-
-
-@pytest.mark.asyncio
-async def test_create_schedule_updates_when_present():
-    mock_client = AsyncMock()
-    with (
-        patch(
-            "posthog.temporal.alerts.schedule.a_schedule_exists",
-            new=AsyncMock(return_value=True),
-        ),
-        patch(
-            "posthog.temporal.alerts.schedule.a_create_schedule",
-            new=AsyncMock(),
-        ) as mock_create,
-        patch(
-            "posthog.temporal.alerts.schedule.a_update_schedule",
-            new=AsyncMock(),
-        ) as mock_update,
-    ):
-        await create_schedule_due_alert_checks_schedule(mock_client)
-
-    mock_update.assert_awaited_once()
-    mock_create.assert_not_awaited()
+    # On the create path, validate the Schedule shape we register.
+    if expect_create:
+        assert mock_create.await_args is not None
+        schedule_arg = mock_create.await_args.args[2]
+        assert isinstance(schedule_arg, Schedule)
+        assert isinstance(schedule_arg.spec, ScheduleSpec)
+        assert schedule_arg.spec.cron_expressions == ["*/2 * * * *"]
+        assert schedule_arg.policy.overlap == ScheduleOverlapPolicy.ALLOW_ALL
+        assert isinstance(schedule_arg.action, ScheduleActionStartWorkflow)
+        assert schedule_arg.action.execution_timeout == dt.timedelta(minutes=10)
+        assert mock_create.await_args.kwargs.get("trigger_immediately") is False
 
 
-# ─── CheckAlertWorkflow integration tests ────────────────────────────
-#
-# Exercise the full prepare → evaluate → notify chain against a real Postgres
-# DB with mocked ClickHouse + SMTP. Catches wiring regressions between the
-# workflow and activities — e.g., missing fields on activity inputs.
-
-
-CHECK_ALERT_ACTIVITIES = [prepare_alert, evaluate_alert, notify_alert]
+CHECK_ALERT_ACTIVITIES: list[Callable[..., Any]] = [prepare_alert, evaluate_alert, notify_alert]
 
 
 def _valid_trends_query() -> dict:
@@ -182,8 +157,6 @@ async def _run_check_alert_workflow(alert_id: str, slo: SloConfig, team_id: int,
             activities=CHECK_ALERT_ACTIVITIES,
             interceptors=[SloInterceptor()],
             workflow_runner=UnsandboxedWorkflowRunner(),
-            activity_executor=ThreadPoolExecutor(max_workers=2),
-            debug_mode=True,
         ):
             await env.client.execute_workflow(
                 CheckAlertWorkflow.run,
@@ -213,7 +186,6 @@ def _completed_slo_props(mock_slo_analytics: MagicMock) -> dict:
 @pytest.mark.django_db(transaction=True)
 async def test_check_alert_workflow_firing_drives_full_chain_with_slo(
     mock_slo_analytics: MagicMock,
-    temporal_client: Client,
     alert_with_subscriber: AlertConfiguration,
 ) -> None:
     evaluation_result = AlertEvaluationResult(value=100.0, breaches=["value above threshold"])
@@ -238,18 +210,11 @@ async def test_check_alert_workflow_firing_drives_full_chain_with_slo(
     assert check.state == AlertState.FIRING
     assert check.targets_notified == {"users": recipients}
 
-    # Contract: workflow pipes breaches from evaluate into notify inputs, and the
-    # idempotency_key is the AlertCheck id (so MessagingRecord dedupes retries).
     mock_send_breaches.assert_called_once()
-    _, pos_args, kw_args = mock_send_breaches.mock_calls[0]
-    passed_breaches = pos_args[1] if len(pos_args) > 1 else kw_args.get("breaches")
-    assert passed_breaches == ["value above threshold"]
-    assert kw_args.get("idempotency_key") == str(check.id)
+    call = mock_send_breaches.call_args
+    assert call.args[1] == ["value above threshold"]
+    assert call.kwargs.get("idempotency_key") == str(check.id)
 
-    started_calls = [
-        c for c in mock_slo_analytics.capture.call_args_list if c.kwargs.get("event") == "slo_operation_started"
-    ]
-    assert len(started_calls) == 1
     completed_props = _completed_slo_props(mock_slo_analytics)
     assert completed_props["outcome"] == SloOutcome.SUCCESS
     assert completed_props["alert_state"] == AlertState.FIRING
@@ -266,8 +231,8 @@ async def test_check_alert_workflow_firing_drives_full_chain_with_slo(
         ),
         pytest.param(
             lambda ateam: _create_alert(ateam, enabled=False),
-            SkipReason.NOT_FOUND,
-            id="disabled_treated_as_not_found",
+            SkipReason.DISABLED,
+            id="disabled",
         ),
     ],
 )
@@ -276,7 +241,6 @@ async def test_check_alert_workflow_firing_drives_full_chain_with_slo(
 @pytest.mark.django_db(transaction=True)
 async def test_check_alert_workflow_skip_short_circuits_before_evaluate(
     mock_slo_analytics: MagicMock,
-    temporal_client: Client,
     ateam,
     setup,
     expected_reason: SkipReason,
@@ -310,12 +274,8 @@ async def test_check_alert_workflow_skip_short_circuits_before_evaluate(
 @pytest.mark.django_db(transaction=True)
 async def test_check_alert_workflow_records_errored_check_on_permanent_evaluation_failure(
     mock_slo_analytics: MagicMock,
-    temporal_client: Client,
     alert_with_subscriber: AlertConfiguration,
 ) -> None:
-    # Permanent evaluation errors are captured into AlertCheck.error (not re-raised),
-    # so the workflow completes normally with state=ERRORED and the notify activity
-    # fires error notifications. This exercises the "error" path end-to-end.
     class PermanentError(Exception):
         pass
 
@@ -324,7 +284,10 @@ async def test_check_alert_workflow_records_errored_check_on_permanent_evaluatio
             "posthog.temporal.alerts.activities.check_alert_for_insight",
             side_effect=PermanentError("insight query broken"),
         ),
-        patch("posthog.tasks.alerts.utils.send_notifications_for_errors") as mock_send_errors,
+        patch(
+            "posthog.tasks.alerts.utils.send_notifications_for_errors",
+            return_value=["alerts-wf-test@posthog.com"],
+        ) as mock_send_errors,
     ):
         await _run_check_alert_workflow(
             alert_id=str(alert_with_subscriber.id),
@@ -343,7 +306,7 @@ async def test_check_alert_workflow_records_errored_check_on_permanent_evaluatio
 
     mock_send_errors.assert_called_once()
 
-    # Error captured → alert degraded (state=ERRORED), not a workflow failure → SLO=SUCCESS.
     completed_props = _completed_slo_props(mock_slo_analytics)
+    # Errored evaluation = degraded alert, not a workflow failure → SLO stays SUCCESS.
     assert completed_props["outcome"] == SloOutcome.SUCCESS
     assert completed_props["alert_state"] == AlertState.ERRORED

--- a/posthog/temporal/tests/test_alerts_workflows.py
+++ b/posthog/temporal/tests/test_alerts_workflows.py
@@ -1,11 +1,37 @@
+import uuid
 import datetime as dt
+from concurrent.futures import ThreadPoolExecutor
 
 import pytest
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
-from temporalio.client import Schedule, ScheduleActionStartWorkflow, ScheduleOverlapPolicy, ScheduleSpec
+from django.conf import settings
 
+import pytest_asyncio
+from asgiref.sync import sync_to_async
+from temporalio.client import Client, Schedule, ScheduleActionStartWorkflow, ScheduleOverlapPolicy, ScheduleSpec
+from temporalio.testing import WorkflowEnvironment
+from temporalio.worker import UnsandboxedWorkflowRunner, Worker
+
+from posthog.schema import (
+    AlertCalculationInterval,
+    AlertState,
+    ChartDisplayType,
+    EventsNode,
+    IntervalType,
+    TrendsFilter,
+    TrendsQuery,
+)
+
+from posthog.models import AlertConfiguration, Insight, User
+from posthog.models.alert import AlertCheck
+from posthog.slo.types import SloArea, SloConfig, SloOperation, SloOutcome
+from posthog.tasks.alerts.utils import AlertEvaluationResult
+from posthog.temporal.alerts.activities import evaluate_alert, notify_alert, prepare_alert
 from posthog.temporal.alerts.schedule import create_schedule_due_alert_checks_schedule
+from posthog.temporal.alerts.types import CheckAlertWorkflowInputs, SkipReason
+from posthog.temporal.alerts.workflows import CheckAlertWorkflow
+from posthog.temporal.common.slo_interceptor import SloInterceptor
 
 
 def test_schedule_is_registered_in_init_schedules():
@@ -69,3 +95,255 @@ async def test_create_schedule_updates_when_present():
 
     mock_update.assert_awaited_once()
     mock_create.assert_not_awaited()
+
+
+# ─── CheckAlertWorkflow integration tests ────────────────────────────
+#
+# Exercise the full prepare → evaluate → notify chain against a real Postgres
+# DB with mocked ClickHouse + SMTP. Catches wiring regressions between the
+# workflow and activities — e.g., missing fields on activity inputs.
+
+
+CHECK_ALERT_ACTIVITIES = [prepare_alert, evaluate_alert, notify_alert]
+
+
+def _valid_trends_query() -> dict:
+    return TrendsQuery(
+        series=[EventsNode(event="$pageview")],
+        interval=IntervalType.DAY,
+        trendsFilter=TrendsFilter(display=ChartDisplayType.BOLD_NUMBER),
+    ).model_dump()
+
+
+@sync_to_async
+def _create_alert(ateam, *, insight_deleted: bool = False, enabled: bool = True) -> AlertConfiguration:
+    insight = Insight.objects.create(team=ateam, name="insight", query=_valid_trends_query(), deleted=insight_deleted)
+    return AlertConfiguration.objects.create(
+        team=ateam,
+        insight=insight,
+        name="wf-test-alert",
+        enabled=enabled,
+        calculation_interval=AlertCalculationInterval.DAILY.value,
+        config={"type": "TrendsAlertConfig", "series_index": 0},
+        condition={"type": "absolute_value"},
+    )
+
+
+@pytest_asyncio.fixture
+async def alert_with_subscriber(ateam, aorganization):
+    @sync_to_async
+    def _create() -> AlertConfiguration:
+        user = User.objects.create_and_join(
+            organization=aorganization,
+            email=f"alerts-wf-{uuid.uuid4().hex[:6]}@posthog.com",
+            password=None,
+        )
+        alert = AlertConfiguration.objects.create(
+            team=ateam,
+            insight=Insight.objects.create(team=ateam, name="insight", query=_valid_trends_query()),
+            name="wf-test-alert",
+            enabled=True,
+            calculation_interval=AlertCalculationInterval.DAILY.value,
+            config={"type": "TrendsAlertConfig", "series_index": 0},
+            condition={"type": "absolute_value"},
+        )
+        alert.subscribed_users.add(user)
+        return alert
+
+    return await _create()
+
+
+def _slo_config(alert: AlertConfiguration) -> SloConfig:
+    return SloConfig(
+        operation=SloOperation.ALERT_CHECK,
+        area=SloArea.ANALYTIC_PLATFORM,
+        team_id=alert.team_id,
+        resource_id=str(alert.id),
+        distinct_id=str(alert.id),
+        start_properties={"calculation_interval": alert.calculation_interval, "insight_id": alert.insight_id},
+        completion_properties={
+            "calculation_interval": alert.calculation_interval,
+            "insight_id": alert.insight_id,
+        },
+    )
+
+
+async def _run_check_alert_workflow(alert_id: str, slo: SloConfig, team_id: int, insight_id: int) -> None:
+    """Spin up a WorkflowEnvironment + Worker and execute CheckAlertWorkflow.
+
+    Caller patches the boundaries (check_alert_for_insight, send_notifications_for_breaches)
+    before invoking. The workflow runs to completion (including its `finally` SLO cleanup).
+    """
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+        async with Worker(
+            env.client,
+            task_queue=settings.TEMPORAL_TASK_QUEUE,
+            workflows=[CheckAlertWorkflow],
+            activities=CHECK_ALERT_ACTIVITIES,
+            interceptors=[SloInterceptor()],
+            workflow_runner=UnsandboxedWorkflowRunner(),
+            activity_executor=ThreadPoolExecutor(max_workers=2),
+            debug_mode=True,
+        ):
+            await env.client.execute_workflow(
+                CheckAlertWorkflow.run,
+                CheckAlertWorkflowInputs(
+                    alert_id=alert_id,
+                    team_id=team_id,
+                    distinct_id=alert_id,
+                    calculation_interval=AlertCalculationInterval.DAILY.value,
+                    insight_id=insight_id,
+                    slo=slo,
+                ),
+                id=f"check-alert-{uuid.uuid4()}",
+                task_queue=settings.TEMPORAL_TASK_QUEUE,
+            )
+
+
+def _completed_slo_props(mock_slo_analytics: MagicMock) -> dict:
+    completed = [
+        c for c in mock_slo_analytics.capture.call_args_list if c.kwargs.get("event") == "slo_operation_completed"
+    ]
+    assert len(completed) == 1, f"expected 1 SLO completion event, got {len(completed)}"
+    return completed[0].kwargs["properties"]
+
+
+@patch("posthog.slo.events.posthoganalytics")
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_check_alert_workflow_firing_drives_full_chain_with_slo(
+    mock_slo_analytics: MagicMock,
+    temporal_client: Client,
+    alert_with_subscriber: AlertConfiguration,
+) -> None:
+    evaluation_result = AlertEvaluationResult(value=100.0, breaches=["value above threshold"])
+    recipients = ["alerts-wf-test@posthog.com"]
+
+    with (
+        patch("posthog.temporal.alerts.activities.check_alert_for_insight", return_value=evaluation_result),
+        patch(
+            "posthog.tasks.alerts.utils.send_notifications_for_breaches", return_value=recipients
+        ) as mock_send_breaches,
+    ):
+        await _run_check_alert_workflow(
+            alert_id=str(alert_with_subscriber.id),
+            slo=_slo_config(alert_with_subscriber),
+            team_id=alert_with_subscriber.team_id,
+            insight_id=alert_with_subscriber.insight_id,
+        )
+
+    checks = await sync_to_async(lambda: list(AlertCheck.objects.filter(alert_configuration=alert_with_subscriber)))()
+    assert len(checks) == 1
+    check = checks[0]
+    assert check.state == AlertState.FIRING
+    assert check.targets_notified == {"users": recipients}
+
+    # Contract: workflow pipes breaches from evaluate into notify inputs, and the
+    # idempotency_key is the AlertCheck id (so MessagingRecord dedupes retries).
+    mock_send_breaches.assert_called_once()
+    _, pos_args, kw_args = mock_send_breaches.mock_calls[0]
+    passed_breaches = pos_args[1] if len(pos_args) > 1 else kw_args.get("breaches")
+    assert passed_breaches == ["value above threshold"]
+    assert kw_args.get("idempotency_key") == str(check.id)
+
+    started_calls = [
+        c for c in mock_slo_analytics.capture.call_args_list if c.kwargs.get("event") == "slo_operation_started"
+    ]
+    assert len(started_calls) == 1
+    completed_props = _completed_slo_props(mock_slo_analytics)
+    assert completed_props["outcome"] == SloOutcome.SUCCESS
+    assert completed_props["alert_state"] == AlertState.FIRING
+    assert completed_props["calculation_interval"] == alert_with_subscriber.calculation_interval
+
+
+@pytest.mark.parametrize(
+    "setup,expected_reason",
+    [
+        pytest.param(
+            lambda ateam: _create_alert(ateam, insight_deleted=True),
+            SkipReason.INSIGHT_DELETED,
+            id="insight_deleted",
+        ),
+        pytest.param(
+            lambda ateam: _create_alert(ateam, enabled=False),
+            SkipReason.NOT_FOUND,
+            id="disabled_treated_as_not_found",
+        ),
+    ],
+)
+@patch("posthog.slo.events.posthoganalytics")
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_check_alert_workflow_skip_short_circuits_before_evaluate(
+    mock_slo_analytics: MagicMock,
+    temporal_client: Client,
+    ateam,
+    setup,
+    expected_reason: SkipReason,
+) -> None:
+    alert = await setup(ateam)
+
+    with (
+        patch("posthog.temporal.alerts.activities.check_alert_for_insight") as mock_ch_query,
+        patch("posthog.tasks.alerts.utils.send_notifications_for_breaches") as mock_send_breaches,
+    ):
+        await _run_check_alert_workflow(
+            alert_id=str(alert.id),
+            slo=_slo_config(alert),
+            team_id=alert.team_id,
+            insight_id=alert.insight_id,
+        )
+
+    check_count = await sync_to_async(AlertCheck.objects.filter(alert_configuration=alert).count)()
+    assert check_count == 0
+    mock_ch_query.assert_not_called()
+    mock_send_breaches.assert_not_called()
+
+    completed_props = _completed_slo_props(mock_slo_analytics)
+    assert completed_props["outcome"] == SloOutcome.SUCCESS
+    assert completed_props.get("skip_reason") == expected_reason
+    assert "alert_state" not in completed_props
+
+
+@patch("posthog.slo.events.posthoganalytics")
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_check_alert_workflow_records_errored_check_on_permanent_evaluation_failure(
+    mock_slo_analytics: MagicMock,
+    temporal_client: Client,
+    alert_with_subscriber: AlertConfiguration,
+) -> None:
+    # Permanent evaluation errors are captured into AlertCheck.error (not re-raised),
+    # so the workflow completes normally with state=ERRORED and the notify activity
+    # fires error notifications. This exercises the "error" path end-to-end.
+    class PermanentError(Exception):
+        pass
+
+    with (
+        patch(
+            "posthog.temporal.alerts.activities.check_alert_for_insight",
+            side_effect=PermanentError("insight query broken"),
+        ),
+        patch("posthog.tasks.alerts.utils.send_notifications_for_errors") as mock_send_errors,
+    ):
+        await _run_check_alert_workflow(
+            alert_id=str(alert_with_subscriber.id),
+            slo=_slo_config(alert_with_subscriber),
+            team_id=alert_with_subscriber.team_id,
+            insight_id=alert_with_subscriber.insight_id,
+        )
+
+    check = await sync_to_async(
+        lambda: AlertCheck.objects.filter(alert_configuration=alert_with_subscriber).order_by("-created_at").first()
+    )()
+    assert check is not None
+    assert check.state == AlertState.ERRORED
+    assert check.error is not None
+    assert "insight query broken" in check.error["message"]
+
+    mock_send_errors.assert_called_once()
+
+    # Error captured → alert degraded (state=ERRORED), not a workflow failure → SLO=SUCCESS.
+    completed_props = _completed_slo_props(mock_slo_analytics)
+    assert completed_props["outcome"] == SloOutcome.SUCCESS
+    assert completed_props["alert_state"] == AlertState.ERRORED

--- a/posthog/temporal/tests/test_alerts_workflows.py
+++ b/posthog/temporal/tests/test_alerts_workflows.py
@@ -66,16 +66,19 @@ async def test_create_schedule_routes_by_existence(
     assert mock_create.await_count == (1 if expect_create else 0)
     assert mock_update.await_count == (1 if expect_update else 0)
 
-    # On the create path, validate the Schedule shape we register.
+    # Same Schedule shape must be registered on both paths — a stale config
+    # passed to a_update_schedule would silently ship otherwise.
+    invoked = mock_create if expect_create else mock_update
+    assert invoked.await_args is not None
+    schedule_arg = invoked.await_args.args[2]
+    assert isinstance(schedule_arg, Schedule)
+    assert isinstance(schedule_arg.spec, ScheduleSpec)
+    assert schedule_arg.spec.cron_expressions == ["*/2 * * * *"]
+    assert schedule_arg.policy.overlap == ScheduleOverlapPolicy.ALLOW_ALL
+    assert isinstance(schedule_arg.action, ScheduleActionStartWorkflow)
+    assert schedule_arg.action.execution_timeout == dt.timedelta(minutes=10)
+
     if expect_create:
-        assert mock_create.await_args is not None
-        schedule_arg = mock_create.await_args.args[2]
-        assert isinstance(schedule_arg, Schedule)
-        assert isinstance(schedule_arg.spec, ScheduleSpec)
-        assert schedule_arg.spec.cron_expressions == ["*/2 * * * *"]
-        assert schedule_arg.policy.overlap == ScheduleOverlapPolicy.ALLOW_ALL
-        assert isinstance(schedule_arg.action, ScheduleActionStartWorkflow)
-        assert schedule_arg.action.execution_timeout == dt.timedelta(minutes=10)
         assert mock_create.await_args.kwargs.get("trigger_immediately") is False
 
 
@@ -90,8 +93,7 @@ def _valid_trends_query() -> dict:
     ).model_dump()
 
 
-@sync_to_async
-def _create_alert(ateam, *, insight_deleted: bool = False, enabled: bool = True) -> AlertConfiguration:
+def _build_alert(ateam, *, insight_deleted: bool = False, enabled: bool = True) -> AlertConfiguration:
     insight = Insight.objects.create(team=ateam, name="insight", query=_valid_trends_query(), deleted=insight_deleted)
     return AlertConfiguration.objects.create(
         team=ateam,
@@ -104,6 +106,11 @@ def _create_alert(ateam, *, insight_deleted: bool = False, enabled: bool = True)
     )
 
 
+@sync_to_async
+def _create_alert(ateam, *, insight_deleted: bool = False, enabled: bool = True) -> AlertConfiguration:
+    return _build_alert(ateam, insight_deleted=insight_deleted, enabled=enabled)
+
+
 @pytest_asyncio.fixture
 async def alert_with_subscriber(ateam, aorganization):
     @sync_to_async
@@ -113,15 +120,7 @@ async def alert_with_subscriber(ateam, aorganization):
             email=f"alerts-wf-{uuid.uuid4().hex[:6]}@posthog.com",
             password=None,
         )
-        alert = AlertConfiguration.objects.create(
-            team=ateam,
-            insight=Insight.objects.create(team=ateam, name="insight", query=_valid_trends_query()),
-            name="wf-test-alert",
-            enabled=True,
-            calculation_interval=AlertCalculationInterval.DAILY.value,
-            config={"type": "TrendsAlertConfig", "series_index": 0},
-            condition={"type": "absolute_value"},
-        )
+        alert = _build_alert(ateam)
         alert.subscribed_users.add(user)
         return alert
 

--- a/posthog/temporal/tests/test_alerts_workflows.py
+++ b/posthog/temporal/tests/test_alerts_workflows.py
@@ -1,0 +1,71 @@
+import datetime as dt
+
+import pytest
+from unittest.mock import AsyncMock, patch
+
+from temporalio.client import Schedule, ScheduleActionStartWorkflow, ScheduleOverlapPolicy, ScheduleSpec
+
+from posthog.temporal.alerts.schedule import create_schedule_due_alert_checks_schedule
+
+
+def test_schedule_is_registered_in_init_schedules():
+    from posthog.temporal.schedule import schedules
+
+    assert create_schedule_due_alert_checks_schedule in schedules
+
+
+@pytest.mark.asyncio
+async def test_create_schedule_creates_when_absent():
+    mock_client = AsyncMock()
+    with (
+        patch(
+            "posthog.temporal.alerts.schedule.a_schedule_exists",
+            new=AsyncMock(return_value=False),
+        ),
+        patch(
+            "posthog.temporal.alerts.schedule.a_create_schedule",
+            new=AsyncMock(),
+        ) as mock_create,
+        patch(
+            "posthog.temporal.alerts.schedule.a_update_schedule",
+            new=AsyncMock(),
+        ) as mock_update,
+    ):
+        await create_schedule_due_alert_checks_schedule(mock_client)
+
+    mock_create.assert_awaited_once()
+    mock_update.assert_not_awaited()
+
+    call_args = mock_create.await_args
+    assert call_args is not None
+    schedule_arg = call_args.args[2]
+    assert isinstance(schedule_arg, Schedule)
+    assert isinstance(schedule_arg.spec, ScheduleSpec)
+    assert schedule_arg.spec.cron_expressions == ["*/2 * * * *"]
+    assert schedule_arg.policy.overlap == ScheduleOverlapPolicy.ALLOW_ALL
+    assert isinstance(schedule_arg.action, ScheduleActionStartWorkflow)
+    assert schedule_arg.action.execution_timeout == dt.timedelta(minutes=10)
+    assert call_args.kwargs.get("trigger_immediately") is False
+
+
+@pytest.mark.asyncio
+async def test_create_schedule_updates_when_present():
+    mock_client = AsyncMock()
+    with (
+        patch(
+            "posthog.temporal.alerts.schedule.a_schedule_exists",
+            new=AsyncMock(return_value=True),
+        ),
+        patch(
+            "posthog.temporal.alerts.schedule.a_create_schedule",
+            new=AsyncMock(),
+        ) as mock_create,
+        patch(
+            "posthog.temporal.alerts.schedule.a_update_schedule",
+            new=AsyncMock(),
+        ) as mock_update,
+    ):
+        await create_schedule_due_alert_checks_schedule(mock_client)
+
+    mock_update.assert_awaited_once()
+    mock_create.assert_not_awaited()


### PR DESCRIPTION
## Problem

This PR migrates the Alert checks from Celery to Temporal and therefore allows us to completely clean up the Celery flow afterwards (done in the next PR in this stack).

## Changes

- Removed the `check_alerts_task` Celery periodic task (every 2 minutes) and its import from `scheduled.py`.
- Added `create_schedule_due_alert_checks_schedule` to the Temporal `schedules` list so it is registered on startup alongside other Temporal schedules.
- Introduced `posthog/temporal/tests/test_alerts_workflows.py` with integration tests covering:
    - Verification that the new schedule is registered in `schedules`.
    - Schedule creation vs. update routing based on whether the schedule already exists, including validation of the cron expression (`*/2 * * * *`), overlap policy (`ALLOW_ALL`), and execution timeout (10 minutes).
    - Full end-to-end `CheckAlertWorkflow` execution for a firing alert, asserting the `AlertCheck` record state, notification delivery with idempotency key, and SLO completion event with `SUCCESS` outcome.
    - Skip short-circuit behaviour for disabled alerts and alerts with deleted insights, asserting no `AlertCheck` is created, no evaluation or notification occurs, and the SLO event carries the correct `skip_reason`.
    - Permanent evaluation failure path, asserting an `ERRORED` `AlertCheck` is persisted, error notifications are sent, and the SLO outcome remains `SUCCESS` (degraded alert, not a workflow failure).

## How did you test this code?

Covered by the new automated tests in `posthog/temporal/tests/test_alerts_workflows.py`. These tests use `temporalio.testing.WorkflowEnvironment` with time-skipping and an `UnsandboxedWorkflowRunner` to execute the full workflow against a real Django test database, patching only external I/O boundaries (`check_alert_for_insight`, `send_notifications_for_breaches`, `send_notifications_for_errors`).

:white_check_mark: Alert schedule registers correctly

![CleanShot 2026-04-22 at 15.13.36@2x.png](https://app.graphite.com/user-attachments/assets/1128d563-fdff-4856-bf13-4f9e94a1e213.png)

![CleanShot 2026-04-22 at 15.13.50@2x.png](https://app.graphite.com/user-attachments/assets/b7305fd3-4008-4762-b83a-614c8291e185.png)

:white_check_mark: Alert checks now pass correctly through Temporal:

![CleanShot 2026-04-22 at 15.14.35@2x.png](https://app.graphite.com/user-attachments/assets/b76a0c87-742c-4f36-8ba3-9d59d0f73663.png)

![CleanShot 2026-04-22 at 15.15.01@2x.png](https://app.graphite.com/user-attachments/assets/ec37cc97-0ac8-451f-948e-43ef1788baa8.png)



## ![CleanShot 2026-04-22 at 15.15.08@2x.png](https://app.graphite.com/user-attachments/assets/d60378c8-5ad6-49df-93d6-e2dfdd0daeb3.png)

![CleanShot 2026-04-22 at 15.15.30@2x.png](https://app.graphite.com/user-attachments/assets/defd77fb-5979-4912-a4fa-dc77d405cd39.png)



## Publish to changelog?

No