### PR TITLE
fix(paths): support non-person funnel aggregation in funnel paths join

### DIFF
--- a/posthog/hogql_queries/insights/paths_query_runner.py
+++ b/posthog/hogql_queries/insights/paths_query_runner.py
@@ -11,6 +11,7 @@ from posthog.schema import (
     FunnelPathType,
     FunnelsActorsQuery,
     FunnelsFilter,
+    FunnelsQuery,
     HogQLQueryModifiers,
     PathCleaningFilter,
     PathsFilter,
@@ -185,6 +186,29 @@ class PathsQueryRunner(AnalyticsQueryRunner[PathsQueryResponse]):
         else:
             raise ValueError("Unexpected `funnelPathType` for funnel path filter.")
 
+    def _funnel_events_join_expr(self, funnelSource: FunnelsQuery) -> ast.Expr:
+        """Return the events-side expression to join against ``funnel_actors.actor_id``.
+
+        Mirrors ``FunnelEventQuery._aggregation_target_expr`` so that funnels aggregated by
+        group or a HogQL expression (currently ``properties.$session_id``) produce a join
+        condition that actually matches. Without this, ``actor_id`` ends up as a session id
+        or group key while the events side uses ``person_id``, and the join silently returns
+        zero rows.
+        """
+        funnelsFilter = funnelSource.funnelsFilter or FunnelsFilter()
+
+        # Group aggregation: events.$group_N
+        if funnelSource.aggregation_group_type_index is not None:
+            return ast.Field(chain=["events", f"$group_{funnelSource.aggregation_group_type_index}"])
+
+        # HogQL aggregation (currently only properties.$session_id is exposed in the UI,
+        # but funnelAggregateByHogQL supports arbitrary expressions).
+        if funnelsFilter.funnelAggregateByHogQL and funnelsFilter.funnelAggregateByHogQL != "person_id":
+            return parse_expr(funnelsFilter.funnelAggregateByHogQL)
+
+        # Default: person aggregation
+        return ast.Field(chain=["events", "person_id"])
+
     def funnel_join(self) -> ast.JoinExpr:
         if not self.query.funnelPathsFilter:
             raise ValueError("Funnel paths filter is required for funnel paths.")
@@ -226,7 +250,7 @@ class PathsQueryRunner(AnalyticsQueryRunner[PathsQueryResponse]):
                 constraint=ast.JoinConstraint(
                     expr=ast.CompareOperation(
                         op=ast.CompareOperationOp.Eq,
-                        left=ast.Field(chain=["events", "person_id"]),
+                        left=self._funnel_events_join_expr(funnelSource),
                         right=ast.Field(chain=["funnel_actors", "actor_id"]),
                     ),
                     constraint_type="ON",
@@ -338,7 +362,10 @@ class PathsQueryRunner(AnalyticsQueryRunner[PathsQueryResponse]):
             select_from=ast.JoinExpr(table=ast.Field(chain=["events"])),
             where=ast.And(exprs=event_filters + self._get_event_query()),
             order_by=[
-                ast.OrderExpr(expr=ast.Field(chain=["person_id"])),
+                # Qualify ``events.person_id`` because the optional funnel_actors join exposes its
+                # own ``person_id`` column when the funnel is aggregated by session, which makes an
+                # unqualified reference ambiguous to the HogQL resolver.
+                ast.OrderExpr(expr=ast.Field(chain=["events", "person_id"])),
                 ast.OrderExpr(expr=ast.Field(chain=["events", "timestamp"])),
             ],
         )

--- a/posthog/hogql_queries/insights/paths_query_runner.py
+++ b/posthog/hogql_queries/insights/paths_query_runner.py
@@ -194,6 +194,10 @@ class PathsQueryRunner(AnalyticsQueryRunner[PathsQueryResponse]):
         condition that actually matches. Without this, ``actor_id`` ends up as a session id
         or group key while the events side uses ``person_id``, and the join silently returns
         zero rows.
+
+        Keep this in sync with ``FunnelEventQuery._aggregation_target_expr`` — that function
+        defines the *inside* of the funnel's aggregation; this one mirrors it on the *outside*
+        so the paths query joins events against the right column.
         """
         funnelsFilter = funnelSource.funnelsFilter or FunnelsFilter()
 

--- a/posthog/hogql_queries/insights/test/test_paths_query_runner_ee.py
+++ b/posthog/hogql_queries/insights/test/test_paths_query_runner_ee.py
@@ -3493,6 +3493,204 @@ class TestClickhousePaths(ClickhouseTestMixin, APIBaseTest):
         )
 
 
+class TestClickhousePathsFunnelSource(ClickhouseTestMixin, APIBaseTest):
+    """Regression tests for paths queries driven by a funnel source with non-person aggregation.
+
+    These exercise the join that paths_query_runner adds when ``funnelPathsFilter`` is set —
+    previously hardcoded to ``events.person_id = funnel_actors.actor_id``, which silently
+    dropped every row when the funnel was aggregated by session or group.
+    """
+
+    def _create_session_funnel_events(self):
+        from posthog.models.utils import uuid7
+
+        session_completed = str(uuid7("2021-05-01 01:00:00"))
+        session_incomplete = str(uuid7("2021-05-01 03:00:00"))
+
+        _create_person(distinct_ids=["user_completed"], team_id=self.team.pk)
+        # Session that completes the funnel and then visits /after.
+        _create_event(
+            event="step one",
+            distinct_id="user_completed",
+            team=self.team,
+            timestamp="2021-05-01 01:00:00",
+            properties={"$session_id": session_completed},
+        )
+        _create_event(
+            event="step two",
+            distinct_id="user_completed",
+            team=self.team,
+            timestamp="2021-05-01 01:01:00",
+            properties={"$session_id": session_completed},
+        )
+        _create_event(
+            event="$pageview",
+            distinct_id="user_completed",
+            team=self.team,
+            timestamp="2021-05-01 01:02:00",
+            properties={"$current_url": "/after", "$session_id": session_completed},
+        )
+
+        # Session that only hits step one — must be filtered out by the funnel join.
+        _create_person(distinct_ids=["user_incomplete"], team_id=self.team.pk)
+        _create_event(
+            event="step one",
+            distinct_id="user_incomplete",
+            team=self.team,
+            timestamp="2021-05-01 03:00:00",
+            properties={"$session_id": session_incomplete},
+        )
+        _create_event(
+            event="$pageview",
+            distinct_id="user_incomplete",
+            team=self.team,
+            timestamp="2021-05-01 03:01:00",
+            properties={"$current_url": "/after", "$session_id": session_incomplete},
+        )
+
+        return session_completed, session_incomplete
+
+    def test_funnel_paths_after_step_session_aggregation(self):
+        """Session-aggregated funnel + ``Show user paths after step`` used to fail with
+        ``Ambiguous query. Found multiple sources for field: person_id`` and, once fixed,
+        ClickHouse would time out because the join matched a session id against person_id.
+        """
+        session_completed, _ = self._create_session_funnel_events()
+
+        funnel_source = {
+            "kind": "FunnelsQuery",
+            "series": [
+                {"kind": "EventsNode", "event": "step one"},
+                {"kind": "EventsNode", "event": "step two"},
+            ],
+            "dateRange": {"date_from": "2021-05-01", "date_to": "2021-05-07"},
+            "funnelsFilter": {
+                "funnelAggregateByHogQL": "properties.$session_id",
+                "funnelWindowInterval": 7,
+                "funnelWindowIntervalUnit": "day",
+            },
+        }
+
+        with freeze_time("2021-05-08T00:00:00.000Z"):
+            result = PathsQueryRunner(
+                query={
+                    "kind": "PathsQuery",
+                    "dateRange": {"date_from": "2021-05-01", "date_to": "2021-05-07"},
+                    "pathsFilter": {"includeEventTypes": ["$pageview", "custom_event"]},
+                    "funnelPathsFilter": {
+                        "funnelPathType": "funnel_path_after_step",
+                        "funnelSource": funnel_source,
+                        "funnelStep": 2,
+                    },
+                },
+                team=self.team,
+            ).run()
+
+            assert isinstance(result, CachedPathsQueryResponse)
+            # Only the /after pageview from the completed session should survive the join.
+            self.assertEqual(
+                [(link.source, link.target, link.value) for link in result.results],
+                [("1_step two", "2_/after", 1)],
+            )
+            # Sanity: the completing session's id actually reached the events join.
+            self.assertIsNotNone(session_completed)
+
+    def test_funnel_paths_after_step_group_aggregation(self):
+        """Group-aggregated funnel + ``Show user paths after step``. Before the fix, the hardcoded
+        join (``events.person_id = funnel_actors.actor_id``) compared a person UUID against a
+        group key string and returned zero rows."""
+        create_group_type_mapping_without_created_at(
+            team=self.team, project_id=self.team.project_id, group_type="organization", group_type_index=0
+        )
+        create_group(
+            team_id=self.team.pk,
+            group_type_index=0,
+            group_key="org:completed",
+            properties={},
+        )
+        create_group(
+            team_id=self.team.pk,
+            group_type_index=0,
+            group_key="org:incomplete",
+            properties={},
+        )
+
+        _create_person(distinct_ids=["group_user_1"], team_id=self.team.pk)
+        _create_event(
+            event="step one",
+            distinct_id="group_user_1",
+            team=self.team,
+            timestamp="2021-05-01 01:00:00",
+            properties={"$group_0": "org:completed"},
+        )
+        _create_event(
+            event="step two",
+            distinct_id="group_user_1",
+            team=self.team,
+            timestamp="2021-05-01 01:01:00",
+            properties={"$group_0": "org:completed"},
+        )
+        _create_event(
+            event="$pageview",
+            distinct_id="group_user_1",
+            team=self.team,
+            timestamp="2021-05-01 01:02:00",
+            properties={"$current_url": "/after", "$group_0": "org:completed"},
+        )
+
+        # Different org that never reaches step two — its /after event must be filtered out.
+        _create_person(distinct_ids=["group_user_2"], team_id=self.team.pk)
+        _create_event(
+            event="step one",
+            distinct_id="group_user_2",
+            team=self.team,
+            timestamp="2021-05-01 03:00:00",
+            properties={"$group_0": "org:incomplete"},
+        )
+        _create_event(
+            event="$pageview",
+            distinct_id="group_user_2",
+            team=self.team,
+            timestamp="2021-05-01 03:01:00",
+            properties={"$current_url": "/after", "$group_0": "org:incomplete"},
+        )
+
+        funnel_source = {
+            "kind": "FunnelsQuery",
+            "series": [
+                {"kind": "EventsNode", "event": "step one"},
+                {"kind": "EventsNode", "event": "step two"},
+            ],
+            "dateRange": {"date_from": "2021-05-01", "date_to": "2021-05-07"},
+            "aggregation_group_type_index": 0,
+            "funnelsFilter": {
+                "funnelWindowInterval": 7,
+                "funnelWindowIntervalUnit": "day",
+            },
+        }
+
+        with freeze_time("2021-05-08T00:00:00.000Z"):
+            result = PathsQueryRunner(
+                query={
+                    "kind": "PathsQuery",
+                    "dateRange": {"date_from": "2021-05-01", "date_to": "2021-05-07"},
+                    "pathsFilter": {"includeEventTypes": ["$pageview", "custom_event"]},
+                    "funnelPathsFilter": {
+                        "funnelPathType": "funnel_path_after_step",
+                        "funnelSource": funnel_source,
+                        "funnelStep": 2,
+                    },
+                },
+                team=self.team,
+            ).run()
+
+            assert isinstance(result, CachedPathsQueryResponse)
+            self.assertEqual(
+                [(link.source, link.target, link.value) for link in result.results],
+                [("1_step two", "2_/after", 1)],
+            )
+
+
 class TestClickhousePathsEdgeValidation(TestCase):
     BASIC_PATH = [("1_a", "2_b"), ("2_b", "3_c"), ("3_c", "4_d")]  # a->b->c->d
     BASIC_PATH_2 = [("1_x", "2_y"), ("2_y", "3_z")]  # x->y->z

--- a/posthog/hogql_queries/insights/test/test_paths_query_runner_ee.py
+++ b/posthog/hogql_queries/insights/test/test_paths_query_runner_ee.py
@@ -18,6 +18,8 @@ from unittest.mock import MagicMock
 from django.test import TestCase, override_settings
 from django.utils import timezone
 
+from parameterized import parameterized
+
 from posthog.schema import CachedPathsQueryResponse, PathsLink
 
 from posthog.constants import FUNNEL_PATH_BETWEEN_STEPS, INSIGHT_FUNNELS
@@ -3499,25 +3501,61 @@ class TestClickhousePathsFunnelSource(ClickhouseTestMixin, APIBaseTest):
     These exercise the join that paths_query_runner adds when ``funnelPathsFilter`` is set —
     previously hardcoded to ``events.person_id = funnel_actors.actor_id``, which silently
     dropped every row when the funnel was aggregated by session or group.
+
+    The fixtures include a completing actor and a dropping-off actor so a regression that
+    joins nothing (zero-row INNER JOIN) and a regression that joins everything (wrong
+    filter) are both caught.
     """
 
-    def _create_session_funnel_events(self):
+    # (name, funnelPathType, funnelStep, expected_paths) for each variant.
+    # The fixtures put five events on the completing actor (``/before``, ``step one``,
+    # ``/between``, ``step two``, ``/after``) so we can assert the exact path output for
+    # all three funnel path types without rebuilding data.
+    FUNNEL_PATH_CASES = [
+        (
+            "after_step",
+            "funnel_path_after_step",
+            2,
+            [("1_step two", "2_/after", 1)],
+        ),
+        (
+            # Both the completing and the incomplete actor reach step one, so both
+            # contribute to this edge — it's the only path type where the incomplete
+            # actor's events survive the funnel filter, which doubles as a "join actually
+            # let multiple actors through" signal.
+            "before_step",
+            "funnel_path_before_step",
+            1,
+            [("1_/before", "2_step one", 2)],
+        ),
+        (
+            "between_steps",
+            "funnel_path_between_steps",
+            2,
+            [
+                ("1_step one", "2_/between", 1),
+                ("2_/between", "3_step two", 1),
+            ],
+        ),
+    ]
+
+    def _create_session_funnel_events(self) -> None:
         from posthog.models.utils import uuid7
 
         session_completed = str(uuid7("2021-05-01 01:00:00"))
         session_incomplete = str(uuid7("2021-05-01 03:00:00"))
 
         _create_person(distinct_ids=["user_completed"], team_id=self.team.pk)
-        # Session that completes the funnel and then visits /after.
+        # Session that completes the funnel, with events on either side of each step.
         _create_event(
-            event="step one",
+            event="$pageview",
             distinct_id="user_completed",
             team=self.team,
             timestamp="2021-05-01 01:00:00",
-            properties={"$session_id": session_completed},
+            properties={"$current_url": "/before", "$session_id": session_completed},
         )
         _create_event(
-            event="step two",
+            event="step one",
             distinct_id="user_completed",
             team=self.team,
             timestamp="2021-05-01 01:01:00",
@@ -3528,77 +3566,49 @@ class TestClickhousePathsFunnelSource(ClickhouseTestMixin, APIBaseTest):
             distinct_id="user_completed",
             team=self.team,
             timestamp="2021-05-01 01:02:00",
+            properties={"$current_url": "/between", "$session_id": session_completed},
+        )
+        _create_event(
+            event="step two",
+            distinct_id="user_completed",
+            team=self.team,
+            timestamp="2021-05-01 01:03:00",
+            properties={"$session_id": session_completed},
+        )
+        _create_event(
+            event="$pageview",
+            distinct_id="user_completed",
+            team=self.team,
+            timestamp="2021-05-01 01:04:00",
             properties={"$current_url": "/after", "$session_id": session_completed},
         )
 
-        # Session that only hits step one — must be filtered out by the funnel join.
+        # Session that only hits step one — must be filtered out by the funnel join because
+        # its session id never reaches the funnel_actors set.
         _create_person(distinct_ids=["user_incomplete"], team_id=self.team.pk)
+        _create_event(
+            event="$pageview",
+            distinct_id="user_incomplete",
+            team=self.team,
+            timestamp="2021-05-01 03:00:00",
+            properties={"$current_url": "/before", "$session_id": session_incomplete},
+        )
         _create_event(
             event="step one",
             distinct_id="user_incomplete",
             team=self.team,
-            timestamp="2021-05-01 03:00:00",
+            timestamp="2021-05-01 03:01:00",
             properties={"$session_id": session_incomplete},
         )
         _create_event(
             event="$pageview",
             distinct_id="user_incomplete",
             team=self.team,
-            timestamp="2021-05-01 03:01:00",
+            timestamp="2021-05-01 03:02:00",
             properties={"$current_url": "/after", "$session_id": session_incomplete},
         )
 
-        return session_completed, session_incomplete
-
-    def test_funnel_paths_after_step_session_aggregation(self):
-        """Session-aggregated funnel + ``Show user paths after step`` used to fail with
-        ``Ambiguous query. Found multiple sources for field: person_id`` and, once fixed,
-        ClickHouse would time out because the join matched a session id against person_id.
-        """
-        session_completed, _ = self._create_session_funnel_events()
-
-        funnel_source = {
-            "kind": "FunnelsQuery",
-            "series": [
-                {"kind": "EventsNode", "event": "step one"},
-                {"kind": "EventsNode", "event": "step two"},
-            ],
-            "dateRange": {"date_from": "2021-05-01", "date_to": "2021-05-07"},
-            "funnelsFilter": {
-                "funnelAggregateByHogQL": "properties.$session_id",
-                "funnelWindowInterval": 7,
-                "funnelWindowIntervalUnit": "day",
-            },
-        }
-
-        with freeze_time("2021-05-08T00:00:00.000Z"):
-            result = PathsQueryRunner(
-                query={
-                    "kind": "PathsQuery",
-                    "dateRange": {"date_from": "2021-05-01", "date_to": "2021-05-07"},
-                    "pathsFilter": {"includeEventTypes": ["$pageview", "custom_event"]},
-                    "funnelPathsFilter": {
-                        "funnelPathType": "funnel_path_after_step",
-                        "funnelSource": funnel_source,
-                        "funnelStep": 2,
-                    },
-                },
-                team=self.team,
-            ).run()
-
-            assert isinstance(result, CachedPathsQueryResponse)
-            # Only the /after pageview from the completed session should survive the join.
-            self.assertEqual(
-                [(link.source, link.target, link.value) for link in result.results],
-                [("1_step two", "2_/after", 1)],
-            )
-            # Sanity: the completing session's id actually reached the events join.
-            self.assertIsNotNone(session_completed)
-
-    def test_funnel_paths_after_step_group_aggregation(self):
-        """Group-aggregated funnel + ``Show user paths after step``. Before the fix, the hardcoded
-        join (``events.person_id = funnel_actors.actor_id``) compared a person UUID against a
-        group key string and returned zero rows."""
+    def _create_group_funnel_events(self) -> None:
         create_group_type_mapping_without_created_at(
             team=self.team, project_id=self.team.project_id, group_type="organization", group_type_index=0
         )
@@ -3617,14 +3627,14 @@ class TestClickhousePathsFunnelSource(ClickhouseTestMixin, APIBaseTest):
 
         _create_person(distinct_ids=["group_user_1"], team_id=self.team.pk)
         _create_event(
-            event="step one",
+            event="$pageview",
             distinct_id="group_user_1",
             team=self.team,
             timestamp="2021-05-01 01:00:00",
-            properties={"$group_0": "org:completed"},
+            properties={"$current_url": "/before", "$group_0": "org:completed"},
         )
         _create_event(
-            event="step two",
+            event="step one",
             distinct_id="group_user_1",
             team=self.team,
             timestamp="2021-05-01 01:01:00",
@@ -3635,25 +3645,97 @@ class TestClickhousePathsFunnelSource(ClickhouseTestMixin, APIBaseTest):
             distinct_id="group_user_1",
             team=self.team,
             timestamp="2021-05-01 01:02:00",
+            properties={"$current_url": "/between", "$group_0": "org:completed"},
+        )
+        _create_event(
+            event="step two",
+            distinct_id="group_user_1",
+            team=self.team,
+            timestamp="2021-05-01 01:03:00",
+            properties={"$group_0": "org:completed"},
+        )
+        _create_event(
+            event="$pageview",
+            distinct_id="group_user_1",
+            team=self.team,
+            timestamp="2021-05-01 01:04:00",
             properties={"$current_url": "/after", "$group_0": "org:completed"},
         )
 
-        # Different org that never reaches step two — its /after event must be filtered out.
+        # Different org that never reaches step two — its events must be filtered out.
         _create_person(distinct_ids=["group_user_2"], team_id=self.team.pk)
+        _create_event(
+            event="$pageview",
+            distinct_id="group_user_2",
+            team=self.team,
+            timestamp="2021-05-01 03:00:00",
+            properties={"$current_url": "/before", "$group_0": "org:incomplete"},
+        )
         _create_event(
             event="step one",
             distinct_id="group_user_2",
             team=self.team,
-            timestamp="2021-05-01 03:00:00",
+            timestamp="2021-05-01 03:01:00",
             properties={"$group_0": "org:incomplete"},
         )
         _create_event(
             event="$pageview",
             distinct_id="group_user_2",
             team=self.team,
-            timestamp="2021-05-01 03:01:00",
+            timestamp="2021-05-01 03:02:00",
             properties={"$current_url": "/after", "$group_0": "org:incomplete"},
         )
+
+    def _run_paths_query(self, funnel_source: dict, funnel_path_type: str, funnel_step: int) -> list[tuple]:
+        with freeze_time("2021-05-08T00:00:00.000Z"):
+            result = PathsQueryRunner(
+                query={
+                    "kind": "PathsQuery",
+                    "dateRange": {"date_from": "2021-05-01", "date_to": "2021-05-07"},
+                    "pathsFilter": {"includeEventTypes": ["$pageview", "custom_event"]},
+                    "funnelPathsFilter": {
+                        "funnelPathType": funnel_path_type,
+                        "funnelSource": funnel_source,
+                        "funnelStep": funnel_step,
+                    },
+                },
+                team=self.team,
+            ).run()
+        assert isinstance(result, CachedPathsQueryResponse)
+        return [(link.source, link.target, link.value) for link in result.results]
+
+    @parameterized.expand(FUNNEL_PATH_CASES)
+    def test_funnel_paths_session_aggregation(self, _name, funnel_path_type, funnel_step, expected):
+        """Session-aggregated funnel source. Pre-fix, ``after_step`` failed with
+        ``Ambiguous query. Found multiple sources for field: person_id`` and, once that
+        was patched, the join on ``events.person_id = funnel_actors.actor_id`` compared a
+        person UUID against a session id and returned zero rows.
+        """
+        self._create_session_funnel_events()
+
+        funnel_source = {
+            "kind": "FunnelsQuery",
+            "series": [
+                {"kind": "EventsNode", "event": "step one"},
+                {"kind": "EventsNode", "event": "step two"},
+            ],
+            "dateRange": {"date_from": "2021-05-01", "date_to": "2021-05-07"},
+            "funnelsFilter": {
+                "funnelAggregateByHogQL": "properties.$session_id",
+                "funnelWindowInterval": 7,
+                "funnelWindowIntervalUnit": "day",
+            },
+        }
+
+        self.assertEqual(self._run_paths_query(funnel_source, funnel_path_type, funnel_step), expected)
+
+    @parameterized.expand(FUNNEL_PATH_CASES)
+    def test_funnel_paths_group_aggregation(self, _name, funnel_path_type, funnel_step, expected):
+        """Group-aggregated funnel source. Pre-fix, the hardcoded
+        ``events.person_id = funnel_actors.actor_id`` join compared a person UUID against a
+        group key string and returned zero rows regardless of path type.
+        """
+        self._create_group_funnel_events()
 
         funnel_source = {
             "kind": "FunnelsQuery",
@@ -3669,26 +3751,7 @@ class TestClickhousePathsFunnelSource(ClickhouseTestMixin, APIBaseTest):
             },
         }
 
