### PR TITLE
chore(livestream): add sse lifecycle capture events for 401 debugging

### DIFF
--- a/frontend/src/layout/navigation-3000/sidepanel/panels/activity/sidePanelNotificationsLogic.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/activity/sidePanelNotificationsLogic.tsx
@@ -215,17 +215,29 @@ export const sidePanelNotificationsLogic = kea<sidePanelNotificationsLogicType>(
             }
         },
         startSSE: () => {
+            // TEMPORARY: lifecycle tracking for /notifications SSE connection.
+            // Remove together with livestream_401_debug once root cause is known.
+            posthog.capture('livestream_sse_startsse_called', {
+                flag_enabled: values.realTimeNotificationsEnabled,
+                has_token: !!values.currentTeam?.live_events_token,
+                has_host: !!liveEventsHostOrigin(),
+                had_prior_connection: !!cache.sseConnection,
+            })
+
             if (!values.realTimeNotificationsEnabled) {
+                posthog.capture('livestream_sse_startsse_skipped', { reason: 'flag_disabled' })
                 return
             }
 
             const token = values.currentTeam?.live_events_token
             if (!token) {
+                posthog.capture('livestream_sse_startsse_skipped', { reason: 'no_token' })
                 return
             }
 
             const host = liveEventsHostOrigin()
             if (!host) {
+                posthog.capture('livestream_sse_startsse_skipped', { reason: 'no_host' })
                 return
             }
 
@@ -234,6 +246,9 @@ export const sidePanelNotificationsLogic = kea<sidePanelNotificationsLogicType>(
             cache.sseConnection?.abort()
             const abortController = new AbortController()
             cache.sseConnection = abortController
+            cache.firstMessageLogged = false
+
+            posthog.capture('livestream_sse_connecting', { url })
 
             void api
                 .stream(url, {
@@ -243,6 +258,10 @@ export const sidePanelNotificationsLogic = kea<sidePanelNotificationsLogicType>(
                     signal: abortController.signal,
                     onMessage: (event) => {
                         actions.clearErrorCount()
+                        if (!cache.firstMessageLogged) {
+                            cache.firstMessageLogged = true
+                            posthog.capture('livestream_sse_first_message', { url })
+                        }
                         if (!values.isInitialLoadComplete) {
                             return
                         }
@@ -288,9 +307,20 @@ export const sidePanelNotificationsLogic = kea<sidePanelNotificationsLogicType>(
                             // Ignore malformed messages
                         }
                     },
-                    onError: () => {
+                    onError: (error) => {
+                        // TEMPORARY: livestream SSE lifecycle tracking.
+                        posthog.capture('livestream_sse_error', {
+                            url,
+                            error_name: (error as Error | undefined)?.name,
+                            error_message: (error as Error | undefined)?.message,
+                            error_count: values.errorCounter + 1,
+                        })
                         actions.incrementErrorCount()
                         if (values.errorCounter >= MAX_SSE_ERRORS) {
+                            posthog.capture('livestream_sse_max_errors', {
+                                url,
+                                max_errors: MAX_SSE_ERRORS,
+                            })
                             abortController.abort()
                             throw new Error(`SSE failed ${MAX_SSE_ERRORS} times, giving up`)
                         }
@@ -299,6 +329,10 @@ export const sidePanelNotificationsLogic = kea<sidePanelNotificationsLogicType>(
                 .catch(() => {})
         },
         stopSSE: () => {
+            // TEMPORARY: livestream SSE lifecycle tracking.
+            posthog.capture('livestream_sse_stopped', {
+                had_connection: !!cache.sseConnection,
+            })
             cache.sseConnection?.abort()
             cache.sseConnection = null
         },

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -6186,6 +6186,11 @@ const api = {
             body: data !== undefined ? JSON.stringify(data) : undefined,
             signal: abortController.signal,
             onopen: async (response) => {
+                // TEMPORARY: livestream SSE lifecycle tracking. Scoped to the two
+                // livestream endpoints so the generic stream helper stays quiet.
+                // Remove together with captureLivestream401Debug once root cause is known.
+                const isLivestreamUrl = /\/(notifications|events)(?:$|\?)/.test(url)
+
                 if (response.status === 429) {
                     const retryAfter = response.headers.get('Retry-After')
                     if (retryAfter) {
@@ -6204,6 +6209,12 @@ const api = {
                     // Remove once root cause is known.
                     if (response.status === 401) {
                         captureLivestream401Debug(url, headers?.Authorization, errorData)
+                    } else if (isLivestreamUrl) {
+                        posthog.capture('livestream_sse_non_ok_non_401', {
+                            url,
+                            status: response.status,
+                            server_message: errorData?.message || errorData?.error,
+                        })
                     }
                     onError(
                         new ApiError(
@@ -6214,6 +6225,11 @@ const api = {
                         )
                     )
                     abortController.abort()
+                } else if (isLivestreamUrl) {
+                    posthog.capture('livestream_sse_opened', {
+                        url,
+                        status: response.status,
+                    })
                 }
             },
             onmessage: onMessage,


### PR DESCRIPTION
## Problem

My earlier PR (#53882) added `livestream_401_debug` capture inside `api.stream.onopen`, but no events have landed in PostHog despite thousands of /notifications 401s in Grafana. Without lifecycle events at each stage of the SSE flow we can't tell whether `startSSE` runs at all, whether `fetchEventSource`'s `onopen` is reached, or whether the real failure mode is elsewhere.

## Changes

- Capture `livestream_sse_startsse_called` at the top of `startSSE` with flag/token/host presence flags, so we can see if the action runs
- Capture `livestream_sse_startsse_skipped` on each early return with a reason tag (`flag_disabled`, `no_token`, `no_host`)
- Capture `livestream_sse_connecting` immediately before `api.stream(...)` is called
- Capture `livestream_sse_opened` in `api.ts` `onopen` when the response is 2xx, scoped to `/notifications` and `/events`
- Capture `livestream_sse_non_ok_non_401` in `api.ts` `onopen` for other 4xx/5xx statuses (so we don't miss e.g. 5xx)
- Capture `livestream_sse_first_message` on the first `onMessage` per connection (using a `cache.firstMessageLogged` flag)
- Capture `livestream_sse_error` inside `onError` on every transport error
- Capture `livestream_sse_max_errors` when the retry budget is exhausted
- Capture `livestream_sse_stopped` in the `stopSSE` listener
- All captures are clearly marked `TEMPORARY` alongside the existing `captureLivestream401Debug` helper; they will be removed together once the 401 root cause is identified

## How did you test this code?

No automated tests added. I verified the file has no new type errors via `tsc --noEmit` (the pre-existing kea-typegen drift errors in `sidePanelNotificationsLogic.tsx` are unrelated to this change). I did not manually test in a running browser; the new captures are all thin `posthog.capture(...)` calls with no runtime branching logic, and my earlier PR already proved the surrounding code paths are correct via a local Playwright reproduction.

## Publish to changelog?

no