### PR TITLE
feat(llma): add trend insight button to evaluation detail view

### DIFF
--- a/products/llm_analytics/frontend/evaluations/LLMAnalyticsEvaluation.tsx
+++ b/products/llm_analytics/frontend/evaluations/LLMAnalyticsEvaluation.tsx
@@ -3,7 +3,7 @@ import { Field, Form } from 'kea-forms'
 import { combineUrl, router } from 'kea-router'
 import { useRef } from 'react'
 
-import { IconArrowLeft, IconInfo, IconPlay } from '@posthog/icons'
+import { IconArrowLeft, IconInfo, IconPlay, IconTrends } from '@posthog/icons'
 import {
     LemonBanner,
     LemonButton,
@@ -26,8 +26,9 @@ import { SceneExport } from 'scenes/sceneTypes'
 import { userLogic } from 'scenes/userLogic'
 
 import { SceneBreadcrumbBackButton } from '~/layout/scenes/components/SceneBreadcrumbs'
+import { InsightVizNode, NodeKind } from '~/queries/schema/schema-general'
 import { urls } from '~/scenes/urls'
-import { AccessControlLevel, AccessControlResourceType } from '~/types'
+import { AccessControlLevel, AccessControlResourceType, ChartDisplayType, HogQLMathType } from '~/types'
 
 import { getModelPickerFooterLink, ModelPicker } from '../ModelPicker'
 import { modelPickerLogic } from '../modelPickerLogic'
@@ -84,6 +85,61 @@ export function LLMAnalyticsEvaluation(): JSX.Element {
             ? combineUrl(urls.llmAnalyticsPlayground(), { source_evaluation_id: evaluation.id }).url
             : null
 
+    const trendInsightUrl =
+        !isNewEvaluation && evaluation.id
+            ? urls.insightNew({
+                  query: {
+                      kind: NodeKind.InsightVizNode,
+                      source: {
+                          kind: NodeKind.TrendsQuery,
+                          series: [
+                              {
+                                  kind: NodeKind.EventsNode,
+                                  event: '$ai_evaluation',
+                                  custom_name: `${evaluation.name} — Pass rate`,
+                                  math: HogQLMathType.HogQL,
+                                  math_hogql: `if(countIf(properties.$ai_evaluation_result IS NOT NULL) > 0, countIf(properties.$ai_evaluation_result = 1) / countIf(properties.$ai_evaluation_result IS NOT NULL) * 100, 0)`,
+                                  properties: [
+                                      {
+                                          key: '$ai_evaluation_id',
+                                          value: evaluation.id,
+                                          operator: 'exact',
+                                          type: 'event',
+                                      },
+                                  ],
+                              },
+                              ...(evaluation.output_config.allows_na
+                                  ? [
+                                        {
+                                            kind: NodeKind.EventsNode as const,
+                                            event: '$ai_evaluation',
+                                            custom_name: `${evaluation.name} — N/A rate`,
+                                            math: HogQLMathType.HogQL as const,
+                                            math_hogql: `if(count() > 0, countIf(properties.$ai_evaluation_result IS NULL) / count() * 100, 0)`,
+                                            properties: [
+                                                {
+                                                    key: '$ai_evaluation_id',
+                                                    value: evaluation.id,
+                                                    operator: 'exact' as const,
+                                                    type: 'event' as const,
+                                                },
+                                            ],
+                                        },
+                                    ]
+                                  : []),
+                          ],
+                          trendsFilter: {
+                              display: ChartDisplayType.ActionsLineGraph,
+                          },
+                          dateRange: {
+                              date_from: '-7d',
+                          },
+                          interval: 'day',
+                      },
+                  } as InsightVizNode,
+              })
+            : null
+
     const isHog = evaluation.evaluation_type === 'hog'
     const configValid = isHog
         ? evaluation.evaluation_config.source.trim().length > 0
@@ -136,6 +192,17 @@ export function LLMAnalyticsEvaluation(): JSX.Element {
                     </div>
                 </div>
                 <div className="flex gap-2">
+                    {trendInsightUrl ? (
+                        <LemonButton
+                            type="secondary"
+                            icon={<IconTrends />}
+                            to={trendInsightUrl}
+                            targetBlank
+                            data-attr="llma-evaluation-trend-insight"
+                        >
+                            Trend insight
+                        </LemonButton>
+                    ) : null}
                     {openInPlaygroundUrl ? (
                         <LemonButton
                             type="secondary"


### PR DESCRIPTION
## Problem

When reviewing an evaluation in LLM analytics, there's no quick way to see how the pass rate (and N/A rate) trends over time as a proper insight. Users have to manually create a trend insight and configure the right filters and HogQL math expressions.

## Changes

Adds a "Trend insight" button to the evaluation detail view header, placed before the existing "Open in Playground" button:

- Uses the `IconTrends` icon for consistency with the errors tab
- Opens a new trend insight in a new tab with pre-configured series:
  - **Pass rate** — `countIf(result = 1) / countIf(result IS NOT NULL) * 100`, filtered to the specific evaluation ID
  - **N/A rate** (only when `allows_na` is enabled) — `countIf(result IS NULL) / count() * 100`
- Defaults to last 7 days with daily interval
- Only visible on existing evaluations (hidden on the "new evaluation" form)

## How did you test this code?

I am an agent and have not tested this manually. The change is a straightforward addition of a `LemonButton` with a pre-built insight URL, following the same pattern used by the errors tab trend buttons. TypeScript compilation passes with no errors on the changed file.

## Publish to changelog?

No

## 🤖 LLM context

Authored by Claude Code. Single-file change to `LLMAnalyticsEvaluation.tsx` — adds imports for `IconTrends`, `NodeKind`, `InsightVizNode`, `ChartDisplayType`, `HogQLMathType`, builds an insight URL using the same HogQL math pattern from `evaluationMetricsLogic.ts`, and renders a new button.

https://claude.ai/code/session_01N7rmu5WUpKitKUiu6NE6jJ