### PR TITLE
fix(dashboard): keep template variable dropdowns above modal

### DIFF
--- a/frontend/src/scenes/dashboard/NewDashboardModal.test.tsx
+++ b/frontend/src/scenes/dashboard/NewDashboardModal.test.tsx
@@ -1,0 +1,130 @@
+import '@testing-library/jest-dom'
+
+import { render } from '@testing-library/react'
+import { useActions, useMountedLogic, useValues } from 'kea'
+import { type ReactNode } from 'react'
+
+import { dashboardTemplateVariablesLogic } from 'scenes/dashboard/dashboardTemplateVariablesLogic'
+import { dashboardTemplatesLogic } from 'scenes/dashboard/dashboards/templates/dashboardTemplatesLogic'
+import { newDashboardLogic } from 'scenes/dashboard/newDashboardLogic'
+
+import { NewDashboardModal } from './NewDashboardModal'
+
+jest.mock('kea', () => ({
+    ...jest.requireActual('kea'),
+    useValues: jest.fn(),
+    useActions: jest.fn(),
+    useMountedLogic: jest.fn(),
+}))
+
+jest.mock('@posthog/lemon-ui', () => ({
+    LemonButton: ({ children, ...props }: any) => <button {...props}>{children}</button>,
+    LemonInput: ({ value, onChange, ...props }: any) => (
+        <input value={value} onChange={(event) => onChange?.(event.target.value)} {...props} />
+    ),
+    LemonLabel: ({ children }: any) => <label>{children}</label>,
+}))
+
+jest.mock('scenes/dashboard/newDashboardLogic', () => ({
+    newDashboardLogic: { __mock: 'newDashboardLogic' },
+}))
+
+jest.mock('scenes/dashboard/dashboards/templates/dashboardTemplatesLogic', () => ({
+    dashboardTemplatesLogic: jest.fn(),
+}))
+
+jest.mock('scenes/dashboard/dashboardTemplateVariablesLogic', () => ({
+    dashboardTemplateVariablesLogic: { __mock: 'dashboardTemplateVariablesLogic' },
+}))
+
+jest.mock('./dashboards/templates/DashboardTemplateChooser', () => ({
+    DashboardTemplateChooser: () => <div data-attr="dashboard-template-chooser" />,
+}))
+
+jest.mock('./DashboardTemplateVariables', () => ({
+    DashboardTemplateVariables: () => <div data-attr="dashboard-template-variables" />,
+}))
+
+jest.mock('lib/ui/DialogPrimitive/DialogPrimitive', () => ({
+    DialogPrimitive: ({ children, className }: { children: ReactNode; className?: string }) => (
+        <div data-attr="dialog-primitive" data-class-name={className}>
+            {children}
+        </div>
+    ),
+    DialogPrimitiveTitle: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+    DialogClose: () => <button type="button">Close</button>,
+}))
+
+const mockedUseValues = useValues as jest.Mock
+const mockedUseActions = useActions as jest.Mock
+const mockedUseMountedLogic = useMountedLogic as jest.Mock
+const mockedDashboardTemplatesLogic = dashboardTemplatesLogic as jest.Mock
+
+const mockTemplatesLogic = { __mock: 'dashboardTemplatesLogic' }
+
+describe('NewDashboardModal', () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+
+        mockedUseMountedLogic.mockReturnValue({ props: {} })
+        mockedDashboardTemplatesLogic.mockReturnValue(mockTemplatesLogic)
+
+        mockedUseValues.mockImplementation((logic) => {
+            if (logic === newDashboardLogic) {
+                return {
+                    newDashboardModalVisible: true,
+                    activeDashboardTemplate: {
+                        template_name: 'Product analytics',
+                        variables: [
+                            {
+                                id: 'VARIABLE_1',
+                                name: 'Daily active user event',
+                                default: { id: '$pageview' },
+                                description: 'Event used for DAU',
+                                required: true,
+                                type: 'event',
+                            },
+                        ],
+                    },
+                    variableSelectModalVisible: false,
+                }
+            }
+
+            if (logic === dashboardTemplateVariablesLogic) {
+                return { variables: [] }
+            }
+
+            if (logic === mockTemplatesLogic) {
+                return { templateFilter: '' }
+            }
+
+            return {}
+        })
+
+        mockedUseActions.mockImplementation((logic) => {
+            if (logic === newDashboardLogic) {
+                return {
+                    hideNewDashboardModal: jest.fn(),
+                    clearActiveDashboardTemplate: jest.fn(),
+                    createDashboardFromTemplate: jest.fn(),
+                }
+            }
+
+            if (logic === mockTemplatesLogic) {
+                return {
+                    setTemplateFilter: jest.fn(),
+                }
+            }
+
+            return {}
+        })
+    })
+
+    it('uses a modal z-index below popovers for variable selection step', () => {
+        render(<NewDashboardModal />)
+
+        const dialogPrimitive = document.querySelector('[data-attr="dialog-primitive"]')
+        expect(dialogPrimitive).toBeInTheDocument()
+        expect(dialogPrimitive?.getAttribute('data-class-name')).toContain('z-[calc(var(--z-popover)-1)]')
+    })
+})

