### PR TITLE
chore(endpoints): remove cache_age_seconds from Django state

### DIFF
--- a/products/endpoints/backend/migrations/0028_remove_cache_age_seconds.py
+++ b/products/endpoints/backend/migrations/0028_remove_cache_age_seconds.py
@@ -1,0 +1,16 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("endpoints", "0027_copy_cache_age_to_data_freshness"),
+    ]
+
+    operations = [
+        migrations.SeparateDatabaseAndState(
+            state_operations=[
+                migrations.RemoveField(model_name="endpointversion", name="cache_age_seconds"),
+            ],
+            database_operations=[],  # No DB changes - column remains for rollback safety
+        ),
+    ]

--- a/products/endpoints/backend/migrations/max_migration.txt
+++ b/products/endpoints/backend/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0027_copy_cache_age_to_data_freshness
+0028_remove_cache_age_seconds

--- a/products/endpoints/backend/models.py
+++ b/products/endpoints/backend/models.py
@@ -9,8 +9,6 @@ from django.db import models
 from django.db.models import Q
 from django.utils import timezone
 
-from django_deprecate_fields import deprecate_field
-
 from posthog.schema import ProductKey
 
 from posthog.hogql import ast
@@ -116,15 +114,6 @@ class EndpointVersion(UpdatedMetaFields, models.Model):
         related_name="endpoint_versions_created",
     )
 
-    # Deprecated: superseded by data_freshness_seconds. Kept for rollback safety until
-    # migration 0028 (state-only) and 0029 (physical drop) land.
-    cache_age_seconds = deprecate_field(
-        models.IntegerField(
-            null=True,
-            blank=True,
-            help_text="Cache age in seconds. If null, uses default interval-based caching.",
-        )
-    )
     data_freshness_seconds = models.IntegerField(
         default=86400,
         help_text="How fresh the data should be, in seconds. Controls cache TTL and materialization sync frequency.",


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

we added data freshness to the model - this cache age is now useless

## Changes

- remove cache_age_seconds from the model

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

- ran it

<!-- Briefly describe the steps you took, and what steps reviewers must take to get to where changes are, and what is the expected behavior. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Publish to changelog?

nah

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->