### PR TITLE
feat(temporal): increase cached filter TTL from 3 to 7 days

### DIFF
--- a/posthog/temporal/messaging/filter_storage.py
+++ b/posthog/temporal/messaging/filter_storage.py
@@ -8,7 +8,7 @@ TTL Considerations:
 - Individual activities have start_to_close_timeout=12h with maximum_attempts=3
 - Coordinator workflows spawn multiple child workflows with batch delays
 - Total workflow execution time in worst case: 3 retries × 12h + batch delays ≈ 40-48h
-- TTL set to 72h (3 days) provides safety margin for retries and delays
+- TTL set to 168h (7 days) provides generous safety margin for retries and delays
 - If workflows consistently exceed 48h, consider TTL refresh logic in get_filters()
 """
 
@@ -25,8 +25,8 @@ from common.hogvm.python.operation import HOGQL_BYTECODE_IDENTIFIER, Operation
 
 KEY_PREFIX = "backfill_person_properties_filters:"
 # TTL sizing: Worst case workflow duration ~48h (3 × 12h retries + batch delays)
-# 72h provides 50% safety margin. Increase if workflows consistently run longer.
-DEFAULT_TTL = 72 * 60 * 60  # 3 days
+# 168h provides generous safety margin for complex backfill operations that may run longer.
+DEFAULT_TTL = 168 * 60 * 60  # 7 days
 
 logger = structlog.get_logger(__name__)
 

--- a/posthog/temporal/messaging/filter_storage.py
+++ b/posthog/temporal/messaging/filter_storage.py
@@ -9,7 +9,7 @@ TTL Considerations:
 - Coordinator workflows spawn multiple child workflows with batch delays
 - Total workflow execution time in worst case: 3 retries × 12h + batch delays ≈ 40-48h
 - TTL set to 168h (7 days) provides generous safety margin for retries and delays
-- If workflows consistently exceed 48h, consider TTL refresh logic in get_filters()
+- If workflows consistently approach TTL (7d), consider TTL refresh logic in get_filters()
 """
 
 import json
@@ -123,7 +123,7 @@ def get_filters_and_properties(storage_key: str) -> tuple[list[PersonPropertyFil
         Tuple of (filters, person_properties, combined_bytecode), or None if not found
 
     Note:
-        If workflows consistently exceed 48h and TTL becomes an issue,
+        If workflows consistently approach TTL (7d) and expiration becomes an issue,
         consider adding TTL refresh logic here using Redis EXPIRE command.
     """
     data = get_client().get(storage_key)


### PR DESCRIPTION
## Problem

Person properties backfill workflows in Temporal can run for extended periods, especially when dealing with complex backfill operations involving retries, batch processing delays, and multiple child workflows. The current 3-day cache TTL for filter storage provides only a 50% safety margin over the estimated worst-case execution time of ~48 hours.

## Changes

- Increased `DEFAULT_TTL` in `posthog/temporal/messaging/filter_storage.py` from 72 hours (3 days) to 168 hours (7 days)
- Updated documentation comments to reflect the more generous safety margin for complex backfill operations
- No functional changes to the caching logic itself

## Publish to changelog?

No - this is an internal performance/reliability improvement that doesn't affect user-facing functionality.

## Docs update

No external documentation updates needed - this is an internal configuration change.

## 🤖 LLM context

This PR was authored by Claude Code. The change increases cache TTL to provide better reliability for long-running person properties backfill workflows in Temporal, reducing the risk of cache misses during extended processing operations.