### PR TITLE
chore(ci): fix flaky kafka-assigner k3s tests

### DIFF
--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -90,7 +90,7 @@ jobs:
                       "ingestion-consumer": 5,
                       "hogvm": 5,
                       "k8s-awareness": 60,
-                      "kafka-assigner": 30,
+                      "kafka-assigner": 150,
                       "kafka-deduplicator": 239,
                       "limiters": 23,
                       "lifecycle": 10,
@@ -286,6 +286,8 @@ jobs:
               run: |
                   for pkg in ${{ matrix.packages }}; do
                       echo "::group::Testing $pkg"
+                      # Free cgroups, overlayfs, and network namespaces from previous testcontainers
+                      docker system prune -f --volumes 2>/dev/null || true
                       extra_args=""
                       # Limit test threads for packages with sqlx pool exhaustion issues
                       if [ "$pkg" = "property-defs-rs" ]; then


### PR DESCRIPTION
## Problem

The `deployment_rollout_reassigns_partitions` k3s integration test is failing recently on master:
- https://github.com/PostHog/posthog/actions/runs/24202239874/job/70648764210
- https://github.com/PostHog/posthog/actions/runs/24201955018/job/70647746312
- https://github.com/PostHog/posthog/actions/runs/24199418598/job/70638650088

Root cause hypothesis: the kafka-assigner shard weight is 30s but actual k3s test runtime is ~143s. The bin-packer co-locates it with heavy packages, causing Docker resource pressure. The k3s API server becomes unreachable (`kube_client::client::builder: failed with error client error (Connect)`) and the assigner can't complete initial partition assignment within the 60s timeout.

## Changes

- Update kafka-assigner shard weight from 30 to 150 (actual runtime) so the bin-packer places it in a lighter shard
- Add `docker system prune` between package test runs to free cgroups/overlayfs from previous testcontainers

## How did you test this code?

CI-only change. Verification is observing the test pass on subsequent runs.

## Publish to changelog?

No

## LLM context

Agent-authored PR. Analysis based on CI logs from three failing runs showing identical `condition not met within 60s` timeout at the initial assignment phase (stack trace points to `k3s_integration.rs:532`, the first `wait_for_condition`).