### PR TITLE
fix(surveys): allow API survey branding edits

### DIFF
--- a/frontend/src/scenes/surveys/SurveyAPIEditor.test.tsx
+++ b/frontend/src/scenes/surveys/SurveyAPIEditor.test.tsx
@@ -2,8 +2,9 @@ import '@testing-library/jest-dom'
 
 import { render, screen } from '@testing-library/react'
 
-import { SurveyQuestionType, SurveyType } from '~/types'
+import { SurveyType } from '~/types'
 
+import { type NewSurvey, NEW_SURVEY } from './constants'
 import { SurveyAPIEditor } from './SurveyAPIEditor'
 
 jest.mock('lib/components/CodeSnippet', () => ({
@@ -13,33 +14,26 @@ jest.mock('lib/components/CodeSnippet', () => ({
 
 describe('SurveyAPIEditor', () => {
     it('includes appearance settings in the rendered payload', () => {
+        const survey = {
+            ...NEW_SURVEY,
+            id: 'survey-id',
+            name: 'API survey',
+            type: SurveyType.API,
+            questions: [
+                {
+                    ...NEW_SURVEY.questions[0],
+                    id: 'question-id',
+                    question: 'How did this go?',
+                },
+            ],
+            appearance: {
+                ...NEW_SURVEY.appearance,
+                whiteLabel: true,
+            },
+        } satisfies NewSurvey
+
         render(
-            <SurveyAPIEditor
-                survey={
-                    {
-                        id: 'survey-id',
-                        name: 'API survey',
-                        description: '',
-                        type: SurveyType.API,
-                        linked_flag: null,
-                        targeting_flag: null,
-                        questions: [
-                            {
-                                id: 'question-id',
-                                type: SurveyQuestionType.Open,
-                                question: 'How did this go?',
-                                description: '',
-                            },
-                        ],
-                        conditions: null,
-                        appearance: {
-                            whiteLabel: true,
-                        },
-                        start_date: null,
-                        end_date: null,
-                    } as any
-                }
-            />
+            <SurveyAPIEditor survey={survey} />
         )
 
         expect(screen.getByText(/"appearance": \{/)).toBeInTheDocument()

--- a/frontend/src/scenes/surveys/SurveyAPIEditor.test.tsx
+++ b/frontend/src/scenes/surveys/SurveyAPIEditor.test.tsx
@@ -1,0 +1,48 @@
+import '@testing-library/jest-dom'
+
+import { render, screen } from '@testing-library/react'
+
+import { SurveyQuestionType, SurveyType } from '~/types'
+
+import { SurveyAPIEditor } from './SurveyAPIEditor'
+
+jest.mock('lib/components/CodeSnippet', () => ({
+    CodeSnippet: ({ children }: { children: string }) => <pre>{children}</pre>,
+    Language: { JSON: 'json' },
+}))
+
+describe('SurveyAPIEditor', () => {
+    it('includes appearance settings in the rendered payload', () => {
+        render(
+            <SurveyAPIEditor
+                survey={
+                    {
+                        id: 'survey-id',
+                        name: 'API survey',
+                        description: '',
+                        type: SurveyType.API,
+                        linked_flag: null,
+                        targeting_flag: null,
+                        questions: [
+                            {
+                                id: 'question-id',
+                                type: SurveyQuestionType.Open,
+                                question: 'How did this go?',
+                                description: '',
+                            },
+                        ],
+                        conditions: null,
+                        appearance: {
+                            whiteLabel: true,
+                        },
+                        start_date: null,
+                        end_date: null,
+                    } as any
+                }
+            />
+        )
+
+        expect(screen.getByText(/"appearance": \{/)).toBeInTheDocument()
+        expect(screen.getByText(/"whiteLabel": true/)).toBeInTheDocument()
+    })
+})

--- a/frontend/src/scenes/surveys/SurveyAPIEditor.tsx
+++ b/frontend/src/scenes/surveys/SurveyAPIEditor.tsx
@@ -5,7 +5,6 @@ import { Survey } from '~/types'
 import { NewSurvey } from './constants'
 
 export function SurveyAPIEditor({ survey }: { survey: Survey | NewSurvey }): JSX.Element {
-    // Make sure this is synced to SurveyAPISerializer
     const apiSurvey = {
         id: survey.id,
         name: survey.name,
@@ -15,6 +14,7 @@ export function SurveyAPIEditor({ survey }: { survey: Survey | NewSurvey }): JSX
         targeting_flag_key: survey.targeting_flag ? survey.targeting_flag.key : null,
         questions: survey.questions,
         conditions: survey.conditions,
+        appearance: survey.appearance,
         start_date: survey.start_date,
         end_date: survey.end_date,
     }

--- a/frontend/src/scenes/surveys/SurveyEdit.tsx
+++ b/frontend/src/scenes/surveys/SurveyEdit.tsx
@@ -72,7 +72,7 @@ import { SurveyEditQuestionGroup, SurveyEditQuestionHeader } from './SurveyEditQ
 import { SurveyFormAppearance } from './SurveyFormAppearance'
 import { DataCollectionType, SurveyEditSection, surveyLogic } from './surveyLogic'
 import { surveysLogic } from './surveysLogic'
-import { canUseSurveyWizard } from './utils'
+import { canUseSurveyWizard, supportsSurveyCustomization } from './utils'
 
 function SurveyCompletionConditions(): JSX.Element {
     const { survey, dataCollectionType, isAdaptiveLimitFFEnabled } = useValues(surveyLogic)
@@ -764,7 +764,7 @@ export default function SurveyEdit({ id }: { id: string }): JSX.Element {
                                     </>
                                 ),
                             },
-                            ...(survey.type !== SurveyType.API
+                            ...(supportsSurveyCustomization(survey.type)
                                 ? [
                                       {
                                           key: SurveyEditSection.Customization,

--- a/frontend/src/scenes/surveys/utils.test.ts
+++ b/frontend/src/scenes/surveys/utils.test.ts
@@ -33,6 +33,7 @@ import {
     sanitizeSurvey,
     sanitizeSurveyAppearance,
     sanitizeSurveyDisplayConditions,
+    supportsSurveyCustomization,
     validateCSSProperty,
 } from './utils'
 
@@ -134,6 +135,15 @@ describe('survey utils', () => {
 
         it('returns undefined for undefined input', () => {
             expect(validateCSSProperty('color', undefined)).toBeUndefined()
+        })
+    })
+
+    describe('supportsSurveyCustomization', () => {
+        it('keeps customization enabled for API surveys', () => {
+            expect(supportsSurveyCustomization(SurveyType.API)).toBe(true)
+            expect(supportsSurveyCustomization(SurveyType.Popover)).toBe(true)
+            expect(supportsSurveyCustomization(SurveyType.Widget)).toBe(true)
+            expect(supportsSurveyCustomization(SurveyType.ExternalSurvey)).toBe(false)
         })
     })
 

--- a/frontend/src/scenes/surveys/utils.test.ts
+++ b/frontend/src/scenes/surveys/utils.test.ts
@@ -139,11 +139,14 @@ describe('survey utils', () => {
     })
 
     describe('supportsSurveyCustomization', () => {
-        it('keeps customization enabled for API surveys', () => {
-            expect(supportsSurveyCustomization(SurveyType.API)).toBe(true)
-            expect(supportsSurveyCustomization(SurveyType.Popover)).toBe(true)
-            expect(supportsSurveyCustomization(SurveyType.Widget)).toBe(true)
-            expect(supportsSurveyCustomization(SurveyType.ExternalSurvey)).toBe(false)
+        it.each([
+            [true, SurveyType.API],
+            [true, SurveyType.ExternalSurvey],
+            [true, SurveyType.FullScreen],
+            [true, SurveyType.Popover],
+            [true, SurveyType.Widget],
+        ])('returns %s for %s', (expected, surveyType) => {
+            expect(supportsSurveyCustomization(surveyType)).toBe(expected)
         })
     })
 

--- a/frontend/src/scenes/surveys/utils.ts
+++ b/frontend/src/scenes/surveys/utils.ts
@@ -441,7 +441,13 @@ export function canUseSurveyWizard(survey: Survey | NewSurvey): boolean {
 }
 
 export function supportsSurveyCustomization(surveyType: SurveyType): boolean {
-    return surveyType !== SurveyType.ExternalSurvey
+    return [
+        SurveyType.API,
+        SurveyType.ExternalSurvey,
+        SurveyType.FullScreen,
+        SurveyType.Popover,
+        SurveyType.Widget,
+    ].includes(surveyType)
 }
 
 export function doesSurveyHaveDisplayConditions(survey: Survey | NewSurvey): boolean {

--- a/frontend/src/scenes/surveys/utils.ts
+++ b/frontend/src/scenes/surveys/utils.ts
@@ -440,6 +440,10 @@ export function canUseSurveyWizard(survey: Survey | NewSurvey): boolean {
     return true
 }
 
+export function supportsSurveyCustomization(surveyType: SurveyType): boolean {
+    return surveyType !== SurveyType.ExternalSurvey
+}
+
 export function doesSurveyHaveDisplayConditions(survey: Survey | NewSurvey): boolean {
     const conditions = sanitizeSurveyDisplayConditions(survey.conditions)
     if (!conditions) {


### PR DESCRIPTION
## Problem

API surveys inherit survey appearance settings, but the full editor hides the customization section for `SurveyType.API`. That leaves `appearance.whiteLabel` effectively uneditable in PostHog once the survey exists, even though the backend supports it.

Closes #53036

## Changes

- allow the full surveys editor to show customization controls for API surveys
- include `appearance` in the API survey JSON preview so branding changes are visible in the payload
- add regression coverage for the API payload preview and the customization gating helper

## How did you test this code?

- `corepack pnpm exec oxlint --quiet frontend/src/scenes/surveys/SurveyEdit.tsx frontend/src/scenes/surveys/SurveyAPIEditor.tsx frontend/src/scenes/surveys/SurveyAPIEditor.test.tsx frontend/src/scenes/surveys/utils.ts frontend/src/scenes/surveys/utils.test.ts`
- `corepack pnpm --filter @posthog/frontend exec jest --config jest.config.ts --runInBand src/scenes/surveys/SurveyAPIEditor.test.tsx src/scenes/surveys/utils.test.ts`

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

no

## Docs update

No docs update needed.

## 🤖 LLM context

Session context: traced the API survey editor path, verified the customization panel was being gated off only for API surveys, then added focused frontend coverage around the editor gating and API payload preview.
