### PR TITLE
fix(llm-gateway): increase token truncation limit

### DIFF
--- a/services/llm-gateway/src/llm_gateway/api/models.py
+++ b/services/llm-gateway/src/llm_gateway/api/models.py
@@ -12,8 +12,10 @@ CREATED_TIMESTAMP = 1669766400  # Nov 30, 2022 - ChatGPT release date - we don't
 
 
 class TruncationPolicyConfig(BaseModel):
-    mode: str = "bytes"  # codex-acp TruncationMode: "bytes" | "tokens"
-    limit: int = 0
+    # Truncation for tool outputs: "bytes" | "tokens". 0 means fully truncated.
+    # Default: bytes(10_000), matches codex fallback. Override with tool_output_token_limit.
+    mode: Literal["bytes", "tokens"] = "bytes"
+    limit: int = 10_000
 
 
 class ModelObject(BaseModel):

--- a/services/llm-gateway/tests/test_models_api.py
+++ b/services/llm-gateway/tests/test_models_api.py
@@ -175,6 +175,14 @@ class TestListModelsEndpoint:
         assert "supports_streaming" in model
         assert "supports_vision" in model
 
+    def test_truncation_policy_limit_is_non_zero(self, client: TestClient):
+        # Ensure truncation_policy.limit is always > 0 (prevents tool output breakage).
+        response = client.get("/v1/models")
+        for model in response.json()["data"]:
+            policy = model["truncation_policy"]
+            assert policy["mode"] in {"bytes", "tokens"}
+            assert policy["limit"] > 0, f"{model['id']} would truncate tool output to zero"
+
 
 class TestListModelsForProductEndpoint:
     def test_returns_models_for_llm_gateway(self, client: TestClient):


### PR DESCRIPTION
## Problem

For `codex-acp` clients, every tool call result was being replaced with a truncated placeholder before the next turn. First-turn tool execution worked, but subsequent turns only saw the placeholder.

## Changes

- Set a default value for the truncation policy

## How did you test this code?

- Updated and ran tests
- Tested locally

## Publish to changelog?

no

## Docs update

n/a