### PR TITLE
fix(stamphog): use PR author GitHub username as PostHog distinct_id

### DIFF
--- a/tools/pr-approval-agent/reviewer.py
+++ b/tools/pr-approval-agent/reviewer.py
@@ -236,7 +236,7 @@ class Reviewer:
         posthog_kwargs: dict = {}
         if _POSTHOG_AI_AVAILABLE:
             posthog_kwargs = {
-                "posthog_distinct_id": "stamphog",
+                "posthog_distinct_id": pr.author,
                 "posthog_properties": {
                     "ai_product": "stamphog",
                     "stamphog_pr_number": pr.number,


### PR DESCRIPTION
## Problem

Stamphog's PostHog analytics events all use the hardcoded distinct_id `"stamphog"`, making it impossible to see per-author usage patterns. The PR author's GitHub username is already available but only sent as a property, not used as the distinct_id.

## Changes

Use `pr.author` (the GitHub username) as the `posthog_distinct_id` instead of the hardcoded `"stamphog"` string. The `ai_product: "stamphog"` property is preserved so all stamphog events can still be filtered/grouped together.

## How did you test this code?

This is a one-line change swapping a hardcoded string for an already-available field (`pr.author`). The field is validated upstream and already used in the same block as a property (`stamphog_author`). No automated tests exist for this analytics integration.

I'm an agent and have not tested this manually.

## Publish to changelog?

no

## 🤖 LLM context

Agent-authored PR. Single-line change in `tools/pr-approval-agent/reviewer.py` replacing `"stamphog"` with `pr.author` for the PostHog distinct_id.

https://claude.ai/code/session_017cRRSvD3ufsrToizBzoFAa