### PR TITLE
fix(surveys): default new survey to guided wizard

### DIFF
--- a/frontend/src/scenes/surveys/Survey.tsx
+++ b/frontend/src/scenes/surveys/Survey.tsx
@@ -1,6 +1,5 @@
 import { BindLogic, useActions, useValues } from 'kea'
 import { Form } from 'kea-forms'
-import { router } from 'kea-router'
 import { useEffect } from 'react'
 
 import { LemonDivider, LemonTag, Link, lemonToast } from '@posthog/lemon-ui'
@@ -19,7 +18,6 @@ import { FeatureFlagFilters, Survey, SurveyMatchType } from '~/types'
 import { LOADING_SURVEY_RESULTS_TOAST_ID, NewSurvey, SurveyMatchTypeLabels } from './constants'
 import SurveyEdit from './SurveyEdit'
 import { SurveyLogicProps, surveyLogic } from './surveyLogic'
-import { surveysLogic } from './surveysLogic'
 import { SurveyView } from './SurveyView'
 
 export const scene: SceneExport<SurveyLogicProps> = {
@@ -31,7 +29,6 @@ export const scene: SceneExport<SurveyLogicProps> = {
 export function SurveyComponent({ id }: SurveyLogicProps): JSX.Element {
     const { editingSurvey, setSelectedPageIndex, loadSurvey } = useActions(surveyLogic)
     const { isEditingSurvey, surveyMissing } = useValues(surveyLogic)
-    const { preferredEditor } = useValues(surveysLogic)
 
     // register tool so edits from AI will always reload the survey data on-page
     useMaxTool({
@@ -43,15 +40,6 @@ export function SurveyComponent({ id }: SurveyLogicProps): JSX.Element {
             }
         },
     })
-
-    // Redirect to the guided wizard if that's the user's persisted preference.
-    // Only for brand-new surveys without a hash (deep links with hash params
-    // like #fromTemplate or #preserveLocalChanges should be respected).
-    useEffect(() => {
-        if (id === 'new' && preferredEditor === 'guided' && !window.location.hash) {
-            router.actions.replace(urls.surveyWizard('new'))
-        }
-    }, [id, preferredEditor])
 
     /**
      * Logic that cleans up surveyLogic state when the component unmounts.

--- a/frontend/src/scenes/surveys/wizard/SurveyWizard.test.tsx
+++ b/frontend/src/scenes/surveys/wizard/SurveyWizard.test.tsx
@@ -12,6 +12,7 @@ describe('SurveyWizard', () => {
     beforeEach(() => {
         localStorage.clear()
         sessionStorage.clear()
+        localStorage.setItem('scenes.surveys.surveysLogic.preferredEditor', JSON.stringify('full'))
 
         useMocks({
             get: {
@@ -22,16 +23,18 @@ describe('SurveyWizard', () => {
                 '/api/environments/:team_id/add_product_intent/': () => [200, {}],
             },
         })
+
+        initKeaTests()
+    })
+
+    afterEach(() => {
+        jest.restoreAllMocks()
     })
 
     it('keeps new surveys on template selection when full editor is preferred', async () => {
-        initKeaTests()
-        localStorage.setItem('scenes.surveys.surveysLogic.preferredEditor', JSON.stringify('full'))
-
         router.actions.push('/surveys/guided/new')
 
-        const replaceSpy = jest.fn()
-        router.actions.replace = replaceSpy
+        const replaceSpy = jest.spyOn(router.actions, 'replace').mockImplementation(() => {})
 
         render(<SurveyWizardComponent id="new" />)
 

--- a/frontend/src/scenes/surveys/wizard/SurveyWizard.test.tsx
+++ b/frontend/src/scenes/surveys/wizard/SurveyWizard.test.tsx
@@ -1,0 +1,44 @@
+import '@testing-library/jest-dom'
+
+import { render, screen, waitFor } from '@testing-library/react'
+import { router } from 'kea-router'
+
+import { useMocks } from '~/mocks/jest'
+import { initKeaTests } from '~/test/init'
+
+import { SurveyWizardComponent } from './SurveyWizard'
+
+describe('SurveyWizard', () => {
+    beforeEach(() => {
+        localStorage.clear()
+        sessionStorage.clear()
+
+        useMocks({
+            get: {
+                '/api/projects/:team/surveys/': () => [200, { count: 0, results: [], next: null, previous: null }],
+                '/api/projects/:team/surveys/responses_count': () => [200, {}],
+            },
+            patch: {
+                '/api/environments/:team_id/add_product_intent/': () => [200, {}],
+            },
+        })
+    })
+
+    it('keeps new surveys on template selection when full editor is preferred', async () => {
+        initKeaTests()
+        localStorage.setItem('scenes.surveys.surveysLogic.preferredEditor', JSON.stringify('full'))
+
+        router.actions.push('/surveys/guided/new')
+
+        const replaceSpy = jest.fn()
+        router.actions.replace = replaceSpy
+
+        render(<SurveyWizardComponent id="new" />)
+
+        await waitFor(() => {
+            expect(screen.getByText('Choose a survey template')).toBeInTheDocument()
+        })
+
+        expect(replaceSpy).not.toHaveBeenCalled()
+    })
+})

--- a/frontend/src/scenes/surveys/wizard/SurveyWizard.tsx
+++ b/frontend/src/scenes/surveys/wizard/SurveyWizard.tsx
@@ -42,7 +42,7 @@ export const scene: SceneExport<SurveyWizardLogicProps> = {
     paramsToProps: ({ params: { id } }): SurveyWizardLogicProps => ({ id: id || 'new' }),
 }
 
-function SurveyWizardComponent({ id }: SurveyWizardLogicProps): JSX.Element {
+export function SurveyWizardComponent({ id }: SurveyWizardLogicProps): JSX.Element {
     return (
         <BindLogic logic={surveyWizardLogic} props={{ id }}>
             <BindLogic logic={surveyLogic} props={{ id }}>
@@ -68,24 +68,21 @@ function SurveyWizard({ id }: SurveyWizardLogicProps): JSX.Element {
     const { survey, surveyWarnings } = useValues(surveyLogic)
     const { setSurveyValue, loadSurvey } = useActions(surveyLogic)
 
-    const { preferredEditor } = useValues(surveysLogic)
     const { setPreferredEditor } = useActions(surveysLogic)
 
-    // Redirect to the full editor when appropriate:
-    //  - brand-new survey + user prefers full editor (per-user preference)
-    //  - existing survey that uses wizard-unsupported fields (capability gate)
+    // Redirect existing surveys that use wizard-unsupported fields to the full
+    // editor. Brand-new surveys should always start on template selection,
+    // regardless of the user's editor preference.
     // Hash-carrying deep links (#fromTemplate, #preserveLocalChanges) are
     // respected and bypass the redirect.
     useEffect(() => {
         if (window.location.hash) {
             return
         }
-        if (!isEditing && preferredEditor === 'full') {
-            router.actions.replace(urls.survey('new'))
-        } else if (isEditing && !surveyLoading && !canUseSurveyWizard(survey)) {
+        if (isEditing && !surveyLoading && !canUseSurveyWizard(survey)) {
             router.actions.replace(`${urls.survey(id)}?edit=true`)
         }
-    }, [isEditing, preferredEditor, survey, surveyLoading, id])
+    }, [isEditing, survey, surveyLoading, id])
 
     // register tool so edits from AI will always reload the survey data on-page
     useMaxTool({


### PR DESCRIPTION
## Problem

Clicking `New survey` could still rely on a client-side redirect from `/surveys/new` into the guided flow. That caused an unnecessary URL change and made the new-survey entrypoint behavior harder to reason about.

## Changes

- removed the `/surveys/new` client-side redirect from the survey scene so the canonical create path can point directly at the guided wizard
- kept brand-new guided surveys on template selection regardless of saved editor preference
- added a regression test covering the guided new-survey route when the persisted preference is `full`

## How did you test this code?

Added a focused regression test in `frontend/src/scenes/surveys/wizard/SurveyWizard.test.tsx`.

Attempted to run:
`hogli test frontend/src/scenes/surveys/wizard/SurveyWizard.test.tsx frontend/src/scenes/surveys/wizard/surveyWizardLogic.test.ts`

That run was blocked by an existing Jest setup issue in this branch because `posthog-js/dist/product-tours-preview` could not be resolved before the survey tests executed.

Also ran:
`git diff --check -- frontend/src/scenes/surveys/Survey.tsx frontend/src/scenes/surveys/wizard/SurveyWizard.tsx frontend/src/scenes/surveys/wizard/SurveyWizard.test.tsx`

## Publish to changelog?

no

## Docs update

No docs update required.

## 🤖 LLM context

Agent-authored PR.

Implemented the survey routing cleanup directly in the frontend and added a regression test for the guided new-survey flow. Automated Jest verification was attempted but blocked by an existing module-resolution failure in the repo test setup.
