### PR TITLE
feat: Added surveys api endpoint to rust

### DIFF
--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -61,6 +61,13 @@ services:
                         path /flags/*
                     }
 
+                    @surveys {
+                        path /surveys
+                        path /surveys/
+                        path /api/surveys
+                        path /api/surveys/
+                    }
+
                     @webhooks {
                         path /public/webhooks
                         path /public/webhooks/
@@ -99,6 +106,10 @@ services:
                     }
 
                     handle @flags {
+                        reverse_proxy feature-flags:3001
+                    }
+
+                    handle @surveys {
                         reverse_proxy feature-flags:3001
                     }
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -53,6 +53,13 @@ services:
                         path /flags*
                     }
 
+                    @surveys {
+                        path /surveys
+                        path /surveys/
+                        path /api/surveys
+                        path /api/surveys/
+                    }
+
                     @webhooks {
                         path /public/webhooks
                         path /public/webhooks/*
@@ -77,6 +84,10 @@ services:
                     }
 
                     handle @flags {
+                        reverse_proxy feature-flags:3001
+                    }
+
+                    handle @surveys {
                         reverse_proxy feature-flags:3001
                     }
 

--- a/docker-compose.sandbox.yml
+++ b/docker-compose.sandbox.yml
@@ -60,6 +60,13 @@ services:
                         path /flags*
                     }
 
+                    @surveys {
+                        path /surveys
+                        path /surveys/
+                        path /api/surveys
+                        path /api/surveys/
+                    }
+
                     @webhooks {
                         path /public/webhooks
                         path /public/webhooks/*
@@ -88,6 +95,10 @@ services:
                     }
 
                     handle @flags {
+                        reverse_proxy app:3001
+                    }
+
+                    handle @surveys {
                         reverse_proxy app:3001
                     }
 

--- a/rust/feature-flags/src/api/mod.rs
+++ b/rust/feature-flags/src/api/mod.rs
@@ -6,4 +6,5 @@ pub mod flag_definitions_rate_limiter;
 pub mod flags_rate_limiter;
 pub mod pak_usage;
 pub mod rate_parser;
+pub mod surveys;
 pub mod types;

--- a/rust/feature-flags/src/api/surveys.rs
+++ b/rust/feature-flags/src/api/surveys.rs
@@ -1,0 +1,133 @@
+use crate::{
+    api::errors::FlagError,
+    router::State as AppState,
+};
+use axum::{
+    debug_handler,
+    extract::{Query, State},
+    http::{Method, StatusCode},
+    response::{IntoResponse, Json, Response},
+};
+use common_hypercache::{KeyType, HYPER_CACHE_EMPTY_VALUE};
+use serde::{Deserialize, Serialize};
+use tracing::info;
+
+/// Query parameters for the surveys endpoint.
+/// Accepts `token` to identify the project — no auth required (public endpoint).
+#[derive(Debug, Deserialize, Serialize)]
+pub struct SurveysQueryParams {
+    pub token: Option<String>,
+}
+
+/// Surveys endpoint handler
+///
+/// Serves pre-cached survey definitions from HyperCache. This is a public endpoint
+/// that only requires a project API token (no secret key or personal API key).
+///
+/// Mirrors Django's `POST /api/surveys` behavior:
+/// - Token passed as query param or form body
+/// - No authentication beyond token validation
+/// - Returns cached `{"surveys": [...], "survey_config": {...}}`
+#[debug_handler]
+pub async fn surveys_endpoint(
+    State(state): State<AppState>,
+    Query(params): Query<SurveysQueryParams>,
+    method: Method,
+) -> Result<Response, FlagError> {
+    info!(
+        method = %method,
+        token = ?params.token,
+        "Processing surveys request"
+    );
+
+    match method {
+        Method::HEAD => {
+            return Ok((
+                StatusCode::OK,
+                [("content-type", "application/json")],
+                axum::body::Body::empty(),
+            )
+                .into_response());
+        }
+        Method::OPTIONS => {
+            return Ok(
+                (StatusCode::NO_CONTENT, [("allow", "GET, POST, OPTIONS, HEAD")]).into_response(),
+            );
+        }
+        _ => {} // GET and POST proceed below
+    }
+
+    let token = params.token.ok_or(FlagError::NoTokenError)?;
+
+    if token.is_empty() {
+        return Err(FlagError::NoTokenError);
+    }
+
+    let key = KeyType::string(&token);
+
+    let value = match state.surveys_hypercache_reader.get(&key).await {
+        Ok(v) => v,
+        Err(e) => {
+            info!(
+                token = %token,
+                error = %e,
+                "Surveys cache miss"
+            );
+            // Return empty surveys response on cache miss, matching Django fallback behavior
+            return Ok(Json(serde_json::json!({
+                "surveys": [],
+                "survey_config": null
+            }))
+            .into_response());
+        }
+    };
+
+    // Handle null / missing marker
+    if value.is_null() {
+        return Ok(Json(serde_json::json!({
+            "surveys": [],
+            "survey_config": null
+        }))
+        .into_response());
+    }
+    if let Some(s) = value.as_str() {
+        if s == HYPER_CACHE_EMPTY_VALUE {
+            return Ok(Json(serde_json::json!({
+                "surveys": [],
+                "survey_config": null
+            }))
+            .into_response());
+        }
+    }
+
+    Ok(Json(value).into_response())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn test_empty_token_is_missing() {
+        let params = SurveysQueryParams { token: None };
+        assert!(params.token.is_none());
+    }
+
+    #[test]
+    fn test_query_params_deserialize() {
+        let params: SurveysQueryParams =
+            serde_json::from_str(r#"{"token": "phc_test"}"#).unwrap();
+        assert_eq!(params.token.as_deref(), Some("phc_test"));
+    }
+
+    #[test]
+    fn test_empty_surveys_response_shape() {
+        let response = json!({
+            "surveys": [],
+            "survey_config": null
+        });
+        assert!(response.get("surveys").unwrap().as_array().unwrap().is_empty());
+        assert!(response.get("survey_config").unwrap().is_null());
+    }
+}

--- a/rust/feature-flags/src/api/surveys.rs
+++ b/rust/feature-flags/src/api/surveys.rs
@@ -1,7 +1,4 @@
-use crate::{
-    api::errors::FlagError,
-    router::State as AppState,
-};
+use crate::{api::errors::FlagError, router::State as AppState};
 use axum::{
     debug_handler,
     extract::{Query, State},
@@ -50,9 +47,11 @@ pub async fn surveys_endpoint(
                 .into_response());
         }
         Method::OPTIONS => {
-            return Ok(
-                (StatusCode::NO_CONTENT, [("allow", "GET, POST, OPTIONS, HEAD")]).into_response(),
-            );
+            return Ok((
+                StatusCode::NO_CONTENT,
+                [("allow", "GET, POST, OPTIONS, HEAD")],
+            )
+                .into_response());
         }
         _ => {} // GET and POST proceed below
     }
@@ -116,8 +115,7 @@ mod tests {
 
     #[test]
     fn test_query_params_deserialize() {
-        let params: SurveysQueryParams =
-            serde_json::from_str(r#"{"token": "phc_test"}"#).unwrap();
+        let params: SurveysQueryParams = serde_json::from_str(r#"{"token": "phc_test"}"#).unwrap();
         assert_eq!(params.token.as_deref(), Some("phc_test"));
     }
 
@@ -127,7 +125,12 @@ mod tests {
             "surveys": [],
             "survey_config": null
         });
-        assert!(response.get("surveys").unwrap().as_array().unwrap().is_empty());
+        assert!(response
+            .get("surveys")
+            .unwrap()
+            .as_array()
+            .unwrap()
+            .is_empty());
         assert!(response.get("survey_config").unwrap().is_null());
     }
 }

--- a/rust/feature-flags/src/config.rs
+++ b/rust/feature-flags/src/config.rs
@@ -45,6 +45,7 @@ pub enum ServiceMode {
     All,         // default — both fleets (current behavior)
     Flags,       // /flags and /decide only
     Definitions, // /flags/definitions only
+    Surveys,     // /surveys only
 }
 
 impl FromStr for ServiceMode {
@@ -55,8 +56,9 @@ impl FromStr for ServiceMode {
             "all" => Ok(ServiceMode::All),
             "flags" => Ok(ServiceMode::Flags),
             "definitions" => Ok(ServiceMode::Definitions),
+            "surveys" => Ok(ServiceMode::Surveys),
             _ => Err(format!(
-                "Invalid SERVICE_MODE: '{s}'. Expected 'all', 'flags', or 'definitions'"
+                "Invalid SERVICE_MODE: '{s}'. Expected 'all', 'flags', 'definitions', or 'surveys'"
             )),
         }
     }
@@ -1345,12 +1347,20 @@ mod service_mode_tests {
             "definitions".parse::<ServiceMode>().unwrap(),
             ServiceMode::Definitions
         );
+        assert_eq!(
+            "surveys".parse::<ServiceMode>().unwrap(),
+            ServiceMode::Surveys
+        );
         // case insensitive
         assert_eq!("ALL".parse::<ServiceMode>().unwrap(), ServiceMode::All);
         assert_eq!("Flags".parse::<ServiceMode>().unwrap(), ServiceMode::Flags);
         assert_eq!(
             "DEFINITIONS".parse::<ServiceMode>().unwrap(),
             ServiceMode::Definitions
+        );
+        assert_eq!(
+            "SURVEYS".parse::<ServiceMode>().unwrap(),
+            ServiceMode::Surveys
         );
     }
 

--- a/rust/feature-flags/src/router.rs
+++ b/rust/feature-flags/src/router.rs
@@ -33,9 +33,10 @@ use tower_http::{
 
 use crate::{
     api::{
-        endpoint, flag_definitions, surveys,
+        endpoint, flag_definitions,
         flag_definitions_rate_limiter::FlagDefinitionsRateLimiter,
         flags_rate_limiter::{FlagsRateLimiter, IpRateLimiter},
+        surveys,
     },
     cohorts::{cohort_cache_manager::CohortCacheManager, membership::CohortMembershipProvider},
     config::{Config, ServiceMode, TeamIdCollection},
@@ -277,10 +278,7 @@ pub fn router(
             );
     }
 
-    if matches!(
-        config.service_mode,
-        ServiceMode::All | ServiceMode::Surveys
-    ) {
+    if matches!(config.service_mode, ServiceMode::All | ServiceMode::Surveys) {
         flags_router = flags_router
             .route("/surveys", any(surveys::surveys_endpoint))
             .route("/surveys/", any(surveys::surveys_endpoint))

--- a/rust/feature-flags/src/router.rs
+++ b/rust/feature-flags/src/router.rs
@@ -33,7 +33,7 @@ use tower_http::{
 
 use crate::{
     api::{
-        endpoint, flag_definitions,
+        endpoint, flag_definitions, surveys,
         flag_definitions_rate_limiter::FlagDefinitionsRateLimiter,
         flags_rate_limiter::{FlagsRateLimiter, IpRateLimiter},
     },
@@ -84,6 +84,10 @@ pub struct State {
     /// Reads pre-computed config from Python's RemoteConfig.build_config()
     /// Uses token-based lookup (api_token)
     pub config_hypercache_reader: Arc<HyperCacheReader>,
+    /// Pre-initialized HyperCacheReader for surveys (surveys/surveys.json)
+    /// Reads pre-computed survey definitions from Python's surveys_hypercache
+    /// Uses token-based lookup (api_token)
+    pub surveys_hypercache_reader: Arc<HyperCacheReader>,
     /// Bounds concurrent large-batch dispatches to the Rayon pool
     pub rayon_dispatcher: RayonDispatcher,
     /// In-memory negative cache for invalid API tokens, preventing repeated
@@ -112,6 +116,7 @@ pub fn router(
     flags_with_cohorts_hypercache_reader: Arc<HyperCacheReader>,
     team_hypercache_reader: Arc<HyperCacheReader>,
     config_hypercache_reader: Arc<HyperCacheReader>,
+    surveys_hypercache_reader: Arc<HyperCacheReader>,
     rayon_dispatcher: RayonDispatcher,
     team_negative_cache: NegativeCache,
     auth_token_cache: Arc<ReadThroughCacheWithMetrics>,
@@ -198,6 +203,7 @@ pub fn router(
         flags_with_cohorts_hypercache_reader,
         team_hypercache_reader,
         config_hypercache_reader,
+        surveys_hypercache_reader,
         rayon_dispatcher,
         team_negative_cache,
         cohort_membership_provider,
@@ -269,6 +275,18 @@ pub fn router(
                 "/api/feature_flag/local_evaluation/",
                 any(flag_definitions::flags_definitions),
             );
+    }
+
+    if matches!(
+        config.service_mode,
+        ServiceMode::All | ServiceMode::Surveys
+    ) {
+        flags_router = flags_router
+            .route("/surveys", any(surveys::surveys_endpoint))
+            .route("/surveys/", any(surveys::surveys_endpoint))
+            // Alias for Django's surveys endpoint
+            .route("/api/surveys", any(surveys::surveys_endpoint))
+            .route("/api/surveys/", any(surveys::surveys_endpoint));
     }
 
     let flags_router = flags_router

--- a/rust/feature-flags/src/server.rs
+++ b/rust/feature-flags/src/server.rs
@@ -345,6 +345,37 @@ pub async fn serve<F>(
             }
         };
 
+    // Create HyperCacheReader for surveys (surveys/surveys.json)
+    // Reads pre-computed survey definitions from Python's surveys_hypercache
+    // Uses token-based lookup (api_token) to match Python's HyperCache key pattern
+    let surveys_redis_client = dedicated_redis_client
+        .clone()
+        .unwrap_or_else(|| redis_client.clone());
+
+    let mut surveys_hypercache_config = HyperCacheConfig::new(
+        "surveys".to_string(),
+        "surveys.json".to_string(),
+        config.object_storage_region.clone(),
+        config.object_storage_bucket.clone(),
+    );
+    surveys_hypercache_config.token_based = true;
+
+    if !config.object_storage_endpoint.is_empty() {
+        surveys_hypercache_config.s3_endpoint = Some(config.object_storage_endpoint.clone());
+    }
+
+    let surveys_hypercache_reader =
+        match HyperCacheReader::new(surveys_redis_client, surveys_hypercache_config).await {
+            Ok(reader) => {
+                tracing::info!("Created HyperCacheReader for surveys");
+                Arc::new(reader)
+            }
+            Err(e) => {
+                tracing::error!("Failed to create surveys HyperCacheReader: {:?}", e);
+                return;
+            }
+        };
+
     let team_negative_cache = NegativeCache::new(
         config.team_negative_cache_capacity,
         config.team_negative_cache_ttl_seconds,
@@ -417,6 +448,7 @@ pub async fn serve<F>(
         flags_with_cohorts_hypercache_reader,
         team_hypercache_reader,
         config_hypercache_reader,
+        surveys_hypercache_reader,
         rayon_dispatcher,
         team_negative_cache,
         auth_token_cache,

--- a/rust/feature-flags/src/server.rs
+++ b/rust/feature-flags/src/server.rs
@@ -348,9 +348,9 @@ pub async fn serve<F>(
     // Create HyperCacheReader for surveys (surveys/surveys.json)
     // Reads pre-computed survey definitions from Python's surveys_hypercache
     // Uses token-based lookup (api_token) to match Python's HyperCache key pattern
-    let surveys_redis_client = dedicated_redis_client
-        .clone()
-        .unwrap_or_else(|| redis_client.clone());
+    // Uses the shared Redis client (not dedicated flags Redis) because Django writes
+    // surveys cache to the default Redis database, not the flags-specific one.
+    let surveys_redis_client = redis_client.clone();
 
     let mut surveys_hypercache_config = HyperCacheConfig::new(
         "surveys".to_string(),

--- a/rust/feature-flags/src/utils/test_utils.rs
+++ b/rust/feature-flags/src/utils/test_utils.rs
@@ -328,6 +328,48 @@ pub async fn insert_config_in_hypercache(
     Ok(())
 }
 
+/// Create a HyperCacheReader for surveys (surveys/surveys.json).
+/// Uses token_based=true for token-based lookups (api_token).
+/// Returns Arc<HyperCacheReader> to match the production pattern.
+pub async fn setup_surveys_hypercache_reader(
+    redis_client: Arc<dyn RedisClientTrait + Send + Sync>,
+) -> Arc<HyperCacheReader> {
+    let mut config = HyperCacheConfig::new(
+        "surveys".to_string(),
+        "surveys.json".to_string(),
+        "us-east-1".to_string(),
+        "posthog".to_string(),
+    );
+    config.token_based = true;
+    Arc::new(
+        HyperCacheReader::new(redis_client, config)
+            .await
+            .expect("Failed to create surveys HyperCacheReader"),
+    )
+}
+
+/// Generate the HyperCache key for surveys.
+/// Format: posthog:1:cache/team_tokens/{api_token}/surveys/surveys.json
+pub fn surveys_hypercache_key(api_token: &str) -> String {
+    format!("posthog:1:cache/team_tokens/{api_token}/surveys/surveys.json")
+}
+
+/// Insert survey data in HyperCache for testing.
+/// Use this when testing the surveys cache reader.
+/// Format: Pickle(JSON string) to match Django's cache format.
+pub async fn insert_surveys_in_hypercache(
+    client: Arc<dyn RedisClientTrait + Send + Sync>,
+    api_token: &str,
+    surveys_json: serde_json::Value,
+) -> Result<(), Error> {
+    let json_string = serde_json::to_string(&surveys_json)?;
+    let pickled_bytes =
+        serde_pickle::to_vec(&json_string, Default::default()).expect("Failed to pickle surveys");
+    let cache_key = surveys_hypercache_key(api_token);
+    client.set_bytes(cache_key, pickled_bytes, None).await?;
+    Ok(())
+}
+
 pub fn create_flag_from_json(json_value: Option<String>) -> Vec<FeatureFlag> {
     let payload = match json_value {
         Some(value) => value,

--- a/rust/feature-flags/tests/common/mod.rs
+++ b/rust/feature-flags/tests/common/mod.rs
@@ -331,6 +331,25 @@ impl ServerHandle {
                     }
                 };
 
+            // Create surveys hypercache reader for surveys (surveys/surveys.json)
+            let mut surveys_hypercache_config = HyperCacheConfig::new(
+                "surveys".to_string(),
+                "surveys.json".to_string(),
+                config.object_storage_region.clone(),
+                config.object_storage_bucket.clone(),
+            );
+            surveys_hypercache_config.token_based = true;
+            let surveys_hypercache_reader =
+                match HyperCacheReader::new(redis_reader_client.clone(), surveys_hypercache_config)
+                    .await
+                {
+                    Ok(reader) => Arc::new(reader),
+                    Err(e) => {
+                        tracing::error!("Failed to create surveys HyperCacheReader: {:?}", e);
+                        return;
+                    }
+                };
+
             let group_type_cache = Arc::new(
                 feature_flags::flags::flag_group_type_mapping::GroupTypeCacheManager::new(
                     persons_reader.clone(),
@@ -354,6 +373,7 @@ impl ServerHandle {
                 flags_with_cohorts_hypercache_reader,
                 team_hypercache_reader,
                 config_hypercache_reader,
+                surveys_hypercache_reader,
                 RayonDispatcher::new(2, None),
                 NegativeCache::new(10_000, 300),
                 Arc::new(ReadThroughCacheWithMetrics::new(


### PR DESCRIPTION
## Problem

I've talked about this since forever - now we have the local eval code in place with all hypercache logic covered we can just easily get a dedicated surveys service up and finally deprecate the django version entirely

## Changes

- [x] Adds surveys endpoints utilising most of the same code for the hypercache side of things
- [x] Kept it in /flags codebase for now - might not be the right long term call but this was quickest to get something we can try as a standalone service with mirrored traffic
- [ ] Uses the existing shared redis - i do think we should move to its own / use the flags one but for testing this is easier as we have a 1-1 data source

## Tests

- [x] Some simple tests added given its a very simple endpoint
- [x] Tested locally to ensure it looks correct, especially with changes

## Rollout plan

- [ ] Deploy in parallel
- [ ] Mirror traffic and monitor success rates (mostly looking for missing teams/configs)
- [ ] Gradually move over traffic
- [ ] Follow up and remove the django endpoint