### PR TITLE
feat(experiments): track creation mode in experiment created analytics

### DIFF
--- a/ee/clickhouse/views/test/test_clickhouse_experiments.py
+++ b/ee/clickhouse/views/test/test_clickhouse_experiments.py
@@ -259,7 +259,7 @@ class TestExperimentCRUD(APILicensedTest):
                 "has_description": False,
                 "variant_count": 2,
                 "created_at": ANY,
-                "creation_mode": "scratch",
+                "creation_mode": "new",
             },
         )
         self.assertEqual(mock_report_user_action.call_args.kwargs["team"], self.team)

--- a/ee/clickhouse/views/test/test_clickhouse_experiments.py
+++ b/ee/clickhouse/views/test/test_clickhouse_experiments.py
@@ -3261,44 +3261,58 @@ class TestExperimentCRUD(APILicensedTest):
             0,
         )
 
+    @parameterized.expand(
+        [
+            ("duplicate", "duplicate", False),
+            ("copy_to_project", "copy_to_project", True),
+        ]
+    )
     @patch("products.experiments.backend.experiment_service.report_user_action")
-    def test_duplicate_experiment_reports_creation_mode(self, mock_report_user_action: MagicMock) -> None:
+    def test_clone_experiment_reports_creation_mode(
+        self, _name: str, expected_mode: str, needs_target_team: bool, mock_report_user_action: MagicMock
+    ) -> None:
+        target_team = (
+            Team.objects.create(organization=self.organization, name="Target Team") if needs_target_team else None
+        )
+
         original_response = self.client.post(
             f"/api/projects/{self.team.id}/experiments/",
-            {
-                "name": "Original Experiment",
-                "feature_flag_key": "duplicate-analytics-flag",
-            },
+            {"name": "Original Experiment", "feature_flag_key": f"{expected_mode}-analytics-flag"},
         )
         self.assertEqual(original_response.status_code, status.HTTP_201_CREATED)
-        original_experiment = original_response.json()
+        original_id = original_response.json()["id"]
         mock_report_user_action.reset_mock()
 
-        duplicate_response = self.client.post(
-            f"/api/projects/{self.team.id}/experiments/{original_experiment['id']}/duplicate/",
-            {},
-        )
+        if target_team:
+            url = f"/api/projects/{self.team.id}/experiments/{original_id}/copy_to_project/"
+            body: dict = {"target_team_id": target_team.id}
+            expected_team = target_team
+        else:
+            url = f"/api/projects/{self.team.id}/experiments/{original_id}/duplicate/"
+            body = {}
+            expected_team = self.team
 
-        self.assertEqual(duplicate_response.status_code, status.HTTP_201_CREATED)
-        duplicate_experiment = duplicate_response.json()
+        response = self.client.post(url, body)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        result = response.json()
 
         mock_report_user_action.assert_called_once_with(
             self.user,
             "experiment created",
             {
-                "experiment_id": duplicate_experiment["id"],
-                "experiment_name": duplicate_experiment["name"],
-                "feature_flag_key": duplicate_experiment["feature_flag_key"],
-                "type": duplicate_experiment["type"],
-                "status": duplicate_experiment["status"],
+                "experiment_id": result["id"],
+                "experiment_name": result["name"],
+                "feature_flag_key": result["feature_flag_key"],
+                "type": result["type"],
+                "status": result["status"],
                 "metrics_count": 0,
                 "secondary_metrics_count": 0,
                 "has_description": False,
                 "variant_count": 2,
                 "created_at": ANY,
-                "creation_mode": "duplicate",
+                "creation_mode": expected_mode,
             },
-            team=self.team,
+            team=expected_team,
             request=ANY,
         )
 
@@ -3368,49 +3382,6 @@ class TestExperimentCRUD(APILicensedTest):
         # Verify experiment was created in the target team
         target_experiment = Experiment.objects.get(id=copied_experiment["id"])
         self.assertEqual(target_experiment.team_id, target_team.id)
