### PR TITLE
chore(flags): fix etag for flags/definitions

### DIFF
--- a/rust/common/hypercache/src/lib.rs
+++ b/rust/common/hypercache/src/lib.rs
@@ -512,6 +512,11 @@ impl HyperCacheReader {
         &self.config
     }
 
+    /// Get access to the Redis client (for reading ETags stored alongside cached data)
+    pub fn redis_client(&self) -> &Arc<dyn RedisClient + Send + Sync> {
+        &self.redis_client
+    }
+
     async fn try_get_from_redis(&self, cache_key: &str) -> Result<Value, HyperCacheError> {
         // The Redis client's get_raw_bytes already handles zstd decompression,
         // so we receive Pickle(JSON) data directly.

--- a/rust/feature-flags/src/api/flag_definitions.rs
+++ b/rust/feature-flags/src/api/flag_definitions.rs
@@ -320,7 +320,14 @@ async fn get_etag_from_redis(state: &AppState, team_key: &KeyType) -> Option<Str
     let cache_key = config.get_redis_cache_key(team_key);
     let etag_key = format!("{}:etag", cache_key);
 
-    match state.redis_client.get_raw_bytes(etag_key.clone()).await {
+    // Use the same Redis client as the HyperCache reader — ETags are stored
+    // alongside the cached data, which may be on a dedicated flags Redis instance.
+    match state
+        .flags_with_cohorts_hypercache_reader
+        .redis_client()
+        .get_raw_bytes(etag_key.clone())
+        .await
+    {
         Ok(raw_bytes) => match serde_pickle::from_slice::<String>(&raw_bytes, Default::default()) {
             Ok(etag) if !etag.is_empty() => Some(etag),
             Ok(_) => None,


### PR DESCRIPTION
## Summary

Fixes ETag support on the Rust `/flags/definitions` endpoint. ETags were always returning `none` because the ETag lookup was using the shared Redis client (`state.redis_client`) instead of the flags-specific Redis client used by the HyperCache reader.

## Changes

- `rust/common/hypercache/src/lib.rs`: Added `pub fn redis_client()` accessor on `HyperCacheReader`
- `rust/feature-flags/src/api/flag_definitions.rs`: Changed ETag lookup to use `flags_with_cohorts_hypercache_reader.redis_client()` instead of `state.redis_client`

## How to verify

After deploy, check `flags_flag_definitions_etag_total` metric — `result` should change from `none` to `hit`/`miss` instead of being `none` for every request.