### PR TITLE
fix(replay): handle CJS/ESM interop for MemLens dynamic import

### DIFF
--- a/frontend/src/@types/memlab-lens.d.ts
+++ b/frontend/src/@types/memlab-lens.d.ts
@@ -21,4 +21,9 @@ declare module '@memlab/lens/dist/memlens.lib.bundle.js' {
     }
 
     export function createReactMemoryScan(options?: MemLensScanOptions): MemLensScanner
+
+    const _default: {
+        createReactMemoryScan: typeof createReactMemoryScan
+    }
+    export default _default
 }

--- a/frontend/src/detachedElementTracker.ts
+++ b/frontend/src/detachedElementTracker.ts
@@ -50,7 +50,13 @@ export function startDetachedElementTracking(posthog: Capturable): void {
 
     requestIdleCallbackCompat(async () => {
         try {
-            const { createReactMemoryScan } = await import('@memlab/lens/dist/memlens.lib.bundle.js')
+            const memlens = await import('@memlab/lens/dist/memlens.lib.bundle.js')
+            const createReactMemoryScan =
+                memlens.createReactMemoryScan ??
+                (memlens as unknown as { default: typeof memlens }).default?.createReactMemoryScan
+            if (!createReactMemoryScan) {
+                throw new Error('createReactMemoryScan not found in MemLens exports')
+            }
 
             state = 'ready'
 


### PR DESCRIPTION
## Problem

The detached element tracker (#53852) fails in production with `[detachedElementTracker] Failed to load MemLens, detached element tracking disabled`. The MemLens bundle loads successfully but `createReactMemoryScan` is `undefined` when destructured.

## Changes

Webpack's CJS-to-ESM interop surfaces UMD exports differently between dev and production modes. In dev, named exports from `module.exports` are accessible directly. In production, optimizations like module concatenation can place them under `.default` instead.

The fix tries both export shapes: `memlens.createReactMemoryScan` first, then `memlens.default.createReactMemoryScan`. Also adds a clear error message if neither works, and updates the `.d.ts` to declare the default export.

## How did you test this code?

- Existing unit tests pass
- TypeScript check passes
- The fix addresses a production-only issue caused by webpack bundling differences

## 🤖 LLM context

Agent-authored fix based on production error report and investigation of the UMD bundle format in `@memlab/lens`.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*