### PR TITLE
fix(llma): normalize prompt jsons to string

### DIFF
--- a/posthog/api/llm_prompt_serializers.py
+++ b/posthog/api/llm_prompt_serializers.py
@@ -26,14 +26,14 @@ def validate_prompt_name_value(value: str) -> str:
     return value
 
 
-def validate_prompt_payload_size(prompt_payload: Any) -> str:
-    normalized = normalize_prompt_to_string(prompt_payload)
-    if len(normalized.encode("utf-8")) > MAX_PROMPT_PAYLOAD_BYTES:
+def validate_prompt_payload_size(prompt_payload: Any) -> Any:
+    prompt_payload_bytes = len(json.dumps(prompt_payload, separators=(",", ":"), ensure_ascii=False).encode("utf-8"))
+    if prompt_payload_bytes > MAX_PROMPT_PAYLOAD_BYTES:
         raise serializers.ValidationError(
             f"Prompt payload must be {MAX_PROMPT_PAYLOAD_BYTES} bytes or fewer.",
             code="max_size",
         )
-    return normalized
+    return prompt_payload
 
 
 class LLMPromptFetchQuerySerializer(serializers.Serializer):
@@ -119,7 +119,7 @@ class LLMPromptPublishSerializer(serializers.Serializer):
         help_text="Latest version you are editing from. Used for optimistic concurrency checks.",
     )
 
-    def validate_prompt(self, value: Any) -> str:
+    def validate_prompt(self, value: Any) -> Any:
         return validate_prompt_payload_size(value)
 
     def validate_edits(self, value: list[dict[str, str]]) -> list[dict[str, str]]:
@@ -205,7 +205,7 @@ class LLMPromptSerializer(serializers.ModelSerializer):
     def validate_name(self, value: str) -> str:
         return validate_prompt_name_value(value)
 
-    def validate_prompt(self, value: Any) -> str:
+    def validate_prompt(self, value: Any) -> Any:
         return validate_prompt_payload_size(value)
 
     def validate(self, attrs: dict[str, Any]) -> dict[str, Any]:

--- a/posthog/api/llm_prompt_serializers.py
+++ b/posthog/api/llm_prompt_serializers.py
@@ -5,7 +5,7 @@ from typing import Any
 from rest_framework import serializers
 
 from posthog.api.shared import UserBasicSerializer
-from posthog.models.llm_prompt import LLMPrompt
+from posthog.models.llm_prompt import LLMPrompt, normalize_prompt_to_string
 
 RESERVED_PROMPT_NAMES = {"new"}
 DEFAULT_VERSION_PAGE_SIZE = 50
@@ -26,14 +26,14 @@ def validate_prompt_name_value(value: str) -> str:
     return value
 
 
-def validate_prompt_payload_size(prompt_payload: Any) -> Any:
-    prompt_payload_bytes = len(json.dumps(prompt_payload, separators=(",", ":"), ensure_ascii=False).encode("utf-8"))
-    if prompt_payload_bytes > MAX_PROMPT_PAYLOAD_BYTES:
+def validate_prompt_payload_size(prompt_payload: Any) -> str:
+    normalized = normalize_prompt_to_string(prompt_payload)
+    if len(normalized.encode("utf-8")) > MAX_PROMPT_PAYLOAD_BYTES:
         raise serializers.ValidationError(
             f"Prompt payload must be {MAX_PROMPT_PAYLOAD_BYTES} bytes or fewer.",
             code="max_size",
         )
-    return prompt_payload
+    return normalized
 
 
 class LLMPromptFetchQuerySerializer(serializers.Serializer):
@@ -119,7 +119,7 @@ class LLMPromptPublishSerializer(serializers.Serializer):
         help_text="Latest version you are editing from. Used for optimistic concurrency checks.",
     )
 
-    def validate_prompt(self, value: Any) -> Any:
+    def validate_prompt(self, value: Any) -> str:
         return validate_prompt_payload_size(value)
 
     def validate_edits(self, value: list[dict[str, str]]) -> list[dict[str, str]]:
@@ -196,10 +196,16 @@ class LLMPromptSerializer(serializers.ModelSerializer):
             return value
         return value.isoformat().replace("+00:00", "Z")
 