-
-    @patch("products.experiments.backend.experiment_service.report_user_action")
-    def test_copy_experiment_to_project_reports_creation_mode(self, mock_report_user_action: MagicMock) -> None:
-        target_team = Team.objects.create(organization=self.organization, name="Target Team")
-
-        original_response = self.client.post(
-            f"/api/projects/{self.team.id}/experiments/",
-            {
-                "name": "Original Experiment",
-                "feature_flag_key": "copy-analytics-flag",
-            },
-        )
-        self.assertEqual(original_response.status_code, status.HTTP_201_CREATED)
-        original_experiment = original_response.json()
-        mock_report_user_action.reset_mock()
-
-        copy_response = self.client.post(
-            f"/api/projects/{self.team.id}/experiments/{original_experiment['id']}/copy_to_project/",
-            {"target_team_id": target_team.id},
-        )
-
-        self.assertEqual(copy_response.status_code, status.HTTP_201_CREATED)
-        copied_experiment = copy_response.json()
-
-        mock_report_user_action.assert_called_once_with(
-            self.user,
-            "experiment created",
-            {
-                "experiment_id": copied_experiment["id"],
-                "experiment_name": copied_experiment["name"],
-                "feature_flag_key": copied_experiment["feature_flag_key"],
-                "type": copied_experiment["type"],
-                "status": copied_experiment["status"],
-                "metrics_count": 0,
-                "secondary_metrics_count": 0,
-                "has_description": False,
-                "variant_count": 2,
-                "created_at": ANY,
-                "creation_mode": "copy_to_project",
-            },
-            team=target_team,
-            request=ANY,
-        )
 
     def test_copy_experiment_to_project_creates_disabled_flag(self) -> None:
         target_team = Team.objects.create(organization=self.organization, name="Target Team")

--- a/ee/clickhouse/views/test/test_clickhouse_experiments.py
+++ b/ee/clickhouse/views/test/test_clickhouse_experiments.py
@@ -259,6 +259,7 @@ class TestExperimentCRUD(APILicensedTest):
                 "has_description": False,
                 "variant_count": 2,
                 "created_at": ANY,
+                "creation_mode": "scratch",
             },
         )
         self.assertEqual(mock_report_user_action.call_args.kwargs["team"], self.team)
@@ -3260,6 +3261,47 @@ class TestExperimentCRUD(APILicensedTest):
             0,
         )
 
+    @patch("products.experiments.backend.experiment_service.report_user_action")
+    def test_duplicate_experiment_reports_creation_mode(self, mock_report_user_action: MagicMock) -> None:
+        original_response = self.client.post(
+            f"/api/projects/{self.team.id}/experiments/",
+            {
+                "name": "Original Experiment",
+                "feature_flag_key": "duplicate-analytics-flag",
+            },
+        )
+        self.assertEqual(original_response.status_code, status.HTTP_201_CREATED)
+        original_experiment = original_response.json()
+        mock_report_user_action.reset_mock()
+
+        duplicate_response = self.client.post(
+            f"/api/projects/{self.team.id}/experiments/{original_experiment['id']}/duplicate/",
+            {},
+        )
+
+        self.assertEqual(duplicate_response.status_code, status.HTTP_201_CREATED)
+        duplicate_experiment = duplicate_response.json()
+
+        mock_report_user_action.assert_called_once_with(
+            self.user,
+            "experiment created",
+            {
+                "experiment_id": duplicate_experiment["id"],
+                "experiment_name": duplicate_experiment["name"],
+                "feature_flag_key": duplicate_experiment["feature_flag_key"],
+                "type": duplicate_experiment["type"],
+                "status": duplicate_experiment["status"],
+                "metrics_count": 0,
+                "secondary_metrics_count": 0,
+                "has_description": False,
+                "variant_count": 2,
+                "created_at": ANY,
+                "creation_mode": "duplicate",
+            },
+            team=self.team,
+            request=ANY,
+        )
+
     def test_copy_experiment_to_project(self) -> None:
         target_team = Team.objects.create(organization=self.organization, name="Target Team")
 
@@ -3326,6 +3368,49 @@ class TestExperimentCRUD(APILicensedTest):
         # Verify experiment was created in the target team
         target_experiment = Experiment.objects.get(id=copied_experiment["id"])
         self.assertEqual(target_experiment.team_id, target_team.id)
