### PR TITLE
fix(insights): vertically center steps header in editor filter tile

### DIFF
--- a/frontend/src/queries/nodes/InsightViz/EditorFilterGroupTile.tsx
+++ b/frontend/src/queries/nodes/InsightViz/EditorFilterGroupTile.tsx
@@ -45,13 +45,13 @@ export function EditorFilterGroupTile({
                     data-attr={'editor-filter-group-collapse-' + slugify(title)}
                     className={clsx('rounded-b-none px-1 py-1', isRowExpanded && 'border-b')}
                 >
-                    <div className={clsx('flex items-baseline gap-2 font-semibold min-w-0', headerExtra && 'flex-1')}>
+                    <div className={clsx('flex items-center gap-2 font-semibold min-w-0', headerExtra && 'flex-1')}>
                         <span className="shrink-0">{title}</span>
                         {!isRowExpanded && collapsedSummary && (
                             <span className="text-xs font-normal text-secondary truncate">{collapsedSummary}</span>
                         )}
                         {headerExtra && (
-                            <div className="ml-auto self-center shrink-0" onClick={(e) => e.stopPropagation()}>
+                            <div className="ml-auto shrink-0" onClick={(e) => e.stopPropagation()}>
                                 {headerExtra}
                             </div>
                         )}


### PR DESCRIPTION
## Problem

In the insight simple editor, the "Steps" header text sits above the conversion-steps dropdown and the collapse chevron instead of lining up with them. It's a small visual bug but makes the header feel off.

## Changes
<img width="456" height="141" alt="Screenshot 2026-04-09 at 17 29 49" src="https://github.com/user-attachments/assets/27269e6e-dfe9-40af-aa04-e561725fef3c" />

- Switch the header row from `items-baseline` to `items-center` in `EditorFilterGroupTile`
- Drop the now-redundant `self-center` override on the `headerExtra` wrapper

## How did you test this code?

I'm an agent — no manual testing beyond reading the diff. No automated tests were run for this change (it's a CSS-only tweak).

## Publish to changelog?