### PR TITLE
fix(ci): fall back when stamphog instrumentation fails

### DIFF
--- a/.github/workflows/pr-approval-agent.yml
+++ b/.github/workflows/pr-approval-agent.yml
@@ -73,16 +73,25 @@ jobs:
                   PR=${{ github.event.pull_request.number }}
                   VERDICT=$(jq -r '.final_verdict // ""' /tmp/review.json 2>/dev/null || echo "")
                   REASONING=$(jq -r '.reviewer.reasoning // ""' /tmp/review.json 2>/dev/null || echo "")
+                  FALLBACK_DEBUG=$(jq -r '.reviewer.fallback_debug_summary // ""' /tmp/review.json 2>/dev/null || echo "")
+                  WORKFLOW_RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                  BODY="$REASONING"
+                  FAIL_BODY="Review agent failed — check the [workflow run](${WORKFLOW_RUN_URL}) and re-apply the label to retry."
+
+                  if [ "$VERDICT" != "APPROVED" ] && [ -n "$FALLBACK_DEBUG" ]; then
+                    BODY=$(printf '%s\n\nDebug note: %s\nWorkflow run: %s' "$BODY" "$FALLBACK_DEBUG" "$WORKFLOW_RUN_URL")
+                    FAIL_BODY=$(printf '%s\n\nDebug note: %s\nWorkflow run: %s' "$FAIL_BODY" "$FALLBACK_DEBUG" "$WORKFLOW_RUN_URL")
+                  fi
 
                   if [ "$VERDICT" = "APPROVED" ]; then
-                    GH_TOKEN="$GH_TOKEN_APPROVE" gh pr review "$PR" --approve --body "$REASONING" \
+                    GH_TOKEN="$GH_TOKEN_APPROVE" gh pr review "$PR" --approve --body "$BODY" \
                       --repo ${{ github.repository }}
                   elif [ -n "$REASONING" ]; then
-                    gh pr review "$PR" --comment --body "$REASONING" \
+                    gh pr review "$PR" --comment --body "$BODY" \
                       --repo ${{ github.repository }}
                   else
                     gh pr comment "$PR" \
-                      --body "Review agent failed — check the [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) and re-apply the label to retry." \
+                      --body "$FAIL_BODY" \
                       --repo ${{ github.repository }}
                   fi
 

--- a/.github/workflows/pr-approval-agent.yml
+++ b/.github/workflows/pr-approval-agent.yml
@@ -73,14 +73,14 @@ jobs:
                   PR=${{ github.event.pull_request.number }}
                   VERDICT=$(jq -r '.final_verdict // ""' /tmp/review.json 2>/dev/null || echo "")
                   REASONING=$(jq -r '.reviewer.reasoning // ""' /tmp/review.json 2>/dev/null || echo "")
-                  FALLBACK_DEBUG=$(jq -r '.reviewer.fallback_debug_summary // ""' /tmp/review.json 2>/dev/null || echo "")
+                  DEBUG_SUMMARY=$(jq -r '.reviewer.debug_summary // .reviewer.fallback_debug_summary // ""' /tmp/review.json 2>/dev/null || echo "")
                   WORKFLOW_RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
                   BODY="$REASONING"
                   FAIL_BODY="Review agent failed — check the [workflow run](${WORKFLOW_RUN_URL}) and re-apply the label to retry."
 
-                  if [ "$VERDICT" != "APPROVED" ] && [ -n "$FALLBACK_DEBUG" ]; then
-                    BODY=$(printf '%s\n\nDebug note: %s\nWorkflow run: %s' "$BODY" "$FALLBACK_DEBUG" "$WORKFLOW_RUN_URL")
-                    FAIL_BODY=$(printf '%s\n\nDebug note: %s\nWorkflow run: %s' "$FAIL_BODY" "$FALLBACK_DEBUG" "$WORKFLOW_RUN_URL")
+                  if [ "$VERDICT" != "APPROVED" ] && [ -n "$DEBUG_SUMMARY" ]; then
+                    BODY=$(printf '%s\n\nDebug note: %s\nWorkflow run: %s' "$BODY" "$DEBUG_SUMMARY" "$WORKFLOW_RUN_URL")
+                    FAIL_BODY=$(printf '%s\n\nDebug note: %s\nWorkflow run: %s' "$FAIL_BODY" "$DEBUG_SUMMARY" "$WORKFLOW_RUN_URL")
                   fi
 
                   if [ "$VERDICT" = "APPROVED" ]; then