--- a/frontend/src/scenes/dashboard/NewDashboardModal.test.tsx
+++ b/frontend/src/scenes/dashboard/NewDashboardModal.test.tsx
@@ -5,7 +5,6 @@ import { useActions, useMountedLogic, useValues } from 'kea'
 import { type ReactNode } from 'react'
 
 import { dashboardTemplateVariablesLogic } from 'scenes/dashboard/dashboardTemplateVariablesLogic'
-import { dashboardTemplatesLogic } from 'scenes/dashboard/dashboards/templates/dashboardTemplatesLogic'
 import { newDashboardLogic } from 'scenes/dashboard/newDashboardLogic'
 
 import { NewDashboardModal } from './NewDashboardModal'
@@ -58,7 +57,9 @@ jest.mock('lib/ui/DialogPrimitive/DialogPrimitive', () => ({
 const mockedUseValues = useValues as jest.Mock
 const mockedUseActions = useActions as jest.Mock
 const mockedUseMountedLogic = useMountedLogic as jest.Mock
-const mockedDashboardTemplatesLogic = dashboardTemplatesLogic as jest.Mock
+const mockedDashboardTemplatesLogic = jest.requireMock<{
+    dashboardTemplatesLogic: jest.Mock
+}>('scenes/dashboard/dashboards/templates/dashboardTemplatesLogic').dashboardTemplatesLogic
 
 const mockTemplatesLogic = { __mock: 'dashboardTemplatesLogic' }
 

--- a/frontend/src/scenes/dashboard/NewDashboardModal.test.tsx
+++ b/frontend/src/scenes/dashboard/NewDashboardModal.test.tsx
@@ -4,6 +4,7 @@ import { render } from '@testing-library/react'
 import { useActions, useMountedLogic, useValues } from 'kea'
 import { type ReactNode } from 'react'
 
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { dashboardTemplateVariablesLogic } from 'scenes/dashboard/dashboardTemplateVariablesLogic'
 import { newDashboardLogic } from 'scenes/dashboard/newDashboardLogic'
 
@@ -71,6 +72,10 @@ describe('NewDashboardModal', () => {
         mockedDashboardTemplatesLogic.mockReturnValue(mockTemplatesLogic)
 
         mockedUseValues.mockImplementation((logic) => {
+            if (logic === featureFlagLogic) {
+                return { featureFlags: {} }
+            }
+
             if (logic === newDashboardLogic) {
                 return {
                     newDashboardModalVisible: true,

--- a/frontend/src/scenes/dashboard/NewDashboardModal.test.tsx
+++ b/frontend/src/scenes/dashboard/NewDashboardModal.test.tsx
@@ -19,7 +19,7 @@ jest.mock('kea', () => ({
 
 jest.mock('@posthog/lemon-ui', () => ({
     LemonButton: ({ children, ...props }: any) => <button {...props}>{children}</button>,
-    LemonInput: ({ value, onChange, ...props }: any) => (
+    LemonInput: ({ value, onChange, fullWidth: _fullWidth, ...props }: any) => (
         <input value={value} onChange={(event) => onChange?.(event.target.value)} {...props} />
     ),
     LemonLabel: ({ children }: any) => <label>{children}</label>,

--- a/frontend/src/scenes/dashboard/NewDashboardModal.test.tsx
+++ b/frontend/src/scenes/dashboard/NewDashboardModal.test.tsx
@@ -1,6 +1,6 @@
 import '@testing-library/jest-dom'
 
-import { render } from '@testing-library/react'
+import { cleanup, render } from '@testing-library/react'
 import { useActions, useMountedLogic, useValues } from 'kea'
 import { type ReactNode } from 'react'
 
@@ -33,6 +33,10 @@ jest.mock('scenes/dashboard/dashboards/templates/dashboardTemplatesLogic', () =>
     dashboardTemplatesLogic: jest.fn(),
 }))
 
+jest.mock('./dashboards/templates/dashboardTemplateChooserLogic', () => ({
+    dashboardTemplateChooserLogic: jest.fn(),
+}))
+
 jest.mock('scenes/dashboard/dashboardTemplateVariablesLogic', () => ({
     dashboardTemplateVariablesLogic: { __mock: 'dashboardTemplateVariablesLogic' },
 }))
@@ -62,53 +66,105 @@ const mockedDashboardTemplatesLogic = jest.requireMock<{
     dashboardTemplatesLogic: jest.Mock
 }>('scenes/dashboard/dashboards/templates/dashboardTemplatesLogic').dashboardTemplatesLogic
 
-const mockTemplatesLogic = { __mock: 'dashboardTemplatesLogic' }
+const mockedDashboardTemplateChooserLogic = jest.requireMock<{
+    dashboardTemplateChooserLogic: jest.Mock
+}>('./dashboards/templates/dashboardTemplateChooserLogic').dashboardTemplateChooserLogic
+
+const mockTemplatesLogic = { __mock: 'dashboardTemplatesLogic' as const }
+const mockChooserLogic = { __mock: 'dashboardTemplateChooserLogic' as const }
+
+function logicPath(logic: unknown): string | undefined {
+    return (logic as { pathString?: string } | null | undefined)?.pathString
+}
+
+function isNewDashboardLogicRef(logic: unknown): boolean {
+    const tag = (logic as { __mock?: string } | null | undefined)?.__mock
+    return logic === newDashboardLogic || tag === 'newDashboardLogic'
+}
+
+function isDashboardTemplateVariablesLogicRef(logic: unknown): boolean {
+    const tag = (logic as { __mock?: string } | null | undefined)?.__mock
+    return logic === dashboardTemplateVariablesLogic || tag === 'dashboardTemplateVariablesLogic'
+}
+
+function isFeatureFlagLogicRef(logic: unknown): boolean {
+    return (
+        logic === featureFlagLogic ||
+        // Duplicate module instances (different resolver paths) still share the Kea path
+        logicPath(logic)?.includes('featureFlagLogic') === true
+    )
+}
+
+function isMockTemplatesLogicRef(logic: unknown): boolean {
+    const tag = (logic as { __mock?: string } | null | undefined)?.__mock
+    return logic === mockTemplatesLogic || tag === 'dashboardTemplatesLogic'
+}
+
+function isMockChooserLogicRef(logic: unknown): boolean {
+    const tag = (logic as { __mock?: string } | null | undefined)?.__mock
+    return logic === mockChooserLogic || tag === 'dashboardTemplateChooserLogic'
+}
+
+const Z_INDEX_CLASS = 'z-[calc(var(--z-popover)-1)]'
 
 describe('NewDashboardModal', () => {
+    let newDashboardValues: Record<string, unknown>
+
     beforeEach(() => {
         jest.clearAllMocks()
+        mockedUseValues.mockReset()
+        mockedUseActions.mockReset()
+
+        newDashboardValues = {
+            newDashboardModalVisible: true,
+            activeDashboardTemplate: {
+                template_name: 'Product analytics',
+                variables: [
+                    {
+                        id: 'VARIABLE_1',
+                        name: 'Daily active user event',
+                        default: { id: '$pageview' },
+                        description: 'Event used for DAU',
+                        required: true,
+                        type: 'event',
+                    },
+                ],
+            },
+            variableSelectModalVisible: false,
+        }
 
         mockedUseMountedLogic.mockReturnValue({ props: {} })
         mockedDashboardTemplatesLogic.mockReturnValue(mockTemplatesLogic)
+        mockedDashboardTemplateChooserLogic.mockReturnValue(mockChooserLogic)
 
-        mockedUseValues.mockImplementation((logic) => {
-            if (logic === featureFlagLogic) {
+        mockedUseValues.mockImplementation((logic: unknown) => {
+            if (isFeatureFlagLogicRef(logic)) {
                 return { featureFlags: {} }
             }
 
-            if (logic === newDashboardLogic) {
-                return {
-                    newDashboardModalVisible: true,
-                    activeDashboardTemplate: {
-                        template_name: 'Product analytics',
-                        variables: [
-                            {
-                                id: 'VARIABLE_1',
-                                name: 'Daily active user event',
-                                default: { id: '$pageview' },
-                                description: 'Event used for DAU',
-                                required: true,
-                                type: 'event',
-                            },
-                        ],
-                    },
-                    variableSelectModalVisible: false,
-                }
+            if (isNewDashboardLogicRef(logic)) {
+                return newDashboardValues
             }
 
-            if (logic === dashboardTemplateVariablesLogic) {
+            if (isDashboardTemplateVariablesLogicRef(logic)) {
                 return { variables: [] }
             }
 
-            if (logic === mockTemplatesLogic) {
+            if (isMockTemplatesLogicRef(logic)) {
                 return { templateFilter: '' }
             }
 
-            return {}
+            if (isMockChooserLogicRef(logic)) {
+                return { allTemplates: [], allTemplatesLoading: false, templateFilter: '' }
+            }
+
+            throw new Error(
+                `NewDashboardModal.test: unhandled useValues(${logicPath(logic) ?? (logic as { __mock?: string })?.__mock ?? typeof logic}). Extend is*Ref helpers or add a branch.`
+            )
         })
 
-        mockedUseActions.mockImplementation((logic) => {
-            if (logic === newDashboardLogic) {
+        mockedUseActions.mockImplementation((logic: unknown) => {
+            if (isNewDashboardLogicRef(logic)) {
                 return {
                     hideNewDashboardModal: jest.fn(),
                     clearActiveDashboardTemplate: jest.fn(),
@@ -116,21 +172,52 @@ describe('NewDashboardModal', () => {
                 }
             }
 
-            if (logic === mockTemplatesLogic) {
+            if (isMockTemplatesLogicRef(logic)) {
                 return {
                     setTemplateFilter: jest.fn(),
                 }
             }
 
-            return {}
+            if (isMockChooserLogicRef(logic)) {
+                return {
+                    templateTileClicked: jest.fn(),
+                    blankTileClicked: jest.fn(),
+                    setTemplateFilter: jest.fn(),
+                }
+            }
+
+            throw new Error(
+                `NewDashboardModal.test: unhandled useActions(${logicPath(logic) ?? (logic as { __mock?: string })?.__mock ?? typeof logic}). Extend is*Ref helpers or add a branch.`
+            )
         })
     })
 
-    it('uses a modal z-index below popovers for variable selection step', () => {
-        render(<NewDashboardModal />)
+    afterEach(() => {
+        cleanup()
+    })
 
+    const expectDialogZIndex = (): void => {
         const dialogPrimitive = document.querySelector('[data-attr="dialog-primitive"]')
         expect(dialogPrimitive).toBeInTheDocument()
-        expect(dialogPrimitive?.getAttribute('data-class-name')).toContain('z-[calc(var(--z-popover)-1)]')
+        const className = dialogPrimitive?.getAttribute('data-class-name') ?? ''
+        expect(className).toContain(Z_INDEX_CLASS)
+    }
+
+    it('uses a modal z-index below popovers for variable selection step', () => {
+        render(<NewDashboardModal />)
+        expectDialogZIndex()
+        expect(document.querySelector('[data-attr="dashboard-template-variables"]')).toBeInTheDocument()
+    })
+
+    it('uses the same modal z-index on the template picker step', () => {
+        newDashboardValues = {
+            newDashboardModalVisible: true,
+            activeDashboardTemplate: null,
+            variableSelectModalVisible: false,
+        }
+
+        render(<NewDashboardModal />)
+        expectDialogZIndex()
+        expect(document.querySelector('[data-attr="dashboard-template-chooser"]')).toBeInTheDocument()
     })
 })

--- a/frontend/src/scenes/dashboard/NewDashboardModal.tsx
+++ b/frontend/src/scenes/dashboard/NewDashboardModal.tsx
@@ -56,7 +56,13 @@ export function NewDashboardModal(): JSX.Element {
         <DialogPrimitive
             open={newDashboardModalVisible}
             onOpenChange={(open) => !open && hideNewDashboardModal()}
-            className={cn('w-[min(100vw-3rem,1200px)] max-h-[calc(100vh-4rem)] top-8', 'bg-surface-primary')}
+            className={cn(
+                'w-[min(100vw-3rem,1200px)] max-h-[calc(100vh-4rem)] top-8',
+                'bg-surface-primary',
+                // Variable selectors in ActionFilter portal to the popover layer; keep this modal just below
+                // that layer so dropdown options render above the dialog instead of behind it.
+                'z-[calc(var(--z-popover)-1)]'
+            )}
         >
             <div className="flex shrink-0 flex-col gap-3 border-b border-primary px-4 py-3 pr-2">
                 <div className="flex items-start justify-between gap-2">

--- a/frontend/src/scenes/dashboard/dashboards/templates/DashboardTemplateChooser.tsx
+++ b/frontend/src/scenes/dashboard/dashboards/templates/DashboardTemplateChooser.tsx
@@ -13,15 +13,15 @@ import { DashboardTemplateType, TemplateAvailabilityContext } from '~/types'
 import BlankDashboardHog from 'public/blank-dashboard-hog.png'
 
 import {
-    dashboardTemplateChooserLogic,
     DashboardTemplateChooserExperimentVariant,
-    DashboardTemplateChooserLogicProps,
-} from './dashboardTemplateChooserLogic'
+    resolveDashboardTemplateChooserExperimentVariant,
+} from './dashboardTemplateChooserExperiment'
+import { dashboardTemplateChooserLogic, DashboardTemplateChooserLogicProps } from './dashboardTemplateChooserLogic'
 import { TemplateItem } from './DashboardTemplateItem'
 import { DashboardTemplateItemSkeleton } from './DashboardTemplateItemSkeleton'
 import { DashboardTemplateProps } from './dashboardTemplatesLogic'
 
-export type { DashboardTemplateChooserExperimentVariant } from './dashboardTemplateChooserLogic'
+export type { DashboardTemplateChooserExperimentVariant } from './dashboardTemplateChooserExperiment'
 
 const gridClass = 'grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5 gap-4'
 
@@ -248,9 +248,9 @@ function NewLayoutVariant(
 
 export function DashboardTemplateChooser(props: DashboardTemplateProps): JSX.Element {
     const { featureFlags } = useValues(featureFlagLogic)
-    const v = featureFlags[FEATURE_FLAGS.DASHBOARD_TEMPLATE_CHOOSER_EXPERIMENT]
-    const variant: DashboardTemplateChooserExperimentVariant =
-        v === 'simple' || v === 'new' || v === 'control' ? v : 'new'
+    const variant = resolveDashboardTemplateChooserExperimentVariant(
+        featureFlags[FEATURE_FLAGS.DASHBOARD_TEMPLATE_CHOOSER_EXPERIMENT]
+    )
 
     switch (variant) {
         case 'simple':

--- a/frontend/src/scenes/dashboard/dashboards/templates/dashboardTemplateChooserExperiment.ts
+++ b/frontend/src/scenes/dashboard/dashboards/templates/dashboardTemplateChooserExperiment.ts
@@ -1,0 +1,10 @@
+export type DashboardTemplateChooserExperimentVariant = 'control' | 'simple' | 'new'
+
+export function resolveDashboardTemplateChooserExperimentVariant(
+    flagValue: string | boolean | undefined
+): DashboardTemplateChooserExperimentVariant {
+    if (flagValue === 'simple' || flagValue === 'new' || flagValue === 'control') {
+        return flagValue
+    }
+    return 'new'
+}

--- a/frontend/src/scenes/dashboard/dashboards/templates/dashboardTemplateChooserLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboards/templates/dashboardTemplateChooserLogic.tsx
@@ -6,11 +6,10 @@ import { newDashboardLogic } from 'scenes/dashboard/newDashboardLogic'
 
 import { DashboardTemplateType } from '~/types'
 
+import type { DashboardTemplateChooserExperimentVariant } from './dashboardTemplateChooserExperiment'
 import type { dashboardTemplateChooserLogicType } from './dashboardTemplateChooserLogicType'
 import { runBlankDashboardFlow, runDashboardTemplateClickFlow } from './dashboardTemplateCreationFlows'
 import { DashboardTemplateProps, dashboardTemplatesLogic } from './dashboardTemplatesLogic'
-
-export type DashboardTemplateChooserExperimentVariant = 'control' | 'simple' | 'new'
 
 export type DashboardTemplateChooserLogicProps = DashboardTemplateProps & {
     experimentVariant: DashboardTemplateChooserExperimentVariant


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

When creating a dashboard from a template, the variable selector dropdown could render behind the dialog on the “Choose your events” step, making options difficult or impossible to see and select.

<img width="1674" height="912" alt="CleanShot 2026-04-10 at 10 22 44@2x" src="https://github.com/user-attachments/assets/74da667f-1b01-4dd4-9acf-c6672547c2c5" />


## Changes

- Updated `NewDashboardModal` to set the dialog popup layer just below the popover layer (`z-[calc(var(--z-popover)-1)]`).

## How did you test this code?

Locally.


## Publish to changelog?

no

## Docs update

No docs updates needed.

## 🤖 LLM context

- Implemented with Cursor Cloud agent.

<!-- CURSOR_AGENT_PR_BODY_END -->


<div><a href="https://cursor.com/agents/bc-400ef205-016c-5c98-9278-0842b24870b2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-400ef205-016c-5c98-9278-0842b24870b2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

