### PR TITLE
fix: stale passkey registration blocks signup

### DIFF
--- a/posthog/api/signup.py
+++ b/posthog/api/signup.py
@@ -134,8 +134,11 @@ class SignupSerializer(serializers.Serializer):
         passkey_credential = request.session.get(WEBAUTHN_SIGNUP_CREDENTIAL_KEY) if request else None
         password = data.get("password")
 
+        # Password signup: if a password is provided, use it even if passkey data exists
+        if password and password != "":
+            pass
         # Passkey signup: credential in session, no password needed
-        if passkey_credential:
+        elif passkey_credential:
             self.is_passkey_signup = True
         # Social signup: password not required
         elif self.is_social_signup:
@@ -144,7 +147,7 @@ class SignupSerializer(serializers.Serializer):
         elif settings.DEMO:
             pass
         # Regular signup: password required
-        elif not password:
+        else:
             raise serializers.ValidationError(
                 {"password": serializers.ErrorDetail("This field is required.", code="required")}
             )
@@ -155,15 +158,16 @@ class SignupSerializer(serializers.Serializer):
         request = self.context.get("request")
         passkey_credential = request.session.get(WEBAUTHN_SIGNUP_CREDENTIAL_KEY) if request else None
         session_email = request.session.get(WEBAUTHN_SIGNUP_EMAIL_KEY) if request else None
+        password = request.data.get("password") if request else None
 
-        # For passkey signup, use the email from session (already validated during registration)
-        if passkey_credential and session_email:
+        # For passkey signup (only if no password provided), use the email from session (already validated during registration)
+        if passkey_credential and session_email and not password:
             if session_email.lower() != value.lower():
                 raise serializers.ValidationError(
                     "Email does not match the email used for passkey registration", code="email_mismatch"
                 )
 
-            return session_email
+            value = session_email
 
         if not settings.DEMO and EmailValidationHelper.user_exists(value):
             raise serializers.ValidationError("There is already an account with this email address.", code="unique")
@@ -178,6 +182,15 @@ class SignupSerializer(serializers.Serializer):
 
         request = self.context["request"]
         passkey_credential = request.session.get(WEBAUTHN_SIGNUP_CREDENTIAL_KEY)
+        password = validated_data.get("password")
+
+        # If a password is provided, clear passkey session data and use password signup
+        if password and passkey_credential:
+            request.session.pop(WEBAUTHN_SIGNUP_CREDENTIAL_KEY, None)
+            request.session.pop(WEBAUTHN_SIGNUP_EMAIL_KEY, None)
+            request.session.pop(WEBAUTHN_SIGNUP_USER_UUID_KEY, None)
+            _save_session_with_recovery(request.session)
+            passkey_credential = None
 
         if not self.is_social_signup:
             auth_method = RadarAuthMethod.PASSKEY if passkey_credential else RadarAuthMethod.PASSWORD
@@ -395,6 +408,16 @@ class InviteSignupSerializer(serializers.Serializer):
         session_email = request.session.get(WEBAUTHN_SIGNUP_EMAIL_KEY)
         session_user_uuid = request.session.get(WEBAUTHN_SIGNUP_USER_UUID_KEY)
 
+        # If a password is provided, clear passkey session data and use password signup
+        if validated_data.get("password") and passkey_credential:
+            request.session.pop(WEBAUTHN_SIGNUP_CREDENTIAL_KEY, None)
+            request.session.pop(WEBAUTHN_SIGNUP_EMAIL_KEY, None)
+            request.session.pop(WEBAUTHN_SIGNUP_USER_UUID_KEY, None)
+            _save_session_with_recovery(request.session)
+            passkey_credential = None
+            session_email = None
+            session_user_uuid = None
+
         if request.user.is_authenticated:
             user = cast(User, request.user)
 
@@ -445,18 +468,21 @@ class InviteSignupSerializer(serializers.Serializer):
                     and session_email
                     and invite.target_email
                     and session_email.lower() != invite.target_email.lower()
+                    and not validated_data.get("password")
                 ):
                     raise serializers.ValidationError(
                         "Email does not match the email used for passkey registration", code="email_mismatch"
                     )
 
                 try:
-                    if passkey_credential:
+                    if passkey_credential and not validated_data.get("password"):
                         validated_data.pop("password", None)
-                    password = None if passkey_credential else validated_data.pop("password")
+                        password = None
+                    else:
+                        password = validated_data.pop("password")
                     first_name = validated_data.pop("first_name")
                     extra_fields: dict[str, Any] = {**validated_data}
