### PR TITLE
fix(exports): improve SSRF validation for heatmap URLs

### DIFF
--- a/posthog/api/exports.py
+++ b/posthog/api/exports.py
@@ -1,4 +1,5 @@
 import threading
+import urllib.parse as urlparse
 from datetime import timedelta
 from typing import Any
 
@@ -155,9 +156,14 @@ class ExportedAssetSerializer(serializers.ModelSerializer):
                 )
 
         if export_context and export_context.get("heatmap_url"):
-            ok, err = is_url_allowed(export_context["heatmap_url"])
-            if not ok:
-                raise ValidationError({"export_context": [f"heatmap_url not allowed: {err}"]})
+            heatmap_url = export_context["heatmap_url"]
+            parsed = urlparse.urlparse(heatmap_url)
+            # Relative paths (no scheme and no netloc) are resolved by the browser
+            # in the exporter context, not fetched by the server — SSRF validation doesn't apply
+            if parsed.scheme or parsed.netloc:
+                ok, err = is_url_allowed(heatmap_url)
+                if not ok:
+                    raise ValidationError({"export_context": [f"heatmap_url not allowed: {err}"]})
 
         data["team_id"] = self.context["team_id"]
         return data

--- a/posthog/api/exports.py
+++ b/posthog/api/exports.py
@@ -159,7 +159,7 @@ class ExportedAssetSerializer(serializers.ModelSerializer):
             heatmap_url = export_context["heatmap_url"]
             parsed = urlparse.urlparse(heatmap_url)
             is_relative_path = not parsed.scheme and not parsed.netloc
-            # Relative paths are resolved by the browser in the exporter context, 
+            # Relative paths are resolved by the browser in the exporter context,
             # not fetched by the server — SSRF validation doesn't apply
             if not is_relative_path:
                 ok, err = is_url_allowed(heatmap_url)

--- a/posthog/api/exports.py
+++ b/posthog/api/exports.py
@@ -158,9 +158,10 @@ class ExportedAssetSerializer(serializers.ModelSerializer):
         if export_context and export_context.get("heatmap_url"):
             heatmap_url = export_context["heatmap_url"]
             parsed = urlparse.urlparse(heatmap_url)
-            # Relative paths (no scheme and no netloc) are resolved by the browser
-            # in the exporter context, not fetched by the server — SSRF validation doesn't apply
-            if parsed.scheme or parsed.netloc:
+            is_relative_path = not parsed.scheme and not parsed.netloc
+            # Relative paths are resolved by the browser in the exporter context, 
+            # not fetched by the server — SSRF validation doesn't apply
+            if not is_relative_path:
                 ok, err = is_url_allowed(heatmap_url)
                 if not ok:
                     raise ValidationError({"export_context": [f"heatmap_url not allowed: {err}"]})

--- a/posthog/api/sharing.py
+++ b/posthog/api/sharing.py
@@ -819,9 +819,13 @@ class SharingViewerPageViewSet(mixins.RetrieveModelMixin, viewsets.GenericViewSe
             if not heatmap_url:
                 raise NotFound("Invalid heatmap export - missing heatmap_url")
 
-            ok, err = is_url_allowed(heatmap_url)
-            if not ok:
-                raise ValidationError(f"heatmap_url not allowed: {err}")
+            parsed = urlparse(heatmap_url)
+            # Relative paths (no scheme and no netloc) are resolved by the browser
+            # in the exporter context, not fetched by the server — SSRF validation doesn't apply
+            if parsed.scheme or parsed.netloc:
+                ok, err = is_url_allowed(heatmap_url)
+                if not ok:
+                    raise ValidationError(f"heatmap_url not allowed: {err}")
 
             heatmap_data_url = resource.export_context.get("heatmap_data_url")
             if not heatmap_data_url:

--- a/posthog/api/sharing.py
+++ b/posthog/api/sharing.py
@@ -820,9 +820,10 @@ class SharingViewerPageViewSet(mixins.RetrieveModelMixin, viewsets.GenericViewSe
                 raise NotFound("Invalid heatmap export - missing heatmap_url")
 
             parsed = urlparse(heatmap_url)
-            # Relative paths (no scheme and no netloc) are resolved by the browser
-            # in the exporter context, not fetched by the server — SSRF validation doesn't apply
-            if parsed.scheme or parsed.netloc:
+            is_relative_path = not parsed.scheme and not parsed.netloc
+            # Relative paths are resolved by the browser in the exporter context,
+            # not fetched by the server — SSRF validation doesn't apply
+            if not is_relative_path:
                 ok, err = is_url_allowed(heatmap_url)
                 if not ok:
                     raise ValidationError(f"heatmap_url not allowed: {err}")

--- a/posthog/api/test/test_exports.py
+++ b/posthog/api/test/test_exports.py
@@ -1059,6 +1059,31 @@ class TestExportHeatmapSSRFValidation(APIBaseTest):
         )
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
+    @patch("posthog.api.exports.ExportedAssetSerializer._start_export_workflow")
+    def test_accepts_relative_path_heatmap_url(self, mock_exporter_task) -> None:
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/exports",
+            {
+                "export_format": "image/png",
+                "export_context": {
+                    "heatmap_url": "/api/environments/1/heatmap_screenshots/42/content/?width=1200",
+                },
+            },
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+    def test_rejects_protocol_relative_heatmap_url(self) -> None:
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/exports",
+            {
+                "export_format": "image/png",
+                "export_context": {
+                    "heatmap_url": "//evil.com/steal-data",
+                },
+            },
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
 
 class TestExportMixin(APIBaseTest):
     def _get_export_output(self, path: str) -> list[str]:

--- a/posthog/api/test/test_exports.py
+++ b/posthog/api/test/test_exports.py
@@ -1028,6 +1028,7 @@ class TestExportHeatmapSSRFValidation(APIBaseTest):
             ("private_ip_192", "http://192.168.1.1/internal"),
             ("internal_domain", "http://service.cluster.local/api"),
             ("file_scheme", "file:///etc/passwd"),
+            ("protocol_relative", "//evil.com/steal-data"),
         ]
     )
     def test_rejects_ssrf_heatmap_url(self, _name: str, url: str) -> None:
