### PR TITLE
feat(integration): add pagination to github branches list API

### DIFF
--- a/posthog/api/integration.py
+++ b/posthog/api/integration.py
@@ -68,6 +68,10 @@ class GitHubReposResponseSerializer(serializers.Serializer):
 
 class GitHubBranchesQuerySerializer(serializers.Serializer):
     repo = serializers.CharField(help_text="Repository in owner/repo format")
+    limit = serializers.IntegerField(
+        required=False, default=100, min_value=1, max_value=1000, help_text="Maximum number of branches to return"
+    )
+    offset = serializers.IntegerField(required=False, default=0, min_value=0, help_text="Number of branches to skip")
 
 
 class GitHubBranchesResponseSerializer(serializers.Serializer):
@@ -75,6 +79,7 @@ class GitHubBranchesResponseSerializer(serializers.Serializer):
     default_branch = serializers.CharField(
         help_text="The default branch of the repository", required=False, allow_null=True
     )
+    has_more = serializers.BooleanField(help_text="Whether more branches exist beyond the returned page")
 
 
 class IntegrationSerializer(serializers.ModelSerializer, UserAccessControlSerializerMixin):
@@ -569,9 +574,13 @@ class IntegrationViewSet(
     )
     @action(methods=["GET"], detail=True, url_path="github_branches")
     def github_branches(self, request: Request, *args: Any, **kwargs: Any) -> Response:
