### PR TITLE
fix: prevent IndexError when accessing request.path segments

### DIFF
--- a/posthog/middleware.py
+++ b/posthog/middleware.py
@@ -122,7 +122,9 @@ class AllowIPMiddleware:
 
     def __call__(self, request: HttpRequest):
         response: HttpResponse = self.get_response(request)
-        if request.path.split("/")[1] in ALWAYS_ALLOWED_ENDPOINTS:
+
+        parts = request.path.split("/")
+        if len(parts) > 1 and parts[1] in ALWAYS_ALLOWED_ENDPOINTS:
             return response
         ip = self.extract_client_ip(request)
         if ip:
@@ -548,7 +550,7 @@ class PostHogTokenCookieMiddleware(SessionMiddleware):
 
         # skip adding the cookie on API requests
         split_request_path = request.path.split("/")
-        if len(split_request_path) and split_request_path[1] in cookie_api_paths_to_ignore:
+        if len(split_request_path) > 1 and split_request_path[1] in cookie_api_paths_to_ignore:
             return response
 
         if request.path.startswith("/logout"):

--- a/posthog/test/test_middleware.py
+++ b/posthog/test/test_middleware.py
@@ -536,6 +536,20 @@ class TestPostHogTokenCookieMiddleware(APIBaseTest):
         self.assertNotIn("ph_current_project_token", response.cookies)
         self.assertNotIn("ph_current_project_name", response.cookies)
 
+    def test_split_path_edge_cases_do_not_raise(self):
+        from django.test import RequestFactory
+        from django.http import HttpResponse
+        from posthog.middleware import PostHogTokenCookieMiddleware
+
+        factory = RequestFactory()
+        middleware = PostHogTokenCookieMiddleware(lambda r: HttpResponse())
+
+        for path in ["", "/", "/api"]:
+            request = factory.get("/")
+            request.path = path
+
+            # should NOT raise IndexError
+            middleware(request)
 
 @override_settings(IMPERSONATION_TIMEOUT_SECONDS=100)
 @override_settings(IMPERSONATION_IDLE_TIMEOUT_SECONDS=20)


### PR DESCRIPTION
## Problem

Some middleware directly accessed `request.path.split("/")[1]` without checking length, which can cause an IndexError for edge-case paths (e.g., "/", empty, malformed).

## Changes

- Added bounds checks before accessing path segments:
  - AllowIPMiddleware
  - PostHogTokenCookieMiddleware
- Ensured safe handling of request paths with fewer segments

## How did you test this code?

- Manually reviewed edge cases like:
  - "/"
  - ""
  - "/api"
- Verified no IndexError occurs when accessing path segments
- Existing behavior remains unchanged for valid paths

## Publish to changelog?

no