### PR TITLE
feat(logs,tracing): refactor out time sliced query and use for both logs and tracing

### DIFF
--- a/posthog/hogql_queries/utils/test/test_time_sliced_query.py
+++ b/posthog/hogql_queries/utils/test/test_time_sliced_query.py
@@ -1,0 +1,229 @@
+import datetime as dt
+from dataclasses import dataclass, field
+from typing import Any
+from zoneinfo import ZoneInfo
+
+from unittest import TestCase
+from unittest.mock import MagicMock
+
+from parameterized import parameterized
+
+from posthog.schema import DateRange
+
+from posthog.hogql_queries.utils.time_sliced_query import time_sliced_results
+
+
+@dataclass
+class FakeDateRange:
+    _date_from: dt.datetime
+    _date_to: dt.datetime
+
+    def date_from(self) -> dt.datetime:
+        return self._date_from
+
+    def date_to(self) -> dt.datetime:
+        return self._date_to
+
+
+@dataclass
+class FakeQuery:
+    dateRange: DateRange
+    limit: int | None = None
+
+
+@dataclass
+class FakeResponse:
+    results: list[Any] = field(default_factory=list)
+
+
+class FakeRunner:
+    """Minimal runner that satisfies the interface expected by time_sliced_results."""
+
+    def __init__(self, date_from: dt.datetime, date_to: dt.datetime, results: list[Any] | None = None):
+        self.query = FakeQuery(dateRange=DateRange(date_from=date_from.isoformat(), date_to=date_to.isoformat()))
+        self._query_date_range = FakeDateRange(date_from, date_to)
+        self._results = results or []
+
+    @property
+    def query_date_range(self):
+        return self._query_date_range
+
+    def run(self, execution_mode, analytics_props=None):
+        return FakeResponse(results=self._results)
+
+
+class TestTimeSlicedResults(TestCase):
+    def _make_runner_factory(self, results_per_call: list[list[Any]]):
+        """Returns a make_runner callable that tracks created date ranges and returns canned results."""
+        call_index = [0]
+        created_ranges: list[DateRange] = []
+
+        def make_runner(date_range: DateRange) -> FakeRunner:
+            idx = call_index[0]
+            call_index[0] += 1
+            created_ranges.append(date_range)
+            results = results_per_call[idx] if idx < len(results_per_call) else []
+            fr = FakeRunner(
+                date_from=dt.datetime.fromisoformat(date_range.date_from).replace(tzinfo=ZoneInfo("UTC"))
+                if date_range.date_from
+                else dt.datetime.now(tz=ZoneInfo("UTC")),
+                date_to=dt.datetime.fromisoformat(date_range.date_to).replace(tzinfo=ZoneInfo("UTC"))
+                if date_range.date_to
+                else dt.datetime.now(tz=ZoneInfo("UTC")),
+                results=results,
+            )
+            return fr
+
+        return make_runner, created_ranges
+
+    def test_small_range_no_slicing(self):
+        now = dt.datetime(2024, 1, 1, 12, 0, tzinfo=ZoneInfo("UTC"))
+        runner = FakeRunner(
+            date_from=now - dt.timedelta(minutes=10),
+            date_to=now,
+            results=["a", "b", "c"],
+        )
+        make_runner, created_ranges = self._make_runner_factory([])
+
+        results = list(time_sliced_results(runner, limit=100, order_by_earliest=False, make_runner=make_runner))
+
+        self.assertEqual(results, ["a", "b", "c"])
+        # No slicing should have been done — make_runner never called
+        self.assertEqual(len(created_ranges), 0)
+
+    def test_medium_range_one_slice(self):
+        now = dt.datetime(2024, 1, 1, 12, 0, tzinfo=ZoneInfo("UTC"))
+        runner = FakeRunner(
+            date_from=now - dt.timedelta(hours=1),
+            date_to=now,
+            results=["initial_not_used"],
+        )
+        # make_runner called twice: slice (3 min) + remainder
+        # The remainder runner is the one that gets run for the final fetch
+        make_runner, created_ranges = self._make_runner_factory(
+            [
+                ["a", "b"],  # 3-min slice
+                ["c"],  # remainder (final runner that gets run)
+            ]
+        )
+
+        results = list(time_sliced_results(runner, limit=100, order_by_earliest=False, make_runner=make_runner))
+
+        self.assertEqual(results, ["a", "b", "c"])
+        self.assertEqual(len(created_ranges), 2)
+
+    def test_large_range_all_slices(self):
+        now = dt.datetime(2024, 1, 1, 12, 0, tzinfo=ZoneInfo("UTC"))
+        runner = FakeRunner(
+            date_from=now - dt.timedelta(days=2),
+            date_to=now,
+            results=[],
+        )
+        # 3 slice levels: 3min, 1hr, 6hr — each creates a slice + remainder pair
+        # The last remainder is the one that gets run for the final fetch
+        make_runner, created_ranges = self._make_runner_factory(
+            [
+                ["a"],  # 3-min slice
+                [],  # 3-min remainder (becomes input for next slice)
+                ["b"],  # 1-hr slice
+                [],  # 1-hr remainder (becomes input for next slice)
+                ["c"],  # 6-hr slice
+                ["d"],  # 6-hr remainder (final runner that gets run)
+            ]
+        )
+
+        results = list(time_sliced_results(runner, limit=100, order_by_earliest=False, make_runner=make_runner))
+
+        self.assertEqual(results, ["a", "b", "c", "d"])
+        self.assertEqual(len(created_ranges), 6)
+
+    def test_stops_when_limit_reached_first_slice(self):
+        now = dt.datetime(2024, 1, 1, 12, 0, tzinfo=ZoneInfo("UTC"))
+        runner = FakeRunner(
+            date_from=now - dt.timedelta(hours=1),
+            date_to=now,
+            results=[],
+        )
+        make_runner, created_ranges = self._make_runner_factory(
+            [
+                ["a", "b", "c"],  # 3-min slice fills limit
+                [],  # remainder (created but never run)
+            ]
+        )
+
+        results = list(time_sliced_results(runner, limit=3, order_by_earliest=False, make_runner=make_runner))
+
+        self.assertEqual(results, ["a", "b", "c"])
+
+    def test_stops_when_limit_reached_second_slice(self):
+        now = dt.datetime(2024, 1, 1, 12, 0, tzinfo=ZoneInfo("UTC"))
+        runner = FakeRunner(
+            date_from=now - dt.timedelta(hours=5),
+            date_to=now,
+            results=[],
+        )
+        make_runner, created_ranges = self._make_runner_factory(
+            [
+                ["a"],  # 3-min slice
+                [],  # 3-min remainder
+                ["b", "c"],  # 1-hr slice fills limit
+                [],  # 1-hr remainder
+            ]
+        )
+
+        results = list(time_sliced_results(runner, limit=3, order_by_earliest=False, make_runner=make_runner))
+
+        self.assertEqual(results, ["a", "b", "c"])
+
+    @parameterized.expand(
+        [
+            ("latest", False),
+            ("earliest", True),
+        ]
+    )
+    def test_slice_direction(self, _name, order_by_earliest):
+        now = dt.datetime(2024, 1, 1, 12, 0, tzinfo=ZoneInfo("UTC"))
+        date_from = now - dt.timedelta(hours=1)
+        runner = FakeRunner(date_from=date_from, date_to=now, results=[])
+
+        make_runner, created_ranges = self._make_runner_factory(
+            [
+                ["a"],  # slice
+                ["b"],  # remainder
+            ]
+        )
+
+        list(time_sliced_results(runner, limit=100, order_by_earliest=order_by_earliest, make_runner=make_runner))
+
+        self.assertEqual(len(created_ranges), 2)
+        slice_range = created_ranges[0]
+        remainder_range = created_ranges[1]
+
+        if order_by_earliest:
+            # Slice should be at the start of the range
+            self.assertEqual(slice_range.date_from, date_from.isoformat())
+            # Remainder should be after the slice
+            self.assertEqual(remainder_range.date_to, now.isoformat())
+        else:
+            # Slice should be at the end of the range
+            self.assertEqual(slice_range.date_to, now.isoformat())
+            # Remainder should be before the slice
+            self.assertEqual(remainder_range.date_from, date_from.isoformat())
+
+    def test_analytics_props_passed_through(self):
+        now = dt.datetime(2024, 1, 1, 12, 0, tzinfo=ZoneInfo("UTC"))
+        runner = FakeRunner(date_from=now - dt.timedelta(minutes=5), date_to=now, results=["a"])
+        runner.run = MagicMock(return_value=FakeResponse(results=["a"]))
+
+        make_runner, _ = self._make_runner_factory([])
+        props = {"source": "test"}
+
+        list(
+            time_sliced_results(
+                runner, limit=100, order_by_earliest=False, make_runner=make_runner, analytics_props=props
+            )
+        )
+
+        runner.run.assert_called_once()
+        _, kwargs = runner.run.call_args
+        self.assertEqual(kwargs["analytics_props"], props)

