### PR TITLE
feat(hogli): add devbox:cleanup:disk command

### DIFF
--- a/common/hogli/devbox/cli.py
+++ b/common/hogli/devbox/cli.py
@@ -599,6 +599,6 @@ def devbox_cleanup_disk(prune_docker: bool, prune_cargo: bool) -> None:
     click.echo()
     click.echo("Tips for more space:")
     if not prune_cargo:
-        click.echo("  hogli devbox:cleanup:disk --cargo  remove Cargo artifacts (~/.cargo/target, forces recompile)")
+        click.echo("  hogli devbox:cleanup:disk --cargo  (rm ~/.cargo/target, forces recompile)")
     if not prune_docker:
-        click.echo("  hogli devbox:cleanup:disk --docker           prune stopped containers")
+        click.echo("  hogli devbox:cleanup:disk --docker  (prune stopped containers)")

--- a/common/hogli/devbox/cli.py
+++ b/common/hogli/devbox/cli.py
@@ -532,8 +532,10 @@ def _run_cleanup_step(label: str, cmd: list[str]) -> None:
     try:
         subprocess.run(cmd, check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)  # noqa: S603
         click.echo(" done")
-    except (subprocess.CalledProcessError, FileNotFoundError):
+    except FileNotFoundError:
         click.echo(" skipped (command unavailable)")
+    except subprocess.CalledProcessError as e:
+        click.echo(f" warning: exited with code {e.returncode}")
 
 
 def _rm_dir(label: str, path: Path) -> None:
@@ -587,8 +589,10 @@ def devbox_cleanup_disk(prune_docker: bool, prune_cargo: bool) -> None:
     try:
         subprocess.run(["nix-collect-garbage", "-d"], check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)  # noqa: S603
         click.echo(" done")
-    except (subprocess.CalledProcessError, FileNotFoundError):
+    except FileNotFoundError:
         click.echo(" skipped (nix-collect-garbage unavailable)")
+    except subprocess.CalledProcessError as e:
+        click.echo(f" warning: exited with code {e.returncode}")
 
     # Cargo build artifacts — opt-in because removing them forces a full Rust recompile
     if prune_cargo:
@@ -601,8 +605,10 @@ def devbox_cleanup_disk(prune_docker: bool, prune_cargo: bool) -> None:
                 ["docker", "container", "prune", "-f"], check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
             )  # noqa: S603
             click.echo(" done")
-        except (subprocess.CalledProcessError, FileNotFoundError):
-            click.echo(" skipped (Docker unavailable)")
+        except FileNotFoundError:
+            click.echo(" skipped (docker unavailable)")
+        except subprocess.CalledProcessError as e:
+            click.echo(f" warning: exited with code {e.returncode}")
 
     actually_freed = _sum_freed(before, _snapshot_free(watch_paths))
 
@@ -612,9 +618,13 @@ def devbox_cleanup_disk(prune_docker: bool, prune_cargo: bool) -> None:
     else:
         click.echo("Nothing significant was freed (caches may already be empty).")
 
-    click.echo()
-    click.echo("Tips for more space:")
+    tips = []
     if not prune_cargo:
-        click.echo("  hogli devbox:cleanup:disk --cargo  (rm ~/.cargo/target, forces recompile)")
+        tips.append("  hogli devbox:cleanup:disk --cargo  (rm ~/.cargo/target, forces recompile)")
     if not prune_docker:
-        click.echo("  hogli devbox:cleanup:disk --docker  (prune stopped containers)")
+        tips.append("  hogli devbox:cleanup:disk --docker  (prune stopped containers)")
+    if tips:
+        click.echo()
+        click.echo("Tips for more space:")
+        for tip in tips:
+            click.echo(tip)

--- a/common/hogli/devbox/cli.py
+++ b/common/hogli/devbox/cli.py
@@ -7,8 +7,11 @@ from __future__ import annotations
 
 import os
 import errno
+import shutil
 import socket
+import subprocess
 from collections.abc import Callable
+from pathlib import Path
 from typing import Any, NoReturn
 
 import click
@@ -272,6 +275,7 @@ def devbox_help() -> None:
     click.echo("  hogli devbox:status      show current workspace status")
     click.echo("  hogli devbox:stop        stop the workspace")
     click.echo("  hogli devbox:destroy     delete the workspace and its data")
+    click.echo("  hogli devbox:cleanup:disk  free disk space (caches, build artifacts)")
     click.echo()
     click.echo("Run `hogli <command> --help` for command-specific options.")
 
@@ -498,3 +502,103 @@ def devbox_forward(workspace_label: str | None, port: int) -> None:
     click.echo("Ctrl+C to stop")
     click.echo()
     port_forward_replace(name, port, 8010)