+    def to_representation(self, instance: LLMPrompt) -> dict[str, Any]:
+        data = super().to_representation(instance)
+        if "prompt" in data and not isinstance(data["prompt"], str):
+            data["prompt"] = normalize_prompt_to_string(data["prompt"])
+        return data
+
     def validate_name(self, value: str) -> str:
         return validate_prompt_name_value(value)
 
-    def validate_prompt(self, value: Any) -> Any:
+    def validate_prompt(self, value: Any) -> str:
         return validate_prompt_payload_size(value)
 
     def validate(self, attrs: dict[str, Any]) -> dict[str, Any]:

--- a/posthog/api/llm_prompt_serializers.py
+++ b/posthog/api/llm_prompt_serializers.py
@@ -198,7 +198,7 @@ class LLMPromptSerializer(serializers.ModelSerializer):
 
     def to_representation(self, instance: LLMPrompt) -> dict[str, Any]:
         data = super().to_representation(instance)
-        if "prompt" in data and not isinstance(data["prompt"], str):
+        if "prompt" in data:
             data["prompt"] = normalize_prompt_to_string(data["prompt"])
         return data
 

--- a/posthog/api/services/llm_prompt.py
+++ b/posthog/api/services/llm_prompt.py
@@ -9,11 +9,7 @@ from django.db.models import QuerySet
 from posthog.api.llm_prompt_serializers import MAX_PROMPT_PAYLOAD_BYTES
 from posthog.exceptions_capture import capture_exception
 from posthog.models import Team, User
-from posthog.models.llm_prompt import (
-    LLMPrompt,
-    annotate_llm_prompt_version_history_metadata,
-    normalize_prompt_to_string,
-)
+from posthog.models.llm_prompt import LLMPrompt, annotate_llm_prompt_version_history_metadata
 from posthog.storage.llm_prompt_cache import invalidate_prompt_latest_cache, invalidate_prompt_version_caches
 
 SYNC_ARCHIVE_VERSION_INVALIDATION_LIMIT = 100
