### PR TITLE
feat(workflows): Add generic schedule trigger type

### DIFF
--- a/nodejs/src/cdp/cdp-api.test.ts
+++ b/nodejs/src/cdp/cdp-api.test.ts
@@ -783,4 +783,92 @@ describe('CDP API', () => {
             expect(res.body.error).toEqual('Kafka producer not available')
         })
     })
+
+    describe('scheduled hogflow invocations', () => {
+        let scheduleHogFlow: HogFlow
+        let mockQueueInvocations: jest.Mock
+
+        beforeEach(async () => {
+            mockQueueInvocations = jest.fn().mockResolvedValue(undefined)
+            api['cyclotronJobQueue'] = { queueInvocations: mockQueueInvocations } as any
+
+            scheduleHogFlow = await insertHogFlow({
+                id: new UUIDT().toString(),
+                name: 'test schedule hog flow',
+                status: 'active',
+                version: 1,
+                exit_condition: 'exit_only_at_end',
+                edges: [],
+                actions: [],
+                trigger: {
+                    type: 'schedule',
+                },
+            })
+        })
+
+        it('errors if missing team', async () => {
+            const nonExistentTeamId = new UUIDT().toString()
+            const res = await supertest(app)
+                .post(`/api/projects/${nonExistentTeamId}/hog_flows/${scheduleHogFlow.id}/scheduled_invocations`)
+                .send({})
+
+            expect(res.status).toEqual(404)
+            expect(res.body.error).toEqual('Team not found')
+        })
+
+        it('errors if missing hog flow', async () => {
+            const nonExistentUuid = new UUIDT().toString()
+            const res = await supertest(app)
+                .post(`/api/projects/${scheduleHogFlow.team_id}/hog_flows/${nonExistentUuid}/scheduled_invocations`)
+                .send({})
+
+            expect(res.status).toEqual(404)
+            expect(res.body.error).toEqual('Workflow not found')
+        })
+
+        it('errors if trigger type is not schedule', async () => {
+            const eventHogFlow = await insertHogFlow({
+                id: new UUIDT().toString(),
+                name: 'test event hog flow',
+                status: 'active',
+                version: 1,
+                exit_condition: 'exit_on_conversion',
+                edges: [],
+                actions: [],
+                trigger: {
+                    type: 'event',
+                    filters: {},
+                },
+            })
+
+            const res = await supertest(app)
+                .post(`/api/projects/${eventHogFlow.team_id}/hog_flows/${eventHogFlow.id}/scheduled_invocations`)
+                .send({})
+
+            expect(res.status).toEqual(400)
+            expect(res.body.error).toEqual('Workflow trigger must be of type "schedule"')
+        })
+
+        it('queues invocation and returns queued status', async () => {
+            const res = await supertest(app)
+                .post(`/api/projects/${scheduleHogFlow.team_id}/hog_flows/${scheduleHogFlow.id}/scheduled_invocations`)
+                .send({ variables: { greeting: 'Hello' } })
+
+            expect(res.status).toEqual(200)
+            expect(res.body.status).toEqual('queued')
+            expect(res.body.invocation_id).toBeDefined()
+            expect(mockQueueInvocations).toHaveBeenCalledTimes(1)
+        })
+
+        it('queues invocation with empty variables when none provided', async () => {
+            const res = await supertest(app)
+                .post(`/api/projects/${scheduleHogFlow.team_id}/hog_flows/${scheduleHogFlow.id}/scheduled_invocations`)
+                .send({})
+
+            expect(res.status).toEqual(200)
+            expect(res.body.status).toEqual('queued')
+            expect(res.body.invocation_id).toBeDefined()
+            expect(mockQueueInvocations).toHaveBeenCalledTimes(1)
+        })
+    })
 })

--- a/nodejs/src/cdp/cdp-api.ts
+++ b/nodejs/src/cdp/cdp-api.ts
@@ -32,6 +32,7 @@ import { BatchExportHogFunctionService, NotFoundError, ParseError } from './serv
 import { HogExecutorExecuteAsyncOptions, HogExecutorService, MAX_ASYNC_STEPS } from './services/hog-executor.service'
 import { HogFlowExecutorService, createHogFlowInvocation } from './services/hogflows/hogflow-executor.service'
 import { HogFlowManagerService } from './services/hogflows/hogflow-manager.service'
+import { CyclotronJobQueue } from './services/job-queue/job-queue'
 import { GroupsManagerService } from './services/managers/groups-manager.service'
 import { HogFunctionManagerService } from './services/managers/hog-function-manager.service'
 import { EmailTrackingService } from './services/messaging/email-tracking.service'
@@ -61,6 +62,7 @@ export class CdpApi {
     private hogTransformer: HogTransformerService
     private hogFunctionMonitoringService: HogFunctionMonitoringService
     private cdpSourceWebhooksConsumer: CdpSourceWebhooksConsumer
+    private cyclotronJobQueue: CyclotronJobQueue
     private emailTrackingService: EmailTrackingService
     private recipientTokensService: RecipientTokensService
     private cdpWarehouseKafkaProducer?: KafkaProducerWrapper
@@ -101,6 +103,7 @@ export class CdpApi {
             }),
         })
         this.cdpSourceWebhooksConsumer = new CdpSourceWebhooksConsumer(config, deps)
+        this.cyclotronJobQueue = new CyclotronJobQueue(config.CONSUMER_BATCH_SIZE, config.KAFKA_CLIENT_RACK, config)
         this.emailTrackingService = new EmailTrackingService(
             this.hogFunctionManager,
             this.hogFlowManager,
@@ -133,12 +136,14 @@ export class CdpApi {
         )
         this.hogFunctionMonitoringService.setWarehouseKafkaProducer(this.cdpWarehouseKafkaProducer)
         await this.cdpSourceWebhooksConsumer.start()
+        await this.cyclotronJobQueue.startAsProducer()
     }
 
     async stop(): Promise<void> {
         await Promise.all([
             this.cdpWarehouseKafkaProducer?.disconnect(),
             this.cdpSourceWebhooksConsumer.stop(),
+            this.cyclotronJobQueue.stop(),
             this.batchExportHogFunctionService.stop(),
         ])
     }