+
+
+def _gib(nbytes: int) -> str:
+    return f"{nbytes / 1024**3:.1f}G"
+
+
+def _run_cleanup_step(label: str, cmd: list[str]) -> int:
+    """Run a cleanup command, print its label, return bytes freed (best-effort)."""
+    click.echo(f"  {label}...", nl=False)
+    try:
+        subprocess.run(cmd, check=True, capture_output=True)  # noqa: S603
+        click.echo(" done")
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        click.echo(" skipped (command unavailable)")
+    # Bytes freed is measured at the call site via disk_usage delta
+    return 0
+
+
+def _rm_dir(label: str, path: Path) -> int:
+    """Delete a directory and return the bytes it occupied (best-effort)."""
+    if not path.exists():
+        click.echo(f"  {label}... skipped (not found)")
+        return 0
+    try:
+        size = sum(f.stat().st_size for f in path.rglob("*") if f.is_file())
+    except OSError:
+        size = 0
+    click.echo(f"  {label}...", nl=False)
+    shutil.rmtree(path, ignore_errors=True)
+    click.echo(" done")
+    return size
+
+
+@cli.command(name="devbox:cleanup:disk", help="Free disk space by cleaning caches and build artifacts")
+@click.option("--docker", "prune_docker", is_flag=True, help="Also prune stopped Docker containers")
+@click.option(
+    "--cargo",
+    "prune_cargo",
+    is_flag=True,
+    help="Also remove Cargo build artifacts (forces full Rust recompile on next build)",
+)
+def devbox_cleanup_disk(prune_docker: bool, prune_cargo: bool) -> None:
+    """Free disk space by removing caches and build artifacts that are safe to delete.
+
+    The default run is safe: it only removes orphaned packages, download caches,
+    and old Nix generations — none of which force a full rebuild on next use.
+    Use --cargo to also remove Cargo build artifacts (forces full Rust recompile).
+    Use --docker to also prune stopped containers.
+    """
+    home = Path.home()
+    disk_before = shutil.disk_usage(home).free
+
+    click.echo("Cleaning caches and build artifacts...")
+    click.echo()
+
+    freed = 0
+
+    # uv wheel/sdist cache
+    _run_cleanup_step("uv cache (~/.cache/uv)", ["uv", "cache", "clean"])
+
+    # sccache compiler cache
+    freed += _rm_dir("sccache (~/.cache/sccache)", home / ".cache" / "sccache")
+
+    # pnpm orphaned store entries
+    _run_cleanup_step("pnpm store (orphaned packages)", ["pnpm", "store", "prune"])
+
+    click.echo("  Nix garbage collection (old generations)...", nl=False)
+    try:
+        subprocess.run(["nix-collect-garbage", "-d"], check=True, capture_output=True)  # noqa: S603
+        click.echo(" done")
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        click.echo(" skipped (nix-collect-garbage unavailable)")
+
+    # Cargo build artifacts — opt-in because removing them forces a full Rust recompile
+    if prune_cargo:
+        freed += _rm_dir("Cargo build artifacts (~/.cargo/target)", home / ".cargo" / "target")
+
+    if prune_docker:
+        click.echo("  Docker stopped containers...", nl=False)
+        try:
+            subprocess.run(["docker", "container", "prune", "-f"], check=True, capture_output=True)  # noqa: S603
+            click.echo(" done")
+        except (subprocess.CalledProcessError, FileNotFoundError):
+            click.echo(" skipped (Docker unavailable)")
+
+    disk_after = shutil.disk_usage(home).free
+    actually_freed = disk_after - disk_before
+
+    click.echo()
+    if actually_freed > 0:
+        click.echo(click.style(f"Freed {_gib(actually_freed)} of disk space.", fg="green"))
+    else:
+        click.echo("Nothing significant was freed (caches may already be empty).")
+
+    click.echo()
+    click.echo("Tips for more space:")
+    if not prune_cargo:
+        click.echo("  hogli devbox:cleanup:disk --cargo  remove Cargo artifacts (~/.cargo/target, forces recompile)")
+    if not prune_docker:
+        click.echo("  hogli devbox:cleanup:disk --docker           prune stopped containers")

--- a/common/hogli/devbox/cli.py
+++ b/common/hogli/devbox/cli.py
@@ -508,31 +508,45 @@ def _gib(nbytes: int) -> str:
     return f"{nbytes / 1024**3:.1f}G"
 
 
-def _run_cleanup_step(label: str, cmd: list[str]) -> int:
-    """Run a cleanup command, print its label, return bytes freed (best-effort)."""
+def _snapshot_free(paths: list[Path]) -> dict[int, int]:
+    """Return free bytes keyed by device ID, deduplicating paths on the same filesystem."""
+    seen: dict[int, int] = {}
+    for path in paths:
+        try:
+            dev = path.stat().st_dev
+            if dev not in seen:
+                seen[dev] = shutil.disk_usage(path).free
+        except OSError:
+            pass
+    return seen
+
+
+def _sum_freed(before: dict[int, int], after: dict[int, int]) -> int:
+    """Sum free-space gains across all watched devices."""
+    return sum(max(0, after[dev] - before[dev]) for dev in after if dev in before)
+
+
+def _run_cleanup_step(label: str, cmd: list[str]) -> None:
+    """Run a cleanup command and print its label."""
     click.echo(f"  {label}...", nl=False)
     try:
