### PR TITLE
chore(alerts): add schedule restriction window count to alert usage events

### DIFF
--- a/posthog/api/test/test_alert.py
+++ b/posthog/api/test/test_alert.py
@@ -1,7 +1,6 @@
 from copy import deepcopy
 from datetime import UTC, datetime, timedelta
 from typing import Any
-from uuid import UUID
 
 from freezegun import freeze_time
 from posthog.test.base import APIBaseTest, QueryMatchingTest
@@ -982,33 +981,3 @@ class TestAlertAPIKeyAccess(APIBaseTest):
         assert response.status_code == expected_status
         if error_scope:
             assert error_scope in response.json()["detail"]
-
-
-class TestInsightAlertUsageEventProperties:
-    """Guarantees usage analytics for insight alerts expose schedule restriction window count."""
-
-    @parameterized.expand(
-        [
-            ("unset", None, None),
-            ("empty object", {}, None),
-            ("empty windows", {"blocked_windows": []}, 0),
-            ("not a list", {"blocked_windows": "oops"}, None),
-            ("single window", {"blocked_windows": [{"start": "22:00", "end": "07:00"}]}, 1),
-            (
-                "two windows",
-                {"blocked_windows": [{"start": "22:00", "end": "23:00"}, {"start": "10:00", "end": "11:00"}]},
-                2,
-            ),
-        ]
-    )
-    def test_alert_usage_payload_includes_schedule_restriction_blocked_window_count(
-        self, _label: str, schedule_restriction: dict[str, Any] | None, expected_count: int | None
-    ) -> None:
-        alert = AlertConfiguration()
-        alert.id = UUID("00000000-0000-0000-0000-000000000001")
-        alert.name = "n"
-        alert.condition = {"type": AlertConditionType.ABSOLUTE_VALUE}
-        alert.calculation_interval = "daily"
-        alert.schedule_restriction = schedule_restriction
-        props = alert._get_event_properties()
-        assert props["schedule_restriction_blocked_window_count"] == expected_count

--- a/posthog/api/test/test_alert.py
+++ b/posthog/api/test/test_alert.py
@@ -1,6 +1,7 @@
 from copy import deepcopy
 from datetime import UTC, datetime, timedelta
 from typing import Any
+from uuid import UUID
 
 from freezegun import freeze_time
 from posthog.test.base import APIBaseTest, QueryMatchingTest
@@ -981,3 +982,33 @@ class TestAlertAPIKeyAccess(APIBaseTest):
         assert response.status_code == expected_status
         if error_scope:
             assert error_scope in response.json()["detail"]
+
+
+class TestInsightAlertUsageEventProperties:
+    """Guarantees usage analytics for insight alerts expose schedule restriction window count."""
+
+    @parameterized.expand(
+        [
+            ("unset", None, None),
+            ("empty object", {}, None),
+            ("empty windows", {"blocked_windows": []}, 0),
+            ("not a list", {"blocked_windows": "oops"}, None),
+            ("single window", {"blocked_windows": [{"start": "22:00", "end": "07:00"}]}, 1),
+            (
+                "two windows",
+                {"blocked_windows": [{"start": "22:00", "end": "23:00"}, {"start": "10:00", "end": "11:00"}]},
+                2,
+            ),
+        ]
+    )
+    def test_alert_usage_payload_includes_schedule_restriction_blocked_window_count(
+        self, _label: str, schedule_restriction: dict[str, Any] | None, expected_count: int | None
+    ) -> None:
+        alert = AlertConfiguration()
+        alert.id = UUID("00000000-0000-0000-0000-000000000001")
+        alert.name = "n"
+        alert.condition = {"type": AlertConditionType.ABSOLUTE_VALUE}
+        alert.calculation_interval = "daily"
+        alert.schedule_restriction = schedule_restriction
+        props = alert._get_event_properties()
+        assert props["schedule_restriction_blocked_window_count"] == expected_count

--- a/posthog/models/alert.py
+++ b/posthog/models/alert.py
@@ -159,7 +159,7 @@ class AlertConfiguration(ModelActivityMixin, CreatedMetaFields, UUIDTModel):
             "alert_name": self.name,
             "condition_type": self.condition.get("type") if self.condition else None,
             "calculation_interval": self.calculation_interval,
-            "schedule_restriction_count": blocked_window_count,
+            "schedule_restriction_blocked_window_count": blocked_window_count,
         }
 
     def report_created(self, user: User, analytics_props: AnalyticsProps | None = None) -> None:

--- a/posthog/models/alert.py
+++ b/posthog/models/alert.py
@@ -147,11 +147,19 @@ class AlertConfiguration(ModelActivityMixin, CreatedMetaFields, UUIDTModel):
         super().save(*args, **kwargs)
 
     def _get_event_properties(self) -> dict:
+        schedule_restriction = self.schedule_restriction
+        blocked_window_count: int | None = None
+        if isinstance(schedule_restriction, dict):
+            windows = schedule_restriction.get("blocked_windows")
+            if isinstance(windows, list):
+                blocked_window_count = len(windows)
+
         return {
             "alert_id": self.id,
             "alert_name": self.name,
             "condition_type": self.condition.get("type") if self.condition else None,
             "calculation_interval": self.calculation_interval,
+            "schedule_restriction_count": blocked_window_count,
         }
 
     def report_created(self, user: User, analytics_props: AnalyticsProps | None = None) -> None:


### PR DESCRIPTION
## Problem

`alert created` and `alert updated` usage events did not include any signal for insight alert quiet hours (`schedule_restriction`), which makes adoption hard to measure.

## Changes

- Add `schedule_restriction_blocked_window_count` to `AlertConfiguration._get_event_properties()` (included on existing backend `report_user_action` calls).
- The value is JSON `null` when schedule restriction is unset or not a well-formed `blocked_windows` list; otherwise it is the integer count of windows (including `0` when an empty list is stored).

## How did you test this code?

Ran `./bin/hogli test posthog/api/test/test_alert.py::TestInsightAlertUsageEventProperties`.

## Publish to changelog?

no

## Docs update

no

## 🤖 LLM context

Agent-authored change: backend-only analytics properties on existing insight alert usage events; parameterized tests in `posthog/api/test/test_alert.py`.
