### PR TITLE
chore(ci): add more bots to outdated comment resolver

### DIFF
--- a/.github/workflows/pr-resolve-outdated-bot-comments.yml
+++ b/.github/workflows/pr-resolve-outdated-bot-comments.yml
@@ -28,7 +28,7 @@ jobs:
                   PR_NUMBER: ${{ github.event.pull_request.number }}
                   REPO: ${{ github.repository }}
               run: |
-                  BOTS="copilot-pull-request-reviewer greptile-apps chatgpt-codex-connector"
+                  BOTS="copilot-pull-request-reviewer greptile-apps chatgpt-codex-connector graphite-app cursor claude claude-code-action claude-review"
 
                   OWNER="${REPO%/*}"
                   REPO_NAME="${REPO#*/}"


### PR DESCRIPTION
## Problem

Several AI review bots (Graphite, Cursor Bugbot, Claude) leave inline review comments on PRs that become outdated after a push. These stale threads add noise and make it harder to focus on relevant feedback.

## Changes

Added `graphite-app`, `cursor`, `claude`, `claude-code-action`, and `claude-review` to the bot list in the "Resolve outdated bot comments" CI workflow so their outdated single-comment threads get auto-resolved on push.

## How did you test this code?

No behavioral change to the workflow logic — only the bot allowlist is extended. Verified the GitHub app slugs exist via `gh api users/<slug>[bot]`.

## Publish to changelog?

No

## Docs update

N/A

## LLM context

Co-authored with Claude Code. Verified bot app slugs via GitHub API before adding.