--- a/tools/pr-approval-agent/review_pr.py
+++ b/tools/pr-approval-agent/review_pr.py
@@ -24,6 +24,7 @@ import json
 import time
 import argparse
 from dataclasses import dataclass, field
+from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
 
 from gates import (
@@ -81,6 +82,22 @@ def _bold(msg: str) -> str:
 
 def _dim(msg: str) -> str:
     return f"\033[2m{msg}\033[0m"
+
+
+def _package_version(package_name: str) -> str:
+    try:
+        return version(package_name)
+    except PackageNotFoundError:
+        return "unknown"
+
+
+def _build_reviewer_error_summary(error: Exception) -> str:
+    return (
+        "Reviewer failed before producing a verdict. "
+        f"error={type(error).__name__}: {error}. "
+        f"posthoganalytics={_package_version('posthoganalytics')}, "
+        f"claude-agent-sdk={_package_version('claude-agent-sdk')}"
+    )
 
 
 # ── Gate result ──────────────────────────────────────────────────
@@ -305,6 +322,7 @@ class Pipeline:
 
         print(_dim("  Calling reviewer..."))
         max_retries = 3
+        last_error_summary: str | None = None
         for attempt in range(max_retries):
             try:
                 self.reviewer_output = reviewer.review(
@@ -314,6 +332,7 @@ class Pipeline:
                 )
                 break
             except Exception as e:
+                last_error_summary = _build_reviewer_error_summary(e)
                 if attempt < max_retries - 1:
                     wait = 2 ** (attempt + 1)
                     print(_warn(f"Reviewer failed (attempt {attempt + 1}/{max_retries}): {e}"))
@@ -326,6 +345,7 @@ class Pipeline:
                         "reasoning": f"Review agent failed after {max_retries} attempts — needs human review.",
                         "risk": "unknown",
                         "issues": [str(e)],
+                        "debug_summary": last_error_summary,
                     }
 
         llm_verdict = self.reviewer_output.get("verdict", "UNKNOWN")

--- a/tools/pr-approval-agent/reviewer.py
+++ b/tools/pr-approval-agent/reviewer.py
@@ -10,18 +10,24 @@ import json
 import asyncio
 import textwrap
 import subprocess
+from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
+from typing import Any
 
-from claude_agent_sdk import ClaudeAgentOptions, ResultMessage
+from claude_agent_sdk import (
+    ClaudeAgentOptions,
+    ResultMessage,
+    query as claude_query,
+)
 from claude_agent_sdk.types import AssistantMessage, ToolUseBlock
 from github import PRData
 
 try:
-    from posthoganalytics.ai.claude_agent_sdk import query
+    from posthoganalytics.ai.claude_agent_sdk import query as posthog_query
 
     _POSTHOG_AI_AVAILABLE = True
 except ImportError:
-    from claude_agent_sdk import query  # type: ignore[no-redef]
+    posthog_query = None
 
     _POSTHOG_AI_AVAILABLE = False
 
@@ -199,10 +205,58 @@ class Reviewer:
     def __init__(self, repo_root: Path, *, verbose: bool = False):
         self.repo_root = repo_root
         self.verbose = verbose
+        self._fallback_debug_summary: str | None = None
 
     def review(self, pr: PRData, classification: dict, gate_context: dict) -> dict:
         """Claude explores the repo and produces a verdict."""
         return asyncio.run(self._review(pr, classification, gate_context))