@@ -159,6 +164,10 @@ export class CdpApi {
         // API routes (authentication handled globally by middleware)
         router.post('/api/projects/:team_id/hog_functions/:id/invocations', asyncHandler(this.postFunctionInvocation))
         router.post('/api/projects/:team_id/hog_flows/:id/invocations', asyncHandler(this.postHogflowInvocation))
+        router.post(
+            '/api/projects/:team_id/hog_flows/:id/scheduled_invocations',
+            asyncHandler(this.postHogflowScheduledInvocation)
+        )
         router.post(
             '/api/projects/:team_id/hog_flows/:id/batch_invocations/:parent_run_id',
             asyncHandler(this.postHogFlowBatchInvocation)
@@ -530,6 +539,67 @@ export class CdpApi {
             })
         } catch (e) {
             console.error(e)
+            res.status(500).json({ error: [e.message] })
+        }
+    }
+
+    private postHogflowScheduledInvocation = async (req: ModifiedRequest, res: express.Response): Promise<any> => {
+        try {
+            const { id, team_id } = req.params
+            const { variables } = req.body
+
+            logger.info('⚡️', 'Received hogflow scheduled invocation', { id, team_id })
+
+            const team = await this.deps.teamManager.getTeam(parseInt(team_id)).catch(() => null)
+            if (!team) {
+                return res.status(404).json({ error: 'Team not found' })
+            }
+
+            const hogFlow = await this.hogFlowManager.getHogFlow(id)
+            if (!hogFlow || hogFlow.team_id !== team.id) {
+                return res.status(404).json({ error: 'Workflow not found' })
+            }
+
+            if (hogFlow.trigger?.type !== 'schedule') {
+                return res.status(400).json({ error: 'Workflow trigger must be of type "schedule"' })
+            }
+
+            // Build a synthetic event for the scheduled run. Schedule triggers don't have a real
+            // event, but the executor expects one to populate globals.event used by downstream actions.
+            const syntheticEvent: HogFunctionInvocationGlobals['event'] = {
+                uuid: new UUIDT().toString(),
+                event: '$workflow_scheduled',
+                distinct_id: `workflow-${hogFlow.id}`,
+                timestamp: DateTime.now().toISO(),
+                url: '',
+                properties: {},
+                elements_chain: '',
+            }
+
+            const triggerGlobals: HogFunctionInvocationGlobals = {
+                event: syntheticEvent,
+                project: {
+                    id: team.id,
+                    name: team.name,
+                    url: `${this.config.SITE_URL ?? 'http://localhost:8000'}/project/${team.id}`,
+                },
+                variables: variables ?? {},
+            }
+
+            const filterGlobals = convertToHogFunctionFilterGlobal({
+                event: syntheticEvent,
+                person: undefined,
+                groups: {},
+                variables: variables ?? {},
+            })
+
+            const invocation = createHogFlowInvocation(triggerGlobals, hogFlow, filterGlobals)
+
+            await this.cyclotronJobQueue.queueInvocations([invocation])
+
+            res.json({ status: 'queued', invocation_id: invocation.id })
+        } catch (e) {
+            logger.error('Error handling hogflow scheduled invocation', { error: e })
             res.status(500).json({ error: [e.message] })
         }
     }

--- a/nodejs/src/cdp/consumers/cdp-source-webhooks.consumer.test.ts
+++ b/nodejs/src/cdp/consumers/cdp-source-webhooks.consumer.test.ts
@@ -380,53 +380,6 @@ describe('SourceWebhooksConsumer', () => {
                 await insertHogFlow(hub.postgres, hogFlow)
             })
 
-            it('should schedule workflow run for scheduled_at on trigger', async () => {
-                const scheduledAt = '2025-01-02T12:00:00.000Z'
-                const scheduledHogFlow = new FixtureHogFlowBuilder()
-                    .withTeamId(team.id)
-                    .withSimpleWorkflow({
-                        trigger: {
-                            type: 'schedule',
-                            template_id: incomingWebhookTemplate.id,
-                            scheduled_at: scheduledAt,
-                            inputs: {
-                                event: {
-                                    value: 'my-event',
-                                    bytecode: await compileHog(`return f'my-event'`),
-                                },
-                                distinct_id: {
-                                    value: '{request.body.distinct_id}',
-                                    bytecode: await compileHog(`return f'{request.body.distinct_id}'`),
-                                },
-                                method: {
-                                    value: 'POST',
-                                    bytecode: await compileHog(`return f'POST'`),
-                                },
-                            },
-                        },
-                    })
-                    .build()
-                await insertHogFlow(hub.postgres, scheduledHogFlow)
-
-                const res = await doPostRequest({
-                    webhookId: scheduledHogFlow.id,
-                    body: {
-                        event: 'my-event',
-                        distinct_id: 'test-distinct-id',
-                    },
-                })
-                expect(res.status).toEqual(201)
-                expect(res.body).toEqual({ status: 'queued' })
-                expect(mockQueueInvocationsSpy).toHaveBeenCalledTimes(1)
-                const call = mockQueueInvocationsSpy.mock.calls[0][0][0]
-                expect(call.queueScheduledAt.toISO()).toEqual(scheduledAt)
-                await waitForBackgroundTasks()
-                expect(getLogs()).toEqual([
-                    expect.stringContaining('[Action:trigger] Function completed in'),
-                    expect.stringContaining(`[Action:trigger] Workflow run scheduled for ${scheduledAt}`),
-                ])
-            })
-
             it('should 404 if the hog flow does not exist', async () => {
                 const res = await doPostRequest({
                     webhookId: 'non-existent-hog-flow-id',

--- a/nodejs/src/cdp/consumers/cdp-source-webhooks.consumer.ts
+++ b/nodejs/src/cdp/consumers/cdp-source-webhooks.consumer.ts
@@ -120,8 +120,7 @@ export class CdpSourceWebhooksConsumer extends CdpConsumerBase<PluginsServerConf
             hogFlow.status === 'active' &&
             (hogFlow.trigger?.type === 'webhook' ||
                 hogFlow.trigger?.type === 'tracking_pixel' ||
-                hogFlow.trigger?.type === 'manual' ||
-                hogFlow.trigger?.type === 'schedule')
+                hogFlow.trigger?.type === 'manual')
         ) {
             const hogFunction = await this.hogFlowFunctionsService.buildHogFunction(hogFlow, hogFlow.trigger)
 
@@ -281,17 +280,6 @@ export class CdpSourceWebhooksConsumer extends CdpConsumerBase<PluginsServerConf
                     hogFlow,
                     {} as HogFunctionFilterGlobals
                 )
-
-                const scheduledAt = hogFlow.trigger && 'scheduled_at' in hogFlow.trigger && hogFlow.trigger.scheduled_at
-                if (scheduledAt) {
-                    const scheduledDateTime = DateTime.fromISO(scheduledAt)
-                    if (!scheduledDateTime.isValid) {
-                        addLog('warn', `Invalid scheduled_at date format: ${scheduledAt}`)
-                    } else {
-                        hogFlowInvocation.queueScheduledAt = scheduledDateTime
-                        addLog('info', `Workflow run scheduled for ${scheduledAt}`)
-                    }
-                }
 
                 hogFlowInvocation.id = invocationId // Keep the IDs consistent
 

--- a/nodejs/src/schema/hogflow.ts
+++ b/nodejs/src/schema/hogflow.ts
@@ -58,19 +58,12 @@ const HogFlowTriggerSchema = z.discriminatedUnion('type', [
     }),
     z.object({
         type: z.literal('schedule'),
-        template_uuid: z.string().uuid().optional(), // May be used later to specify a specific template version
-        template_id: z.string(),
-        inputs: z.record(z.string(), CyclotronInputSchema),
-        scheduled_at: z.string().optional(), // ISO 8601 datetime string for one-time scheduling
-        // Future: recurring schedule fields can be added here
     }),
     z.object({
         type: z.literal('batch'),
         filters: z.object({
             properties: z.array(z.any()),
         }),
-        scheduled_at: z.string().optional(), // ISO 8601 datetime string for one-time scheduling
-        // Future: recurring schedule fields can be added here
     }),
 ])
 

