### PR TITLE
feat(flags): preserve conditions when switching targeting modes

### DIFF
--- a/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditionsCollapsible.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditionsCollapsible.tsx
@@ -801,6 +801,7 @@ export function FeatureFlagReleaseConditionsCollapsible({
         setConditionAggregation,
         setOpenConditions,
         setIsMixedTargeting,
+        switchToMixedTargeting,
         setMixedGroupTypeIndex,
         setIsAnyItemDragging,
         setDraggedGroup,
@@ -926,8 +927,7 @@ export function FeatureFlagReleaseConditionsCollapsible({
             }
             onBucketingIdentifierChange?.(null)
         } else if (value === 'mixed') {
-            setIsMixedTargeting(true)
-            setAggregationGroupTypeIndex(null)
+            switchToMixedTargeting()
             onBucketingIdentifierChange?.(null)
         }
     }
@@ -1095,7 +1095,8 @@ export function FeatureFlagReleaseConditionsCollapsible({
                                         {option.value === 'group' &&
                                             isSelected &&
                                             releaseFilters.aggregation_group_type_index != null &&
-                                            !isMixedTargeting && (
+                                            !isMixedTargeting &&
+                                            (groupTypeValues.length > 1 ? (
                                                 <div onClick={(e) => e.stopPropagation()}>
                                                     <LemonSelect
                                                         size="xsmall"
@@ -1113,27 +1114,34 @@ export function FeatureFlagReleaseConditionsCollapsible({
                                                         }))}
                                                     />
                                                 </div>
-                                            )}
+                                            ) : (
+                                                <span className="text-xs font-medium">
+                                                    {groupTypeValues[0]?.group_type}
+                                                </span>
+                                            ))}
                                         {/* Mixed group type selector */}
-                                        {option.value === 'mixed' && isSelected && isMixedTargeting && (
-                                            <div onClick={(e) => e.stopPropagation()}>
-                                                <LemonSelect
-                                                    size="xsmall"
-                                                    dropdownMatchSelectWidth={false}
-                                                    data-attr="feature-flag-mixed-group-type-select"
-                                                    value={mixedGroupTypeIndex}
-                                                    onChange={(value) => {
-                                                        if (value != null) {
-                                                            setMixedGroupTypeIndex(value)
-                                                        }
-                                                    }}
-                                                    options={groupTypeValues.map((groupType) => ({
-                                                        value: groupType.group_type_index,
-                                                        label: groupType.group_type,
-                                                    }))}
-                                                />
-                                            </div>
-                                        )}
+                                        {option.value === 'mixed' &&
+                                            isSelected &&
+                                            isMixedTargeting &&
+                                            groupTypeValues.length > 1 && (
+                                                <div onClick={(e) => e.stopPropagation()}>
+                                                    <LemonSelect
+                                                        size="xsmall"
+                                                        dropdownMatchSelectWidth={false}
+                                                        data-attr="feature-flag-mixed-group-type-select"
+                                                        value={mixedGroupTypeIndex}
+                                                        onChange={(value) => {
+                                                            if (value != null) {
+                                                                setMixedGroupTypeIndex(value)
+                                                            }
+                                                        }}
+                                                        options={groupTypeValues.map((groupType) => ({
+                                                            value: groupType.group_type_index,
+                                                            label: groupType.group_type,
+                                                        }))}
+                                                    />
+                                                </div>
+                                            )}
                                     </div>
                                 </div>
                             )

--- a/frontend/src/scenes/feature-flags/featureFlagReleaseConditionsLogic.test.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagReleaseConditionsLogic.test.ts
@@ -1068,109 +1068,97 @@ describe('the feature flag release conditions logic', () => {
             })
         })
 
