### PR TITLE
fix(llma): fix stamphog posthog SDK integration

### DIFF
--- a/.github/workflows/pr-approval-agent.yml
+++ b/.github/workflows/pr-approval-agent.yml
@@ -54,6 +54,7 @@ jobs:
             - name: Run review
               env:
                   ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+                  POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_TOKEN }}
                   GH_TOKEN: ${{ steps.app-token.outputs.token }}
               run: |
                   uv run tools/pr-approval-agent/review_pr.py \

--- a/tools/pr-approval-agent/reviewer.py
+++ b/tools/pr-approval-agent/reviewer.py
@@ -17,7 +17,12 @@ from claude_agent_sdk.types import AssistantMessage, ToolUseBlock
 from github import PRData
 
 try:
+    import os
+
     import posthoganalytics
+
+    posthoganalytics.api_key = os.environ.get("POSTHOG_API_KEY", "")
+    posthoganalytics.host = os.environ.get("POSTHOG_HOST", "https://us.i.posthog.com")
 
     if posthoganalytics.api_key:
         from posthoganalytics.ai.claude_agent_sdk import query  # type: ignore[no-redef]  # noqa: F811

--- a/tools/pr-approval-agent/reviewer.py
+++ b/tools/pr-approval-agent/reviewer.py
@@ -12,11 +12,7 @@ import textwrap
 import subprocess
 from pathlib import Path
 
-from claude_agent_sdk import (
-    ClaudeAgentOptions,
-    ResultMessage,
-    query as _original_query,
-)
+from claude_agent_sdk import ClaudeAgentOptions, ResultMessage, query
 from claude_agent_sdk.types import AssistantMessage, ToolUseBlock
 from github import PRData
 
@@ -24,14 +20,12 @@ try:
     import posthoganalytics
 
     if posthoganalytics.api_key:
-        from posthoganalytics.ai.claude_agent_sdk import query  # type: ignore[no-redef]
+        from posthoganalytics.ai.claude_agent_sdk import query  # type: ignore[no-redef]  # noqa: F811
 
         _POSTHOG_AI_AVAILABLE = True
     else:
-        query = _original_query
         _POSTHOG_AI_AVAILABLE = False
 except ImportError:
-    query = _original_query
     _POSTHOG_AI_AVAILABLE = False
 
 MODEL = "claude-sonnet-4-6"

--- a/tools/pr-approval-agent/reviewer.py
+++ b/tools/pr-approval-agent/reviewer.py
@@ -12,17 +12,26 @@ import textwrap
 import subprocess
 from pathlib import Path
 
-from claude_agent_sdk import ClaudeAgentOptions, ResultMessage
+from claude_agent_sdk import (
+    ClaudeAgentOptions,
+    ResultMessage,
+    query as _original_query,
+)
 from claude_agent_sdk.types import AssistantMessage, ToolUseBlock
 from github import PRData
 
 try:
-    from posthoganalytics.ai.claude_agent_sdk import query
+    import posthoganalytics
 
-    _POSTHOG_AI_AVAILABLE = True
+    if posthoganalytics.api_key:
+        from posthoganalytics.ai.claude_agent_sdk import query  # type: ignore[no-redef]
+
+        _POSTHOG_AI_AVAILABLE = True
+    else:
+        query = _original_query
+        _POSTHOG_AI_AVAILABLE = False
 except ImportError:
-    from claude_agent_sdk import query  # type: ignore[no-redef]
-
+    query = _original_query
     _POSTHOG_AI_AVAILABLE = False
 
 MODEL = "claude-sonnet-4-6"


### PR DESCRIPTION
## Problem

StampHog CI failures since `posthoganalytics` 7.10.x added `ai.claude_agent_sdk`. The import in `reviewer.py` now succeeds where it previously raised `ImportError`, but without a PostHog API key configured in CI, `posthog.setup()` raises `ValueError("API key is required")` at runtime — failing all 3 retry attempts.

Note: #53881 attempts a similar fix but doesn't work — it sets `_POSTHOG_AI_AVAILABLE = False` when no key is present, but `query` is still bound to the PostHog-wrapped version since no `ImportError` is raised. The wrapped `query()` still calls `setup()` and crashes.

## Changes

1. **Graceful fallback**: Import `query` from `claude_agent_sdk` as the default binding, then only shadow it with the PostHog wrapper when `posthoganalytics.api_key` is present. No key = plain SDK, no crash.

2. **Wire up the API key**: Pass `POSTHOG_API_TOKEN` secret as `POSTHOG_API_KEY` env var in the pr-approval-agent workflow and initialize `posthoganalytics` from it. When the key is present, LLMA tracing activates automatically.

## How did you test this code?

Verified by reading the import/binding flow: `query` is imported from `claude_agent_sdk` on line 15. The posthoganalytics wrapper only shadows it when `api_key` is truthy. No runtime path can reach `posthog.setup()` without a key.

## Publish to changelog?

no