### PR TITLE
perf(tasks): SANDBOX_REPO_MOUNT_MAP

### DIFF
--- a/products/tasks/backend/services/docker_sandbox.py
+++ b/products/tasks/backend/services/docker_sandbox.py
@@ -83,6 +83,35 @@ class DockerSandbox:
         return f"http://localhost:{self._host_port}"
 
     @staticmethod
+    def _parse_repo_mount_map() -> dict[str, str]:
+        """Parse SANDBOX_REPO_MOUNT_MAP into {lower(org/repo): expanded_local_path}.
+
+        Format: ``org/repo:/local/path,org2/repo2:~/other/path``
+        """
+        raw = os.environ.get("SANDBOX_REPO_MOUNT_MAP", "")
+        if not raw:
+            return {}
+
+        result: dict[str, str] = {}
+        for entry in raw.split(","):
+            entry = entry.strip()
+            if not entry:
+                continue
+            # Split on first colon only — paths on macOS/Linux won't have extra colons,
+            # but be safe anyway
+            parts = entry.split(":", 1)
+            if len(parts) != 2 or "/" not in parts[0]:
+                logger.warning(f"Ignoring malformed SANDBOX_REPO_MOUNT_MAP entry: {entry}")
+                continue
+            repo_key = parts[0].strip().lower()
+            local_path = os.path.expanduser(parts[1].strip())
+            if not os.path.isdir(local_path):
+                logger.warning(f"SANDBOX_REPO_MOUNT_MAP: path does not exist, skipping: {local_path}")
+                continue
+            result[repo_key] = os.path.abspath(local_path)
+        return result
+
+    @staticmethod
     def _find_available_port() -> int:
         """Find an available port on the host machine."""
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
@@ -277,6 +306,13 @@ class DockerSandbox:
             host_port = DockerSandbox._find_available_port()
             port_args = ["-p", f"{host_port}:{AGENT_SERVER_PORT}"]
 
+            mount_map = DockerSandbox._parse_repo_mount_map()
+            volume_args: list[str] = []
+            for repo_key, local_path in mount_map.items():
+                org, repo = repo_key.split("/", 1)
+                container_path = f"{WORKING_DIR}/repos/{org}/{repo}"
+                volume_args.extend(["-v", f"{local_path}:{container_path}:ro"])
+
             docker_args = [
                 "docker",
                 "run",
@@ -293,6 +329,7 @@ class DockerSandbox:
                 f"--cpus={config.cpu_cores}",
                 *env_args,
                 *port_args,
+                *volume_args,
                 image,
                 "tail",
                 "-f",
@@ -524,6 +561,11 @@ class DockerSandbox:
     ) -> ExecutionResult:
         if not self.is_running():
             raise RuntimeError("Sandbox not in running state.")
+
+        mount_map = DockerSandbox._parse_repo_mount_map()
+        if repository.lower() in mount_map:
+            logger.info(f"Repository {repository} is bind-mounted from host, skipping clone")
+            return ExecutionResult(stdout="", stderr="", exit_code=0, error=None)
 
         org, repo = repository.lower().split("/")
         repo_url = (


### PR DESCRIPTION
## Problem

When developing locally with `SANDBOX_PROVIDER=docker`, every sandbox run clones repositories from GitHub. This is slow and unnecessary when you already have the repo checked out on your machine.

## Changes

Add `SANDBOX_REPO_MOUNT_MAP` env var support to `DockerSandbox`. When set, configured repositories are bind-mounted (read-only) from the host into the container at the expected path, and `clone_repository` becomes a no-op for those repos.

Format: `SANDBOX_REPO_MOUNT_MAP=PostHog/posthog:~/Developer/posthog,org/other-repo:~/other`

Three touch points in `DockerSandbox`:
- `_parse_repo_mount_map()` — parses the env var, expands `~`, validates dirs exist, normalizes keys to lowercase
- `create()` — adds `-v host:container:ro` bind mounts for every entry
- `clone_repository()` — short-circuits when the repo is already mounted

## How did you test this code?

This is a dev-only code path (`DockerSandbox` is gated behind `DEBUG=True`). I'm an agent and haven't run this end-to-end manually.

## Publish to changelog?

No.

## Docs update

N/A

## 🤖 LLM context

Agent-authored PR. Single-file change to `products/tasks/backend/services/docker_sandbox.py`.

Made with [Cursor](https://cursor.com)