### PR TITLE
feat(hogql): rewrite JSONExtractString to use materialized columns

### DIFF
--- a/posthog/hogql/printer/clickhouse.py
+++ b/posthog/hogql/printer/clickhouse.py
@@ -260,6 +260,69 @@ class ClickHousePrinter(HogQLPrinter):
 
         return None  # nothing to optimize
 
+    def _get_materialized_json_extract_string(self, node: ast.Call) -> str | None:
+        """
+        Rewrites JSONExtractString(properties, '$prop') to use a materialized column
+        when one exists, avoiding expensive JSON parsing.
+
+        JSONExtractString returns '' for missing properties (never NULL), so:
+        - Non-nullable mat cols: raw column value (stores '' for missing — same semantics)
+        - Nullable mat cols: ifNull(mat_col, '') (stores NULL for missing — restore '' semantics)
+
+        For nested access (3+ args), only non-nullable mat cols are used because
+        nullable mat cols may store NULL for non-existent properties, losing the raw
+        JSON needed for sub-path extraction.
+        """
+        if node.name != "JSONExtractString":
+            return None
+
+        if len(node.args) < 2:
+            return None
+
+        # First arg must resolve to a FieldType for properties/person_properties
+        field_type = resolve_field_type(node.args[0])
+        if not isinstance(field_type, ast.FieldType):
+            return None
+
+        field = field_type.resolve_database_field(self.context)
+        if field is None or not isinstance(field, DatabaseField):
+            return None
+        if field.name not in ("properties", "person_properties"):
+            return None
+
+        # Second arg must be a constant string (the property name)
+        if not isinstance(node.args[1], ast.Constant) or not isinstance(node.args[1].value, str):
+            return None
+        property_name = node.args[1].value
+
+        # Look up materialized column (skip property group sources)
+        mat_source: PrintableMaterializedColumn | None = None
+        for source in self._get_all_materialized_property_sources(field_type, property_name):
+            if isinstance(source, PrintableMaterializedColumn):
+                mat_source = source
+                break
+
+        if mat_source is None:
+            return None
+
+        has_nested_path = len(node.args) > 2
+
+        # For nested access with nullable columns, bail out (semantic mismatch)
+        if has_nested_path and mat_source.is_nullable:
+            return None
+
+        mat_col_sql = str(mat_source)
+
+        if not has_nested_path:
+            if mat_source.is_nullable:
+                return f"ifNull({mat_col_sql}, '')"
+            else:
+                return mat_col_sql
+        else:
+            # Nested: JSONExtractString(properties, '$foo', 'bar') → JSONExtractString(mat_col, 'bar')
+            remaining_args = [self.visit(arg) for arg in node.args[2:]]
+            return f"JSONExtractString({mat_col_sql}, {', '.join(remaining_args)})"
+
     def _get_optimized_materialized_column_equals_operation(self, node: ast.CompareOperation) -> str | None:
         """
         Returns an optimized printed expression for comparisons involving individually materialized columns.
@@ -895,6 +958,10 @@ class ClickHousePrinter(HogQLPrinter):
         # skipping indexes can be used when possible.
         if optimized_property_group_call := self._get_optimized_property_group_call(node):
             return optimized_property_group_call
+
+        # Rewrite JSONExtractString(properties, '$prop') to use materialized columns when available
+        if materialized_json_extract := self._get_materialized_json_extract_string(node):
+            return materialized_json_extract
 
         return super().visit_call(node)
 

--- a/posthog/hogql/printer/test/test_printer.py
+++ b/posthog/hogql/printer/test/test_printer.py
@@ -631,6 +631,64 @@ class TestPrinter(BaseTest):
             "events.mat_nullable_property",
         )
 
+    def test_json_extract_string_uses_materialized_column_non_nullable(self):
+        with materialized("events", "$browser") as mat_col:
+            self.assertEqual(
+                self._expr("JSONExtractString(properties, '$browser')"),
+                f"events.`{mat_col.name}`",
+            )
+
+    def test_json_extract_string_uses_materialized_column_nullable(self):
+        with materialized("events", "$browser", is_nullable=True) as mat_col:
+            self.assertEqual(
+                self._expr("JSONExtractString(properties, '$browser')"),
+                f"ifNull(events.`{mat_col.name}`, '')",
+            )
+
+    def test_json_extract_string_nested_uses_materialized_column(self):
+        with materialized("events", "withmat") as mat_col:
+            context = HogQLContext(team_id=self.team.pk, enable_select_queries=True)
+            self.assertEqual(
+                self._expr("JSONExtractString(properties, 'withmat', 'nested')", context),
+                f"JSONExtractString(events.{mat_col.name}, %(hogql_val_0)s)",
+            )
+            self.assertEqual(context.values["hogql_val_0"], "nested")
+
+    def test_json_extract_string_nested_does_not_use_nullable_materialized_column(self):
+        with materialized("events", "withmat", is_nullable=True):
+            result = self._expr("JSONExtractString(properties, 'withmat', 'nested')")
+            self.assertIn("JSONExtractString(events.properties", result)
+
+    def test_json_extract_string_no_materialized_column(self):
+        result = self._expr("JSONExtractString(properties, '$nonexistent')")
+        self.assertIn("JSONExtractString(events.properties", result)
+        self.assertNotIn("mat_", result)
+
+    def test_json_extract_string_non_field_first_arg_not_optimized(self):
+        with materialized("events", "$browser"):
+            result = self._expr("JSONExtractString(toString(properties), '$browser')")
+            self.assertNotIn("mat_", result)
+
+    def test_json_extract_string_non_constant_property_not_optimized(self):
+        with materialized("events", "$browser"):
+            result = self._expr("JSONExtractString(properties, event)")
+            self.assertNotIn("mat_", result)
+
+    def test_json_extract_int_not_rewritten_to_materialized(self):
+        with materialized("events", "$browser"):
+            result = self._expr("JSONExtractInt(properties, '$browser')")
+            self.assertNotIn("mat_", result)
+
+    def test_json_extract_string_materialization_disabled(self):
+        with materialized("events", "$browser"):
+            context = HogQLContext(
+                team_id=self.team.pk,
+                enable_select_queries=True,
+                modifiers=HogQLQueryModifiers(materializationMode=MaterializationMode.DISABLED),
+            )
+            result = self._expr("JSONExtractString(properties, '$browser')", context)
+            self.assertNotIn("mat_", result)
+
     def test_property_groups(self):
         context = HogQLContext(
             team_id=self.team.pk,

--- a/posthog/hogql/printer/test/test_printer.py
+++ b/posthog/hogql/printer/test/test_printer.py
@@ -631,18 +631,15 @@ class TestPrinter(BaseTest):
             "events.mat_nullable_property",
         )
 
-    def test_json_extract_string_uses_materialized_column_non_nullable(self):
-        with materialized("events", "$browser") as mat_col:
+    @parameterized.expand([
+        ("non_nullable", False, lambda n: f"events.`{n}`"),
+        ("nullable", True, lambda n: f"ifNull(events.`{n}`, '')"),
+    ])
+    def test_json_extract_string_uses_materialized_column(self, _name, is_nullable, expected_fn):
+        with materialized("events", "$browser", is_nullable=is_nullable) as mat_col:
             self.assertEqual(
                 self._expr("JSONExtractString(properties, '$browser')"),
-                f"events.`{mat_col.name}`",
-            )
-
-    def test_json_extract_string_uses_materialized_column_nullable(self):
-        with materialized("events", "$browser", is_nullable=True) as mat_col:
-            self.assertEqual(
-                self._expr("JSONExtractString(properties, '$browser')"),
-                f"ifNull(events.`{mat_col.name}`, '')",
+                expected_fn(mat_col.name),
             )
 
     def test_json_extract_string_nested_uses_materialized_column(self):
@@ -659,24 +656,19 @@ class TestPrinter(BaseTest):
             result = self._expr("JSONExtractString(properties, 'withmat', 'nested')")
             self.assertIn("JSONExtractString(events.properties", result)
 
-    def test_json_extract_string_no_materialized_column(self):
-        result = self._expr("JSONExtractString(properties, '$nonexistent')")
-        self.assertIn("JSONExtractString(events.properties", result)
-        self.assertNotIn("mat_", result)
-
-    def test_json_extract_string_non_field_first_arg_not_optimized(self):
-        with materialized("events", "$browser"):
-            result = self._expr("JSONExtractString(toString(properties), '$browser')")
-            self.assertNotIn("mat_", result)
-
-    def test_json_extract_string_non_constant_property_not_optimized(self):
-        with materialized("events", "$browser"):
-            result = self._expr("JSONExtractString(properties, event)")
-            self.assertNotIn("mat_", result)
-
-    def test_json_extract_int_not_rewritten_to_materialized(self):
-        with materialized("events", "$browser"):
-            result = self._expr("JSONExtractInt(properties, '$browser')")
+    @parameterized.expand([
+        ("no_materialized_column", None, "JSONExtractString(properties, '$nonexistent')"),
+        ("non_field_first_arg", "$browser", "JSONExtractString(toString(properties), '$browser')"),
+        ("non_constant_property", "$browser", "JSONExtractString(properties, event)"),
+        ("wrong_function", "$browser", "JSONExtractInt(properties, '$browser')"),
+    ])
+    def test_json_extract_string_not_optimized(self, _name, mat_prop, hogql_expr):
+        if mat_prop:
+            with materialized("events", mat_prop):
+                result = self._expr(hogql_expr)
+                self.assertNotIn("mat_", result)
+        else:
+            result = self._expr(hogql_expr)
             self.assertNotIn("mat_", result)
 
     def test_json_extract_string_materialization_disabled(self):


### PR DESCRIPTION
## Problem

`JSONExtractString(properties, '$prop')` calls in HogQL always parse the full JSON blob at query time, even when a materialized column already exists for that property. This is a common pattern in custom HogQL queries and causes unnecessary ClickHouse CPU usage.

## Changes

Add a HogQL printer optimization that rewrites `JSONExtractString(properties, '$prop')` to read from the materialized column when one exists:

- **Non-nullable columns**: rewrite directly to the materialized column (stores `''` for missing — same as `JSONExtractString`)
- **Nullable columns**: wrap in `ifNull(mat_col, '')` to preserve `JSONExtractString`'s empty-string semantics
- **Nested path access** (3+ args): pass remaining path args through to `JSONExtractString(mat_col, ...)`; skip nullable columns here since NULL vs missing-property semantics diverge
- **Respects** `materializationMode=DISABLED` setting
- Only applies to `JSONExtractString`, not other `JSONExtract*` variants

## Test plan

- [x] 9 new unit tests covering: non-nullable, nullable, nested path, nested+nullable skip, no-mat-col fallback, non-field first arg, non-constant property name, wrong function name, materialization disabled
- [x] All 51 existing materialization tests pass

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*