--- a/posthog/hogql_queries/utils/test/test_time_sliced_query.py
+++ b/posthog/hogql_queries/utils/test/test_time_sliced_query.py
@@ -10,7 +10,7 @@ from parameterized import parameterized
 
 from posthog.schema import DateRange
 
-from posthog.hogql_queries.utils.time_sliced_query import TimeSliceableRunner, time_sliced_results
+from posthog.hogql_queries.utils.time_sliced_query import time_sliced_results
 
 
 @dataclass
@@ -49,10 +49,10 @@ class FakeRunner:
         self._results = results or []
 
     @property
-    def query_date_range(self):
+    def query_date_range(self) -> Any:
         return self._query_date_range
 
-    def run(self, execution_mode, analytics_props=None):
+    def run(self, execution_mode: Any, **kwargs: Any) -> FakeResponse:
         return FakeResponse(results=self._results)
 
 
@@ -62,7 +62,7 @@ class TestTimeSlicedResults(TestCase):
         call_index = [0]
         created_ranges: list[DateRange] = []
 
-        def make_runner(date_range: DateRange) -> TimeSliceableRunner:
+        def make_runner(date_range: DateRange) -> FakeRunner:
             idx = call_index[0]
             call_index[0] += 1
             created_ranges.append(date_range)

--- a/posthog/hogql_queries/utils/test/test_time_sliced_query.py
+++ b/posthog/hogql_queries/utils/test/test_time_sliced_query.py
@@ -10,7 +10,7 @@ from parameterized import parameterized
 
 from posthog.schema import DateRange
 
