### PR TITLE
fix(replay): convert webGLVarMap to WeakMap

### DIFF
--- a/common/replay-shared/src/canvas/deserialize-canvas-args.ts
+++ b/common/replay-shared/src/canvas/deserialize-canvas-args.ts
@@ -5,7 +5,7 @@ import { base64ArrayBuffer } from '../utils'
 
 type GLVarMap = Map<string, any[]>
 type CanvasContexts = CanvasRenderingContext2D | WebGLRenderingContext | WebGL2RenderingContext
-const webGLVarMap: Map<CanvasContexts, GLVarMap> = new Map()
+const webGLVarMap: WeakMap<CanvasContexts, GLVarMap> = new WeakMap()
 
 const variableListFor = (ctx: CanvasContexts, ctor: string): any[] => {
     let contextMap = webGLVarMap.get(ctx)


### PR DESCRIPTION
## Problem

Canvas replay functionality may experience memory leaks when canvas contexts are not properly garbage collected. The current implementation uses a `Map` to store WebGL variable mappings, which maintains strong references to canvas contexts and prevents them from being cleaned up even when they're no longer needed.

## Changes

Changed `webGLVarMap` from a `Map` to a `WeakMap` in the canvas argument deserializer. This allows canvas contexts to be garbage collected when they go out of scope, preventing potential memory leaks during canvas replay operations.

## How did you test this code?

As an agent, I have not manually tested this code. The change is a straightforward type modification that maintains the same API while improving memory management. Manual testing would involve:

1. Creating multiple canvas contexts during replay
2. Monitoring memory usage over time
3. Verifying that contexts are properly garbage collected when no longer referenced
4. Ensuring canvas replay functionality continues to work as expected

## Publish to changelog?

No

## Docs update

No documentation update needed for this internal memory management improvement.

Related to #32479
