### PR TITLE
fix(funnels): unwrap single-element breakdown value arrays for recording filters

### DIFF
--- a/frontend/src/scenes/funnels/FunnelBarHorizontal/FunnelBarHorizontal.tsx
+++ b/frontend/src/scenes/funnels/FunnelBarHorizontal/FunnelBarHorizontal.tsx
@@ -25,9 +25,9 @@ import {
     formatDroppedOffPercentage,
     getBreakdownMaxIndex,
     getReferenceStep,
+    getStepBreakdownSeries,
     getTooltipTitleForConverted,
     getTooltipTitleForDroppedOff,
-    shouldRenderStepAsBreakdown,
 } from '../funnelUtils'
 import { ValueInspectorButton } from '../ValueInspectorButton'
 import { Bar } from './Bar'
@@ -48,8 +48,6 @@ export function FunnelBarHorizontal({
 
     const { canOpenPersonModal } = useValues(funnelPersonsModalLogic(insightProps))
     const { openPersonsModalForStep, openPersonsModalForSeries } = useActions(funnelPersonsModalLogic(insightProps))
-
-    const hasBreakdown = !!breakdownFilter?.breakdown
 
     const steps = visibleStepsWithConversionMetrics
     const stepReference = funnelsFilter?.funnelStepReference || FunnelStepReference.total
@@ -79,7 +77,23 @@ export function FunnelBarHorizontal({
                         step.nested_breakdown?.reduce((sum, item) => sum + item.count, 0)) ||
                     0
 
-                const isBreakdown = shouldRenderStepAsBreakdown(step.nested_breakdown, hasBreakdown)
+                const isBreakdown =
+                    Array.isArray(step.nested_breakdown) &&
+                    step.nested_breakdown?.length !== undefined &&
+                    !(step.nested_breakdown.length === 1)
+
+                // When the funnel has a breakdown filter that resolves to a single visible value
+                // we still render the non-breakdown layout (so the bar fills correctly), but we
+                // route clicks through openPersonsModalForSeries so the persons modal is scoped
+                // to that breakdown value rather than opened unfiltered.
+                const stepBreakdownSeries = !isBreakdown ? getStepBreakdownSeries(step, breakdownFilter) : null
+                const openStep = (converted: boolean): void => {
+                    if (stepBreakdownSeries) {
+                        openPersonsModalForSeries({ step, series: stepBreakdownSeries, converted })
+                    } else {
+                        openPersonsModalForStep({ step, converted })
+                    }
+                }
 
                 return (
                     <section
@@ -172,7 +186,7 @@ export function FunnelBarHorizontal({
                                     <Bar
                                         name={step.name}
                                         percentage={step.conversionRates.fromBasisStep}
-                                        onBarClick={() => openPersonsModalForStep({ step, converted: true })}
+                                        onBarClick={() => openStep(true)}
                                         step={step.nested_breakdown![0]}
                                         stepIndex={stepIndex}
                                         breakdownFilter={breakdownFilter}
@@ -181,11 +195,7 @@ export function FunnelBarHorizontal({
                                     />
                                     <div
                                         className="funnel-bar-empty-space"
-                                        onClick={
-                                            showPersonsModal
-                                                ? () => openPersonsModalForStep({ step, converted: false }) // dropoff value for steps is negative
-                                                : undefined
-                                        }
+                                        onClick={showPersonsModal ? () => openStep(false) : undefined}
                                         // eslint-disable-next-line react/forbid-dom-props
                                         style={{
                                             flex: `${1 - step.conversionRates.fromBasisStep} 1 0`,
@@ -200,13 +210,7 @@ export function FunnelBarHorizontal({
                                 title={getTooltipTitleForConverted(funnelsFilter, aggregationTargetLabel, stepIndex)}
                                 placement="bottom"
                             >
-                                <ValueInspectorButton
-                                    onClick={
-                                        showPersonsModal
-                                            ? () => openPersonsModalForStep({ step, converted: true })
-                                            : undefined
-                                    }
-                                >
+                                <ValueInspectorButton onClick={showPersonsModal ? () => openStep(true) : undefined}>
                                     <IconTrendingFlat
                                         style={{ color: 'var(--success)' }}
                                         className="value-inspector-button-icon"
@@ -226,11 +230,7 @@ export function FunnelBarHorizontal({
                                         placement="bottom"
                                     >
                                         <ValueInspectorButton
-                                            onClick={
-                                                showPersonsModal
-                                                    ? () => openPersonsModalForStep({ step, converted: false })
-                                                    : undefined
-                                            }
+                                            onClick={showPersonsModal ? () => openStep(false) : undefined}
                                         >
                                             <IconTrendingFlatDown
                                                 style={{ color: 'var(--danger)' }}

--- a/frontend/src/scenes/funnels/FunnelBarHorizontal/FunnelBarHorizontal.tsx
+++ b/frontend/src/scenes/funnels/FunnelBarHorizontal/FunnelBarHorizontal.tsx
@@ -27,6 +27,7 @@ import {
     getReferenceStep,
     getTooltipTitleForConverted,
     getTooltipTitleForDroppedOff,
+    shouldRenderStepAsBreakdown,
 } from '../funnelUtils'
 import { ValueInspectorButton } from '../ValueInspectorButton'
 import { Bar } from './Bar'
@@ -47,6 +48,8 @@ export function FunnelBarHorizontal({
 
     const { canOpenPersonModal } = useValues(funnelPersonsModalLogic(insightProps))
     const { openPersonsModalForStep, openPersonsModalForSeries } = useActions(funnelPersonsModalLogic(insightProps))
+
+    const hasBreakdown = !!breakdownFilter?.breakdown
 
     const steps = visibleStepsWithConversionMetrics
     const stepReference = funnelsFilter?.funnelStepReference || FunnelStepReference.total
@@ -76,10 +79,7 @@ export function FunnelBarHorizontal({
                         step.nested_breakdown?.reduce((sum, item) => sum + item.count, 0)) ||
                     0
 
-                const isBreakdown =
-                    Array.isArray(step.nested_breakdown) &&
-                    step.nested_breakdown?.length !== undefined &&
-                    !(step.nested_breakdown.length === 1)
+                const isBreakdown = shouldRenderStepAsBreakdown(step.nested_breakdown, hasBreakdown)
 
                 return (
                     <section

--- a/frontend/src/scenes/funnels/FunnelBarHorizontal/FunnelBarHorizontal.tsx
+++ b/frontend/src/scenes/funnels/FunnelBarHorizontal/FunnelBarHorizontal.tsx
@@ -82,11 +82,12 @@ export function FunnelBarHorizontal({
                     step.nested_breakdown?.length !== undefined &&
                     !(step.nested_breakdown.length === 1)
 
-                // When the funnel has a breakdown filter that resolves to a single visible value
-                // we still render the non-breakdown layout (so the bar fills correctly), but we
-                // route clicks through openPersonsModalForSeries so the persons modal is scoped
-                // to that breakdown value rather than opened unfiltered.
+                // When a breakdown filter resolves to a single visible value, use that series'
+                // counts and rates for display so the bar/labels match the tooltip instead of
+                // showing aggregate (cross-breakdown) values. Clicks also route through
+                // openPersonsModalForSeries so the persons modal is scoped to that value.
                 const stepBreakdownSeries = !isBreakdown ? getStepBreakdownSeries(step, breakdownFilter) : null
+                const displayStep = stepBreakdownSeries ?? step
                 const openStep = (converted: boolean): void => {
                     if (stepBreakdownSeries) {
                         openPersonsModalForSeries({ step, series: stepBreakdownSeries, converted })
@@ -184,8 +185,8 @@ export function FunnelBarHorizontal({
                             ) : (
                                 <>
                                     <Bar
-                                        name={step.name}
-                                        percentage={step.conversionRates.fromBasisStep}
+                                        name={displayStep.name}
+                                        percentage={displayStep.conversionRates.fromBasisStep}
                                         onBarClick={() => openStep(true)}
                                         step={step.nested_breakdown![0]}
                                         stepIndex={stepIndex}
@@ -198,7 +199,7 @@ export function FunnelBarHorizontal({
                                         onClick={showPersonsModal ? () => openStep(false) : undefined}
                                         // eslint-disable-next-line react/forbid-dom-props
                                         style={{
-                                            flex: `${1 - step.conversionRates.fromBasisStep} 1 0`,
+                                            flex: `${1 - displayStep.conversionRates.fromBasisStep} 1 0`,
                                             cursor: `${showPersonsModal && !inCardView ? 'pointer' : ''}`,
                                         }}
                                     />
@@ -215,11 +216,11 @@ export function FunnelBarHorizontal({
                                         style={{ color: 'var(--success)' }}
                                         className="value-inspector-button-icon"
                                     />
-                                    <b>{formatConvertedCount(step, aggregationTargetLabel)}</b>
+                                    <b>{formatConvertedCount(displayStep, aggregationTargetLabel)}</b>
                                 </ValueInspectorButton>{' '}
                                 {!isFirstStep && (
                                     <span className="text-secondary grow">
-                                        {`(${formatConvertedPercentage(step)}) completed step`}
+                                        {`(${formatConvertedPercentage(displayStep)}) completed step`}
                                     </span>
                                 )}
                             </Tooltip>
@@ -236,10 +237,10 @@ export function FunnelBarHorizontal({
                                                 style={{ color: 'var(--danger)' }}
                                                 className="value-inspector-button-icon"
                                             />
-                                            <b>{formatDroppedOffCount(step, aggregationTargetLabel)}</b>
+                                            <b>{formatDroppedOffCount(displayStep, aggregationTargetLabel)}</b>
                                         </ValueInspectorButton>{' '}
                                         <span className="text-secondary">
-                                            {`(${formatDroppedOffPercentage(step)}) dropped off`}
+                                            {`(${formatDroppedOffPercentage(displayStep)}) dropped off`}
                                         </span>
                                     </Tooltip>
                                 </div>

--- a/frontend/src/scenes/funnels/funnelUtils.test.ts
+++ b/frontend/src/scenes/funnels/funnelUtils.test.ts
@@ -20,9 +20,9 @@ import {
     getLastFilledStep,
     getMeanAndStandardDeviation,
     getReferenceStep,
+    getStepBreakdownSeries,
     getVisibilityKey,
     parseDisplayNameForCorrelation,
-    shouldRenderStepAsBreakdown,
     stepsWithConversionMetrics,
 } from './funnelUtils'
 
@@ -703,51 +703,52 @@ describe('getLastFilledStep', () => {
     })
 })
 
-describe('shouldRenderStepAsBreakdown', () => {
+describe('getStepBreakdownSeries', () => {
+    const series = { breakdown_value: 'NL' } as any
     it.each([
         {
-            scenario: 'multiple breakdown values → breakdown',
-            nested: [{ breakdown_value: 'NL' }, { breakdown_value: 'US' }],
-            hasBreakdown: true,
-            expected: true,
+            scenario: 'single breakdown value with breakdown filter set → returns the series',
+            step: { nested_breakdown: [series] },
+            breakdownFilter: { breakdown: '$geoip_country_code', breakdown_type: 'event' },
+            expected: series,
         },
         {
-            scenario: 'single breakdown value with breakdown filter set → breakdown',
-            nested: [{ breakdown_value: 'NL' }],
-            hasBreakdown: true,
-            expected: true,
+            scenario: 'no breakdown filter → null',
+            step: { nested_breakdown: [series] },
+            breakdownFilter: null,
+            expected: null,
         },
         {
-            scenario: 'single entry without breakdown filter → not a breakdown',
-            nested: [{ breakdown_value: 'NL' }],
-            hasBreakdown: false,
-            expected: false,
+            scenario: 'breakdown filter without breakdown property → null',
+            step: { nested_breakdown: [series] },
+            breakdownFilter: {},
+            expected: null,
         },
         {
-            scenario: 'single entry with breakdown filter but null breakdown_value → not a breakdown',
-            nested: [{ breakdown_value: null as any }],
-            hasBreakdown: true,
-            expected: false,
+            scenario: 'multiple breakdown values → null (use existing per-bar handlers)',
+            step: { nested_breakdown: [series, { breakdown_value: 'US' }] },
+            breakdownFilter: { breakdown: '$geoip_country_code', breakdown_type: 'event' },
+            expected: null,
         },
         {
-            scenario: 'empty array → breakdown (matches original behavior so empty branch renders nothing)',
-            nested: [],
-            hasBreakdown: true,
-            expected: true,
+            scenario: 'empty nested_breakdown → null',
+            step: { nested_breakdown: [] },
+            breakdownFilter: { breakdown: '$geoip_country_code', breakdown_type: 'event' },
+            expected: null,
         },
         {
-            scenario: 'undefined nested_breakdown → not a breakdown',
-            nested: undefined,
-            hasBreakdown: true,
-            expected: false,
+            scenario: 'undefined nested_breakdown → null',
+            step: { nested_breakdown: undefined },
+            breakdownFilter: { breakdown: '$geoip_country_code', breakdown_type: 'event' },
+            expected: null,
         },
         {
-            scenario: 'null nested_breakdown → not a breakdown',
-            nested: null,
-            hasBreakdown: true,
-            expected: false,
+            scenario: 'single entry with null breakdown_value → null',
+            step: { nested_breakdown: [{ breakdown_value: null }] },
+            breakdownFilter: { breakdown: '$geoip_country_code', breakdown_type: 'event' },
+            expected: null,
         },
-    ])('$scenario', ({ nested, hasBreakdown, expected }) => {
-        expect(shouldRenderStepAsBreakdown(nested as any, hasBreakdown)).toBe(expected)
+    ])('$scenario', ({ step, breakdownFilter, expected }) => {
+        expect(getStepBreakdownSeries(step as any, breakdownFilter as any)).toBe(expected)
     })
 })

--- a/frontend/src/scenes/funnels/funnelUtils.test.ts
+++ b/frontend/src/scenes/funnels/funnelUtils.test.ts
@@ -22,6 +22,7 @@ import {
     getReferenceStep,
     getVisibilityKey,
     parseDisplayNameForCorrelation,
+    shouldRenderStepAsBreakdown,
     stepsWithConversionMetrics,
 } from './funnelUtils'
 
@@ -699,5 +700,54 @@ describe('getLastFilledStep', () => {
         },
     ])('$scenario', ({ steps, index, expectedOrder }) => {
         expect(getLastFilledStep(steps, index).order).toBe(expectedOrder)
+    })
+})
+
+describe('shouldRenderStepAsBreakdown', () => {
+    it.each([
+        {
+            scenario: 'multiple breakdown values → breakdown',
+            nested: [{ breakdown_value: 'NL' }, { breakdown_value: 'US' }],
+            hasBreakdown: true,
+            expected: true,
+        },
+        {
+            scenario: 'single breakdown value with breakdown filter set → breakdown',
+            nested: [{ breakdown_value: 'NL' }],
+            hasBreakdown: true,
+            expected: true,
+        },
+        {
+            scenario: 'single entry without breakdown filter → not a breakdown',
+            nested: [{ breakdown_value: 'NL' }],
+            hasBreakdown: false,
+            expected: false,
+        },
+        {
+            scenario: 'single entry with breakdown filter but null breakdown_value → not a breakdown',
+            nested: [{ breakdown_value: null as any }],
+            hasBreakdown: true,
+            expected: false,
+        },
+        {
+            scenario: 'empty array → breakdown (matches original behavior so empty branch renders nothing)',
+            nested: [],
+            hasBreakdown: true,
+            expected: true,
+        },
+        {
+            scenario: 'undefined nested_breakdown → not a breakdown',
+            nested: undefined,
+            hasBreakdown: true,
+            expected: false,
+        },
+        {
+            scenario: 'null nested_breakdown → not a breakdown',
+            nested: null,
+            hasBreakdown: true,
+            expected: false,
+        },
+    ])('$scenario', ({ nested, hasBreakdown, expected }) => {
+        expect(shouldRenderStepAsBreakdown(nested as any, hasBreakdown)).toBe(expected)
     })
 })

--- a/frontend/src/scenes/funnels/funnelUtils.tsx
+++ b/frontend/src/scenes/funnels/funnelUtils.tsx
@@ -654,3 +654,26 @@ export function getTooltipTitleForDroppedOff(
         </>
     )
 }
+
+/**
+ * Whether a funnel step should be rendered using the breakdown layout.
+ *
+ * The single-entry case is treated as "not a breakdown" only when there's no real breakdown value
+ * — otherwise (i.e. the user filtered the funnel down to a single segment) we treat it as a
+ * breakdown so clicks scope the persons modal to that breakdown value.
+ *
+ * Empty arrays are treated as a breakdown (matching the original logic) so the breakdown
+ * rendering branch can safely render nothing instead of crashing on `nested_breakdown![0]`.
+ */
+export function shouldRenderStepAsBreakdown(
+    nestedBreakdown: Pick<FunnelStepWithConversionMetrics, 'breakdown_value'>[] | null | undefined,
+    hasBreakdown: boolean
+): boolean {
+    if (!Array.isArray(nestedBreakdown)) {
+        return false
+    }
+    if (nestedBreakdown.length === 1) {
+        return hasBreakdown && nestedBreakdown[0]?.breakdown_value != null
+    }
+    return true
+}

--- a/frontend/src/scenes/funnels/funnelUtils.tsx
+++ b/frontend/src/scenes/funnels/funnelUtils.tsx
@@ -12,7 +12,7 @@ import { elementsToAction } from 'scenes/activity/explore/createActionFromEvent'
 import { teamLogic } from 'scenes/teamLogic'
 
 import { Noun } from '~/models/groupsModel'
-import { AnyEntityNode, FunnelExclusionSteps, FunnelsFilter } from '~/queries/schema/schema-general'
+import { AnyEntityNode, BreakdownFilter, FunnelExclusionSteps, FunnelsFilter } from '~/queries/schema/schema-general'
 import { integer } from '~/queries/schema/type-utils'
 import {
     AnyPropertyFilter,
@@ -656,24 +656,32 @@ export function getTooltipTitleForDroppedOff(
 }
 
 /**
- * Whether a funnel step should be rendered using the breakdown layout.
+ * When a funnel step is shown without a per-breakdown bar (i.e. a non-breakdown rendering)
+ * but the funnel actually has a breakdown filter set with a single visible value, this returns
+ * the corresponding series so callers can route clicks through `openPersonsModalForSeries` —
+ * which carries the breakdown value — instead of `openPersonsModalForStep`, which would open
+ * the modal unfiltered.
  *
- * The single-entry case is treated as "not a breakdown" only when there's no real breakdown value
- * — otherwise (i.e. the user filtered the funnel down to a single segment) we treat it as a
- * breakdown so clicks scope the persons modal to that breakdown value.
- *
- * Empty arrays are treated as a breakdown (matching the original logic) so the breakdown
- * rendering branch can safely render nothing instead of crashing on `nested_breakdown![0]`.
+ * Returns null when there is no breakdown filter, when nested_breakdown has any number of
+ * items other than one, or when the single entry has no breakdown value (e.g. it's a bare
+ * step placeholder rather than a real breakdown).
  */
-export function shouldRenderStepAsBreakdown(
-    nestedBreakdown: Pick<FunnelStepWithConversionMetrics, 'breakdown_value'>[] | null | undefined,
-    hasBreakdown: boolean
-): boolean {
-    if (!Array.isArray(nestedBreakdown)) {
-        return false
+export function getStepBreakdownSeries(
+    step: Pick<FunnelStepWithConversionMetrics, 'nested_breakdown'>,
+    breakdownFilter: BreakdownFilter | null | undefined
+): FunnelStepWithConversionMetrics | null {
+    if (!breakdownFilter?.breakdown) {
+        return null
     }
-    if (nestedBreakdown.length === 1) {
-        return hasBreakdown && nestedBreakdown[0]?.breakdown_value != null
+
+    if (!Array.isArray(step.nested_breakdown) || step.nested_breakdown.length !== 1) {
+        return null
     }
-    return true
+
+    const single = step.nested_breakdown[0]
+    if (!single || single.breakdown_value == null) {
+        return null
+    }
+
+    return single
 }

--- a/frontend/src/scenes/funnels/funnelUtils.tsx
+++ b/frontend/src/scenes/funnels/funnelUtils.tsx
@@ -655,17 +655,9 @@ export function getTooltipTitleForDroppedOff(
     )
 }
 
-/**
- * When a funnel step is shown without a per-breakdown bar (i.e. a non-breakdown rendering)
- * but the funnel actually has a breakdown filter set with a single visible value, this returns
- * the corresponding series so callers can route clicks through `openPersonsModalForSeries` —
- * which carries the breakdown value — instead of `openPersonsModalForStep`, which would open
- * the modal unfiltered.
- *
- * Returns null when there is no breakdown filter, when nested_breakdown has any number of
- * items other than one, or when the single entry has no breakdown value (e.g. it's a bare
- * step placeholder rather than a real breakdown).
- */
+// Returns the single visible breakdown series on a funnel step, when the step is rendered
+// with the non-breakdown layout but a breakdown filter is set. Lets callers route clicks
+// through `openPersonsModalForSeries` so the persons modal is scoped to that value.
 export function getStepBreakdownSeries(
     step: Pick<FunnelStepWithConversionMetrics, 'nested_breakdown'>,
     breakdownFilter: BreakdownFilter | null | undefined

--- a/frontend/src/scenes/trends/persons-modal/personsModalLogic.test.ts
+++ b/frontend/src/scenes/trends/persons-modal/personsModalLogic.test.ts
@@ -3,7 +3,7 @@ import { expectLogic } from 'kea-test-utils'
 import { useMocks } from '~/mocks/jest'
 import { NodeKind } from '~/queries/schema/schema-general'
 import { initKeaTests } from '~/test/init'
-import { FilterLogicalOperator, PersonActorType } from '~/types'
+import { FilterLogicalOperator, PersonActorType, PropertyFilterType, PropertyOperator } from '~/types'
 
 import { personsModalLogic } from './personsModalLogic'
 
@@ -176,6 +176,72 @@ describe('personsModalLogic', () => {
                     filter_group: {
                         type: FilterLogicalOperator.And,
                         values: [{ type: FilterLogicalOperator.And, values: [] }],
+                    },
+                    duration: [],
+                },
+            })
+        })
+
+        it('includes breakdown filter for funnel breakdown queries with session IDs', () => {
+            logic = personsModalLogic({
+                query: {
+                    kind: NodeKind.FunnelsActorsQuery,
+                    source: {
+                        kind: NodeKind.FunnelsQuery,
+                        series: [{ kind: NodeKind.EventsNode, event: '$pageview' }],
+                        breakdownFilter: {
+                            breakdown: '$geoip_country_code',
+                            breakdown_type: 'event',
+                        },
+                    },
+                    funnelStep: 1,
+                    funnelStepBreakdown: 'NL',
+                    includeRecordings: true,
+                } as any,
+                url: '/api/environments/1/persons?',
+                additionalSelect: { matched_recordings: 'matched_recordings' },
+            })
+            logic.mount()
+
+            logic.actions.loadActorsSuccess({
+                results: [
+                    {
+                        count: 1,
+                        people: [
+                            {
+                                type: 'person',
+                                id: 'person-1',
+                                distinct_ids: ['user-1'],
+                                is_identified: true,
+                                properties: {},
+                                created_at: '2024-01-01',
+                                matched_recordings: [{ session_id: 'session-1', events: [] }],
+                                value_at_data_point: null,
+                            },
+                        ],
+                    },
+                ],
+                missing_persons: 0,
+            })
+
+            expectLogic(logic).toMatchValues({
+                recordingFilters: {
+                    session_ids: ['session-1'],
+                    filter_group: {
+                        type: FilterLogicalOperator.And,
+                        values: [
+                            {
+                                type: FilterLogicalOperator.And,
+                                values: [
+                                    {
+                                        key: '$geoip_country_code',
+                                        value: 'NL',
+                                        operator: PropertyOperator.Exact,
+                                        type: PropertyFilterType.Event,
+                                    },
+                                ],
+                            },
+                        ],
                     },
                     duration: [],
                 },

--- a/frontend/src/scenes/trends/persons-modal/personsModalLogic.test.ts
+++ b/frontend/src/scenes/trends/persons-modal/personsModalLogic.test.ts
@@ -304,11 +304,84 @@ describe('personsModalLogic', () => {
             )
         })
 
+        it('includes group_type_index for group breakdown filters', () => {
+            logic = personsModalLogic({
+                query: {
+                    kind: NodeKind.FunnelsActorsQuery,
+                    source: {
+                        kind: NodeKind.FunnelsQuery,
+                        series: [{ kind: NodeKind.EventsNode, event: '$pageview' }],
+                        breakdownFilter: {
+                            breakdown: 'company_name',
+                            breakdown_type: 'group',
+                            breakdown_group_type_index: 0,
+                        },
+                    },
+                    funnelStep: 1,
+                    funnelStepBreakdown: 'Acme',
+                    includeRecordings: true,
+                } as any,
+                url: '/api/environments/1/persons?',
+                additionalSelect: { matched_recordings: 'matched_recordings' },
+            })
+            logic.mount()
+
+            logic.actions.loadActorsSuccess({
+                results: [
+                    {
+                        count: 1,
+                        people: [
+                            {
+                                type: 'person',
+                                id: 'person-1',
+                                distinct_ids: ['user-1'],
+                                is_identified: true,
+                                properties: {},
+                                created_at: '2024-01-01',
+                                matched_recordings: [{ session_id: 'session-1', events: [] }],
+                                value_at_data_point: null,
+                            },
+                        ],
+                    },
+                ],
+                missing_persons: 0,
+            })
+
+            expectLogic(logic).toMatchValues({
+                recordingFilters: {
+                    session_ids: ['session-1'],
+                    filter_group: {
+                        type: FilterLogicalOperator.And,
+                        values: [
+                            {
+                                type: FilterLogicalOperator.And,
+                                values: [
+                                    {
+                                        key: 'company_name',
+                                        value: 'Acme',
+                                        operator: PropertyOperator.Exact,
+                                        type: PropertyFilterType.Group,
+                                        group_type_index: 0,
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                    duration: [],
+                },
+            })
+        })
+
         it.each([
             {
                 scenario: 'cohort breakdown',
                 breakdownFilter: { breakdown: [1, 2], breakdown_type: 'cohort' },
                 funnelStepBreakdown: 1,
+            },
+            {
+                scenario: 'group breakdown without breakdown_group_type_index',
+                breakdownFilter: { breakdown: 'company_name', breakdown_type: 'group' },
+                funnelStepBreakdown: 'Acme',
             },
             {
                 scenario: 'multi-key breakdown property',

--- a/frontend/src/scenes/trends/persons-modal/personsModalLogic.test.ts
+++ b/frontend/src/scenes/trends/persons-modal/personsModalLogic.test.ts
@@ -372,6 +372,72 @@ describe('personsModalLogic', () => {
             })
         })
 
+        it('unwraps a single-element breakdown value array to a scalar filter', () => {
+            logic = personsModalLogic({
+                query: {
+                    kind: NodeKind.FunnelsActorsQuery,
+                    source: {
+                        kind: NodeKind.FunnelsQuery,
+                        series: [{ kind: NodeKind.EventsNode, event: '$pageview' }],
+                        breakdownFilter: {
+                            breakdown: '$geoip_country_code',
+                            breakdown_type: 'event',
+                        },
+                    },
+                    funnelStep: 1,
+                    funnelStepBreakdown: ['NL'],
+                    includeRecordings: true,
+                } as any,
+                url: '/api/environments/1/persons?',
+                additionalSelect: { matched_recordings: 'matched_recordings' },
+            })
+            logic.mount()
+
+            logic.actions.loadActorsSuccess({
+                results: [
+                    {
+                        count: 1,
+                        people: [
+                            {
+                                type: 'person',
+                                id: 'person-1',
+                                distinct_ids: ['user-1'],
+                                is_identified: true,
+                                properties: {},
+                                created_at: '2024-01-01',
+                                matched_recordings: [{ session_id: 'session-1', events: [] }],
+                                value_at_data_point: null,
+                            },
+                        ],
+                    },
+                ],
+                missing_persons: 0,
+            })
+
+            expectLogic(logic).toMatchValues({
+                recordingFilters: {
+                    session_ids: ['session-1'],
+                    filter_group: {
+                        type: FilterLogicalOperator.And,
+                        values: [
+                            {
+                                type: FilterLogicalOperator.And,
+                                values: [
+                                    {
+                                        key: '$geoip_country_code',
+                                        value: 'NL',
+                                        operator: PropertyOperator.Exact,
+                                        type: PropertyFilterType.Event,
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                    duration: [],
+                },
+            })
+        })
+
         it.each([
             {
                 scenario: 'cohort breakdown',
@@ -389,7 +455,7 @@ describe('personsModalLogic', () => {
                 funnelStepBreakdown: 'NL',
             },
             {
-                scenario: 'array breakdown value',
+                scenario: 'multi-value breakdown array',
                 breakdownFilter: { breakdown: '$geoip_country_code', breakdown_type: 'event' },
                 funnelStepBreakdown: ['NL', 'BE'],
             },

--- a/frontend/src/scenes/trends/persons-modal/personsModalLogic.test.ts
+++ b/frontend/src/scenes/trends/persons-modal/personsModalLogic.test.ts
@@ -248,6 +248,129 @@ describe('personsModalLogic', () => {
             })
         })
 
+        it('includes breakdown filter for funnel breakdown queries in fallback path (no session IDs)', () => {
+            logic = personsModalLogic({
+                query: {
+                    kind: NodeKind.FunnelsActorsQuery,
+                    source: {
+                        kind: NodeKind.FunnelsQuery,
+                        series: [{ kind: NodeKind.EventsNode, event: '$pageview' }],
+                        breakdownFilter: {
+                            breakdown: '$geoip_country_code',
+                            breakdown_type: 'event',
+                        },
+                    },
+                    funnelStep: 1,
+                    funnelStepBreakdown: 'NL',
+                    includeRecordings: true,
+                } as any,
+                url: '/api/environments/1/persons?',
+                additionalSelect: { matched_recordings: 'matched_recordings' },
+            })
+            logic.mount()
+
+            logic.actions.loadActorsSuccess({
+                results: [
+                    {
+                        count: 1,
+                        people: [
+                            {
+                                type: 'person',
+                                id: 'person-1',
+                                distinct_ids: ['user-1'],
+                                is_identified: true,
+                                properties: {},
+                                created_at: '2024-01-01',
+                                matched_recordings: [],
+                                value_at_data_point: null,
+                            },
+                        ],
+                    },
+                ],
+                missing_persons: 0,
+            })
+
+            const filters = logic.values.recordingFilters
+            const innerValues = (filters.filter_group as any)?.values?.[0]?.values
+            expect(innerValues).toEqual(
+                expect.arrayContaining([
+                    expect.objectContaining({
+                        key: '$geoip_country_code',
+                        value: 'NL',
+                        operator: PropertyOperator.Exact,
+                        type: PropertyFilterType.Event,
+                    }),
+                ])
+            )
+        })
+
+        it.each([
+            {
+                scenario: 'cohort breakdown',
+                breakdownFilter: { breakdown: [1, 2], breakdown_type: 'cohort' },
+                funnelStepBreakdown: 1,
+            },
+            {
+                scenario: 'multi-key breakdown property',
+                breakdownFilter: { breakdown: ['$geoip_country_code', '$browser'], breakdown_type: 'event' },
+                funnelStepBreakdown: 'NL',
+            },
+            {
+                scenario: 'array breakdown value',
+                breakdownFilter: { breakdown: '$geoip_country_code', breakdown_type: 'event' },
+                funnelStepBreakdown: ['NL', 'BE'],
+            },
+        ])('does not add a malformed breakdown filter for $scenario', ({ breakdownFilter, funnelStepBreakdown }) => {
+            logic = personsModalLogic({
+                query: {
+                    kind: NodeKind.FunnelsActorsQuery,
+                    source: {
+                        kind: NodeKind.FunnelsQuery,
+                        series: [{ kind: NodeKind.EventsNode, event: '$pageview' }],
+                        breakdownFilter,
+                    },
+                    funnelStep: 1,
+                    funnelStepBreakdown,
+                    includeRecordings: true,
+                } as any,
+                url: '/api/environments/1/persons?',
+                additionalSelect: { matched_recordings: 'matched_recordings' },
+            })
+            logic.mount()
+
+            logic.actions.loadActorsSuccess({
+                results: [
+                    {
+                        count: 1,
+                        people: [
+                            {
+                                type: 'person',
+                                id: 'person-1',
+                                distinct_ids: ['user-1'],
+                                is_identified: true,
+                                properties: {},
+                                created_at: '2024-01-01',
+                                matched_recordings: [{ session_id: 'session-1', events: [] }],
+                                value_at_data_point: null,
+                            },
+                        ],
+                    },
+                ],
+                missing_persons: 0,
+            })
+
+            expectLogic(logic).toMatchValues({
+                recordingFilters: {
+                    session_ids: ['session-1'],
+                    filter_group: {
+                        type: FilterLogicalOperator.And,
+                        values: [{ type: FilterLogicalOperator.And, values: [] }],
+                    },
+                    duration: [],
+                },
+            })
+        })
+
         it('falls back to event filters when no session IDs are available', () => {
             logic = personsModalLogic({
                 query: {

--- a/frontend/src/scenes/trends/persons-modal/personsModalLogic.ts
+++ b/frontend/src/scenes/trends/persons-modal/personsModalLogic.ts
@@ -51,8 +51,8 @@ import type { personsModalLogicType } from './personsModalLogicType'
 const RESULTS_PER_PAGE = 100
 
 // Build a property filter that scopes session recordings to a funnel's selected breakdown
-// value. Returns null for cohort, multi-key, or array-value breakdowns (not expressible as
-// a single Exact filter).
+// value. Returns null for cohort or multi-key breakdowns (not expressible as a single Exact
+// filter). Single-element breakdown value arrays are unwrapped to their scalar value.
 function buildFunnelBreakdownFilter(source: ActorsQuery['source'] | null): UniversalFilterValue | null {
     if (!source || source.kind !== NodeKind.FunnelsActorsQuery || source.funnelStepBreakdown == null) {
         return null
@@ -60,17 +60,22 @@ function buildFunnelBreakdownFilter(source: ActorsQuery['source'] | null): Unive
     const breakdownFilter = source.source.breakdownFilter
     const breakdown = breakdownFilter?.breakdown
     const breakdownType = breakdownFilter?.breakdown_type ?? 'event'
-    if (
-        !breakdown ||
-        Array.isArray(breakdown) ||
-        breakdownType === 'cohort' ||
-        Array.isArray(source.funnelStepBreakdown)
-    ) {
+    if (!breakdown || Array.isArray(breakdown) || breakdownType === 'cohort') {
         return null
+    }
+    // The backend canonicalizes single-value breakdowns as a one-element array (e.g. ["NL"]).
+    // Unwrap that here; bail out only for genuine multi-value arrays which can't be a single
+    // Exact filter.
+    let breakdownValue: string | number | boolean = source.funnelStepBreakdown as any
+    if (Array.isArray(source.funnelStepBreakdown)) {
+        if (source.funnelStepBreakdown.length !== 1) {
+            return null
+        }
+        breakdownValue = source.funnelStepBreakdown[0] as string | number
     }
     const base = {
         key: String(breakdown),
-        value: source.funnelStepBreakdown,
+        value: breakdownValue,
         operator: PropertyOperator.Exact,
     }
     if (breakdownType === 'person') {

--- a/frontend/src/scenes/trends/persons-modal/personsModalLogic.ts
+++ b/frontend/src/scenes/trends/persons-modal/personsModalLogic.ts
@@ -57,8 +57,9 @@ function buildFunnelBreakdownFilter(source: ActorsQuery['source'] | null): Unive
     if (!source || source.kind !== NodeKind.FunnelsActorsQuery || source.funnelStepBreakdown == null) {
         return null
     }
-    const breakdown = source.source.breakdownFilter?.breakdown
-    const breakdownType = source.source.breakdownFilter?.breakdown_type ?? 'event'
+    const breakdownFilter = source.source.breakdownFilter
+    const breakdown = breakdownFilter?.breakdown
+    const breakdownType = breakdownFilter?.breakdown_type ?? 'event'
     if (
         !breakdown ||
         Array.isArray(breakdown) ||
@@ -67,18 +68,27 @@ function buildFunnelBreakdownFilter(source: ActorsQuery['source'] | null): Unive
     ) {
         return null
     }
-    const filterType: PropertyFilterType =
-        breakdownType === 'person'
-            ? PropertyFilterType.Person
-            : breakdownType === 'group'
-              ? PropertyFilterType.Group
-              : PropertyFilterType.Event
-    return {
+    const base = {
         key: String(breakdown),
         value: source.funnelStepBreakdown,
         operator: PropertyOperator.Exact,
-        type: filterType,
-    } as UniversalFilterValue
+    }
+    if (breakdownType === 'person') {
+        return { ...base, type: PropertyFilterType.Person } as UniversalFilterValue
+    }
+    if (breakdownType === 'group') {
+        // Group filters must carry the group_type_index so the backend can match the filter
+        // against the correct group type. Bail out if we don't know which group type this is.
+        if (breakdownFilter?.breakdown_group_type_index == null) {
+            return null
+        }
+        return {
+            ...base,
+            type: PropertyFilterType.Group,
+            group_type_index: breakdownFilter.breakdown_group_type_index,
+        } as UniversalFilterValue
+    }
+    return { ...base, type: PropertyFilterType.Event } as UniversalFilterValue
 }
 
 export interface PersonModalLogicProps {

--- a/frontend/src/scenes/trends/persons-modal/personsModalLogic.ts
+++ b/frontend/src/scenes/trends/persons-modal/personsModalLogic.ts
@@ -50,6 +50,45 @@ import type { personsModalLogicType } from './personsModalLogicType'
 
 const RESULTS_PER_PAGE = 100
 
+/**
+ * For a funnel actors query with `funnelStepBreakdown` set (i.e. the user clicked a specific
+ * breakdown segment), build a property filter that scopes session recordings to that breakdown
+ * value. Returns null when the source isn't a funnel, or when the breakdown can't be expressed
+ * as a single Exact property filter:
+ *  - cohort breakdowns (`breakdown_type === 'cohort'`, breakdown is an array of cohort IDs)
+ *  - multi-key breakdowns (`breakdown` is an array of property names)
+ *  - array breakdown values (`funnelStepBreakdown` is an array)
+ */
+function buildFunnelBreakdownFilter(
+    source: NonNullable<ActorsQuery['source']> | null | undefined
+): UniversalFilterValue | null {
+    if (!source || source.kind !== NodeKind.FunnelsActorsQuery || source.funnelStepBreakdown == null) {
+        return null
+    }
+    const breakdown = source.source.breakdownFilter?.breakdown
+    const breakdownType = source.source.breakdownFilter?.breakdown_type ?? 'event'
+    if (
+        !breakdown ||
+        Array.isArray(breakdown) ||
+        breakdownType === 'cohort' ||
+        Array.isArray(source.funnelStepBreakdown)
+    ) {
+        return null
+    }
+    const filterType: PropertyFilterType =
+        breakdownType === 'person'
+            ? PropertyFilterType.Person
+            : breakdownType === 'group'
+              ? PropertyFilterType.Group
+              : PropertyFilterType.Event
+    return {
+        key: String(breakdown),
+        value: source.funnelStepBreakdown,
+        operator: PropertyOperator.Exact,
+        type: filterType,
+    } as UniversalFilterValue
+}
+
 export interface PersonModalLogicProps {
     query?: InsightActorsQuery | FunnelsActorsQuery | FunnelCorrelationActorsQuery | ExperimentActorsQuery | null
     url?: string | null
@@ -480,45 +519,24 @@ export const personsModalLogic = kea<personsModalLogicType>([
 
                 const source = actorsQuery.source
 
+                // For funnel breakdowns, build a property filter so recordings are scoped to
+                // the selected breakdown value (e.g. country = "NL"). Bails out for cases that
+                // can't be represented as a single Exact property filter (cohort lists,
+                // multi-key breakdowns, array breakdown values).
+                const funnelBreakdownFilter = buildFunnelBreakdownFilter(source)
+
                 // If we have session IDs from matched_recordings, use them directly for efficient lookup
                 if (sessionIds.length > 0) {
-                    // For funnel breakdowns, add a property filter so recordings are
-                    // scoped to the selected breakdown value (e.g. country = "NL").
-                    const breakdownFilters: UniversalFilterValue[] = []
-                    if (
-                        source.kind === NodeKind.FunnelsActorsQuery &&
-                        (source as FunnelsActorsQuery).funnelStepBreakdown != null
-                    ) {
-                        const funnelSource = source as FunnelsActorsQuery
-                        const funnelsQuery = funnelSource.source
-                        const breakdownProp = funnelsQuery.breakdownFilter?.breakdown
-                        const breakdownType = funnelsQuery.breakdownFilter?.breakdown_type ?? 'event'
-                        if (breakdownProp) {
-                            let filterType: PropertyFilterType
-                            switch (breakdownType) {
-                                case 'person':
-                                    filterType = PropertyFilterType.Person
-                                    break
-                                case 'group':
-                                    filterType = PropertyFilterType.Group
-                                    break
-                                default:
-                                    filterType = PropertyFilterType.Event
-                            }
-                            breakdownFilters.push({
-                                key: String(breakdownProp),
-                                value: funnelSource.funnelStepBreakdown,
-                                operator: PropertyOperator.Exact,
-                                type: filterType,
-                            } as UniversalFilterValue)
-                        }
-                    }
-
                     return {
                         session_ids: sessionIds,
                         filter_group: {
                             type: FilterLogicalOperator.And,
-                            values: [{ type: FilterLogicalOperator.And, values: breakdownFilters }],
+                            values: [
+                                {
+                                    type: FilterLogicalOperator.And,
+                                    values: funnelBreakdownFilter ? [funnelBreakdownFilter] : [],
+                                },
+                            ],
                         },
                         duration: [],
                     }
@@ -565,34 +583,9 @@ export const personsModalLogic = kea<personsModalLogicType>([
                     filters.push(breakdownFilter as UniversalFilterValue)
                 }
 
-                // Add breakdown filters for funnels
-                if (
-                    source.kind === NodeKind.FunnelsActorsQuery &&
-                    (source as FunnelsActorsQuery).funnelStepBreakdown != null
-                ) {
-                    const funnelSource = source as FunnelsActorsQuery
-                    const funnelsQuery = funnelSource.source
-                    const breakdownProp = funnelsQuery.breakdownFilter?.breakdown
-                    const breakdownType = funnelsQuery.breakdownFilter?.breakdown_type ?? 'event'
-                    if (breakdownProp) {
-                        let filterType: PropertyFilterType
-                        switch (breakdownType) {
-                            case 'person':
-                                filterType = PropertyFilterType.Person
-                                break
-                            case 'group':
-                                filterType = PropertyFilterType.Group
-                                break
-                            default:
-                                filterType = PropertyFilterType.Event
-                        }
-                        filters.push({
-                            key: String(breakdownProp),
-                            value: funnelSource.funnelStepBreakdown,
-                            operator: PropertyOperator.Exact,
-                            type: filterType,
-                        } as UniversalFilterValue)
-                    }
+                // Add breakdown filter for funnels
+                if (funnelBreakdownFilter) {
+                    filters.push(funnelBreakdownFilter)
                 }
 
                 // Add global properties from the insight query

--- a/frontend/src/scenes/trends/persons-modal/personsModalLogic.ts
+++ b/frontend/src/scenes/trends/persons-modal/personsModalLogic.ts
@@ -481,16 +481,46 @@ export const personsModalLogic = kea<personsModalLogicType>([
                 const source = actorsQuery.source
 
                 // If we have session IDs from matched_recordings, use them directly for efficient lookup
-                // No need for additional event/property filters since we already have the exact list of sessions
                 if (sessionIds.length > 0) {
+                    // For funnel breakdowns, add a property filter so recordings are
+                    // scoped to the selected breakdown value (e.g. country = "NL").
+                    const breakdownFilters: UniversalFilterValue[] = []
+                    if (
+                        source.kind === NodeKind.FunnelsActorsQuery &&
+                        (source as FunnelsActorsQuery).funnelStepBreakdown != null
+                    ) {
+                        const funnelSource = source as FunnelsActorsQuery
+                        const funnelsQuery = funnelSource.source
+                        const breakdownProp = funnelsQuery.breakdownFilter?.breakdown
+                        const breakdownType = funnelsQuery.breakdownFilter?.breakdown_type ?? 'event'
+                        if (breakdownProp) {
+                            let filterType: PropertyFilterType
+                            switch (breakdownType) {
+                                case 'person':
+                                    filterType = PropertyFilterType.Person
+                                    break
+                                case 'group':
+                                    filterType = PropertyFilterType.Group
+                                    break
+                                default:
+                                    filterType = PropertyFilterType.Event
+                            }
+                            breakdownFilters.push({
+                                key: String(breakdownProp),
+                                value: funnelSource.funnelStepBreakdown,
+                                operator: PropertyOperator.Exact,
+                                type: filterType,
+                            } as UniversalFilterValue)
+                        }
+                    }
+
                     return {
                         session_ids: sessionIds,
-                        // Use minimal valid structure required by conversion functions
                         filter_group: {
                             type: FilterLogicalOperator.And,
-                            values: [{ type: FilterLogicalOperator.And, values: [] }],
+                            values: [{ type: FilterLogicalOperator.And, values: breakdownFilters }],
                         },
-                        duration: [], // Empty duration means no duration filtering (we have explicit session IDs)
+                        duration: [],
                     }
                 }
 
@@ -524,7 +554,7 @@ export const personsModalLogic = kea<personsModalLogicType>([
                     })
                 }
 
-                // Add breakdown filters if present
+                // Add breakdown filters if present (trends path)
                 if ('breakdown' in source && source.breakdown && propertiesTimelineFilter?.breakdown) {
                     const breakdownFilter = {
                         key: propertiesTimelineFilter.breakdown,
@@ -533,6 +563,36 @@ export const personsModalLogic = kea<personsModalLogicType>([
                         type: PropertyFilterType.Event,
                     }
                     filters.push(breakdownFilter as UniversalFilterValue)
+                }
+
+                // Add breakdown filters for funnels
+                if (
+                    source.kind === NodeKind.FunnelsActorsQuery &&
+                    (source as FunnelsActorsQuery).funnelStepBreakdown != null
+                ) {
+                    const funnelSource = source as FunnelsActorsQuery
+                    const funnelsQuery = funnelSource.source
+                    const breakdownProp = funnelsQuery.breakdownFilter?.breakdown
+                    const breakdownType = funnelsQuery.breakdownFilter?.breakdown_type ?? 'event'
+                    if (breakdownProp) {
+                        let filterType: PropertyFilterType
+                        switch (breakdownType) {
+                            case 'person':
+                                filterType = PropertyFilterType.Person
+                                break
+                            case 'group':
+                                filterType = PropertyFilterType.Group
+                                break
+                            default:
+                                filterType = PropertyFilterType.Event
+                        }
+                        filters.push({
+                            key: String(breakdownProp),
+                            value: funnelSource.funnelStepBreakdown,
+                            operator: PropertyOperator.Exact,
+                            type: filterType,
+                        } as UniversalFilterValue)
+                    }
                 }
 
                 // Add global properties from the insight query

--- a/frontend/src/scenes/trends/persons-modal/personsModalLogic.ts
+++ b/frontend/src/scenes/trends/persons-modal/personsModalLogic.ts
@@ -50,18 +50,10 @@ import type { personsModalLogicType } from './personsModalLogicType'
 
 const RESULTS_PER_PAGE = 100
 
-/**
- * For a funnel actors query with `funnelStepBreakdown` set (i.e. the user clicked a specific
- * breakdown segment), build a property filter that scopes session recordings to that breakdown
- * value. Returns null when the source isn't a funnel, or when the breakdown can't be expressed
- * as a single Exact property filter:
- *  - cohort breakdowns (`breakdown_type === 'cohort'`, breakdown is an array of cohort IDs)
- *  - multi-key breakdowns (`breakdown` is an array of property names)
- *  - array breakdown values (`funnelStepBreakdown` is an array)
- */
-function buildFunnelBreakdownFilter(
-    source: NonNullable<ActorsQuery['source']> | null | undefined
-): UniversalFilterValue | null {
+// Build a property filter that scopes session recordings to a funnel's selected breakdown
+// value. Returns null for cohort, multi-key, or array-value breakdowns (not expressible as
+// a single Exact filter).
+function buildFunnelBreakdownFilter(source: ActorsQuery['source'] | null): UniversalFilterValue | null {
     if (!source || source.kind !== NodeKind.FunnelsActorsQuery || source.funnelStepBreakdown == null) {
         return null
     }
@@ -519,10 +511,7 @@ export const personsModalLogic = kea<personsModalLogicType>([
 
                 const source = actorsQuery.source
 
-                // For funnel breakdowns, build a property filter so recordings are scoped to
-                // the selected breakdown value (e.g. country = "NL"). Bails out for cases that
-                // can't be represented as a single Exact property filter (cohort lists,
-                // multi-key breakdowns, array breakdown values).
+                // Scope recordings to the selected funnel breakdown value (e.g. country = "NL").
                 const funnelBreakdownFilter = buildFunnelBreakdownFilter(source)
 
                 // If we have session IDs from matched_recordings, use them directly for efficient lookup


### PR DESCRIPTION
## Problem

The backend canonicalizes single-value funnel breakdowns as a one-element array (e.g. `["NL"]`). The `buildFunnelBreakdownFilter` helper added in #53819 bailed out for any array value, so when a user clicked into a funnel breakdown and then into session recordings, the recordings weren't scoped to that breakdown value — the filter was dropped entirely and the list showed unscoped recordings.

## Changes

- `buildFunnelBreakdownFilter` unwraps single-element `funnelStepBreakdown` arrays to their scalar value
- Genuine multi-value arrays (e.g. `["NL", "BE"]`) still bail out since they can't be expressed as a single Exact filter
- Rename the existing bailout test case from `'array breakdown value'` to `'multi-value breakdown array'`
- Add a new test covering the single-element unwrap case

## How did you test this code?

I'm an agent. Ran the updated `personsModalLogic.test.ts` suite — all 14 tests pass. Visually verified the fix in the dev environment against the funnel → persons modal → view recordings flow: the recordings query URL now contains the correct property filter (e.g. `$geoip_city_name = "San Francisco"`). The recordings list is still empty in the test environment because the team has no session replays, but the filter itself is correctly built and sent.

## Publish to changelog?