-from posthog.hogql_queries.utils.time_sliced_query import time_sliced_results
+from posthog.hogql_queries.utils.time_sliced_query import TimeSliceableRunner, time_sliced_results
 
 
 @dataclass
@@ -58,7 +58,7 @@ class TestTimeSlicedResults(TestCase):
         call_index = [0]
         created_ranges: list[DateRange] = []
 
-        def make_runner(date_range: DateRange) -> FakeRunner:
+        def make_runner(date_range: DateRange) -> TimeSliceableRunner:
             idx = call_index[0]
             call_index[0] += 1
             created_ranges.append(date_range)
@@ -212,8 +212,9 @@ class TestTimeSlicedResults(TestCase):
 
     def test_analytics_props_passed_through(self):
         now = dt.datetime(2024, 1, 1, 12, 0, tzinfo=ZoneInfo("UTC"))
+        run_mock = MagicMock(return_value=FakeResponse(results=["a"]))
         runner = FakeRunner(date_from=now - dt.timedelta(minutes=5), date_to=now, results=["a"])
-        runner.run = MagicMock(return_value=FakeResponse(results=["a"]))
+        runner.run = run_mock  # type: ignore[method-assign]
 
         make_runner, _ = self._make_runner_factory([])
         props = {"source": "test"}
@@ -224,6 +225,6 @@ class TestTimeSlicedResults(TestCase):
             )
         )
 
-        runner.run.assert_called_once()
-        _, kwargs = runner.run.call_args
+        run_mock.assert_called_once()
+        _, kwargs = run_mock.call_args
         self.assertEqual(kwargs["analytics_props"], props)

--- a/posthog/hogql_queries/utils/test/test_time_sliced_query.py
+++ b/posthog/hogql_queries/utils/test/test_time_sliced_query.py
@@ -39,8 +39,12 @@ class FakeResponse:
 class FakeRunner:
     """Minimal runner that satisfies the interface expected by time_sliced_results."""
 
