### PR TITLE
feat(capture): update capture token:distinct_id rate limiter behavior

### DIFF
--- a/rust/capture/src/events/analytics.rs
+++ b/rust/capture/src/events/analytics.rs
@@ -3,18 +3,21 @@
 //! This module handles processing of regular analytics events (pageviews, custom events,
 //! exceptions, etc.) as opposed to recordings (session replay).
 
+use std::collections::HashSet;
 use std::sync::Arc;
 
 use chrono::DateTime;
 use common_types::{CapturedEvent, RawEvent};
 use limiters::token_dropper::TokenDropper;
+use metrics::counter;
 use serde_json;
-use tracing::{error, instrument, Span};
+use tracing::{error, instrument, warn, Span};
 
 use crate::{
     api::CaptureError,
     debug_or_info,
     event_restrictions::{EventContext as RestrictionEventContext, EventRestrictionService},
+    global_rate_limiter::{GlobalRateLimitKey, GlobalRateLimiter},
     prometheus::{report_clock_skew, report_dropped_events},
     router, sinks,
     utils::uuid_v7,
@@ -130,6 +133,7 @@ pub async fn process_events<'a>(
     dropper: Arc<TokenDropper>,
     restriction_service: Option<EventRestrictionService>,
     historical_cfg: router::HistoricalConfig,
+    global_rate_limiter: Option<Arc<GlobalRateLimiter>>,
     events: &'a [RawEvent],
     context: &'a ProcessingContext,
 ) -> Result<(), CaptureError> {
@@ -191,6 +195,41 @@ pub async fn process_events<'a>(
 
         events = filtered_events;
         debug_or_info!(chatty_debug_enabled, context=?context, event_count=?events.len(), "filtered by event_restrictions");
+    }
+
+    // Apply per-(token, distinct_id) global rate limiting -- reroute to overflow
+    if let Some(ref limiter) = global_rate_limiter {
+        let mut rerouted_distinct_ids: HashSet<&str> = HashSet::new();
+        for event in events.iter_mut() {
+            let cache_key =
+                GlobalRateLimitKey::TokenDistinctId(&context.token, &event.event.distinct_id)
+                    .to_cache_key();
+            if limiter.is_limited(&cache_key, 1).await.is_some() {
+                event.metadata.force_overflow = true;
+                event.metadata.skip_person_processing = true;
+                rerouted_distinct_ids.insert(&event.event.distinct_id);
+            }
+        }
+        if !rerouted_distinct_ids.is_empty() {
+            let count = rerouted_distinct_ids.len();
+            let ids: Vec<&str> = rerouted_distinct_ids.iter().copied().collect();
+            let preview: String = if ids.len() > 10 {
+                format!("{}...", ids[..10].join(", "))
+            } else {
+                ids.join(", ")
+            };
+            counter!(
+                "capture_events_rerouted_overflow",
+                "reason" => "global_rate_limit_token_distinctid",
+            )
+            .increment(count as u64);
+            warn!(
+                token = context.token,
+                rerouted_count = count,
+                distinct_ids = %preview,
+                "events rerouted to overflow by distinct_id rate limit"
+            );
+        }
     }
 
     if events.is_empty() {
@@ -459,6 +498,7 @@ mod tests {
             dropper,
             Some(service),
             historical_cfg,
+            None,
             &events,
             &context,
         )
@@ -503,6 +543,7 @@ mod tests {
             dropper,
             Some(service),
             historical_cfg,
+            None,
             &events,
             &context,
         )
@@ -548,6 +589,7 @@ mod tests {
             dropper,
             Some(service),
             historical_cfg,
+            None,
             &events,
             &context,
         )
@@ -593,6 +635,7 @@ mod tests {
             dropper,
             Some(service),
             historical_cfg,
+            None,
             &events,
             &context,
         )
@@ -645,6 +688,7 @@ mod tests {
             dropper,
             Some(service),
             historical_cfg,
+            None,
             &events,
             &context,
         )
@@ -679,6 +723,7 @@ mod tests {
             dropper,
             None,
             historical_cfg,
+            None,
             &events,
             &context,
         )
@@ -729,6 +774,7 @@ mod tests {
             dropper,
             Some(service),
             historical_cfg,
+            None,
             &events,
             &context,
         )
@@ -738,6 +784,52 @@ mod tests {
         // Event should NOT be dropped because filter doesn't match
         let captured = sink.get_events();
         assert_eq!(captured.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_process_events_exception_node_rollout() {
+        // Initialize the error tracking sampler at 100% to route all exceptions to Node.
+        // Note: OnceLock means this only succeeds once per test binary, so this test
+        // assumes no other test initializes the sampler first.
+        crate::error_tracking_sampler::init(true, 100.0);
+
+        let now = DateTime::parse_from_rfc3339("2023-01-01T12:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let context = create_test_context(now, None);
+        let events = vec![create_test_event_with_name(
+            "$exception",
+            Some("2023-01-01T11:00:00Z".to_string()),
+            None,
+            None,
+        )];
+
+        let sink = Arc::new(MockSink::new());
+        let dropper = Arc::new(limiters::token_dropper::TokenDropper::default());
+        let historical_cfg = router::HistoricalConfig::new(false, 1);
+
+        let service = EventRestrictionService::new(CaptureMode::Events, Duration::from_secs(300));
+
+        let result = process_events(
+            sink.clone(),
+            dropper,
+            Some(service),
+            historical_cfg,
+            None,
+            &events,
+            &context,
+        )
+        .await;
+
+        assert!(result.is_ok());
+        let captured = sink.get_events();
+
+        // At 100% rollout, the exception should be routed to Node (ExceptionErrorTracking)
+        assert_eq!(captured.len(), 1);
+        assert_eq!(
+            captured[0].metadata.data_type,
+            DataType::ExceptionErrorTracking
+        );
     }
 
     #[tokio::test]
@@ -773,6 +865,7 @@ mod tests {
             dropper,
             Some(service),
             historical_cfg,
+            None,
             &events,
             &context,
         )

--- a/rust/capture/src/events/analytics.rs
+++ b/rust/capture/src/events/analytics.rs
@@ -197,39 +197,38 @@ pub async fn process_events<'a>(
         debug_or_info!(chatty_debug_enabled, context=?context, event_count=?events.len(), "filtered by event_restrictions");
     }
 
-    // Apply per-(token, distinct_id) global rate limiting -- reroute to overflow
+    // Apply per-(token, distinct_id) global rate limiting -- skip person processing for high-volume distinct_ids
     if let Some(ref limiter) = global_rate_limiter {
-        let mut rerouted_distinct_ids: HashSet<&str> = HashSet::new();
-        let mut rerouted_event_count: u64 = 0;
+        let mut limited_distinct_ids: HashSet<&str> = HashSet::new();
+        let mut limited_event_count: u64 = 0;
         for event in events.iter_mut() {
             let cache_key =
                 GlobalRateLimitKey::TokenDistinctId(&context.token, &event.event.distinct_id)
                     .to_cache_key();
             if limiter.is_limited(&cache_key, 1).await.is_some() {
-                event.metadata.force_overflow = true;
                 event.metadata.skip_person_processing = true;
-                rerouted_distinct_ids.insert(&event.event.distinct_id);
-                rerouted_event_count += 1;
+                limited_distinct_ids.insert(&event.event.distinct_id);
+                limited_event_count += 1;
             }
         }
-        if rerouted_event_count > 0 {
-            let ids: Vec<&str> = rerouted_distinct_ids.iter().copied().collect();
+        if limited_event_count > 0 {
+            let ids: Vec<&str> = limited_distinct_ids.iter().copied().collect();
             let preview: String = if ids.len() > 10 {
                 format!("{}...", ids[..10].join(", "))
             } else {
                 ids.join(", ")
             };
             counter!(
-                "capture_events_rerouted_overflow",
+                "capture_events_rate_limited_token_distinctid",
                 "reason" => "global_rate_limit_token_distinctid",
             )
-            .increment(rerouted_event_count);
+            .increment(limited_event_count);
             warn!(
                 token = context.token,
-                rerouted_event_count = rerouted_event_count,
-                distinct_id_count = rerouted_distinct_ids.len(),
+                limited_event_count = limited_event_count,
+                distinct_id_count = limited_distinct_ids.len(),
                 distinct_ids = %preview,
-                "events rerouted to overflow by distinct_id rate limit"
+                "events rate limited by distinct_id -- person processing disabled"
             );
         }
     }
@@ -786,52 +785,6 @@ mod tests {
         // Event should NOT be dropped because filter doesn't match
         let captured = sink.get_events();
         assert_eq!(captured.len(), 1);
-    }
-
-    #[tokio::test]
-    async fn test_process_events_exception_node_rollout() {
-        // Initialize the error tracking sampler at 100% to route all exceptions to Node.
-        // Note: OnceLock means this only succeeds once per test binary, so this test
-        // assumes no other test initializes the sampler first.
-        crate::error_tracking_sampler::init(true, 100.0);
-
-        let now = DateTime::parse_from_rfc3339("2023-01-01T12:00:00Z")
-            .unwrap()
-            .with_timezone(&Utc);
-        let context = create_test_context(now, None);
-        let events = vec![create_test_event_with_name(
-            "$exception",
-            Some("2023-01-01T11:00:00Z".to_string()),
-            None,
-            None,
-        )];
-
-        let sink = Arc::new(MockSink::new());
-        let dropper = Arc::new(limiters::token_dropper::TokenDropper::default());
-        let historical_cfg = router::HistoricalConfig::new(false, 1);
-
-        let service = EventRestrictionService::new(CaptureMode::Events, Duration::from_secs(300));
-
-        let result = process_events(
-            sink.clone(),
-            dropper,
-            Some(service),
-            historical_cfg,
-            None,
-            &events,
-            &context,
-        )
-        .await;
-
-        assert!(result.is_ok());
-        let captured = sink.get_events();
-
-        // At 100% rollout, the exception should be routed to Node (ExceptionErrorTracking)
-        assert_eq!(captured.len(), 1);
-        assert_eq!(
-            captured[0].metadata.data_type,
-            DataType::ExceptionErrorTracking
-        );
     }
 
     #[tokio::test]

--- a/rust/capture/src/events/analytics.rs
+++ b/rust/capture/src/events/analytics.rs
@@ -200,6 +200,7 @@ pub async fn process_events<'a>(
     // Apply per-(token, distinct_id) global rate limiting -- reroute to overflow
     if let Some(ref limiter) = global_rate_limiter {
         let mut rerouted_distinct_ids: HashSet<&str> = HashSet::new();
+        let mut rerouted_event_count: u64 = 0;
         for event in events.iter_mut() {
             let cache_key =
                 GlobalRateLimitKey::TokenDistinctId(&context.token, &event.event.distinct_id)
@@ -208,10 +209,10 @@ pub async fn process_events<'a>(
                 event.metadata.force_overflow = true;
                 event.metadata.skip_person_processing = true;
                 rerouted_distinct_ids.insert(&event.event.distinct_id);
+                rerouted_event_count += 1;
             }
         }
-        if !rerouted_distinct_ids.is_empty() {
-            let count = rerouted_distinct_ids.len();
+        if rerouted_event_count > 0 {
             let ids: Vec<&str> = rerouted_distinct_ids.iter().copied().collect();
             let preview: String = if ids.len() > 10 {
                 format!("{}...", ids[..10].join(", "))
@@ -222,10 +223,11 @@ pub async fn process_events<'a>(
                 "capture_events_rerouted_overflow",
                 "reason" => "global_rate_limit_token_distinctid",
             )
-            .increment(count as u64);
+            .increment(rerouted_event_count);
             warn!(
                 token = context.token,
-                rerouted_count = count,
+                rerouted_event_count = rerouted_event_count,
+                distinct_id_count = rerouted_distinct_ids.len(),
                 distinct_ids = %preview,
                 "events rerouted to overflow by distinct_id rate limit"
             );

--- a/rust/capture/src/payload/analytics.rs
+++ b/rust/capture/src/payload/analytics.rs
@@ -16,7 +16,6 @@ use crate::{
     api::CaptureError,
     debug_or_info,
     extractors::extract_body_with_timeout,
-    global_rate_limiter::GlobalRateLimitKey,
     payload::{extract_and_record_metadata, extract_payload_bytes, EventQuery},
     router,
     utils::extract_and_verify_token,
@@ -136,8 +135,6 @@ pub async fn handle_event_payload(
     };
     debug_or_info!(chatty_debug_enabled, context=?context, event_count=?events.len(), "processing complete");
 
-    check_global_rate_limits(state, &context, &events).await?;
-
     // Apply all billing limit quotas and drop partial or whole
     // payload if any are exceeded for this token (team)
     events = state
@@ -147,38 +144,4 @@ pub async fn handle_event_payload(
     debug_or_info!(chatty_debug_enabled, context=?context, event_count=?events.len(), "quota limits filter applied");
 
     Ok((context, events))
-}
-
-async fn check_global_rate_limits(
-    state: &State<router::State>,
-    context: &ProcessingContext,
-    events: &[RawEvent],
-) -> Result<(), CaptureError> {
-    if let Some(limiter) = &state.global_rate_limiter_token_distinctid {
-        let mut is_rate_limited = false;
-        for event in events {
-            let maybe_distinct_id = event
-                .distinct_id
-                .as_ref()
-                .or_else(|| event.properties.get("distinct_id"))
-                .and_then(|v| v.as_str());
-            if let Some(distinct_id) = maybe_distinct_id {
-                let cache_key =
-                    GlobalRateLimitKey::TokenDistinctId(&context.token, distinct_id).to_cache_key();
-                if let Some(limited) = limiter.is_limited(&cache_key, 1).await {
-                    debug_or_info!(context.chatty_debug_enabled,
-                        context=?context,
-                        distinct_id,
-                        details=?limited,
-                        "global token+distinct_id rate limit applied");
-                    is_rate_limited = true;
-                }
-            }
-        }
-        if is_rate_limited {
-            return Err(CaptureError::GlobalRateLimitExceeded());
-        }
-    }
-
-    Ok(())
 }

--- a/rust/capture/src/payload/recordings.rs
+++ b/rust/capture/src/payload/recordings.rs
@@ -16,7 +16,6 @@ use crate::{
     debug_or_info,
     events::recordings::RawRecording,
     extractors::extract_body_with_timeout,
-    global_rate_limiter::GlobalRateLimitKey,
     payload::{decompress_payload, extract_and_record_metadata, extract_payload_bytes, EventQuery},
     router,
     token::validate_token,
@@ -132,8 +131,6 @@ pub async fn handle_recording_payload(
         chatty_debug_enabled,
     };
 
-    check_global_rate_limits(state, &context, &events).await?;
-
     // Apply all billing limit quotas and drop partial or whole
     // payload if any are exceeded for this token (team)
     debug_or_info!(chatty_debug_enabled, context=?context, event_count=?events.len(), "evaluating quota limits");
@@ -144,40 +141,6 @@ pub async fn handle_recording_payload(
 
     debug_or_info!(chatty_debug_enabled, context=?context, event_count=?events.len(), "processing complete");
     Ok((context, events))
-}
-
-async fn check_global_rate_limits(
-    state: &State<router::State>,
-    context: &ProcessingContext,
-    events: &[RawRecording],
-) -> Result<(), CaptureError> {
-    if let Some(limiter) = &state.global_rate_limiter_token_distinctid {
-        let mut is_rate_limited = false;
-        for event in events {
-            let maybe_distinct_id = event
-                .distinct_id
-                .as_ref()
-                .or(event.properties.distinct_id.as_ref())
-                .and_then(|v| v.as_str());
-            if let Some(distinct_id) = maybe_distinct_id {
-                let cache_key =
-                    GlobalRateLimitKey::TokenDistinctId(&context.token, distinct_id).to_cache_key();
-                if let Some(limited) = limiter.is_limited(&cache_key, 1).await {
-                    debug_or_info!(context.chatty_debug_enabled,
-                        context=?context,
-                        distinct_id,
-                        details=?limited,
-                        "global token+distinct_id rate limit applied");
-                    is_rate_limited = true;
-                }
-            }
-        }
-        if is_rate_limited {
-            return Err(CaptureError::GlobalRateLimitExceeded());
-        }
-    }
-
-    Ok(())
 }
 
 #[cfg(test)]

--- a/rust/capture/src/v0_endpoint.rs
+++ b/rust/capture/src/v0_endpoint.rs
@@ -74,6 +74,7 @@ pub async fn event(
                 state.token_dropper.clone(),
                 state.event_restriction_service.clone(),
                 state.historical_cfg.clone(),
+                state.global_rate_limiter_token_distinctid.clone(),
                 &events,
                 &context,
             )

--- a/rust/capture/src/v1/analytics/constants.rs
+++ b/rust/capture/src/v1/analytics/constants.rs
@@ -50,7 +50,7 @@ pub(crate) const CAPTURE_V1_EVENTS_QUOTA_LIMITED: &str = "capture_v1_events_quot
 /// Counter/gauge key for the per-token global rate limiter.
 pub(crate) const CAPTURE_V1_RATE_LIMITER: &str = "capture_v1_rate_limiter";
 
-/// Detail tag for events dropped by the per-token:distinct_id rate limiter.
+/// Detail tag for events flagged by the per-token:distinct_id rate limiter.
 pub(super) const DETAIL_RATE_LIMITED_TOKEN_DISTINCT_ID: &str = "rate_limited_token_distinct_id";
 
 // ---------------------------------------------------------------------------

--- a/rust/capture/src/v1/analytics/process.rs
+++ b/rust/capture/src/v1/analytics/process.rs
@@ -306,7 +306,6 @@ async fn apply_token_distinct_id_limits(
             GlobalRateLimitKey::TokenDistinctId(&context.api_token, &event.event.distinct_id)
                 .to_cache_key();
         if limiter.is_limited(&cache_key, 1).await.is_some() {
-            event.destination = Destination::Overflow;
             event.skip_person_processing = true;
             event.details = Some(DETAIL_RATE_LIMITED_TOKEN_DISTINCT_ID);
             limited_distinct_ids.insert(event.event.distinct_id.as_str());
@@ -336,14 +335,14 @@ async fn apply_token_distinct_id_limits(
         metrics::counter!(
             CAPTURE_V1_RATE_LIMITER,
             "limiter" => "token_distinct_id",
-            "outcome" => "rerouted",
+            "outcome" => "limited",
         )
         .increment(limited_count as u64);
 
         crate::ctx_log!(Level::WARN, context,
             limited_count = limited_count,
             distinct_ids = %preview,
-            "events rerouted to overflow by distinct_id rate limit"
+            "events rate limited by distinct_id -- person processing disabled"
         );
     }
 }
@@ -1133,7 +1132,7 @@ mod tests {
         assert!(ok_ev.details.is_none());
         let limited_ev = find_by_did(&events, "user-2");
         assert_eq!(limited_ev.result, EventResult::Ok);
-        assert_eq!(limited_ev.destination, Destination::Overflow);
+        assert_eq!(limited_ev.destination, Destination::AnalyticsMain);
         assert!(limited_ev.skip_person_processing);
         assert_eq!(
             limited_ev.details,
@@ -1169,7 +1168,11 @@ mod tests {
 
         for ev in events.values() {
             assert_eq!(ev.result, EventResult::Ok, "should stay Ok");
-            assert_eq!(ev.destination, Destination::Overflow, "should be Overflow");
+            assert_eq!(
+                ev.destination,
+                Destination::AnalyticsMain,
+                "should stay on main topic"
+            );
             assert!(ev.skip_person_processing, "should skip person processing");
             assert_eq!(
                 ev.details,
@@ -1196,10 +1199,10 @@ mod tests {
         let dropped = find_by_did(&events, "user-1");
         assert_eq!(dropped.result, EventResult::Drop);
         assert_eq!(dropped.destination, Destination::Drop);
-        // Other event rerouted to overflow
+        // Other event rate-limited (person processing disabled, stays on main topic)
         let limited = find_by_did(&events, "user-2");
         assert_eq!(limited.result, EventResult::Ok);
-        assert_eq!(limited.destination, Destination::Overflow);
+        assert_eq!(limited.destination, Destination::AnalyticsMain);
         assert!(limited.skip_person_processing);
         assert_eq!(limited.details, Some(DETAIL_RATE_LIMITED_TOKEN_DISTINCT_ID));
     }

--- a/rust/capture/src/v1/analytics/process.rs
+++ b/rust/capture/src/v1/analytics/process.rs
@@ -306,8 +306,8 @@ async fn apply_token_distinct_id_limits(
             GlobalRateLimitKey::TokenDistinctId(&context.api_token, &event.event.distinct_id)
                 .to_cache_key();
         if limiter.is_limited(&cache_key, 1).await.is_some() {
-            event.result = EventResult::Limited;
-            event.destination = Destination::Drop;
+            event.destination = Destination::Overflow;
+            event.skip_person_processing = true;
             event.details = Some(DETAIL_RATE_LIMITED_TOKEN_DISTINCT_ID);
             limited_distinct_ids.insert(event.event.distinct_id.as_str());
         } else {
@@ -336,14 +336,14 @@ async fn apply_token_distinct_id_limits(
         metrics::counter!(
             CAPTURE_V1_RATE_LIMITER,
             "limiter" => "token_distinct_id",
-            "outcome" => "limited",
+            "outcome" => "rerouted",
         )
         .increment(limited_count as u64);
 
         crate::ctx_log!(Level::WARN, context,
             limited_count = limited_count,
             distinct_ids = %preview,
-            "events rate limited by distinct_id"
+            "events rerouted to overflow by distinct_id rate limit"
         );
     }
 }
@@ -1132,8 +1132,9 @@ mod tests {
         assert_eq!(ok_ev.destination, Destination::AnalyticsMain);
         assert!(ok_ev.details.is_none());
         let limited_ev = find_by_did(&events, "user-2");
-        assert_eq!(limited_ev.result, EventResult::Limited);
-        assert_eq!(limited_ev.destination, Destination::Drop);
+        assert_eq!(limited_ev.result, EventResult::Ok);
+        assert_eq!(limited_ev.destination, Destination::Overflow);
+        assert!(limited_ev.skip_person_processing);
         assert_eq!(
             limited_ev.details,
             Some(DETAIL_RATE_LIMITED_TOKEN_DISTINCT_ID)
@@ -1167,8 +1168,9 @@ mod tests {
         apply_token_distinct_id_limits(&limiter, &ctx, &mut events).await;
 
         for ev in events.values() {
-            assert_eq!(ev.result, EventResult::Limited, "should be Limited");
-            assert_eq!(ev.destination, Destination::Drop, "should be Drop");
+            assert_eq!(ev.result, EventResult::Ok, "should stay Ok");
+            assert_eq!(ev.destination, Destination::Overflow, "should be Overflow");
+            assert!(ev.skip_person_processing, "should skip person processing");
             assert_eq!(
                 ev.details,
                 Some(DETAIL_RATE_LIMITED_TOKEN_DISTINCT_ID),
@@ -1194,10 +1196,11 @@ mod tests {
         let dropped = find_by_did(&events, "user-1");
         assert_eq!(dropped.result, EventResult::Drop);
         assert_eq!(dropped.destination, Destination::Drop);
-        // Other event rate-limited
+        // Other event rerouted to overflow
         let limited = find_by_did(&events, "user-2");
-        assert_eq!(limited.result, EventResult::Limited);
-        assert_eq!(limited.destination, Destination::Drop);
+        assert_eq!(limited.result, EventResult::Ok);
+        assert_eq!(limited.destination, Destination::Overflow);
+        assert!(limited.skip_person_processing);
         assert_eq!(limited.details, Some(DETAIL_RATE_LIMITED_TOKEN_DISTINCT_ID));
     }
 


### PR DESCRIPTION
## Problem
As part of the upcoming rollout plans for capture rate limiting, we've changed the output behavior for `(api_token, distinct_id)` keys found to be over threshold:
* Disable person processing (forced, via header no `event.properties.$process_person_profile` prop changes)
* Skipped: forced route to overflow, as discussed at sync mtg

Removing the token-only global rate limiter was performed in a prev PR ✅ 
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
* Implement new limiter behavior for events over GRL threshold (no more dropping)
* Remove GRL checks from non-analytics endpoints (AI and replay)
* Related test/comment cleanups
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally and in CI. GRL well smoke tested on prod data in previous step
<!-- Briefly describe the steps you took, and what steps reviewers must take to get to where changes are, and what is the expected behavior. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
N/A
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update
N/A
<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