-                    if passkey_credential and session_user_uuid:
+                    if passkey_credential and session_user_uuid and not password:
                         extra_fields["uuid"] = uuid_module.UUID(session_user_uuid)
 
                     user = User.objects.create_user(

--- a/posthog/api/signup.py
+++ b/posthog/api/signup.py
@@ -135,7 +135,7 @@ class SignupSerializer(serializers.Serializer):
         password = data.get("password")
 
         # Password signup: if a password is provided, use it even if passkey data exists
-        if password and password != "":
+        if password:
             pass
         # Passkey signup: credential in session, no password needed
         elif passkey_credential:

--- a/posthog/api/test/test_signup.py
+++ b/posthog/api/test/test_signup.py
@@ -1616,6 +1616,130 @@ class TestPasskeySignupAPI(APIBaseTest):
         )
         self.assertEqual(User.objects.count(), count)
 
+    @pytest.mark.skip_on_multitenancy
+    def test_password_signup_with_passkey_in_session(self):
+        """
+        When a password is provided, password signup should work even if passkey data exists in session.
+        This handles the case where a user registers a passkey but then reloads the page and tries to signup with a password.
+        """
+        from django.contrib.sessions.backends.db import SessionStore
+
+        from webauthn.helpers import bytes_to_base64url
+
+        from posthog.api.webauthn import (
+            WEBAUTHN_SIGNUP_CREDENTIAL_KEY,
+            WEBAUTHN_SIGNUP_EMAIL_KEY,
+            WEBAUTHN_SIGNUP_USER_UUID_KEY,
+        )
+
+        # Create a session and set passkey data (simulating a user who registered a passkey but reloaded)
+        session = SessionStore()
+        session[WEBAUTHN_SIGNUP_EMAIL_KEY] = "passkey_user@posthog.com"
+        session[WEBAUTHN_SIGNUP_USER_UUID_KEY] = str(uuid.uuid4())
+        session[WEBAUTHN_SIGNUP_CREDENTIAL_KEY] = {
+            "credential_id": bytes_to_base64url(b"test-credential-id-12345"),
+            "public_key": bytes_to_base64url(b"test-public-key-bytes"),
+            "algorithm": -7,
+            "sign_count": 0,
+            "transports": ["internal"],
+        }
+        session.create()
+        session_key = session.session_key
+
+        # Set the session cookie on the client
+        self.client.cookies["sessionid"] = session_key or ""
+
+        # Sign up with a password (using a different email)
+        response = self.client.post(
+            "/api/signup/",
+            {
+                "first_name": "Password",
+                "last_name": "User",
+                "email": "password_fallback@posthog.com",
+                "password": VALID_TEST_PASSWORD,
+                "organization_name": "Password Fallback Org",
+                "role_at_organization": "engineering",
+            },
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+        user = User.objects.get(email="password_fallback@posthog.com")
+        self.assertTrue(user.has_usable_password())
+
+        # No passkey credential should exist for this user
+        from posthog.models.webauthn_credential import WebauthnCredential
+
+        self.assertEqual(WebauthnCredential.objects.filter(user=user).count(), 0)
+
+        # Verify the passkey session data was cleared
+        session = SessionStore(session_key=session_key)
+        self.assertIsNone(session.get(WEBAUTHN_SIGNUP_CREDENTIAL_KEY))
+        self.assertIsNone(session.get(WEBAUTHN_SIGNUP_EMAIL_KEY))
+        self.assertIsNone(session.get(WEBAUTHN_SIGNUP_USER_UUID_KEY))
+
+    @pytest.mark.skip_on_multitenancy
+    def test_password_signup_with_passkey_in_session_same_email(self):
+        """
+        When a password is provided, password signup should work even if passkey data exists in session,
+        even when using the same email that was used for passkey registration.
+        """
+        from django.contrib.sessions.backends.db import SessionStore
+
+        from webauthn.helpers import bytes_to_base64url
+
+        from posthog.api.webauthn import (
+            WEBAUTHN_SIGNUP_CREDENTIAL_KEY,
+            WEBAUTHN_SIGNUP_EMAIL_KEY,
+            WEBAUTHN_SIGNUP_USER_UUID_KEY,
+        )
+
+        passkey_email = "same_email@posthog.com"
+
+        # Create a session and set passkey data
+        session = SessionStore()
+        session[WEBAUTHN_SIGNUP_EMAIL_KEY] = passkey_email
+        session[WEBAUTHN_SIGNUP_USER_UUID_KEY] = str(uuid.uuid4())
+        session[WEBAUTHN_SIGNUP_CREDENTIAL_KEY] = {
+            "credential_id": bytes_to_base64url(b"test-credential-id-67890"),
+            "public_key": bytes_to_base64url(b"test-public-key-bytes-67890"),
+            "algorithm": -7,
+            "sign_count": 0,
+            "transports": ["internal"],
+        }
+        session.create()
+        session_key = session.session_key
+
+        # Set the session cookie on the client
+        self.client.cookies["sessionid"] = session_key or ""
+
+        # Sign up with a password using the same email
+        response = self.client.post(
+            "/api/signup/",
+            {
+                "first_name": "Password",
+                "last_name": "SameEmail",
+                "email": passkey_email,
+                "password": VALID_TEST_PASSWORD,
+                "organization_name": "Same Email Org",
+                "role_at_organization": "engineering",
+            },
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+        user = User.objects.get(email=passkey_email)
+        self.assertTrue(user.has_usable_password())
+
+        # No passkey credential should exist for this user
+        from posthog.models.webauthn_credential import WebauthnCredential
+
+        self.assertEqual(WebauthnCredential.objects.filter(user=user).count(), 0)
+
+        # Verify the passkey session data was cleared
+        session = SessionStore(session_key=session_key)
+        self.assertIsNone(session.get(WEBAUTHN_SIGNUP_CREDENTIAL_KEY))
+        self.assertIsNone(session.get(WEBAUTHN_SIGNUP_EMAIL_KEY))
+        self.assertIsNone(session.get(WEBAUTHN_SIGNUP_USER_UUID_KEY))
+
 
 class TestSignupSessionSaveRecovery(unittest.TestCase):
     def test_save_session_with_recovery_uses_save_when_row_exists(self):
@@ -2524,3 +2648,66 @@ class TestInviteSignupAPI(APIBaseTest):
         nonexistent_id = str(uuid.uuid4())
         result = process_social_invite_signup(mock.MagicMock(), nonexistent_id, "test@example.com", "Test User")
         self.assertIsNone(result)
+
+    @pytest.mark.skip_on_multitenancy
+    def test_password_invite_signup_with_passkey_in_session(self):
+        """
+        When a password is provided for invite signup, it should work even if passkey data exists in session.
+        This handles the case where a user registers a passkey but then reloads the page and tries to signup with a password.
+        """
+        from django.contrib.sessions.backends.db import SessionStore
+
+        from webauthn.helpers import bytes_to_base64url
+
+        from posthog.api.webauthn import (
+            WEBAUTHN_SIGNUP_CREDENTIAL_KEY,
+            WEBAUTHN_SIGNUP_EMAIL_KEY,
+            WEBAUTHN_SIGNUP_USER_UUID_KEY,
+        )
+
+        # Create an invite
+        invite: OrganizationInvite = OrganizationInvite.objects.create(
+            target_email="password_invite_user@posthog.com", organization=self.organization
+        )
+
+        # Create a session and set passkey data (simulating a user who registered a passkey but reloaded)
+        session = SessionStore()
+        session[WEBAUTHN_SIGNUP_EMAIL_KEY] = "passkey_user@posthog.com"
+        session[WEBAUTHN_SIGNUP_USER_UUID_KEY] = str(uuid.uuid4())
+        session[WEBAUTHN_SIGNUP_CREDENTIAL_KEY] = {
+            "credential_id": bytes_to_base64url(b"test-credential-id-invite"),
+            "public_key": bytes_to_base64url(b"test-public-key-invite"),
+            "algorithm": -7,
+            "sign_count": 0,
+            "transports": ["internal"],
+        }
+        session.create()
+        session_key = session.session_key
+
+        # Set the session cookie on the client
+        self.client.cookies["sessionid"] = session_key or ""
+
+        # Sign up with a password using the invite
+        response = self.client.post(
+            f"/api/signup/{invite.id}/",
+            {
+                "first_name": "Password",
+                "last_name": "Invite",
+                "password": VALID_TEST_PASSWORD,
+            },
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+        user = User.objects.get(email="password_invite_user@posthog.com")
+        self.assertTrue(user.has_usable_password())
+
+        # No passkey credential should exist for this user
+        from posthog.models.webauthn_credential import WebauthnCredential
+
+        self.assertEqual(WebauthnCredential.objects.filter(user=user).count(), 0)
+
+        # Verify the passkey session data was cleared
+        session = SessionStore(session_key=session_key)
+        self.assertIsNone(session.get(WEBAUTHN_SIGNUP_CREDENTIAL_KEY))
+        self.assertIsNone(session.get(WEBAUTHN_SIGNUP_EMAIL_KEY))
+        self.assertIsNone(session.get(WEBAUTHN_SIGNUP_USER_UUID_KEY))


### PR DESCRIPTION
## Problem

Start sign up and register a passkey. Reload the page and boom now you can't signup if you enter a different email. 

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

When the password is provided to signup api ignore passkey session data. Also update the validations to operate under these new assumptions and clear out stale session data to prevent errors.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Tests

<!-- Briefly describe the steps you took, and what steps reviewers must take to get to where changes are, and what is the expected behavior. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
