### PR TITLE
fix(tasks): send owner/repo format from repository picker to API

### DIFF
--- a/products/tasks/frontend/components/RepositorySelector.tsx
+++ b/products/tasks/frontend/components/RepositorySelector.tsx
@@ -19,7 +19,21 @@ export interface RepositorySelectorProps {
 }
 
 export function RepositorySelector({ value, onChange }: RepositorySelectorProps): JSX.Element {
-    const { integrationsLoading } = useValues(integrationsLogic)
+    const { integrations, integrationsLoading } = useValues(integrationsLogic)
+
+    // The picker uses plain repo names as keys, but the Task API expects owner/repo format
+    const pickerValue = value.repository?.split('/')?.pop() ?? ''
+
+    const handleRepositoryChange = (repoName: string): void => {
+        if (!repoName) {
+            onChange({ ...value, repository: undefined })
+            return
+        }
+        const integration = integrations?.find((i) => i.id === value.integrationId)
+        const owner = integration?.config?.account?.name || integration?.config?.account?.login
+        const repository = owner ? `${owner}/${repoName}` : repoName
+        onChange({ ...value, repository })
+    }
 
     if (integrationsLoading) {
         return <LemonSkeleton className="h-24" />
@@ -48,8 +62,8 @@ export function RepositorySelector({ value, onChange }: RepositorySelectorProps)
                     <label className="block text-sm font-medium mb-2">Repository</label>
                     <GitHubRepositoryPicker
                         integrationId={value.integrationId}
-                        value={value.repository ?? ''}
-                        onChange={(repo) => onChange({ ...value, repository: repo ?? undefined })}
+                        value={pickerValue}
+                        onChange={handleRepositoryChange}
                     />
                 </div>
             ) : null}


### PR DESCRIPTION
## Problem

  PR #52141 simplified the repository selector to reuse `GitHubRepositoryPicker`, but that component uses plain repo names (e.g. `posthog`) as its values, while the Task API expects the `owner/repo` format (e.g. `PostHog/posthog`). This caused the repository field to be sent without the owner prefix, breaking task creation.

  ## Changes

  - Derive the picker's display value by extracting the repo name from the stored `owner/repo` string
  - On selection, look up the integration's account owner and reconstruct the `owner/repo` format before passing it upstream

  ## How did you test this code?

  Manually verified that the repository selector now sends the correct `owner/repo` format to the API when creating a task.

  ## Publish to changelog?

  No

  ## Docs update

  No