-    def __init__(self, date_from: dt.datetime, date_to: dt.datetime, results: list[Any] | None = None):
-        self.query = FakeQuery(dateRange=DateRange(date_from=date_from.isoformat(), date_to=date_to.isoformat()))
+    def __init__(
+        self, date_from: dt.datetime, date_to: dt.datetime, results: list[Any] | None = None, limit: int = 100
+    ):
+        self.query = FakeQuery(
+            dateRange=DateRange(date_from=date_from.isoformat(), date_to=date_to.isoformat()), limit=limit
+        )
         self._query_date_range = FakeDateRange(date_from, date_to)
         self._results = results or []
 
@@ -85,7 +89,7 @@ class TestTimeSlicedResults(TestCase):
         )
         make_runner, created_ranges = self._make_runner_factory([])
 
-        results = list(time_sliced_results(runner, limit=100, order_by_earliest=False, make_runner=make_runner))
+        results = list(time_sliced_results(runner, order_by_earliest=False, make_runner=make_runner))
 
         self.assertEqual(results, ["a", "b", "c"])
         # No slicing should have been done — make_runner never called
@@ -107,7 +111,7 @@ class TestTimeSlicedResults(TestCase):
             ]
         )
 
-        results = list(time_sliced_results(runner, limit=100, order_by_earliest=False, make_runner=make_runner))
+        results = list(time_sliced_results(runner, order_by_earliest=False, make_runner=make_runner))
 
         self.assertEqual(results, ["a", "b", "c"])
         self.assertEqual(len(created_ranges), 2)
@@ -132,7 +136,7 @@ class TestTimeSlicedResults(TestCase):
             ]
         )
 
-        results = list(time_sliced_results(runner, limit=100, order_by_earliest=False, make_runner=make_runner))
+        results = list(time_sliced_results(runner, order_by_earliest=False, make_runner=make_runner))
 
         self.assertEqual(results, ["a", "b", "c", "d"])
         self.assertEqual(len(created_ranges), 6)
@@ -143,6 +147,7 @@ class TestTimeSlicedResults(TestCase):
             date_from=now - dt.timedelta(hours=1),
             date_to=now,
             results=[],
+            limit=3,
         )
         make_runner, created_ranges = self._make_runner_factory(
             [
@@ -151,7 +156,7 @@ class TestTimeSlicedResults(TestCase):
             ]
         )
 
-        results = list(time_sliced_results(runner, limit=3, order_by_earliest=False, make_runner=make_runner))
+        results = list(time_sliced_results(runner, order_by_earliest=False, make_runner=make_runner))
 
         self.assertEqual(results, ["a", "b", "c"])
 
@@ -161,6 +166,7 @@ class TestTimeSlicedResults(TestCase):
             date_from=now - dt.timedelta(hours=5),
             date_to=now,
             results=[],
+            limit=3,
         )
         make_runner, created_ranges = self._make_runner_factory(
             [
@@ -171,7 +177,7 @@ class TestTimeSlicedResults(TestCase):
             ]
         )
 
-        results = list(time_sliced_results(runner, limit=3, order_by_earliest=False, make_runner=make_runner))
+        results = list(time_sliced_results(runner, order_by_earliest=False, make_runner=make_runner))
 
         self.assertEqual(results, ["a", "b", "c"])
 
@@ -193,7 +199,7 @@ class TestTimeSlicedResults(TestCase):
             ]
         )
 
-        list(time_sliced_results(runner, limit=100, order_by_earliest=order_by_earliest, make_runner=make_runner))
+        list(time_sliced_results(runner, order_by_earliest=order_by_earliest, make_runner=make_runner))
 
         self.assertEqual(len(created_ranges), 2)
         slice_range = created_ranges[0]
@@ -219,11 +225,7 @@ class TestTimeSlicedResults(TestCase):
         make_runner, _ = self._make_runner_factory([])
         props = {"source": "test"}
 
-        list(
-            time_sliced_results(
-                runner, limit=100, order_by_earliest=False, make_runner=make_runner, analytics_props=props
-            )
-        )
+        list(time_sliced_results(runner, order_by_earliest=False, make_runner=make_runner, analytics_props=props))
 
         run_mock.assert_called_once()
         _, kwargs = run_mock.call_args

