### PR TITLE
feat: add exploring-autocapture-events skill

### DIFF
--- a/products/product_analytics/skills/exploring-autocapture-events/SKILL.md
+++ b/products/product_analytics/skills/exploring-autocapture-events/SKILL.md
@@ -10,7 +10,7 @@ description: >
 
 # Exploring autocapture events
 
-posthog-js automatically captures clicks, form submissions, and page changes as `$autocapture` events.
+if users opt in then posthog-js automatically captures clicks, form submissions, and page changes as `$autocapture` events.
 Each event records the clicked DOM element and its ancestors in the `elements_chain` column.
 
 `$autocapture` is intentionally excluded from the `posthog:read-data-schema` taxonomy

--- a/products/product_analytics/skills/exploring-autocapture-events/SKILL.md
+++ b/products/product_analytics/skills/exploring-autocapture-events/SKILL.md
@@ -1,0 +1,202 @@
+---
+name: exploring-autocapture-events
+description: >
+  Guides exploration of $autocapture events captured by posthog-js to understand user interactions,
+  find CSS selectors (especially data-attr attributes), evaluate selector uniqueness, query matching
+  clicks ad-hoc, and create actions. Use when the user asks about autocapture data, wants to find
+  what users are clicking, needs to build actions from click events, or asks about elements_chain.
+  Only applies to projects using posthog-js autocapture.
+---
+
+# Exploring autocapture events
+
+posthog-js automatically captures clicks, form submissions, and page changes as `$autocapture` events.
+Each event records the clicked DOM element and its ancestors in the `elements_chain` column.
+
+`$autocapture` is intentionally excluded from the `posthog:read-data-schema` taxonomy
+because it is only useful with autocapture-specific filters (selector, tag, text, href).
+This skill fills that gap.
+
+## Materialized columns
+
+The `events` table provides fast access to common element fields without parsing the full chain string.
+
+| Column                    | Type          | Description                                                                                            |
+| ------------------------- | ------------- | ------------------------------------------------------------------------------------------------------ |
+| `elements_chain`          | String        | Full semicolon-separated element chain (see [format reference](./references/elements-chain-format.md)) |
+| `elements_chain_href`     | String        | Last href value from the chain                                                                         |
+| `elements_chain_texts`    | Array(String) | All text values from elements                                                                          |
+| `elements_chain_ids`      | Array(String) | All id attribute values                                                                                |
+| `elements_chain_elements` | Array(String) | Useful tag names: a, button, input, select, textarea, label                                            |
+
+Use materialized columns for exploration queries whenever possible — they avoid regex parsing.
+
+## Workflow
+
+### 1. Confirm autocapture data exists
+
+Run a count query before doing anything else.
+If the count is zero, autocapture may be disabled. There are two ways this happens:
+
+- **Project settings** — the team can set `autocapture_opt_out` in PostHog project settings
+- **SDK config** — the posthog-js `init()` call can pass `autocapture: false`
+
+Tell the user if no data is found so they can check both settings.
+
+```sql
+SELECT count() as cnt
+FROM events
+WHERE event = '$autocapture'
+  AND timestamp > now() - INTERVAL 7 DAY
+```
+
+### 2. Explore what users are interacting with
+
+Start broad using the materialized columns.
+The goal is to understand what users are clicking before narrowing down.
+
+Useful explorations:
+
+- Top clicked tag names (via `elements_chain_elements`)
+- Top clicked text values (via `elements_chain_texts`)
+- Top clicked hrefs (via `elements_chain_href`)
+- Raw `elements_chain` values for a specific page (filtered by `properties.$current_url`)
+
+See [example queries](./references/example-queries.md) for all patterns.
+
+### 3. Find candidate selectors
+
+Once the user identifies an interaction they care about, find a CSS selector that identifies it.
+
+Priority order for selector attributes (best first):
+
+1. **`data-attr` or other `data-*` attributes** — highest specificity, stable across deploys, developer-intended anchors.
+   Search with `match(elements_chain, 'data-attr=')` or `extractAll`.
+2. **Element ID** (`attr_id`) — also highly stable, queryable via `elements_chain_ids`.
+3. **Tag + class combination** — moderately stable but classes change with CSS refactors.
+4. **Text content** — fragile (changes with copy edits, i18n) but sometimes the only option.
+5. **Tag name alone** — too broad on its own, useful as a qualifier.
+
+When a `data-attr` value is found, construct a selector like `[data-attr="value"]` or `button[data-attr="value"]`.
+
+### 4. Evaluate selector uniqueness
+
+A selector is only useful if it matches the intended interaction and not unrelated events.
+
+Run a uniqueness check using `elements_chain =~` with the regex pattern for the selector.
+Then sample matching events to inspect what the selector actually captures.
+Compare the count against total autocapture volume to understand selectivity.
+
+A good selector matches a single logical interaction.
+If it matches too many distinct elements, refine it in the next step.
+
+### 5. Refine with additional filters
+
+If the selector alone is not unique enough, layer on additional filters:
+
+- **Text filter** — match by element text content using `elements_chain_texts`
+- **URL filter** — restrict to a specific page using `properties.$current_url`
+- **Href filter** — match by link target using `elements_chain_href`
+
+Re-run the uniqueness check after each refinement.
+Only include filters that are needed — fewer filters means more resilience to minor DOM changes.
+
+### 6. Use in ad-hoc queries
+
+The discovered selector can be used directly in HogQL without creating an action.
+
+**Trends** — count matching clicks over time:
+
+```sql
+SELECT
+  toStartOfDay(timestamp) as day,
+  count() as clicks
+FROM events
+WHERE event = '$autocapture'
+  AND timestamp > now() - INTERVAL 14 DAY
+  AND elements_chain =~ '(^|;)button.*?data-attr="checkout"'
+GROUP BY day
+ORDER BY day
+```
+
+**Funnel** — pageview to click conversion:
+
+```sql
+SELECT
+  person_id,
+  first_pageview,
+  first_click_after
+FROM (
+  SELECT
+    p.person_id,
+    p.pageview_time as first_pageview,
+    min(c.click_time) as first_click_after
+  FROM (
+    SELECT person_id, min(timestamp) as pageview_time
+    FROM events
+    WHERE event = '$pageview'
+      AND timestamp > now() - INTERVAL 14 DAY
+      AND properties.$current_url ILIKE '%/pricing%'
+    GROUP BY person_id
+  ) p
+  INNER JOIN (
+    SELECT person_id, timestamp as click_time
+    FROM events
+    WHERE event = '$autocapture'
+      AND timestamp > now() - INTERVAL 14 DAY
+      AND elements_chain =~ '(^|;)button.*?data-attr="signup"'
+  ) c ON p.person_id = c.person_id AND c.click_time > p.pageview_time
+  GROUP BY p.person_id, p.pageview_time
+)
+```
+
+For recurring analysis, prefer creating an action (next step) or using `posthog:query-trends` / `posthog:query-funnel` with the action.
+
+### 7. Create an action
+
+Actions are the durable version of ad-hoc selector queries.
+Once the criteria uniquely identify the interaction, create an action using `posthog:action-create`.
+
+Construct the step with only the filters needed for uniqueness:
+
+```json
+{
+  "name": "Clicked checkout button",
+  "steps": [
+    {
+      "event": "$autocapture",
+      "selector": "button[data-attr='checkout']",
+      "text": "Complete Purchase",
+      "text_matching": "exact",
+      "url": "/checkout",
+      "url_matching": "contains"
+    }
+  ]
+}
+```
+
+Available step fields for `$autocapture`:
+
+- `selector` — CSS selector (e.g. `button[data-attr='checkout']`)
+- `tag_name` — HTML tag name (e.g. `button`, `a`, `input`)
+- `text` / `text_matching` — element text (`exact`, `contains`, or `regex`)
+- `href` / `href_matching` — link href (`exact`, `contains`, or `regex`)
+- `url` / `url_matching` — page URL (`exact`, `contains`, or `regex`)
+
+After creation, verify with `matchesAction()`:
+
+```sql
+SELECT count() as matching_events
+FROM events
+WHERE matchesAction('Clicked checkout button')
+  AND timestamp > now() - INTERVAL 7 DAY
+```
+
+## Tips
+
+- Always set timestamp filters — `$autocapture` is high volume
+- Use `LIMIT` generously when sampling `elements_chain` — the strings can be long
+- The `elements_chain =~` operator matches CSS selectors as regex internally;
+  prefer materialized columns when possible for performance
+- `$autocapture` events also carry standard properties like `$current_url`, `$browser`, `$os`
+- This workflow only applies to posthog-js — other SDKs do not capture elements