+
+    def _should_fallback_to_plain_sdk(self, error: Exception) -> bool:
+        message = str(error).lower()
+        return "api key is required" in message
+
+    def _package_version(self, package_name: str) -> str:
+        try:
+            return version(package_name)
+        except PackageNotFoundError:
+            return "unknown"
+
+    def _build_fallback_debug_summary(self, error: Exception) -> str:
+        return (
+            "PostHog Claude instrumentation failed before review started; "
+            f"fell back to plain Claude SDK. "
+            f"error={type(error).__name__}: {error}. "
+            f"posthoganalytics={self._package_version('posthoganalytics')}, "
+            f"claude-agent-sdk={self._package_version('claude-agent-sdk')}"
+        )
+
+    async def _query_with_fallback(
+        self,
+        *,
+        prompt: Any,
+        options: ClaudeAgentOptions,
+        posthog_kwargs: dict,
+    ):
+        if _POSTHOG_AI_AVAILABLE and posthog_query is not None:
+            yielded_message = False
+            try:
+                async for message in posthog_query(prompt=prompt, options=options, **posthog_kwargs):
+                    yielded_message = True
+                    yield message
+                return
+            except Exception as error:
+                if yielded_message or not self._should_fallback_to_plain_sdk(error):
+                    raise
+                self._fallback_debug_summary = self._build_fallback_debug_summary(error)
+                print(
+                    "\033[2m"
+                    f"  PostHog instrumentation failed before review started ({error}); "
+                    "retrying with plain Claude SDK."
+                    "\033[0m"
+                )
+
+        async for message in claude_query(prompt=prompt, options=options):
+            yield message
 
     async def _review(self, pr: PRData, classification: dict, gate_context: dict) -> dict:
         diff_path = self._write_diff_file(pr)
@@ -240,7 +294,7 @@ class Reviewer:
             }
 
         structured_output = None
-        async for message in query(prompt=prompt, options=options, **posthog_kwargs):
+        async for message in self._query_with_fallback(prompt=prompt, options=options, posthog_kwargs=posthog_kwargs):
             if self.verbose:
                 print(f"\033[2m    [{type(message).__name__}]\033[0m", flush=True)
             if isinstance(message, ResultMessage):
@@ -257,7 +311,10 @@ class Reviewer:
 
         if structured_output is None:
             raise RuntimeError("Reviewer agent returned no structured output")
-        return _validate_verdict(structured_output)
+        validated_output = _validate_verdict(structured_output)
+        if self._fallback_debug_summary:
+            validated_output["fallback_debug_summary"] = self._fallback_debug_summary
+        return validated_output
 
     def _log_tool_call(self, block: ToolUseBlock) -> None:
         name = block.name

--- a/tools/pr-approval-agent/reviewer.py
+++ b/tools/pr-approval-agent/reviewer.py
@@ -314,6 +314,7 @@ class Reviewer:
             raise RuntimeError("Reviewer agent returned no structured output")
         validated_output = _validate_verdict(structured_output)
         if self._fallback_debug_summary:
+            validated_output["debug_summary"] = self._fallback_debug_summary
             validated_output["fallback_debug_summary"] = self._fallback_debug_summary
         return validated_output
 

--- a/tools/pr-approval-agent/reviewer.py
+++ b/tools/pr-approval-agent/reviewer.py
@@ -209,6 +209,7 @@ class Reviewer:
 
     def review(self, pr: PRData, classification: dict, gate_context: dict) -> dict:
         """Claude explores the repo and produces a verdict."""
+        self._fallback_debug_summary = None
         return asyncio.run(self._review(pr, classification, gate_context))
 
     def _should_fallback_to_plain_sdk(self, error: Exception) -> bool:

