### PR TITLE
fix(cohorts): improve error handling in resave_cohorts command

### DIFF
--- a/posthog/api/cohort.py
+++ b/posthog/api/cohort.py
@@ -87,14 +87,30 @@ def validate_filters_and_compute_realtime_support(
     team: Team,
     current_cohort_type: str | None = None,
     cohort_count: int | None = None,
-) -> tuple[dict, str | None, list | None]:
+) -> tuple[dict, str | None, list[str] | None]:
     try:
         if not filters_dict:
             return filters_dict, current_cohort_type, None
 
-        validated_filters = CohortFilters.model_validate(
-            {"properties": filters_dict["properties"]}, context={"team": team}
-        )
+        # Defensive check: ensure properties exists and has required structure
+        if "properties" not in filters_dict:
+            error_msg = "Cohort filter missing properties key"
+            logger.warning(error_msg)
+            return filters_dict, current_cohort_type, [error_msg]
+
+        properties = filters_dict["properties"]
+        if not isinstance(properties, dict):
+            error_msg = "Cohort filter properties is not a dict"
+            logger.warning(error_msg)
+            return filters_dict, current_cohort_type, [error_msg]
+
+        # Check if properties is empty or missing required fields
+        if not properties or ("type" not in properties and "values" not in properties):
+            error_msg = "Cohort filter properties missing type or values"
+            logger.warning(error_msg)
+            return filters_dict, current_cohort_type, [error_msg]
+
+        validated_filters = CohortFilters.model_validate({"properties": properties}, context={"team": team})
 
         clean_filters = validated_filters.model_dump(exclude_none=True)
 
@@ -113,7 +129,7 @@ def validate_filters_and_compute_realtime_support(
 
     except Exception as e:
         logger.warning(f"Failed to validate cohort filters: {e}")
-        return filters_dict, current_cohort_type, None
+        return filters_dict, current_cohort_type, [str(e)]
 
 
 def generate_cohort_filter_bytecode(filter_data: dict, team: Team) -> tuple[list[Any] | None, str | None, str | None]:

--- a/posthog/management/commands/resave_cohorts.py
+++ b/posthog/management/commands/resave_cohorts.py
@@ -59,6 +59,7 @@ class Command(BaseCommand):
         global_total = 0
         global_changed = 0
         global_errors = 0
+        global_validation_errors = 0
         global_prospective_realtime = 0
         teams_processed = 0
         total_teams = teams_qs.count()
@@ -78,6 +79,7 @@ class Command(BaseCommand):
             global_total += stats["total"]
             global_changed += stats["changed"]
             global_errors += stats["errors"]
+            global_validation_errors += stats["validation_errors"]
             global_prospective_realtime += stats["prospective_realtime"]
 
             # Log team completion
@@ -89,6 +91,7 @@ class Command(BaseCommand):
                     changed_cohorts=stats["changed"],
                     realtime_cohorts=stats["prospective_realtime"],
                     error_count=stats["errors"],
+                    validation_error_count=stats["validation_errors"],
                     dry_run=dry_run,
                 )
 
@@ -101,6 +104,7 @@ class Command(BaseCommand):
             changed_cohorts=global_changed,
             realtime_cohorts=global_prospective_realtime,
             error_count=global_errors,
+            validation_error_count=global_validation_errors,
             change_percentage=round((global_changed / global_total * 100), 2) if global_total > 0 else 0,
             realtime_percentage=round((global_prospective_realtime / global_total * 100), 2) if global_total > 0 else 0,
         )
@@ -111,6 +115,7 @@ class Command(BaseCommand):
         total = 0
         changed = 0
         errors = 0
+        validation_errors = 0
         prospective_realtime = 0
 
         # Get all cohorts for this team using pagination
@@ -153,9 +158,22 @@ class Command(BaseCommand):
                     continue
 
                 # Compute the new filters with inline bytecode and cohort_type
-                clean_filters, computed_type, _ = validate_filters_and_compute_realtime_support(
+                # Use defensive validation with detailed error reporting
+                clean_filters, computed_type, validation_error_list = validate_filters_and_compute_realtime_support(
                     cohort.filters, cohort.team, current_cohort_type=cohort.cohort_type, cohort_count=cohort.count
                 )
+
+                # If validation failed but we got the original filters back, log the issue and skip
+                if validation_error_list:
+                    validation_errors += 1
+                    logger.warning(
+                        "cohort_validation_skipped",
+                        cohort_id=cohort.id,
+                        team_id=team.pk,
+                        reason="Invalid filter structure - keeping original filters",
+                        validation_error_details=validation_error_list,
+                    )
+                    continue
 
                 # Check if any directly referenced cohorts have dependencies
                 if computed_type == "realtime" and cohort.filters:
@@ -213,6 +231,7 @@ class Command(BaseCommand):
             "total": total,
             "changed": changed,
             "errors": errors,
+            "validation_errors": validation_errors,
             "prospective_realtime": prospective_realtime,
         }
 

--- a/posthog/management/commands/resave_cohorts.py
+++ b/posthog/management/commands/resave_cohorts.py
@@ -171,7 +171,6 @@ class Command(BaseCommand):
                         cohort_id=cohort.id,
                         team_id=team.pk,
                         reason="Invalid filter structure - keeping original filters",
-                        validation_error_details=validation_error_list,
                     )
                     continue
 


### PR DESCRIPTION
## Problem

The resave_cohorts management command was crashing when encountering cohorts with invalid or malformed filter structures during validation.

## Changes

- Enhanced error handling to track validation errors separately from processing errors
- Modified the command to skip cohorts with validation failures while preserving their original filters  

## How did you test this code?

- Manually