--- a/products/product_analytics/skills/exploring-autocapture-events/references/elements-chain-format.md
+++ b/products/product_analytics/skills/exploring-autocapture-events/references/elements-chain-format.md
@@ -1,0 +1,53 @@
+# elements_chain format
+
+The `elements_chain` column stores the clicked DOM element and its ancestors as a single string.
+
+## Structure
+
+```text
+tag_name.class1.class2:key1="value1":key2="value2";parent_tag.parent_class:key="val"
+```
+
+- Elements are separated by `;` (semicolons)
+- First element is the clicked element, subsequent elements are ancestors up the DOM tree
+- Each element starts with `tag_name` optionally followed by `.class` segments (sorted alphabetically)
+- After the tag/class portion, key-value attributes follow as `:key="value"` pairs
+- Quotes within values are escaped as `\"`
+
+## Standard attribute keys
+
+| Key           | Description                                       |
+| ------------- | ------------------------------------------------- |
+| `text`        | Inner text content of the element                 |
+| `href`        | Link href attribute                               |
+| `attr_id`     | HTML id attribute                                 |
+| `nth-child`   | Position among siblings                           |
+| `nth-of-type` | Position among siblings of the same type          |
+| `attr_class`  | CSS classes (also encoded in the `.class` prefix) |
+
+## Custom attributes
+
+Custom DOM attributes appear verbatim in the chain.
+The most useful for analytics are `data-*` attributes:
+
+- `data-attr` — PostHog's default data attribute (configurable per team)
+- `data-testid` — common testing attribute, also useful for analytics
+- `aria-label` — accessibility label, sometimes useful as a selector
+
+Example chain with a data-attr:
+
+```text
+button.btn.primary:data-attr="checkout":text="Buy Now";div.container:attr_id="main"
+```
+
+## How CSS selectors map to regex
+
+PostHog converts CSS selectors to regex patterns matched against `elements_chain`:
+
+- `button` → `(^|;)button(\.|$|;|:)`
+- `button.cta` → `(^|;)button.*?cta.*?`
+- `#submit` → uses `indexOf(elements_chain_ids, 'submit') > 0` (optimized)
+- `[data-attr="checkout"]` → `(^|;).*?data-attr="checkout".*?`
+- `button[data-attr="checkout"]` → `(^|;)button.*?data-attr="checkout".*?`
+
+In HogQL, use `elements_chain =~ '{regex}'` for matching.