--- a/posthog/api/hog_flow.py
+++ b/posthog/api/hog_flow.py
@@ -792,7 +792,8 @@ class InternalHogFlowViewSet(TeamAndOrgViewSetMixin, LogEntryMixin, AppMetricsMi
                         )
                         processed.append(str(schedule_id))
                     elif schedule_invocation_params:
-                        create_hog_flow_scheduled_invocation(**schedule_invocation_params)
+                        response = create_hog_flow_scheduled_invocation(**schedule_invocation_params)
+                        response.raise_for_status()
                         processed.append(str(schedule_id))
                 except Exception:
                     logger.exception("Error processing schedule", schedule_id=str(schedule_id))

--- a/posthog/api/hog_flow.py
+++ b/posthog/api/hog_flow.py
@@ -38,10 +38,10 @@ from posthog.models.feature_flag.user_blast_radius import (
 )
 from posthog.models.hog_flow.hog_flow import BILLABLE_ACTION_TYPES, HogFlow
 from posthog.models.hog_function_template import HogFunctionTemplate
-from posthog.plugins.plugin_server_api import create_hog_flow_invocation_test
+from posthog.plugins.plugin_server_api import create_hog_flow_invocation_test, create_hog_flow_scheduled_invocation
 
 from products.workflows.backend.models.hog_flow_batch_job import HogFlowBatchJob
-from products.workflows.backend.models.hog_flow_schedule import HogFlowSchedule
+from products.workflows.backend.models.hog_flow_schedule import SCHEDULED_TRIGGER_TYPES, HogFlowSchedule
 from products.workflows.backend.utils.rrule_utils import compute_next_occurrences, validate_rrule
 
 logger = structlog.get_logger(__name__)
@@ -93,7 +93,7 @@ class HogFlowActionSerializer(serializers.Serializer):
 
         trigger_is_function = False
         if data.get("type") == "trigger":
-            if data.get("config", {}).get("type") in ["webhook", "manual", "tracking_pixel", "schedule"]:
+            if data.get("config", {}).get("type") in ["webhook", "manual", "tracking_pixel"]:
                 trigger_is_function = True
             elif data.get("config", {}).get("type") == "event":
                 filters = data.get("config", {}).get("filters", {})
@@ -118,6 +118,10 @@ class HogFlowActionSerializer(serializers.Serializer):
                     properties = filters.get("properties", None)
                     if properties is not None and not isinstance(properties, list):
                         raise serializers.ValidationError({"filters": {"properties": "Properties must be an array."}})
+            elif data.get("config", {}).get("type") == "schedule":
+                # Schedule triggers have no extra validation - the schedule definition
+                # lives on a separate HogFlowSchedule row keyed by hog_flow_id.
+                pass
             else:
                 if not is_draft:
                     raise serializers.ValidationError({"config": "Invalid trigger type"})
@@ -260,6 +264,7 @@ class HogFlowScheduleSerializer(serializers.ModelSerializer):
         if any(field in validated_data for field in ("rrule", "starts_at", "timezone")):
             # Force the scheduler to recalculate the next occurrence on its next poll
             instance.next_run_at = None
+            instance.status = HogFlowSchedule.Status.ACTIVE
         return super().update(instance, validated_data)
 
 