+
+    @patch("products.experiments.backend.experiment_service.report_user_action")
+    def test_copy_experiment_to_project_reports_creation_mode(self, mock_report_user_action: MagicMock) -> None:
+        target_team = Team.objects.create(organization=self.organization, name="Target Team")
+
+        original_response = self.client.post(
+            f"/api/projects/{self.team.id}/experiments/",
+            {
+                "name": "Original Experiment",
+                "feature_flag_key": "copy-analytics-flag",
+            },
+        )
+        self.assertEqual(original_response.status_code, status.HTTP_201_CREATED)
+        original_experiment = original_response.json()
+        mock_report_user_action.reset_mock()
+
+        copy_response = self.client.post(
+            f"/api/projects/{self.team.id}/experiments/{original_experiment['id']}/copy_to_project/",
+            {"target_team_id": target_team.id},
+        )
+
+        self.assertEqual(copy_response.status_code, status.HTTP_201_CREATED)
+        copied_experiment = copy_response.json()
+
+        mock_report_user_action.assert_called_once_with(
+            self.user,
+            "experiment created",
+            {
+                "experiment_id": copied_experiment["id"],
+                "experiment_name": copied_experiment["name"],
+                "feature_flag_key": copied_experiment["feature_flag_key"],
+                "type": copied_experiment["type"],
+                "status": copied_experiment["status"],
+                "metrics_count": 0,
+                "secondary_metrics_count": 0,
+                "has_description": False,
+                "variant_count": 2,
+                "created_at": ANY,
+                "creation_mode": "copy_to_project",
+            },
+            team=target_team,
+            request=ANY,
+        )
 
     def test_copy_experiment_to_project_creates_disabled_flag(self) -> None:
         target_team = Team.objects.create(organization=self.organization, name="Target Team")

--- a/posthog/api/test/test_web_experiment.py
+++ b/posthog/api/test/test_web_experiment.py
@@ -99,6 +99,7 @@ class TestWebExperiment(APIBaseTest):
                 "has_description": False,
                 "variant_count": 2,
                 "created_at": web_experiment.created_at,
+                "creation_mode": "scratch",
             },
             team=ANY,
             request=ANY,

--- a/posthog/api/test/test_web_experiment.py
+++ b/posthog/api/test/test_web_experiment.py
@@ -99,7 +99,7 @@ class TestWebExperiment(APIBaseTest):
                 "has_description": False,
                 "variant_count": 2,
                 "created_at": web_experiment.created_at,
-                "creation_mode": "scratch",
+                "creation_mode": "new",
             },
             team=ANY,
             request=ANY,

--- a/posthog/api/web_experiment.py
+++ b/posthog/api/web_experiment.py
@@ -228,7 +228,7 @@ class WebExperimentsAPISerializer(serializers.ModelSerializer):
         report_user_action(
             self.context["request"].user,
             "experiment created",
-            experiment.get_analytics_metadata(),
+            {**experiment.get_analytics_metadata(), "creation_mode": "scratch"},
             team=team,
             request=self.context["request"],
         )

--- a/posthog/api/web_experiment.py
+++ b/posthog/api/web_experiment.py
@@ -228,7 +228,7 @@ class WebExperimentsAPISerializer(serializers.ModelSerializer):
         report_user_action(
             self.context["request"].user,
             "experiment created",
-            {**experiment.get_analytics_metadata(), "creation_mode": "scratch"},
+            {**experiment.get_analytics_metadata(), "creation_mode": "new"},
             team=team,
             request=self.context["request"],
         )

--- a/products/experiments/backend/experiment_service.py
+++ b/products/experiments/backend/experiment_service.py
@@ -47,7 +47,7 @@ logger = structlog.get_logger(__name__)
 
 DEFAULT_ROLLOUT_PERCENTAGE = 100
 
-ExperimentCreationMode = Literal["scratch", "duplicate", "copy_to_project"]
+ExperimentCreationMode = Literal["new", "duplicate", "copy_to_project"]
 
 DEFAULT_VARIANTS = [
     {"key": "control", "name": "Control Group", "rollout_percentage": 50},
@@ -280,7 +280,7 @@ class ExperimentService:
         conclusion_comment: str | None = None,
         serializer_context: dict | None = None,
         event_source: EventSource | None = None,
-        creation_mode: ExperimentCreationMode = "scratch",
+        creation_mode: ExperimentCreationMode = "new",
     ) -> Experiment:
         """Create experiment with full validation and defaults."""
         self.validate_variant_shapes(parameters)

