### PR TITLE
feat(temporal): fix CH queries in ingestion-acceptance-test job

### DIFF
--- a/posthog/temporal/ingestion_acceptance_test/client.py
+++ b/posthog/temporal/ingestion_acceptance_test/client.py
@@ -25,6 +25,14 @@ logger = structlog.get_logger(__name__)
 
 T = TypeVar("T")
 
+RETRYABLE_CH_ERROR_CODES: frozenset[int] = frozenset(
+    {
+        ErrorCodes.TOO_MANY_SIMULTANEOUS_QUERIES,
+        ErrorCodes.TIMEOUT_EXCEEDED,
+        ErrorCodes.MEMORY_LIMIT_EXCEEDED,
+    }
+)
+
 
 def _person_has_min_version(person: "Person | None", min_version: int | None) -> "Person | None":
     """Return the person only if it exists and meets the minimum version requirement."""
@@ -286,16 +294,31 @@ class PostHogClient:
                 try:
                     result = fetch_fn()
                 except (InternalCHQueryError, EOFError, ConnectionError, OSError) as e:
-                    if isinstance(e, InternalCHQueryError) and e.code != ErrorCodes.TOO_MANY_SIMULTANEOUS_QUERIES:
+                    is_retryable = not isinstance(e, InternalCHQueryError) or e.code in RETRYABLE_CH_ERROR_CODES
+                    if is_retryable:
+                        logger.warning(
+                            "Transient error during polling, will retry",
+                            retry_action="retrying",
+                            error=str(e),
+                            error_type=type(e).__name__,
+                            error_code=getattr(e, "code", None),
+                            error_code_name=getattr(e, "code_name", None),
+                            description=description,
+                            attempt=attempt,
+                        )
+                        result = None
+                    else:
+                        logger.exception(
+                            "Fatal ClickHouse error, aborting poll",
+                            retry_action="fatal",
+                            error=str(e),
+                            error_type=type(e).__name__,
+                            error_code=getattr(e, "code", None),
+                            error_code_name=getattr(e, "code_name", None),
+                            description=description,
+                            attempt=attempt,
+                        )
                         raise
-                    logger.warning(
-                        "Transient error during polling, will retry",
-                        error=str(e),
-                        error_type=type(e).__name__,
-                        description=description,
-                        attempt=attempt,
-                    )
-                    result = None
                 if result is not None:
                     elapsed = time.time() - start_time
                     logger.info(
@@ -363,11 +386,15 @@ class PostHogClient:
         )
 
     def _fetch_person_by_distinct_id(self, distinct_id: str) -> Person | None:
-        """Fetch a person by distinct_id via direct ClickHouse query."""
+        """Fetch a person by distinct_id via direct ClickHouse query.
+
+        Uses FINAL on both ReplacingMergeTree tables to ensure correct deduplication
+        after merges/aliases without waiting for background merges.
+        """
         query = """
             SELECT p.id, p.properties, p.created_at
-            FROM person p
-            JOIN person_distinct_id2 pdi ON p.id = pdi.person_id AND pdi.team_id = %(team_id)s
+            FROM person FINAL AS p
+            JOIN person_distinct_id2 FINAL AS pdi ON p.id = pdi.person_id AND pdi.team_id = %(team_id)s
             WHERE p.team_id = %(team_id)s
               AND pdi.distinct_id = %(distinct_id)s
               AND pdi.is_deleted = 0
@@ -398,14 +425,22 @@ class PostHogClient:
     def _fetch_events_by_person_id(self, person_id: str, expected_event_uuids: set[str]) -> list[CapturedEvent] | None:
         """Fetch events by person_id. Returns None if not all expected UUIDs are found.
 
-        Includes a timestamp filter to benefit from ClickHouse's table partitioning
-        (PARTITION BY toYYYYMM(timestamp)) and ordering (ORDER BY includes toDate(timestamp)).
+        Resolves the person's distinct_ids via person_distinct_id2 FINAL rather than
+        filtering on events.person_id directly. After merges/aliases, person_distinct_id2
+        is updated immediately, while events.person_id is only rewritten by async
+        background mutations that may lag significantly.
         """
         query = """
             SELECT uuid, event, distinct_id, properties, timestamp
             FROM events
             WHERE team_id = %(team_id)s