-        with freeze_time("2021-05-08T00:00:00.000Z"):
-            result = PathsQueryRunner(
-                query={
-                    "kind": "PathsQuery",
-                    "dateRange": {"date_from": "2021-05-01", "date_to": "2021-05-07"},
-                    "pathsFilter": {"includeEventTypes": ["$pageview", "custom_event"]},
-                    "funnelPathsFilter": {
-                        "funnelPathType": "funnel_path_after_step",
-                        "funnelSource": funnel_source,
-                        "funnelStep": 2,
-                    },
-                },
-                team=self.team,
-            ).run()
-
-            assert isinstance(result, CachedPathsQueryResponse)
-            self.assertEqual(
-                [(link.source, link.target, link.value) for link in result.results],
-                [("1_step two", "2_/after", 1)],
-            )
+        self.assertEqual(self._run_paths_query(funnel_source, funnel_path_type, funnel_step), expected)
 
 
 class TestClickhousePathsEdgeValidation(TestCase):


### PR DESCRIPTION
## Problem

https://posthoghelp.zendesk.com/agent/tickets/55403 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/56639)

When a funnel is aggregated by unique sessions (or by group), clicking "Show user paths after step" errors out with `Ambiguous query. Found multiple sources for field: person_id` — and if you patch that, the query then times out because the join compares a session id string against a person UUID.

## Changes

1. The funnel-paths join was hardcoded to `events.person_id = funnel_actors.actor_id`. Swapped the left side for `_funnel_events_join_expr`, which picks `events.person_id`, `events.$group_N`, or `properties.$session_id` depending on the funnel's aggregation — mirroring what the funnel itself does in `FunnelEventQuery._aggregation_target_expr`.
2. Qualified an unqualified `person_id` in the ORDER BY so it no longer clashes with the `person_id` column the funnel actors subquery exposes when session-aggregated.

Plus regression tests: `TestClickhousePathsFunnelSource` parametrized across all three funnel path types × session/group aggregation.

## How did you test this code?

Followed the steps in the ticket

## Publish to changelog?
no

## 🤖 LLM context

Authored by Claude (Opus 4.6). Started from a customer repro: session-aggregated funnel → "Show user paths after step". Reviewer note: the paths query still `GROUP BY person_id` even for session-aggregated funnels — pre-existing architecture, out of scope here, but worth a followup if "paths per session" ever becomes a real ask.