@@ -170,8 +166,6 @@ def publish_prompt_version(
             resolved_payload = apply_prompt_edits(current_latest.prompt, edits)
         else:
             resolved_payload = prompt_payload
-
-        resolved_payload = normalize_prompt_to_string(resolved_payload)
 
         LLMPrompt.objects.filter(pk=current_latest.pk).update(is_latest=False)
         published_prompt = LLMPrompt.objects.create(

--- a/posthog/api/services/llm_prompt.py
+++ b/posthog/api/services/llm_prompt.py
@@ -9,7 +9,11 @@ from django.db.models import QuerySet
 from posthog.api.llm_prompt_serializers import MAX_PROMPT_PAYLOAD_BYTES
 from posthog.exceptions_capture import capture_exception
 from posthog.models import Team, User
-from posthog.models.llm_prompt import LLMPrompt, annotate_llm_prompt_version_history_metadata
+from posthog.models.llm_prompt import (
+    LLMPrompt,
+    annotate_llm_prompt_version_history_metadata,
+    normalize_prompt_to_string,
+)
 from posthog.storage.llm_prompt_cache import invalidate_prompt_latest_cache, invalidate_prompt_version_caches
 
 SYNC_ARCHIVE_VERSION_INVALIDATION_LIMIT = 100
@@ -166,6 +170,8 @@ def publish_prompt_version(
             resolved_payload = apply_prompt_edits(current_latest.prompt, edits)
         else:
             resolved_payload = prompt_payload
+
+        resolved_payload = normalize_prompt_to_string(resolved_payload)
 
         LLMPrompt.objects.filter(pk=current_latest.pk).update(is_latest=False)
         published_prompt = LLMPrompt.objects.create(

--- a/posthog/models/llm_prompt.py
+++ b/posthog/models/llm_prompt.py
@@ -1,3 +1,6 @@
+import json
+from typing import Any
+
 from django.db import models, transaction
 from django.db.models import Count, DateTimeField, IntegerField, OuterRef, QuerySet, Subquery, UUIDField
 from django.db.models.signals import post_delete, post_save
@@ -6,6 +9,12 @@ from django.utils import timezone
 
 from posthog.exceptions_capture import capture_exception
 from posthog.models.utils import UUIDModel
+
+
+def normalize_prompt_to_string(value: Any) -> str:
+    if isinstance(value, str):
+        return value
+    return json.dumps(value, ensure_ascii=False)
 
 
 class LLMPrompt(UUIDModel):

--- a/posthog/models/llm_prompt.py
+++ b/posthog/models/llm_prompt.py
@@ -16,8 +16,8 @@ def normalize_prompt_to_string(value: Any) -> str:
         return value
     try:
         return json.dumps(value, ensure_ascii=False)
-    except (TypeError, ValueError):
-        return str(value)
+    except Exception:
+        return ""
 
 
 class LLMPrompt(UUIDModel):

--- a/posthog/models/llm_prompt.py
+++ b/posthog/models/llm_prompt.py
@@ -14,7 +14,10 @@ from posthog.models.utils import UUIDModel
 def normalize_prompt_to_string(value: Any) -> str:
     if isinstance(value, str):
         return value
-    return json.dumps(value, ensure_ascii=False)
+    try:
+        return json.dumps(value, ensure_ascii=False)
+    except (TypeError, ValueError):
+        return str(value)
 
 
 class LLMPrompt(UUIDModel):

--- a/posthog/models/test/test_llm_prompt.py
+++ b/posthog/models/test/test_llm_prompt.py
@@ -1,0 +1,22 @@
+from unittest import TestCase
+
+from parameterized import parameterized
+
+from posthog.models.llm_prompt import normalize_prompt_to_string
+
+
+class TestNormalizePromptToString(TestCase):
+    @parameterized.expand(
+        [
+            ("plain_string", "hello world", "hello world"),
+            ("empty_string", "", ""),
+            ("object", {"role": "system", "content": "hi"}, '{"role": "system", "content": "hi"}'),
+            ("array", [{"role": "user", "content": "hi"}], '[{"role": "user", "content": "hi"}]'),
+            ("number", 42, "42"),
+            ("boolean", True, "true"),
+            ("null", None, "null"),
+            ("unicode", {"text": "héllo 🌍"}, '{"text": "héllo 🌍"}'),
+        ]
+    )
+    def test_normalize_prompt_to_string(self, _name: str, value: object, expected: str) -> None:
+        assert normalize_prompt_to_string(value) == expected

--- a/posthog/storage/llm_prompt_cache_payloads.py
+++ b/posthog/storage/llm_prompt_cache_payloads.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from typing import Any
 
-from posthog.models.llm_prompt import LLMPrompt
+from posthog.models.llm_prompt import LLMPrompt, normalize_prompt_to_string
 
 INTERNAL_FIRST_VERSION_ID_KEY = "_first_version_id"
 
@@ -23,7 +23,7 @@ def serialize_prompt(prompt: LLMPrompt, *, include_internal: bool = False) -> di
     serialized_prompt = {
         "id": str(prompt.id),
         "name": prompt.name,
-        "prompt": prompt.prompt,
+        "prompt": normalize_prompt_to_string(prompt.prompt),
         "version": prompt.version,
         "created_at": _serialize_timestamp(prompt.created_at),
         "updated_at": _serialize_timestamp(prompt.updated_at),
@@ -42,7 +42,7 @@ def serialize_prompt_version(prompt: LLMPrompt, *, include_internal: bool = Fals
     serialized_prompt = {
         "id": str(prompt.id),
         "name": prompt.name,
-        "prompt": prompt.prompt,
+        "prompt": normalize_prompt_to_string(prompt.prompt),
         "version": prompt.version,
         "created_at": _serialize_timestamp(prompt.created_at),
         "updated_at": _serialize_timestamp(prompt.updated_at),


### PR DESCRIPTION
## Problem

Prompts, when added via API, can be in any format. The frontend expects a string but we could be returning an object, array, number, or boolean. This will lead to a crash.

Closes #ISSUE_ID https://posthoghelp.zendesk.com/agent/tickets/55017 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/56382)

## Changes

- added normalization to string in the serializer on write and read to account for existing entries

## How did you test this code?

- wrote a script to introduce prompts via API in object, array, boolean, and number formats
- reproduced crash
- confirmed fix on prompts stored as non-string formats, confirmed fix on prompts newly added

## Publish to changelog?

No

## Docs update

No

<!-- ## 🤖 LLM context -->

I definitely wrote this without Claude. 🤖🤖🤖🤖🤖🤖🤖
