### PR TITLE
fix(experiments): Fix confidence level displaying raw decimal instead of percentage

### DIFF
--- a/frontend/src/scenes/settings/environment/DefaultExperimentConfidenceLevel.tsx
+++ b/frontend/src/scenes/settings/environment/DefaultExperimentConfidenceLevel.tsx
@@ -16,7 +16,7 @@ export function DefaultExperimentConfidenceLevel(): JSX.Element {
         minimumAccessLevel: TeamMembershipLevel.Admin,
     })
 
-    const currentValue = experimentsConfig?.default_experiment_confidence_level ?? 0.95
+    const currentValue = Number(experimentsConfig?.default_experiment_confidence_level ?? 0.95)
 
     const handleChange = (value: number | null): void => {
         if (value === null) {


### PR DESCRIPTION
## Problem

The confidence level selector on the experiment settings page sometimes displays "0.9" instead of "90%". The backend `DecimalField` serializes as a string (e.g., `"0.90"`), which doesn't match the numeric option values (`0.9`) in `LemonSelect`, so it falls back to showing the raw value.

## Changes

Coerce the value to a number with `Number()` so it always matches the select options.

## How did you test this code?

Traced the data flow from backend `DecimalField` → API JSON response → kea reducer → `LemonSelect` value matching.