### PR TITLE
fix(replay): track and destroy HLS instances on replayer teardown

### DIFF
--- a/common/replay-shared/src/index.ts
+++ b/common/replay-shared/src/index.ts
@@ -56,5 +56,6 @@ export {
     CorsPlugin,
     COMMON_REPLAYER_CONFIG,
     HLSPlayerPlugin,
+    createHLSPlayerPlugin,
     WindowTitlePlugin,
 } from './rrweb-plugins'

--- a/common/replay-shared/src/rrweb-plugins/index.ts
+++ b/common/replay-shared/src/rrweb-plugins/index.ts
@@ -75,46 +75,61 @@ export const COMMON_REPLAYER_CONFIG: Partial<playerConfig> = {
 export { AudioMuteReplayerPlugin } from './audio-mute-plugin'
 export { WindowTitlePlugin } from './window-title-plugin'
 
-export const HLSPlayerPlugin: ReplayPlugin = {
-    onBuild: (node) => {
-        if (node && node.nodeName === 'VIDEO' && node.nodeType === 1) {
-            const videoEl = node as HTMLVideoElement
-            const hlsSrc = videoEl.getAttribute('hls-src')
+export function createHLSPlayerPlugin(): ReplayPlugin & { destroy: () => void } {
+    const instances: Set<{ destroy: () => void }> = new Set()
 
-            if (videoEl && hlsSrc) {
-                void import('hls.js')
-                    .then(({ default: Hls }) => {
-                        if (Hls.isSupported()) {
-                            const hls = new Hls()
-                            hls.loadSource(hlsSrc)
-                            hls.attachMedia(videoEl)
+    return {
+        onBuild: (node) => {
+            if (node && node.nodeName === 'VIDEO' && node.nodeType === 1) {
+                const videoEl = node as HTMLVideoElement
+                const hlsSrc = videoEl.getAttribute('hls-src')
 
-                            hls.on(Hls.Events.ERROR, (_, data) => {
-                                if (data.fatal) {
-                                    switch (data.type) {
-                                        case Hls.ErrorTypes.NETWORK_ERROR:
-                                            hls.startLoad()
-                                            break
-                                        case Hls.ErrorTypes.MEDIA_ERROR:
-                                            hls.recoverMediaError()
-                                            break
-                                        default:
-                                            hls.destroy()
-                                            break
+                if (videoEl && hlsSrc) {
+                    void import('hls.js')
+                        .then(({ default: Hls }) => {
+                            if (Hls.isSupported()) {
+                                const hls = new Hls()
+                                instances.add(hls)
+                                hls.loadSource(hlsSrc)
+                                hls.attachMedia(videoEl)
+
+                                hls.on(Hls.Events.ERROR, (_, data) => {
+                                    if (data.fatal) {
+                                        switch (data.type) {
+                                            case Hls.ErrorTypes.NETWORK_ERROR:
+                                                hls.startLoad()
+                                                break
+                                            case Hls.ErrorTypes.MEDIA_ERROR:
+                                                hls.recoverMediaError()
+                                                break
+                                            default:
+                                                hls.destroy()
+                                                instances.delete(hls)
+                                                break
+                                        }
                                     }
-                                }
-                            })
-                        } else if (videoEl.canPlayType('application/vnd.apple.mpegurl')) {
-                            videoEl.src = hlsSrc
-                        }
-                    })
-                    .catch(() => {
-                        // Chunk load failure — fall back to native HLS if the browser supports it
-                        if (videoEl.canPlayType('application/vnd.apple.mpegurl')) {
-                            videoEl.src = hlsSrc
-                        }
-                    })
+                                })
+                            } else if (videoEl.canPlayType('application/vnd.apple.mpegurl')) {
+                                videoEl.src = hlsSrc
+                            }
+                        })
+                        .catch(() => {
+                            if (videoEl.canPlayType('application/vnd.apple.mpegurl')) {
+                                videoEl.src = hlsSrc
+                            }
+                        })
+                }
             }
-        }
-    },
+        },
+
+        destroy: () => {
+            for (const hls of instances) {
+                hls.destroy()
+            }
+            instances.clear()
+        },
+    }
 }
+
+/** @deprecated Use createHLSPlayerPlugin() for proper lifecycle management */
+export const HLSPlayerPlugin: ReplayPlugin = createHLSPlayerPlugin()

--- a/common/replay-shared/src/rrweb-plugins/index.ts
+++ b/common/replay-shared/src/rrweb-plugins/index.ts
@@ -77,6 +77,7 @@ export { WindowTitlePlugin } from './window-title-plugin'
 
 export function createHLSPlayerPlugin(): ReplayPlugin & { destroy: () => void } {
     const instances: Set<{ destroy: () => void }> = new Set()
+    let destroyed = false
 
     return {
         onBuild: (node) => {
@@ -87,6 +88,9 @@ export function createHLSPlayerPlugin(): ReplayPlugin & { destroy: () => void } 
                 if (videoEl && hlsSrc) {
                     void import('hls.js')
                         .then(({ default: Hls }) => {
+                            if (destroyed) {
+                                return
+                            }
                             if (Hls.isSupported()) {
                                 const hls = new Hls()
                                 instances.add(hls)
@@ -123,6 +127,8 @@ export function createHLSPlayerPlugin(): ReplayPlugin & { destroy: () => void } 
         },
 
         destroy: () => {
+            destroyed = true
+
             for (const hls of instances) {
                 hls.destroy()
             }

--- a/common/replay-shared/src/rrweb-plugins/index.ts
+++ b/common/replay-shared/src/rrweb-plugins/index.ts
@@ -118,6 +118,10 @@ export function createHLSPlayerPlugin(): ReplayPlugin & { destroy: () => void } 
                             }
                         })
                         .catch(() => {
+                            // Chunk load failure — fall back to native HLS if the browser supports it
+                            if (destroyed) {
+                                return
+                            }
                             if (videoEl.canPlayType('application/vnd.apple.mpegurl')) {
                                 videoEl.src = hlsSrc
                             }

--- a/common/replay-shared/src/rrweb-plugins/rrweb-plugins.test.ts
+++ b/common/replay-shared/src/rrweb-plugins/rrweb-plugins.test.ts
@@ -1,7 +1,7 @@
 /**
  * @jest-environment jsdom
  */
-import { CorsPlugin, HLSPlayerPlugin, WindowTitlePlugin } from './index'
+import { CorsPlugin, createHLSPlayerPlugin, WindowTitlePlugin } from './index'
 
 describe('CorsPlugin', () => {
     it.each(['https://some-external.js'])('should replace JS urls', (jsUrl) => {
@@ -58,20 +58,23 @@ const mockHlsClass = Object.assign(
 jest.mock('hls.js', () => ({ __esModule: true, default: mockHlsClass }))
 
 describe('HLSPlayerPlugin', () => {
+    let plugin: ReturnType<typeof createHLSPlayerPlugin>
+
     beforeEach(() => {
         jest.clearAllMocks()
         mockHlsClass.isSupported.mockReturnValue(true)
+        plugin = createHLSPlayerPlugin()
     })
 
     it('does nothing for non-video elements', async () => {
         const div = document.createElement('div')
-        await HLSPlayerPlugin.onBuild?.(div, { id: 1, replayer: null as any })
+        await plugin.onBuild?.(div, { id: 1, replayer: null as any })
         expect(mockHlsClass).not.toHaveBeenCalled()
     })
 
     it('does nothing for video elements without hls-src', async () => {
         const video = document.createElement('video')
-        await HLSPlayerPlugin.onBuild?.(video, { id: 1, replayer: null as any })
+        await plugin.onBuild?.(video, { id: 1, replayer: null as any })
         expect(mockHlsClass).not.toHaveBeenCalled()
     })
 
@@ -79,7 +82,7 @@ describe('HLSPlayerPlugin', () => {
         const video = document.createElement('video')
         video.setAttribute('hls-src', 'https://example.com/stream.m3u8')
 
-        await HLSPlayerPlugin.onBuild?.(video, { id: 1, replayer: null as any })
+        await plugin.onBuild?.(video, { id: 1, replayer: null as any })
 
         expect(mockHlsClass).toHaveBeenCalled()
         expect(mockHlsInstance.loadSource).toHaveBeenCalledWith('https://example.com/stream.m3u8')
@@ -93,7 +96,7 @@ describe('HLSPlayerPlugin', () => {
         video.setAttribute('hls-src', 'https://example.com/stream.m3u8')
         video.canPlayType = jest.fn(() => 'maybe') as any
 
-        await HLSPlayerPlugin.onBuild?.(video, { id: 1, replayer: null as any })
+        await plugin.onBuild?.(video, { id: 1, replayer: null as any })
 
         expect(mockHlsInstance.loadSource).not.toHaveBeenCalled()
         expect(video.src).toContain('https://example.com/stream.m3u8')

--- a/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
@@ -24,7 +24,7 @@ import {
     COMMON_REPLAYER_CONFIG,
     CanvasReplayerPlugin,
     CorsPlugin,
-    HLSPlayerPlugin,
+    createHLSPlayerPlugin,
 } from '@posthog/replay-shared'
 import { ReplayPlugin, Replayer, playerConfig } from '@posthog/rrweb'
 import { EventType, IncrementalSource, eventWithTime } from '@posthog/rrweb-types'
@@ -1253,7 +1253,8 @@ export const sessionRecordingPlayerLogic = kea<sessionRecordingPlayerLogicType>(
                 return
             }
 
-            const plugins: ReplayPlugin[] = [HLSPlayerPlugin]
+            const hlsPlugin = createHLSPlayerPlugin()
+            const plugins: ReplayPlugin[] = [hlsPlugin]
 
             // We don't want non-cloud products to talk to our proxy as it likely won't work, but we _do_ want local testing to work
             if (values.preflight?.cloud || window.location.hostname === 'localhost') {
@@ -1406,6 +1407,7 @@ export const sessionRecordingPlayerLogic = kea<sessionRecordingPlayerLogicType>(
 
                     return () => {
                         canvasPlugin.destroy()
+                        hlsPlugin.destroy()
 
                         if (replayer) {
                             for (const cleanup of iframeCleanups) {


### PR DESCRIPTION
## Problem

The HLS player plugin was not properly cleaning up HLS.js instances when the session recording player was destroyed, leading to potential memory leaks and resource management issues.

## Changes

- Refactored `HLSPlayerPlugin` into a factory function `createHLSPlayerPlugin()` that returns a plugin instance with proper lifecycle management
- Added instance tracking to keep references to all created HLS.js instances
- Implemented a `destroy()` method that properly cleans up all HLS instances and prevents new ones from being created after destruction
- Added destroyed state checking to prevent operations after cleanup
- Marked the original `HLSPlayerPlugin` as deprecated in favor of the new factory function
- Updated the session recording player logic to use the new factory function and call `destroy()` during cleanup
- Updated tests to use the new factory function

## How did you test this code?

The existing unit tests were updated to use the new `createHLSPlayerPlugin()` factory function and continue to pass, ensuring the core functionality remains intact. The tests verify that:
- Non-video elements are ignored
- Video elements without HLS source are ignored  
- HLS.js is properly initialized for video elements with HLS source
- Fallback to native HLS works when HLS.js is not supported

Manual testing would involve creating and destroying session recording players with HLS video content to verify that HLS instances are properly cleaned up without memory leaks.

## Publish to changelog?

No

## Docs update

No documentation update needed as this is an internal refactoring for better resource management.

Related to #32479
