### PR TITLE
fix: gate posthog wrapper on api_key presence

### DIFF
--- a/tools/pr-approval-agent/reviewer.py
+++ b/tools/pr-approval-agent/reviewer.py
@@ -17,9 +17,10 @@ from claude_agent_sdk.types import AssistantMessage, ToolUseBlock
 from github import PRData
 
 try:
+    import posthoganalytics
     from posthoganalytics.ai.claude_agent_sdk import query
 
-    _POSTHOG_AI_AVAILABLE = True
+    _POSTHOG_AI_AVAILABLE = bool(posthoganalytics.api_key)
 except ImportError:
     from claude_agent_sdk import query  # type: ignore[no-redef]
 


### PR DESCRIPTION
## Problem

stamphog CI failures: `posthoganalytics` 7.10.x (released Apr 7-8) added `ai.claude_agent_sdk`, so the import in `reviewer.py` now succeeds where it previously raised `ImportError`. But without `POSTHOG_API_KEY` in CI, `posthoganalytics.setup()` raises `ValueError("API key is required")` at runtime — failing all 3 retry attempts and producing an ESCALATE verdict.

Example run (look into Run Review section): https://github.com/PostHog/posthog/actions/runs/24191989823/job/70611423402?pr=53832

## Changes

Gate `_POSTHOG_AI_AVAILABLE` on `bool(posthoganalytics.api_key)` at import time instead of just catching `ImportError`. When no PostHog API key is configured, the plain `claude_agent_sdk.query` is used — same behavior as before 7.10. When `POSTHOG_API_KEY` is added to CI later, the observability wrapper activates automatically.

## How did you test this code?

Agent-authored — not tested manually. The fix is a one-line gate on a module-level attribute that's set from `os.environ.get('POSTHOG_API_KEY')` at import time.

## Publish to changelog?

no

## LLM context

Root-caused by tracing the "API key is required" error through `posthoganalytics.setup()` → `PostHogClaudeAgentProcessor.__init__` → `query()` wrapper. The 7.10.x release added the `ai.claude_agent_sdk` module, changing the import behavior.