### PR TITLE
feat: Added array config routing to rust

### DIFF
--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -68,6 +68,10 @@ services:
                         path /api/surveys/
                     }
 
+                    @remote-config {
+                        path /array/*
+                    }
+
                     @webhooks {
                         path /public/webhooks
                         path /public/webhooks/
@@ -110,6 +114,10 @@ services:
                     }
 
                     handle @surveys {
+                        reverse_proxy feature-flags:3001
+                    }
+
+                    handle @remote-config {
                         reverse_proxy feature-flags:3001
                     }
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -60,6 +60,10 @@ services:
                         path /api/surveys/
                     }
 
+                    @remote-config {
+                        path /array/*
+                    }
+
                     @webhooks {
                         path /public/webhooks
                         path /public/webhooks/*
@@ -88,6 +92,10 @@ services:
                     }
 
                     handle @surveys {
+                        reverse_proxy feature-flags:3001
+                    }
+
+                    handle @remote-config {
                         reverse_proxy feature-flags:3001
                     }
 

--- a/docker-compose.sandbox.yml
+++ b/docker-compose.sandbox.yml
@@ -67,6 +67,10 @@ services:
                         path /api/surveys/
                     }
 
+                    @remote-config {
+                        path /array/*
+                    }
+
                     @webhooks {
                         path /public/webhooks
                         path /public/webhooks/*
@@ -99,6 +103,10 @@ services:
                     }
 
                     handle @surveys {
+                        reverse_proxy app:3001
+                    }
+
+                    handle @remote-config {
                         reverse_proxy app:3001
                     }
 

--- a/rust/feature-flags/src/api/mod.rs
+++ b/rust/feature-flags/src/api/mod.rs
@@ -6,5 +6,6 @@ pub mod flag_definitions_rate_limiter;
 pub mod flags_rate_limiter;
 pub mod pak_usage;
 pub mod rate_parser;
+pub mod remote_config;
 pub mod surveys;
 pub mod types;

--- a/rust/feature-flags/src/api/remote_config.rs
+++ b/rust/feature-flags/src/api/remote_config.rs
@@ -1,0 +1,277 @@
+use crate::{
+    config_cache::get_cached_config, handler::config_response_builder::sanitize_config_for_client,
+    router::State as AppState,
+};
+use axum::{
+    debug_handler,
+    extract::{Path, State},
+    http::{HeaderMap, Method, StatusCode},
+    response::{IntoResponse, Json, Response},
+};
+use common_metrics::inc;
+use serde_json::Value;
+use tracing::info;
+
+const REMOTE_CONFIG_COUNTER: &str = "remote_config_requests_total";
+
+/// Validate a project API token.
+///
+/// Matches Django's `BaseRemoteConfigAPIView.check_token`:
+/// - Max 200 characters
+/// - Only alphanumeric, underscore, and hyphen
+fn is_valid_token(token: &str) -> bool {
+    token.len() <= 200
+        && !token.is_empty()
+        && token
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || b == b'_' || b == b'-')
+}
+
+/// Cache-Control and Vary headers matching Django's `add_config_cache_headers`.
+fn config_cache_headers() -> [(&'static str, &'static str); 2] {
+    [
+        ("cache-control", "public, max-age=300"),
+        ("vary", "Origin, Referer"),
+    ]
+}
+
+/// Fetch config from HyperCache, returning the raw value.
+///
+/// Returns `Ok(config)` on hit, or an HTTP error response on failure:
+/// - 400 for invalid tokens
+/// - 404 for unknown tokens (cache miss / explicit missing marker)
+async fn get_validated_config(state: &AppState, token: &str) -> Result<Value, Response> {
+    if !is_valid_token(token) {
+        inc(
+            REMOTE_CONFIG_COUNTER,
+            &[
+                ("endpoint".to_string(), "config".to_string()),
+                ("result".to_string(), "invalid_token".to_string()),
+            ],
+            1,
+        );
+        return Err((StatusCode::BAD_REQUEST, "Invalid token").into_response());
+    }
+
+    match get_cached_config(&state.config_hypercache_reader, token).await {
+        Some(value) => {
+            inc(
+                REMOTE_CONFIG_COUNTER,
+                &[
+                    ("endpoint".to_string(), "config".to_string()),
+                    ("result".to_string(), "hit".to_string()),
+                ],
+                1,
+            );
+            Ok(value)
+        }
+        None => {
+            inc(
+                REMOTE_CONFIG_COUNTER,
+                &[
+                    ("endpoint".to_string(), "config".to_string()),
+                    ("result".to_string(), "not_found".to_string()),
+                ],
+                1,
+            );
+            info!(token = %token, "Remote config not found");
+            Err(StatusCode::NOT_FOUND.into_response())
+        }
+    }
+}
+
+/// `GET /array/:token/config` — returns JSON config blob.
+///
+/// Reads pre-computed config from HyperCache (written by Django's RemoteConfig.sync).
+/// Public endpoint — no auth beyond token validation.
+///
+/// Response headers: `Cache-Control: public, max-age=300`, `Vary: Origin, Referer`
+#[debug_handler]
+pub async fn config_endpoint(
+    State(state): State<AppState>,
+    Path(token): Path<String>,
+    headers: HeaderMap,
+    method: Method,
+) -> Response {
+    if method == Method::OPTIONS {
+        return (StatusCode::NO_CONTENT, [("allow", "GET, OPTIONS, HEAD")]).into_response();
+    }
+    if method == Method::HEAD {
+        return (
+            StatusCode::OK,
+            config_cache_headers(),
+            [("content-type", "application/json")],
+            axum::body::Body::empty(),
+        )
+            .into_response();
+    }
+
+    let mut config = match get_validated_config(&state, &token).await {
+        Ok(c) => c,
+        Err(r) => return r,
+    };
+
+    sanitize_config_for_client(&mut config, &headers);
+
+    (StatusCode::OK, config_cache_headers(), Json(config)).into_response()
+}
+
+/// `GET /array/:token/config.js` — returns JS wrapper around config.
+///
+/// Wraps the config JSON in an IIFE that sets `window._POSTHOG_REMOTE_CONFIG[token]`
+/// with the config and site apps. This is what the SDK snippet loads.
+///
+/// Response headers: same cache headers + `Content-Type: application/javascript`
+#[debug_handler]
+pub async fn config_js_endpoint(
+    State(state): State<AppState>,
+    Path(token): Path<String>,
+    headers: HeaderMap,
+    method: Method,
+) -> Response {
+    if method == Method::OPTIONS {
+        return (StatusCode::NO_CONTENT, [("allow", "GET, OPTIONS, HEAD")]).into_response();
+    }
+    if method == Method::HEAD {
+        return (
+            StatusCode::OK,
+            [
+                ("content-type", "application/javascript"),
+                ("cache-control", "public, max-age=300"),
+                ("vary", "Origin, Referer"),
+            ],
+            axum::body::Body::empty(),
+        )
+            .into_response();
+    }
+
+    let mut config = match get_validated_config(&state, &token).await {
+        Ok(c) => c,
+        Err(r) => return r,
+    };
+
+    // Extract siteAppsJS (raw JS strings) before sanitization removes it
+    let site_apps_js = config
+        .as_object_mut()
+        .and_then(|obj| obj.remove("siteAppsJS"))
+        .and_then(|v| {
+            if let Value::Array(arr) = v {
+                Some(
+                    arr.into_iter()
+                        .filter_map(|item| {
+                            if let Value::String(s) = item {
+                                Some(s)
+                            } else {
+                                None
+                            }
+                        })
+                        .collect::<Vec<String>>(),
+                )
+            } else {
+                None
+            }
+        })
+        .unwrap_or_default();
+
+    // Remove siteApps (minimal metadata) — the JS version has the full JS instead
+    if let Some(obj) = config.as_object_mut() {
+        obj.remove("siteApps");
+    }
+
+    sanitize_config_for_client(&mut config, &headers);
+
+    let config_json = serde_json::to_string(&config).unwrap_or_else(|_| "{}".to_string());
+    let site_apps_joined = site_apps_js.join(",");
+
+    let js_content = format!(
+        "(function() {{\n\
+         \x20 window._POSTHOG_REMOTE_CONFIG = window._POSTHOG_REMOTE_CONFIG || {{}};\n\
+         \x20 window._POSTHOG_REMOTE_CONFIG['{token}'] = {{\n\
+         \x20   config: {config_json},\n\
+         \x20   siteApps: [{site_apps_joined}]\n\
+         \x20 }}\n\
+         }})();"
+    );
+
+    (
+        StatusCode::OK,
+        [
+            ("content-type", "application/javascript"),
+            ("cache-control", "public, max-age=300"),
+            ("vary", "Origin, Referer"),
+        ],
+        js_content,
+    )
+        .into_response()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn test_valid_tokens() {
+        assert!(is_valid_token("phc_abc123"));
+        assert!(is_valid_token(
+            "phc_leDMtGUQ1TDiPxotanVngOdEsShwcpDsLFLROFcGK9W"
+        ));
+        assert!(is_valid_token("some-old-token_with-dashes"));
+        assert!(is_valid_token("a"));
+    }
+
+    #[test]
+    fn test_invalid_tokens() {
+        assert!(!is_valid_token(""));
+        assert!(!is_valid_token("token with spaces"));
+        assert!(!is_valid_token("token/with/slashes"));
+        assert!(!is_valid_token("token.with.dots"));
+        assert!(!is_valid_token(&"a".repeat(201)));
+    }
+
+    #[test]
+    fn test_config_js_template_format() {
+        let config = json!({"sessionRecording": true, "heatmaps": false});
+        let config_json = serde_json::to_string(&config).unwrap();
+        let site_apps_joined = "";
+        let token = "phc_test123";
+
+        let js = format!(
+            "(function() {{\n\
+             \x20 window._POSTHOG_REMOTE_CONFIG = window._POSTHOG_REMOTE_CONFIG || {{}};\n\
+             \x20 window._POSTHOG_REMOTE_CONFIG['{token}'] = {{\n\
+             \x20   config: {config_json},\n\
+             \x20   siteApps: [{site_apps_joined}]\n\
+             \x20 }}\n\
+             }})();"
+        );
+
+        assert!(js.contains("window._POSTHOG_REMOTE_CONFIG"));
+        assert!(js.contains("phc_test123"));
+        assert!(js.contains("\"sessionRecording\":true"));
+        assert!(js.contains("siteApps: []"));
+    }
+
+    #[test]
+    fn test_config_js_template_with_site_apps() {
+        let config_json = "{}";
+        let site_apps = vec![
+            "function() { return 1; }".to_string(),
+            "function() { return 2; }".to_string(),
+        ];
+        let site_apps_joined = site_apps.join(",");
+        let token = "phc_test";
+
+        let js = format!(
+            "(function() {{\n\
+             \x20 window._POSTHOG_REMOTE_CONFIG = window._POSTHOG_REMOTE_CONFIG || {{}};\n\
+             \x20 window._POSTHOG_REMOTE_CONFIG['{token}'] = {{\n\
+             \x20   config: {config_json},\n\
+             \x20   siteApps: [{site_apps_joined}]\n\
+             \x20 }}\n\
+             }})();"
+        );
+
+        assert!(js.contains("siteApps: [function() { return 1; },function() { return 2; }]"));
+    }
+}

--- a/rust/feature-flags/src/handler/config_response_builder.rs
+++ b/rust/feature-flags/src/handler/config_response_builder.rs
@@ -162,7 +162,7 @@ fn set_cached_quota_limits_without_recordings(response: &mut FlagsResponse) {
 /// - Removes `siteAppsJS` (raw JS only needed for array.js bundle, not JSON API)
 /// - Removes `sessionRecording.domains` (internal field, not needed by SDK)
 /// - Sets `sessionRecording` to `false` if request origin not in permitted domains
-fn sanitize_config_for_client(cached_config: &mut Value, headers: &HeaderMap) {
+pub fn sanitize_config_for_client(cached_config: &mut Value, headers: &HeaderMap) {
     if let Some(obj) = cached_config.as_object_mut() {
         obj.remove("siteAppsJS");
     }

--- a/rust/feature-flags/src/router.rs
+++ b/rust/feature-flags/src/router.rs
@@ -36,7 +36,7 @@ use crate::{
         endpoint, flag_definitions,
         flag_definitions_rate_limiter::FlagDefinitionsRateLimiter,
         flags_rate_limiter::{FlagsRateLimiter, IpRateLimiter},
-        surveys,
+        remote_config, surveys,
     },
     cohorts::{cohort_cache_manager::CohortCacheManager, membership::CohortMembershipProvider},
     config::{Config, ServiceMode, TeamIdCollection},
@@ -286,6 +286,14 @@ pub fn router(
             .route("/api/surveys", any(surveys::surveys_endpoint))
             .route("/api/surveys/", any(surveys::surveys_endpoint));
     }
+
+    // Remote config endpoints — reuses config_hypercache_reader (array/config.json)
+    flags_router = flags_router
+        .route("/array/:token/config", any(remote_config::config_endpoint))
+        .route(
+            "/array/:token/config.js",
+            any(remote_config::config_js_endpoint),
+        );
 
     let flags_router = flags_router
         .layer(ConcurrencyLimitLayer::new(config.max_concurrency))

--- a/rust/feature-flags/src/server.rs
+++ b/rust/feature-flags/src/server.rs
@@ -317,9 +317,9 @@ pub async fn serve<F>(
     // Create HyperCacheReader for remote config (array/config.json)
     // This reads the pre-computed config blob from Python's RemoteConfig.build_config()
     // Uses token-based lookup (api_token) to match Python's HyperCache key pattern
-    let config_redis_client = dedicated_redis_client
-        .clone()
-        .unwrap_or_else(|| redis_client.clone());
+    // Uses the shared Redis client (not dedicated flags Redis) because Django writes
+    // remote config to the default Redis database, not the flags-specific one.
+    let config_redis_client = redis_client.clone();
 
     let mut config_hypercache_config = HyperCacheConfig::new(
         "array".to_string(),


### PR DESCRIPTION
## Problem

Similar to https://github.com/PostHog/posthog/pull/53839

Adds the endpoints for serving the `array` endpoints - i.e. the endpoints that serve the static content

## Changes

- [x] Adds new endpoints. Like surveys this is part of the flag service atm - probably wants abstracting out eventually even though this is "fine" for now as we will deploy it as its own k8s deployment
- [x] Adds tests - hit both locally and it worked identically
- [x] Doesn't bother with `array.js` - we never released this and its a bit flawed anyways


## How did you test this code?

Tests - but very minimally