### PR TITLE
fix(tasks): Add blob size filter to full-depth git clone

### DIFF
--- a/products/notebooks/backend/kernel_runtime.py
+++ b/products/notebooks/backend/kernel_runtime.py
@@ -24,9 +24,9 @@ from posthog.redis import get_client
 
 from products.notebooks.backend.models import KernelRuntime, Notebook
 from products.tasks.backend.services.sandbox import (
+    SandboxBase,
     SandboxClass,
     SandboxConfig,
-    SandboxProtocol,
     SandboxStatus,
     SandboxTemplate,
     get_sandbox_class_for_backend,
@@ -809,7 +809,7 @@ class KernelRuntimeService:
             sandbox_id=sandbox.id,
         )
 
-    def _start_kernel_process(self, sandbox: SandboxProtocol, connection_file: str) -> int:
+    def _start_kernel_process(self, sandbox: SandboxBase, connection_file: str) -> int:
         start_command = (
             "mkdir -p /tmp/jupyter && "
             f"nohup python3 -m ipykernel_launcher -f {connection_file} "
@@ -838,7 +838,7 @@ class KernelRuntimeService:
             raise RuntimeError(f"Kernel did not become ready: {result.stdout} {result.stderr}")
 
     def _bootstrap_kernel(
-        self, sandbox: SandboxProtocol, connection_file: str, notebook: Notebook, user: User | None
+        self, sandbox: SandboxBase, connection_file: str, notebook: Notebook, user: User | None
     ) -> None:
         code = self._build_kernel_bootstrap_code(notebook, user, sandbox.id)
         if not code:

--- a/products/tasks/backend/services/docker_sandbox.py
+++ b/products/tasks/backend/services/docker_sandbox.py
@@ -43,8 +43,8 @@ from .sandbox import (
     AgentServerResult,
     ExecutionResult,
     ExecutionStream,
+    SandboxBase,
     SandboxConfig,
-    SandboxProtocol,
     SandboxStatus,
     SandboxTemplate,
     wait_for_health_check,
@@ -57,7 +57,7 @@ NOTEBOOK_IMAGE_NAME = "posthog-sandbox-notebook"
 AGENT_SERVER_PORT = 47821  # Arbitrary high port unlikely to conflict with dev servers
 
 
-class DockerSandbox(SandboxProtocol):
+class DockerSandbox(SandboxBase):
     """
     Docker-based sandbox for local development and testing.
     Implements the same interface as the Modal-based Sandbox.

--- a/products/tasks/backend/services/docker_sandbox.py
+++ b/products/tasks/backend/services/docker_sandbox.py
@@ -536,13 +536,14 @@ class DockerSandbox:
         org_path = f"/tmp/workspace/repos/{org}"
 
         depth_flag = f" --depth {shlex.quote('1')}" if shallow else ""
+        # Skip blobs over 128kB during full clones — large test snapshots and auto-generated
+        # files get fetched on demand. Shallow clones are already small enough.
+        blob_filter = "" if shallow else " --filter=blob:limit=128k"
         clone_command = (
             f"rm -rf {shlex.quote(target_path)} && "
             f"mkdir -p {shlex.quote(org_path)} && "
             f"cd {shlex.quote(org_path)} && "
-            # Skip blobs over 128kB during clone — large test snapshots and auto-generated files
-            # get fetched on demand. Most code files are well under this limit.
-            f"git clone --single-branch --filter=blob:limit=128k{depth_flag} {shlex.quote(repo_url)} {shlex.quote(repo)}"
+            f"git clone --single-branch{blob_filter}{depth_flag} {shlex.quote(repo_url)} {shlex.quote(repo)}"
         )
         logger.info(f"Cloning repository {repository} to {target_path} in sandbox {self.id} (shallow={shallow})")
         return self.execute(clone_command, timeout_seconds=5 * 60)

--- a/products/tasks/backend/services/docker_sandbox.py
+++ b/products/tasks/backend/services/docker_sandbox.py
@@ -540,7 +540,9 @@ class DockerSandbox:
             f"rm -rf {shlex.quote(target_path)} && "
             f"mkdir -p {shlex.quote(org_path)} && "
             f"cd {shlex.quote(org_path)} && "
-            f"git clone --single-branch{depth_flag} {shlex.quote(repo_url)} {shlex.quote(repo)}"
+            # Skip blobs over 128kB during clone — large test snapshots and auto-generated files
+            # get fetched on demand. Most code files are well under this limit.
+            f"git clone --single-branch --filter=blob:limit=128k{depth_flag} {shlex.quote(repo_url)} {shlex.quote(repo)}"
         )
         logger.info(f"Cloning repository {repository} to {target_path} in sandbox {self.id} (shallow={shallow})")
         return self.execute(clone_command, timeout_seconds=5 * 60)

--- a/products/tasks/backend/services/docker_sandbox.py
+++ b/products/tasks/backend/services/docker_sandbox.py
@@ -39,10 +39,12 @@ from .agentsh import (
     generate_policy_yaml,
 )
 from .sandbox import (
+    WORKING_DIR,
     AgentServerResult,
     ExecutionResult,
     ExecutionStream,
     SandboxConfig,
+    SandboxProtocol,
     SandboxStatus,
     SandboxTemplate,
     wait_for_health_check,
@@ -50,13 +52,12 @@ from .sandbox import (
 
 logger = logging.getLogger(__name__)
 
-WORKING_DIR = "/tmp/workspace"
 DEFAULT_IMAGE_NAME = "posthog-sandbox-base"
 NOTEBOOK_IMAGE_NAME = "posthog-sandbox-notebook"
 AGENT_SERVER_PORT = 47821  # Arbitrary high port unlikely to conflict with dev servers
 
 
-class DockerSandbox:
+class DockerSandbox(SandboxProtocol):
     """
     Docker-based sandbox for local development and testing.
     Implements the same interface as the Modal-based Sandbox.
@@ -519,35 +520,6 @@ class DockerSandbox:
 
         return result
 
-    def clone_repository(
-        self, repository: str, github_token: Optional[str] = "", shallow: bool = True
-    ) -> ExecutionResult:
-        if not self.is_running():
-            raise RuntimeError("Sandbox not in running state.")
-
-        org, repo = repository.lower().split("/")
-        repo_url = (
-            f"https://x-access-token:{github_token}@github.com/{org}/{repo}.git"
-            if github_token
-            else f"https://github.com/{org}/{repo}.git"
-        )
-
-        target_path = f"/tmp/workspace/repos/{org}/{repo}"
-        org_path = f"/tmp/workspace/repos/{org}"
-
-        depth_flag = f" --depth {shlex.quote('1')}" if shallow else ""
-        # Skip blobs over 128kB during full clones — large test snapshots and auto-generated
-        # files get fetched on demand. Shallow clones are already small enough.
-        blob_filter = "" if shallow else " --filter=blob:limit=128k"
-        clone_command = (
-            f"rm -rf {shlex.quote(target_path)} && "
-            f"mkdir -p {shlex.quote(org_path)} && "
-            f"cd {shlex.quote(org_path)} && "
-            f"git clone --single-branch{blob_filter}{depth_flag} {shlex.quote(repo_url)} {shlex.quote(repo)}"
-        )
-        logger.info(f"Cloning repository {repository} to {target_path} in sandbox {self.id} (shallow={shallow})")
-        return self.execute(clone_command, timeout_seconds=5 * 60)
-
     def setup_repository(self, repository: str) -> ExecutionResult:
         """No-op: Repository setup is now handled by agent-server."""
         return ExecutionResult(stdout="", stderr="", exit_code=0, error=None)
@@ -826,12 +798,6 @@ class DockerSandbox:
                 {"sandbox_id": self.id, "error": str(e)},
                 cause=e,
             )
-
-    def __enter__(self):
-        return self
-
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        self.destroy()
 
     def is_running(self) -> bool:
         return self.get_status() == SandboxStatus.RUNNING

--- a/products/tasks/backend/services/modal_sandbox.py
+++ b/products/tasks/backend/services/modal_sandbox.py
@@ -33,7 +33,7 @@ from products.tasks.backend.services.agentsh import (
     generate_policy_yaml,
 )
 from products.tasks.backend.services.local_packages import get_local_posthog_code_packages
-from products.tasks.backend.services.sandbox import WORKING_DIR, SandboxProtocol, wait_for_health_check
+from products.tasks.backend.services.sandbox import WORKING_DIR, SandboxBase, wait_for_health_check
 from products.tasks.backend.temporal.exceptions import (
     SandboxCleanupError,
     SandboxExecutionError,
@@ -198,7 +198,7 @@ def _prepare_local_modal_build_context(template: SandboxTemplate) -> tuple[str, 
     return str(destination_dockerfile_path), str(context_dir)
 
 
-class ModalSandbox(SandboxProtocol):
+class ModalSandbox(SandboxBase):
     """
     Modal-based sandbox for production use.
     A box in the cloud. Sand optional.

--- a/products/tasks/backend/services/modal_sandbox.py
+++ b/products/tasks/backend/services/modal_sandbox.py
@@ -483,13 +483,14 @@ class ModalSandbox:
         org_path = f"/tmp/workspace/repos/{org}"
 
         depth_flag = f" --depth {shlex.quote('1')}" if shallow else ""
+        # Skip blobs over 128kB during full clones — large test snapshots and auto-generated
+        # files get fetched on demand. Shallow clones are already small enough.
+        blob_filter = "" if shallow else " --filter=blob:limit=128k"
         clone_command = (
             f"rm -rf {shlex.quote(target_path)} && "
             f"mkdir -p {shlex.quote(org_path)} && "
             f"cd {shlex.quote(org_path)} && "
-            # Skip blobs over 128kB during clone — large test snapshots and auto-generated files
-            # get fetched on demand. Most code files are well under this limit.
-            f"git clone --single-branch --filter=blob:limit=128k{depth_flag} {shlex.quote(repo_url)} {shlex.quote(repo)}"
+            f"git clone --single-branch{blob_filter}{depth_flag} {shlex.quote(repo_url)} {shlex.quote(repo)}"
         )
 
         logger.info(f"Cloning repository {repository} to {target_path} in sandbox {self.id} (shallow={shallow})")

--- a/products/tasks/backend/services/modal_sandbox.py
+++ b/products/tasks/backend/services/modal_sandbox.py
@@ -33,7 +33,7 @@ from products.tasks.backend.services.agentsh import (
     generate_policy_yaml,
 )
 from products.tasks.backend.services.local_packages import get_local_posthog_code_packages
-from products.tasks.backend.services.sandbox import wait_for_health_check
+from products.tasks.backend.services.sandbox import WORKING_DIR, SandboxProtocol, wait_for_health_check
 from products.tasks.backend.temporal.exceptions import (
     SandboxCleanupError,
     SandboxExecutionError,
@@ -47,7 +47,6 @@ from .sandbox import AgentServerResult, ExecutionResult, ExecutionStream, Sandbo
 
 logger = logging.getLogger(__name__)
 
-WORKING_DIR = "/tmp/workspace"
 DEFAULT_MODAL_APP_NAME = "posthog-sandbox-default"
 NOTEBOOK_MODAL_APP_NAME = "posthog-sandbox-notebook"
 SANDBOX_BASE_IMAGE = "ghcr.io/posthog/posthog-sandbox-base"
@@ -199,7 +198,7 @@ def _prepare_local_modal_build_context(template: SandboxTemplate) -> tuple[str, 
     return str(destination_dockerfile_path), str(context_dir)
 
 
-class ModalSandbox:
+class ModalSandbox(SandboxProtocol):
     """
     Modal-based sandbox for production use.
     A box in the cloud. Sand optional.
@@ -468,34 +467,6 @@ class ModalSandbox:
                 cause=e,
             )
 
-    def clone_repository(self, repository: str, github_token: str | None = "", shallow: bool = True) -> ExecutionResult:
-        if not self.is_running():
-            raise RuntimeError(f"Sandbox not in running state.")
-
-        org, repo = repository.lower().split("/")
-        repo_url = (
-            f"https://x-access-token:{github_token}@github.com/{org}/{repo}.git"
-            if github_token
-            else f"https://github.com/{org}/{repo}.git"
-        )
-
-        target_path = f"/tmp/workspace/repos/{org}/{repo}"
-        org_path = f"/tmp/workspace/repos/{org}"
-
-        depth_flag = f" --depth {shlex.quote('1')}" if shallow else ""
-        # Skip blobs over 128kB during full clones — large test snapshots and auto-generated
-        # files get fetched on demand. Shallow clones are already small enough.
-        blob_filter = "" if shallow else " --filter=blob:limit=128k"
-        clone_command = (
-            f"rm -rf {shlex.quote(target_path)} && "
-            f"mkdir -p {shlex.quote(org_path)} && "
-            f"cd {shlex.quote(org_path)} && "
-            f"git clone --single-branch{blob_filter}{depth_flag} {shlex.quote(repo_url)} {shlex.quote(repo)}"
-        )
-
-        logger.info(f"Cloning repository {repository} to {target_path} in sandbox {self.id} (shallow={shallow})")
-        return self.execute(clone_command, timeout_seconds=5 * 60)
-
     def setup_repository(self, repository: str) -> ExecutionResult:
         """No-op: Repository setup is now handled by agent-server."""
         return ExecutionResult(stdout="", stderr="", exit_code=0, error=None)
@@ -718,12 +689,6 @@ class ModalSandbox:
             raise SandboxCleanupError(
                 f"Failed to destroy sandbox: {e}", {"sandbox_id": self.id, "error": str(e)}, cause=e
             )
-
-    def __enter__(self):
-        return self
-
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        self.destroy()
 
     def is_running(self) -> bool:
         return self.get_status() == SandboxStatus.RUNNING

--- a/products/tasks/backend/services/modal_sandbox.py
+++ b/products/tasks/backend/services/modal_sandbox.py
@@ -487,7 +487,9 @@ class ModalSandbox:
             f"rm -rf {shlex.quote(target_path)} && "
             f"mkdir -p {shlex.quote(org_path)} && "
             f"cd {shlex.quote(org_path)} && "
-            f"git clone --single-branch{depth_flag} {shlex.quote(repo_url)} {shlex.quote(repo)}"
+            # Skip blobs over 128kB during clone — large test snapshots and auto-generated files
+            # get fetched on demand. Most code files are well under this limit.
+            f"git clone --single-branch --filter=blob:limit=128k{depth_flag} {shlex.quote(repo_url)} {shlex.quote(repo)}"
         )
 
         logger.info(f"Cloning repository {repository} to {target_path} in sandbox {self.id} (shallow={shallow})")

--- a/products/tasks/backend/services/sandbox.py
+++ b/products/tasks/backend/services/sandbox.py
@@ -79,7 +79,7 @@ class SandboxConfig(BaseModel):
 WORKING_DIR = "/tmp/workspace"
 
 
-class SandboxProtocol(ABC):
+class SandboxBase(ABC):
     id: str
     config: SandboxConfig
 
@@ -91,11 +91,11 @@ class SandboxProtocol(ABC):
 
     @staticmethod
     @abstractmethod
-    def create(config: SandboxConfig) -> SandboxProtocol: ...
+    def create(config: SandboxConfig) -> SandboxBase: ...
 
     @staticmethod
     @abstractmethod
-    def get_by_id(sandbox_id: str) -> SandboxProtocol: ...
+    def get_by_id(sandbox_id: str) -> SandboxBase: ...
 
     @staticmethod
     @abstractmethod
@@ -188,7 +188,7 @@ class SandboxProtocol(ABC):
     @abstractmethod
     def is_running(self) -> bool: ...
 
-    def __enter__(self) -> SandboxProtocol:
+    def __enter__(self) -> SandboxBase:
         return self
 
     def __exit__(
@@ -232,7 +232,7 @@ def wait_for_health_check(
     return False
 
 
-SandboxClass = type[SandboxProtocol]
+SandboxClass = type[SandboxBase]
 
 
 def _get_docker_sandbox_class() -> SandboxClass:
@@ -302,7 +302,7 @@ __all__ = [
     "ExecutionResult",
     "ExecutionStream",
     "SANDBOX_TTL_SECONDS",
-    "SandboxProtocol",
+    "SandboxBase",
     "WORKING_DIR",
     "get_sandbox_class",
     "get_sandbox_class_for_backend",

--- a/products/tasks/backend/services/sandbox.py
+++ b/products/tasks/backend/services/sandbox.py
@@ -11,6 +11,8 @@ This module exports:
 
 from __future__ import annotations
 
+import shlex
+from abc import ABC, abstractmethod
 from collections.abc import Callable, Iterable
 from dataclasses import dataclass
 from enum import Enum
@@ -74,44 +76,82 @@ class SandboxConfig(BaseModel):
     disk_size_gb: float = 64
 
 
-class SandboxProtocol(Protocol):
+WORKING_DIR = "/tmp/workspace"
+
+
+class SandboxProtocol(ABC):
     id: str
     config: SandboxConfig
 
     @property
+    @abstractmethod
     def sandbox_url(self) -> str | None:
         """Return the URL for connecting to the agent server, or None if not available."""
         ...
 
     @staticmethod
+    @abstractmethod
     def create(config: SandboxConfig) -> SandboxProtocol: ...
 
     @staticmethod
+    @abstractmethod
     def get_by_id(sandbox_id: str) -> SandboxProtocol: ...
 
     @staticmethod
+    @abstractmethod
     def delete_snapshot(external_id: str) -> None: ...
 
+    @abstractmethod
     def get_status(self) -> SandboxStatus: ...
 
+    @abstractmethod
     def execute(self, command: str, timeout_seconds: int | None = None) -> ExecutionResult: ...
 
+    @abstractmethod
     def execute_stream(self, command: str, timeout_seconds: int | None = None) -> ExecutionStream: ...
 
+    @abstractmethod
     def write_file(self, path: str, payload: bytes) -> ExecutionResult: ...
 
-    def clone_repository(
-        self, repository: str, github_token: str | None = "", shallow: bool = True
-    ) -> ExecutionResult: ...
+    def clone_repository(self, repository: str, github_token: str | None = "", shallow: bool = True) -> ExecutionResult:
+        if not self.is_running():
+            raise RuntimeError("Sandbox not in running state.")
 
+        org, repo = repository.lower().split("/")
+        repo_url = (
+            f"https://x-access-token:{github_token}@github.com/{org}/{repo}.git"
+            if github_token
+            else f"https://github.com/{org}/{repo}.git"
+        )
+
+        target_path = f"{WORKING_DIR}/repos/{org}/{repo}"
+        org_path = f"{WORKING_DIR}/repos/{org}"
+
+        depth_flag = f" --depth {shlex.quote('1')}" if shallow else ""
+        # Skip blobs over 128kB during full clones — large test snapshots and auto-generated
+        # files get fetched on demand. Shallow clones are already small enough.
+        blob_filter = "" if shallow else " --filter=blob:limit=128k"
+        clone_command = (
+            f"rm -rf {shlex.quote(target_path)} && "
+            f"mkdir -p {shlex.quote(org_path)} && "
+            f"cd {shlex.quote(org_path)} && "
+            f"git clone --single-branch{blob_filter}{depth_flag} {shlex.quote(repo_url)} {shlex.quote(repo)}"
+        )
+        _logger.info(f"Cloning repository {repository} to {target_path} in sandbox {self.id} (shallow={shallow})")
+        return self.execute(clone_command, timeout_seconds=5 * 60)
+
+    @abstractmethod
     def setup_repository(self, repository: str) -> ExecutionResult: ...
 
+    @abstractmethod
     def is_git_clean(self, repository: str) -> tuple[bool, str]: ...
 
+    @abstractmethod
     def execute_task(
         self, task_id: str, run_id: str, repository: str | None = None, create_pr: bool = True
     ) -> ExecutionResult: ...
 
+    @abstractmethod
     def get_connect_credentials(self) -> AgentServerResult:
         """Get connect credentials (URL and token) for this sandbox.
 
@@ -120,6 +160,7 @@ class SandboxProtocol(Protocol):
         """
         ...
 
+    @abstractmethod
     def start_agent_server(
         self,
         repository: str | None,
@@ -138,20 +179,25 @@ class SandboxProtocol(Protocol):
         """
         ...
 
+    @abstractmethod
     def create_snapshot(self) -> str: ...
 
+    @abstractmethod
     def destroy(self) -> None: ...
 
+    @abstractmethod
     def is_running(self) -> bool: ...
 
-    def __enter__(self) -> SandboxProtocol: ...
+    def __enter__(self) -> SandboxProtocol:
+        return self
 
     def __exit__(
         self,
         exc_type: type[BaseException] | None,
         exc_val: BaseException | None,
         exc_tb: TracebackType | None,
-    ) -> None: ...
+    ) -> None:
+        self.destroy()
 
 
 _ExecuteFn = Callable[..., ExecutionResult]
@@ -257,6 +303,7 @@ __all__ = [
     "ExecutionStream",
     "SANDBOX_TTL_SECONDS",
     "SandboxProtocol",
+    "WORKING_DIR",
     "get_sandbox_class",
     "get_sandbox_class_for_backend",
     "wait_for_health_check",

--- a/products/tasks/backend/temporal/process_task/activities/start_agent_server.py
+++ b/products/tasks/backend/temporal/process_task/activities/start_agent_server.py
@@ -9,7 +9,7 @@ from posthog.temporal.oauth import PosthogMcpScopes
 
 from products.tasks.backend.models import Task
 from products.tasks.backend.services.agentsh import ENV_FILE, ENV_WRAPPER_SCRIPT, build_exec_prefix
-from products.tasks.backend.services.sandbox import Sandbox, SandboxProtocol
+from products.tasks.backend.services.sandbox import Sandbox, SandboxBase
 from products.tasks.backend.temporal.exceptions import OAuthTokenError, SandboxExecutionError
 from products.tasks.backend.temporal.oauth import create_oauth_access_token
 from products.tasks.backend.temporal.observability import emit_agent_log, log_activity_execution
@@ -20,7 +20,7 @@ from .get_task_processing_context import TaskProcessingContext
 logger = get_logger(__name__)
 
 
-def _emit_agentsh_log_tail(ctx: TaskProcessingContext, sandbox: SandboxProtocol) -> None:
+def _emit_agentsh_log_tail(ctx: TaskProcessingContext, sandbox: SandboxBase) -> None:
     try:
         result = sandbox.execute("tail -n 20 /var/log/agentsh/agentsh.log 2>/dev/null || true", timeout_seconds=5)
     except Exception:
@@ -32,7 +32,7 @@ def _emit_agentsh_log_tail(ctx: TaskProcessingContext, sandbox: SandboxProtocol)
         emit_agent_log(ctx.run_id, "debug", f"agentsh log tail:\n{log_tail}")
 
 
-def _emit_agent_server_log_tail(ctx: TaskProcessingContext, sandbox: SandboxProtocol) -> None:
+def _emit_agent_server_log_tail(ctx: TaskProcessingContext, sandbox: SandboxBase) -> None:
     try:
         result = sandbox.execute("tail -n 40 /tmp/agent-server.log 2>/dev/null || true", timeout_seconds=5)
     except Exception:
@@ -44,7 +44,7 @@ def _emit_agent_server_log_tail(ctx: TaskProcessingContext, sandbox: SandboxProt
         emit_agent_log(ctx.run_id, "debug", f"agent-server log tail:\n{log_tail}")
 
 
-def _run_connectivity_diagnostics(ctx: TaskProcessingContext, sandbox: SandboxProtocol) -> None:
+def _run_connectivity_diagnostics(ctx: TaskProcessingContext, sandbox: SandboxBase) -> None:
     """Emit diagnostic info about env vars and network connectivity.
 
     When allowed_domains is set, runs the checks inside the agentsh exec


### PR DESCRIPTION
## Problem

Large test snapshots, auto-generated files, and binary assets bloat repos, and e.g. for `PostHog/posthog`, the effect is massive (visual snapshots mostly). This slows down sandbox startup every time… but especially research agent runs, which need full clone depth for `git blame` to work.

## Changes

I was looking for options to cut down on the useless historical file contents (while avoiding depth-limiting), and turns out there's one good one: `--filter=blob:limit=k`, which allows downloading only files below size `k`. This is about a 50% reduction in the `PostHog/posthog` download size (don't quote me on the exact percentage, but that kind of scale of reduction).

So here, adding `--filter=blob:limit=128k` to the `git clone` command in `clone_repository()`. This means blobs over 128kB are skipped during clone and fetched on demand if accessed. The number comes from research, as I write in the comment - 99.99% of code files are well under this threshold.

## How did you test this code?

Ran some research tasks.

## Publish to changelog?

No.