-        it('preserves everything when switching from group to mixed', async () => {
+        it.each([
+            {
+                name: 'group → mixed',
+                initialGlobal: 0 as number | null,
+                initialGroups: [
+                    {
+                        properties: groupProperties,
+                        rollout_percentage: 50,
+                        variant: 'control' as string | null,
+                        sort_key: 'cond-1',
+                        description: 'Tech orgs',
+                    },
+                    {
+                        properties: groupProperties,
+                        rollout_percentage: 100,
+                        variant: null as string | null,
+                        sort_key: 'cond-2',
+                        description: 'All orgs',
+                    },
+                ],
+                expectedPerConditionAgg: 0 as number | null,
+            },
+            {
+                name: 'user → mixed',
+                initialGlobal: null,
+                initialGroups: [
+                    {
+                        properties: userProperties,
+                        rollout_percentage: 75,
+                        variant: null as string | null,
+                        sort_key: 'cond-1',
+                    },
+                ],
+                expectedPerConditionAgg: null,
+            },
+        ])(
+            'preserves everything when switching $name',
+            async ({ initialGlobal, initialGroups, expectedPerConditionAgg }) => {
+                logic?.unmount()
+
+                logic = featureFlagReleaseConditionsLogic({
+                    id: `transition-to-mixed`,
+                    filters: {
+                        ...generateFeatureFlagFilters(initialGroups),
+                        aggregation_group_type_index: initialGlobal,
+                    },
+                })
+
+                await expectLogic(logic, () => {
+                    logic.mount()
+                })
+
+                await expectLogic(logic, () => {
+                    logic.actions.switchToMixedTargeting()
+                }).toMatchValues({
+                    isMixedTargeting: true,
+                    filters: expect.objectContaining({
+                        aggregation_group_type_index: null,
+                        groups: initialGroups.map((g) =>
+                            expect.objectContaining({
+                                ...g,
+                                aggregation_group_type_index: expectedPerConditionAgg,
+                            })
+                        ),
+                    }),
+                })
+            }
+        )
+
+        it.each([
+            {
+                name: 'mixed → user',
+                targetAggregation: null as number | null,
+                expectedGroups: [
+                    { sort_key: 'user-cond', rollout_percentage: 50, properties: userProperties },
+                    { sort_key: 'group-cond', rollout_percentage: 30, variant: 'test', properties: [] },
+                ],
+            },
+            {
+                name: 'mixed → group',
+                targetAggregation: 0 as number | null,
+                expectedGroups: [
+                    { sort_key: 'user-cond', rollout_percentage: 50, properties: [] },
+                    { sort_key: 'group-cond', rollout_percentage: 30, properties: groupProperties },
+                ],
+            },
+        ])('selectively clears properties when switching $name', async ({ targetAggregation, expectedGroups }) => {
             logic?.unmount()
 
             logic = featureFlagReleaseConditionsLogic({
-                id: 'transition-group-to-mixed',
-                filters: {
-                    ...generateFeatureFlagFilters([
-                        {
-                            properties: groupProperties,
-                            rollout_percentage: 50,
-                            variant: 'control',
-                            sort_key: 'cond-1',
-                            description: 'Tech orgs',
-                        },
-                        {
-                            properties: groupProperties,
-                            rollout_percentage: 100,
-                            variant: null,
-                            sort_key: 'cond-2',
-                            description: 'All orgs',
-                        },
-                    ]),
-                    aggregation_group_type_index: 0,
-                },
-            })
-
-            await expectLogic(logic, () => {
-                logic.mount()
-            })
-
-            await expectLogic(logic, () => {
-                logic.actions.switchToMixedTargeting()
-            }).toMatchValues({
-                isMixedTargeting: true,
-                filters: expect.objectContaining({
-                    aggregation_group_type_index: null,
-                    groups: [
-                        expect.objectContaining({
-                            sort_key: 'cond-1',
-                            rollout_percentage: 50,
-                            variant: 'control',
-                            description: 'Tech orgs',
-                            properties: groupProperties, // Preserved
-                            aggregation_group_type_index: 0, // Inherited from global
-                        }),
-                        expect.objectContaining({
-                            sort_key: 'cond-2',
-                            rollout_percentage: 100,
-                            variant: null,
-                            description: 'All orgs',
-                            properties: groupProperties, // Preserved
-                            aggregation_group_type_index: 0, // Inherited from global
-                        }),
-                    ],
-                }),
-            })
-        })
-
-        it('preserves everything when switching from user to mixed', async () => {
-            logic?.unmount()
-
-            logic = featureFlagReleaseConditionsLogic({
-                id: 'transition-user-to-mixed',
-                filters: {
-                    ...generateFeatureFlagFilters([
-                        {
-                            properties: userProperties,
-                            rollout_percentage: 75,
-                            variant: null,
-                            sort_key: 'cond-1',
-                        },
-                    ]),
-                    aggregation_group_type_index: null,
-                },
-            })
-
-            await expectLogic(logic, () => {
-                logic.mount()
-            })
-
-            await expectLogic(logic, () => {
-                logic.actions.switchToMixedTargeting()
-            }).toMatchValues({
-                isMixedTargeting: true,
-                filters: expect.objectContaining({
-                    aggregation_group_type_index: null,
-                    groups: [
-                        expect.objectContaining({
-                            sort_key: 'cond-1',
-                            rollout_percentage: 75,
-                            properties: userProperties, // Preserved
-                            aggregation_group_type_index: null, // User-scoped
-                        }),
-                    ],
-                }),
-            })
-        })
-
-        it('selectively clears properties when switching from mixed to user', async () => {
-            logic?.unmount()
-
-            logic = featureFlagReleaseConditionsLogic({
-                id: 'transition-mixed-to-user',
+                id: `transition-from-mixed`,
                 filters: {
                     ...generateFeatureFlagFilters([
                         {
@@ -1196,77 +1184,12 @@ describe('the feature flag release conditions logic', () => {
                 logic.mount()
             })
 
-            // Switch to user-only targeting
             await expectLogic(logic, () => {
-                logic.actions.setAggregationGroupTypeIndex(null)
+                logic.actions.setAggregationGroupTypeIndex(targetAggregation)
             }).toMatchValues({
                 filters: expect.objectContaining({
-                    aggregation_group_type_index: null,
-                    groups: [
-                        expect.objectContaining({
-                            sort_key: 'user-cond',
-                            rollout_percentage: 50,
-                            properties: userProperties, // Preserved: was already user-scoped
-                        }),
-                        expect.objectContaining({
-                            sort_key: 'group-cond',
-                            rollout_percentage: 30,
-                            variant: 'test',
-                            properties: [], // Cleared: was group-scoped
-                        }),
-                    ],
-                }),
-            })
-        })
-
-        it('selectively clears properties when switching from mixed to group', async () => {
-            logic?.unmount()
-
-            logic = featureFlagReleaseConditionsLogic({
-                id: 'transition-mixed-to-group',
-                filters: {
-                    ...generateFeatureFlagFilters([
-                        {
-                            properties: userProperties,
-                            rollout_percentage: 50,
-                            variant: null,
-                            sort_key: 'user-cond',
-                            aggregation_group_type_index: null,
-                        },
-                        {
-                            properties: groupProperties,
-                            rollout_percentage: 30,
-                            variant: null,
-                            sort_key: 'group-cond',
-                            aggregation_group_type_index: 0,
-                        },
-                    ]),
-                    aggregation_group_type_index: null,
-                },
-            })
-
-            await expectLogic(logic, () => {
-                logic.mount()
-            })
-
-            // Switch to group-only targeting (group type 0)
-            await expectLogic(logic, () => {
-                logic.actions.setAggregationGroupTypeIndex(0)
-            }).toMatchValues({
-                filters: expect.objectContaining({
-                    aggregation_group_type_index: 0,
-                    groups: [
-                        expect.objectContaining({
-                            sort_key: 'user-cond',
-                            rollout_percentage: 50,
-                            properties: [], // Cleared: was user-scoped
-                        }),
-                        expect.objectContaining({
-                            sort_key: 'group-cond',
-                            rollout_percentage: 30,
-                            properties: groupProperties, // Preserved: was already group 0
-                        }),
-                    ],
+                    aggregation_group_type_index: targetAggregation,
+                    groups: expectedGroups.map((g) => expect.objectContaining(g)),
                 }),
             })
         })

--- a/frontend/src/scenes/feature-flags/featureFlagReleaseConditionsLogic.test.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagReleaseConditionsLogic.test.ts
@@ -6,6 +6,7 @@ import api from 'lib/api'
 import { useMocks } from '~/mocks/jest'
 import { initKeaTests } from '~/test/init'
 import {
+    AnyPropertyFilter,
     FeatureFlagGroupType,
     FeatureFlagType,
     MultivariateFlagOptions,
@@ -908,14 +909,13 @@ describe('the feature flag release conditions logic', () => {
                     openConditions: ['condition-OLD-KEY'],
                 })
 
-            // Switch to group aggregation - this resets groups with new sort_key
+            // Switch to group aggregation - direct user→group resets groups with new sort_key
             nextUuid = 'NEW-KEY'
             await expectLogic(logic, () => {
                 logic.actions.setAggregationGroupTypeIndex(0)
             })
                 .toDispatchActions(['setAggregationGroupTypeIndex', 'setOpenConditions'])
                 .toMatchValues({
-                    // The open state should be preserved by index (first condition stays open)
                     openConditions: ['condition-NEW-KEY'],
                 })
         })
@@ -995,6 +995,279 @@ describe('the feature flag release conditions logic', () => {
                     expect.objectContaining({ sort_key: 'first', rollout_percentage: 50 }),
                     expect.objectContaining({ sort_key: 'second', rollout_percentage: 30 }),
                 ],
+            })
+        })
+    })
+
+    describe('targeting mode transitions', () => {
+        const userProperties: AnyPropertyFilter[] = [
+            {
+                key: 'email',
+                value: ['test@posthog.com'],
+                operator: PropertyOperator.Exact,
+                type: PropertyFilterType.Person,
+            },
+        ]
+
+        const groupProperties: AnyPropertyFilter[] = [
+            {
+                key: 'industry',
+                value: ['tech'],
+                operator: PropertyOperator.Exact,
+                type: PropertyFilterType.Group,
+            },
+        ]
+
+        it('fully resets conditions when switching between incompatible types (user to group)', async () => {
+            logic?.unmount()
+
+            nextUuid = 'RESET'
+            logic = featureFlagReleaseConditionsLogic({
+                id: 'transition-user-to-group',
+                filters: {
+                    ...generateFeatureFlagFilters([
+                        {
+                            properties: userProperties,
+                            rollout_percentage: 50,
+                            variant: 'control',
+                            sort_key: 'cond-1',
+                            description: 'Beta users',
+                        },
+                        {
+                            properties: userProperties,
+                            rollout_percentage: 30,
+                            variant: 'test',
+                            sort_key: 'cond-2',
+                            description: 'Alpha users',
+                        },
+                    ]),
+                    aggregation_group_type_index: null,
+                },
+            })
+
+            await expectLogic(logic, () => {
+                logic.mount()
+            })
+
+            // Direct user→group transition resets to a single empty condition
+            nextUuid = 'NEW'
+            await expectLogic(logic, () => {
+                logic.actions.setAggregationGroupTypeIndex(0)
+            }).toMatchValues({
+                filters: expect.objectContaining({
+                    aggregation_group_type_index: 0,
+                    groups: [
+                        expect.objectContaining({
+                            sort_key: 'NEW',
+                            rollout_percentage: 50, // Preserves first condition's rollout %
+                            variant: null,
+                            properties: [],
+                        }),
+                    ],
+                }),
+            })
+        })
+
+        it('preserves everything when switching from group to mixed', async () => {
+            logic?.unmount()
+
+            logic = featureFlagReleaseConditionsLogic({
+                id: 'transition-group-to-mixed',
+                filters: {
+                    ...generateFeatureFlagFilters([
+                        {
+                            properties: groupProperties,
+                            rollout_percentage: 50,
+                            variant: 'control',
+                            sort_key: 'cond-1',
+                            description: 'Tech orgs',
+                        },
+                        {
+                            properties: groupProperties,
+                            rollout_percentage: 100,
+                            variant: null,
+                            sort_key: 'cond-2',
+                            description: 'All orgs',
+                        },
+                    ]),
+                    aggregation_group_type_index: 0,
+                },
+            })
+
+            await expectLogic(logic, () => {
+                logic.mount()
+            })
+
+            await expectLogic(logic, () => {
+                logic.actions.switchToMixedTargeting()
+            }).toMatchValues({
+                isMixedTargeting: true,
+                filters: expect.objectContaining({
+                    aggregation_group_type_index: null,
+                    groups: [
+                        expect.objectContaining({
+                            sort_key: 'cond-1',
+                            rollout_percentage: 50,
+                            variant: 'control',
+                            description: 'Tech orgs',
+                            properties: groupProperties, // Preserved
+                            aggregation_group_type_index: 0, // Inherited from global
+                        }),
+                        expect.objectContaining({
+                            sort_key: 'cond-2',
+                            rollout_percentage: 100,
+                            variant: null,
+                            description: 'All orgs',
+                            properties: groupProperties, // Preserved
+                            aggregation_group_type_index: 0, // Inherited from global
+                        }),
+                    ],
+                }),
+            })
+        })
+
+        it('preserves everything when switching from user to mixed', async () => {
+            logic?.unmount()
+
+            logic = featureFlagReleaseConditionsLogic({
+                id: 'transition-user-to-mixed',
+                filters: {
+                    ...generateFeatureFlagFilters([
+                        {
+                            properties: userProperties,
+                            rollout_percentage: 75,
+                            variant: null,
+                            sort_key: 'cond-1',
+                        },
+                    ]),
+                    aggregation_group_type_index: null,
+                },
+            })
+
+            await expectLogic(logic, () => {
+                logic.mount()
+            })
+
+            await expectLogic(logic, () => {
+                logic.actions.switchToMixedTargeting()
+            }).toMatchValues({
+                isMixedTargeting: true,
+                filters: expect.objectContaining({
+                    aggregation_group_type_index: null,
+                    groups: [
+                        expect.objectContaining({
+                            sort_key: 'cond-1',
+                            rollout_percentage: 75,
+                            properties: userProperties, // Preserved
+                            aggregation_group_type_index: null, // User-scoped
+                        }),
+                    ],
+                }),
+            })
+        })
+
+        it('selectively clears properties when switching from mixed to user', async () => {
+            logic?.unmount()
+
+            logic = featureFlagReleaseConditionsLogic({
+                id: 'transition-mixed-to-user',
+                filters: {
+                    ...generateFeatureFlagFilters([
+                        {
+                            properties: userProperties,
+                            rollout_percentage: 50,
+                            variant: null,
+                            sort_key: 'user-cond',
+                            aggregation_group_type_index: null,
+                        },
+                        {
+                            properties: groupProperties,
+                            rollout_percentage: 30,
+                            variant: 'test',
+                            sort_key: 'group-cond',
+                            aggregation_group_type_index: 0,
+                        },
+                    ]),
+                    aggregation_group_type_index: null,
+                },
+            })
+
+            await expectLogic(logic, () => {
+                logic.mount()
+            })
+
+            // Switch to user-only targeting
+            await expectLogic(logic, () => {
+                logic.actions.setAggregationGroupTypeIndex(null)
+            }).toMatchValues({
+                filters: expect.objectContaining({
+                    aggregation_group_type_index: null,
+                    groups: [
+                        expect.objectContaining({
+                            sort_key: 'user-cond',
+                            rollout_percentage: 50,
+                            properties: userProperties, // Preserved: was already user-scoped
+                        }),
+                        expect.objectContaining({
+                            sort_key: 'group-cond',
+                            rollout_percentage: 30,
+                            variant: 'test',
+                            properties: [], // Cleared: was group-scoped
+                        }),
+                    ],
+                }),
+            })
+        })
+
+        it('selectively clears properties when switching from mixed to group', async () => {
+            logic?.unmount()
+
+            logic = featureFlagReleaseConditionsLogic({
+                id: 'transition-mixed-to-group',
+                filters: {
+                    ...generateFeatureFlagFilters([
+                        {
+                            properties: userProperties,
+                            rollout_percentage: 50,
+                            variant: null,
+                            sort_key: 'user-cond',
+                            aggregation_group_type_index: null,
+                        },
+                        {
+                            properties: groupProperties,
+                            rollout_percentage: 30,
+                            variant: null,
+                            sort_key: 'group-cond',
+                            aggregation_group_type_index: 0,
+                        },
+                    ]),
+                    aggregation_group_type_index: null,
+                },
+            })
+
+            await expectLogic(logic, () => {
+                logic.mount()
+            })
+
+            // Switch to group-only targeting (group type 0)
+            await expectLogic(logic, () => {
+                logic.actions.setAggregationGroupTypeIndex(0)
+            }).toMatchValues({
+                filters: expect.objectContaining({
+                    aggregation_group_type_index: 0,
+                    groups: [
+                        expect.objectContaining({
+                            sort_key: 'user-cond',
+                            rollout_percentage: 50,
+                            properties: [], // Cleared: was user-scoped
+                        }),
+                        expect.objectContaining({
+                            sort_key: 'group-cond',
+                            rollout_percentage: 30,
+                            properties: groupProperties, // Preserved: was already group 0
+                        }),
+                    ],
+                }),
             })
         })
     })

--- a/frontend/src/scenes/feature-flags/featureFlagReleaseConditionsLogic.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagReleaseConditionsLogic.ts
@@ -190,11 +190,10 @@ export const featureFlagReleaseConditionsLogic = kea<featureFlagReleaseCondition
                             const scopeChanged = previousEffective != value
                             return {
                                 ...group,
-                                sort_key: group.sort_key,
                                 aggregation_group_type_index: undefined,
                                 properties: scopeChanged ? [] : group.properties,
                             }
-                        }),
+                        }) as FeatureFlagGroupTypeWithSortKey[],
                     }
                 }
 