--- a/products/product_analytics/skills/exploring-autocapture-events/references/example-queries.md
+++ b/products/product_analytics/skills/exploring-autocapture-events/references/example-queries.md
@@ -1,0 +1,230 @@
+# Example queries for autocapture exploration
+
+All queries filter by timestamp — adjust the interval to match your analysis window.
+
+## Confirm autocapture exists
+
+```sql
+SELECT count() as cnt
+FROM events
+WHERE event = '$autocapture'
+  AND timestamp > now() - INTERVAL 7 DAY
+```
+
+## Top clicked tag names
+
+```sql
+SELECT
+  arrayJoin(elements_chain_elements) as tag,
+  count() as cnt
+FROM events
+WHERE event = '$autocapture'
+  AND timestamp > now() - INTERVAL 7 DAY
+GROUP BY tag
+ORDER BY cnt DESC
+LIMIT 20
+```
+
+## Top clicked text values
+
+```sql
+SELECT
+  arrayJoin(elements_chain_texts) as text,
+  count() as cnt
+FROM events
+WHERE event = '$autocapture'
+  AND timestamp > now() - INTERVAL 7 DAY
+  AND length(text) > 0
+GROUP BY text
+ORDER BY cnt DESC
+LIMIT 30
+```
+
+## Top clicked hrefs
+
+```sql
+SELECT
+  elements_chain_href as href,
+  count() as cnt
+FROM events
+WHERE event = '$autocapture'
+  AND timestamp > now() - INTERVAL 7 DAY
+  AND elements_chain_href != ''
+GROUP BY href
+ORDER BY cnt DESC
+LIMIT 20
+```
+
+## Sample raw elements_chain for a page
+
+Replace the URL pattern to match the page of interest.
+
+```sql
+SELECT
+  elements_chain,
+  count() as cnt
+FROM events
+WHERE event = '$autocapture'
+  AND timestamp > now() - INTERVAL 7 DAY
+  AND properties.$current_url ILIKE '%/pricing%'
+  AND elements_chain != ''
+GROUP BY elements_chain
+ORDER BY cnt DESC
+LIMIT 10
+```
+
+## Find elements with data-attr attributes
+
+```sql
+SELECT
+  arrayJoin(extractAll(elements_chain, 'data-attr="([^"]*)"')) as data_attr_value,
+  count() as cnt
+FROM events
+WHERE event = '$autocapture'
+  AND timestamp > now() - INTERVAL 7 DAY
+  AND match(elements_chain, 'data-attr=')
+GROUP BY data_attr_value
+ORDER BY cnt DESC
+LIMIT 20
+```
+
+## Find all data-\* attribute keys in use
+
+Useful for discovering which data attributes the application sets on interactive elements.
+
+```sql
+SELECT
+  arrayJoin(extractAll(elements_chain, '(data-[a-zA-Z0-9_-]+)=')) as data_key,
+  count() as cnt
+FROM events
+WHERE event = '$autocapture'
+  AND timestamp > now() - INTERVAL 7 DAY
+  AND match(elements_chain, 'data-')
+GROUP BY data_key
+ORDER BY cnt DESC
+LIMIT 20
+```
+
+## Test selector uniqueness
+
+Replace the regex pattern with one matching your candidate selector.
+See [elements-chain-format.md](./elements-chain-format.md) for how selectors map to regex.
+
+```sql
+SELECT count() as matching_events
+FROM events
+WHERE event = '$autocapture'
+  AND timestamp > now() - INTERVAL 7 DAY
+  AND elements_chain =~ '(^|;)button.*?data-attr="checkout"'
+```
+
+## Sample matching events to inspect captures
+
+Verify that the selector matches only the intended interaction by inspecting what it captures.
+
+```sql
+SELECT
+  elements_chain,
+  properties.$current_url as url,
+  elements_chain_texts as texts,
+  timestamp
+FROM events
+WHERE event = '$autocapture'
+  AND timestamp > now() - INTERVAL 7 DAY
+  AND elements_chain =~ '(^|;)button.*?data-attr="checkout"'
+ORDER BY timestamp DESC
+LIMIT 10
+```
+
+## Refine with text filter
+
+```sql
+SELECT count() as matching_events
+FROM events
+WHERE event = '$autocapture'
+  AND timestamp > now() - INTERVAL 7 DAY
+  AND elements_chain =~ '(^|;)button.*?data-attr="checkout"'
+  AND arrayExists(x -> x = 'Complete Purchase', elements_chain_texts)
+```
+
+## Refine with URL filter
+
+```sql
+SELECT count() as matching_events
+FROM events
+WHERE event = '$autocapture'
+  AND timestamp > now() - INTERVAL 7 DAY
+  AND elements_chain =~ '(^|;)button.*?data-attr="checkout"'
+  AND properties.$current_url ILIKE '%/checkout%'
+```
+
+## Ad-hoc trends: count matching clicks over time
+
+```sql
+SELECT
+  toStartOfDay(timestamp) as day,
+  count() as clicks
+FROM events
+WHERE event = '$autocapture'
+  AND timestamp > now() - INTERVAL 14 DAY
+  AND elements_chain =~ '(^|;)button.*?data-attr="checkout"'
+GROUP BY day
+ORDER BY day
+```
+
+## Ad-hoc trends: breakdown by page
+
+```sql
+SELECT
+  properties.$current_url as url,
+  count() as clicks
+FROM events
+WHERE event = '$autocapture'
+  AND timestamp > now() - INTERVAL 7 DAY
+  AND elements_chain =~ '(^|;)button.*?data-attr="checkout"'
+GROUP BY url
+ORDER BY clicks DESC
+LIMIT 20
+```
+
+## Ad-hoc funnel: pageview to click
+
+```sql
+SELECT
+  person_id,
+  first_pageview,
+  first_click_after
+FROM (
+  SELECT
+    p.person_id,
+    p.pageview_time as first_pageview,
+    min(c.click_time) as first_click_after
+  FROM (
+    SELECT person_id, min(timestamp) as pageview_time
+    FROM events
+    WHERE event = '$pageview'
+      AND timestamp > now() - INTERVAL 14 DAY
+      AND properties.$current_url ILIKE '%/pricing%'
+    GROUP BY person_id
+  ) p
+  INNER JOIN (
+    SELECT person_id, timestamp as click_time
+    FROM events
+    WHERE event = '$autocapture'
+      AND timestamp > now() - INTERVAL 14 DAY
+      AND elements_chain =~ '(^|;)button.*?data-attr="signup"'
+  ) c ON p.person_id = c.person_id AND c.click_time > p.pageview_time
+  GROUP BY p.person_id, p.pageview_time
+)
+```
+
+## Verify an action matches correctly
+
+After creating an action, verify it captures the right events.
+
+```sql
+SELECT count() as matching_events
+FROM events
+WHERE matchesAction('Clicked checkout button')
+  AND timestamp > now() - INTERVAL 7 DAY
+```