--- a/products/experiments/backend/experiment_service.py
+++ b/products/experiments/backend/experiment_service.py
@@ -4,7 +4,7 @@ from collections.abc import Mapping
 from copy import deepcopy
 from datetime import date, datetime, timedelta
 from enum import Enum
-from typing import Any
+from typing import Any, Literal
 from uuid import uuid4
 from zoneinfo import ZoneInfo
 
@@ -46,6 +46,8 @@ from ee.clickhouse.views.experiment_saved_metrics import ExperimentToSavedMetric
 logger = structlog.get_logger(__name__)
 
 DEFAULT_ROLLOUT_PERCENTAGE = 100
+
+ExperimentCreationMode = Literal["scratch", "duplicate", "copy_to_project"]
 
 DEFAULT_VARIANTS = [
     {"key": "control", "name": "Control Group", "rollout_percentage": 50},
@@ -278,6 +280,7 @@ class ExperimentService:
         conclusion_comment: str | None = None,
         serializer_context: dict | None = None,
         event_source: EventSource | None = None,
+        creation_mode: ExperimentCreationMode = "scratch",
     ) -> Experiment:
         """Create experiment with full validation and defaults."""
         self.validate_variant_shapes(parameters)
@@ -385,6 +388,7 @@ class ExperimentService:
             experiment,
             serializer_context=serializer_context,
             event_source=event_source,
+            creation_mode=creation_mode,
         )
 
         return experiment
@@ -399,12 +403,14 @@ class ExperimentService:
         *,
         serializer_context: dict | None,
         event_source: EventSource | None,
+        creation_mode: ExperimentCreationMode,
     ) -> None:
         request = serializer_context.get("request") if serializer_context else None
         if request is None and event_source is None:
             return
 
         analytics_metadata = experiment.get_analytics_metadata()
+        analytics_metadata["creation_mode"] = creation_mode
         if event_source is not None:
             analytics_metadata["source"] = event_source
 
@@ -1408,6 +1414,7 @@ class ExperimentService:
             ] or None
 
         service = ExperimentService(team=target, user=self.user) if is_cross_project else self
+        creation_mode: ExperimentCreationMode = "copy_to_project" if is_cross_project else "duplicate"
         return service.create_experiment(
             name=clone_name,
             feature_flag_key=feature_flag_key,
@@ -1426,6 +1433,7 @@ class ExperimentService:
             exposure_preaggregation_enabled=source_experiment.exposure_preaggregation_enabled,
             only_count_matured_users=source_experiment.only_count_matured_users,
             serializer_context=serializer_context,
+            creation_mode=creation_mode,
         )
 
     def duplicate_experiment(

--- a/products/experiments/backend/test/test_max_tools.py
+++ b/products/experiments/backend/test/test_max_tools.py
@@ -167,6 +167,7 @@ class TestCreateExperimentTool(APIBaseTest):
             "has_description": False,
             "variant_count": 2,
             "created_at": ANY,
+            "creation_mode": "new",
             "source": EventSource.POSTHOG_AI,
         }
         assert mock_report_user_action.call_args.kwargs["team"] == self.team


### PR DESCRIPTION
## Problem

The "experiment created" analytics event doesn't distinguish how the experiment was created — whether from scratch, by duplicating an existing one, or by copying to another project. This makes it hard to understand experiment creation patterns.

## Changes

- Add a `creation_mode` field (`"new"` | `"duplicate"` | `"copy_to_project"`) to the "experiment created" analytics event
- Thread `creation_mode` through `ExperimentService.create_experiment` and `_report_experiment_created`
- Also track creation mode for web experiments (always `"new"`)

## Testing

- Added test for duplicate experiment reporting `creation_mode: "duplicate"`
- Added test for copy-to-project reporting `creation_mode: "copy_to_project"`
- Updated existing creation tests to assert `creation_mode: "new"`