-        subprocess.run(cmd, check=True, capture_output=True)  # noqa: S603
+        subprocess.run(cmd, check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)  # noqa: S603
         click.echo(" done")
     except (subprocess.CalledProcessError, FileNotFoundError):
         click.echo(" skipped (command unavailable)")
-    # Bytes freed is measured at the call site via disk_usage delta
-    return 0
 
 
-def _rm_dir(label: str, path: Path) -> int:
-    """Delete a directory and return the bytes it occupied (best-effort)."""
+def _rm_dir(label: str, path: Path) -> None:
+    """Delete a directory and print its label."""
     if not path.exists():
         click.echo(f"  {label}... skipped (not found)")
-        return 0
-    try:
-        size = sum(f.stat().st_size for f in path.rglob("*") if f.is_file())
-    except OSError:
-        size = 0
+        return
     click.echo(f"  {label}...", nl=False)
-    shutil.rmtree(path, ignore_errors=True)
-    click.echo(" done")
-    return size
+    try:
+        shutil.rmtree(path)
+        click.echo(" done")
+    except OSError as e:
+        click.echo(f" warning: partial deletion ({e})")
 
 
 @cli.command(name="devbox:cleanup:disk", help="Free disk space by cleaning caches and build artifacts")
@@ -552,43 +566,45 @@ def devbox_cleanup_disk(prune_docker: bool, prune_cargo: bool) -> None:
     Use --docker to also prune stopped containers.
     """
     home = Path.home()
-    disk_before = shutil.disk_usage(home).free
+    # Watch distinct filesystems: home covers uv/sccache/cargo; /nix covers Nix store
+    # (may be a separate volume); / covers Docker storage and anything else.
+    watch_paths = [p for p in [home, Path("/nix"), Path("/")] if p.exists()]
+    before = _snapshot_free(watch_paths)
 
     click.echo("Cleaning caches and build artifacts...")
     click.echo()
-
-    freed = 0
 
     # uv wheel/sdist cache
     _run_cleanup_step("uv cache (~/.cache/uv)", ["uv", "cache", "clean"])
 
     # sccache compiler cache
-    freed += _rm_dir("sccache (~/.cache/sccache)", home / ".cache" / "sccache")
+    _rm_dir("sccache (~/.cache/sccache)", home / ".cache" / "sccache")
 
     # pnpm orphaned store entries
     _run_cleanup_step("pnpm store (orphaned packages)", ["pnpm", "store", "prune"])
 
     click.echo("  Nix garbage collection (old generations)...", nl=False)
     try:
-        subprocess.run(["nix-collect-garbage", "-d"], check=True, capture_output=True)  # noqa: S603
+        subprocess.run(["nix-collect-garbage", "-d"], check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)  # noqa: S603
         click.echo(" done")
     except (subprocess.CalledProcessError, FileNotFoundError):
         click.echo(" skipped (nix-collect-garbage unavailable)")
 
     # Cargo build artifacts — opt-in because removing them forces a full Rust recompile
     if prune_cargo:
-        freed += _rm_dir("Cargo build artifacts (~/.cargo/target)", home / ".cargo" / "target")
+        _rm_dir("Cargo build artifacts (~/.cargo/target)", home / ".cargo" / "target")
 
     if prune_docker:
         click.echo("  Docker stopped containers...", nl=False)
         try:
-            subprocess.run(["docker", "container", "prune", "-f"], check=True, capture_output=True)  # noqa: S603
+            subprocess.run(
+                ["docker", "container", "prune", "-f"], check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
+            )  # noqa: S603
             click.echo(" done")
         except (subprocess.CalledProcessError, FileNotFoundError):
             click.echo(" skipped (Docker unavailable)")
 
-    disk_after = shutil.disk_usage(home).free
-    actually_freed = disk_after - disk_before
+    actually_freed = _sum_freed(before, _snapshot_free(watch_paths))
 
     click.echo()
     if actually_freed > 0:

--- a/common/hogli/manifest.yaml
+++ b/common/hogli/manifest.yaml
@@ -106,6 +106,7 @@ devbox:
     devbox:destroy: null
     devbox:status: null
     devbox:forward: null
+    devbox:cleanup:disk: null
 devenv:
     dev:setup: null
     dev:generate: null


### PR DESCRIPTION
## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

Adds `hogli devbox:cleanup:disk` to free disk space in Coder sandboxes. Default run cleans uv cache, sccache, pnpm orphaned packages, and Nix old generations — none of which force a rebuild. Use `--cargo` to also remove `~/.cargo/target` (opt-in, forces full Rust recompile). Use `--docker` to prune stopped containers.

## How did you test this code?

<!-- Briefly describe the steps you took, and what steps reviewers must take to get to where changes are, and what is the expected behavior. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

```
Cleaning caches and build artifacts...

  uv cache (~/.cache/uv)... skipped (command unavailable)
  sccache (~/.cache/sccache)... done
  pnpm store (orphaned packages)... done
  Nix garbage collection (old generations)... done

Freed 1.9G of disk space.
```

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

no

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->