### PR DESCRIPTION
## Problem

Agents currently have no guidance for working with `$autocapture` data — it's intentionally excluded from the `read-data-schema` taxonomy tool because it's "only useful with autocapture-specific filters". This means the most common source of retroactive analytics in posthog-js projects is invisible to agents.

![CleanShot 2026-04-09 at 14.18.29@2x.png](https://app.graphite.com/user-attachments/assets/7d609031-5891-4d6a-89b7-4f36281d43f2.png)

## Changes

Adds a new skill `exploring-autocapture-events` to `products/product_analytics/skills/` (first skill for this product) with:

- [**SKILL.md**](http://SKILL.md) — 7-step workflow: confirm data exists → explore interactions → find selectors (prioritizing `data-attr`) → evaluate uniqueness → refine with text/URL → use in ad-hoc SQL → create durable action
- **references/elements-chain-format.md** — documents the `elements_chain` string format and how CSS selectors map to regex
- **references/example-queries.md** — copy-pasteable HogQL queries for every step of the workflow

## How did you test this code?

- `hogli lint:skills` passes (all 10 skills validated)
- Pre-commit markdown lint passes
- This is documentation/skill content only — no runtime code changes

## Publish to changelog?

No

## Docs update

N/A — this is an agent skill, not user-facing docs.

## 🤖 LLM context

Authored by PostHog Code. The skill was designed based on exploration of the autocapture data model (`elements_chain` storage, materialized columns, CSS selector parsing in `posthog/hogql/property.py`, action step schema) and existing skill patterns in the repo.

---

_Created with_ [_PostHog Code_](https://posthog.com/code?ref=pr)