### PR TITLE
feat(revenue-analytics): Auto-create persons join when enabling revenue analytics

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -6016,11 +6016,7 @@ const api = {
 
         resolveByName(
             promptName: string,
-            params?: { version?: number
-                version_id?: string
-                offset?: number
-                before_version?: number
-                limit?: number }
+            params?: { version?: number; version_id?: string; offset?: number; before_version?: number; limit?: number }
         ): Promise<LLMPromptResolveResponse> {
             return new ApiRequest().llmPromptResolveByName(promptName).withQueryString(params).get()
         },

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1947,6 +1947,11 @@ export class ApiRequest {
     public heatmapScreenshotSaved(id: number | string, teamId?: TeamType['id']): ApiRequest {
         return this.heatmapScreenshotsSaved(teamId).addPathComponent(id)
     }
+
+    // Revenue analytics
+    public revenueAnalyticsJoins(teamId?: TeamType['id']): ApiRequest {
+        return this.environmentsDetail(teamId).addPathComponent('revenue_analytics').addPathComponent('joins')
+    }
 }
 
 const normalizeUrl = (url: string): string => {
@@ -6011,7 +6016,11 @@ const api = {
 
         resolveByName(
             promptName: string,
-            params?: { version?: number; version_id?: string; offset?: number; before_version?: number; limit?: number }
+            params?: { version?: number
+                version_id?: string
+                offset?: number
+                before_version?: number
+                limit?: number }
         ): Promise<LLMPromptResolveResponse> {
             return new ApiRequest().llmPromptResolveByName(promptName).withQueryString(params).get()
         },
@@ -6342,6 +6351,12 @@ const api = {
             kind: DataWarehouseManagedViewsetKind
         ): Promise<{ views: DataWarehouseManagedViewsetSavedQuery[]; count: number }> {
             return await new ApiRequest().dataWarehouseManagedViewset(kind).get()
+        },
+    },
+
+    revenueAnalyticsJoins: {
+        async sync(enabled: boolean): Promise<void> {
+            return await new ApiRequest().revenueAnalyticsJoins().create({ data: { enabled } })
         },
     },
 

--- a/frontend/src/scenes/data-management/managed-viewsets/DataWarehouseManagedViewsetsScene.tsx
+++ b/frontend/src/scenes/data-management/managed-viewsets/DataWarehouseManagedViewsetsScene.tsx
@@ -60,6 +60,9 @@ export function DataWarehouseManagedViewsetsScene(): JSX.Element {
 
         try {
             await api.dataWarehouseManagedViewsets.toggle(kind, false)
+            if (kind === 'revenue_analytics') {
+                await api.revenueAnalyticsJoins.sync(false)
+            }
             lemonToast.success(`${VIEWSET_TITLES[kind]} viewset disabled and views deleted successfully`)
             loadCurrentTeam()
             return true

--- a/frontend/src/scenes/data-management/managed-viewsets/dataWarehouseManagedViewsetsLogic.ts
+++ b/frontend/src/scenes/data-management/managed-viewsets/dataWarehouseManagedViewsetsLogic.ts
@@ -55,6 +55,9 @@ export const dataWarehouseManagedViewsetsLogic = kea<dataWarehouseManagedViewset
                     // If enabling, proceed directly
                     try {
                         await api.dataWarehouseManagedViewsets.toggle(kind, true)
+                        if (kind === 'revenue_analytics') {
+                            await api.revenueAnalyticsJoins.sync(true)
+                        }
                         lemonToast.success(`Viewset enabled successfully`)
                         actions.loadCurrentTeam()
                     } catch (error: any) {

--- a/posthog/api/__init__.py
+++ b/posthog/api/__init__.py
@@ -1220,6 +1220,13 @@ environments_router.register(
     ["team_id"],
 )
 
+environments_router.register(
+    r"revenue_analytics/joins",
+    revenue_analytics.RevenueAnalyticsJoinViewSet,
+    "environment_revenue_analytics_joins",
+    ["team_id"],
+)
+
 projects_router.register(
     r"flag_value",
     flag_value.FlagValueViewSet,

--- a/products/data_warehouse/backend/api/external_data_source.py
+++ b/products/data_warehouse/backend/api/external_data_source.py
@@ -864,7 +864,7 @@ class ExternalDataSourceViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixi
                 kind=DataWarehouseManagedViewSetKind.REVENUE_ANALYTICS,
             )
             managed_viewset.sync_views()
-            ensure_person_join(self.team.pk, new_source_model.prefix or "")
+            ensure_person_join(self.team.pk, new_source_model.prefix)
 
         return Response(status=status.HTTP_201_CREATED, data={"id": new_source_model.pk})
 

--- a/products/data_warehouse/backend/api/external_data_source.py
+++ b/products/data_warehouse/backend/api/external_data_source.py
@@ -81,6 +81,7 @@ from products.data_warehouse.backend.models.external_data_schema import sync_old
 from products.data_warehouse.backend.models.revenue_analytics_config import ExternalDataSourceRevenueAnalyticsConfig
 from products.data_warehouse.backend.models.util import postgres_columns_to_dwh_columns, validate_source_prefix
 from products.data_warehouse.backend.types import DataWarehouseManagedViewSetKind, ExternalDataSourceType
+from products.revenue_analytics.backend.joins import ensure_person_join, remove_person_join
 
 logger = structlog.get_logger(__name__)
 
@@ -863,6 +864,7 @@ class ExternalDataSourceViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixi
                 kind=DataWarehouseManagedViewSetKind.REVENUE_ANALYTICS,
             )
             managed_viewset.sync_views()
+            ensure_person_join(self.team.pk, new_source_model.prefix or "")
 
         return Response(status=status.HTTP_201_CREATED, data={"id": new_source_model.pk})
 
@@ -1351,12 +1353,15 @@ class ExternalDataSourceViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixi
         config_serializer.is_valid(raise_exception=True)
         config_serializer.save()
 
+        table_prefix = external_data_source.prefix or ""
+
         if config.enabled:
             managed_viewset, _ = DataWarehouseManagedViewSet.objects.get_or_create(
                 team=self.team,
                 kind=DataWarehouseManagedViewSetKind.REVENUE_ANALYTICS,
             )
             managed_viewset.sync_views()
+            ensure_person_join(self.team.pk, table_prefix)
         else:
             try:
                 managed_viewset = DataWarehouseManagedViewSet.objects.get(
@@ -1367,6 +1372,7 @@ class ExternalDataSourceViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixi
 
             except DataWarehouseManagedViewSet.DoesNotExist:
                 pass
+            remove_person_join(self.team.pk, table_prefix)
 
         # Return the full external data source with updated config
         source_serializer = self.get_serializer(external_data_source, context=self.get_serializer_context())

--- a/products/data_warehouse/backend/api/test/test_external_data_source.py
+++ b/products/data_warehouse/backend/api/test/test_external_data_source.py
@@ -56,8 +56,10 @@ from products.data_warehouse.backend.direct_postgres import DIRECT_POSTGRES_URL_
 from products.data_warehouse.backend.models import ExternalDataSchema, ExternalDataSource
 from products.data_warehouse.backend.models.external_data_job import ExternalDataJob
 from products.data_warehouse.backend.models.external_data_schema import sync_frequency_interval_to_sync_frequency
+from products.data_warehouse.backend.models.join import DataWarehouseJoin
 from products.data_warehouse.backend.models.revenue_analytics_config import ExternalDataSourceRevenueAnalyticsConfig
 from products.data_warehouse.backend.models.table import DataWarehouseTable
+from products.revenue_analytics.backend.joins import get_customer_revenue_view_name
 
 
 class TestExternalDataSource(APIBaseTest):
@@ -3361,6 +3363,44 @@ class TestExternalDataSource(APIBaseTest):
             for source in sources:
                 # This should not trigger additional queries due to select_related
                 _ = source.revenue_analytics_config.enabled
+
+    def test_enabling_revenue_analytics_creates_person_join(self):
+        source = self._create_external_data_source()
+        source.revenue_analytics_config_safe.enabled = False
+        source.revenue_analytics_config_safe.save()
+
+        self.client.patch(
+            f"/api/environments/{self.team.pk}/external_data_sources/{source.pk}/revenue_analytics_config/",
+            data={"enabled": True},
+        )
+
+        view_name = get_customer_revenue_view_name(source.prefix or "")
+        assert DataWarehouseJoin.objects.filter(
+            team=self.team,
+            source_table_name=view_name,
+            joining_table_name="persons",
+            field_name="persons",
+            deleted=False,
+        ).exists()
+
+    def test_disabling_revenue_analytics_removes_person_join(self):
+        source = self._create_external_data_source()
+
+        self.client.patch(
+            f"/api/environments/{self.team.pk}/external_data_sources/{source.pk}/revenue_analytics_config/",
+            data={"enabled": True},
+        )
+
+        view_name = get_customer_revenue_view_name(source.prefix or "")
+        assert DataWarehouseJoin.objects.filter(team=self.team, source_table_name=view_name, deleted=False).exists()
+
+        self.client.patch(
+            f"/api/environments/{self.team.pk}/external_data_sources/{source.pk}/revenue_analytics_config/",
+            data={"enabled": False},
+        )
+
+        assert not DataWarehouseJoin.objects.filter(team=self.team, source_table_name=view_name, deleted=False).exists()
+        assert DataWarehouseJoin.objects.filter(team=self.team, source_table_name=view_name, deleted=True).exists()
 
     def test_create_external_data_source_rejects_invalid_prefix(self):
         """Test that invalid characters in prefix are rejected."""

--- a/products/data_warehouse/backend/api/test/test_external_data_source.py
+++ b/products/data_warehouse/backend/api/test/test_external_data_source.py
@@ -3374,7 +3374,7 @@ class TestExternalDataSource(APIBaseTest):
             data={"enabled": True},
         )
 
-        view_name = get_customer_revenue_view_name(source.prefix or "")
+        view_name = get_customer_revenue_view_name(source.prefix)
         assert DataWarehouseJoin.objects.filter(
             team=self.team,
             source_table_name=view_name,
@@ -3391,7 +3391,7 @@ class TestExternalDataSource(APIBaseTest):
             data={"enabled": True},
         )
 
-        view_name = get_customer_revenue_view_name(source.prefix or "")
+        view_name = get_customer_revenue_view_name(source.prefix)
         assert DataWarehouseJoin.objects.filter(team=self.team, source_table_name=view_name, deleted=False).exists()
 
         self.client.patch(

--- a/products/data_warehouse/backend/data_load/source_templates.py
+++ b/products/data_warehouse/backend/data_load/source_templates.py
@@ -5,15 +5,9 @@ from posthog.temporal.common.logger import get_logger
 from products.data_warehouse.backend.models.external_data_job import ExternalDataJob
 from products.data_warehouse.backend.models.join import DataWarehouseJoin
 from products.data_warehouse.backend.types import ExternalDataSourceType
+from products.revenue_analytics.backend.joins import ensure_person_join
 
 LOGGER = get_logger(__name__)
-
-
-def _revenue_view_name(table_prefix: str) -> str:
-    stripped = table_prefix.strip("_")
-    if stripped:
-        return f"stripe.{stripped}.customer_revenue_view"
-    return "stripe.customer_revenue_view"
 
 
 def database_operations(team_id: int, table_prefix: str) -> None:
@@ -37,15 +31,7 @@ def database_operations(team_id: int, table_prefix: str) -> None:
         field_name=f"{table_prefix}stripe_invoice",
     )
 
-    DataWarehouseJoin.objects.get_or_create(
-        team_id=team_id,
-        deleted=False,
-        source_table_name=_revenue_view_name(table_prefix),
-        source_table_key="JSONExtractString(metadata, 'posthog_person_distinct_id')",
-        joining_table_name="persons",
-        joining_table_key="pdi.distinct_id",
-        field_name="persons",
-    )
+    ensure_person_join(team_id, table_prefix)
 
 
 def create_warehouse_templates_for_source(team_id: int, run_id: str) -> None:

--- a/products/data_warehouse/backend/data_load/test/test_source_templates.py
+++ b/products/data_warehouse/backend/data_load/test/test_source_templates.py
@@ -10,22 +10,11 @@ from posthog.hogql.database.schema.test.base import RevenueAnalyticsTestBase
 from posthog.hogql.parser import parse_select
 from posthog.hogql.query import execute_hogql_query
 
-from products.data_warehouse.backend.data_load.source_templates import _revenue_view_name, database_operations
+from products.data_warehouse.backend.data_load.source_templates import database_operations
 from products.data_warehouse.backend.models.join import DataWarehouseJoin
+from products.revenue_analytics.backend.joins import get_customer_revenue_view_name
 
 pytestmark = [pytest.mark.django_db]
-
-
-class TestRevenueViewName(BaseTest):
-    @parameterized.expand(
-        [
-            ("", "stripe.customer_revenue_view"),
-            ("my_prefix_", "stripe.my_prefix.customer_revenue_view"),
-            ("org_123_", "stripe.org_123.customer_revenue_view"),
-        ]
-    )
-    def test_revenue_view_name(self, table_prefix, expected):
-        assert _revenue_view_name(table_prefix) == expected
 
 
 class TestDatabaseOperations(BaseTest):
@@ -66,7 +55,7 @@ class TestDatabaseOperations(BaseTest):
             joining_table_name=f"{prefix}stripe_customer", field_name=f"{prefix}stripe_customer"
         ).exists()
         assert joins.filter(joining_table_name=f"{prefix}stripe_invoice", field_name=f"{prefix}stripe_invoice").exists()
-        assert joins.filter(source_table_name=_revenue_view_name(prefix)).exists()
+        assert joins.filter(source_table_name=get_customer_revenue_view_name(prefix)).exists()
 
     def test_idempotent(self):
         database_operations(self.team.pk, "")
@@ -110,7 +99,7 @@ class TestCustomerRevenueViewPersonsJoin(RevenueAnalyticsTestBase):
         self.create_sources()
         self.team.base_currency = CurrencyCode.GBP.value
         self.team.save()
-        self.view_name = _revenue_view_name(self.source.prefix or "")
+        self.view_name = get_customer_revenue_view_name(self.source.prefix or "")
 
     def test_persons_join_resolves_on_customer_view(self):
         _create_person(

--- a/products/data_warehouse/backend/data_load/test/test_source_templates.py
+++ b/products/data_warehouse/backend/data_load/test/test_source_templates.py
@@ -99,7 +99,7 @@ class TestCustomerRevenueViewPersonsJoin(RevenueAnalyticsTestBase):
         self.create_sources()
         self.team.base_currency = CurrencyCode.GBP.value
         self.team.save()
-        self.view_name = get_customer_revenue_view_name(self.source.prefix or "")
+        self.view_name = get_customer_revenue_view_name(self.source.prefix)
 
     def test_persons_join_resolves_on_customer_view(self):
         _create_person(

--- a/products/revenue_analytics/backend/api.py
+++ b/products/revenue_analytics/backend/api.py
@@ -1,6 +1,7 @@
 from typing import cast
 
 from posthoganalytics import capture_exception
+from rest_framework import serializers, status
 from rest_framework.decorators import action
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.request import Request
@@ -17,6 +18,7 @@ from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.clickhouse.query_tagging import Feature, tag_queries
 from posthog.models.team.team import Team
 
+from products.revenue_analytics.backend.joins import ensure_person_join_for_team, remove_person_join_for_team
 from products.revenue_analytics.backend.views import RevenueAnalyticsBaseView
 from products.revenue_analytics.backend.views.schemas import SCHEMAS as VIEW_SCHEMAS
 
@@ -84,3 +86,25 @@ class RevenueAnalyticsTaxonomyViewSet(TeamAndOrgViewSetMixin, GenericViewSet):
 
         values = find_values_for_revenue_analytics_property(key, self.team)
         return Response({"results": [{"name": value} for value in values], "refreshing": False})
+
+
+class RevenueAnalyticsJoinSerializer(serializers.Serializer):
+    enabled = serializers.BooleanField(required=True)
+
+
+class RevenueAnalyticsJoinViewSet(TeamAndOrgViewSetMixin, GenericViewSet):
+    scope_object = "INTERNAL"
+    permission_classes = [IsAuthenticated]
+
+    def create(self, request: Request, **kwargs):
+        serializer = RevenueAnalyticsJoinSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+
+        if serializer.validated_data["enabled"]:
+            ensure_person_join_for_team(self.team.pk)
+            msg = "Joins created successfully"
+        else:
+            remove_person_join_for_team(self.team.pk)
+            msg = "Joins removed successfully"
+
+        return Response({"detail": msg}, status=status.HTTP_200_OK)

--- a/products/revenue_analytics/backend/joins.py
+++ b/products/revenue_analytics/backend/joins.py
@@ -1,0 +1,31 @@
+from products.data_warehouse.backend.models.join import DataWarehouseJoin
+
+
+def get_customer_revenue_view_name(table_prefix: str) -> str:
+    stripped = table_prefix.strip("_")
+    if stripped:
+        return f"stripe.{stripped}.customer_revenue_view"
+    return "stripe.customer_revenue_view"
+
+
+def ensure_person_join(team_id: int, table_prefix: str) -> None:
+    DataWarehouseJoin.objects.get_or_create(
+        team_id=team_id,
+        deleted=False,
+        source_table_name=get_customer_revenue_view_name(table_prefix),
+        source_table_key="JSONExtractString(metadata, 'posthog_person_distinct_id')",
+        joining_table_name="persons",
+        joining_table_key="pdi.distinct_id",
+        field_name="persons",
+    )
+
+
+def remove_person_join(team_id: int, table_prefix: str) -> None:
+    for join in DataWarehouseJoin.objects.filter(
+        team_id=team_id,
+        source_table_name=get_customer_revenue_view_name(table_prefix),
+        joining_table_name="persons",
+        field_name="persons",
+        deleted=False,
+    ):
+        join.soft_delete()

--- a/products/revenue_analytics/backend/joins.py
+++ b/products/revenue_analytics/backend/joins.py
@@ -1,14 +1,32 @@
+from django.db.models import QuerySet
+
+from products.data_warehouse.backend.models import ExternalDataSource
 from products.data_warehouse.backend.models.join import DataWarehouseJoin
+from products.data_warehouse.backend.types import ExternalDataSourceType
 
 
-def get_customer_revenue_view_name(table_prefix: str) -> str:
+def get_customer_revenue_view_name(table_prefix: str = "") -> str:
     stripped = table_prefix.strip("_")
     if stripped:
         return f"stripe.{stripped}.customer_revenue_view"
     return "stripe.customer_revenue_view"
 
 
-def ensure_person_join(team_id: int, table_prefix: str) -> None:
+def get_stripe_sources_for_team(team_id: int) -> QuerySet[ExternalDataSource]:
+    return ExternalDataSource.objects.filter(
+        team_id=team_id,
+        source_type=ExternalDataSourceType.STRIPE,
+    ).exclude(deleted=True)
+
+
+def ensure_person_join_for_team(team_id: int) -> None:
+    sources = get_stripe_sources_for_team(team_id)
+    for source in sources:
+        if source.revenue_analytics_config_safe.enabled:
+            ensure_person_join(team_id, source.prefix)
+
+
+def ensure_person_join(team_id: int, table_prefix: str = "") -> None:
     DataWarehouseJoin.objects.get_or_create(
         team_id=team_id,
         deleted=False,
@@ -20,7 +38,14 @@ def ensure_person_join(team_id: int, table_prefix: str) -> None:
     )
 
 
-def remove_person_join(team_id: int, table_prefix: str) -> None:
+def remove_person_join_for_team(team_id: int) -> None:
+    sources = get_stripe_sources_for_team(team_id)
+    for source in sources:
+        if source.revenue_analytics_config_safe.enabled:
+            remove_person_join(team_id, source.prefix)
+
+
+def remove_person_join(team_id: int, table_prefix: str = "") -> None:
     for join in DataWarehouseJoin.objects.filter(
         team_id=team_id,
         source_table_name=get_customer_revenue_view_name(table_prefix),

--- a/products/revenue_analytics/backend/joins.py
+++ b/products/revenue_analytics/backend/joins.py
@@ -5,10 +5,10 @@ from products.data_warehouse.backend.models.join import DataWarehouseJoin
 from products.data_warehouse.backend.types import ExternalDataSourceType
 
 
-def get_customer_revenue_view_name(table_prefix: str = "") -> str:
-    stripped = table_prefix.strip("_")
-    if stripped:
-        return f"stripe.{stripped}.customer_revenue_view"
+def get_customer_revenue_view_name(table_prefix: str | None = None) -> str:
+    prefix = table_prefix.strip("_") if table_prefix else ""
+    if prefix:
+        return f"stripe.{prefix}.customer_revenue_view"
     return "stripe.customer_revenue_view"
 
 
@@ -23,14 +23,15 @@ def ensure_person_join_for_team(team_id: int) -> None:
     sources = get_stripe_sources_for_team(team_id)
     for source in sources:
         if source.revenue_analytics_config_safe.enabled:
-            ensure_person_join(team_id, source.prefix or "")
+            ensure_person_join(team_id, source.prefix)
 
 
-def ensure_person_join(team_id: int, table_prefix: str = "") -> None:
+def ensure_person_join(team_id: int, table_prefix: str | None = None) -> None:
+    prefix = table_prefix or ""
     DataWarehouseJoin.objects.get_or_create(
         team_id=team_id,
         deleted=False,
-        source_table_name=get_customer_revenue_view_name(table_prefix),
+        source_table_name=get_customer_revenue_view_name(prefix),
         source_table_key="JSONExtractString(metadata, 'posthog_person_distinct_id')",
         joining_table_name="persons",
         joining_table_key="pdi.distinct_id",
@@ -42,13 +43,14 @@ def remove_person_join_for_team(team_id: int) -> None:
     sources = get_stripe_sources_for_team(team_id)
     for source in sources:
         if source.revenue_analytics_config_safe.enabled:
-            remove_person_join(team_id, source.prefix or "")
+            remove_person_join(team_id, source.prefix)
 
 
-def remove_person_join(team_id: int, table_prefix: str = "") -> None:
+def remove_person_join(team_id: int, table_prefix: str | None = None) -> None:
+    prefix = table_prefix or ""
     for join in DataWarehouseJoin.objects.filter(
         team_id=team_id,
-        source_table_name=get_customer_revenue_view_name(table_prefix),
+        source_table_name=get_customer_revenue_view_name(prefix),
         joining_table_name="persons",
         field_name="persons",
         deleted=False,

--- a/products/revenue_analytics/backend/joins.py
+++ b/products/revenue_analytics/backend/joins.py
@@ -23,7 +23,7 @@ def ensure_person_join_for_team(team_id: int) -> None:
     sources = get_stripe_sources_for_team(team_id)
     for source in sources:
         if source.revenue_analytics_config_safe.enabled:
-            ensure_person_join(team_id, source.prefix)
+            ensure_person_join(team_id, source.prefix or "")
 
 
 def ensure_person_join(team_id: int, table_prefix: str = "") -> None:
@@ -42,7 +42,7 @@ def remove_person_join_for_team(team_id: int) -> None:
     sources = get_stripe_sources_for_team(team_id)
     for source in sources:
         if source.revenue_analytics_config_safe.enabled:
-            remove_person_join(team_id, source.prefix)
+            remove_person_join(team_id, source.prefix or "")
 
 
 def remove_person_join(team_id: int, table_prefix: str = "") -> None:

--- a/products/revenue_analytics/backend/test/test_api.py
+++ b/products/revenue_analytics/backend/test/test_api.py
@@ -1,0 +1,90 @@
+import uuid
+
+import pytest
+from posthog.test.base import APIBaseTest
+
+from parameterized import parameterized
+from rest_framework import status
+
+from posthog.models.organization import Organization
+from posthog.models.team.team import Team
+
+from products.data_warehouse.backend.models.external_data_source import ExternalDataSource
+from products.data_warehouse.backend.models.join import DataWarehouseJoin
+from products.data_warehouse.backend.types import ExternalDataSourceType
+from products.revenue_analytics.backend.joins import get_customer_revenue_view_name
+
+pytestmark = [pytest.mark.django_db]
+
+
+class TestRevenueAnalyticsPersonJoinsAPI(APIBaseTest):
+    def setUp(self):
+        super().setUp()
+        self.url = f"/api/environments/{self.team.pk}/revenue_analytics/joins/"
+
+    def _create_stripe_source(self, prefix="") -> ExternalDataSource:
+        return ExternalDataSource.objects.create(
+            team=self.team,
+            source_id=str(uuid.uuid4()),
+            connection_id=str(uuid.uuid4()),
+            destination_id=str(uuid.uuid4()),
+            source_type=ExternalDataSourceType.STRIPE,
+            prefix=prefix,
+            job_inputs={},
+        )
+
+    def _get_active_joins(self):
+        return DataWarehouseJoin.objects.filter(team=self.team).exclude(deleted=True)
+
+    def test_enable_creates_joins_for_stripe_sources(self):
+        source = self._create_stripe_source(prefix="test_")
+
+        response = self.client.post(self.url, data={"enabled": True})
+
+        assert response.status_code == status.HTTP_200_OK
+        view_name = get_customer_revenue_view_name(source.prefix)
+        assert (
+            self._get_active_joins()
+            .filter(
+                source_table_name=view_name,
+                source_table_key="JSONExtractString(metadata, 'posthog_person_distinct_id')",
+                joining_table_name="persons",
+                joining_table_key="pdi.distinct_id",
+                field_name="persons",
+            )
+            .exists()
+        )
+
+    def test_disable_removes_joins(self):
+        source = self._create_stripe_source(prefix="test_")
+
+        self.client.post(self.url, data={"enabled": True})
+
+        view_name = get_customer_revenue_view_name(source.prefix)
+        assert self._get_active_joins().filter(source_table_name=view_name).exists()
+
+        response = self.client.post(self.url, data={"enabled": False})
+
+        assert response.status_code == status.HTTP_200_OK
+        assert not self._get_active_joins().filter(source_table_name=view_name).exists()
+
+    @parameterized.expand([True, False])
+    def test_cannot_change_joins_for_another_team(self, enabled: bool):
+        other_org = Organization.objects.create(name="Other Org")
+        other_team = Team.objects.create(organization=other_org, name="Other Project")
+        other_url = f"/api/environments/{other_team.pk}/revenue_analytics/joins/"
+
+        response = self.client.post(other_url, data={"enabled": enabled})
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert response.json() == self.permission_denied_response("You don't have access to the project.")
+
+    def test_skips_disabled_sources(self):
+        source = self._create_stripe_source(prefix="test_")
+        source.revenue_analytics_config_safe.enabled = False
+        source.revenue_analytics_config_safe.save()
+
+        self.client.post(self.url, data={"enabled": True})
+
+        view_name = get_customer_revenue_view_name(source.prefix or "")
+        assert not self._get_active_joins().filter(source_table_name=view_name).exists()

--- a/products/revenue_analytics/backend/test/test_joins.py
+++ b/products/revenue_analytics/backend/test/test_joins.py
@@ -1,0 +1,97 @@
+import pytest
+from posthog.test.base import BaseTest
+
+from parameterized import parameterized
+
+from products.data_warehouse.backend.models.join import DataWarehouseJoin
+from products.revenue_analytics.backend.joins import (
+    ensure_person_join,
+    get_customer_revenue_view_name,
+    remove_person_join,
+)
+
+pytestmark = [pytest.mark.django_db]
+
+
+class TestGetCustomerRevenueViewName(BaseTest):
+    @parameterized.expand(
+        [
+            ("", "stripe.customer_revenue_view"),
+            ("my_prefix_", "stripe.my_prefix.customer_revenue_view"),
+            ("org_123_", "stripe.org_123.customer_revenue_view"),
+        ]
+    )
+    def test_get_customer_revenue_view_name(self, table_prefix, expected):
+        assert get_customer_revenue_view_name(table_prefix) == expected
+
+
+class TestEnsurePersonJoin(BaseTest):
+    def _get_active_joins(self):
+        return DataWarehouseJoin.objects.filter(team=self.team).exclude(deleted=True)
+
+    def test_creates_join(self):
+        ensure_person_join(self.team.pk, "")
+
+        joins = self._get_active_joins()
+        assert joins.count() == 1
+
+        join = joins.first()
+        assert join.source_table_name == "stripe.customer_revenue_view"
+        assert join.source_table_key == "JSONExtractString(metadata, 'posthog_person_distinct_id')"
+        assert join.joining_table_name == "persons"
+        assert join.joining_table_key == "pdi.distinct_id"
+        assert join.field_name == "persons"
+
+    @parameterized.expand(["my_prefix_", "org_123_"])
+    def test_applies_table_prefix(self, prefix):
+        ensure_person_join(self.team.pk, prefix)
+
+        join = self._get_active_joins().first()
+        assert join.source_table_name == get_customer_revenue_view_name(prefix)
+
+    def test_idempotent(self):
+        ensure_person_join(self.team.pk, "")
+        ensure_person_join(self.team.pk, "")
+
+        assert self._get_active_joins().count() == 1
+
+    def test_recreates_after_soft_delete(self):
+        ensure_person_join(self.team.pk, "")
+        self._get_active_joins().first().soft_delete()
+
+        ensure_person_join(self.team.pk, "")
+
+        assert self._get_active_joins().count() == 1
+        assert DataWarehouseJoin.objects.filter(
+            team=self.team, source_table_name="stripe.customer_revenue_view", deleted=True
+        ).exists()
+
+
+class TestRemovePersonJoin(BaseTest):
+    def _get_active_joins(self):
+        return DataWarehouseJoin.objects.filter(team=self.team).exclude(deleted=True)
+
+    def test_soft_deletes_join(self):
+        ensure_person_join(self.team.pk, "")
+        assert self._get_active_joins().count() == 1
+
+        remove_person_join(self.team.pk, "")
+
+        assert self._get_active_joins().count() == 0
+        assert DataWarehouseJoin.objects.filter(
+            team=self.team, source_table_name="stripe.customer_revenue_view", deleted=True
+        ).exists()
+
+    def test_noop_when_missing(self):
+        remove_person_join(self.team.pk, "")
+
+        assert self._get_active_joins().count() == 0
+
+    def test_only_deletes_matching_prefix(self):
+        ensure_person_join(self.team.pk, "")
+        ensure_person_join(self.team.pk, "org_123_")
+
+        remove_person_join(self.team.pk, "")
+
+        assert self._get_active_joins().count() == 1
+        assert self._get_active_joins().first().source_table_name == "stripe.org_123.customer_revenue_view"

--- a/products/revenue_analytics/backend/test/test_joins.py
+++ b/products/revenue_analytics/backend/test/test_joins.py
@@ -29,8 +29,9 @@ class TestEnsurePersonJoin(BaseTest):
     def _get_active_joins(self):
         return DataWarehouseJoin.objects.filter(team=self.team).exclude(deleted=True)
 
-    def test_creates_join(self):
-        ensure_person_join(self.team.pk, "")
+    @parameterized.expand(["", None])
+    def test_creates_join(self, prefix):
+        ensure_person_join(self.team.pk, prefix)
 
         joins = self._get_active_joins()
         assert joins.count() == 1
@@ -71,11 +72,12 @@ class TestRemovePersonJoin(BaseTest):
     def _get_active_joins(self):
         return DataWarehouseJoin.objects.filter(team=self.team).exclude(deleted=True)
 
-    def test_soft_deletes_join(self):
-        ensure_person_join(self.team.pk, "")
+    @parameterized.expand(["", None])
+    def test_soft_deletes_join(self, prefix):
+        ensure_person_join(self.team.pk, prefix)
         assert self._get_active_joins().count() == 1
 
-        remove_person_join(self.team.pk, "")
+        remove_person_join(self.team.pk, prefix)
 
         assert self._get_active_joins().count() == 0
         assert DataWarehouseJoin.objects.filter(

--- a/products/revenue_analytics/backend/test/test_joins_api.py
+++ b/products/revenue_analytics/backend/test/test_joins_api.py
@@ -42,7 +42,7 @@ class TestRevenueAnalyticsPersonJoinsAPI(APIBaseTest):
         response = self.client.post(self.url, data={"enabled": True})
 
         assert response.status_code == status.HTTP_200_OK
-        view_name = get_customer_revenue_view_name(source.prefix or "")
+        view_name = get_customer_revenue_view_name(source.prefix)
         assert (
             self._get_active_joins()
             .filter(
@@ -60,7 +60,7 @@ class TestRevenueAnalyticsPersonJoinsAPI(APIBaseTest):
 
         self.client.post(self.url, data={"enabled": True})
 
-        view_name = get_customer_revenue_view_name(source.prefix or "")
+        view_name = get_customer_revenue_view_name(source.prefix)
         assert self._get_active_joins().filter(source_table_name=view_name).exists()
 
         response = self.client.post(self.url, data={"enabled": False})
@@ -86,5 +86,5 @@ class TestRevenueAnalyticsPersonJoinsAPI(APIBaseTest):
 
         self.client.post(self.url, data={"enabled": True})
 
-        view_name = get_customer_revenue_view_name(source.prefix or "")
+        view_name = get_customer_revenue_view_name(source.prefix)
         assert not self._get_active_joins().filter(source_table_name=view_name).exists()

--- a/products/revenue_analytics/backend/test/test_joins_api.py
+++ b/products/revenue_analytics/backend/test/test_joins_api.py
@@ -42,7 +42,7 @@ class TestRevenueAnalyticsPersonJoinsAPI(APIBaseTest):
         response = self.client.post(self.url, data={"enabled": True})
 
         assert response.status_code == status.HTTP_200_OK
-        view_name = get_customer_revenue_view_name(source.prefix)
+        view_name = get_customer_revenue_view_name(source.prefix or "")
         assert (
             self._get_active_joins()
             .filter(
@@ -60,7 +60,7 @@ class TestRevenueAnalyticsPersonJoinsAPI(APIBaseTest):
 
         self.client.post(self.url, data={"enabled": True})
 
-        view_name = get_customer_revenue_view_name(source.prefix)
+        view_name = get_customer_revenue_view_name(source.prefix or "")
         assert self._get_active_joins().filter(source_table_name=view_name).exists()
 
         response = self.client.post(self.url, data={"enabled": False})

--- a/products/revenue_analytics/frontend/generated/api.ts
+++ b/products/revenue_analytics/frontend/generated/api.ts
@@ -9,6 +9,17 @@
  */
 import { apiMutator } from '../../../../frontend/src/lib/api-orval-mutator'
 
+export const getRevenueAnalyticsJoinsCreateUrl = (projectId: string) => {
+    return `/api/environments/${projectId}/revenue_analytics/joins/`
+}
+
+export const revenueAnalyticsJoinsCreate = async (projectId: string, options?: RequestInit): Promise<void> => {
+    return apiMutator<void>(getRevenueAnalyticsJoinsCreateUrl(projectId), {
+        ...options,
+        method: 'POST',
+    })
+}
+
 export const getRevenueAnalyticsTaxonomyValuesRetrieveUrl = (projectId: string) => {
     return `/api/environments/${projectId}/revenue_analytics/taxonomy/values/`
 }

--- a/products/revenue_analytics/frontend/settings/DataWarehouseManagedViewsetConfiguration.tsx
+++ b/products/revenue_analytics/frontend/settings/DataWarehouseManagedViewsetConfiguration.tsx
@@ -20,6 +20,7 @@ export function DataWarehouseManagedViewsetConfiguration(): JSX.Element {
     const onConfirmDisable = async (): Promise<boolean> => {
         try {
             await api.dataWarehouseManagedViewsets.toggle('revenue_analytics', false)
+            await api.revenueAnalyticsJoins.sync(false)
             lemonToast.success('Revenue analytics disabled successfully')
             loadCurrentTeam()
             return true


### PR DESCRIPTION
## Problem
In a [previous PR](https://github.com/PostHog/posthog/pull/52943) we started creating revenue analytics person joins when first syncing a Stripe source.
The problem is if users synced Stripe _before_ that fix got in, they won't have the join automatically created when they enable revenue analytics.

What this PR does is to ensure the joins exist when enabling revenue analytics.
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->
Part of https://github.com/PostHog/posthog/issues/52270

## Changes
- Create endpoint to create/delete persons joins
- Call endpoint when enabling revenue analytics managed viewsets (`managed-viewsets` flag on)
- Create/delete joins when enabling/disabling revenue analytics (`managed-viewsets` flag off)
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
- Unit tests
- Manual tests in the UI
	- Synced Stripe
	- Deleted joins
	- Enabled revenue analytics
	- Asserted joins were created
<!-- Briefly describe the steps you took, and what steps reviewers must take to get to where changes are, and what is the expected behavior. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
No
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update
No
<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