@@ -269,9 +268,8 @@ export const featureFlagReleaseConditionsLogic = kea<featureFlagReleaseCondition
                     // per-condition value, so properties remain valid
                     groups: state.groups.map((group) => ({
                         ...group,
-                        sort_key: group.sort_key,
                         aggregation_group_type_index: group.aggregation_group_type_index ?? previousGlobal ?? null,
-                    })),
+                    })) as FeatureFlagGroupTypeWithSortKey[],
                 }
             },
             setConditionAggregation: (state, { index, groupTypeIndex }) => {

--- a/frontend/src/scenes/feature-flags/featureFlagReleaseConditionsLogic.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagReleaseConditionsLogic.ts
@@ -183,7 +183,7 @@ export const featureFlagReleaseConditionsLogic = kea<featureFlagReleaseCondition
                     return {
                         ...state,
                         aggregation_group_type_index: value,
-                        groups: state.groups.map((group) => {
+                        groups: state.groups.map((group): FeatureFlagGroupTypeWithSortKey => {
                             const previousEffective =
                                 group.aggregation_group_type_index ?? state.aggregation_group_type_index ?? null
                             // Use == to treat null and undefined equivalently
@@ -209,7 +209,7 @@ export const featureFlagReleaseConditionsLogic = kea<featureFlagReleaseCondition
                             rollout_percentage: originalRolloutPercentage,
                             variant: null,
                             sort_key: uuidv4(),
-                        },
+                        } as FeatureFlagGroupTypeWithSortKey,
                     ],
                 }
             },
@@ -266,10 +266,12 @@ export const featureFlagReleaseConditionsLogic = kea<featureFlagReleaseCondition
                     aggregation_group_type_index: null,
                     // Each condition inherits the global aggregation type as its
                     // per-condition value, so properties remain valid
-                    groups: state.groups.map((group) => ({
-                        ...group,
-                        aggregation_group_type_index: group.aggregation_group_type_index ?? previousGlobal ?? null,
-                    })),
+                    groups: state.groups.map(
+                        (group): FeatureFlagGroupTypeWithSortKey => ({
+                            ...group,
+                            aggregation_group_type_index: group.aggregation_group_type_index ?? previousGlobal ?? null,
+                        })
+                    ),
                 }
             },
             setConditionAggregation: (state, { index, groupTypeIndex }) => {

--- a/frontend/src/scenes/feature-flags/featureFlagReleaseConditionsLogic.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagReleaseConditionsLogic.ts
@@ -183,13 +183,15 @@ export const featureFlagReleaseConditionsLogic = kea<featureFlagReleaseCondition
                     return {
                         ...state,
                         aggregation_group_type_index: value,
-                        groups: state.groups.map(({ aggregation_group_type_index: perConditionAgg, ...rest }) => {
-                            const previousEffective = perConditionAgg ?? state.aggregation_group_type_index ?? null
+                        groups: state.groups.map((group) => {
+                            const previousEffective =
+                                group.aggregation_group_type_index ?? state.aggregation_group_type_index ?? null
                             // Use == to treat null and undefined equivalently
                             const scopeChanged = previousEffective != value
                             return {
-                                ...rest,
-                                properties: scopeChanged ? [] : rest.properties,
+                                ...group,
+                                aggregation_group_type_index: undefined,
+                                properties: scopeChanged ? [] : group.properties,
                             }
                         }),
                     }

--- a/frontend/src/scenes/feature-flags/featureFlagReleaseConditionsLogic.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagReleaseConditionsLogic.ts
@@ -183,13 +183,14 @@ export const featureFlagReleaseConditionsLogic = kea<featureFlagReleaseCondition
                     return {
                         ...state,
                         aggregation_group_type_index: value,
-                        groups: state.groups.map((group): FeatureFlagGroupTypeWithSortKey => {
+                        groups: state.groups.map((group) => {
                             const previousEffective =
                                 group.aggregation_group_type_index ?? state.aggregation_group_type_index ?? null
                             // Use == to treat null and undefined equivalently
                             const scopeChanged = previousEffective != value
                             return {
                                 ...group,
+                                sort_key: group.sort_key,
                                 aggregation_group_type_index: undefined,
                                 properties: scopeChanged ? [] : group.properties,
                             }
@@ -266,12 +267,11 @@ export const featureFlagReleaseConditionsLogic = kea<featureFlagReleaseCondition
                     aggregation_group_type_index: null,
                     // Each condition inherits the global aggregation type as its
                     // per-condition value, so properties remain valid
-                    groups: state.groups.map(
-                        (group): FeatureFlagGroupTypeWithSortKey => ({
-                            ...group,
-                            aggregation_group_type_index: group.aggregation_group_type_index ?? previousGlobal ?? null,
-                        })
-                    ),
+                    groups: state.groups.map((group) => ({
+                        ...group,
+                        sort_key: group.sort_key,
+                        aggregation_group_type_index: group.aggregation_group_type_index ?? previousGlobal ?? null,
+                    })),
                 }
             },
             setConditionAggregation: (state, { index, groupTypeIndex }) => {

--- a/frontend/src/scenes/feature-flags/featureFlagReleaseConditionsLogic.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagReleaseConditionsLogic.ts
@@ -137,6 +137,7 @@ export const featureFlagReleaseConditionsLogic = kea<featureFlagReleaseCondition
         setOpenConditions: (openConditions: string[]) => ({ openConditions }),
         openCondition: (sortKey: string) => ({ sortKey }),
         setIsMixedTargeting: (isMixedTargeting: boolean) => ({ isMixedTargeting }),
+        switchToMixedTargeting: true,
         setMixedGroupTypeIndex: (mixedGroupTypeIndex: number) => ({ mixedGroupTypeIndex }),
         setIsAnyItemDragging: (isAnyItemDragging: boolean) => ({ isAnyItemDragging }),
         setDraggedGroup: (draggedGroup: FeatureFlagGroupType | null) => ({ draggedGroup }),
@@ -165,16 +166,41 @@ export const featureFlagReleaseConditionsLogic = kea<featureFlagReleaseCondition
                 return { ...filters, groups: groupsWithKeys }
             },
             setAggregationGroupTypeIndex: (state, { value }) => {
-                if (!state || state.aggregation_group_type_index == value) {
+                if (!state) {
                     return state
                 }
 
-                const originalRolloutPercentage = state.groups[0].rollout_percentage
+                const globalUnchanged = state.aggregation_group_type_index == value
+                const hasPerConditionAggregations = state.groups.some((g) => g.aggregation_group_type_index != null)
 
+                if (globalUnchanged && !hasPerConditionAggregations) {
+                    return state
+                }
+
+                // Coming from mixed mode: selectively preserve conditions whose
+                // aggregation scope matches the new target
+                if (hasPerConditionAggregations) {
+                    return {
+                        ...state,
+                        aggregation_group_type_index: value,
+                        groups: state.groups.map(({ aggregation_group_type_index: perConditionAgg, ...rest }) => {
+                            const previousEffective = perConditionAgg ?? state.aggregation_group_type_index ?? null
+                            // Use == to treat null and undefined equivalently
+                            const scopeChanged = previousEffective != value
+                            return {
+                                ...rest,
+                                properties: scopeChanged ? [] : rest.properties,
+                            }
+                        }),
+                    }
+                }
+
+                // Direct transition between incompatible types (user ↔ group):
+                // full reset since property filters from one scope don't apply to another
+                const originalRolloutPercentage = state.groups[0]?.rollout_percentage
                 return {
                     ...state,
                     aggregation_group_type_index: value,
-                    // :TRICKY: We reset property filters after changing what you're aggregating by.
                     groups: [
                         {
                             properties: [],
@@ -227,6 +253,22 @@ export const featureFlagReleaseConditionsLogic = kea<featureFlagReleaseCondition
                 }
 
                 return { ...state, groups }
+            },
+            switchToMixedTargeting: (state) => {
+                if (!state) {
+                    return state
+                }
+                const previousGlobal = state.aggregation_group_type_index
+                return {
+                    ...state,
+                    aggregation_group_type_index: null,
+                    // Each condition inherits the global aggregation type as its
+                    // per-condition value, so properties remain valid
+                    groups: state.groups.map((group) => ({
+                        ...group,
+                        aggregation_group_type_index: group.aggregation_group_type_index ?? previousGlobal ?? null,
+                    })),
+                }
             },
             setConditionAggregation: (state, { index, groupTypeIndex }) => {
                 if (!state) {
@@ -342,6 +384,7 @@ export const featureFlagReleaseConditionsLogic = kea<featureFlagReleaseCondition
             false as boolean,
             {
                 setIsMixedTargeting: (_, { isMixedTargeting }) => isMixedTargeting,
+                switchToMixedTargeting: () => true,
             },
         ],
         mixedGroupTypeIndex: [
@@ -454,6 +497,9 @@ export const featureFlagReleaseConditionsLogic = kea<featureFlagReleaseCondition
             if (newOpenConditions.length !== values.openConditions.length) {
                 actions.setOpenConditions(newOpenConditions)
             }
+        },
+        switchToMixedTargeting: () => {
+            actions.calculateBlastRadius()
         },
         setAggregationGroupTypeIndex: () => {
             actions.calculateBlastRadius()


### PR DESCRIPTION
## Problem

When switching between targeting modes (user/group/mixed) on a feature flag, all existing condition sets were destroyed and replaced with a single empty one. This was particularly painful when a flag had many conditions — e.g. 50 orgs in a conditional — because switching from "group" to "user & group" would wipe all that configuration.

Additionally, the group type dropdown was shown even when only one group type exists, which is unnecessary UI noise.

## Changes

**Preserve conditions on mixed mode transitions:**
- Group → Mixed: all conditions preserved with their properties, rollout %, variants, and descriptions. Each condition inherits the global aggregation type as its per-condition value.
- User → Mixed: same preservation behavior.
- Mixed → User: user-scoped conditions keep their properties, group-scoped conditions have properties cleared.
- Mixed → Group: group-scoped conditions matching the target type keep their properties, others are cleared.

**Full reset on incompatible direct transitions:**
- User ↔ Group: full reset to a single empty condition (preserving the first condition's rollout %). Property filters from one scope don't apply to another.

**New `switchToMixedTargeting` action** that atomically transitions to mixed mode — sets `isMixedTargeting = true`, moves the global aggregation to per-condition, and preserves all properties in one state update.

**Hide group type dropdown when only one group type exists**, showing the type name as plain text instead.

## How did you test this code?

- Manually tested (see the below cases)
- 5 new unit tests covering each targeting mode transition (user→group reset, group→mixed preserve, user→mixed preserve, mixed→user selective clear, mixed→group selective clear)
- Updated existing aggregation change test to match new behavior
- All 33 tests pass

## Publish to changelog?

No