--- a/posthog/hogql_queries/utils/time_sliced_query.py
+++ b/posthog/hogql_queries/utils/time_sliced_query.py
@@ -1,0 +1,87 @@
+import datetime as dt
+from collections.abc import Callable, Generator
+from typing import Any
+
+from posthog.schema import DateRange
+
+from posthog.hogql_queries.query_runner import AnalyticsQueryRunner, ExecutionMode
+
+
+def time_sliced_results(
+    runner: AnalyticsQueryRunner,
+    limit: int,
+    order_by_earliest: bool,
+    make_runner: Callable[[DateRange], AnalyticsQueryRunner],
+    analytics_props: dict[str, Any] | None = None,
+) -> Generator[Any, None, None]:
+    """
+    A generator that yields results by splitting the query into progressive time slices.
+
+    Instead of scanning the full date range, we fetch progressively larger slices:
+        - first 3 minutes
+        - then 1 hour
+        - then 6 hours
+        - then the remainder
+
+    Most queries hit the limit within the first 3 minutes, avoiding a full scan.
+    """
+    qdr = runner.query_date_range
+    date_range_length = qdr.date_to() - qdr.date_from()
+
+    def runner_slice(
+        current_runner: AnalyticsQueryRunner, slice_length: dt.timedelta
+    ) -> tuple[AnalyticsQueryRunner, AnalyticsQueryRunner]:
+        """
+        Splits a runner into two: one for the slice closest to the sort edge,
+        and one for the remainder.
+        """
+        if not order_by_earliest:
+            slice_date_range = DateRange(
+                date_from=(current_runner.query_date_range.date_to() - slice_length).isoformat(),
+                date_to=current_runner.query_date_range.date_to().isoformat(),
+            )
+            remainder_date_range = DateRange(
+                date_from=current_runner.query_date_range.date_from().isoformat(),
+                date_to=(current_runner.query_date_range.date_to() - slice_length).isoformat(),
+            )
+        else:
+            slice_date_range = DateRange(
+                date_from=current_runner.query_date_range.date_from().isoformat(),
+                date_to=(current_runner.query_date_range.date_from() + slice_length).isoformat(),
+            )
+            remainder_date_range = DateRange(
+                date_from=(current_runner.query_date_range.date_from() + slice_length).isoformat(),
+                date_to=current_runner.query_date_range.date_to().isoformat(),
+            )
+
+        return make_runner(slice_date_range), make_runner(remainder_date_range)
+
+    if date_range_length > dt.timedelta(minutes=20):
+        recent_runner, runner = runner_slice(runner, dt.timedelta(minutes=3))
+        response = recent_runner.run(ExecutionMode.CALCULATE_BLOCKING_ALWAYS, analytics_props=analytics_props)
+        limit -= len(response.results)
+        yield from response.results
+        if limit <= 0:
+            return
+        runner.query.limit = limit
+
+    if date_range_length > dt.timedelta(hours=4):
+        recent_runner, runner = runner_slice(runner, dt.timedelta(minutes=60))
+        response = recent_runner.run(ExecutionMode.CALCULATE_BLOCKING_ALWAYS, analytics_props=analytics_props)
+        limit -= len(response.results)
+        yield from response.results
+        if limit <= 0:
+            return
+        runner.query.limit = limit
+
+    if date_range_length > dt.timedelta(hours=24):
+        recent_runner, runner = runner_slice(runner, dt.timedelta(hours=6))
+        response = recent_runner.run(ExecutionMode.CALCULATE_BLOCKING_ALWAYS, analytics_props=analytics_props)
+        limit -= len(response.results)
+        yield from response.results
+        if limit <= 0:
+            return
+        runner.query.limit = limit
+
+    response = runner.run(ExecutionMode.CALCULATE_BLOCKING_ALWAYS, analytics_props=analytics_props)
+    yield from response.results

--- a/posthog/hogql_queries/utils/time_sliced_query.py
+++ b/posthog/hogql_queries/utils/time_sliced_query.py
@@ -1,18 +1,36 @@
 import datetime as dt
 from collections.abc import Callable, Generator
-from typing import Any
+from typing import Any, Protocol, runtime_checkable
 
 from posthog.schema import DateRange
 