--- a/tools/pr-approval-agent/test_review_pr.py
+++ b/tools/pr-approval-agent/test_review_pr.py
@@ -1,0 +1,134 @@
+"""Tests for review_pr pipeline debug summaries."""
+
+import sys
+import types
+from dataclasses import dataclass
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+
+
+def _load_review_pr_module(monkeypatch, *, reviewer_class):
+    gates_module = types.ModuleType("gates")
+    gates_module.MAX_FILES = 100
+    gates_module.MAX_LINES = 1000
+    gates_module.assign_tier = lambda **kwargs: "T1-agent"
+    gates_module.classify_files = lambda file_paths: {"categories": [], "top_dirs": []}
+    gates_module.detect_deny_categories = lambda file_paths, title: []
+    gates_module.detect_ownership = lambda file_paths, ownership_rules: {
+        "team_count": 0,
+        "teams": [],
+        "cross_team": False,
+    }
+    gates_module.has_ci_workflow_changes = lambda file_paths: False
+    gates_module.has_dependency_changes = lambda file_paths: False
+    gates_module.is_allow_listed_only = lambda file_paths: False
+    gates_module.parse_codeowners_soft = lambda path: []
+    gates_module.parse_conventional_commit = lambda title: {"type": "fix", "scope": "ci"}
+    gates_module.scope_breadth = lambda top_dirs: "single-area"
+    gates_module.t1_risk_subclass = lambda **kwargs: "T1b-small"
+    gates_module.test_only = lambda categories: False
+
+    @dataclass
+    class PRData:
+        number: int
+        repo: str
+        title: str
+        state: str
+        draft: bool
+        mergeable_state: str
+        author: str
+        labels: list[str]
+        base_sha: str
+        head_sha: str
+        files: list[dict]
+        reviews: list[dict]
+        review_comments: list[dict]
+        check_runs: list[dict]
+
+        @property
+        def file_paths(self) -> list[str]:
+            return [f["filename"] for f in self.files]
+
+        @property
+        def has_new_files(self) -> bool:
+            return any(f.get("status") == "A" for f in self.files)
+
+        @property
+        def lines_added(self) -> int:
+            return sum(f["additions"] for f in self.files)
+
+        @property
+        def lines_deleted(self) -> int:
+            return sum(f["deletions"] for f in self.files)
+
+        @property
+        def lines_total(self) -> int:
+            return self.lines_added + self.lines_deleted
+
+    github_module = types.ModuleType("github")
+    github_module.PRData = PRData
+    github_module.check_team_membership = lambda author, team_slug: False
+    github_module.fetch_pr = lambda pr_number, repo, repo_root=None: None
+
+    reviewer_module = types.ModuleType("reviewer")
+    reviewer_module.Reviewer = reviewer_class
+
+    monkeypatch.setitem(sys.modules, "gates", gates_module)
+    monkeypatch.setitem(sys.modules, "github", github_module)
+    monkeypatch.setitem(sys.modules, "reviewer", reviewer_module)
+
+    review_pr_path = Path(__file__).with_name("review_pr.py")
+    spec = spec_from_file_location("review_pr_under_test", review_pr_path)
+    module = module_from_spec(spec)
+    assert spec and spec.loader
+    monkeypatch.setitem(sys.modules, "review_pr_under_test", module)
+    spec.loader.exec_module(module)
+    return module, PRData
+
+
+def test_pipeline_surfaces_debug_summary_when_reviewer_retries_exhaust(monkeypatch) -> None:
+    class Reviewer:
+        def __init__(self, repo_root, *, verbose: bool = False):
+            self.repo_root = repo_root
+            self.verbose = verbose
+
+        def review(self, pr, classification, gate_context):
+            raise RuntimeError("connection refused")
+
+    review_pr_module, pr_data_class = _load_review_pr_module(monkeypatch, reviewer_class=Reviewer)
+    monkeypatch.setattr(review_pr_module.time, "sleep", lambda seconds: None)
+
+    pipeline = review_pr_module.Pipeline(53958, "PostHog/posthog")
+    pipeline.pr = pr_data_class(
+        number=53958,
+        repo="PostHog/posthog",
+        title="fix(ci): fall back when stamphog instrumentation fails",
+        state="OPEN",
+        draft=False,
+        mergeable_state="MERGEABLE",
+        author="lucasheriques",
+        labels=[],
+        base_sha="base",
+        head_sha="head",
+        files=[{"filename": "tools/pr-approval-agent/reviewer.py", "additions": 10, "deletions": 2}],
+        reviews=[],
+        review_comments=[],
+        check_runs=[],
+    )
+    pipeline.classification = {
+        "tier": "T1-agent",
+        "t1_subclass": "T1b-small",
+        "breadth": "single-area",
+        "commit_type": "fix",
+    }
+    pipeline.gate_results = []
+
+    pipeline._llm_review("PENDING")
+
+    assert pipeline.final_verdict == "ESCALATE"
+    assert pipeline.reviewer_output["verdict"] == "ESCALATE"
+    assert pipeline.reviewer_output["reasoning"] == "Review agent failed after 3 attempts — needs human review."
+    assert pipeline.reviewer_output["issues"] == ["connection refused"]
+    assert pipeline.reviewer_output["debug_summary"].startswith(
+        "Reviewer failed before producing a verdict. error=RuntimeError: connection refused."
+    )

