### PR TITLE
chore(tasks): Support SANDBOX_REPO_MOUNT_MAP for local repo mounts

### DIFF
--- a/products/tasks/backend/services/docker_sandbox.py
+++ b/products/tasks/backend/services/docker_sandbox.py
@@ -47,6 +47,7 @@ from .sandbox import (
     SandboxConfig,
     SandboxStatus,
     SandboxTemplate,
+    parse_sandbox_repo_mount_map,
     wait_for_health_check,
 )
 
@@ -82,33 +83,6 @@ class DockerSandbox(SandboxBase):
         if self._host_port is None:
             return None
         return f"http://localhost:{self._host_port}"
-
-    @staticmethod
-    def _parse_repo_mount_map() -> dict[str, str]:
-        """Parse SANDBOX_REPO_MOUNT_MAP into {lower(org/repo): expanded_local_path}.
-
-        Format: ``org/repo:/local/path,org2/repo2:~/other/path``
-        """
-        raw = os.environ.get("SANDBOX_REPO_MOUNT_MAP", "")
-        if not raw:
-            return {}
-
-        result: dict[str, str] = {}
-        for entry in raw.split(","):
-            entry = entry.strip()
-            if not entry:
-                continue
-            parts = entry.split(":", 1)
-            if len(parts) != 2 or "/" not in parts[0]:
-                logger.warning(f"Ignoring malformed SANDBOX_REPO_MOUNT_MAP entry: {entry}")
-                continue
-            repo_key = parts[0].strip().lower()
-            local_path = os.path.expanduser(parts[1].strip())
-            if not os.path.isdir(local_path):
-                logger.warning(f"SANDBOX_REPO_MOUNT_MAP: path does not exist, skipping: {local_path}")
-                continue
-            result[repo_key] = os.path.abspath(local_path)
-        return result
 
     @staticmethod
     def _find_available_port() -> int:
@@ -305,12 +279,12 @@ class DockerSandbox(SandboxBase):
             host_port = DockerSandbox._find_available_port()
             port_args = ["-p", f"{host_port}:{AGENT_SERVER_PORT}"]
 
-            mount_map = DockerSandbox._parse_repo_mount_map()
+            mount_map = parse_sandbox_repo_mount_map()
             volume_args: list[str] = []
             for repo_key, local_path in mount_map.items():
                 org, repo = repo_key.split("/", 1)
                 container_path = f"{WORKING_DIR}/repos/{org}/{repo}"
