### PR TITLE
fix: Use us.posthog.com as authoritative source for OAuth metadata

### DIFF
--- a/services/oauth-proxy/src/handlers/metadata.ts
+++ b/services/oauth-proxy/src/handlers/metadata.ts
@@ -4,56 +4,65 @@
  * Returns metadata pointing to oauth.posthog.com endpoints.
  * MCP clients and other OAuth integrations use this to discover where to register,
  * authorize, and exchange tokens.
+ *
+ * We always cache the information exposed by the authoritative source - us.posthog.com
+ * and simply alter the endpoint-related fields to point to oauth.posthog.com.
+ *
+ * The actual underlying metadata is defined in posthog/api/oauth/views.py#OAuthAuthorizationServerMetadataView.get()
  */
-export function handleMetadata(request: Request): Response {
+
+interface WellKnownOAuthAuthorizationServerMetadata {
+    issuer: string
+    authorization_endpoint: string
+    token_endpoint: string
+    revocation_endpoint: string
+    introspection_endpoint: string
+    userinfo_endpoint: string
+    jwks_uri: string
+    registration_endpoint: string
+    scopes_supported: string[]
+    response_types_supported: string[]
+    response_modes_supported: string[]
+    grant_types_supported: string[]
+    token_endpoint_auth_methods_supported: string[]
+    code_challenge_methods_supported: string[]
+    service_documentation: string
+    client_id_metadata_document_supported: boolean
+}
+
+let authoritativeMetadataCache: WellKnownOAuthAuthorizationServerMetadata | null = null
+let cachedUntil: Date | null = null
+
+// We do not have to worry about local development since the proxy is not used when developing the MCP locally.
+async function fetchAuthoritativeMetadata(): Promise<WellKnownOAuthAuthorizationServerMetadata> {
+    const response = await fetch('https://us.posthog.com/.well-known/oauth-authorization-server')
+    if (!response.ok) {
+        throw new Error(`Failed to fetch authoritative metadata: ${response.statusText}`)
+    }
+
+    return response.json() as Promise<WellKnownOAuthAuthorizationServerMetadata>
+}
+
+export async function handleMetadata(request: Request): Promise<Response> {
+    if (!authoritativeMetadataCache || !cachedUntil || cachedUntil < new Date()) {
+        authoritativeMetadataCache = await fetchAuthoritativeMetadata()
+        cachedUntil = new Date(Date.now() + 600 * 1000) // cache for 10 minutes (600 seconds)
+    }
+
     const url = new URL(request.url)
     const baseUrl = `${url.protocol}//${url.host}`
 
-    const metadata = {
+    // Alter the endpoint-related fields to point to the oauth.posthog.com base domain.
+    const metadata: WellKnownOAuthAuthorizationServerMetadata = {
+        ...authoritativeMetadataCache,
         issuer: baseUrl,
         authorization_endpoint: `${baseUrl}/oauth/authorize/`,
         token_endpoint: `${baseUrl}/oauth/token/`,
-        registration_endpoint: `${baseUrl}/oauth/register/`,
         revocation_endpoint: `${baseUrl}/oauth/revoke/`,
         introspection_endpoint: `${baseUrl}/oauth/introspect/`,
         userinfo_endpoint: `${baseUrl}/oauth/userinfo/`,
         jwks_uri: `${baseUrl}/.well-known/jwks.json`,
-        scopes_supported: [
-            'openid',
-            'profile',
-            'email',
-            'introspection',
-            'action:read',
-            'action:write',
-            'dashboard:read',
-            'dashboard:write',
-            'error_tracking:read',
-            'error_tracking:write',
-            'event_definition:read',
-            'event_definition:write',
-            'experiment:read',
-            'experiment:write',
-            'feature_flag:read',
-            'feature_flag:write',
-            'insight:read',
-            'insight:write',
-            'logs:read',
-            'organization:read',
-            'project:read',
-            'property_definition:read',
-            'query:read',
-            'survey:read',
-            'survey:write',
-            'user:read',
-            'warehouse_table:read',
-            'warehouse_view:read',
-        ],
-        response_types_supported: ['code'],
-        response_modes_supported: ['query'],
-        grant_types_supported: ['authorization_code', 'refresh_token'],
-        token_endpoint_auth_methods_supported: ['none', 'client_secret_post'],
-        code_challenge_methods_supported: ['S256'],
-        service_documentation: 'https://posthog.com/docs/model-context-protocol',
+        registration_endpoint: `${baseUrl}/oauth/register/`,
     }
 
     return new Response(JSON.stringify(metadata), {

--- a/services/oauth-proxy/src/index.ts
+++ b/services/oauth-proxy/src/index.ts
@@ -33,43 +33,43 @@ function normalizePath(path: string): string {
 const routes: Route[] = [
     {
         paths: ['/.well-known/oauth-authorization-server'],
-        handler: (req) => handleMetadata(req),
+        handler: handleMetadata,
     },
     {
         paths: ['/.well-known/jwks.json'],
-        handler: (req) => handleJwks(req),
+        handler: handleJwks,
     },
     {
         paths: ['/oauth/register', '/register'],
         method: 'POST',
-        handler: (req, kv) => handleRegister(req, kv),
+        handler: handleRegister,
     },
     {
         paths: ['/oauth/authorize', '/authorize'],
-        handler: (req, kv) => handleAuthorize(req, kv),
+        handler: handleAuthorize,
     },
     {
         paths: ['/oauth/callback'],
-        handler: (req, kv) => handleCallback(req, kv),
+        handler: handleCallback,
     },
     {
         paths: ['/oauth/token', '/token'],
         method: 'POST',
-        handler: (req, kv) => handleToken(req, kv),
+        handler: handleToken,
     },
     {
         paths: ['/oauth/revoke'],
         method: 'POST',
-        handler: (req, kv) => handleRevoke(req, kv),
+        handler: handleRevoke,
     },
     {
         paths: ['/oauth/introspect'],
         method: 'POST',
-        handler: (req) => handleIntrospect(req),
+        handler: handleIntrospect,
     },
     {
         paths: ['/oauth/userinfo'],
-        handler: (req) => handleUserInfo(req),
+        handler: handleUserInfo,
     },
 ]
 

--- a/services/oauth-proxy/tests/metadata.test.ts
+++ b/services/oauth-proxy/tests/metadata.test.ts
@@ -1,18 +1,110 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { handleMetadata } from '@/handlers/metadata'
+const AUTHORITATIVE_METADATA = {
+    issuer: 'https://us.posthog.com',
+    authorization_endpoint: 'https://us.posthog.com/oauth/authorize/',
+    token_endpoint: 'https://us.posthog.com/oauth/token/',
+    revocation_endpoint: 'https://us.posthog.com/oauth/revoke/',
+    introspection_endpoint: 'https://us.posthog.com/oauth/introspect/',
+    userinfo_endpoint: 'https://us.posthog.com/oauth/userinfo/',
+    jwks_uri: 'https://us.posthog.com/.well-known/jwks.json',
+    registration_endpoint: 'https://us.posthog.com/oauth/register/',
+    scopes_supported: ['openid', 'profile', 'email'],
+    response_types_supported: ['code'],
+    response_modes_supported: ['query'],
+    grant_types_supported: ['authorization_code', 'refresh_token'],
+    token_endpoint_auth_methods_supported: ['none', 'client_secret_post'],
+    code_challenge_methods_supported: ['S256'],
+    service_documentation: 'https://posthog.com/docs/model-context-protocol',
+    client_id_metadata_document_supported: true,
+}
 
 describe('handleMetadata', () => {
-    it('returns valid OAuth authorization server metadata', async () => {
+    beforeEach(() => {
+        vi.resetModules()
+        vi.stubGlobal(
+            'fetch',
+            vi.fn().mockResolvedValue({
+                ok: true,
+                json: () => Promise.resolve(AUTHORITATIVE_METADATA),
+            })
+        )
+    })
+
+    afterEach(() => {
+        vi.restoreAllMocks()
+    })
+
+    it('returns valid OAuth authorization server metadata with endpoints rewritten', async () => {
+        const { handleMetadata } = await import('@/handlers/metadata')
         const request = new Request('https://oauth.posthog.com/.well-known/oauth-authorization-server')
-        const response = handleMetadata(request)
+        const response = await handleMetadata(request)
         const data = (await response.json()) as Record<string, unknown>
 
         expect(response.status).toBe(200)
         expect(data.issuer).toBe('https://oauth.posthog.com')
         expect(data.authorization_endpoint).toBe('https://oauth.posthog.com/oauth/authorize/')
         expect(data.token_endpoint).toBe('https://oauth.posthog.com/oauth/token/')
+        expect(data.revocation_endpoint).toBe('https://oauth.posthog.com/oauth/revoke/')
+        expect(data.introspection_endpoint).toBe('https://oauth.posthog.com/oauth/introspect/')
+        expect(data.userinfo_endpoint).toBe('https://oauth.posthog.com/oauth/userinfo/')
+        expect(data.jwks_uri).toBe('https://oauth.posthog.com/.well-known/jwks.json')
         expect(data.registration_endpoint).toBe('https://oauth.posthog.com/oauth/register/')
+    })
+
+    it('preserves non-endpoint fields from authoritative metadata', async () => {
+        const { handleMetadata } = await import('@/handlers/metadata')
+        const request = new Request('https://oauth.posthog.com/.well-known/oauth-authorization-server')
+        const response = await handleMetadata(request)
+        const data = (await response.json()) as Record<string, unknown>
+
+        expect(data.scopes_supported).toEqual(AUTHORITATIVE_METADATA.scopes_supported)
+        expect(data.response_types_supported).toEqual(AUTHORITATIVE_METADATA.response_types_supported)
+        expect(data.grant_types_supported).toEqual(AUTHORITATIVE_METADATA.grant_types_supported)
         expect(data.code_challenge_methods_supported).toContain('S256')
+        expect(data.service_documentation).toBe(AUTHORITATIVE_METADATA.service_documentation)
+        expect(data.client_id_metadata_document_supported).toBe(true)
+    })
+
+    it('caches the authoritative metadata', async () => {
+        const { handleMetadata } = await import('@/handlers/metadata')
+        const request = new Request('https://oauth.posthog.com/.well-known/oauth-authorization-server')
+
+        await handleMetadata(request)
+        await handleMetadata(request)
+
+        expect(fetch).toHaveBeenCalledTimes(1)
+    })
+
+    it('re-fetches after cache expires', async () => {
+        vi.useFakeTimers()
+        const { handleMetadata } = await import('@/handlers/metadata')
+        const request = new Request('https://oauth.posthog.com/.well-known/oauth-authorization-server')
+
+        await handleMetadata(request)
+        expect(fetch).toHaveBeenCalledTimes(1)
+
+        // Advance past the 10-minute cache TTL
+        vi.advanceTimersByTime(601 * 1000)
+
+        await handleMetadata(request)
+        expect(fetch).toHaveBeenCalledTimes(2)
+
+        vi.useRealTimers()
+    })
+
+    it('throws when authoritative metadata fetch fails', async () => {
+        vi.stubGlobal(
+            'fetch',
+            vi.fn().mockResolvedValue({
+                ok: false,
+                statusText: 'Internal Server Error',
+            })
+        )
+
+        const { handleMetadata } = await import('@/handlers/metadata')
+        const request = new Request('https://oauth.posthog.com/.well-known/oauth-authorization-server')
+
+        await expect(handleMetadata(request)).rejects.toThrow('Failed to fetch authoritative metadata')
     })
 })


### PR DESCRIPTION
This pull request refactors the OAuth metadata handler to fetch configuration dynamically from the authoritative PostHog server instead of using hardcoded values. 

The metadata handler now fetches the OAuth server configuration from `https://us.posthog.com/.well-known/oauth-authorization-server` and caches it for 10 minutes to reduce API calls. The cached metadata is then modified to point OAuth endpoints to the proxy domain while preserving all other configuration details like supported scopes, response types, and grant types from the authoritative source.

This is being introduced to fix consistency problems where the authoritative server was returning some data, but oauth.posthog.com was skipping some of the fields - like the CIMD field.