--- a/tools/pr-approval-agent/test_reviewer.py
+++ b/tools/pr-approval-agent/test_reviewer.py
@@ -1,0 +1,170 @@
+"""Tests for reviewer fallback behavior."""
+
+import sys
+import types
+from dataclasses import dataclass
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+
+
+def _load_reviewer_module(monkeypatch, *, posthog_query_factory):
+    call_order: list[str] = []
+
+    class ClaudeAgentOptions:
+        def __init__(self, **kwargs):
+            self.system_prompt = kwargs.get("system_prompt")
+            self.allowed_tools = kwargs.get("allowed_tools")
+            self.disallowed_tools = kwargs.get("disallowed_tools")
+            self.cwd = kwargs.get("cwd")
+            self.max_turns = kwargs.get("max_turns")
+            self.model = kwargs.get("model")
+            self.permission_mode = kwargs.get("permission_mode")
+            self.output_format = kwargs.get("output_format")
+            self.effort = kwargs.get("effort")
+            self.extra_args = kwargs.get("extra_args")
+            self.include_partial_messages = kwargs.get("include_partial_messages", False)
+
+    class ResultMessage:
+        def __init__(self, structured_output=None, subtype=None):
+            self.structured_output = structured_output
+            self.subtype = subtype
+
+    class AssistantMessage:
+        def __init__(self, content=None):
+            self.content = content or []
+
+    class ToolUseBlock:
+        def __init__(self, name="", input=None):
+            self.name = name
+            self.input = input or {}
+
+    async def base_query(*, prompt, options, transport=None):
+        call_order.append("plain")
+        yield ResultMessage(
+            structured_output={
+                "verdict": "APPROVE",
+                "reasoning": "No showstoppers, low-risk fix.",
+                "risk": "low",
+                "issues": [],
+            }
+        )
+
+    claude_agent_sdk = types.ModuleType("claude_agent_sdk")
+    claude_agent_sdk.ClaudeAgentOptions = ClaudeAgentOptions
+    claude_agent_sdk.ResultMessage = ResultMessage
+    claude_agent_sdk.query = base_query
+
+    claude_agent_sdk_types = types.ModuleType("claude_agent_sdk.types")
+    claude_agent_sdk_types.AssistantMessage = AssistantMessage
+    claude_agent_sdk_types.ToolUseBlock = ToolUseBlock
+
+    @dataclass
+    class PRData:
+        number: int
+        repo: str
+        title: str
+        state: str
+        draft: bool
+        mergeable_state: str
+        author: str
+        labels: list[str]
+        base_sha: str
+        head_sha: str
+        files: list[dict]
+        reviews: list[dict]
+        review_comments: list[dict]
+        check_runs: list[dict]
+
+        @property
+        def lines_added(self) -> int:
+            return sum(f["additions"] for f in self.files)
+
+        @property
+        def lines_deleted(self) -> int:
+            return sum(f["deletions"] for f in self.files)
+
+        @property
+        def lines_total(self) -> int:
+            return self.lines_added + self.lines_deleted
+
+    github_module = types.ModuleType("github")
+    github_module.PRData = PRData
+
+    monkeypatch.setitem(sys.modules, "claude_agent_sdk", claude_agent_sdk)
+    monkeypatch.setitem(sys.modules, "claude_agent_sdk.types", claude_agent_sdk_types)
+    monkeypatch.setitem(sys.modules, "github", github_module)
+
+    if posthog_query_factory is not None:
+        posthoganalytics_module = types.ModuleType("posthoganalytics")
+        posthoganalytics_ai_module = types.ModuleType("posthoganalytics.ai")
+        posthoganalytics_claude_module = types.ModuleType("posthoganalytics.ai.claude_agent_sdk")
+        posthoganalytics_claude_module.query = posthog_query_factory(call_order, ResultMessage)
+        monkeypatch.setitem(sys.modules, "posthoganalytics", posthoganalytics_module)
+        monkeypatch.setitem(sys.modules, "posthoganalytics.ai", posthoganalytics_ai_module)
+        monkeypatch.setitem(sys.modules, "posthoganalytics.ai.claude_agent_sdk", posthoganalytics_claude_module)
+    else:
+        monkeypatch.delitem(sys.modules, "posthoganalytics.ai.claude_agent_sdk", raising=False)
+        monkeypatch.delitem(sys.modules, "posthoganalytics.ai", raising=False)
+        monkeypatch.delitem(sys.modules, "posthoganalytics", raising=False)
+
+    reviewer_path = Path(__file__).with_name("reviewer.py")
+    spec = spec_from_file_location("reviewer_under_test", reviewer_path)
+    module = module_from_spec(spec)
+    assert spec and spec.loader
+    monkeypatch.setitem(sys.modules, "reviewer_under_test", module)
+    spec.loader.exec_module(module)
+    return module, PRData, call_order
+
+
+def test_reviewer_falls_back_to_plain_sdk_when_posthog_wrapper_requires_api_key(monkeypatch, tmp_path) -> None:
+    def failing_posthog_query_factory(call_order, _result_message_class):
+        async def failing_posthog_query(*, prompt, options, **kwargs):
+            call_order.append("posthog")
+            raise RuntimeError("API key is required")
+            yield
+
+        return failing_posthog_query
+
+    reviewer_module, pr_data_class, call_order = _load_reviewer_module(
+        monkeypatch, posthog_query_factory=failing_posthog_query_factory
+    )
+
+    diff_path = tmp_path / "diff.patch"
+    diff_path.write_text("")
+    monkeypatch.setattr(reviewer_module.Reviewer, "_write_diff_file", lambda self, pr: diff_path)
+
+    reviewer = reviewer_module.Reviewer(tmp_path)
+    pr = pr_data_class(
+        number=53945,
+        repo="PostHog/posthog",
+        title="fix(surveys): default new survey to guided wizard",
+        state="OPEN",
+        draft=False,
+        mergeable_state="MERGEABLE",
+        author="lucasheriques",
+        labels=[],
+        base_sha="base",
+        head_sha="head",
+        files=[
+            {"filename": "frontend/src/scenes/surveys/wizard/SurveyWizard.test.tsx", "additions": 5, "deletions": 1}
+        ],
+        reviews=[],
+        review_comments=[],
+        check_runs=[],
+    )
+
+    result = reviewer.review(
+        pr,
+        {"tier": "T1-agent", "t1_subclass": "T1b-small", "breadth": "single-area", "commit_type": "fix"},
+        {"gate_verdict": "ALLOWED", "gates": []},
+    )
+
+    assert result["verdict"] == "APPROVE"
+    assert result["reasoning"] == "No showstoppers, low-risk fix."
+    assert result["risk"] == "low"
+    assert result["issues"] == []
+    assert result["fallback_debug_summary"].startswith(
+        "PostHog Claude instrumentation failed before review started; fell back to plain Claude SDK. "
+        "error=RuntimeError: API key is required."
+    )
+    assert call_order == ["posthog", "plain"]

