### PR TITLE
chore(ci): download mmdb in ci-python workflow

### DIFF
--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -105,6 +105,11 @@ jobs:
               run: |
                   UV_PROJECT_ENVIRONMENT=$pythonLocation uv sync --frozen --dev
 
+            - name: Download GeoIP database
+              shell: bash
+              run: |
+                  ./bin/download-mmdb
+
             - name: Check for syntax errors, import sort, and code style violations
               shell: bash
               run: |


### PR DESCRIPTION
## Problem

The `ci-python.yml` workflow prints a noisy `GeoIP2Exception` traceback during mypy runs, which confused a contributor into thinking it was the cause of a CI failure (see #53748). The mypy Django plugin (`django_settings_module = "posthog.settings"`) partially bootstraps Django, triggering the module-level `GeoIP2()` call in `posthog/geoip.py` — which fails loudly when the mmdb file is missing.

## Changes

Add `./bin/download-mmdb` step to `ci-python.yml`, matching every other CI workflow that touches Python.

## How did you test this code?

Agent-authored — not tested manually. The change mirrors the existing `download-mmdb` step in `ci-backend.yml`, `ci-e2e-playwright.yml`, `ci-nodejs.yml`, `ci-rust.yml`, and `ci-rust-flags-integration.yml`.

## Publish to changelog?

No

## Docs update

N/A

## 🤖 LLM context

Investigated the GeoIP noise in `ci-python.yml` after it confused a bot reporting on #53748. Root cause: mypy's Django plugin loads `posthog.settings`, which imports `posthog/geoip.py` at module level, and the mmdb was never downloaded in this workflow.