### PR TITLE
chore(ci): use GHCR playwright mirror

### DIFF
--- a/.github/workflows/ci-storybook.yml
+++ b/.github/workflows/ci-storybook.yml
@@ -146,7 +146,7 @@ jobs:
         if: needs.changes.outputs.frontend == 'true'
         timeout-minutes: 60
         container:
-            image: mcr.microsoft.com/playwright:v1.45.0
+            image: ghcr.io/posthog/playwright:v1.45.0
         strategy:
             fail-fast: false
             matrix:
@@ -411,7 +411,7 @@ jobs:
         if: needs.changes.outputs.frontend == 'true' && github.event_name == 'pull_request'
         timeout-minutes: 30
         container:
-            image: mcr.microsoft.com/playwright:v1.45.0
+            image: ghcr.io/posthog/playwright:v1.45.0
         env:
             NODE_OPTIONS: --max-old-space-size=16384
             OPT_OUT_CAPTURE: 1

--- a/Dockerfile.playwright
+++ b/Dockerfile.playwright
@@ -3,7 +3,7 @@
 # We do this to ensure our reference images for visual regression tests are the same during development and in CI.
 #
 
-FROM mcr.microsoft.com/playwright:v1.45.0
+FROM ghcr.io/posthog/playwright:v1.45.0
 
 WORKDIR /work
 


### PR DESCRIPTION
## Problem

Storybook visual regression CI jobs pull `mcr.microsoft.com/playwright:v1.45.0` directly from Microsoft Container Registry (MCR) at job start. MCR has a history of transient pull failures (see https://github.com/microsoft/containerregistry/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) that break CI before any workflow steps can run.

Depends on #53899 which adds the GHCR mirror workflow and seeds the image.

## Changes

- Update `ci-storybook.yml` to pull from `ghcr.io/posthog/playwright:v1.45.0` instead of MCR
- Update `Dockerfile.playwright` to use the same GHCR mirror

## How did you test this code?

Agent-authored. Merge #53899 first and run its `workflow_dispatch` to seed the GHCR image, then this PR's CI will validate the swap.

## 🤖 LLM context

Agent-authored PR, second of a two-part change. Part 1: #53899 (mirror workflow).