@@ -736,7 +741,8 @@ class InternalHogFlowViewSet(TeamAndOrgViewSetMixin, LogEntryMixin, AppMetricsMi
 
             for schedule_id in due_schedule_ids:
                 try:
-                    batch_job_params = None
+                    batch_job_params: dict | None = None
+                    schedule_invocation_params: dict | None = None
                     with transaction.atomic():
                         # Per-schedule transaction: lock only one row at a time to minimize
                         # lock duration and allow concurrent replicas via skip_locked.
@@ -757,27 +763,36 @@ class InternalHogFlowViewSet(TeamAndOrgViewSetMixin, LogEntryMixin, AppMetricsMi
                         hog_flow = schedule.hog_flow
                         trigger_type = (hog_flow.trigger or {}).get("type")
 
-                        if hog_flow.status != "active" or trigger_type != "batch":
+                        if hog_flow.status != "active" or trigger_type not in SCHEDULED_TRIGGER_TYPES:
                             schedule.next_run_at = None
                             schedule.save(update_fields=["next_run_at", "updated_at"])
                             continue
 
                         advance_next_run(schedule, after=schedule.next_run_at)
 
-                        batch_job_params = {
-                            "team_id": schedule.team_id,
-                            "hog_flow": hog_flow,
-                            "variables": resolve_variables(hog_flow, schedule),
-                            "filters": (hog_flow.trigger or {}).get("filters", {}),
-                        }
+                        if trigger_type == "batch":
+                            batch_job_params = {
+                                "team_id": schedule.team_id,
+                                "hog_flow": hog_flow,
+                                "variables": resolve_variables(hog_flow, schedule),
+                                "filters": (hog_flow.trigger or {}).get("filters", {}),
+                            }
+                        else:
+                            schedule_invocation_params = {
+                                "team_id": schedule.team_id,
+                                "hog_flow_id": str(hog_flow.id),
+                                "variables": resolve_variables(hog_flow, schedule),
+                            }
 
-                    # Create the batch job outside the transaction so the
-                    # post_save signal's HTTP call doesn't hold the row lock.
+                    # Dispatch outside the transaction so HTTP calls don't hold the row lock.
                     if batch_job_params:
                         HogFlowBatchJob.objects.create(
                             **batch_job_params,
                             status=HogFlowBatchJob.State.QUEUED,
                         )
+                        processed.append(str(schedule_id))
+                    elif schedule_invocation_params:
+                        create_hog_flow_scheduled_invocation(**schedule_invocation_params)
                         processed.append(str(schedule_id))
                 except Exception:
                     logger.exception("Error processing schedule", schedule_id=str(schedule_id))
@@ -790,7 +805,7 @@ class InternalHogFlowViewSet(TeamAndOrgViewSetMixin, LogEntryMixin, AppMetricsMi
                     status=HogFlowSchedule.Status.ACTIVE,
                     next_run_at__isnull=True,
                     hog_flow__status="active",
-                    hog_flow__trigger__type="batch",
+                    hog_flow__trigger__type__in=SCHEDULED_TRIGGER_TYPES,
                 ).values_list("id", flat=True)
             )
 

--- a/posthog/models/resource_transfer/test/__snapshots__/test_visitor_field_snapshots.ambr
+++ b/posthog/models/resource_transfer/test/__snapshots__/test_visitor_field_snapshots.ambr
@@ -451,7 +451,6 @@
   list([
     'DoesNotExist',
     'MultipleObjectsReturned',
-    '__annotations__',
     '__doc__',
     '__module__',
     '__repr__',

--- a/posthog/plugins/plugin_server_api.py
+++ b/posthog/plugins/plugin_server_api.py
@@ -86,6 +86,17 @@ def create_hog_flow_invocation_test(team_id: int, hog_flow_id: str, payload: dic
     )
 
 
+def create_hog_flow_scheduled_invocation(
+    team_id: int, hog_flow_id: str, variables: dict[str, object]
+) -> requests.Response:
+    logger.info(f"Creating scheduled hog flow invocation for hog flow {hog_flow_id} on workers")
+    return internal_requests.post(
+        CDP_API_URL + f"/api/projects/{team_id}/hog_flows/{hog_flow_id}/scheduled_invocations",
+        json={"variables": variables},
+        headers=get_internal_api_headers(),
+    )
+
+
 def get_hog_function_status(team_id: int, hog_function_id: UUIDT) -> requests.Response:
     return internal_requests.get(
         CDP_API_URL + f"/api/projects/{team_id}/hog_functions/{hog_function_id}/status",

--- a/products/workflows/backend/models/hog_flow_schedule/__init__.py
+++ b/products/workflows/backend/models/hog_flow_schedule/__init__.py
@@ -1,3 +1,6 @@
-from products.workflows.backend.models.hog_flow_schedule.hog_flow_schedule import HogFlowSchedule
+from products.workflows.backend.models.hog_flow_schedule.hog_flow_schedule import (
+    SCHEDULED_TRIGGER_TYPES,
+    HogFlowSchedule,
+)
 
-__all__ = ["HogFlowSchedule"]
+__all__ = ["SCHEDULED_TRIGGER_TYPES", "HogFlowSchedule"]

--- a/products/workflows/backend/models/hog_flow_schedule/hog_flow_schedule.py
+++ b/products/workflows/backend/models/hog_flow_schedule/hog_flow_schedule.py
@@ -2,6 +2,9 @@ from django.db import models
 
 from posthog.models.utils import RootTeamMixin, UUIDTModel
 
+# Trigger types that use HogFlowSchedule for recurring execution
+SCHEDULED_TRIGGER_TYPES = ("batch", "schedule")
+
 
 class HogFlowSchedule(RootTeamMixin, UUIDTModel):
     """

--- a/products/workflows/backend/test/test_hog_flow_schedule.py
+++ b/products/workflows/backend/test/test_hog_flow_schedule.py
@@ -355,3 +355,100 @@ class TestProcessDueSchedules(APIBaseTest):
 
         schedule.refresh_from_db()
         assert schedule.next_run_at is None
+
+
+@override_settings(INTERNAL_API_SECRET="test-secret")
+@unittest.mock.patch("posthog.api.hog_flow.create_hog_flow_scheduled_invocation")
+class TestProcessDueScheduleTriggers(APIBaseTest):
+    INTERNAL_URL = "/api/internal/hog_flows/process_due_schedules"
+
+    def _create_workflow_with_schedule(self, next_run_at=None, rrule="FREQ=HOURLY;INTERVAL=1"):
+        hog_flow = HogFlow.objects.create(
+            team=self.team,
+            name="Test Schedule Workflow",
+            status="active",
+            trigger={"type": "schedule"},
+            actions=[],
+            variables=[{"key": "greeting", "default": "Hello"}],
+        )
+        schedule = HogFlowSchedule.objects.create(
+            team=self.team,
+            hog_flow=hog_flow,
+            rrule=rrule,
+            starts_at=datetime(2026, 1, 1, 9, 0, 0, tzinfo=UTC),
+            timezone="UTC",
+            status="active",
+            next_run_at=next_run_at,
+        )
+        return hog_flow, schedule
+
+    def _post(self):
+        return self.client.post(
+            self.INTERNAL_URL,
+            content_type="application/json",
+            HTTP_X_INTERNAL_API_SECRET="test-secret",
+        )
+
+    def test_due_schedule_trigger_dispatches_scheduled_invocation(self, mock_invocation):
+        hog_flow, schedule = self._create_workflow_with_schedule(
+            next_run_at=datetime(2020, 1, 1, tzinfo=UTC),
+        )
+        response = self._post()
+        assert response.status_code == 200
+        assert str(schedule.id) in response.json()["processed"]
+
+        mock_invocation.assert_called_once()
+        call_kwargs = mock_invocation.call_args.kwargs
+        assert call_kwargs["team_id"] == self.team.id
+        assert call_kwargs["hog_flow_id"] == str(hog_flow.id)
+        assert call_kwargs["variables"] == {"greeting": "Hello"}
+
+    def test_schedule_trigger_advances_next_run_at(self, mock_invocation):
+        _, schedule = self._create_workflow_with_schedule(
+            next_run_at=datetime(2020, 1, 1, tzinfo=UTC),
+        )
+        response = self._post()
+        assert response.status_code == 200
+
+        schedule.refresh_from_db()
+        assert schedule.next_run_at is not None
+        assert schedule.next_run_at > datetime(2020, 1, 1, tzinfo=UTC)
+
+    def test_schedule_trigger_uses_variable_overrides(self, mock_invocation):
+        hog_flow, schedule = self._create_workflow_with_schedule(
+            next_run_at=datetime(2020, 1, 1, tzinfo=UTC),
+        )
+        schedule.variables = {"greeting": "Hi there", "extra": "value"}
+        schedule.save()
+
+        response = self._post()
+        assert response.status_code == 200
+
+        mock_invocation.assert_called_once()
+        variables = mock_invocation.call_args.kwargs["variables"]
+        assert variables["greeting"] == "Hi there"
+        assert variables["extra"] == "value"
+
+    def test_inactive_schedule_trigger_workflow_clears_next_run_at(self, mock_invocation):
+        hog_flow, schedule = self._create_workflow_with_schedule(
+            next_run_at=datetime(2020, 1, 1, tzinfo=UTC),
+        )
+        hog_flow.status = "draft"
+        hog_flow.save()
+
+        response = self._post()
+        assert response.status_code == 200
+        assert len(response.json()["processed"]) == 0
+
+        schedule.refresh_from_db()
+        assert schedule.next_run_at is None
+        mock_invocation.assert_not_called()
+
+    def test_uninitialized_schedule_trigger_gets_next_run_at(self, mock_invocation):
+        _, schedule = self._create_workflow_with_schedule(next_run_at=None)
+        response = self._post()
+        assert response.status_code == 200
+        assert str(schedule.id) in response.json()["initialized"]
+
+        schedule.refresh_from_db()
+        assert schedule.next_run_at is not None

--- a/products/workflows/backend/test/test_hog_flow_schedule.py
+++ b/products/workflows/backend/test/test_hog_flow_schedule.py
@@ -452,3 +452,17 @@ class TestProcessDueScheduleTriggers(APIBaseTest):
 
         schedule.refresh_from_db()
         assert schedule.next_run_at is not None
+
+    def test_cdp_api_error_lands_in_failed(self, mock_invocation):
+        mock_response = unittest.mock.MagicMock()
+        mock_response.status_code = 500
+        mock_response.raise_for_status.side_effect = Exception("CDP API returned 500")
+        mock_invocation.return_value = mock_response
+
+        _, schedule = self._create_workflow_with_schedule(
+            next_run_at=datetime(2020, 1, 1, tzinfo=UTC),
+        )
+        response = self._post()
+        assert response.status_code == 200
+        assert str(schedule.id) in response.json()["failed"]
+        assert len(response.json()["processed"]) == 0

--- a/products/workflows/frontend/Workflows/WorkflowSceneHeader.tsx
+++ b/products/workflows/frontend/Workflows/WorkflowSceneHeader.tsx
@@ -35,7 +35,7 @@ export const WorkflowSceneHeader = (props: WorkflowSceneLogicProps = {}): JSX.El
 
     const isSavedWorkflow = props.id && props.id !== 'new'
     const isCreatedFromTemplate = props.id === 'new' && !!templateId
-    const isManualWorkflow = ['manual', 'schedule', 'batch'].includes(workflow?.trigger?.type || '')
+    const isManualWorkflow = ['manual', 'batch'].includes(workflow?.trigger?.type || '')
     const [displayStatus, setDisplayStatus] = useState(workflow?.status)
     const [isTransitioning, setIsTransitioning] = useState(false)
     const prevStatusRef = useRef(workflow?.status)

--- a/products/workflows/frontend/Workflows/hogflows/HogFlowManualTriggerButton.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/HogFlowManualTriggerButton.tsx
@@ -1,6 +1,6 @@
 import { useActions, useValues } from 'kea'
 
-import { IconClock, IconPlayFilled } from '@posthog/icons'
+import { IconPlayFilled } from '@posthog/icons'
 import { IconChevronDown } from '@posthog/icons'
 import { LemonButton, LemonInput, Popover } from '@posthog/lemon-ui'
 
@@ -21,7 +21,7 @@ const TriggerPopover = ({
     props: WorkflowLogicProps
 }): JSX.Element => {
     const logic = hogFlowManualTriggerButtonLogic(props)
-    const { workflow, variableValues, inputs, isScheduleTrigger } = useValues(logic)
+    const { workflow, variableValues, inputs } = useValues(logic)
     const { setInput, clearInputs, triggerManualWorkflow, triggerBatchWorkflow } = useActions(logic)
 
     const { blastRadius, blastRadiusLoading } = useValues(
@@ -41,10 +41,7 @@ const TriggerPopover = ({
         return ''
     }
 
-    const getButtonText = (): string => {
-        const action = isScheduleTrigger ? 'Schedule workflow' : 'Run workflow'
-        return `${action}${blastRadiusSuffix()}`
-    }
+    const getButtonText = (): string => `Run workflow${blastRadiusSuffix()}`
 
     const variablesSection =
         !workflow?.variables || workflow.variables.length === 0 ? (
@@ -113,22 +110,16 @@ const TriggerPopover = ({
                     }
                     onClick={() => {
                         if (workflow?.trigger?.type === 'batch') {
-                            triggerBatchWorkflow(
-                                variableValues,
-                                workflow?.trigger?.filters || { properties: [] },
-                                workflow?.trigger?.scheduled_at || null
-                            )
-                        } else if (workflow?.trigger?.type === 'manual') {
+                            triggerBatchWorkflow(variableValues, workflow?.trigger?.filters || { properties: [] }, null)
+                        } else {
                             triggerManualWorkflow(variableValues)
-                        } else if (workflow?.trigger?.type === 'schedule') {
-                            triggerManualWorkflow(variableValues, workflow?.trigger?.scheduled_at)
                         }
 
                         setPopoverVisible(false)
                         clearInputs()
                     }}
                     data-attr="run-workflow-btn"
-                    sideIcon={isScheduleTrigger ? <IconClock /> : <IconPlayFilled />}
+                    sideIcon={<IconPlayFilled />}
                 >
                     {getButtonText()}
                 </LemonButton>
@@ -143,8 +134,6 @@ export const HogFlowManualTriggerButton = (props: WorkflowLogicProps = {}): JSX.
     const { popoverVisible } = useValues(logic)
     const { setPopoverVisible } = useActions(logic)
 
-    const isScheduleTrigger = workflow?.trigger?.type === 'schedule'
-
     const triggerButton = (
         <LemonButton
             type="primary"
@@ -157,10 +146,10 @@ export const HogFlowManualTriggerButton = (props: WorkflowLogicProps = {}): JSX.
                       : undefined
             }
             sideIcon={<IconChevronDown className={`transition-transform ${popoverVisible ? 'rotate-180' : ''}`} />}
-            tooltip={isScheduleTrigger ? 'Schedule workflow' : 'Triggers workflow immediately'}
+            tooltip="Triggers workflow immediately"
             onClick={() => setPopoverVisible(!popoverVisible)}
         >
-            {isScheduleTrigger ? 'Schedule' : 'Trigger'}
+            Trigger
         </LemonButton>
     )
 

--- a/products/workflows/frontend/Workflows/hogflows/HogFlowManualTriggerButtonLogic.ts
+++ b/products/workflows/frontend/Workflows/hogflows/HogFlowManualTriggerButtonLogic.ts
@@ -77,11 +77,5 @@ export const hogFlowManualTriggerButtonLogic = kea<hogFlowManualTriggerButtonLog
                 )
             },
         ],
-        isScheduleTrigger: [
-            (s) => [s.workflow],
-            (workflow: any): boolean =>
-                (workflow?.trigger?.type === 'schedule' || workflow?.trigger?.type === 'batch') &&
-                Boolean(workflow?.trigger?.scheduled_at),
-        ],
     }),
 ])

--- a/products/workflows/frontend/Workflows/hogflows/registry/triggers/surveys.test.ts
+++ b/products/workflows/frontend/Workflows/hogflows/registry/triggers/surveys.test.ts
@@ -154,7 +154,7 @@ describe('surveys', () => {
             },
             {
                 name: 'non-event config',
-                config: { type: 'schedule', scheduled_at: '2026-01-01' },
+                config: { type: 'schedule' },
                 expected: null,
             },
         ])('returns $expected for $name', ({ config, expected }) => {

--- a/products/workflows/frontend/Workflows/hogflows/steps/StepTrigger.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/steps/StepTrigger.tsx
@@ -15,7 +15,6 @@ import {
 } from '@posthog/icons'
 import {
     LemonButton,
-    LemonCalendarSelectInput,
     LemonCollapse,
     LemonDivider,
     LemonDropdown,
@@ -32,7 +31,6 @@ import { CodeSnippet } from 'lib/components/CodeSnippet'
 import { PropertyFilters } from 'lib/components/PropertyFilters/PropertyFilters'
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 import { FEATURE_FLAGS } from 'lib/constants'
-import { dayjs } from 'lib/dayjs'
 import { IconAdsClick } from 'lib/lemon-ui/icons'
 import { LemonField } from 'lib/lemon-ui/LemonField'
 import { LemonRadio } from 'lib/lemon-ui/LemonRadio'
@@ -54,6 +52,7 @@ import { HogFlowAction } from '../types'
 import { batchTriggerLogic, BLAST_RADIUS_LIMIT } from './batchTriggerLogic'
 import { HogFlowFunctionConfiguration } from './components/HogFlowFunctionConfiguration'
 import { RecurringSchedulePicker } from './components/RecurringSchedulePicker'
+import { ScheduleStatusBadge } from './components/ScheduleStatus'
 
 type TriggerAction = Extract<HogFlowAction, { type: 'trigger' }>
 type EventTriggerConfig = {
@@ -239,16 +238,12 @@ export function StepTriggerConfiguration({ node }: { node: Node<TriggerAction> }
                       },
                   ]
                 : []),
-            ...(type === 'schedule'
-                ? [
-                      {
-                          label: 'Schedule',
-                          description: 'Schedule your workflow to run at a specific time in the future',
-                          value: 'schedule',
-                          icon: <IconClock />,
-                      },
-                  ]
-                : []),
+            {
+                label: 'Schedule',
+                description: 'Run your workflow on a schedule',
+                value: 'schedule',
+                icon: <IconClock />,
+            },
             {
                 label: 'Tracking pixel',
                 description: 'Trigger your workflow using a 1x1 tracking pixel',
@@ -304,21 +299,11 @@ export function StepTriggerConfiguration({ node }: { node: Node<TriggerAction> }
                 },
             })
         } else if (value === 'schedule') {
-            setWorkflowActionConfig(node.id, {
-                type: 'schedule',
-                template_id: 'template-source-webhook',
-                inputs: {
-                    event: { order: 0, value: '$workflow_triggered' },
-                    distinct_id: { order: 1, value: '{request.body.user_id}' },
-                    method: { order: 2, value: 'POST' },
-                },
-                scheduled_at: undefined,
-            })
+            setWorkflowActionConfig(node.id, { type: 'schedule' })
         } else if (value === 'batch') {
             setWorkflowActionConfig(node.id, {
                 type: 'batch',
                 filters: { properties: [] },
-                scheduled_at: undefined,
             })
         } else if (value === 'tracking_pixel') {
             setWorkflowActionConfig(node.id, {
@@ -336,9 +321,12 @@ export function StepTriggerConfiguration({ node }: { node: Node<TriggerAction> }
                 <span className="text-md font-semibold">Trigger type</span>
             </span>
             <span>What causes this workflow to begin?</span>
-            <LemonField.Pure error={validationResult?.errors?.type}>
-                <TriggerTypeDropdown items={allTriggerItems} selectedItem={selectedItem} onSelect={handleSelect} />
-            </LemonField.Pure>
+            <div className="flex items-center gap-2">
+                <LemonField.Pure error={validationResult?.errors?.type}>
+                    <TriggerTypeDropdown items={allTriggerItems} selectedItem={selectedItem} onSelect={handleSelect} />
+                </LemonField.Pure>
+                {type === 'schedule' && <ScheduleStatusBadge />}
+            </div>
             {node.data.config.type === 'event' ? (
                 (() => {
                     const match = getRegisteredTriggerTypes().find((t) => t.matchConfig?.(node.data.config))
@@ -352,7 +340,7 @@ export function StepTriggerConfiguration({ node }: { node: Node<TriggerAction> }
             ) : node.data.config.type === 'manual' ? (
                 <StepTriggerConfigurationManual />
             ) : node.data.config.type === 'schedule' ? (
-                <StepTriggerConfigurationSchedule action={node.data} config={node.data.config} />
+                <RecurringSchedulePicker />
             ) : node.data.config.type === 'batch' ? (
                 <StepTriggerConfigurationBatch action={node.data} config={node.data.config} />
             ) : node.data.config.type === 'tracking_pixel' ? (
@@ -486,53 +474,6 @@ function StepTriggerConfigurationManual(): JSX.Element {
                     </Tooltip>
                     .
                 </p>
-            </div>
-        </>
-    )
-}
-
-function StepTriggerConfigurationSchedule({
-    action,
-    config,
-}: {
-    action: Extract<HogFlowAction, { type: 'trigger' }>
-    config: Extract<HogFlowAction['config'], { type: 'schedule' }>
-}): JSX.Element {
-    const { setWorkflowActionConfig } = useActions(workflowLogic)
-    const { actionValidationErrorsById } = useValues(workflowLogic)
-    const validationResult = actionValidationErrorsById[action.id]
-
-    const scheduledDateTime = config.scheduled_at ? dayjs(config.scheduled_at) : null
-
-    return (
-        <>
-            <div className="flex flex-col gap-2">
-                <p className="mb-0">Schedule this workflow to run at a specific time in the future.</p>
-                <LemonField.Pure label="Scheduled time" error={validationResult?.errors?.scheduled_at}>
-                    <div className="flex flex-col gap-2">
-                        <LemonCalendarSelectInput
-                            value={scheduledDateTime}
-                            onChange={(date) => {
-                                setWorkflowActionConfig(action.id, {
-                                    type: 'schedule',
-                                    template_id: config.template_id,
-                                    template_uuid: config.template_uuid,
-                                    inputs: config.inputs,
-                                    scheduled_at: date ? date.toISOString() : undefined,
-                                })
-                            }}
-                            granularity="minute"
-                            selectionPeriod="upcoming"
-                            showTimeToggle={false}
-                        />
-                        {scheduledDateTime && (
-                            <div className="text-xs text-muted">
-                                Timezone: {dayjs.tz.guess()} • Scheduled for:{' '}
-                                {scheduledDateTime.format('MMMM D, YYYY [at] h:mm A')}
-                            </div>
-                        )}
-                    </div>
-                </LemonField.Pure>
             </div>
         </>
     )

--- a/products/workflows/frontend/Workflows/hogflows/steps/components/ScheduleStatus.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/steps/components/ScheduleStatus.tsx
@@ -1,0 +1,38 @@
+import { useValues } from 'kea'
+
+import { LemonTag } from '@posthog/lemon-ui'
+
+import { workflowLogic } from '../../../workflowLogic'
+
+export function ScheduleStatusBadge(): JSX.Element | null {
+    const { currentSchedule, workflow } = useValues(workflowLogic)
+
+    if (!currentSchedule) {
+        return null
+    }
+
+    const isWorkflowActive = workflow?.status === 'active'
+    const isCompleted = currentSchedule.status === 'completed'
+
+    if (isCompleted) {
+        return (
+            <LemonTag type="default" size="small">
+                Completed
+            </LemonTag>
+        )
+    }
+
+    if (!isWorkflowActive) {
+        return (
+            <LemonTag type="warning" size="small">
+                Paused
+            </LemonTag>
+        )
+    }
+
+    return (
+        <LemonTag type="success" size="small">
+            Active
+        </LemonTag>
+    )
+}

--- a/products/workflows/frontend/Workflows/hogflows/steps/components/StepView.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/steps/components/StepView.tsx
@@ -14,6 +14,7 @@ import { hogFlowEditorLogic } from '../../hogFlowEditorLogic'
 import { NODE_HEIGHT, NODE_WIDTH } from '../../react_flow_utils/constants'
 import { HogFlowAction } from '../../types'
 import { useHogFlowStep } from '../HogFlowSteps'
+import { buildSummary } from './rrule-helpers'
 import { StepViewLogicProps, stepViewLogic } from './stepViewLogic'
 import { StepViewMetrics } from './StepViewMetrics'
 
@@ -28,8 +29,23 @@ export function StepView({ action }: { action: HogFlowAction }): JSX.Element {
         workflow,
     } = useValues(hogFlowEditorLogic)
     const { setSelectedNodeId, startCopyingNode, startMovingNode } = useActions(hogFlowEditorLogic)
-    const { actionValidationErrorsById, logicProps } = useValues(workflowLogic)
+    const { actionValidationErrorsById, logicProps, scheduleState, scheduleStartsAt, isScheduleRepeating } =
+        useValues(workflowLogic)
     const { deleteElements } = useReactFlow()
+
+    const isScheduleTrigger = action.type === 'trigger' && (action.config as any)?.type === 'schedule'
+    const scheduleDescription = useMemo(() => {
+        if (!isScheduleTrigger) {
+            return null
+        }
+        if (!scheduleStartsAt) {
+            return 'No schedule configured'
+        }
+        if (!isScheduleRepeating) {
+            return 'One-time run'
+        }
+        return buildSummary(scheduleState, scheduleStartsAt)
+    }, [isScheduleTrigger, scheduleState, scheduleStartsAt, isScheduleRepeating])
 
     const isSelected = selectedNode?.id === action.id
     const node = nodesById[action.id]
@@ -168,17 +184,17 @@ export function StepView({ action }: { action: HogFlowAction }): JSX.Element {
                             />
                         </div>
                     ) : (
-                        <Tooltip title={action.description || ''}>
+                        <Tooltip title={scheduleDescription ?? action.description ?? ''}>
                             <div
-                                className={`text-[0.3rem]/1.5 text-muted line-clamp-2 !rounded-sm px-0.5 -mx-0.5 transition-colors pl-1 min-w-0 min-h-[0.45rem] overflow-hidden ${isSelected ? 'cursor-text hover:bg-fill-button-tertiary-hover' : ''}`}
+                                className={`text-[0.3rem]/1.5 text-muted line-clamp-2 !rounded-sm px-0.5 -mx-0.5 transition-colors pl-1 min-w-0 min-h-[0.45rem] overflow-hidden ${isSelected && !isScheduleTrigger ? 'cursor-text hover:bg-fill-button-tertiary-hover' : ''}`}
                                 onClick={(e) => {
-                                    if (isSelected) {
+                                    if (isSelected && !isScheduleTrigger) {
                                         e.stopPropagation()
                                         startEditingDescription()
                                     }
                                 }}
                             >
-                                {action.description || ''}
+                                {scheduleDescription ?? action.description ?? ''}
                             </div>
                         </Tooltip>
                     )}

--- a/products/workflows/frontend/Workflows/hogflows/steps/types.ts
+++ b/products/workflows/frontend/Workflows/hogflows/steps/types.ts
@@ -135,21 +135,17 @@ export const HogFlowTriggerSchema = z.discriminatedUnion('type', [
     }),
     z.object({
         type: z.literal('schedule'),
-        template_uuid: z.string().uuid().optional(), // May be used later to specify a specific template version
-        template_id: z.string(),
-        inputs: z.record(CyclotronInputSchema),
-        scheduled_at: z.string().optional(), // ISO 8601 datetime string for one-time scheduling
-        // Future: recurring schedule fields can be added here
     }),
     z.object({
         type: z.literal('batch'),
         filters: z.object({
             properties: z.array(z.any()),
         }),
-        scheduled_at: z.string().optional(), // ISO 8601 datetime string for one-time scheduling
-        // Future: recurring schedule fields can be added here
     }),
 ])
+
+/** Trigger types that use HogFlowSchedule for recurring execution */
+export const SCHEDULED_TRIGGER_TYPES: readonly string[] = ['batch', 'schedule'] as const
 
 export const HogFlowActionSchema = z.discriminatedUnion('type', [
     // Trigger
@@ -291,15 +287,12 @@ export const isFunctionAction = (
 
 export const isTriggerFunction = (
     action: HogFlowAction
-): action is Extract<
-    HogFlowAction,
-    { type: 'trigger'; config: { type: 'webhook' | 'tracking_pixel' | 'manual' | 'schedule' } }
-> => {
+): action is Extract<HogFlowAction, { type: 'trigger'; config: { type: 'webhook' | 'tracking_pixel' | 'manual' } }> => {
     if (action.type !== 'trigger') {
         return false
     }
     const trigger = action as Extract<HogFlowAction, { type: 'trigger' }>
-    return ['webhook', 'tracking_pixel', 'manual', 'schedule'].includes(trigger.config.type)
+    return ['webhook', 'tracking_pixel', 'manual'].includes(trigger.config.type)
 }
 
 export interface HogflowTestResult {

--- a/products/workflows/frontend/Workflows/workflowLogic.ts
+++ b/products/workflows/frontend/Workflows/workflowLogic.ts
@@ -30,7 +30,12 @@ import {
     stateToRRule,
 } from './hogflows/steps/components/rrule-helpers'
 import type { ScheduleState } from './hogflows/steps/components/rrule-helpers'
-import { HogFlowActionSchema, isFunctionAction, isTriggerFunction } from './hogflows/steps/types'
+import {
+    HogFlowActionSchema,
+    SCHEDULED_TRIGGER_TYPES,
+    isFunctionAction,
+    isTriggerFunction,
+} from './hogflows/steps/types'
 import {
     type HogFlow,
     type HogFlowAction,
@@ -397,11 +402,12 @@ export const workflowLogic = kea<workflowLogicType>([
         ],
 
         actionValidationErrorsById: [
-            (s) => [s.workflow, s.hogFunctionTemplatesById, s.hogFunctionTemplatesByIdLoading],
+            (s) => [s.workflow, s.hogFunctionTemplatesById, s.hogFunctionTemplatesByIdLoading, s.scheduleStartsAt],
             (
                 workflow,
                 hogFunctionTemplatesById,
-                hogFunctionTemplatesByIdLoading
+                hogFunctionTemplatesByIdLoading,
+                scheduleStartsAt
             ): Record<string, HogFlowActionValidationResult | null> => {
                 return workflow.actions.reduce(
                     (acc, action) => {
@@ -493,10 +499,10 @@ export const workflowLogic = kea<workflowLogicType>([
                                     }
                                 }
                             } else if (action.config.type === 'schedule') {
-                                if (!action.config.scheduled_at) {
+                                if (!scheduleStartsAt) {
                                     result.valid = false
                                     result.errors = {
-                                        scheduled_at: 'A scheduled time is required',
+                                        schedule: 'A start date is required for schedule triggers',
                                     }
                                 }
                             } else if (action.config.type === 'batch') {
@@ -576,7 +582,8 @@ export const workflowLogic = kea<workflowLogicType>([
         },
         loadWorkflowSuccess: async ({ originalWorkflow }) => {
             actions.resetWorkflow(originalWorkflow)
-            if (originalWorkflow.id && originalWorkflow.trigger?.type === 'batch') {
+            const triggerType = originalWorkflow.trigger?.type
+            if (originalWorkflow.id && SCHEDULED_TRIGGER_TYPES.includes(triggerType ?? '')) {
                 try {
                     const schedules = await api.hogFlows.getHogFlowSchedules(originalWorkflow.id)
                     actions.setSchedules(schedules)
@@ -745,8 +752,7 @@ export const workflowLogic = kea<workflowLogicType>([
 
             const webhookUrl = publicWebhooksHostOrigin() + '/public/webhooks/' + values.workflow.id
 
-            const isScheduleTrigger = 'scheduled_at' in (values.workflow.trigger || {})
-            lemonToast.info(isScheduleTrigger ? 'Scheduling workflow...' : 'Triggering workflow...')
+            lemonToast.info('Triggering workflow...')
 
             try {
                 await fetch(webhookUrl, {
@@ -761,7 +767,7 @@ export const workflowLogic = kea<workflowLogicType>([
                     credentials: 'omit',
                 })
 
-                lemonToast.success(`Workflow ${isScheduleTrigger ? 'scheduled' : 'triggered'}`, {
+                lemonToast.success('Workflow triggered', {
                     button: {
                         label: 'View logs',
                         action: () => router.actions.push(urls.workflow(values.workflow.id!, 'logs')),
@@ -778,8 +784,7 @@ export const workflowLogic = kea<workflowLogicType>([
                 return
             }
 
-            const isScheduleTrigger = 'scheduled_at' in (values.workflow.trigger || {})
-            lemonToast.info(isScheduleTrigger ? 'Scheduling batch workflow...' : 'Triggering batch workflow...')
+            lemonToast.info('Triggering batch workflow...')
 
             try {
                 await api.hogFlows.createHogFlowBatchJob(values.workflow.id, {
@@ -787,7 +792,7 @@ export const workflowLogic = kea<workflowLogicType>([
                     filters,
                     scheduled_at: scheduledAt,
                 })
-                lemonToast.success(`Batch workflow ${scheduledAt ? 'scheduled' : 'triggered'}`, {
+                lemonToast.success('Batch workflow triggered', {
                     button: {
                         label: 'View logs',
                         action: () => router.actions.push(urls.workflow(values.workflow.id!, 'logs')),


### PR DESCRIPTION
## Problem

No way to run a workflow on a recurring schedule without targeting a person audience. Users who want cron-style "run every Monday at 9am" workflows had to use batch triggers as a workaround.

## Changes

- **New `schedule` trigger type**: reuses `RecurringSchedulePicker`, no person filtering or hog-function template
- **New CDP endpoint** `POST /hog_flows/:id/scheduled_invocations`: builds invocation with synthetic `$workflow_scheduled` event, enqueues via `CyclotronJobQueue` for full lifecycle execution
- **Backend scheduler** dispatches schedule triggers via the new endpoint (previously used the test-only invocation endpoint which only ran one action)
- **Removed deprecated `trigger.scheduled_at`** from both batch and schedule trigger schemas, along with all frontend references (will also remove the DB field and possibly other things in further clean up)
- **`SCHEDULED_TRIGGER_TYPES` constant** extracted for the batch/schedule condition used in scheduler dispatch
- **Schedule status badge** inline next to trigger dropdown (Active/Paused/Completed), dynamic summary on canvas node
- **Validation** for schedule trigger without a start date
- **Status reset**: updating a completed schedule's config resets it to active
- **Hidden manual trigger button** for schedule workflows
- **Deprecated schedule trigger**: ~36 existing workflows use the old hog-function-based schedule trigger (most are draft and many are our testing workflows). All have past `scheduled_at` dates and are effectively dormant.

<img width="1010" height="746" alt="Screenshot 2026-04-10 at 15 58 58" src="https://github.com/user-attachments/assets/4b7e08e3-49a3-4e8d-9cf5-b8d437b3505b" />

## How did you test this code?

- Python tests for scheduler dispatch, variable overrides, status transitions
- CDP API tests for the new endpoint (404s, wrong trigger type, happy path)
- Verified locally: schedules fire, full workflow runs through Cyclotron, invocations appear in UI

## Publish to changelog?

Yes