-from posthog.hogql_queries.query_runner import AnalyticsQueryRunner, ExecutionMode
+from posthog.hogql_queries.query_runner import ExecutionMode
+from posthog.hogql_queries.utils.query_date_range import QueryDateRange
+
+
+class _HasResults(Protocol):
+    results: Any
+
+
+@runtime_checkable
+class TimeSliceableRunner(Protocol):
+    """Protocol for runners that support time-sliced execution."""
+
+    @property
+    def query_date_range(self) -> QueryDateRange: ...
+
+    @property
+    def query(self) -> Any: ...
+
+    def run(self, execution_mode: ExecutionMode, **kwargs: Any) -> _HasResults: ...
 
 
 def time_sliced_results(
-    runner: AnalyticsQueryRunner,
+    runner: TimeSliceableRunner,
     limit: int,
     order_by_earliest: bool,
-    make_runner: Callable[[DateRange], AnalyticsQueryRunner],
-    analytics_props: dict[str, Any] | None = None,
+    make_runner: Callable[[DateRange], TimeSliceableRunner],
+    analytics_props: Any = None,
 ) -> Generator[Any, None, None]:
     """
     A generator that yields results by splitting the query into progressive time slices.
@@ -29,29 +47,30 @@ def time_sliced_results(
     date_range_length = qdr.date_to() - qdr.date_from()
 
     def runner_slice(
-        current_runner: AnalyticsQueryRunner, slice_length: dt.timedelta
-    ) -> tuple[AnalyticsQueryRunner, AnalyticsQueryRunner]:
+        current_runner: TimeSliceableRunner, slice_length: dt.timedelta
+    ) -> tuple[TimeSliceableRunner, TimeSliceableRunner]:
         """
         Splits a runner into two: one for the slice closest to the sort edge,
         and one for the remainder.
         """
+        current_qdr = current_runner.query_date_range
         if not order_by_earliest:
             slice_date_range = DateRange(
-                date_from=(current_runner.query_date_range.date_to() - slice_length).isoformat(),
-                date_to=current_runner.query_date_range.date_to().isoformat(),
+                date_from=(current_qdr.date_to() - slice_length).isoformat(),
+                date_to=current_qdr.date_to().isoformat(),
             )
             remainder_date_range = DateRange(
-                date_from=current_runner.query_date_range.date_from().isoformat(),
-                date_to=(current_runner.query_date_range.date_to() - slice_length).isoformat(),
+                date_from=current_qdr.date_from().isoformat(),
+                date_to=(current_qdr.date_to() - slice_length).isoformat(),
             )
         else:
             slice_date_range = DateRange(
-                date_from=current_runner.query_date_range.date_from().isoformat(),
-                date_to=(current_runner.query_date_range.date_from() + slice_length).isoformat(),
+                date_from=current_qdr.date_from().isoformat(),
+                date_to=(current_qdr.date_from() + slice_length).isoformat(),
             )
             remainder_date_range = DateRange(
-                date_from=(current_runner.query_date_range.date_from() + slice_length).isoformat(),
-                date_to=current_runner.query_date_range.date_to().isoformat(),
+                date_from=(current_qdr.date_from() + slice_length).isoformat(),
+                date_to=current_qdr.date_to().isoformat(),
             )
 
         return make_runner(slice_date_range), make_runner(remainder_date_range)

--- a/posthog/hogql_queries/utils/time_sliced_query.py
+++ b/posthog/hogql_queries/utils/time_sliced_query.py
@@ -27,7 +27,6 @@ class TimeSliceableRunner(Protocol):
 
 def time_sliced_results(
     runner: TimeSliceableRunner,
-    limit: int,
     order_by_earliest: bool,
     make_runner: Callable[[DateRange], TimeSliceableRunner],
     analytics_props: Any = None,
@@ -42,7 +41,9 @@ def time_sliced_results(
         - then the remainder
 
     Most queries hit the limit within the first 3 minutes, avoiding a full scan.
+    The limit is read from runner.query.limit.
     """
+    limit = runner.query.limit or 0
     qdr = runner.query_date_range
     date_range_length = qdr.date_to() - qdr.date_from()
 