--- a/tools/pr-approval-agent/test_reviewer.py
+++ b/tools/pr-approval-agent/test_reviewer.py
@@ -6,6 +6,8 @@ from dataclasses import dataclass
 from importlib.util import module_from_spec, spec_from_file_location
 from pathlib import Path
 
+import pytest
+
 
 def _load_reviewer_module(monkeypatch, *, posthog_query_factory):
     call_order: list[str] = []
@@ -116,25 +118,8 @@ def _load_reviewer_module(monkeypatch, *, posthog_query_factory):
     return module, PRData, call_order
 
 
-def test_reviewer_falls_back_to_plain_sdk_when_posthog_wrapper_requires_api_key(monkeypatch, tmp_path) -> None:
-    def failing_posthog_query_factory(call_order, _result_message_class):
-        async def failing_posthog_query(*, prompt, options, **kwargs):
-            call_order.append("posthog")
-            raise RuntimeError("API key is required")
-            yield
-
-        return failing_posthog_query
-
-    reviewer_module, pr_data_class, call_order = _load_reviewer_module(
-        monkeypatch, posthog_query_factory=failing_posthog_query_factory
-    )
-
-    diff_path = tmp_path / "diff.patch"
-    diff_path.write_text("")
-    monkeypatch.setattr(reviewer_module.Reviewer, "_write_diff_file", lambda self, pr: diff_path)
-
-    reviewer = reviewer_module.Reviewer(tmp_path)
-    pr = pr_data_class(
+def _build_test_pr(pr_data_class) -> object:
+    return pr_data_class(
         number=53945,
         repo="PostHog/posthog",
         title="fix(surveys): default new survey to guided wizard",
@@ -153,18 +138,58 @@ def test_reviewer_falls_back_to_plain_sdk_when_posthog_wrapper_requires_api_key(
         check_runs=[],
     )
 
-    result = reviewer.review(
-        pr,
-        {"tier": "T1-agent", "t1_subclass": "T1b-small", "breadth": "single-area", "commit_type": "fix"},
-        {"gate_verdict": "ALLOWED", "gates": []},
-    )
 
-    assert result["verdict"] == "APPROVE"
-    assert result["reasoning"] == "No showstoppers, low-risk fix."
-    assert result["risk"] == "low"
-    assert result["issues"] == []
-    assert result["fallback_debug_summary"].startswith(
-        "PostHog Claude instrumentation failed before review started; fell back to plain Claude SDK. "
-        "error=RuntimeError: API key is required."
+@pytest.mark.parametrize(
+    ("error_message", "yields_first", "expect_fallback"),
+    [
+        ("API key is required", False, True),
+        ("connection refused", False, False),
+        ("API key is required", True, False),
+    ],
+)
+def test_query_with_fallback_behavior(
+    monkeypatch, tmp_path, error_message: str, yields_first: bool, expect_fallback: bool
+) -> None:
+    def posthog_query_factory(call_order, result_message_class):
+        async def posthog_query(*, prompt, options, **kwargs):
+            call_order.append("posthog")
+            if yields_first:
+                yield result_message_class()
+            raise RuntimeError(error_message)
+
+        return posthog_query
+
+    reviewer_module, pr_data_class, call_order = _load_reviewer_module(
+        monkeypatch, posthog_query_factory=posthog_query_factory
     )
-    assert call_order == ["posthog", "plain"]
+    diff_path = tmp_path / "diff.patch"
+    diff_path.write_text("")
+    monkeypatch.setattr(reviewer_module.Reviewer, "_write_diff_file", lambda self, pr: diff_path)
+
+    reviewer = reviewer_module.Reviewer(tmp_path)
+    pr = _build_test_pr(pr_data_class)
+
+    if expect_fallback:
+        result = reviewer.review(
+            pr,
+            {"tier": "T1-agent", "t1_subclass": "T1b-small", "breadth": "single-area", "commit_type": "fix"},
+            {"gate_verdict": "ALLOWED", "gates": []},
+        )
+
+        assert result["verdict"] == "APPROVE"
+        assert result["reasoning"] == "No showstoppers, low-risk fix."
+        assert result["risk"] == "low"
+        assert result["issues"] == []
+        assert result["fallback_debug_summary"].startswith(
+            "PostHog Claude instrumentation failed before review started; fell back to plain Claude SDK. "
+            "error=RuntimeError: API key is required."
+        )
+        assert call_order == ["posthog", "plain"]
+    else:
+        with pytest.raises(RuntimeError, match=error_message):
+            reviewer.review(
+                pr,
+                {"tier": "T1-agent", "t1_subclass": "T1b-small", "breadth": "single-area", "commit_type": "fix"},
+                {"gate_verdict": "ALLOWED", "gates": []},
+            )
+        assert call_order == ["posthog"]


### PR DESCRIPTION
## Problem

Stamphog can fail before producing a review verdict, but today the PR thread often only gets a generic failure comment. That makes it slow to triage reviewer/runtime issues because the useful context lives in the workflow logs.

## Changes

- fall back to plain `claude_agent_sdk.query` when the PostHog wrapper fails before producing output with the known startup auth error
- clear fallback state between review calls so stale debug context does not leak across reviews
- expose a generic `debug_summary` in `review.json` for non-approval outcomes, including repeated reviewer failures that never reach the fallback path
- include that debug summary in the PR comment together with the workflow run link
- add tests for fallback, non-fallback, and retry-exhausted reviewer failures

## How did you test this code?

- `pytest tools/pr-approval-agent/test_reviewer.py tools/pr-approval-agent/test_review_pr.py tools/pr-approval-agent/test_gates.py tools/pr-approval-agent/test_github.py -q`
- `ruff check tools/pr-approval-agent/reviewer.py tools/pr-approval-agent/review_pr.py tools/pr-approval-agent/test_reviewer.py tools/pr-approval-agent/test_review_pr.py`

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

no

## Docs update

no docs update needed

## 🤖 LLM context

Authored in Codex while investigating stamphog review failures. The change keeps successful review output unchanged, but makes non-approval failures easier to debug from the PR thread instead of requiring workflow log inspection first.