-        repo = request.query_params.get("repo")
-        if not repo:
-            raise ValidationError("repo query parameter is required")
+        params = GitHubBranchesQuerySerializer(data=request.query_params)
+        params.is_valid(raise_exception=True)
+
+        repo: str = params.validated_data["repo"]
+        limit: int = params.validated_data["limit"]
+        offset: int = params.validated_data["offset"]
+
         parts = repo.split("/")
         if (
             len(parts) != 2
@@ -581,19 +590,22 @@ class IntegrationViewSet(
             or parts[1] in (".", "..")
         ):
             raise ValidationError("repo must be in owner/repo format")
+
         github = GitHubIntegration(self.get_object())
-        branches = github.list_branches(repo)
+        branches, has_more = github.list_branches(repo, limit=limit, offset=offset)
+
         try:
             default_branch = github.get_default_branch(repo)
         except Exception:
             default_branch = None
 
-        # Default branch first
-        if default_branch and default_branch in branches:
+        # Put the default branch first, but only on the first page so
+        # paginated results stay consistent with GitHub's alphabetical order.
+        if offset == 0 and default_branch and default_branch in branches:
             branches.remove(default_branch)
             branches.insert(0, default_branch)
 
-        return Response({"branches": branches, "default_branch": default_branch})
+        return Response({"branches": branches, "default_branch": default_branch, "has_more": has_more})
 
     @action(methods=["GET"], detail=True, url_path="jira_projects")
     def jira_projects(self, request: Request, *args: Any, **kwargs: Any) -> Response:

--- a/posthog/api/integration.py
+++ b/posthog/api/integration.py
@@ -599,11 +599,13 @@ class IntegrationViewSet(
         except Exception:
             default_branch = None
 
-        # Put the default branch first, but only on the first page so
-        # paginated results stay consistent with GitHub's alphabetical order.
-        if offset == 0 and default_branch and default_branch in branches:
-            branches.remove(default_branch)
-            branches.insert(0, default_branch)
+        # The default branch is always shown first on page 1 and removed
+        # from all other pages to avoid duplicates.
+        if default_branch:
+            if default_branch in branches:
+                branches.remove(default_branch)
+            if offset == 0:
+                branches.insert(0, default_branch)
 
         return Response({"branches": branches, "default_branch": default_branch, "has_more": has_more})
 

--- a/posthog/api/test/test_integration.py
+++ b/posthog/api/test/test_integration.py
@@ -12,6 +12,7 @@ from rest_framework import status
 from posthog.models.integration import (
     PRIVATE_CHANNEL_WITHOUT_ACCESS,
     EmailIntegration,
+    GitHubIntegration,
     Integration,
     SlackIntegration,
     StripeIntegration,
@@ -1085,3 +1086,169 @@ class TestStripeIntegrationOAuthTokens:
         for call in calls:
             assert call.kwargs["params"]["scope"] == {"type": "account"}
             assert call.kwargs["options"] == {"stripe_account": "acct_789"}
+
+
+def _make_github_branches_response(names: list[str], has_next: bool = False) -> MagicMock:
+    """Build a mock requests.Response for the GitHub branches API."""
+    response = MagicMock()
+    response.status_code = 200
+    response.json.return_value = [{"name": n} for n in names]
+    link = '<https://api.github.com/next>; rel="next"' if has_next else ""
+    response.headers = {"Link": link}
+    return response
+
+
+class TestGitHubBranches:
+    @pytest.fixture(autouse=True)
+    def setup_integration(self, db):
+        self.organization = Organization.objects.create(name="Test Org")
+        self.team = Team.objects.create(organization=self.organization, name="Test Team")
+        self.user = User.objects.create_and_join(
+            self.organization, "test@posthog.com", "test", level=OrganizationMembership.Level.ADMIN
+        )
+        self.integration = Integration.objects.create(
+            team=self.team,
+            kind="github",
+            config={"installation_id": "12345", "refreshed_at": 0, "expires_in": 999999},
+            sensitive_config={"access_token": "test-token"},
+        )
+        self.github = GitHubIntegration(self.integration)
+
+    @patch("posthog.models.integration.requests.get")
+    def test_list_branches_returns_first_page(self, mock_get):
+        names = [f"branch-{i}" for i in range(100)]
+        mock_get.return_value = _make_github_branches_response(names, has_next=True)
+
+        branches, has_more = self.github.list_branches("org/repo", limit=100, offset=0)
+
+        assert branches == names
+        assert has_more is True
+        mock_get.assert_called_once()
+        assert "page=1" in mock_get.call_args[0][0]
+
+    @patch("posthog.models.integration.requests.get")
+    def test_list_branches_offset_skips_pages(self, mock_get):
+        """Requesting offset=200 should start fetching from GitHub page 3."""
+        page3_names = [f"branch-{i}" for i in range(200, 300)]
+        mock_get.return_value = _make_github_branches_response(page3_names, has_next=True)
+
+        branches, has_more = self.github.list_branches("org/repo", limit=100, offset=200)
+
+        assert branches == page3_names
+        assert has_more is True
+        assert mock_get.call_count == 1
+        assert "page=3" in mock_get.call_args[0][0]
+
+    @patch("posthog.models.integration.requests.get")
+    def test_list_branches_last_page_no_more(self, mock_get):
+        names = [f"branch-{i}" for i in range(50)]
+        mock_get.return_value = _make_github_branches_response(names, has_next=False)
+
+        branches, has_more = self.github.list_branches("org/repo", limit=100, offset=0)
+
+        assert branches == names
+        assert has_more is False
+
+    @patch("posthog.models.integration.requests.get")
+    def test_list_branches_spans_two_github_pages(self, mock_get):
+        """An offset that doesn't align with per_page=100 requires fetching two GitHub pages."""
+        page1_names = [f"branch-{i}" for i in range(100)]
+        page2_names = [f"branch-{i}" for i in range(100, 200)]
+
+        mock_get.side_effect = [
+            _make_github_branches_response(page1_names, has_next=True),
+            _make_github_branches_response(page2_names, has_next=False),
+        ]
+
+        branches, has_more = self.github.list_branches("org/repo", limit=100, offset=50)
+
+        assert len(branches) == 100
+        assert branches == [f"branch-{i}" for i in range(50, 150)]
+        # There are still branches 150-199 beyond this window
+        assert has_more is True
+        assert mock_get.call_count == 2
+
+    @patch("posthog.models.integration.requests.get")
+    def test_list_branches_empty_repo(self, mock_get):
+        mock_get.return_value = _make_github_branches_response([], has_next=False)
+
+        branches, has_more = self.github.list_branches("org/repo")
+
+        assert branches == []
+        assert has_more is False
+
+    @patch("posthog.models.integration.requests.get")
+    def test_list_branches_401_triggers_refresh_and_retry(self, mock_get):
+        unauthorized = MagicMock()
+        unauthorized.status_code = 401
+
+        names = ["main", "develop"]
+        success = _make_github_branches_response(names, has_next=False)
+
+        mock_get.side_effect = [unauthorized, success]
+
+        with patch.object(self.github, "refresh_access_token"):
+            branches, has_more = self.github.list_branches("org/repo")
+
+        assert branches == names
+        assert mock_get.call_count == 2
+
+    @patch("posthog.models.integration.GitHubIntegration.get_default_branch", return_value="main")
+    @patch("posthog.models.integration.GitHubIntegration.list_branches")
+    def test_api_endpoint_passes_limit_offset(self, mock_list, mock_default, client: HttpClient):
+        mock_list.return_value = ([f"branch-{i}" for i in range(10)], True)
+        client.force_login(self.user)
+
+        response = client.get(
+            f"/api/environments/{self.team.pk}/integrations/{self.integration.pk}/github_branches/",
+            {"repo": "org/repo", "limit": "10", "offset": "50"},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data["branches"]) == 10
+        assert data["has_more"] is True
+        mock_list.assert_called_once_with("org/repo", limit=10, offset=50)
+
+    @patch("posthog.models.integration.GitHubIntegration.get_default_branch", return_value="main")
+    @patch("posthog.models.integration.GitHubIntegration.list_branches")
+    def test_api_endpoint_default_branch_first_on_page_one(self, mock_list, mock_default, client: HttpClient):
+        mock_list.return_value = (["alpha", "main", "zebra"], False)
+        client.force_login(self.user)
+
+        response = client.get(
+            f"/api/environments/{self.team.pk}/integrations/{self.integration.pk}/github_branches/",
+            {"repo": "org/repo"},
+        )
+
+        data = response.json()
+        assert data["branches"][0] == "main"
+        assert data["default_branch"] == "main"
+
+    @patch("posthog.models.integration.GitHubIntegration.get_default_branch", return_value="main")
+    @patch("posthog.models.integration.GitHubIntegration.list_branches")
+    def test_api_endpoint_no_reorder_on_subsequent_pages(self, mock_list, mock_default, client: HttpClient):
+        mock_list.return_value = (["main", "other"], False)
+        client.force_login(self.user)
+
+        response = client.get(
+            f"/api/environments/{self.team.pk}/integrations/{self.integration.pk}/github_branches/",
+            {"repo": "org/repo", "offset": "100"},
+        )
+
+        data = response.json()
+        # "main" should not be moved to front on non-first pages
+        assert data["branches"] == ["main", "other"]
+
+    @patch("posthog.models.integration.GitHubIntegration.get_default_branch", return_value="main")
+    @patch("posthog.models.integration.GitHubIntegration.list_branches")
+    def test_api_endpoint_validates_limit_max(self, mock_list, mock_default, client: HttpClient):
+        mock_list.return_value = ([], False)
+        client.force_login(self.user)
+
+        response = client.get(
+            f"/api/environments/{self.team.pk}/integrations/{self.integration.pk}/github_branches/",
+            {"repo": "org/repo", "limit": "1001"},
+        )
+
+        assert response.status_code == 400

--- a/posthog/api/test/test_integration.py
+++ b/posthog/api/test/test_integration.py
@@ -1252,3 +1252,21 @@ class TestGitHubBranches:
         )
 
         assert response.status_code == 400
+
+    @patch("posthog.models.integration.requests.get")
+    def test_get_default_branch_is_cached(self, mock_get):
+        from django.core.cache import cache
+
+        cache.clear()
+
+        response = MagicMock()
+        response.status_code = 200
+        response.json.return_value = {"default_branch": "develop"}
+        mock_get.return_value = response
+
+        first = self.github.get_default_branch("org/repo-cache-test")
+        second = self.github.get_default_branch("org/repo-cache-test")
+
+        assert first == "develop"
+        assert second == "develop"
+        assert mock_get.call_count == 1

--- a/posthog/api/test/test_integration.py
+++ b/posthog/api/test/test_integration.py
@@ -1227,7 +1227,7 @@ class TestGitHubBranches:
 
     @patch("posthog.models.integration.GitHubIntegration.get_default_branch", return_value="main")
     @patch("posthog.models.integration.GitHubIntegration.list_branches")
-    def test_api_endpoint_no_reorder_on_subsequent_pages(self, mock_list, mock_default, client: HttpClient):
+    def test_api_endpoint_removes_default_branch_on_subsequent_pages(self, mock_list, mock_default, client: HttpClient):
         mock_list.return_value = (["main", "other"], False)
         client.force_login(self.user)
 
@@ -1237,8 +1237,24 @@ class TestGitHubBranches:
         )
 
         data = response.json()
-        # "main" should not be moved to front on non-first pages
-        assert data["branches"] == ["main", "other"]
+        assert data["branches"] == ["other"]
+
+    @patch("posthog.models.integration.GitHubIntegration.get_default_branch", return_value="main")
+    @patch("posthog.models.integration.GitHubIntegration.list_branches")
+    def test_api_endpoint_prepends_default_branch_even_when_not_in_list(
+        self, mock_list, mock_default, client: HttpClient
+    ):
+        """Default branch is prepended on page 1 even if it isn't in the alphabetical window."""
+        mock_list.return_value = (["alpha", "beta"], False)
+        client.force_login(self.user)
+
+        response = client.get(
+            f"/api/environments/{self.team.pk}/integrations/{self.integration.pk}/github_branches/",
+            {"repo": "org/repo"},
+        )
+
+        data = response.json()
+        assert data["branches"] == ["main", "alpha", "beta"]
 
     @patch("posthog.models.integration.GitHubIntegration.get_default_branch", return_value="main")
     @patch("posthog.models.integration.GitHubIntegration.list_branches")

--- a/posthog/models/integration.py
+++ b/posthog/models/integration.py
@@ -2249,18 +2249,26 @@ class GitHubIntegration:
 
         return None
 
-    def list_branches(self, repo: str) -> list[str]:
-        """List branches for a given repository via the GitHub API."""
+    def list_branches(self, repo: str, *, limit: int = 100, offset: int = 0) -> tuple[list[str], bool]:
+        """List branches for a given repository via the GitHub API.
+
+        Fetches only the GitHub pages needed to satisfy the requested
+        ``[offset, offset+limit)`` window. Returns a tuple of
+        ``(branch_names, has_more)`` where *has_more* indicates whether
+        additional branches exist beyond the returned window.
+        """
+        GITHUB_PER_PAGE = 100
+
         try:
             if self.access_token_expired():
                 self.refresh_access_token()
         except Exception:
             logger.warning("GitHubIntegration: token refresh pre-check failed", exc_info=True)
 
-        def fetch(page: int = 1) -> requests.Response:
+        def fetch(page: int) -> requests.Response:
             access_token = self.integration.sensitive_config.get("access_token")
             return requests.get(
-                f"https://api.github.com/repos/{repo}/branches?per_page=100&page={page}",
+                f"https://api.github.com/repos/{repo}/branches?per_page={GITHUB_PER_PAGE}&page={page}",
                 headers={
                     "Accept": "application/vnd.github+json",
                     "Authorization": f"Bearer {access_token}",
@@ -2269,24 +2277,35 @@ class GitHubIntegration:
                 timeout=10,
             )
 
+        def extract_names(data: list) -> list[str]:
+            return [
+                branch["name"] for branch in data if isinstance(branch, dict) and isinstance(branch.get("name"), str)
+            ]
+
+        # Work out which GitHub pages cover the requested window.
+        first_page = offset // GITHUB_PER_PAGE + 1
+        skip = offset % GITHUB_PER_PAGE
+        needed = skip + limit
+
+        # Fetch the first required page (with 401-retry logic).
+        current_page = first_page
         try:
-            response = fetch()
+            response = fetch(current_page)
         except requests.RequestException:
             logger.warning("GitHubIntegration: list_branches network error", repo=repo, exc_info=True)
-            return []
+            return [], False
 
         if response.status_code == 401:
             try:
                 self.refresh_access_token()
             except Exception:
                 logger.warning("GitHubIntegration: token refresh after 401 failed", exc_info=True)
-                return []
-            else:
-                try:
-                    response = fetch()
-                except requests.RequestException:
-                    logger.warning("GitHubIntegration: list_branches network error on retry", repo=repo, exc_info=True)
-                    return []
+                return [], False
+            try:
+                response = fetch(current_page)
+            except requests.RequestException:
+                logger.warning("GitHubIntegration: list_branches network error on retry", repo=repo, exc_info=True)
+                return [], False
 
         if response.status_code != 200:
             logger.warning(
@@ -2294,7 +2313,7 @@ class GitHubIntegration:
                 status_code=response.status_code,
                 repo=repo,
             )
-            return []
+            return [], False
 
         try:
             body = response.json()
@@ -2303,22 +2322,16 @@ class GitHubIntegration:
                 "GitHubIntegration: list_branches non-JSON response",
                 status_code=response.status_code,
             )
-            return []
+            return [], False
 
         if not isinstance(body, list):
-            return []
+            return [], False
 
-        def extract_names(data: list) -> list[str]:
-            return [
-                branch["name"] for branch in data if isinstance(branch, dict) and isinstance(branch.get("name"), str)
-            ]
+        all_fetched = extract_names(body)
+        has_next_page = 'rel="next"' in response.headers.get("Link", "")
 
-        all_branches = extract_names(body)
-
-        # Paginate through remaining pages (w/cap)
-        max_pages = 20
-        current_page = 1
-        while current_page < max_pages and 'rel="next"' in response.headers.get("Link", ""):
+        # Fetch subsequent pages until we have enough items.
+        while len(all_fetched) < needed and has_next_page:
             current_page += 1
             try:
                 response = fetch(current_page)
@@ -2338,9 +2351,13 @@ class GitHubIntegration:
                 break
             if not isinstance(body, list):
                 break
-            all_branches.extend(extract_names(body))
+            all_fetched.extend(extract_names(body))
+            has_next_page = 'rel="next"' in response.headers.get("Link", "")
 
-        return all_branches
+        result = all_fetched[skip : skip + limit]
+        has_more = has_next_page or (skip + limit < len(all_fetched))
+
+        return result, has_more
 
     def create_issue(self, config: dict[str, str]):
         title: str = config.pop("title")

--- a/posthog/models/integration.py
+++ b/posthog/models/integration.py
@@ -15,6 +15,7 @@ if TYPE_CHECKING:
     import aiohttp
 
 from django.conf import settings
+from django.core.cache import cache
 from django.db import models
 from django.http import HttpRequest
 from django.utils import timezone
@@ -1910,6 +1911,12 @@ class GitHubCommitAuthor:
     commit_url: str
 
 
+# Default branches change rarely; a multi-hour TTL is plenty to avoid hitting
+# GitHub on every paginated branch request while keeping the window in which a
+# renamed default branch stays stale tolerably short.
+GITHUB_DEFAULT_BRANCH_CACHE_TTL_SECONDS = 60 * 60 * 6
+
+
 class GitHubIntegration:
     integration: Integration
 
@@ -2384,6 +2391,12 @@ class GitHubIntegration:
     def get_default_branch(self, repository: str) -> str:
         """Get the default branch for a repository."""
         repo_path = repository if "/" in repository else f"{self.organization()}/{repository}"
+        cache_key = f"github_integration:default_branch:{self.integration.id}:{repo_path}"
+
+        cached = cache.get(cache_key)
+        if isinstance(cached, str):
+            return cached
+
         access_token = self.integration.sensitive_config.get("access_token")
         if not access_token:
             raise ValueError("GitHub access token not configured")
@@ -2400,7 +2413,9 @@ class GitHubIntegration:
 
         if response.status_code == 200:
             repo_data = response.json()
-            return repo_data.get("default_branch", "main")
+            default_branch = repo_data.get("default_branch", "main")
+            cache.set(cache_key, default_branch, timeout=60 * 60 * 24)
+            return default_branch
         else:
             raise Exception(f"Failed to get default branch: HTTP {response.status_code}")
 

--- a/products/integrations/frontend/generated/api.schemas.ts
+++ b/products/integrations/frontend/generated/api.schemas.ts
@@ -221,6 +221,8 @@ export interface GitHubBranchesResponseApi {
      * @nullable
      */
     default_branch?: string | null
+    /** Whether more branches exist beyond the returned page */
+    has_more: boolean
 }
 
 export interface GitHubRepoApi {
@@ -256,6 +258,17 @@ export type IntegrationsList2Params = {
 }
 
 export type IntegrationsGithubBranchesRetrieveParams = {
+    /**
+     * Maximum number of branches to return
+     * @minimum 1
+     * @maximum 1000
+     */
+    limit?: number
+    /**
+     * Number of branches to skip
+     * @minimum 0
+     */
+    offset?: number
     /**
      * Repository in owner/repo format
      * @minLength 1

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -15973,6 +15973,8 @@ export namespace Schemas {
        * @nullable
        */
       default_branch?: string | null;
+      /** Whether more branches exist beyond the returned page */
+      has_more: boolean;
     }
 
     export interface GitHubRepo {
@@ -32243,6 +32245,17 @@ export namespace Schemas {
 
     export type EnvironmentsIntegrationsGithubBranchesRetrieveParams = {
     /**
+     * Maximum number of branches to return
+     * @minimum 1
+     * @maximum 1000
+     */
+    limit?: number;
+    /**
+     * Number of branches to skip
+     * @minimum 0
+     */
+    offset?: number;
+    /**
      * Repository in owner/repo format
      * @minLength 1
      */
@@ -35390,6 +35403,17 @@ export namespace Schemas {
     };
 
     export type IntegrationsGithubBranchesRetrieveParams = {
+    /**
+     * Maximum number of branches to return
+     * @minimum 1
+     * @maximum 1000
+     */
+    limit?: number;
+    /**
+     * Number of branches to skip
+     * @minimum 0
+     */
+    offset?: number;
     /**
      * Repository in owner/repo format
      * @minLength 1


### PR DESCRIPTION
## Problem

  The GitHub integration's branch listing was hard-capped at 2,000 branches (20 pages × 100 per page). Repositories with more than 2,000 branches — like the PostHog monorepo with 5,000+ — had their branch list silently truncated. Additionally, every request fetched all pages from GitHub sequentially with no pagination support on the PostHog API side.

  ## Changes

  - **Removed the 2,000-branch cap** from `GitHubIntegration.list_branches` — now accepts `limit`/`offset` params and fetches only the GitHub
  API pages needed for the requested window
  - **Added pagination to the `github_branches` endpoint** — supports `?limit=` (1–1000, default 100) and `?offset=` (default 0) query params
  - **Response includes `has_more`** boolean so consumers can paginate progressively
  - Default branch reordering (`main` first) now only applies on the first page (`offset=0`) to keep paginated results consistent

  ## How did you test this code?

  Added 10 unit tests covering:
  - Model layer: first page, offset skipping, cross-page spans, last page detection, empty repo, 401 retry
  - API endpoint: limit/offset passthrough, default branch ordering, no reorder on subsequent pages, limit validation
  - Tested together with [Posthog Code changes](https://github.com/PostHog/code/pull/1592)

  ## Publish to changelog?

  No

  ## Docs update

  No