--- a/products/logs/backend/api.py
+++ b/products/logs/backend/api.py
@@ -243,7 +243,6 @@ class LogsViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.ViewSet):
             results = list(
                 time_sliced_results(
                     runner=LogsQueryRunner(query, self.team),
-                    limit=logs_query_params["limit"],
                     order_by_earliest=order_by == LogsOrderBy.EARLIEST,
                     make_runner=make_runner,
                     analytics_props=analytics_props,

--- a/products/logs/backend/api.py
+++ b/products/logs/backend/api.py
@@ -28,6 +28,7 @@ from posthog.api.mixins import PydanticModelMixin
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.event_usage import get_request_analytics_properties, report_user_action
 from posthog.hogql_queries.query_runner import ExecutionMode
+from posthog.hogql_queries.utils.time_sliced_query import time_sliced_results
 from posthog.models import User
 from posthog.models.exported_asset import ExportedAsset
 from posthog.tasks.exporter import export_asset
@@ -227,115 +228,27 @@ class LogsViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.ViewSet):
         query = LogsQuery(**logs_query_params)
         analytics_props = get_request_analytics_properties(request)
 
-        def results_generator(query: LogsQuery, logs_query_params: dict):
-            """
-            A generator that yields results by splitting the query into time slices
+        def make_runner(date_range: DateRange) -> LogsQueryRunner:
+            return LogsQueryRunner(LogsQuery(**{**query.model_dump(), "dateRange": date_range}), self.team)
 
-            We fetch the first:
-                - 3 minutes
-                - 1 hour
-                - 6 hours
-
-            Of logs at a time, stopping if we hit the limit first (most queries hit it in the first 3 minutes)
-            """
-            runner = LogsQueryRunner(query, self.team)
-
-            qdr = runner.query_date_range
-            date_range_length = qdr.date_to() - qdr.date_from()
-            limit = logs_query_params["limit"]
-
-            def runner_slice(
-                runner: LogsQueryRunner, slice_length: dt.timedelta, orderBy: LogsOrderBy | None
-            ) -> tuple[LogsQueryRunner, LogsQueryRunner]:
-                """
-                Slices a LogsQueryRunner into two query runners
-                The first one returns just the `slice_length` most recent logs
-                The second one returns the rest of the logs
-                """
-                if orderBy == LogsOrderBy.LATEST or orderBy is None:
-                    slice_query = LogsQuery(
-                        **{
-                            **query.model_dump(),
-                            "dateRange": DateRange(
-                                date_from=(runner.query_date_range.date_to() - slice_length).isoformat(),
-                                date_to=runner.query_date_range.date_to().isoformat(),
-                            ),
-                        }
-                    )
-                    remainder_query = LogsQuery(
-                        **{
-                            **query.model_dump(),
-                            "dateRange": DateRange(
-                                date_from=runner.query_date_range.date_from().isoformat(),
-                                date_to=(runner.query_date_range.date_to() - slice_length).isoformat(),
-                            ),
-                        }
-                    )
-                else:
-                    # invert the logic as we're looking at earliest logs not latest
-                    slice_query = LogsQuery(
-                        **{
-                            **query.model_dump(),
-                            "dateRange": DateRange(
-                                date_from=runner.query_date_range.date_from().isoformat(),
-                                date_to=(runner.query_date_range.date_from() + slice_length).isoformat(),
-                            ),
-                        }
-                    )
-                    remainder_query = LogsQuery(
-                        **{
-                            **query.model_dump(),
-                            "dateRange": DateRange(
-                                date_to=runner.query_date_range.date_to().isoformat(),
-                                date_from=(runner.query_date_range.date_from() + slice_length).isoformat(),
-                            ),
-                        }
-                    )
-
-                return LogsQueryRunner(slice_query, self.team), LogsQueryRunner(remainder_query, self.team)
-
-            # Skip time-slicing for live tailing - we're always only looking at the most recent 1-2 minutes
-            # Note: cursor pagination no longer skips time-slicing because we narrow the date range
-            # to end at the cursor timestamp, allowing time-slicing to work on the remaining range.
-            if live_logs_checkpoint:
-                response = runner.run(ExecutionMode.CALCULATE_BLOCKING_ALWAYS, analytics_props=analytics_props)
-                yield from response.results
-                return
-
-            # if we're searching more than 20 minutes, first fetch the first 3 minutes of logs and see if that hits the limit
-            if date_range_length > dt.timedelta(minutes=20):
-                recent_runner, runner = runner_slice(runner, dt.timedelta(minutes=3), query.orderBy)
-                response = recent_runner.run(ExecutionMode.CALCULATE_BLOCKING_ALWAYS, analytics_props=analytics_props)
-                limit -= len(response.results)
-                yield from response.results
-                if limit <= 0:
-                    return
-                runner.query.limit = limit
-
-            # otherwise if we're searching more than 4 hours search the next hour
-            if date_range_length > dt.timedelta(hours=4):
-                recent_runner, runner = runner_slice(runner, dt.timedelta(minutes=60), query.orderBy)
-                response = recent_runner.run(ExecutionMode.CALCULATE_BLOCKING_ALWAYS, analytics_props=analytics_props)
-                limit -= len(response.results)
-                yield from response.results
-                if limit <= 0:
-                    return
-                runner.query.limit = limit
-
-            # otherwise if we're searching more than 24 hours search the next 6 hours
-            if date_range_length > dt.timedelta(hours=24):
-                recent_runner, runner = runner_slice(runner, dt.timedelta(hours=6), query.orderBy)
-                response = recent_runner.run(ExecutionMode.CALCULATE_BLOCKING_ALWAYS, analytics_props=analytics_props)
-                limit -= len(response.results)
-                yield from response.results
-                if limit <= 0:
-                    return
-                runner.query.limit = limit
-
-            response = runner.run(ExecutionMode.CALCULATE_BLOCKING_ALWAYS, analytics_props=analytics_props)
-            yield from response.results
-
-        results = list(results_generator(query, logs_query_params))
+        # Skip time-slicing for live tailing - we're always only looking at the most recent 1-2 minutes
+        # Note: cursor pagination no longer skips time-slicing because we narrow the date range
+        # to end at the cursor timestamp, allowing time-slicing to work on the remaining range.
+        if live_logs_checkpoint:
+            response = LogsQueryRunner(query, self.team).run(
+                ExecutionMode.CALCULATE_BLOCKING_ALWAYS, analytics_props=analytics_props
+            )
+            results = list(response.results)
+        else:
+            results = list(
+                time_sliced_results(
+                    runner=LogsQueryRunner(query, self.team),
+                    limit=logs_query_params["limit"],
+                    order_by_earliest=order_by == LogsOrderBy.EARLIEST,
+                    make_runner=make_runner,
+                    analytics_props=analytics_props,
+                )
+            )
         has_more = len(results) > requested_limit
         results = results[:requested_limit]  # Rm the +1 we used to check for another page
 

--- a/products/tracing/backend/presentation/views.py
+++ b/products/tracing/backend/presentation/views.py
@@ -30,6 +30,7 @@ from posthog.schema import (
 from posthog.api.mixins import PydanticModelMixin
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.hogql_queries.query_runner import ExecutionMode
+from posthog.hogql_queries.utils.time_sliced_query import time_sliced_results
 
 from ..logic import (
     TraceSpansQueryRunner,
@@ -89,11 +90,17 @@ class SpansViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.ViewSet)
             prefetchSpans=prefetch_spans,
         )
 
-        runner = TraceSpansQueryRunner(spans_query, self.team)
-        response = runner.run(ExecutionMode.CALCULATE_BLOCKING_ALWAYS)
-        assert isinstance(response, TraceSpansQueryResponse | CachedTraceSpansQueryResponse)
+        def make_runner(dr: DateRange) -> TraceSpansQueryRunner:
+            return TraceSpansQueryRunner(TraceSpansQuery(**{**spans_query.model_dump(), "dateRange": dr}), self.team)
 
-        results = response.results
+        results = list(
+            time_sliced_results(
+                runner=TraceSpansQueryRunner(spans_query, self.team),
+                limit=requested_limit + 1,
+                order_by_earliest=order_by == "earliest",
+                make_runner=make_runner,
+            )
+        )
 
         return Response(
             {

--- a/products/tracing/backend/presentation/views.py
+++ b/products/tracing/backend/presentation/views.py
@@ -96,7 +96,6 @@ class SpansViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.ViewSet)
         results = list(
             time_sliced_results(
                 runner=TraceSpansQueryRunner(spans_query, self.team),
-                limit=requested_limit + 1,
                 order_by_earliest=order_by == "earliest",
                 make_runner=make_runner,
             )


### PR DESCRIPTION
## Problem

for logs, we slice queries so we first fetch e.g. the first 3 minutes, then hour, then 6 hours etc of long queries as this is much quicker in clickhouse as it's not very good at reading earliest timestamps first

we need this same logic for traces - so we need to refactor it out

## Changes

pull out time slicing code to a helper, use for logs and traces
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
existing logs time slicing test + local testing
<!-- Briefly describe the steps you took, and what steps reviewers must take to get to where changes are, and what is the expected behavior. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
no
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
