### PR TITLE
fix(funnels): scope horizontal funnel display and clicks to single breakdown value

### DIFF
--- a/frontend/src/scenes/funnels/FunnelBarHorizontal/FunnelBarHorizontal.tsx
+++ b/frontend/src/scenes/funnels/FunnelBarHorizontal/FunnelBarHorizontal.tsx
@@ -25,6 +25,7 @@ import {
     formatDroppedOffPercentage,
     getBreakdownMaxIndex,
     getReferenceStep,
+    getStepBreakdownSeries,
     getTooltipTitleForConverted,
     getTooltipTitleForDroppedOff,
 } from '../funnelUtils'
@@ -80,6 +81,20 @@ export function FunnelBarHorizontal({
                     Array.isArray(step.nested_breakdown) &&
                     step.nested_breakdown?.length !== undefined &&
                     !(step.nested_breakdown.length === 1)
+
+                // When a breakdown filter resolves to a single visible value, use that series'
+                // counts and rates for display so the bar/labels match the tooltip instead of
+                // showing aggregate (cross-breakdown) values. Clicks also route through
+                // openPersonsModalForSeries so the persons modal is scoped to that value.
+                const stepBreakdownSeries = !isBreakdown ? getStepBreakdownSeries(step, breakdownFilter) : null
+                const displayStep = stepBreakdownSeries ?? step
+                const openStep = (converted: boolean): void => {
+                    if (stepBreakdownSeries) {
+                        openPersonsModalForSeries({ step, series: stepBreakdownSeries, converted })
+                    } else {
+                        openPersonsModalForStep({ step, converted })
+                    }
+                }
 
                 return (
                     <section
@@ -170,9 +185,9 @@ export function FunnelBarHorizontal({
                             ) : (
                                 <>
                                     <Bar
-                                        name={step.name}
-                                        percentage={step.conversionRates.fromBasisStep}
-                                        onBarClick={() => openPersonsModalForStep({ step, converted: true })}
+                                        name={displayStep.name}
+                                        percentage={displayStep.conversionRates.fromBasisStep}
+                                        onBarClick={() => openStep(true)}
                                         step={step.nested_breakdown![0]}
                                         stepIndex={stepIndex}
                                         breakdownFilter={breakdownFilter}
@@ -181,14 +196,10 @@ export function FunnelBarHorizontal({
                                     />
                                     <div
                                         className="funnel-bar-empty-space"
-                                        onClick={
-                                            showPersonsModal
-                                                ? () => openPersonsModalForStep({ step, converted: false }) // dropoff value for steps is negative
-                                                : undefined
-                                        }
+                                        onClick={showPersonsModal ? () => openStep(false) : undefined}
                                         // eslint-disable-next-line react/forbid-dom-props
                                         style={{
-                                            flex: `${1 - step.conversionRates.fromBasisStep} 1 0`,
+                                            flex: `${1 - displayStep.conversionRates.fromBasisStep} 1 0`,
                                             cursor: `${showPersonsModal && !inCardView ? 'pointer' : ''}`,
                                         }}
                                     />
@@ -200,22 +211,16 @@ export function FunnelBarHorizontal({
                                 title={getTooltipTitleForConverted(funnelsFilter, aggregationTargetLabel, stepIndex)}
                                 placement="bottom"
                             >
-                                <ValueInspectorButton
-                                    onClick={
-                                        showPersonsModal
-                                            ? () => openPersonsModalForStep({ step, converted: true })
-                                            : undefined
-                                    }
-                                >
+                                <ValueInspectorButton onClick={showPersonsModal ? () => openStep(true) : undefined}>
                                     <IconTrendingFlat
                                         style={{ color: 'var(--success)' }}
                                         className="value-inspector-button-icon"
                                     />
-                                    <b>{formatConvertedCount(step, aggregationTargetLabel)}</b>
+                                    <b>{formatConvertedCount(displayStep, aggregationTargetLabel)}</b>
                                 </ValueInspectorButton>{' '}
                                 {!isFirstStep && (
                                     <span className="text-secondary grow">
-                                        {`(${formatConvertedPercentage(step)}) completed step`}
+                                        {`(${formatConvertedPercentage(displayStep)}) completed step`}
                                     </span>
                                 )}
                             </Tooltip>
@@ -226,20 +231,16 @@ export function FunnelBarHorizontal({
                                         placement="bottom"
                                     >
                                         <ValueInspectorButton
-                                            onClick={
-                                                showPersonsModal
-                                                    ? () => openPersonsModalForStep({ step, converted: false })
-                                                    : undefined
-                                            }
+                                            onClick={showPersonsModal ? () => openStep(false) : undefined}
                                         >
                                             <IconTrendingFlatDown
                                                 style={{ color: 'var(--danger)' }}
                                                 className="value-inspector-button-icon"
                                             />
-                                            <b>{formatDroppedOffCount(step, aggregationTargetLabel)}</b>
+                                            <b>{formatDroppedOffCount(displayStep, aggregationTargetLabel)}</b>
                                         </ValueInspectorButton>{' '}
                                         <span className="text-secondary">
-                                            {`(${formatDroppedOffPercentage(step)}) dropped off`}
+                                            {`(${formatDroppedOffPercentage(displayStep)}) dropped off`}
                                         </span>
                                     </Tooltip>
                                 </div>

--- a/frontend/src/scenes/funnels/funnelUtils.test.ts
+++ b/frontend/src/scenes/funnels/funnelUtils.test.ts
@@ -20,6 +20,7 @@ import {
     getLastFilledStep,
     getMeanAndStandardDeviation,
     getReferenceStep,
+    getStepBreakdownSeries,
     getVisibilityKey,
     parseDisplayNameForCorrelation,
     stepsWithConversionMetrics,
@@ -699,5 +700,55 @@ describe('getLastFilledStep', () => {
         },
     ])('$scenario', ({ steps, index, expectedOrder }) => {
         expect(getLastFilledStep(steps, index).order).toBe(expectedOrder)
+    })
+})
+
+describe('getStepBreakdownSeries', () => {
+    const series = { breakdown_value: 'NL' } as any
+    it.each([
+        {
+            scenario: 'single breakdown value with breakdown filter set → returns the series',
+            step: { nested_breakdown: [series] },
+            breakdownFilter: { breakdown: '$geoip_country_code', breakdown_type: 'event' },
+            expected: series,
+        },
+        {
+            scenario: 'no breakdown filter → null',
+            step: { nested_breakdown: [series] },
+            breakdownFilter: null,
+            expected: null,
+        },
+        {
+            scenario: 'breakdown filter without breakdown property → null',
+            step: { nested_breakdown: [series] },
+            breakdownFilter: {},
+            expected: null,
+        },
+        {
+            scenario: 'multiple breakdown values → null (use existing per-bar handlers)',
+            step: { nested_breakdown: [series, { breakdown_value: 'US' }] },
+            breakdownFilter: { breakdown: '$geoip_country_code', breakdown_type: 'event' },
+            expected: null,
+        },
+        {
+            scenario: 'empty nested_breakdown → null',
+            step: { nested_breakdown: [] },
+            breakdownFilter: { breakdown: '$geoip_country_code', breakdown_type: 'event' },
+            expected: null,
+        },
+        {
+            scenario: 'undefined nested_breakdown → null',
+            step: { nested_breakdown: undefined },
+            breakdownFilter: { breakdown: '$geoip_country_code', breakdown_type: 'event' },
+            expected: null,
+        },
+        {
+            scenario: 'single entry with null breakdown_value → null',
+            step: { nested_breakdown: [{ breakdown_value: null }] },
+            breakdownFilter: { breakdown: '$geoip_country_code', breakdown_type: 'event' },
+            expected: null,
+        },
+    ])('$scenario', ({ step, breakdownFilter, expected }) => {
+        expect(getStepBreakdownSeries(step as any, breakdownFilter as any)).toBe(expected)
     })
 })

--- a/frontend/src/scenes/funnels/funnelUtils.tsx
+++ b/frontend/src/scenes/funnels/funnelUtils.tsx
@@ -12,7 +12,7 @@ import { elementsToAction } from 'scenes/activity/explore/createActionFromEvent'
 import { teamLogic } from 'scenes/teamLogic'
 
 import { Noun } from '~/models/groupsModel'
-import { AnyEntityNode, FunnelExclusionSteps, FunnelsFilter } from '~/queries/schema/schema-general'
+import { AnyEntityNode, BreakdownFilter, FunnelExclusionSteps, FunnelsFilter } from '~/queries/schema/schema-general'
 import { integer } from '~/queries/schema/type-utils'
 import {
     AnyPropertyFilter,
@@ -653,4 +653,27 @@ export function getTooltipTitleForDroppedOff(
             {funnelsFilter?.funnelStepReference === FunnelStepReference.previous ? 'previous' : 'first'} step
         </>
     )
+}
+
+// Returns the single visible breakdown series on a funnel step, when the step is rendered
+// with the non-breakdown layout but a breakdown filter is set. Lets callers route clicks
+// through `openPersonsModalForSeries` so the persons modal is scoped to that value.
+export function getStepBreakdownSeries(
+    step: Pick<FunnelStepWithConversionMetrics, 'nested_breakdown'>,
+    breakdownFilter: BreakdownFilter | null | undefined
+): FunnelStepWithConversionMetrics | null {
+    if (!breakdownFilter?.breakdown) {
+        return null
+    }
+
+    if (!Array.isArray(step.nested_breakdown) || step.nested_breakdown.length !== 1) {
+        return null
+    }
+
+    const single = step.nested_breakdown[0]
+    if (!single || single.breakdown_value == null) {
+        return null
+    }
+
+    return single
 }


### PR DESCRIPTION
## Problem

When a horizontal (top-to-bottom) funnel has a breakdown filter with a single visible value, the bar width, converted / dropped-off counts, and click targets all showed aggregate (cross-breakdown) data instead of that breakdown's own numbers.

## Changes

- Bar width, converted count, dropped-off count, and conversion percentages in the horizontal funnel now match what the tooltip already shows for the selected breakdown value.
- Clicking the bar or the converted / dropped-off counts opens the persons modal scoped to that breakdown value (previously it showed everyone across all breakdowns).
- Multi-value breakdowns still render the existing per-bar breakdown view — only the single-visible-value case changes.

## Stacked on

#53819 — this PR depends on the `recordingFilters` changes there. Rebase onto master once #53819 merges.

## How did you test this code?

I'm an agent. Ran the updated test suite — 80 tests pass across `funnelUtils.test.ts`, `personsModalLogic.test.ts`, and `funnelPersonsModalLogic.test.ts`, including 7 new parameterized cases for `getStepBreakdownSeries`. Visually verified in the dev environment that the bar fills to 100%, the counts match the tooltip, and clicks open the correctly scoped persons modal.

## Publish to changelog?