### PR TITLE
refactor(tasks): Convert SandboxProtocol to an ABC

### DIFF
--- a/products/notebooks/backend/kernel_runtime.py
+++ b/products/notebooks/backend/kernel_runtime.py
@@ -24,9 +24,9 @@ from posthog.redis import get_client
 
 from products.notebooks.backend.models import KernelRuntime, Notebook
 from products.tasks.backend.services.sandbox import (
+    SandboxBase,
     SandboxClass,
     SandboxConfig,
-    SandboxProtocol,
     SandboxStatus,
     SandboxTemplate,
     get_sandbox_class_for_backend,
@@ -809,7 +809,7 @@ class KernelRuntimeService:
             sandbox_id=sandbox.id,
         )
 
-    def _start_kernel_process(self, sandbox: SandboxProtocol, connection_file: str) -> int:
+    def _start_kernel_process(self, sandbox: SandboxBase, connection_file: str) -> int:
         start_command = (
             "mkdir -p /tmp/jupyter && "
             f"nohup python3 -m ipykernel_launcher -f {connection_file} "
@@ -838,7 +838,7 @@ class KernelRuntimeService:
             raise RuntimeError(f"Kernel did not become ready: {result.stdout} {result.stderr}")
 
     def _bootstrap_kernel(
-        self, sandbox: SandboxProtocol, connection_file: str, notebook: Notebook, user: User | None
+        self, sandbox: SandboxBase, connection_file: str, notebook: Notebook, user: User | None
     ) -> None:
         code = self._build_kernel_bootstrap_code(notebook, user, sandbox.id)
         if not code:

--- a/products/tasks/backend/services/docker_sandbox.py
+++ b/products/tasks/backend/services/docker_sandbox.py
@@ -39,9 +39,11 @@ from .agentsh import (
     generate_policy_yaml,
 )
 from .sandbox import (
+    WORKING_DIR,
     AgentServerResult,
     ExecutionResult,
     ExecutionStream,
+    SandboxBase,
     SandboxConfig,
     SandboxStatus,
     SandboxTemplate,
@@ -50,13 +52,12 @@ from .sandbox import (
 
 logger = logging.getLogger(__name__)
 
-WORKING_DIR = "/tmp/workspace"
 DEFAULT_IMAGE_NAME = "posthog-sandbox-base"
 NOTEBOOK_IMAGE_NAME = "posthog-sandbox-notebook"
 AGENT_SERVER_PORT = 47821  # Arbitrary high port unlikely to conflict with dev servers
 
 
-class DockerSandbox:
+class DockerSandbox(SandboxBase):
     """
     Docker-based sandbox for local development and testing.
     Implements the same interface as the Modal-based Sandbox.
@@ -519,32 +520,6 @@ class DockerSandbox:
 
         return result
 
-    def clone_repository(
-        self, repository: str, github_token: Optional[str] = "", shallow: bool = True
-    ) -> ExecutionResult:
-        if not self.is_running():
-            raise RuntimeError("Sandbox not in running state.")
-
-        org, repo = repository.lower().split("/")
-        repo_url = (
-            f"https://x-access-token:{github_token}@github.com/{org}/{repo}.git"
-            if github_token
-            else f"https://github.com/{org}/{repo}.git"
-        )
-
-        target_path = f"/tmp/workspace/repos/{org}/{repo}"
-        org_path = f"/tmp/workspace/repos/{org}"
-
-        depth_flag = f" --depth {shlex.quote('1')}" if shallow else ""
-        clone_command = (
-            f"rm -rf {shlex.quote(target_path)} && "
-            f"mkdir -p {shlex.quote(org_path)} && "
-            f"cd {shlex.quote(org_path)} && "
-            f"git clone --single-branch{depth_flag} {shlex.quote(repo_url)} {shlex.quote(repo)}"
-        )
-        logger.info(f"Cloning repository {repository} to {target_path} in sandbox {self.id} (shallow={shallow})")
-        return self.execute(clone_command, timeout_seconds=5 * 60)
-
     def setup_repository(self, repository: str) -> ExecutionResult:
         """No-op: Repository setup is now handled by agent-server."""
         return ExecutionResult(stdout="", stderr="", exit_code=0, error=None)
@@ -823,12 +798,6 @@ class DockerSandbox:
                 {"sandbox_id": self.id, "error": str(e)},
                 cause=e,
             )
-
-    def __enter__(self):
-        return self
-
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        self.destroy()
 
     def is_running(self) -> bool:
         return self.get_status() == SandboxStatus.RUNNING

--- a/products/tasks/backend/services/modal_sandbox.py
+++ b/products/tasks/backend/services/modal_sandbox.py
@@ -40,7 +40,7 @@ from products.tasks.backend.services.modal_provision_diagnostics import (
     capture_modal_output_if_debug,
     summarize_modal_output,
 )
-from products.tasks.backend.services.sandbox import wait_for_health_check
+from products.tasks.backend.services.sandbox import WORKING_DIR, SandboxBase, wait_for_health_check
 from products.tasks.backend.temporal.exceptions import (
     SandboxCleanupError,
     SandboxExecutionError,
@@ -54,7 +54,6 @@ from .sandbox import AgentServerResult, ExecutionResult, ExecutionStream, Sandbo
 
 logger = logging.getLogger(__name__)
 
-WORKING_DIR = "/tmp/workspace"
 DEFAULT_MODAL_APP_NAME = "posthog-sandbox-default"
 NOTEBOOK_MODAL_APP_NAME = "posthog-sandbox-notebook"
 SANDBOX_BASE_IMAGE = "ghcr.io/posthog/posthog-sandbox-base"
@@ -219,7 +218,7 @@ def _prepare_local_modal_build_context(template: SandboxTemplate) -> tuple[str, 
     return str(destination_dockerfile_path), str(context_dir)
 
 
-class ModalSandbox:
+class ModalSandbox(SandboxBase):
     """
     Modal-based sandbox for production use.
     A box in the cloud. Sand optional.
@@ -498,31 +497,6 @@ class ModalSandbox:
                 cause=e,
             )
 
-    def clone_repository(self, repository: str, github_token: str | None = "", shallow: bool = True) -> ExecutionResult:
-        if not self.is_running():
-            raise RuntimeError(f"Sandbox not in running state.")
-
-        org, repo = repository.lower().split("/")
-        repo_url = (
-            f"https://x-access-token:{github_token}@github.com/{org}/{repo}.git"
-            if github_token
-            else f"https://github.com/{org}/{repo}.git"
-        )
-
-        target_path = f"/tmp/workspace/repos/{org}/{repo}"
-        org_path = f"/tmp/workspace/repos/{org}"
-
-        depth_flag = f" --depth {shlex.quote('1')}" if shallow else ""
-        clone_command = (
-            f"rm -rf {shlex.quote(target_path)} && "
-            f"mkdir -p {shlex.quote(org_path)} && "
-            f"cd {shlex.quote(org_path)} && "
-            f"git clone --single-branch{depth_flag} {shlex.quote(repo_url)} {shlex.quote(repo)}"
-        )
-
-        logger.info(f"Cloning repository {repository} to {target_path} in sandbox {self.id} (shallow={shallow})")
-        return self.execute(clone_command, timeout_seconds=5 * 60)
-
     def setup_repository(self, repository: str) -> ExecutionResult:
         """No-op: Repository setup is now handled by agent-server."""
         return ExecutionResult(stdout="", stderr="", exit_code=0, error=None)
@@ -745,12 +719,6 @@ class ModalSandbox:
             raise SandboxCleanupError(
                 f"Failed to destroy sandbox: {e}", {"sandbox_id": self.id, "error": str(e)}, cause=e
             )
-
-    def __enter__(self):
-        return self
-
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        self.destroy()
 
     def is_running(self) -> bool:
         return self.get_status() == SandboxStatus.RUNNING

--- a/products/tasks/backend/services/sandbox.py
+++ b/products/tasks/backend/services/sandbox.py
@@ -11,11 +11,13 @@ This module exports:
 
 from __future__ import annotations
 
+import shlex
+from abc import ABC, abstractmethod
 from collections.abc import Callable, Iterable
 from dataclasses import dataclass
 from enum import Enum
 from types import TracebackType
-from typing import TYPE_CHECKING, Protocol
+from typing import TYPE_CHECKING, Protocol, Self
 
 from django.conf import settings
 
@@ -74,44 +76,79 @@ class SandboxConfig(BaseModel):
     disk_size_gb: float = 64
 
 
-class SandboxProtocol(Protocol):
+WORKING_DIR = "/tmp/workspace"
+
+
+class SandboxBase(ABC):
     id: str
     config: SandboxConfig
 
     @property
+    @abstractmethod
     def sandbox_url(self) -> str | None:
         """Return the URL for connecting to the agent server, or None if not available."""
         ...
 
     @staticmethod
-    def create(config: SandboxConfig) -> SandboxProtocol: ...
+    @abstractmethod
+    def create(config: SandboxConfig) -> SandboxBase: ...
 
     @staticmethod
-    def get_by_id(sandbox_id: str) -> SandboxProtocol: ...
+    @abstractmethod
+    def get_by_id(sandbox_id: str) -> SandboxBase: ...
 
     @staticmethod
+    @abstractmethod
     def delete_snapshot(external_id: str) -> None: ...
 
+    @abstractmethod
     def get_status(self) -> SandboxStatus: ...
 
+    @abstractmethod
     def execute(self, command: str, timeout_seconds: int | None = None) -> ExecutionResult: ...
 
+    @abstractmethod
     def execute_stream(self, command: str, timeout_seconds: int | None = None) -> ExecutionStream: ...
 
+    @abstractmethod
     def write_file(self, path: str, payload: bytes) -> ExecutionResult: ...
 
-    def clone_repository(
-        self, repository: str, github_token: str | None = "", shallow: bool = True
-    ) -> ExecutionResult: ...
+    def clone_repository(self, repository: str, github_token: str | None = "", shallow: bool = True) -> ExecutionResult:
+        if not self.is_running():
+            raise RuntimeError("Sandbox not in running state.")
 
+        org, repo = repository.lower().split("/")
+        repo_url = (
+            f"https://x-access-token:{github_token}@github.com/{org}/{repo}.git"
+            if github_token
+            else f"https://github.com/{org}/{repo}.git"
+        )
+
+        target_path = f"{WORKING_DIR}/repos/{org}/{repo}"
+        org_path = f"{WORKING_DIR}/repos/{org}"
+
+        depth_flag = f" --depth {shlex.quote('1')}" if shallow else ""
+        clone_command = (
+            f"rm -rf {shlex.quote(target_path)} && "
+            f"mkdir -p {shlex.quote(org_path)} && "
+            f"cd {shlex.quote(org_path)} && "
+            f"git clone --single-branch{depth_flag} {shlex.quote(repo_url)} {shlex.quote(repo)}"
+        )
+        _logger.info(f"Cloning repository {repository} to {target_path} in sandbox {self.id} (shallow={shallow})")
+        return self.execute(clone_command, timeout_seconds=5 * 60)
+
+    @abstractmethod
     def setup_repository(self, repository: str) -> ExecutionResult: ...
 
+    @abstractmethod
     def is_git_clean(self, repository: str) -> tuple[bool, str]: ...
 
+    @abstractmethod
     def execute_task(
         self, task_id: str, run_id: str, repository: str | None = None, create_pr: bool = True
     ) -> ExecutionResult: ...
 
+    @abstractmethod
     def get_connect_credentials(self) -> AgentServerResult:
         """Get connect credentials (URL and token) for this sandbox.
 
@@ -120,6 +157,7 @@ class SandboxProtocol(Protocol):
         """
         ...
 
+    @abstractmethod
     def start_agent_server(
         self,
         repository: str | None,
@@ -138,20 +176,25 @@ class SandboxProtocol(Protocol):
         """
         ...
 
+    @abstractmethod
     def create_snapshot(self) -> str: ...
 
+    @abstractmethod
     def destroy(self) -> None: ...
 
+    @abstractmethod
     def is_running(self) -> bool: ...
 
-    def __enter__(self) -> SandboxProtocol: ...
+    def __enter__(self) -> Self:
+        return self
 
     def __exit__(
         self,
         exc_type: type[BaseException] | None,
         exc_val: BaseException | None,
         exc_tb: TracebackType | None,
-    ) -> None: ...
+    ) -> None:
+        self.destroy()
 
 
 _ExecuteFn = Callable[..., ExecutionResult]
@@ -186,7 +229,7 @@ def wait_for_health_check(
     return False
 
 
-SandboxClass = type[SandboxProtocol]
+SandboxClass = type[SandboxBase]
 
 
 def _get_docker_sandbox_class() -> SandboxClass:
@@ -256,7 +299,8 @@ __all__ = [
     "ExecutionResult",
     "ExecutionStream",
     "SANDBOX_TTL_SECONDS",
-    "SandboxProtocol",
+    "SandboxBase",
+    "WORKING_DIR",
     "get_sandbox_class",
     "get_sandbox_class_for_backend",
     "wait_for_health_check",

--- a/products/tasks/backend/temporal/process_task/activities/start_agent_server.py
+++ b/products/tasks/backend/temporal/process_task/activities/start_agent_server.py
@@ -9,7 +9,7 @@ from posthog.temporal.oauth import PosthogMcpScopes
 
 from products.tasks.backend.models import Task
 from products.tasks.backend.services.agentsh import ENV_FILE, ENV_WRAPPER_SCRIPT, build_exec_prefix
-from products.tasks.backend.services.sandbox import Sandbox, SandboxProtocol
+from products.tasks.backend.services.sandbox import Sandbox, SandboxBase
 from products.tasks.backend.temporal.exceptions import OAuthTokenError, SandboxExecutionError
 from products.tasks.backend.temporal.oauth import create_oauth_access_token
 from products.tasks.backend.temporal.observability import emit_agent_log, log_activity_execution
@@ -20,7 +20,7 @@ from .get_task_processing_context import TaskProcessingContext
 logger = get_logger(__name__)
 
 
-def _emit_agentsh_log_tail(ctx: TaskProcessingContext, sandbox: SandboxProtocol) -> None:
+def _emit_agentsh_log_tail(ctx: TaskProcessingContext, sandbox: SandboxBase) -> None:
     try:
         result = sandbox.execute("tail -n 20 /var/log/agentsh/agentsh.log 2>/dev/null || true", timeout_seconds=5)
     except Exception:
@@ -32,7 +32,7 @@ def _emit_agentsh_log_tail(ctx: TaskProcessingContext, sandbox: SandboxProtocol)
         emit_agent_log(ctx.run_id, "debug", f"agentsh log tail:\n{log_tail}")
 
 
-def _emit_agent_server_log_tail(ctx: TaskProcessingContext, sandbox: SandboxProtocol) -> None:
+def _emit_agent_server_log_tail(ctx: TaskProcessingContext, sandbox: SandboxBase) -> None:
     try:
         result = sandbox.execute("tail -n 40 /tmp/agent-server.log 2>/dev/null || true", timeout_seconds=5)
     except Exception:
@@ -44,7 +44,7 @@ def _emit_agent_server_log_tail(ctx: TaskProcessingContext, sandbox: SandboxProt
         emit_agent_log(ctx.run_id, "debug", f"agent-server log tail:\n{log_tail}")
 
 
-def _run_connectivity_diagnostics(ctx: TaskProcessingContext, sandbox: SandboxProtocol) -> None:
+def _run_connectivity_diagnostics(ctx: TaskProcessingContext, sandbox: SandboxBase) -> None:
     """Emit diagnostic info about env vars and network connectivity.
 
     When allowed_domains is set, runs the checks inside the agentsh exec


### PR DESCRIPTION
## Problem

`DockerSandbox` and `ModalSandbox` both implement the same `SandboxProtocol` duck-typing Protocol, but share no implementation. Yet `clone_repository`, `__enter__`, and `__exit__` are copy-pasted identically between the two classes. `WORKING_DIR` is duplicated as a module-level constant in both files.

## Changes

Converting `SandboxProtocol` (a `Protocol`) into `SandboxBase` (an `ABC`)

`clone_repository` becomes a concrete method on `SandboxBase` (shared for both Docker and Modal). Moved `__enter__`/`__exit__` to `SandboxBase` as well.

## How did you test this code?

No behavioral changes. Existing tests should cover.

## Publish to changelog?

No.

##  