### PR TITLE
feat(onboarding): add wizard instructions copy experiment

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -390,6 +390,7 @@ export const FEATURE_FLAGS = {
     ONBOARDING_SOCIAL_PROOF_INFO: 'onboarding-social-proof-info', // owner: @fercgomes #team-growth, payload overrides social proof strings per product
     ONBOARDING_SKIP_INSTALL_STEP: 'onboarding-skip-install-step', // owner: @rafaeelaudibert #team-growth multivariate=true
     ONBOARDING_WIZARD_PROMINENCE: 'onboarding-wizard-prominence', // owner: #team-growth multivariate=control,wizard-hero,wizard-tab,wizard-only
+    ONBOARDING_WIZARD_INSTALLATION_IMPROVED_COPY: 'onboarding-wizard-installation-improved-copy', // owner: @fercgomes #team-growth multivariate=control,test
     OWNER_ONLY_BILLING: 'owner-only-billing', // owner: @pawelcebula #team-billing
     POST_ONBOARDING_MODAL_EXPERIMENT: 'post-onboarding-modal-experiment', // owner: @fercgomes #team-growth multivariate=control,test
     PASSKEY_SIGNUP_ENABLED: 'passkey-signup-enabled', // owner: @reecejones #team-platform-features

--- a/frontend/src/scenes/onboarding/sdks/OnboardingInstallStep/variants/WizardOnlyIntro.tsx
+++ b/frontend/src/scenes/onboarding/sdks/OnboardingInstallStep/variants/WizardOnlyIntro.tsx
@@ -1,0 +1,48 @@
+import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
+
+/**
+ * Intro for the wizard-only install variant.
+ *
+ * Experiment: onboarding-wizard-installation-improved-copy (#team-growth)
+ *   control — original one-line tagline
+ *   test    — expanded copy that concretely enumerates what the wizard does,
+ *             adds short "how it works" instructions (run from project root,
+ *             follow prompts), and surfaces that PostHog covers LLM inference
+ *             (no user API key required)
+ *
+ * Hypothesis: users are more likely to try the wizard when they understand
+ * what it does, where to run it, and that it's free to run.
+ *
+ * Flag lookup is encapsulated here so WizardOnlyVariant stays agnostic of
+ * the experiment. When the experiment concludes, the winning variant
+ * replaces the dispatcher and this file collapses to a single component.
+ */
+export function WizardOnlyIntro(): JSX.Element {
+    const isImprovedCopy = useFeatureFlag('ONBOARDING_WIZARD_INSTALLATION_IMPROVED_COPY', 'test')
+    return isImprovedCopy ? <ImprovedIntro /> : <ControlIntro />
+}
+
+function ControlIntro(): JSX.Element {
+    return (
+        <div className="text-center max-w-lg mx-auto">
+            <h2 className="text-2xl font-bold mb-2">Install PostHog with one command</h2>
+            <p className="text-muted">
+                Our AI wizard detects your framework, installs the right SDK, and configures event capture
+                automatically.
+            </p>
+        </div>
+    )
+}
+
+function ImprovedIntro(): JSX.Element {
+    return (
+        <div className="text-center max-w-xl mx-auto space-y-3">
+            <h2 className="text-2xl font-bold">Let the AI wizard install PostHog for you</h2>
+            <p className="text-muted">
+                Run this command from your project&apos;s root directory. The wizard detects your framework, installs
+                the right SDK, configures your environment variables, and wires up event capture automatically.
+            </p>
+            <p className="text-muted text-xs">LLM inference is on us — no API key needed.</p>
+        </div>
+    )
+}

--- a/frontend/src/scenes/onboarding/sdks/OnboardingInstallStep/variants/WizardOnlyVariant.tsx
+++ b/frontend/src/scenes/onboarding/sdks/OnboardingInstallStep/variants/WizardOnlyVariant.tsx
@@ -10,6 +10,7 @@ import { SDKGrid } from '../SDKGrid'
 import { SDKInstructionsModal } from '../SDKInstructionsModal'
 import { VariantProps } from '../types'
 import { WizardCommandBlock } from '../WizardCommandBlock'
+import { WizardOnlyIntro } from './WizardOnlyIntro'
 
 /**
  * ONBOARDING_WIZARD_PROMINENCE = "wizard-only"
@@ -21,6 +22,11 @@ import { WizardCommandBlock } from '../WizardCommandBlock'
  * modal and opens the instructions modal; closing the instructions modal re-opens the
  * manual-setup modal (back-button behavior). That coordination can't live in the
  * parent, so the shared modal in index.tsx is skipped for this variant.
+ *
+ * Nested experiment (ONBOARDING_WIZARD_INSTALLATION_IMPROVED_COPY, #team-growth):
+ *   WizardOnlyIntro dispatches between control and test copy internally. The
+ *   variant stays agnostic — it just renders the intro and the shared
+ *   WizardCommandBlock; the intro file handles the copy swap.
  */
 export function WizardOnlyVariant({
     sdkGridProps,
@@ -59,13 +65,7 @@ export function WizardOnlyVariant({
             {header}
             {!installationComplete && <AdblockWarning adblockResult={adblockResult} />}
             <div className="mt-6 space-y-8">
-                <div className="text-center max-w-lg mx-auto">
-                    <h2 className="text-2xl font-bold mb-2">Install PostHog with one command</h2>
-                    <p className="text-muted">
-                        Our AI wizard detects your framework, installs the right SDK, and configures event capture
-                        automatically.
-                    </p>
-                </div>
+                <WizardOnlyIntro />
 
                 <div className="max-w-xl mx-auto">
                     <WizardCommandBlock />


### PR DESCRIPTION
## Problem

We've rolled out the `wizard-only` arm of `ONBOARDING_WIZARD_PROMINENCE` — the CLI wizard (`npx @posthog/wizard@latest`) is now the primary install path on the onboarding install step. This PR tests whether users try the wizard more often when the surrounding copy explains what it concretely does and surfaces that PostHog covers LLM inference (no user API key required).

**Experiment:** `onboarding-wizard-installation-improved-copy` (#team-growth, multivariate `control,test`).

**Hypothesis:** wizard uptake increases when the copy (a) names the concrete steps the wizard performs, (b) tells the user where to run the command, and (c) makes clear there's no API key required because PostHog pays for the inference.

## Changes

- New feature flag `ONBOARDING_WIZARD_INSTALLATION_IMPROVED_COPY` in [`frontend/src/lib/constants.tsx`](vscode-webview://1i2ubsas7ju313c38f0q950kldje6l84a6n4hcgb08l2rtbqjrqk/frontend/src/lib/constants.tsx) (owner `@fercgomes #team-growth`, multivariate `control,test`).
- New file `WizardOnlyIntro.tsx` — a dispatcher that reads the flag and returns either `ControlIntro` (original copy, unchanged) or `ImprovedIntro` (the test arm).
- `WizardOnlyVariant.tsx` now renders `<WizardOnlyIntro />` in place of the previously-inline heading + paragraph markup. No other behavior change.

**Copy comparison:**

|  | Control | Test |
| --- | --- | --- |
| Heading | Install PostHog with one command | Let the AI wizard install PostHog for you |
| Body | Our AI wizard detects your framework, installs the right SDK, and configures event capture automatically. | Run this command from your project's root directory. The wizard detects your framework, installs the right SDK, configures your environment variables, and wires up event capture automatically. |
| Inference note | — | LLM inference is on us — no API key needed. |

The flag lookup is intentionally encapsulated in `WizardOnlyIntro.tsx` so that `WizardOnlyVariant.tsx` stays agnostic of this nested experiment — when it concludes, collapsing to the winning copy is a one-file change.

## How did you test this code?

Manually.

## Publish to changelog?

No — behind a flag, growth experiment.

## Docs update

No docs impact.