### PR TITLE
fix: add allowed_updates to analytics service for plan upgrades

### DIFF
--- a/ee/api/agentic_provisioning/test/test_services.py
+++ b/ee/api/agentic_provisioning/test/test_services.py
@@ -88,6 +88,13 @@ class TestProvisioningServices(StripeProvisioningTestBase):
 
     @patch("ee.api.agentic_provisioning.views.requests.get", return_value=_mock_billing_response())
     @patch("ee.api.agentic_provisioning.views.cache", new_callable=_mock_cache_empty)
+    def test_analytics_deployable_allows_service_ref_updates(self, mock_cache, mock_get):
+        res = self._get_signed("/api/agentic/provisioning/services")
+        analytics = res.json()["data"][2]
+        assert analytics["allowed_updates"] == ["service_ref"]
+
+    @patch("ee.api.agentic_provisioning.views.requests.get", return_value=_mock_billing_response())
+    @patch("ee.api.agentic_provisioning.views.cache", new_callable=_mock_cache_empty)
     def test_analytics_deployable_has_component_pricing(self, mock_cache, mock_get):
         res = self._get_signed("/api/agentic/provisioning/services")
         analytics = res.json()["data"][2]

--- a/ee/api/agentic_provisioning/views.py
+++ b/ee/api/agentic_provisioning/views.py
@@ -132,6 +132,9 @@ def _build_analytics_service(description: str) -> dict[str, Any]:
             },
         },
         "kind": "deployable",
+        # Stripe validates allowed_updates client-side before calling update_service.
+        # Without this, `stripe projects update` rejects plan changes.
+        "allowed_updates": ["service_ref"],
     }
 
 


### PR DESCRIPTION
## Problem

`stripe projects update posthog/analytics pay_as_you_go` fails with `service_ref is not an allowed update` because the analytics service doesn't declare what updates are permitted.

Stripe validates the `allowed_updates` field client-side before calling our `update_service` endpoint. Without it, plan upgrades are blocked even though our endpoint handles them correctly.

### Why we missed this

The `allowed_updates` field is optional in the provisioning schema - `services-list` passes validation without it. The check only happens at update time in the Stripe CLI, which validates client-side before hitting our endpoint. Our `update_service` tests mock the orchestrator layer and go directly to the endpoint, so they never exercise this validation. The posthog-spec-toolkit also doesn't catch this because its `update-resource` flow doesn't validate `allowed_updates` the way the real CLI does.

This would be good feedback for the toolkit - it should validate `allowed_updates` during `update-resource` the same way the production CLI does, so providers can catch this during development.

## Changes

Added `"allowed_updates": ["service_ref"]` to the analytics deployable service, allowing plan upgrades/downgrades via the Stripe CLI.

## How did you test this code?

- Ran posthog-spec-toolkit `services-list` against local dev server - 200 OK with `allowed_updates: ["service_ref"]` in analytics service
- Ran `update-resource --service-id pay_as_you_go` - request reaches our endpoint (returns expected auth error locally, confirming orchestrator validation passes)
- Reproduced the original CLI error: `stripe projects update posthog/analytics pay_as_you_go` fails without this field

## Changelog

No