-                volume_args.extend(["-v", f"{local_path}:{container_path}:ro"])
+                volume_args.extend(["-v", f"{local_path}:{container_path}"])
 
             docker_args = [
                 "docker",
@@ -556,7 +530,7 @@ class DockerSandbox(SandboxBase):
         return result
 
     def clone_repository(self, repository: str, github_token: str | None = "", shallow: bool = True) -> ExecutionResult:
-        mount_map = DockerSandbox._parse_repo_mount_map()
+        mount_map = parse_sandbox_repo_mount_map()
         if repository.lower() in mount_map:
             logger.info(f"Repository {repository} is bind-mounted from host, skipping clone")
             return ExecutionResult(stdout="", stderr="", exit_code=0, error=None)

--- a/products/tasks/backend/services/docker_sandbox.py
+++ b/products/tasks/backend/services/docker_sandbox.py
@@ -84,6 +84,33 @@ class DockerSandbox(SandboxBase):
         return f"http://localhost:{self._host_port}"
 
     @staticmethod
+    def _parse_repo_mount_map() -> dict[str, str]:
+        """Parse SANDBOX_REPO_MOUNT_MAP into {lower(org/repo): expanded_local_path}.
+
+        Format: ``org/repo:/local/path,org2/repo2:~/other/path``
+        """
+        raw = os.environ.get("SANDBOX_REPO_MOUNT_MAP", "")
+        if not raw:
+            return {}
+
+        result: dict[str, str] = {}
+        for entry in raw.split(","):
+            entry = entry.strip()
+            if not entry:
+                continue
+            parts = entry.split(":", 1)
+            if len(parts) != 2 or "/" not in parts[0]:
+                logger.warning(f"Ignoring malformed SANDBOX_REPO_MOUNT_MAP entry: {entry}")
+                continue
+            repo_key = parts[0].strip().lower()
+            local_path = os.path.expanduser(parts[1].strip())
+            if not os.path.isdir(local_path):
+                logger.warning(f"SANDBOX_REPO_MOUNT_MAP: path does not exist, skipping: {local_path}")
+                continue
+            result[repo_key] = os.path.abspath(local_path)
+        return result
+
+    @staticmethod
     def _find_available_port() -> int:
         """Find an available port on the host machine."""
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
@@ -278,6 +305,13 @@ class DockerSandbox(SandboxBase):
             host_port = DockerSandbox._find_available_port()
             port_args = ["-p", f"{host_port}:{AGENT_SERVER_PORT}"]
 
+            mount_map = DockerSandbox._parse_repo_mount_map()
+            volume_args: list[str] = []
+            for repo_key, local_path in mount_map.items():
+                org, repo = repo_key.split("/", 1)
+                container_path = f"{WORKING_DIR}/repos/{org}/{repo}"
+                volume_args.extend(["-v", f"{local_path}:{container_path}:ro"])
+
             docker_args = [
                 "docker",
                 "run",
@@ -294,6 +328,7 @@ class DockerSandbox(SandboxBase):
                 f"--cpus={config.cpu_cores}",
                 *env_args,
                 *port_args,
+                *volume_args,
                 image,
                 "tail",
                 "-f",
@@ -519,6 +554,13 @@ class DockerSandbox(SandboxBase):
                 )
 
         return result
+
+    def clone_repository(self, repository: str, github_token: str | None = "", shallow: bool = True) -> ExecutionResult:
+        mount_map = DockerSandbox._parse_repo_mount_map()
+        if repository.lower() in mount_map:
+            logger.info(f"Repository {repository} is bind-mounted from host, skipping clone")
+            return ExecutionResult(stdout="", stderr="", exit_code=0, error=None)
+        return super().clone_repository(repository, github_token, shallow)
 
     def setup_repository(self, repository: str) -> ExecutionResult:
         """No-op: Repository setup is now handled by agent-server."""

--- a/products/tasks/backend/services/sandbox.py
+++ b/products/tasks/backend/services/sandbox.py
@@ -11,6 +11,7 @@ This module exports:
 
 from __future__ import annotations
 
+import os
 import shlex
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Iterable
@@ -205,6 +206,34 @@ _ExecuteFn = Callable[..., ExecutionResult]
 _logger = structlog.get_logger(__name__)
 
 
+def parse_sandbox_repo_mount_map() -> dict[str, str]:
+    """Parse SANDBOX_REPO_MOUNT_MAP into {lower(org/repo): expanded_local_path}.
+
+    Used by Docker sandbox for bind mounts and by task activities for user-facing logs.
+    Format: ``org/repo:/local/path,org2/repo2:~/other/path``
+    """
+    raw = os.environ.get("SANDBOX_REPO_MOUNT_MAP", "")
+    if not raw:
+        return {}
+
+    result: dict[str, str] = {}
+    for entry in raw.split(","):
+        entry = entry.strip()
+        if not entry:
+            continue
+        parts = entry.split(":", 1)
+        if len(parts) != 2 or "/" not in parts[0]:
+            _logger.warning(f"Ignoring malformed SANDBOX_REPO_MOUNT_MAP entry: {entry}")
+            continue
+        repo_key = parts[0].strip().lower()
+        local_path = os.path.expanduser(parts[1].strip())
+        if not os.path.isdir(local_path):
+            _logger.warning(f"SANDBOX_REPO_MOUNT_MAP: path does not exist, skipping: {local_path}")
+            continue
+        result[repo_key] = os.path.abspath(local_path)
+    return result
+
+
 def wait_for_health_check(
     execute: _ExecuteFn,
     sandbox_id: str,
@@ -304,6 +333,7 @@ __all__ = [
     "SANDBOX_TTL_SECONDS",
     "SandboxBase",
     "WORKING_DIR",
+    "parse_sandbox_repo_mount_map",
     "get_sandbox_class",
     "get_sandbox_class_for_backend",
     "wait_for_health_check",

--- a/products/tasks/backend/services/test_docker_sandbox.py
+++ b/products/tasks/backend/services/test_docker_sandbox.py
@@ -241,6 +241,72 @@ class TestDockerSandboxUnit:
                 assert shlex.quote(run_id) in command
                 assert shlex.quote(mode) in command
 
+    def test_parse_repo_mount_map_empty(self):
+        with patch.dict(os.environ, {}, clear=True):
+            assert DockerSandbox._parse_repo_mount_map() == {}
+
+    def test_parse_repo_mount_map_valid(self, tmp_path):
+        with patch.dict(os.environ, {"SANDBOX_REPO_MOUNT_MAP": f"PostHog/posthog:{tmp_path}"}):
+            result = DockerSandbox._parse_repo_mount_map()
+            assert result == {"posthog/posthog": str(tmp_path)}
+
+    def test_parse_repo_mount_map_multiple(self, tmp_path):
+        dir_a = tmp_path / "a"
+        dir_b = tmp_path / "b"
+        dir_a.mkdir()
+        dir_b.mkdir()
+        with patch.dict(os.environ, {"SANDBOX_REPO_MOUNT_MAP": f"Org/repoA:{dir_a}, Org/repoB:{dir_b}"}):
+            result = DockerSandbox._parse_repo_mount_map()
+            assert result == {"org/repoa": str(dir_a), "org/repob": str(dir_b)}
+
+    def test_parse_repo_mount_map_skips_nonexistent(self):
+        with patch.dict(os.environ, {"SANDBOX_REPO_MOUNT_MAP": "Org/repo:/nonexistent/path"}):
+            assert DockerSandbox._parse_repo_mount_map() == {}
+
+    def test_parse_repo_mount_map_skips_malformed(self, tmp_path):
+        with patch.dict(os.environ, {"SANDBOX_REPO_MOUNT_MAP": f"no-slash:{tmp_path},,bad"}):
+            assert DockerSandbox._parse_repo_mount_map() == {}
+
+    def test_clone_repository_skipped_when_mounted(self, tmp_path):
+        sandbox = DockerSandbox.__new__(DockerSandbox)
+        sandbox._container_id = "abc123"
+        sandbox.id = "abc123"
+        sandbox.config = SandboxConfig(name="test")
+
+        with patch.dict(os.environ, {"SANDBOX_REPO_MOUNT_MAP": f"PostHog/posthog:{tmp_path}"}):
+            with patch.object(sandbox, "is_running", return_value=True):
+                with patch.object(sandbox, "execute") as mock_execute:
+                    result = sandbox.clone_repository("PostHog/posthog", github_token="tok")
+                    assert result.exit_code == 0
+                    mock_execute.assert_not_called()
+
+    def test_clone_repository_proceeds_when_not_mounted(self):
+        sandbox = DockerSandbox.__new__(DockerSandbox)
+        sandbox._container_id = "abc123"
+        sandbox.id = "abc123"
+        sandbox.config = SandboxConfig(name="test")
+
+        with patch.dict(os.environ, {}, clear=True):
+            with patch.object(sandbox, "is_running", return_value=True):
+                with patch.object(sandbox, "execute") as mock_execute:
+                    sandbox.clone_repository("PostHog/posthog", github_token="tok")
+                    mock_execute.assert_called_once()
+
+    @patch("products.tasks.backend.services.docker_sandbox.subprocess.run")
+    def test_create_adds_volume_mounts(self, mock_run, tmp_path):
+        mock_run.return_value = MagicMock(stdout="abc123container", returncode=0)
+
+        config = SandboxConfig(name="test-sandbox")
+
+        with patch.dict(os.environ, {"SANDBOX_REPO_MOUNT_MAP": f"PostHog/posthog:{tmp_path}"}):
+            with patch.object(DockerSandbox, "_get_image", return_value="posthog-sandbox-base"):
+                DockerSandbox.create(config)
+
+        docker_run_call = mock_run.call_args_list[-1]
+        docker_args = docker_run_call[0][0]
+        args_str = " ".join(docker_args)
+        assert f"-v {tmp_path}:/tmp/workspace/repos/posthog/posthog:ro" in args_str
+
     def test_start_agent_server_without_domains_skips_agentsh(self):
         sandbox = DockerSandbox.__new__(DockerSandbox)
         sandbox._container_id = "abc123"

--- a/products/tasks/backend/services/test_docker_sandbox.py
+++ b/products/tasks/backend/services/test_docker_sandbox.py
@@ -11,6 +11,7 @@ from products.tasks.backend.services.sandbox import (
     SandboxStatus,
     SandboxTemplate,
     get_sandbox_class,
+    parse_sandbox_repo_mount_map,
 )
 
 
@@ -243,11 +244,11 @@ class TestDockerSandboxUnit:
 
     def test_parse_repo_mount_map_empty(self):
         with patch.dict(os.environ, {}, clear=True):
-            assert DockerSandbox._parse_repo_mount_map() == {}
+            assert parse_sandbox_repo_mount_map() == {}
 
     def test_parse_repo_mount_map_valid(self, tmp_path):
         with patch.dict(os.environ, {"SANDBOX_REPO_MOUNT_MAP": f"PostHog/posthog:{tmp_path}"}):
-            result = DockerSandbox._parse_repo_mount_map()
+            result = parse_sandbox_repo_mount_map()
             assert result == {"posthog/posthog": str(tmp_path)}
 
     def test_parse_repo_mount_map_multiple(self, tmp_path):
@@ -256,16 +257,16 @@ class TestDockerSandboxUnit:
         dir_a.mkdir()
         dir_b.mkdir()
         with patch.dict(os.environ, {"SANDBOX_REPO_MOUNT_MAP": f"Org/repoA:{dir_a}, Org/repoB:{dir_b}"}):
-            result = DockerSandbox._parse_repo_mount_map()
+            result = parse_sandbox_repo_mount_map()
             assert result == {"org/repoa": str(dir_a), "org/repob": str(dir_b)}
 
     def test_parse_repo_mount_map_skips_nonexistent(self):
         with patch.dict(os.environ, {"SANDBOX_REPO_MOUNT_MAP": "Org/repo:/nonexistent/path"}):
-            assert DockerSandbox._parse_repo_mount_map() == {}
+            assert parse_sandbox_repo_mount_map() == {}
 
     def test_parse_repo_mount_map_skips_malformed(self, tmp_path):
         with patch.dict(os.environ, {"SANDBOX_REPO_MOUNT_MAP": f"no-slash:{tmp_path},,bad"}):
-            assert DockerSandbox._parse_repo_mount_map() == {}
+            assert parse_sandbox_repo_mount_map() == {}
 
     def test_clone_repository_skipped_when_mounted(self, tmp_path):
         sandbox = DockerSandbox.__new__(DockerSandbox)
@@ -305,7 +306,7 @@ class TestDockerSandboxUnit:
         docker_run_call = mock_run.call_args_list[-1]
         docker_args = docker_run_call[0][0]
         args_str = " ".join(docker_args)
-        assert f"-v {tmp_path}:/tmp/workspace/repos/posthog/posthog:ro" in args_str
+        assert f"-v {tmp_path}:/tmp/workspace/repos/posthog/posthog" in args_str
 
     def test_start_agent_server_without_domains_skips_agentsh(self):
         sandbox = DockerSandbox.__new__(DockerSandbox)

--- a/products/tasks/backend/temporal/process_task/activities/get_sandbox_for_repository.py
+++ b/products/tasks/backend/temporal/process_task/activities/get_sandbox_for_repository.py
@@ -10,7 +10,12 @@ from posthog.temporal.common.utils import asyncify
 
 from products.tasks.backend.models import SandboxEnvironment, SandboxSnapshot, Task, TaskRun
 from products.tasks.backend.services.connection_token import get_sandbox_jwt_public_key
-from products.tasks.backend.services.sandbox import Sandbox, SandboxConfig, SandboxTemplate
+from products.tasks.backend.services.sandbox import (
+    Sandbox,
+    SandboxConfig,
+    SandboxTemplate,
+    parse_sandbox_repo_mount_map,
+)
 from products.tasks.backend.temporal.exceptions import GitHubAuthenticationError, OAuthTokenError, TaskNotFoundError
 from products.tasks.backend.temporal.metrics import StepTimer, increment_snapshot_usage
 from products.tasks.backend.temporal.oauth import create_oauth_access_token
@@ -253,7 +258,16 @@ def get_sandbox_for_repository(input: GetSandboxForRepositoryInput) -> GetSandbo
 
         if has_repo and not used_snapshot:
             assert repository is not None
-            emit_agent_log(ctx.run_id, "info", f"Cloning {repository} into sandbox")
+            local_bind = parse_sandbox_repo_mount_map().get(repository.lower())
+            # Bind mounts are only applied for Docker sandboxes; Modal ignores SANDBOX_REPO_MOUNT_MAP.
+            if local_bind is not None and getattr(settings, "SANDBOX_PROVIDER", None) == "docker":
+                emit_agent_log(
+                    ctx.run_id,
+                    "info",
+                    f"Using local checkout for {repository} at {local_bind} (SANDBOX_REPO_MOUNT_MAP); skipping clone from GitHub",
+                )
+            else:
+                emit_agent_log(ctx.run_id, "info", f"Cloning {repository} into sandbox")
             with StepTimer("repository_clone", used_snapshot=used_snapshot):
                 clone_result = sandbox.clone_repository(repository, github_token=github_token, shallow=shallow)
             if clone_result.exit_code != 0:


### PR DESCRIPTION
## Problem

When developing locally with `SANDBOX_PROVIDER=docker`, every sandbox run clones repositories from GitHub. This takes time and is just unnecessary when you already have the repo checked out on your machine.

## Changes

Adding a new env var called `SANDBOX_REPO_MOUNT_MAP`. When set, configured repositories are bind-mounted in DockerSandbox (read-only for safety and okay for signals research runs at least) from the host into the container – makes `clone_repository` basically a no-op for those repos.

Format: `SANDBOX_REPO_MOUNT_MAP=PostHog/posthog:~/Developer/posthog,etcetera`

EDIT: Actually, for the ability to write code, let's mount read-write

## How did you test this code?

Added test cases to `TestDockerSandboxUnit`. And ofc ran locally - reports that used to take many minutes due to massive `PostHog/posthog` downloads now take less than 60s.

## Publish to changelog?

No.