### PR TITLE
fix: avoid redundant localStorage writes from feature flag polling

### DIFF
--- a/frontend/src/lib/logic/featureFlagLogic.ts
+++ b/frontend/src/lib/logic/featureFlagLogic.ts
@@ -34,6 +34,9 @@ function getPersistedFeatureFlags(appContext: AppContext | undefined = getAppCon
     return flags
 }
 
+let cachedFlagsSerialized: string | null = null
+let cachedFlagsProxy: FeatureFlagsSet | null = null
+
 function spyOnFeatureFlags(featureFlags: FeatureFlagsSet): FeatureFlagsSet {
     const appContext = getAppContext()
     const persistedFlags = getPersistedFeatureFlags(appContext)
@@ -42,8 +45,14 @@ function spyOnFeatureFlags(featureFlags: FeatureFlagsSet): FeatureFlagsSet {
             ? { ...persistedFlags, ...featureFlags }
             : persistedFlags
 
+    const serialized = JSON.stringify(availableFlags)
+    if (serialized === cachedFlagsSerialized && cachedFlagsProxy) {
+        return cachedFlagsProxy
+    }
+    cachedFlagsSerialized = serialized
+
     if (typeof window.Proxy !== 'undefined') {
-        return new Proxy(
+        cachedFlagsProxy = new Proxy(
             {},
             {
                 get(_, flag) {
@@ -57,6 +66,7 @@ function spyOnFeatureFlags(featureFlags: FeatureFlagsSet): FeatureFlagsSet {
                 },
             }
         )
+        return cachedFlagsProxy
     }
     // Fallback for IE11. Won't track "false" results. ¯\_(ツ)_/¯
     const flags: FeatureFlagsSet = {}
@@ -71,6 +81,7 @@ function spyOnFeatureFlags(featureFlags: FeatureFlagsSet): FeatureFlagsSet {
             },
         })
     }
+    cachedFlagsProxy = flags
     return flags
 }
 


### PR DESCRIPTION
## Problem

Feature flag logic was creating new proxy objects on every call, leading to unnecessary object creation and potential performance issues when feature flags are accessed frequently.

## Changes

Added caching mechanism to the `spyOnFeatureFlags` function that:
- Caches the serialized feature flags and the corresponding proxy object
- Returns the cached proxy when feature flags haven't changed
- Only creates new proxy objects when the feature flag configuration actually changes
- Applies caching to both the Proxy-based implementation and the fallback implementation

## How did you test this code?

👉 _I am an agent and have not manually tested this code. The changes preserve the existing API and behavior while adding performance optimizations through caching._

The caching logic should be tested by:
- Verifying that feature flag access still works correctly
- Confirming that the same proxy object is returned when feature flags haven't changed
- Ensuring new proxy objects are created when feature flags are updated

## Publish to changelog?

No

## Docs update

No documentation changes needed as this is an internal performance optimization that doesn't change the public API.