### PR TITLE
fix(experiments): Show spinner while loading project experiment settings

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentsSettings.tsx
+++ b/frontend/src/scenes/experiments/ExperimentsSettings.tsx
@@ -1,13 +1,24 @@
+import { useValues } from 'kea'
+
 import { LemonLabel } from 'lib/lemon-ui/LemonLabel'
+import { Spinner } from 'lib/lemon-ui/Spinner'
 import { DefaultExperimentConfidenceLevel } from 'scenes/settings/environment/DefaultExperimentConfidenceLevel'
 import { DefaultExperimentStatsMethod } from 'scenes/settings/environment/DefaultExperimentStatsMethod'
 import { ExperimentRecalculationTime } from 'scenes/settings/environment/ExperimentRecalculationTime'
+
+import { teamLogic } from '~/scenes/teamLogic'
 
 /**
  * although this works fine for now, if we keep adding more settings we need to refactor this to use the
  * <Settings /> component. That will require we create a new section for experiments on the SettingsMap.
  */
 export function ExperimentsSettings(): JSX.Element {
+    const { currentTeamLoading } = useValues(teamLogic)
+
+    if (currentTeamLoading) {
+        return <Spinner className="text-2xl" />
+    }
+
     return (
         <div className="space-y-8">
             <div>

--- a/frontend/src/scenes/experiments/ExperimentsSettings.tsx
+++ b/frontend/src/scenes/experiments/ExperimentsSettings.tsx
@@ -13,9 +13,9 @@ import { teamLogic } from '~/scenes/teamLogic'
  * <Settings /> component. That will require we create a new section for experiments on the SettingsMap.
  */
 export function ExperimentsSettings(): JSX.Element {
-    const { currentTeamLoading } = useValues(teamLogic)
+    const { currentTeam, currentTeamLoading } = useValues(teamLogic)
 
-    if (currentTeamLoading) {
+    if (currentTeamLoading && !currentTeam) {
         return <Spinner className="text-2xl" />
     }
 


### PR DESCRIPTION
## Problem

The experiment settings page (statistical method, confidence level, recalculation time) flashes default values before the actual team data loads.

## Changes

Show a spinner in `ExperimentsSettings` while `currentTeam` is loading, instead of rendering children that fall back to hardcoded defaults.

## How did you test this code?

Verified spinner displays while team data loads, then settings render with correct values.