-              AND person_id = %(person_id)s
+              AND distinct_id IN (
+                SELECT distinct_id
+                FROM person_distinct_id2 FINAL
+                WHERE team_id = %(team_id)s
+                  AND person_id = %(person_id)s
+                  AND is_deleted = 0
+              )
               AND timestamp >= %(min_timestamp)s
             ORDER BY timestamp ASC
         """

--- a/posthog/temporal/ingestion_acceptance_test/runner.py
+++ b/posthog/temporal/ingestion_acceptance_test/runner.py
@@ -140,6 +140,8 @@ def _run_single_test(
         test_name=test_case.full_name,
         status=status,
         duration_seconds=round(duration, 1),
+        error_message=error_message,
+        error_details=error_details,
     )
 
     return TestResult(

--- a/posthog/temporal/ingestion_acceptance_test/schedule.py
+++ b/posthog/temporal/ingestion_acceptance_test/schedule.py
@@ -30,7 +30,7 @@ async def create_ingestion_acceptance_test_schedule(client: Client) -> None:
                 maximum_attempts=1,  # Don't retry - we want to know immediately if it fails
             ),
         ),
-        spec=ScheduleSpec(intervals=[ScheduleIntervalSpec(every=timedelta(minutes=10))]),
+        spec=ScheduleSpec(intervals=[ScheduleIntervalSpec(every=timedelta(minutes=15))]),
     )
 
     if await a_schedule_exists(client, SCHEDULE_ID):

--- a/posthog/temporal/tests/ingestion_acceptance_test/test_client.py
+++ b/posthog/temporal/tests/ingestion_acceptance_test/test_client.py
@@ -133,8 +133,8 @@ class TestFetchPersonByDistinctId:
         query = mock_sync_execute.call_args[0][0]
         params = mock_sync_execute.call_args[0][1]
 
-        assert "FROM person p" in query
-        assert "JOIN person_distinct_id2 pdi" in query
+        assert "FROM person FINAL AS p" in query
+        assert "JOIN person_distinct_id2 FINAL AS pdi" in query
         assert "pdi.distinct_id = %(distinct_id)s" in query
         assert "pdi.is_deleted = 0" in query
         assert "p.is_deleted = 0" in query
@@ -186,7 +186,7 @@ class TestFetchPersonByDistinctId:
 
 class TestFetchEventsByPersonId:
     @patch("posthog.temporal.ingestion_acceptance_test.client.sync_execute")
-    def test_includes_timestamp_filter(self, mock_sync_execute: MagicMock, client: PostHogClient) -> None:
+    def test_resolves_via_person_distinct_id2_final(self, mock_sync_execute: MagicMock, client: PostHogClient) -> None:
         mock_sync_execute.return_value = []
 
         client._fetch_events_by_person_id("test-person-id", expected_event_uuids={"some-uuid"})
@@ -195,7 +195,10 @@ class TestFetchEventsByPersonId:
         query = mock_sync_execute.call_args[0][0]
         params = mock_sync_execute.call_args[0][1]
 
+        assert "person_distinct_id2 FINAL" in query
+        assert "distinct_id IN" in query
         assert "timestamp >= %(min_timestamp)s" in query
+        assert params["person_id"] == "test-person-id"
         assert params["min_timestamp"] == client._test_start_date.isoformat()
 
     @patch("posthog.temporal.ingestion_acceptance_test.client.sync_execute")

--- a/posthog/temporal/tests/ingestion_acceptance_test/test_slack.py
+++ b/posthog/temporal/tests/ingestion_acceptance_test/test_slack.py
@@ -215,7 +215,7 @@ class TestSendSlackTimeoutNotification:
         context_text = payload["blocks"][1]["elements"][0]["text"]
         assert "test.posthog.com" in context_text
         assert "12345" in context_text
-        assert "600s" in context_text
+        assert "3600s" in context_text
         assert "phc_test_k..." in context_text
 
     @patch("posthog.temporal.ingestion_acceptance_test.slack.requests.post")


### PR DESCRIPTION
## Problem
Recent update to ingestion acceptance tests job changed query target from HogQL to CH direct. This created a couple problems:
* We need to ensure the queries can pick up the latest changes on person merge results, pre-CH-merge
* We need to log inline errors to internal logs so we can see more clearly when something goes wrong, rather than just in test result output
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
Things stated above. Should resolve the issue where test jobs pile up waiting for data they can't see. New inline logging should reveal more signal if there are other problems. 

I waited on lengthening the timeout on the output checks in the job due to the findings about the CH queries, but let's get some more log signal before make more changes.
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally and in CI (new test updates)
<!-- Briefly describe the steps you took, and what steps reviewers must take to get to where changes are, and what is the expected behavior. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
N/A
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update
N/A
<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
