### PR TITLE
feat(tracing): implement filtering on trace_id/span_id/duration

### DIFF
--- a/frontend/src/lib/components/PropertyFilters/components/OperatorValueSelect.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/OperatorValueSelect.tsx
@@ -189,6 +189,25 @@ export function OperatorValueSelect({
             )
         }
 
+        // Restrict trace_id and span_id to only equals/not equals
+        if ((propertyKey === 'trace_id' || propertyKey === 'span_id') && type === PropertyFilterType.Span) {
+            operators = operators.filter((op) => [PropertyOperator.Exact, PropertyOperator.IsNot].includes(op))
+        }
+
+        // Restrict duration to equals, not equals, and numeric comparisons
+        if (propertyKey === 'duration' && type === PropertyFilterType.Span) {
+            operators = operators.filter((op) =>
+                [
+                    PropertyOperator.Exact,
+                    PropertyOperator.IsNot,
+                    PropertyOperator.GreaterThan,
+                    PropertyOperator.GreaterThanOrEqual,
+                    PropertyOperator.LessThan,
+                    PropertyOperator.LessThanOrEqual,
+                ].includes(op)
+            )
+        }
+
         setOperators(operators)
         if ((currentOperator !== operator && operators.includes(startingOperator)) || !propertyDefinition) {
             setCurrentOperator(startingOperator)

--- a/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
@@ -810,9 +810,9 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>([
                         searchPlaceholder: 'spans',
                         type: TaxonomicFilterGroupType.Spans,
                         options: [
-                            { key: 'message', name: 'Message', propertyFilterType: 'span' },
                             { key: 'trace_id', name: 'trace_id', propertyFilterType: 'span' },
                             { key: 'span_id', name: 'span_id', propertyFilterType: 'span' },
+                            { key: 'duration', name: 'duration (ms)', propertyFilterType: 'span' },
                         ],
                         localItemsSearch: (items: any[], q: string): any[] => {
                             if (!q) {

--- a/frontend/src/models/propertyDefinitionsModel.ts
+++ b/frontend/src/models/propertyDefinitionsModel.ts
@@ -413,7 +413,7 @@ export const propertyDefinitionsModel = kea<propertyDefinitionsModelType>([
             { endpoint, type, newInput, propertyKey, eventNames, properties, refresh },
             breakpoint
         ) => {
-            if (['cohort', 'log', 'workflow_variable'].includes(type)) {
+            if (['cohort', 'log', 'span', 'workflow_variable'].includes(type)) {
                 return
             }
             if (!propertyKey || values.currentTeamId === null) {

--- a/posthog/hogql/property.py
+++ b/posthog/hogql/property.py
@@ -763,6 +763,9 @@ def property_to_expr(
         elif property.type == "log":
             chain = [property.key]
             property.key = ""
+        elif property.type == "span":
+            chain = [property.key]
+            property.key = ""
         elif scope == "log_resource":
             # log resource attributes are stored in a separate table as `attribute_key` and `attribute_value`
             # columns. The `attribute_key` filter needs to be added separately outside of property_to_expr

--- a/products/tracing/backend/logic.py
+++ b/products/tracing/backend/logic.py
@@ -48,6 +48,14 @@ def _normalise_to_base64(value: str) -> str:
         return value
 
 
+def _is_number(value: str) -> bool:
+    try:
+        float(value)
+        return True
+    except ValueError:
+        return False
+
+
 class TraceSpansQueryRunnerMixin(QueryRunner):
     """Shared WHERE clause and settings for all trace span query runners."""
 
@@ -143,9 +151,12 @@ class TraceSpansQueryRunnerMixin(QueryRunner):
                     span_filter.key = "duration_nano"
 
                     if isinstance(span_filter.value, list):
-                        span_filter.value = [str(decimal.Decimal(str(v)) * 1000000) for v in span_filter.value]
+                        span_filter.value = [
+                            str(decimal.Decimal(str(v)) * 1000000) for v in span_filter.value if _is_number(str(v))
+                        ]
                     else:
-                        span_filter.value = str(decimal.Decimal(str(span_filter.value)) * 1000000)
+                        if _is_number(str(span_filter.value)):
+                            span_filter.value = str(decimal.Decimal(str(span_filter.value)) * 1000000)
 
                 exprs.append(property_to_expr(span_filter, team=self.team))
 
@@ -355,12 +366,13 @@ class TraceSpansQueryRunner(TraceSpansQueryRunnerMixin, AnalyticsQueryRunner[Tra
                 is_root_span,
                 {where} as matched_filter
             FROM posthog.trace_spans
-            WHERE trace_id IN ({trace_id_query}) LIMIT {limit}
+            WHERE {filters} AND trace_id IN ({trace_id_query}) LIMIT {limit}
         """,
             placeholders={
                 "where": self.where(),
                 "trace_id_query": trace_id_query,
                 "limit": ast.Constant(value=(self.query.limit or 1) * limit_by_n),
+                "filters": ast.Placeholder(expr=ast.Field(chain=["filters"])),
             },
         )
         assert isinstance(query, ast.SelectQuery)

--- a/products/tracing/backend/logic.py
+++ b/products/tracing/backend/logic.py
@@ -7,6 +7,7 @@ Called by facade/api.py.
 
 import json
 import base64
+import decimal
 import datetime as dt
 from typing import TYPE_CHECKING
 from zoneinfo import ZoneInfo
@@ -39,6 +40,14 @@ if TYPE_CHECKING:
     from posthog.models import Team, User
 
 
+def _normalise_to_base64(value: str) -> str:
+    try:
+        int(value, 16)
+        return base64.b64encode(bytes.fromhex(value)).decode()
+    except ValueError:
+        return value
+
+
 class TraceSpansQueryRunnerMixin(QueryRunner):
     """Shared WHERE clause and settings for all trace span query runners."""
 
@@ -62,6 +71,7 @@ class TraceSpansQueryRunnerMixin(QueryRunner):
                 pass
             return "str"
 
+        self.span_filters: list[SpanPropertyFilter] = []
         self.span_attribute_filters: list[SpanPropertyFilter] = []
         self.resource_attribute_filters: list[SpanPropertyFilter] = []
         if self.query.filterGroup and self.query.filterGroup.values:
@@ -70,6 +80,8 @@ class TraceSpansQueryRunnerMixin(QueryRunner):
                     prop_type = getattr(prop, "type", None)
                     if prop_type == SpanPropertyFilterType.SPAN_RESOURCE_ATTRIBUTE:
                         self.resource_attribute_filters.append(prop)
+                    if prop_type == SpanPropertyFilterType.SPAN:
+                        self.span_filters.append(prop)
                     elif prop_type == SpanPropertyFilterType.SPAN_ATTRIBUTE:
                         if isinstance(prop, SpanPropertyFilter) and prop.value:
                             property_type = "str"
@@ -118,6 +130,24 @@ class TraceSpansQueryRunnerMixin(QueryRunner):
                     },
                 )
             )
+
+        if self.span_filters:
+            for span_filter in self.span_filters:
+                if span_filter.key in ("trace_id", "span_id"):
+                    if isinstance(span_filter.value, list):
+                        span_filter.value = [_normalise_to_base64(str(v)) for v in span_filter.value]
+                    else:
+                        span_filter.value = _normalise_to_base64(str(span_filter.value))
+
+                if span_filter.key in ("duration"):
+                    span_filter.key = "duration_nano"
+
+                    if isinstance(span_filter.value, list):
+                        span_filter.value = [str(decimal.Decimal(str(v)) * 1000000) for v in span_filter.value]
+                    else:
+                        span_filter.value = str(decimal.Decimal(str(span_filter.value)) * 1000000)
+
+                exprs.append(property_to_expr(span_filter, team=self.team))
 
         if self.span_attribute_filters:
             exprs.append(property_to_expr(self.span_attribute_filters, team=self.team))
@@ -271,6 +301,7 @@ class TraceSpansQueryRunner(TraceSpansQueryRunnerMixin, AnalyticsQueryRunner[Tra
                 "end_time": result[9].replace(tzinfo=ZoneInfo("UTC")),
                 "duration_nano": result[10],
                 "is_root_span": result[11],
+                "matched_filter": result[12],
             }
             results.append(row)
 
@@ -291,7 +322,8 @@ class TraceSpansQueryRunner(TraceSpansQueryRunnerMixin, AnalyticsQueryRunner[Tra
             SELECT
                 trace_id
             FROM posthog.trace_spans
-            WHERE {where} AND is_root_span = 1
+            WHERE {where}
+            LIMIT 1 by trace_id
             LIMIT {limit}
         """,
                 placeholders={
@@ -320,9 +352,10 @@ class TraceSpansQueryRunner(TraceSpansQueryRunnerMixin, AnalyticsQueryRunner[Tra
                 timestamp,
                 end_time,
                 duration_nano,
-                is_root_span
+                is_root_span,
+                {where} as matched_filter
             FROM posthog.trace_spans
-            WHERE {where} AND trace_id IN ({trace_id_query}) LIMIT {limit}
+            WHERE trace_id IN ({trace_id_query}) LIMIT {limit}
         """,
             placeholders={
                 "where": self.where(),
@@ -333,6 +366,8 @@ class TraceSpansQueryRunner(TraceSpansQueryRunnerMixin, AnalyticsQueryRunner[Tra
         assert isinstance(query, ast.SelectQuery)
 
         query.order_by = [
+            parse_order_expr("is_root_span DESC"),
+            parse_order_expr("matched_filter DESC"),
             parse_order_expr(f"timestamp {order_dir}"),
         ]
 

--- a/products/tracing/backend/presentation/views.py
+++ b/products/tracing/backend/presentation/views.py
@@ -11,7 +11,6 @@ No business logic here - that belongs in logic.py via the facade.
 """
 
 import json
-import base64
 
 from pydantic import ValidationError
 from rest_framework import status, viewsets
@@ -95,22 +94,12 @@ class SpansViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.ViewSet)
         assert isinstance(response, TraceSpansQueryResponse | CachedTraceSpansQueryResponse)
 
         results = response.results
-        has_more = len(results) > requested_limit
-
-        next_cursor = None
-        if has_more and results:
-            last_result = results[-1]
-            cursor_data = {
-                "timestamp": last_result["timestamp"].isoformat(),
-                "uuid": last_result["uuid"],
-            }
-            next_cursor = base64.b64encode(json.dumps(cursor_data).encode("utf-8")).decode("utf-8")
 
         return Response(
             {
                 "results": results,
-                "hasMore": has_more,
-                "nextCursor": next_cursor,
+                "hasMore": False,  # TODO: tricky with the traces query as we prefetch an unknown number of spans
+                "nextCursor": None,
             },
             status=status.HTTP_200_OK,
         )

--- a/products/tracing/backend/sparkline_query_runner.py
+++ b/products/tracing/backend/sparkline_query_runner.py
@@ -69,7 +69,7 @@ class TraceSpansSparklineQueryRunner(TraceSpansQueryRunner):
                     WHERE {where} AND time >= {date_from_start_of_interval} AND time <= {date_to}
                     GROUP BY {breakdown_field}, time
                 ) AS ac ON am.time_bucket = ac.time
-                ORDER BY time asc, {breakdown_field} desc
+                ORDER BY time asc, count desc
                 LIMIT 10 BY time LIMIT 10000
         """,
             placeholders={

--- a/products/tracing/frontend/TraceFlameChart.tsx
+++ b/products/tracing/frontend/TraceFlameChart.tsx
@@ -400,8 +400,10 @@ export function TraceFlameChart({ spans }: TraceFlameChartProps): JSX.Element {
                 const widthPct = Math.max(Math.min(rawWidthPct, 100 - leftPct), 0.3)
 
                 const isError = span.status_code === 2
+                const isUnmatched = !span.matched_filter
                 const seriesIndex = serviceColorMap.get(span.service_name) ?? 0
                 const seriesColor = isError ? ERROR_COLOR : getSeriesColor(seriesIndex)
+                const barColor = isUnmatched ? 'var(--border)' : seriesColor
                 const isSelected = selectedSpanId === span.uuid
 
                 return (
@@ -437,7 +439,7 @@ export function TraceFlameChart({ spans }: TraceFlameChartProps): JSX.Element {
                                 )}
                                 <Tooltip title={span.name}>
                                     <span
-                                        className={`text-xs truncate ${isError ? 'text-danger font-semibold' : 'font-medium'}`}
+                                        className={`text-xs truncate ${isError ? 'text-danger font-semibold' : 'font-medium'} ${isUnmatched ? 'opacity-40' : ''}`}
                                     >
                                         {span.name}
                                     </span>
@@ -481,11 +483,13 @@ export function TraceFlameChart({ spans }: TraceFlameChartProps): JSX.Element {
                                             left: `${leftPct}%`,
                                             width: `${widthPct}%`,
                                             minWidth: 2,
-                                            backgroundColor: `color-mix(in srgb, ${seriesColor} 20%, transparent)`,
-                                            borderLeft: `1px solid ${seriesColor}`,
+                                            backgroundColor: `color-mix(in srgb, ${barColor} 20%, transparent)`,
+                                            borderLeft: `1px solid ${barColor}`,
                                         }}
                                     >
-                                        <span className="text-[11px] truncate whitespace-nowrap flex items-center gap-1.5">
+                                        <span
+                                            className={`text-[11px] truncate whitespace-nowrap flex items-center gap-1.5 ${isUnmatched ? 'opacity-40' : ''}`}
+                                        >
                                             <span className="text-muted-alt font-medium">{span.service_name}</span>
                                             <span className="text-muted">{formatDuration(span.duration_nano)}</span>
                                         </span>

--- a/products/tracing/frontend/TracingScene.tsx
+++ b/products/tracing/frontend/TracingScene.tsx
@@ -111,7 +111,7 @@ export default function TracingScene(): JSX.Element {
             <TracingFilterBar />
             {!sparklineLoading && totalSpansMatchingFilters > 0 && (
                 <div className="text-xs text-muted px-1">
-                    {totalSpansMatchingFilters.toLocaleString()} traces matching filters
+                    {totalSpansMatchingFilters.toLocaleString()} spans matching filters
                 </div>
             )}
             <LemonTable

--- a/products/tracing/frontend/tracingSceneLogic.ts
+++ b/products/tracing/frontend/tracingSceneLogic.ts
@@ -71,7 +71,7 @@ export const tracingSceneLogic = kea<tracingSceneLogicType>([
         setServiceNames: () => {
             actions.syncUrlAndRunQuery()
         },
-        setSearchTerm: () => {
+        setFilterGroup: () => {
             actions.syncUrlAndRunQuery()
         },
         setOrderBy: () => {

--- a/products/tracing/frontend/types.ts
+++ b/products/tracing/frontend/types.ts
@@ -11,6 +11,7 @@ export interface Span {
     end_time: string
     duration_nano: number
     is_root_span: boolean
+    matched_filter: boolean
 }
 
 export const SPAN_KIND_LABELS: Record<number, string> = {


### PR DESCRIPTION
## Problem

we currently only support filtering on attributes

we also only return "root spans", so if you filter for a specific span, nothing comes up, which is confusing.

We now find _all spans_, and then fetch the root span and up to 20 sub-spans for all the originally matching traces

## Changes

enable filtering on trace_id/span_id/duration
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

fetch the root span of filtered spans - show in UI which spans match filter

<img width="2750" height="656" alt="image" src="https://github.com/user-attachments/assets/50687f34-350c-400e-9bf7-6d949db33313" />

## How did you test this code?
locally
<!-- Briefly describe the steps you took, and what steps reviewers must take to get to where changes are, and what is the expected behavior. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
no
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
