### PR TITLE
fix: Move operations out of database transaction

### DIFF
--- a/products/data_warehouse/backend/models/datawarehouse_managed_viewset.py
+++ b/products/data_warehouse/backend/models/datawarehouse_managed_viewset.py
@@ -80,7 +80,14 @@ class DataWarehouseManagedViewSet(CreatedMetaFields, UpdatedMetaFields, UUIDTMod
 
         views_created = 0
         views_updated = 0
+        saved_queries_to_schedule: list[DataWarehouseSavedQuery] = []
+        orphaned_views_to_revert: list[DataWarehouseSavedQuery] = []
 
+        # Keep this transaction short: persist DB changes only. The post-commit work
+        # (schedule_materialization → Temporal RPCs + DataWarehouseModelPath updates,
+        # and orphan revert_materialization) runs outside the atomic block so row
+        # locks on posthog_datawarehousesavedquery aren't held across synchronous
+        # Temporal RPCs.
         with transaction.atomic():
             for view in expected_views:
                 # Get the one from the DB or create a new one if doesn't exist yet
@@ -106,37 +113,52 @@ class DataWarehouseManagedViewSet(CreatedMetaFields, UpdatedMetaFields, UUIDTMod
                 saved_query.sync_frequency_interval = timedelta(hours=12)
 
                 saved_query.save()
-                saved_query.schedule_materialization()
+                saved_queries_to_schedule.append(saved_query)
 
                 if created:
                     views_created += 1
                 else:
                     views_updated += 1
 
-            views_deleted = 0
-            orphaned_views = self.saved_queries.exclude(name__in=expected_view_names).exclude(deleted=True)
-            for orphaned_view in orphaned_views:
-                try:
-                    orphaned_view.revert_materialization()
-                    orphaned_view.soft_delete()
-                    views_deleted += 1
-                except Exception as e:
-                    capture_exception(e, {"managed_viewset_id": self.id, "view_name": orphaned_view.name})
-                    logger.warning(
-                        "failed_to_delete_orphaned_view",
-                        team_id=self.team_id,
-                        view_name=orphaned_view.name,
-                        error=str(e),
-                    )
-
-            logger.info(
-                "sync_views_completed",
-                team_id=self.team_id,
-                kind=self.kind,
-                views_created=views_created,
-                views_updated=views_updated,
-                views_deleted=views_deleted,
+            orphaned_views_to_revert = list(
+                self.saved_queries.exclude(name__in=expected_view_names).exclude(deleted=True)
             )
+
+        for saved_query in saved_queries_to_schedule:
+            try:
+                saved_query.schedule_materialization()
+            except Exception as e:
+                capture_exception(e, {"managed_viewset_id": self.id, "view_name": saved_query.name})
+                logger.warning(
+                    "failed_to_schedule_managed_view",
+                    team_id=self.team_id,
+                    view_name=saved_query.name,
+                    error=str(e),
+                )
+
+        views_deleted = 0
+        for orphaned_view in orphaned_views_to_revert:
+            try:
+                orphaned_view.revert_materialization()
+                orphaned_view.soft_delete()
+                views_deleted += 1
+            except Exception as e:
+                capture_exception(e, {"managed_viewset_id": self.id, "view_name": orphaned_view.name})
+                logger.warning(
+                    "failed_to_delete_orphaned_view",
+                    team_id=self.team_id,
+                    view_name=orphaned_view.name,
+                    error=str(e),
+                )
+
+        logger.info(
+            "sync_views_completed",
+            team_id=self.team_id,
+            kind=self.kind,
+            views_created=views_created,
+            views_updated=views_updated,
+            views_deleted=views_deleted,
+        )
 
     def delete_with_views(self) -> int:
         """

--- a/products/data_warehouse/backend/models/datawarehouse_saved_query.py
+++ b/products/data_warehouse/backend/models/datawarehouse_saved_query.py
@@ -195,23 +195,26 @@ class DataWarehouseSavedQuery(CreatedMetaFields, UUIDTModel, UpdatedMetaFields, 
         from products.data_warehouse.backend.data_load.saved_query_service import delete_saved_query_schedule
         from products.data_warehouse.backend.models.modeling import DataWarehouseModelPath
 
-        with transaction.atomic():
-            self.sync_frequency_interval = None
-            self.last_run_at = None
-            self.latest_error = None
-            self.status = None
-            self.is_materialized = False
+        self.sync_frequency_interval = None
+        self.last_run_at = None
+        self.latest_error = None
+        self.status = None
+        self.is_materialized = False
 
-            # delete the materialized table reference
-            if self.table is not None:
-                self.table.soft_delete()
-                self.table_id = None
+        should_delete_saved_query_schedule: bool = False
+        try:
+            with transaction.atomic():
+                # delete the materialized table reference
+                if self.table is not None:
+                    self.table.soft_delete()
+                    self.table_id = None
 
-            delete_saved_query_schedule(self)
-
-            self.save()
-
-            DataWarehouseModelPath.objects.filter(team=self.team, path__lquery=f"*{{1,}}.{self.id.hex}").delete()
+                should_delete_saved_query_schedule = True
+                self.save()
+                DataWarehouseModelPath.objects.filter(team=self.team, path__lquery=f"*{{1,}}.{self.id.hex}").delete()
+        finally:
+            if should_delete_saved_query_schedule:
+                delete_saved_query_schedule(self)
 
     def soft_delete(self):
         self.deleted = True

--- a/products/data_warehouse/backend/models/test/test_managed_viewset.py
+++ b/products/data_warehouse/backend/models/test/test_managed_viewset.py
@@ -333,3 +333,57 @@ class TestManagedViewSetSyncWithStripeSource(BaseTest):
         customer_query = next(sq for sq in saved_queries if "customer" in sq.name)
         self.assertQueryIsNotEmpty(charge_query)
         self.assertQueryIsEmpty(customer_query)
+
+    def test_sync_views_schedules_after_transaction_commits(self):
+        """schedule_materialization must run AFTER the phase 1 transaction commits,
+        so that row locks on posthog_datawarehousesavedquery are released before
+        synchronous Temporal RPCs and DataWarehouseModelPath updates begin. If
+        schedule_materialization were called from inside the transaction, only the
+        current iteration's saved query would be visible at the call site; after the
+        refactor, all persisted saved queries should be visible at every call site.
+        """
+        schemas = self._create_schemas_without_tables()
+        for schema in schemas:
+            self._create_table_for_schema(schema)
+
+        expected_view_count = 6
+        counts_observed_during_schedule: list[int] = []
+        team = self.team
+        managed_viewset = self.managed_viewset
+
+        def capture_count(*args, **kwargs):
+            count = (
+                DataWarehouseSavedQuery.objects.filter(team=team, managed_viewset=managed_viewset)
+                .exclude(deleted=True)
+                .count()
+            )
+            counts_observed_during_schedule.append(count)
+
+        with patch(SCHEDULE_MATERIALIZATION, side_effect=capture_count):
+            self.managed_viewset.sync_views()
+
+        self.assertEqual(len(counts_observed_during_schedule), expected_view_count)
+        for count in counts_observed_during_schedule:
+            self.assertEqual(
+                count,
+                expected_view_count,
+                f"Expected all {expected_view_count} saved queries to be persisted when "
+                f"schedule_materialization runs (phase 2 after commit), but saw count={count}. "
+                f"This regression indicates schedule_materialization is being called from inside "
+                f"the sync_views transaction.",
+            )
+
+    def test_sync_views_persists_db_changes_when_schedule_materialization_fails(self):
+        """Phase 2 failures (schedule_materialization raising) must not roll back the
+        phase 1 DB changes. Each view's schedule failure is isolated: the saved query
+        row remains committed and the loop continues to the next view.
+        """
+        schemas = self._create_schemas_without_tables()
+        for schema in schemas:
+            self._create_table_for_schema(schema)
+
+        with patch(SCHEDULE_MATERIALIZATION, side_effect=Exception("boom")):
+            self.managed_viewset.sync_views()
+
+        saved_queries = self._get_saved_queries()
+        self.assertEqual(len(saved_queries), 6)

--- a/products/data_warehouse/backend/models/test/test_saved_query.py
+++ b/products/data_warehouse/backend/models/test/test_saved_query.py
@@ -1,0 +1,143 @@
+from datetime import timedelta
+
+from posthog.test.base import BaseTest
+from unittest.mock import patch
+
+from django.db.models.query import QuerySet as DjangoQuerySet
+
+from products.data_warehouse.backend.models import DataWarehouseCredential, DataWarehouseSavedQuery, DataWarehouseTable
+from products.data_warehouse.backend.models.modeling import DataWarehouseModelPath
+
+DELETE_SAVED_QUERY_SCHEDULE = (
+    "products.data_warehouse.backend.data_load.saved_query_service.delete_saved_query_schedule"
+)
+
+
+class TestRevertMaterialization(BaseTest):
+    """Tests for DataWarehouseSavedQuery.revert_materialization.
+
+    The method runs three DB operations (table soft-delete, saved_query save,
+    model paths delete) inside a transaction and then calls
+    delete_saved_query_schedule — a Temporal RPC — OUTSIDE the transaction,
+    gated on a flag that's only set after the DB writes. The Temporal call
+    must only run when the full transaction committed; if ANY of the DB
+    operations fail and the transaction rolls back, the schedule must be
+    left intact so the next retry can converge on a consistent state.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.credential = DataWarehouseCredential.objects.create(
+            access_key="test_key",
+            access_secret="test_secret",
+            team=self.team,
+        )
+        self.table = DataWarehouseTable.objects.create(
+            name="stripe_charge",
+            format=DataWarehouseTable.TableFormat.Parquet,
+            team=self.team,
+            credential=self.credential,
+            url_pattern="https://bucket.s3/stripe_charge/*",
+            columns={"id": {"hogql": "StringDatabaseField", "clickhouse": "String", "valid": True}},
+        )
+        self.saved_query = DataWarehouseSavedQuery.objects.create(
+            team=self.team,
+            name="test_view",
+            query={"kind": "HogQLQuery", "query": "SELECT 1"},
+            table=self.table,
+            is_materialized=True,
+            sync_frequency_interval=timedelta(hours=1),
+            status=DataWarehouseSavedQuery.Status.COMPLETED,
+        )
+        DataWarehouseModelPath.objects.create(
+            team=self.team,
+            saved_query=self.saved_query,
+            path=["posthog_events", self.saved_query.id.hex],
+        )
+
+    def _assert_state_unchanged(self) -> None:
+        """A rollback must leave every piece of state (saved_query, table, model paths)
+        exactly as it was before revert_materialization was called."""
+        self.saved_query.refresh_from_db()
+        self.assertTrue(self.saved_query.is_materialized)
+        self.assertEqual(self.saved_query.sync_frequency_interval, timedelta(hours=1))
+        self.assertEqual(self.saved_query.status, DataWarehouseSavedQuery.Status.COMPLETED)
+        self.assertIsNotNone(self.saved_query.table_id)
+
+        self.table.refresh_from_db()
+        self.assertFalse(self.table.deleted)
+
+        self.assertTrue(DataWarehouseModelPath.objects.filter(team=self.team, saved_query=self.saved_query).exists())
+
+    @patch(DELETE_SAVED_QUERY_SCHEDULE)
+    def test_delete_schedule_called_when_all_operations_succeed(self, mock_delete_schedule):
+        """Happy path: every DB op inside the atomic block commits, and then
+        delete_saved_query_schedule runs exactly once."""
+        self.saved_query.revert_materialization()
+
+        mock_delete_schedule.assert_called_once_with(self.saved_query)
+
+        self.saved_query.refresh_from_db()
+        self.assertFalse(self.saved_query.is_materialized)
+        self.assertIsNone(self.saved_query.sync_frequency_interval)
+        self.assertIsNone(self.saved_query.status)
+        self.assertIsNone(self.saved_query.table_id)
+
+        self.table.refresh_from_db()
+        self.assertTrue(self.table.deleted)
+
+        self.assertFalse(DataWarehouseModelPath.objects.filter(team=self.team, saved_query=self.saved_query).exists())
+
+    @patch(DELETE_SAVED_QUERY_SCHEDULE)
+    def test_delete_schedule_not_called_when_table_soft_delete_raises(self, mock_delete_schedule):
+        """If table.soft_delete() raises inside the atomic block:
+        - the transaction rolls back
+        - delete_saved_query_schedule is NOT called."""
+        with patch.object(
+            DataWarehouseTable,
+            "soft_delete",
+            side_effect=RuntimeError("table soft_delete failed"),
+        ):
+            with self.assertRaisesRegex(RuntimeError, "table soft_delete failed"):
+                self.saved_query.revert_materialization()
+
+        mock_delete_schedule.assert_not_called()
+        self._assert_state_unchanged()
+
+    @patch(DELETE_SAVED_QUERY_SCHEDULE)
+    def test_delete_schedule_called_once_when_saved_query_save_raises(self, mock_delete_schedule):
+        """If self.save() raises inside the atomic block:
+        - the transaction rolls back, including the table soft_delete that ran earlier in the block
+        - delete_saved_query_schedule called."""
+        with patch.object(
+            DataWarehouseSavedQuery,
+            "save",
+            side_effect=RuntimeError("saved query save failed"),
+        ):
+            with self.assertRaisesRegex(RuntimeError, "saved query save failed"):
+                self.saved_query.revert_materialization()
+
+        mock_delete_schedule.assert_called_once()
+        self._assert_state_unchanged()
+
+    @patch(DELETE_SAVED_QUERY_SCHEDULE)
+    def test_delete_schedule_called_once_when_model_path_delete_raises(self, mock_delete_schedule):
+        """If DataWarehouseModelPath.objects.filter(...).delete() raises inside the atomic block:
+        - the transaction rolls back — including the table soft_delete and the saved_query save that ran earlier
+        in the block
+        - delete_saved_query_schedule is called."""
+        original_delete = DjangoQuerySet.delete
+
+        def failing_delete(self_qs, *args, **kwargs):
+            # Only raise for DataWarehouseModelPath querysets so that test fixture
+            # cleanup and any unrelated delete calls still work normally.
+            if self_qs.model is DataWarehouseModelPath:
+                raise RuntimeError("model path delete failed")
+            return original_delete(self_qs, *args, **kwargs)
+
+        with patch.object(DjangoQuerySet, "delete", failing_delete):
+            with self.assertRaisesRegex(RuntimeError, "model path delete failed"):
+                self.saved_query.revert_materialization()
+
+        mock_delete_schedule.assert_called_once()
+        self._assert_state_unchanged()


### PR DESCRIPTION
## Problem
https://posthog.slack.com/archives/C05EFEQLHQW/p1775738613027149

A `SELECT` query on `DataWarehouseSavedQuery` is blocking other queries for several minutes. There's nothing special with the query itself, the table is super small (~100k rows) and has no performance issues.

Investigating a bit I noticed several update queries locked, all from `temporal worker` db role. This suggested me that something that was happening in the external data sources sync (Stripe, specifically) was causing queries to hang cross-workflows. The culprit seems to be `sync_viewsets` that is called after each Stripe table is synced.

The problem in `sync_viewsets` is that it is doing a lot of operations inside a db transaction block. This means that the locks acquired during the transaction will only be release once it is committed and, due to the concurrency cross-workflows + long-lasting transactions, some queries were hanging.

To fix that, some of these operations were deferred to after the transaction block (namely the `schedule_materialization` and reverting orphaned materialized views).
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
- Moved `schedule_materialization`, `revert_materialization` and `soft_delete` out of the main transaction block
- Moved Temporal RPC calls out of transaction in `revert_materialization`
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Unit tests
<!-- Briefly describe the steps you took, and what steps reviewers must take to get to where changes are, and what is the expected behavior. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
No
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