@@ -1071,18 +1072,6 @@ class TestExportHeatmapSSRFValidation(APIBaseTest):
             },
         )
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-
-    def test_rejects_protocol_relative_heatmap_url(self) -> None:
-        response = self.client.post(
-            f"/api/projects/{self.team.id}/exports",
-            {
-                "export_format": "image/png",
-                "export_context": {
-                    "heatmap_url": "//evil.com/steal-data",
-                },
-            },
-        )
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
 
 class TestExportMixin(APIBaseTest):

--- a/posthog/tasks/exports/image_exporter.py
+++ b/posthog/tasks/exports/image_exporter.py
@@ -5,7 +5,7 @@ import uuid
 import tempfile
 from datetime import timedelta
 from typing import Literal, Optional
-from urllib.parse import quote
+from urllib.parse import quote, urlparse
 
 from django.conf import settings
 
@@ -201,9 +201,13 @@ def _export_to_png(
             )
         elif exported_asset.export_context and exported_asset.export_context.get("heatmap_url"):
             heatmap_url = exported_asset.export_context["heatmap_url"]
-            ok, err = is_url_allowed(heatmap_url)
-            if not ok:
-                raise Exception(f"heatmap_url blocked by SSRF protection: {err}")
+            parsed = urlparse(heatmap_url)
+            # Relative paths (no scheme and no netloc) are resolved by the browser
+            # in the exporter context, not fetched by the server — SSRF validation doesn't apply
+            if parsed.scheme or parsed.netloc:
+                ok, err = is_url_allowed(heatmap_url)
+                if not ok:
+                    raise Exception(f"heatmap_url blocked by SSRF protection: {err}")
 
             # Handle replay export using /exporter route (same as insights/dashboards)
             url_to_render = absolute_uri(

--- a/posthog/tasks/exports/image_exporter.py
+++ b/posthog/tasks/exports/image_exporter.py
@@ -202,9 +202,10 @@ def _export_to_png(
         elif exported_asset.export_context and exported_asset.export_context.get("heatmap_url"):
             heatmap_url = exported_asset.export_context["heatmap_url"]
             parsed = urlparse(heatmap_url)
-            # Relative paths (no scheme and no netloc) are resolved by the browser
-            # in the exporter context, not fetched by the server — SSRF validation doesn't apply
-            if parsed.scheme or parsed.netloc:
+            is_relative_path = not parsed.scheme and not parsed.netloc
+            # Relative paths are resolved by the browser in the exporter context,
+            # not fetched by the server — SSRF validation doesn't apply
+            if not is_relative_path:
                 ok, err = is_url_allowed(heatmap_url)
                 if not ok:
                     raise Exception(f"heatmap_url blocked by SSRF protection: {err}")


### PR DESCRIPTION
## Problem

Exporting a screenshot-type heatmap in production fails with:
```json
{
    "type": "validation_error",
    "code": "invalid_input",
    "detail": "heatmap_url not allowed: Disallowed scheme",
    "attr": "export_context"
}
```

Screenshot-type heatmaps use a relative API path (`/api/environments/{team_id}/heatmap_screenshots/{id}/content/`) as `heatmap_url`. The SSRF validation (`is_url_allowed`) expects absolute URLs with `http`/`https` scheme, so it rejects relative paths. This only affects production because `is_url_allowed` short-circuits with `True` in dev mode.

The SSRF validation was added to protect the browser-type heatmap flow, where `heatmap_url` is an absolute external URL loaded in an iframe inside Selenium. That flow is unaffected by this change.

## Changes

Use `urlparse` to detect relative paths (no `scheme` and no `netloc`) and skip SSRF validation for them. Relative paths are resolved by the browser in the exporter context, not fetched by the Python server, so SSRF protection doesn't apply. Absolute and protocol-relative URLs (`//evil.com/...`) still go through `is_url_allowed`.

Applied in all three validation points:
- `posthog/api/exports.py` — export creation
- `posthog/api/sharing.py` — export rendering
- `posthog/tasks/exports/image_exporter.py` — export worker

## How did you test this code?

- Added `test_accepts_relative_path_heatmap_url` — verifies relative API paths are accepted (fails without fix, passes with fix)
- Added `test_rejects_protocol_relative_heatmap_url` — verifies `//evil.com/...` is still rejected
- All 10 existing SSRF tests continue to pass

No publish to changelog.