### PR TITLE
feat(surveys): add tailored survey notifications

### DIFF
--- a/frontend/src/scenes/hog-functions/list/NewNotificationDialog.tsx
+++ b/frontend/src/scenes/hog-functions/list/NewNotificationDialog.tsx
@@ -22,14 +22,17 @@ export interface NewNotificationDialogProps {
     onCreated: () => void
     /** Dialog title shown in the modal header */
     title?: string
+    /** Override the default filters used by the sub-template */
+    filtersOverride?: NewNotificationDialogLogicProps['filtersOverride']
 }
 
 export function NewNotificationDialog({
     subTemplateId,
     onCreated,
     title = 'New notification',
+    filtersOverride,
 }: NewNotificationDialogProps): JSX.Element {
-    const logicProps: NewNotificationDialogLogicProps = { subTemplateId, onCreated }
+    const logicProps: NewNotificationDialogLogicProps = { subTemplateId, onCreated, filtersOverride }
     const logic = newNotificationDialogLogic(logicProps)
 
     const {

--- a/frontend/src/scenes/hog-functions/list/newNotificationDialogLogic.ts
+++ b/frontend/src/scenes/hog-functions/list/newNotificationDialogLogic.ts
@@ -6,7 +6,7 @@ import { lemonToast } from '@posthog/lemon-ui'
 import api from 'lib/api'
 import { integrationsLogic } from 'lib/integrations/integrationsLogic'
 
-import { HogFunctionSubTemplateIdType, HogFunctionType } from '~/types'
+import { CyclotronJobFiltersType, HogFunctionSubTemplateIdType, HogFunctionType } from '~/types'
 
 import { HOG_FUNCTION_SUB_TEMPLATE_COMMON_PROPERTIES, HOG_FUNCTION_SUB_TEMPLATES } from '../sub-templates/sub-templates'
 import type { newNotificationDialogLogicType } from './newNotificationDialogLogicType'
@@ -40,12 +40,13 @@ export interface NewNotificationForm {
 export interface NewNotificationDialogLogicProps {
     subTemplateId: HogFunctionSubTemplateIdType
     onCreated: () => void
+    filtersOverride?: CyclotronJobFiltersType
 }
 
 export const newNotificationDialogLogic = kea<newNotificationDialogLogicType>([
     path(['scenes', 'hog-functions', 'list', 'newNotificationDialogLogic']),
     props({} as NewNotificationDialogLogicProps),
-    key((props) => props.subTemplateId),
+    key((props) => `${props.subTemplateId}-${JSON.stringify(props.filtersOverride ?? null)}`),
     connect(() => ({
         values: [integrationsLogic, ['integrations']],
     })),
@@ -134,7 +135,7 @@ export const newNotificationDialogLogic = kea<newNotificationDialogLogicType>([
                     description: subTemplate?.description ?? '',
                     inputs_schema: template.inputs_schema,
                     inputs,
-                    filters: commonProps.filters,
+                    filters: props.filtersOverride ?? commonProps.filters,
                     hog: template.code,
                     icon_url: template.icon_url,
                     enabled: true,

--- a/frontend/src/scenes/surveys/SurveyView.tsx
+++ b/frontend/src/scenes/surveys/SurveyView.tsx
@@ -25,12 +25,14 @@ import { LemonSkeleton } from 'lib/lemon-ui/LemonSkeleton'
 import { LemonTabs } from 'lib/lemon-ui/LemonTabs'
 import { ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
 import { userHasAccess } from 'lib/utils/accessControlUtils'
-import { LinkedHogFunctions } from 'scenes/hog-functions/list/LinkedHogFunctions'
 import { organizationLogic } from 'scenes/organizationLogic'
 import { interProjectCopyLogic } from 'scenes/resource-transfer/interProjectCopyLogic'
 import { LaunchSurveyButton } from 'scenes/surveys/components/LaunchSurveyButton'
 import { SurveyQuestionVisualization } from 'scenes/surveys/components/question-visualizations/SurveyQuestionVisualization'
 import { SurveyFeedbackButton } from 'scenes/surveys/components/SurveyFeedbackButton'
+import { SurveyNotificationModal } from 'scenes/surveys/components/SurveyNotificationModal'
+import { SurveyNotifications } from 'scenes/surveys/components/SurveyNotifications'
+import { SurveyNotificationsCallout } from 'scenes/surveys/components/SurveyNotificationsCallout'
 import { DuplicateToProjectModal } from 'scenes/surveys/DuplicateToProjectModal'
 import { canDeleteSurvey, openArchiveSurveyDialog, openDeleteSurveyDialog } from 'scenes/surveys/surveyDialogs'
 import { surveyLogic } from 'scenes/surveys/surveyLogic'
@@ -53,17 +55,7 @@ import {
 } from '~/layout/scenes/SceneLayout'
 import { Query } from '~/queries/Query/Query'
 import { QueryContextColumn } from '~/queries/types'
-import {
-    AccessControlLevel,
-    AccessControlResourceType,
-    ActivityScope,
-    PropertyFilterType,
-    PropertyOperator,
-    Survey,
-    SurveyEventName,
-    SurveyEventProperties,
-    SurveyQuestionType,
-} from '~/types'
+import { AccessControlLevel, AccessControlResourceType, ActivityScope, Survey, SurveyQuestionType } from '~/types'
 
 import { SurveyResultsRefreshStatus } from './components/SurveyResultsRefreshStatus'
 import { NEW_SURVEY } from './constants'
@@ -93,11 +85,12 @@ export const getThumbIcon = (value: unknown): JSX.Element | null => {
 export function SurveyView({ id }: { id: string }): JSX.Element {
     const isRedesignEnabled = useFeatureFlag('SURVEYS_REDESIGNED_VIEW')
 
-    if (isRedesignEnabled) {
-        return <SurveyViewRedesign />
-    }
-
-    return <SurveyViewLegacy id={id} />
+    return (
+        <>
+            {isRedesignEnabled ? <SurveyViewRedesign /> : <SurveyViewLegacy id={id} />}
+            <SurveyNotificationModal surveyId={id} />
+        </>
+    )
 }
 
 function SurveyViewLegacy({ id }: { id: string }): JSX.Element {
@@ -356,31 +349,10 @@ function SurveyViewLegacy({ id }: { id: string }): JSX.Element {
                                 key: 'notifications',
                                 label: 'Notifications',
                                 content: (
-                                    <div>
-                                        <p>Get notified whenever a survey result is submitted</p>
-                                        <LinkedHogFunctions
-                                            type="destination"
-                                            subTemplateIds={['survey-response']}
-                                            forceFilterGroups={[
-                                                {
-                                                    events: [
-                                                        {
-                                                            id: SurveyEventName.SENT,
-                                                            type: 'events',
-                                                            properties: [
-                                                                {
-                                                                    key: SurveyEventProperties.SURVEY_ID,
-                                                                    type: PropertyFilterType.Event,
-                                                                    value: id,
-                                                                    operator: PropertyOperator.Exact,
-                                                                },
-                                                            ],
-                                                        },
-                                                    ],
-                                                },
-                                            ]}
-                                        />
-                                    </div>
+                                    <SurveyNotifications
+                                        surveyId={id}
+                                        description="Get notified whenever a survey result is submitted."
+                                    />
                                 ),
                             },
                             {
@@ -496,6 +468,7 @@ export function SurveyResult({ disableEventsTable }: { disableEventsTable?: bool
         <div className="deprecated-space-y-4">
             {isSurveyHeadlineEnabled && <SurveyHeadline />}
             <SurveyResponseFilters />
+            <SurveyNotificationsCallout surveyId={survey.id} />
             {isRefreshingResults || atLeastOneResponse ? (
                 <>
                     <SurveyResultsRefreshStatus visible={isRefreshingResults} />

--- a/frontend/src/scenes/surveys/SurveyView.tsx
+++ b/frontend/src/scenes/surveys/SurveyView.tsx
@@ -55,7 +55,14 @@ import {
 } from '~/layout/scenes/SceneLayout'
 import { Query } from '~/queries/Query/Query'
 import { QueryContextColumn } from '~/queries/types'
-import { AccessControlLevel, AccessControlResourceType, ActivityScope, Survey, SurveyQuestionType } from '~/types'
+import {
+    AccessControlLevel,
+    AccessControlResourceType,
+    ActivityScope,
+    Survey,
+    SurveyEventName,
+    SurveyQuestionType,
+} from '~/types'
 
 import { SurveyResultsRefreshStatus } from './components/SurveyResultsRefreshStatus'
 import { NEW_SURVEY } from './constants'

--- a/frontend/src/scenes/surveys/SurveyViewRedesign/SurveySidebar.tsx
+++ b/frontend/src/scenes/surveys/SurveyViewRedesign/SurveySidebar.tsx
@@ -2,26 +2,20 @@ import { useActions, useValues } from 'kea'
 import { getNextSurveyStep } from 'posthog-js/dist/surveys-preview'
 import { ReactNode } from 'react'
 
-import { IconDownload, IconPlus } from '@posthog/icons'
-import { LemonButton, LemonMenu, LemonSelect, LemonSkeleton, LemonSwitch, Link } from '@posthog/lemon-ui'
+import { IconDownload } from '@posthog/icons'
+import { LemonButton, LemonMenu, LemonSelect, Link } from '@posthog/lemon-ui'
 
 import { exportsLogic } from 'lib/components/ExportButton/exportsLogic'
 import { TZLabel } from 'lib/components/TZLabel'
 import { pluralize } from 'lib/utils'
-import { HogFunctionIcon } from 'scenes/hog-functions/configuration/HogFunctionIcon'
+import { SurveyNotifications } from 'scenes/surveys/components/SurveyNotifications'
 import { SURVEY_TYPE_LABEL_MAP } from 'scenes/surveys/constants'
 import { SurveyAppearancePreview } from 'scenes/surveys/SurveyAppearancePreview'
 import { surveyLogic } from 'scenes/surveys/surveyLogic'
-import {
-    getSurveyCollectionLimitSummary,
-    getSurveyDisplayConditionsSummary,
-    newSurveyNotificationUrl,
-} from 'scenes/surveys/utils'
-import { urls } from 'scenes/urls'
+import { getSurveyCollectionLimitSummary, getSurveyDisplayConditionsSummary } from 'scenes/surveys/utils'
 
 import {
     ExporterFormat,
-    HogFunctionType,
     Survey,
     SurveyQuestionBranchingType,
     SurveySchedule as SurveyScheduleEnum,
@@ -193,84 +187,10 @@ export function SurveyDetailsPanel(): JSX.Element {
     )
 }
 
-function getNotificationDescription(fn: HogFunctionType): string | null {
-    const inputs = fn.inputs
-    if (!inputs) {
-        return null
-    }
-    if (inputs.url?.value) {
-        try {
-            return new URL(String(inputs.url.value)).hostname
-        } catch {
-            return String(inputs.url.value)
-        }
-    }
-    if (inputs.channel?.value) {
-        return String(inputs.channel.value)
-    }
-    if (inputs.email?.value) {
-        return String(inputs.email.value)
-    }
-    return null
-}
-
 export function SurveyNotificationsPanel(): JSX.Element {
-    const { survey, surveyNotifications, surveyNotificationsLoading } = useValues(surveyLogic)
-    const { toggleSurveyNotificationEnabled } = useActions(surveyLogic)
+    const { survey } = useValues(surveyLogic)
 
-    if (surveyNotificationsLoading) {
-        return (
-            <div className="flex flex-col gap-2">
-                <LemonSkeleton className="h-12" />
-                <LemonSkeleton className="h-12" />
-            </div>
-        )
-    }
-
-    return (
-        <div className="flex flex-col gap-3">
-            {surveyNotifications.length > 0 ? (
-                <div className="flex flex-col gap-1.5">
-                    {surveyNotifications.map((fn) => {
-                        const description = getNotificationDescription(fn)
-                        return (
-                            <div key={fn.id} className="flex items-center gap-2 rounded border p-2">
-                                <HogFunctionIcon src={fn.icon_url} size="small" />
-                                <div className="flex-1 min-w-0">
-                                    <LemonButton
-                                        type="tertiary"
-                                        size="xsmall"
-                                        to={urls.hogFunction(fn.id)}
-                                        className="font-medium p-0 h-auto min-h-0"
-                                        noPadding
-                                    >
-                                        <span className="truncate">{fn.name}</span>
-                                    </LemonButton>
-                                    {description && <div className="text-xs text-muted truncate">{description}</div>}
-                                </div>
-                                <LemonSwitch
-                                    checked={fn.enabled}
-                                    onChange={() => toggleSurveyNotificationEnabled(fn.id, !fn.enabled)}
-                                    size="small"
-                                />
-                            </div>
-                        )
-                    })}
-                </div>
-            ) : (
-                <p className="text-xs text-muted m-0">No notifications configured yet.</p>
-            )}
-            <LemonButton
-                type="secondary"
-                size="small"
-                icon={<IconPlus />}
-                to={newSurveyNotificationUrl(survey.id)}
-                fullWidth
-            >
-                New notification
-            </LemonButton>
-        </div>
-    )
+    return <SurveyNotifications surveyId={survey.id} buttonFullWidth />
 }
 
 export function SurveyExportPanel(): JSX.Element {

--- a/frontend/src/scenes/surveys/SurveyViewRedesign/SurveyViewRedesign.tsx
+++ b/frontend/src/scenes/surveys/SurveyViewRedesign/SurveyViewRedesign.tsx
@@ -19,6 +19,7 @@ import { interProjectCopyLogic } from 'scenes/resource-transfer/interProjectCopy
 import { LaunchSurveyButton } from 'scenes/surveys/components/LaunchSurveyButton'
 import { SurveyQuestionVisualization } from 'scenes/surveys/components/question-visualizations/SurveyQuestionVisualization'
 import { SurveyFeedbackButton } from 'scenes/surveys/components/SurveyFeedbackButton'
+import { SurveyNotificationsCallout } from 'scenes/surveys/components/SurveyNotificationsCallout'
 import { DuplicateToProjectModal } from 'scenes/surveys/DuplicateToProjectModal'
 import { canDeleteSurvey, openArchiveSurveyDialog, openDeleteSurveyDialog } from 'scenes/surveys/surveyDialogs'
 import { SurveyHeadline } from 'scenes/surveys/SurveyHeadline'
@@ -484,6 +485,7 @@ function SurveySummaryContent({ onViewResponses }: { onViewResponses: () => void
             <div className="px-4 pb-4">
                 <div className="mx-auto w-full max-w-[1200px] space-y-4">
                     <SurveyResultsFiltersBar />
+                    <SurveyNotificationsCallout surveyId={survey.id} />
                     <SurveyStatsSummary />
                     <SurveyNoResponsesBanner
                         type="survey"
@@ -504,6 +506,7 @@ function SurveySummaryContent({ onViewResponses }: { onViewResponses: () => void
         <div className="px-4 pb-4">
             <div className="mx-auto w-full max-w-[1200px] space-y-4">
                 <SurveyResultsFiltersBar />
+                <SurveyNotificationsCallout surveyId={survey.id} />
                 <SurveyResultsRefreshStatus visible={isRefreshingResults} />
                 <div
                     aria-busy={isRefreshingResults}
@@ -558,6 +561,7 @@ function SurveyResponsesContent(): JSX.Element {
     return (
         <div className="px-4 pb-4 space-y-4">
             <SurveyResultsFiltersBar />
+            <SurveyNotificationsCallout surveyId={survey.id} />
             <SurveyResultsRefreshStatus visible={isRefreshingResults} />
             {isInitialSurveyLoad ? (
                 <LemonSkeleton />

--- a/frontend/src/scenes/surveys/components/SurveyNotificationModal.tsx
+++ b/frontend/src/scenes/surveys/components/SurveyNotificationModal.tsx
@@ -63,6 +63,10 @@ function TemplateEditor({
     )
 }
 
+function SectionEyebrow({ children }: { children: string }): JSX.Element {
+    return <div className="text-[11px] font-medium uppercase tracking-[0.14em] text-muted">{children}</div>
+}
+
 type MessageFormattingActionProps = {
     questions: SurveyQuestionForNotification[]
     onReset: () => void
@@ -83,28 +87,29 @@ function MessageFormattingActions({
     const applicableQuestions = questions.filter((question) => question.id && question.type !== SurveyQuestionType.Link)
 
     return (
-        <div className="rounded border border-dashed bg-surface-primary p-2">
-            <div className="mb-2 text-xs text-muted">
-                Start with a readable template, then add survey answers or metadata as needed.
+        <div className="border-t border-border pt-3">
+            <div className="mb-2 flex flex-col gap-1 sm:flex-row sm:items-baseline sm:justify-between">
+                <div className="text-xs font-medium text-default">Quick inserts</div>
+                <div className="text-xs text-muted">Keep the default compact, then add context only where needed.</div>
             </div>
             <div className="flex flex-wrap gap-1.5">
                 <LemonButton size="xsmall" type="secondary" onClick={onReset}>
                     Use suggested format
                 </LemonButton>
-                <LemonButton size="xsmall" type="secondary" onClick={onInsertSurveyName}>
+                <LemonButton size="xsmall" type="tertiary" onClick={onInsertSurveyName}>
                     Insert survey name
                 </LemonButton>
-                <LemonButton size="xsmall" type="secondary" onClick={onInsertRespondent}>
+                <LemonButton size="xsmall" type="tertiary" onClick={onInsertRespondent}>
                     Insert respondent
                 </LemonButton>
-                <LemonButton size="xsmall" type="secondary" onClick={onInsertEmail}>
+                <LemonButton size="xsmall" type="tertiary" onClick={onInsertEmail}>
                     Insert email
                 </LemonButton>
                 {applicableQuestions.map((question, index) => (
                     <LemonButton
                         key={question.id}
                         size="xsmall"
-                        type="secondary"
+                        type="tertiary"
                         onClick={() => onInsertQuestion(question, index)}
                     >
                         Insert: {getQuestionLabel(question, index)}
@@ -204,26 +209,51 @@ export function SurveyNotificationModal({ surveyId }: { surveyId: string }): JSX
                     enableFormOnSubmit
                 >
                     <div className="flex flex-col gap-4">
-                        <Field name="destination" label="Destination">
-                            {({ value, onChange }) => (
-                                <LemonSelect
-                                    value={value}
-                                    onChange={onChange}
-                                    options={DESTINATION_OPTIONS.map((option) => ({
-                                        value: option.value,
-                                        label: option.label,
-                                        icon: <img src={option.iconUrl} alt="" className="h-5 w-5 object-contain" />,
-                                    }))}
-                                    fullWidth
-                                />
-                            )}
-                        </Field>
-
-                        <div className="text-xs text-muted">
-                            {destinationDeliveryDescription(notificationForm.destination)}
-                        </div>
-                        <div className="text-xs text-muted">
-                            Tailored to surveys: notifications fire only for completed submissions by default.
+                        <div className="rounded-xl bg-fill-secondary p-4 shadow-xs">
+                            <SectionEyebrow>Setup</SectionEyebrow>
+                            <div className="mt-3 grid gap-4 md:grid-cols-[minmax(0,1.35fr)_minmax(18rem,1fr)]">
+                                <div className="flex flex-col gap-2">
+                                    <Field name="destination" label="Destination">
+                                        {({ value, onChange }) => (
+                                            <LemonSelect
+                                                value={value}
+                                                onChange={onChange}
+                                                options={DESTINATION_OPTIONS.map((option) => ({
+                                                    value: option.value,
+                                                    label: option.label,
+                                                    icon: (
+                                                        <img
+                                                            src={option.iconUrl}
+                                                            alt=""
+                                                            className="h-5 w-5 object-contain"
+                                                        />
+                                                    ),
+                                                }))}
+                                                fullWidth
+                                            />
+                                        )}
+                                    </Field>
+                                    <div className="text-xs text-muted">
+                                        {destinationDeliveryDescription(notificationForm.destination)}
+                                    </div>
+                                </div>
+                                <div className="rounded-lg bg-surface-primary p-3 shadow-xs">
+                                    <Field name="onlyCompletedResponses">
+                                        {({ value, onChange }) => (
+                                            <LemonSwitch
+                                                checked={value}
+                                                onChange={onChange}
+                                                label="Only notify for full responses"
+                                                bordered
+                                            />
+                                        )}
+                                    </Field>
+                                    <div className="mt-2 text-xs text-muted">
+                                        Leave this on to avoid partial-response noise, or turn it off if early answers
+                                        matter for this survey.
+                                    </div>
+                                </div>
+                            </div>
                         </div>
 
                         {notificationForm.destination === 'slack' ? (
@@ -257,9 +287,16 @@ export function SurveyNotificationModal({ surveyId }: { surveyId: string }): JSX
                                         ) : null}
                                     </>
                                 )}
-                                <Field name="slackMessage" label="Message">
+                                <Field name="slackMessage">
                                     {({ value, onChange }) => (
-                                        <div className="flex flex-col gap-2">
+                                        <div className="rounded-xl border bg-surface-primary p-4 shadow-xs">
+                                            <SectionEyebrow>Message</SectionEyebrow>
+                                            <div className="mt-1 text-sm font-medium text-default">
+                                                Slack message template
+                                            </div>
+                                            <div className="mb-3 mt-1 text-xs text-muted">
+                                                Built for scanning fast in busy channels, with optional details below.
+                                            </div>
                                             <TemplateEditor
                                                 value={value}
                                                 onChange={onChange}
@@ -268,17 +305,19 @@ export function SurveyNotificationModal({ surveyId }: { surveyId: string }): JSX
                                             {messageFormattingActions ? (
                                                 <MessageFormattingActions {...messageFormattingActions} />
                                             ) : null}
+                                            <div className="mt-3 border-t border-border pt-3">
+                                                <Field name="includeSlackButtons">
+                                                    {({ value: switchValue, onChange: switchOnChange }) => (
+                                                        <LemonSwitch
+                                                            checked={switchValue}
+                                                            onChange={switchOnChange}
+                                                            label="Include buttons to view the survey and person"
+                                                            bordered
+                                                        />
+                                                    )}
+                                                </Field>
+                                            </div>
                                         </div>
-                                    )}
-                                </Field>
-                                <Field name="includeSlackButtons">
-                                    {({ value, onChange }) => (
-                                        <LemonSwitch
-                                            checked={value}
-                                            onChange={onChange}
-                                            label="Include buttons to view the survey and person"
-                                            bordered
-                                        />
                                     )}
                                 </Field>
                             </>
@@ -296,9 +335,17 @@ export function SurveyNotificationModal({ surveyId }: { surveyId: string }): JSX
                                         />
                                     )}
                                 </Field>
-                                <Field name="discordMessage" label="Message">
+                                <Field name="discordMessage">
                                     {({ value, onChange }) => (
-                                        <div className="flex flex-col gap-2">
+                                        <div className="rounded-xl border bg-surface-primary p-4 shadow-xs">
+                                            <SectionEyebrow>Message</SectionEyebrow>
+                                            <div className="mt-1 text-sm font-medium text-default">
+                                                Discord message template
+                                            </div>
+                                            <div className="mb-3 mt-1 text-xs text-muted">
+                                                Keep it compact by default, then use quick inserts when you need more
+                                                context.
+                                            </div>
                                             <TemplateEditor
                                                 value={value}
                                                 onChange={onChange}
@@ -325,9 +372,17 @@ export function SurveyNotificationModal({ surveyId }: { surveyId: string }): JSX
                                         />
                                     )}
                                 </Field>
-                                <Field name="teamsMessage" label="Message">
+                                <Field name="teamsMessage">
                                     {({ value, onChange }) => (
-                                        <div className="flex flex-col gap-2">
+                                        <div className="rounded-xl border bg-surface-primary p-4 shadow-xs">
+                                            <SectionEyebrow>Message</SectionEyebrow>
+                                            <div className="mt-1 text-sm font-medium text-default">
+                                                Microsoft Teams message template
+                                            </div>
+                                            <div className="mb-3 mt-1 text-xs text-muted">
+                                                Default to a high-signal summary and add metadata only if the team needs
+                                                it.
+                                            </div>
                                             <TemplateEditor
                                                 value={value}
                                                 onChange={onChange}
@@ -354,47 +409,55 @@ export function SurveyNotificationModal({ surveyId }: { surveyId: string }): JSX
                                         />
                                     )}
                                 </Field>
-                                <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:gap-4">
-                                    <div className="flex min-w-48 flex-col gap-2">
-                                        <Field name="webhookMethod" label="HTTP method">
-                                            {({ value, onChange }) => (
-                                                <LemonSelect
-                                                    value={value}
-                                                    onChange={onChange}
-                                                    options={WEBHOOK_METHOD_OPTIONS}
-                                                    fullWidth
-                                                />
-                                            )}
-                                        </Field>
-                                    </div>
-                                    <div className="flex-1 rounded border border-dashed bg-surface-primary p-3 text-xs text-muted">
+                                <div className="rounded-xl border bg-surface-primary p-4 shadow-xs">
+                                    <SectionEyebrow>Payload</SectionEyebrow>
+                                    <div className="mt-1 text-sm font-medium text-default">Webhook request body</div>
+                                    <div className="mb-3 mt-1 text-xs text-muted">
                                         Survey webhooks send the survey metadata, person context, and one answer field
-                                        per question. You can tailor the payload before saving it.
+                                        per question.
                                     </div>
+                                    <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:gap-4">
+                                        <div className="flex min-w-48 flex-col gap-2">
+                                            <Field name="webhookMethod" label="HTTP method">
+                                                {({ value, onChange }) => (
+                                                    <LemonSelect
+                                                        value={value}
+                                                        onChange={onChange}
+                                                        options={WEBHOOK_METHOD_OPTIONS}
+                                                        fullWidth
+                                                    />
+                                                )}
+                                            </Field>
+                                        </div>
+                                        <div className="flex-1 rounded-lg bg-fill-secondary p-3 text-xs text-muted">
+                                            Tailor the JSON before saving it if your endpoint expects a specific shape.
+                                        </div>
+                                    </div>
+                                    <Field name="webhookBody" label="JSON body">
+                                        {({ value, onChange }) => (
+                                            <CodeEditorResizeable
+                                                embedded
+                                                language="json"
+                                                value={value}
+                                                onChange={(nextValue) => onChange(nextValue ?? '')}
+                                                minHeight="14rem"
+                                                maxHeight="20rem"
+                                                allowManualResize={false}
+                                                options={{
+                                                    minimap: { enabled: false },
+                                                    scrollBeyondLastLine: false,
+                                                    fixedOverflowWidgets: true,
+                                                }}
+                                            />
+                                        )}
+                                    </Field>
                                 </div>
-                                <Field name="webhookBody" label="JSON body">
-                                    {({ value, onChange }) => (
-                                        <CodeEditorResizeable
-                                            embedded
-                                            language="json"
-                                            value={value}
-                                            onChange={(nextValue) => onChange(nextValue ?? '')}
-                                            minHeight="14rem"
-                                            maxHeight="20rem"
-                                            allowManualResize={false}
-                                            options={{
-                                                minimap: { enabled: false },
-                                                scrollBeyondLastLine: false,
-                                                fixedOverflowWidgets: true,
-                                            }}
-                                        />
-                                    )}
-                                </Field>
                             </>
                         ) : null}
 
-                        <div className="rounded border bg-fill-secondary p-3">
-                            <div className="mb-2 text-sm font-medium">Available survey placeholders</div>
+                        <div className="rounded-xl bg-fill-secondary p-4 shadow-xs">
+                            <SectionEyebrow>Reference</SectionEyebrow>
+                            <div className="mb-2 mt-1 text-sm font-medium">Available survey placeholders</div>
                             <div className="mb-3 text-xs text-muted">
                                 Need deeper customization later? After you create a notification, open it from the
                                 survey notifications list to use the full Hog function editor.

--- a/frontend/src/scenes/surveys/components/SurveyNotificationModal.tsx
+++ b/frontend/src/scenes/surveys/components/SurveyNotificationModal.tsx
@@ -1,182 +1,31 @@
 import { useActions, useValues } from 'kea'
-import { useEffect, useMemo, useState } from 'react'
+import { Field, Form } from 'kea-forms'
 
 import { LemonButton, LemonInput, LemonSelect, LemonSwitch } from '@posthog/lemon-ui'
 
-import api from 'lib/api'
 import { IntegrationChoice } from 'lib/components/CyclotronJob/integrations/IntegrationChoice'
-import { integrationsLogic } from 'lib/integrations/integrationsLogic'
 import { SlackChannelPicker, SlackNotConfiguredBanner } from 'lib/integrations/SlackIntegrationHelpers'
 import { LemonModal } from 'lib/lemon-ui/LemonModal'
-import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
 import { CodeEditorResizeable } from 'lib/monaco/CodeEditorResizable'
-import { DESTINATION_OPTIONS, DestinationKey } from 'scenes/hog-functions/list/newNotificationDialogLogic'
-import {
-    HOG_FUNCTION_SUB_TEMPLATE_COMMON_PROPERTIES,
-    HOG_FUNCTION_SUB_TEMPLATES,
-} from 'scenes/hog-functions/sub-templates/sub-templates'
+import { DESTINATION_OPTIONS } from 'scenes/hog-functions/list/newNotificationDialogLogic'
 import { SurveyResponseKeysReference } from 'scenes/surveys/components/SurveyResponseKeysReference'
-import { NEW_SURVEY } from 'scenes/surveys/constants'
-import { surveyLogic } from 'scenes/surveys/surveyLogic'
-import { getSurveyNotificationFilters, getSurveyIdBasedResponseKey } from 'scenes/surveys/utils'
+import {
+    RESPONDENT_EMAIL_TOKEN,
+    RESPONDENT_NAME_TOKEN,
+    SURVEY_NAME_TOKEN,
+    SurveyNotificationForm,
+    SurveyQuestionForNotification,
+    WEBHOOK_METHOD_OPTIONS,
+    appendQuestionToken,
+    appendTemplateLine,
+    destinationDeliveryDescription,
+    getDefaultSurveyMessage,
+    getMessageFieldForDestination,
+    getQuestionLabel,
+    surveyNotificationModalLogic,
+} from 'scenes/surveys/surveyNotificationModalLogic'
 
-import { HogFunctionTemplateType, HogFunctionType, SurveyQuestionType } from '~/types'
-
-const WEBHOOK_METHOD_OPTIONS = [
-    { value: 'POST', label: 'POST' },
-    { value: 'PUT', label: 'PUT' },
-    { value: 'PATCH', label: 'PATCH' },
-    { value: 'GET', label: 'GET' },
-    { value: 'DELETE', label: 'DELETE' },
-]
-
-type SurveyQuestionForNotification = {
-    id?: string
-    question: string | null | undefined
-    type: SurveyQuestionType
-}
-
-const MAX_EXAMPLE_QUESTIONS = 3
-const SURVEY_NAME_TOKEN = "{event.properties['$survey_name']}"
-const SURVEY_ID_TOKEN = "{event.properties['$survey_id']}"
-const RESPONDENT_NAME_TOKEN = '{person.name}'
-const RESPONDENT_EMAIL_TOKEN = '{person.properties.email}'
-
-function getResponseToken(questionId: string): string {
-    return `{event.properties['${getSurveyIdBasedResponseKey(questionId)}']}`
-}
-
-function getQuestionLabel(question: SurveyQuestionForNotification, index: number): string {
-    return question.question?.trim() || `Question ${index + 1}`
-}
-
-function getQuestionLine(question: SurveyQuestionForNotification, index: number): string {
-    return `- ${getQuestionLabel(question, index)}: ${getResponseToken(question.id!)}`
-}
-
-function getDefaultSurveyMessage(questions: SurveyQuestionForNotification[] = []): string {
-    const exampleQuestions = questions
-        .filter((question) => question.id && question.type !== SurveyQuestionType.Link)
-        .slice(0, MAX_EXAMPLE_QUESTIONS)
-
-    return [
-        '*New survey response*',
-        `Survey: *${SURVEY_NAME_TOKEN}*`,
-        `Respondent: ${RESPONDENT_NAME_TOKEN}`,
-        `Email: ${RESPONDENT_EMAIL_TOKEN}`,
-        ...(exampleQuestions.length > 0
-            ? ['', '*Responses*', ...exampleQuestions.map((question, index) => getQuestionLine(question, index))]
-            : []),
-    ].join('\n')
-}
-
-function isValidHttpUrl(value: string): boolean {
-    return URL.canParse(value) && /^https?:\/\//.test(value)
-}
-
-function buildSlackBlocks(message: string, includeButtons: boolean): Record<string, unknown>[] {
-    return [
-        {
-            type: 'section',
-            text: {
-                type: 'mrkdwn',
-                text: message,
-            },
-        },
-        ...(includeButtons
-            ? [
-                  {
-                      type: 'actions',
-                      elements: [
-                          {
-                              url: "{project.url}/surveys/{event.properties['$survey_id']}",
-                              text: { text: 'View survey', type: 'plain_text' },
-                              type: 'button',
-                          },
-                          {
-                              url: '{person.url}',
-                              text: { text: 'View person', type: 'plain_text' },
-                              type: 'button',
-                          },
-                      ],
-                  },
-              ]
-            : []),
-    ]
-}
-
-function buildWebhookBodyTemplate(questions: SurveyQuestionForNotification[]): Record<string, unknown> {
-    return {
-        survey: {
-            id: SURVEY_ID_TOKEN,
-            name: SURVEY_NAME_TOKEN,
-            url: `{project.url}/surveys/${SURVEY_ID_TOKEN}`,
-        },
-        person: {
-            name: RESPONDENT_NAME_TOKEN,
-            email: RESPONDENT_EMAIL_TOKEN,
-            url: '{person.url}',
-        },
-        responses: questions
-            .filter((question) => question.id && question.type !== SurveyQuestionType.Link)
-            .map((question, index) => ({
-                question: getQuestionLabel(question, index),
-                answer: getResponseToken(question.id!),
-            })),
-    }
-}
-
-function appendQuestionToken(value: string, question: SurveyQuestionForNotification, index: number): string {
-    if (!question.id) {
-        return value
-    }
-
-    const line = getQuestionLine(question, index)
-    const trimmedValue = value.trim()
-
-    if (trimmedValue.includes(line)) {
-        return trimmedValue
-    }
-
-    if (!trimmedValue) {
-        return getDefaultSurveyMessage([question])
-    }
-
-    if (trimmedValue.includes('*Responses*')) {
-        return `${trimmedValue}\n${line}`
-    }
-
-    return `${trimmedValue}\n\n*Responses*\n${line}`
-}
-
-function appendTemplateLine(value: string, line: string): string {
-    const trimmedValue = value.trim()
-
-    if (trimmedValue.includes(line)) {
-        return trimmedValue
-    }
-
-    return trimmedValue ? `${trimmedValue}\n${line}` : line
-}
-
-function notificationNameFor(destination: DestinationKey, surveyName?: string | null): string {
-    const destinationLabel = DESTINATION_OPTIONS.find((option) => option.value === destination)?.label || 'Notification'
-    const baseName = surveyName?.trim() || 'Survey'
-    return `${baseName} → ${destinationLabel}`
-}
-
-function destinationDeliveryDescription(destination: DestinationKey): string {
-    switch (destination) {
-        case 'slack':
-            return 'Slack messages are sent as a formatted post with buttons to view the survey and person.'
-        case 'discord':
-            return 'Discord sends a single message to your webhook URL using the content below.'
-        case 'microsoft-teams':
-            return 'Microsoft Teams sends an Adaptive Card message using the text below.'
-        case 'webhook':
-            return 'Webhooks send a JSON request. You can tailor the method and request body here.'
-    }
-}
+import { SurveyQuestionType } from '~/types'
 
 function TemplateEditor({
     value,
@@ -214,6 +63,15 @@ function TemplateEditor({
     )
 }
 
+type MessageFormattingActionProps = {
+    questions: SurveyQuestionForNotification[]
+    onReset: () => void
+    onInsertSurveyName: () => void
+    onInsertRespondent: () => void
+    onInsertEmail: () => void
+    onInsertQuestion: (question: SurveyQuestionForNotification, index: number) => void
+}
+
 function MessageFormattingActions({
     questions,
     onReset,
@@ -221,14 +79,7 @@ function MessageFormattingActions({
     onInsertRespondent,
     onInsertEmail,
     onInsertQuestion,
-}: {
-    questions: SurveyQuestionForNotification[]
-    onReset: () => void
-    onInsertSurveyName: () => void
-    onInsertRespondent: () => void
-    onInsertEmail: () => void
-    onInsertQuestion: (question: SurveyQuestionForNotification, index: number) => void
-}): JSX.Element {
+}: MessageFormattingActionProps): JSX.Element {
     const applicableQuestions = questions.filter((question) => question.id && question.type !== SurveyQuestionType.Link)
 
     return (
@@ -264,316 +115,75 @@ function MessageFormattingActions({
     )
 }
 
-function createSurveyNotificationPayload({
-    template,
-    destination,
-    surveyName,
-    surveyId,
-    slackIntegrationId,
-    slackChannel,
-    slackMessage,
-    includeSlackButtons,
-    discordWebhookUrl,
-    discordMessage,
-    teamsWebhookUrl,
-    teamsMessage,
-    webhookUrl,
-    webhookMethod,
-    webhookBody,
+function getMessageFormattingActions({
+    field,
+    value,
+    questions,
+    setNotificationFormValue,
 }: {
-    template: HogFunctionTemplateType
-    destination: DestinationKey
-    surveyName?: string | null
-    surveyId: string
-    slackIntegrationId: number | null
-    slackChannel: string | null
-    slackMessage: string
-    includeSlackButtons: boolean
-    discordWebhookUrl: string
-    discordMessage: string
-    teamsWebhookUrl: string
-    teamsMessage: string
-    webhookUrl: string
-    webhookMethod: string
-    webhookBody: string
-}): Partial<HogFunctionType> {
-    const destinationOption = DESTINATION_OPTIONS.find((option) => option.value === destination)
-    if (!destinationOption) {
-        throw new Error('Unsupported destination')
-    }
-
-    const subTemplate = HOG_FUNCTION_SUB_TEMPLATES['survey-response'].find(
-        (template) => template.template_id === destinationOption.templateId
-    )
-
-    const inputs: Record<string, { value: unknown }> = {}
-
-    for (const schema of template.inputs_schema ?? []) {
-        if (schema.default !== undefined) {
-            inputs[schema.key] = { value: schema.default }
-        }
-    }
-
-    if (subTemplate?.inputs) {
-        for (const [key, value] of Object.entries(subTemplate.inputs)) {
-            inputs[key] = value as { value: unknown }
-        }
-    }
-
-    switch (destination) {
-        case 'slack':
-            if (!slackIntegrationId || !slackChannel) {
-                throw new Error('Select a Slack workspace and channel.')
-            }
-            inputs.slack_workspace = { value: slackIntegrationId }
-            inputs.channel = { value: slackChannel.split('|')[0] }
-            inputs.text = { value: slackMessage.trim() }
-            inputs.blocks = { value: buildSlackBlocks(slackMessage.trim(), includeSlackButtons) }
-            break
-        case 'discord':
-            inputs.webhookUrl = { value: discordWebhookUrl.trim() }
-            inputs.content = { value: discordMessage.trim() }
-            break
-        case 'microsoft-teams':
-            inputs.webhookUrl = { value: teamsWebhookUrl.trim() }
-            inputs.text = { value: teamsMessage.trim() }
-            break
-        case 'webhook':
-            inputs.url = { value: webhookUrl.trim() }
-            inputs.method = { value: webhookMethod }
-            inputs.body = { value: JSON.parse(webhookBody) }
-            break
-    }
-
+    field: 'slackMessage' | 'discordMessage' | 'teamsMessage'
+    value: string
+    questions: SurveyQuestionForNotification[]
+    setNotificationFormValue: <K extends keyof SurveyNotificationForm>(key: K, value: SurveyNotificationForm[K]) => void
+}): MessageFormattingActionProps {
     return {
-        template_id: destinationOption.templateId,
-        type: HOG_FUNCTION_SUB_TEMPLATE_COMMON_PROPERTIES['survey-response'].type,
-        name: notificationNameFor(destination, surveyName),
-        description: subTemplate?.description ?? `Survey notification for ${destinationOption.label}`,
-        inputs,
-        inputs_schema: template.inputs_schema,
-        filters: getSurveyNotificationFilters(surveyId),
-        hog: template.code,
-        icon_url: template.icon_url,
-        enabled: true,
+        questions,
+        onReset: () => setNotificationFormValue(field, getDefaultSurveyMessage(questions)),
+        onInsertSurveyName: () =>
+            setNotificationFormValue(field, appendTemplateLine(value, `Survey: *${SURVEY_NAME_TOKEN}*`)),
+        onInsertRespondent: () =>
+            setNotificationFormValue(field, appendTemplateLine(value, `Respondent: ${RESPONDENT_NAME_TOKEN}`)),
+        onInsertEmail: () =>
+            setNotificationFormValue(field, appendTemplateLine(value, `Email: ${RESPONDENT_EMAIL_TOKEN}`)),
+        onInsertQuestion: (question, index) =>
+            setNotificationFormValue(field, appendQuestionToken(value, question, index)),
     }
 }
 
 export function SurveyNotificationModal({ surveyId }: { surveyId: string }): JSX.Element {
-    const logic = surveyLogic({ id: surveyId })
-    const { survey, surveyNotificationModalOpen } = useValues(logic)
-    const { closeSurveyNotificationModal, loadSurveyNotifications } = useActions(logic)
-    const { integrations } = useValues(integrationsLogic)
-
-    const [destination, setDestination] = useState<DestinationKey>('slack')
-    const [slackIntegrationId, setSlackIntegrationId] = useState<number | null>(null)
-    const [slackChannel, setSlackChannel] = useState<string | null>(null)
-    const [slackMessage, setSlackMessage] = useState(() => getDefaultSurveyMessage(survey.questions))
-    const [includeSlackButtons, setIncludeSlackButtons] = useState(true)
-    const [discordWebhookUrl, setDiscordWebhookUrl] = useState('')
-    const [discordMessage, setDiscordMessage] = useState(() => getDefaultSurveyMessage(survey.questions))
-    const [teamsWebhookUrl, setTeamsWebhookUrl] = useState('')
-    const [teamsMessage, setTeamsMessage] = useState(() => getDefaultSurveyMessage(survey.questions))
-    const [webhookUrl, setWebhookUrl] = useState('')
-    const [webhookMethod, setWebhookMethod] = useState('POST')
-    const [webhookBody, setWebhookBody] = useState('')
-    const [isSubmitting, setIsSubmitting] = useState(false)
-    const [error, setError] = useState<string | null>(null)
-
-    const selectedSlackIntegration = integrations?.find((integration) => integration.id === slackIntegrationId) ?? null
-    const hasSlackIntegration = integrations?.some((integration) => integration.kind === 'slack') ?? false
-
-    const defaultWebhookBody = useMemo(
-        () => JSON.stringify(buildWebhookBodyTemplate(survey.questions), null, 2),
-        [survey.questions]
-    )
-    const templateGlobals = useMemo(() => {
-        const responseProperties = Object.fromEntries(
-            survey.questions
-                .filter((question) => question.id && question.type !== SurveyQuestionType.Link)
-                .map((question, index) => [
-                    getSurveyIdBasedResponseKey(question.id!),
-                    question.question || `Example answer ${index + 1}`,
-                ])
-        )
-
-        return {
-            project: {
-                id: 1,
-                name: 'Project',
-                url: 'https://app.posthog.com/project/1',
-            },
-            event: {
-                event: 'survey sent',
-                uuid: '00000000-0000-0000-0000-000000000000',
-                distinct_id: 'example-distinct-id',
-                timestamp: '2026-04-09T12:00:00Z',
-                properties: {
-                    $survey_id: survey.id === NEW_SURVEY.id ? 'survey-id' : survey.id,
-                    $survey_name: survey.name || 'Survey',
-                    $survey_completed: true,
-                    ...responseProperties,
-                },
-                url: 'https://app.posthog.com/project/1/events/example/2026-04-09T12%3A00%3A00Z',
-            },
-            person: {
-                id: 'person-id',
-                name: 'Jane Doe',
-                url: 'https://app.posthog.com/project/1/person/example-distinct-id',
-                properties: {
-                    email: 'jane@example.com',
-                },
-            },
-            groups: {},
-        }
-    }, [survey.id, survey.name, survey.questions])
-
-    useEffect(() => {
-        if (!surveyNotificationModalOpen) {
-            return
-        }
-
-        setDestination('slack')
-        setSlackIntegrationId(null)
-        setSlackChannel(null)
-        setSlackMessage(getDefaultSurveyMessage(survey.questions))
-        setIncludeSlackButtons(true)
-        setDiscordWebhookUrl('')
-        setDiscordMessage(getDefaultSurveyMessage(survey.questions))
-        setTeamsWebhookUrl('')
-        setTeamsMessage(getDefaultSurveyMessage(survey.questions))
-        setWebhookUrl('')
-        setWebhookMethod('POST')
-        setWebhookBody(defaultWebhookBody)
-        setIsSubmitting(false)
-        setError(null)
-    }, [defaultWebhookBody, survey.questions, surveyNotificationModalOpen])
-
-    const submitDisabledReason = useMemo(() => {
-        if (survey.id === NEW_SURVEY.id) {
-            return 'Save the survey before creating notifications.'
-        }
-        if (isSubmitting) {
-            return 'Creating notification...'
-        }
-
-        switch (destination) {
-            case 'slack':
-                if (!hasSlackIntegration) {
-                    return 'Configure Slack for this project first.'
-                }
-                if (!slackIntegrationId) {
-                    return 'Select a Slack workspace.'
-                }
-                if (!slackChannel) {
-                    return 'Select a Slack channel.'
-                }
-                if (!slackMessage.trim()) {
-                    return 'Enter the Slack message.'
-                }
-                return undefined
-            case 'discord':
-                if (!discordMessage.trim()) {
-                    return 'Enter the Discord message.'
-                }
-                if (!isValidHttpUrl(discordWebhookUrl.trim())) {
-                    return 'Enter a valid Discord webhook URL.'
-                }
-                return undefined
-            case 'microsoft-teams':
-                if (!teamsMessage.trim()) {
-                    return 'Enter the Microsoft Teams message.'
-                }
-                if (!isValidHttpUrl(teamsWebhookUrl.trim())) {
-                    return 'Enter a valid Microsoft Teams webhook URL.'
-                }
-                return undefined
-            case 'webhook':
-                if (!isValidHttpUrl(webhookUrl.trim())) {
-                    return 'Enter a valid webhook URL.'
-                }
-                try {
-                    JSON.parse(webhookBody)
-                } catch {
-                    return 'Enter valid JSON for the webhook body.'
-                }
-                return undefined
-        }
-    }, [
-        destination,
-        discordMessage,
-        discordWebhookUrl,
+    const logicProps = { surveyId }
+    const logic = surveyNotificationModalLogic(logicProps)
+    const {
+        isOpen,
+        survey,
+        notificationForm,
+        isNotificationFormSubmitting,
+        selectedSlackIntegration,
         hasSlackIntegration,
-        isSubmitting,
-        slackChannel,
-        slackIntegrationId,
-        slackMessage,
-        survey.id,
-        teamsMessage,
-        teamsWebhookUrl,
-        webhookBody,
-        webhookUrl,
-    ])
+        templateGlobals,
+        submitDisabledReason,
+        notificationSubmissionError,
+    } = useValues(logic)
+    const { closeDialog, setNotificationFormValue } = useActions(logic)
 
-    const onSubmit = async (): Promise<void> => {
-        if (submitDisabledReason) {
-            return
-        }
-
-        setError(null)
-        setIsSubmitting(true)
-
-        try {
-            const templateId = DESTINATION_OPTIONS.find((option) => option.value === destination)?.templateId
-            const template = await api.hogFunctions.getTemplate(templateId || 'template-slack')
-
-            const payload = createSurveyNotificationPayload({
-                template,
-                destination,
-                surveyName: survey.name,
-                surveyId: survey.id,
-                slackIntegrationId,
-                slackChannel,
-                slackMessage,
-                includeSlackButtons,
-                discordWebhookUrl,
-                discordMessage,
-                teamsWebhookUrl,
-                teamsMessage,
-                webhookUrl,
-                webhookMethod,
-                webhookBody,
-            })
-
-            const response = await api.hogFunctions.create(payload)
-
-            await loadSurveyNotifications()
-            closeSurveyNotificationModal()
-            lemonToast.success(`Notification "${response.name}" created`)
-        } catch (e) {
-            const message = e instanceof Error ? e.message : 'Failed to create notification. Please try again.'
-            setError(message)
-        } finally {
-            setIsSubmitting(false)
-        }
-    }
+    const messageField = getMessageFieldForDestination(notificationForm.destination)
+    const messageFormattingActions =
+        messageField !== null
+            ? getMessageFormattingActions({
+                  field: messageField,
+                  value: notificationForm[messageField],
+                  questions: survey.questions,
+                  setNotificationFormValue,
+              })
+            : null
 
     return (
         <LemonModal
-            isOpen={surveyNotificationModalOpen}
-            onClose={closeSurveyNotificationModal}
+            isOpen={isOpen}
+            onClose={closeDialog}
             title="Add survey notification"
             description="Send survey responses to Slack, Discord, Microsoft Teams, or a webhook without leaving this page."
             width={720}
             footer={
                 <>
-                    <LemonButton type="secondary" onClick={closeSurveyNotificationModal}>
+                    <LemonButton type="secondary" onClick={closeDialog}>
                         Cancel
                     </LemonButton>
                     <LemonButton
                         type="primary"
-                        onClick={() => void onSubmit()}
-                        loading={isSubmitting}
+                        form="survey-notification-form"
+                        htmlType="submit"
+                        loading={isNotificationFormSubmitting}
                         disabledReason={submitDisabledReason}
                     >
                         Add notification
@@ -582,234 +192,217 @@ export function SurveyNotificationModal({ surveyId }: { surveyId: string }): JSX
             }
         >
             <div className="flex flex-col gap-4">
-                {error ? <div className="text-sm text-danger">{error}</div> : null}
-
-                <div className="flex flex-col gap-2">
-                    <label className="text-sm font-medium">Destination</label>
-                    <LemonSelect
-                        value={destination}
-                        onChange={(value) => setDestination(value)}
-                        options={DESTINATION_OPTIONS.map((option) => ({
-                            value: option.value,
-                            label: option.label,
-                            icon: <img src={option.iconUrl} alt="" className="h-5 w-5 object-contain" />,
-                        }))}
-                        fullWidth
-                    />
-                    <div className="text-xs text-muted">{destinationDeliveryDescription(destination)}</div>
-                    <div className="text-xs text-muted">
-                        Tailored to surveys: notifications fire only for completed submissions by default.
-                    </div>
-                </div>
-
-                {destination === 'slack' ? (
-                    <>
-                        {!hasSlackIntegration ? (
-                            <SlackNotConfiguredBanner />
-                        ) : (
-                            <>
-                                <div className="flex flex-col gap-2">
-                                    <label className="text-sm font-medium">Slack workspace</label>
-                                    <IntegrationChoice
-                                        integration="slack"
-                                        value={slackIntegrationId ?? undefined}
-                                        onChange={(value) => {
-                                            setSlackIntegrationId(value ?? null)
-                                            setSlackChannel(null)
-                                        }}
-                                    />
-                                </div>
-                                {selectedSlackIntegration ? (
-                                    <div className="flex flex-col gap-2">
-                                        <label className="text-sm font-medium">Channel</label>
-                                        <SlackChannelPicker
-                                            value={slackChannel ?? undefined}
-                                            onChange={(value) => setSlackChannel(value ?? null)}
-                                            integration={selectedSlackIntegration}
-                                        />
-                                    </div>
-                                ) : null}
-                            </>
-                        )}
-                        <div className="flex flex-col gap-2">
-                            <label className="text-sm font-medium">Message</label>
-                            <TemplateEditor value={slackMessage} onChange={setSlackMessage} globals={templateGlobals} />
-                            <MessageFormattingActions
-                                questions={survey.questions}
-                                onReset={() => setSlackMessage(getDefaultSurveyMessage(survey.questions))}
-                                onInsertSurveyName={() =>
-                                    setSlackMessage((currentValue) =>
-                                        appendTemplateLine(currentValue, `Survey: *${SURVEY_NAME_TOKEN}*`)
-                                    )
-                                }
-                                onInsertRespondent={() =>
-                                    setSlackMessage((currentValue) =>
-                                        appendTemplateLine(currentValue, `Respondent: ${RESPONDENT_NAME_TOKEN}`)
-                                    )
-                                }
-                                onInsertEmail={() =>
-                                    setSlackMessage((currentValue) =>
-                                        appendTemplateLine(currentValue, `Email: ${RESPONDENT_EMAIL_TOKEN}`)
-                                    )
-                                }
-                                onInsertQuestion={(question, index) =>
-                                    setSlackMessage((currentValue) =>
-                                        appendQuestionToken(currentValue, question, index)
-                                    )
-                                }
-                            />
-                        </div>
-                        <LemonSwitch
-                            checked={includeSlackButtons}
-                            onChange={setIncludeSlackButtons}
-                            label="Include buttons to view the survey and person"
-                            bordered
-                        />
-                    </>
+                {notificationSubmissionError ? (
+                    <div className="text-sm text-danger">{notificationSubmissionError}</div>
                 ) : null}
 
-                {destination === 'discord' ? (
-                    <>
-                        <div className="flex flex-col gap-2">
-                            <label className="text-sm font-medium">Discord webhook URL</label>
-                            <LemonInput
-                                value={discordWebhookUrl}
-                                onChange={setDiscordWebhookUrl}
-                                placeholder="https://discord.com/api/webhooks/..."
-                                fullWidth
-                            />
-                        </div>
-                        <div className="flex flex-col gap-2">
-                            <label className="text-sm font-medium">Message</label>
-                            <TemplateEditor
-                                value={discordMessage}
-                                onChange={setDiscordMessage}
-                                globals={templateGlobals}
-                            />
-                            <MessageFormattingActions
-                                questions={survey.questions}
-                                onReset={() => setDiscordMessage(getDefaultSurveyMessage(survey.questions))}
-                                onInsertSurveyName={() =>
-                                    setDiscordMessage((currentValue) =>
-                                        appendTemplateLine(currentValue, `Survey: *${SURVEY_NAME_TOKEN}*`)
-                                    )
-                                }
-                                onInsertRespondent={() =>
-                                    setDiscordMessage((currentValue) =>
-                                        appendTemplateLine(currentValue, `Respondent: ${RESPONDENT_NAME_TOKEN}`)
-                                    )
-                                }
-                                onInsertEmail={() =>
-                                    setDiscordMessage((currentValue) =>
-                                        appendTemplateLine(currentValue, `Email: ${RESPONDENT_EMAIL_TOKEN}`)
-                                    )
-                                }
-                                onInsertQuestion={(question, index) =>
-                                    setDiscordMessage((currentValue) =>
-                                        appendQuestionToken(currentValue, question, index)
-                                    )
-                                }
-                            />
-                        </div>
-                    </>
-                ) : null}
-
-                {destination === 'microsoft-teams' ? (
-                    <>
-                        <div className="flex flex-col gap-2">
-                            <label className="text-sm font-medium">Microsoft Teams webhook URL</label>
-                            <LemonInput
-                                value={teamsWebhookUrl}
-                                onChange={setTeamsWebhookUrl}
-                                placeholder="https://..."
-                                fullWidth
-                            />
-                        </div>
-                        <div className="flex flex-col gap-2">
-                            <label className="text-sm font-medium">Message</label>
-                            <TemplateEditor value={teamsMessage} onChange={setTeamsMessage} globals={templateGlobals} />
-                            <MessageFormattingActions
-                                questions={survey.questions}
-                                onReset={() => setTeamsMessage(getDefaultSurveyMessage(survey.questions))}
-                                onInsertSurveyName={() =>
-                                    setTeamsMessage((currentValue) =>
-                                        appendTemplateLine(currentValue, `Survey: *${SURVEY_NAME_TOKEN}*`)
-                                    )
-                                }
-                                onInsertRespondent={() =>
-                                    setTeamsMessage((currentValue) =>
-                                        appendTemplateLine(currentValue, `Respondent: ${RESPONDENT_NAME_TOKEN}`)
-                                    )
-                                }
-                                onInsertEmail={() =>
-                                    setTeamsMessage((currentValue) =>
-                                        appendTemplateLine(currentValue, `Email: ${RESPONDENT_EMAIL_TOKEN}`)
-                                    )
-                                }
-                                onInsertQuestion={(question, index) =>
-                                    setTeamsMessage((currentValue) =>
-                                        appendQuestionToken(currentValue, question, index)
-                                    )
-                                }
-                            />
-                        </div>
-                    </>
-                ) : null}
-
-                {destination === 'webhook' ? (
-                    <>
-                        <div className="flex flex-col gap-2">
-                            <label className="text-sm font-medium">Webhook URL</label>
-                            <LemonInput
-                                value={webhookUrl}
-                                onChange={setWebhookUrl}
-                                placeholder="https://..."
-                                fullWidth
-                            />
-                        </div>
-                        <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:gap-4">
-                            <div className="flex min-w-48 flex-col gap-2">
-                                <label className="text-sm font-medium">HTTP method</label>
+                <Form
+                    logic={surveyNotificationModalLogic}
+                    props={logicProps}
+                    formKey="notificationForm"
+                    id="survey-notification-form"
+                    enableFormOnSubmit
+                >
+                    <div className="flex flex-col gap-4">
+                        <Field name="destination" label="Destination">
+                            {({ value, onChange }) => (
                                 <LemonSelect
-                                    value={webhookMethod}
-                                    onChange={setWebhookMethod}
-                                    options={WEBHOOK_METHOD_OPTIONS}
+                                    value={value}
+                                    onChange={onChange}
+                                    options={DESTINATION_OPTIONS.map((option) => ({
+                                        value: option.value,
+                                        label: option.label,
+                                        icon: <img src={option.iconUrl} alt="" className="h-5 w-5 object-contain" />,
+                                    }))}
                                     fullWidth
                                 />
-                            </div>
-                            <div className="flex-1 rounded border border-dashed bg-surface-primary p-3 text-xs text-muted">
-                                Survey webhooks send the survey metadata, person context, and one answer field per
-                                question. You can tailor the payload before saving it.
-                            </div>
-                        </div>
-                        <div className="flex flex-col gap-2">
-                            <label className="text-sm font-medium">JSON body</label>
-                            <CodeEditorResizeable
-                                embedded
-                                language="json"
-                                value={webhookBody}
-                                onChange={(nextValue) => setWebhookBody(nextValue ?? '')}
-                                minHeight="14rem"
-                                maxHeight="20rem"
-                                allowManualResize={false}
-                                options={{
-                                    minimap: { enabled: false },
-                                    scrollBeyondLastLine: false,
-                                    fixedOverflowWidgets: true,
-                                }}
-                            />
-                        </div>
-                    </>
-                ) : null}
+                            )}
+                        </Field>
 
-                <div className="rounded border bg-fill-secondary p-3">
-                    <div className="mb-2 text-sm font-medium">Available survey placeholders</div>
-                    <div className="mb-3 text-xs text-muted">
-                        Need deeper customization later? After you create a notification, open it from the survey
-                        notifications list to use the full Hog function editor.
+                        <div className="text-xs text-muted">
+                            {destinationDeliveryDescription(notificationForm.destination)}
+                        </div>
+                        <div className="text-xs text-muted">
+                            Tailored to surveys: notifications fire only for completed submissions by default.
+                        </div>
+
+                        {notificationForm.destination === 'slack' ? (
+                            <>
+                                {!hasSlackIntegration ? (
+                                    <SlackNotConfiguredBanner />
+                                ) : (
+                                    <>
+                                        <Field name="slackIntegrationId" label="Slack workspace">
+                                            {({ value, onChange }) => (
+                                                <IntegrationChoice
+                                                    integration="slack"
+                                                    value={value ?? undefined}
+                                                    onChange={(nextValue) => {
+                                                        onChange(nextValue ?? null)
+                                                        setNotificationFormValue('slackChannel', null)
+                                                    }}
+                                                />
+                                            )}
+                                        </Field>
+                                        {selectedSlackIntegration ? (
+                                            <Field name="slackChannel" label="Channel">
+                                                {({ value, onChange }) => (
+                                                    <SlackChannelPicker
+                                                        value={value ?? undefined}
+                                                        onChange={(nextValue) => onChange(nextValue ?? null)}
+                                                        integration={selectedSlackIntegration}
+                                                    />
+                                                )}
+                                            </Field>
+                                        ) : null}
+                                    </>
+                                )}
+                                <Field name="slackMessage" label="Message">
+                                    {({ value, onChange }) => (
+                                        <div className="flex flex-col gap-2">
+                                            <TemplateEditor
+                                                value={value}
+                                                onChange={onChange}
+                                                globals={templateGlobals}
+                                            />
+                                            {messageFormattingActions ? (
+                                                <MessageFormattingActions {...messageFormattingActions} />
+                                            ) : null}
+                                        </div>
+                                    )}
+                                </Field>
+                                <Field name="includeSlackButtons">
+                                    {({ value, onChange }) => (
+                                        <LemonSwitch
+                                            checked={value}
+                                            onChange={onChange}
+                                            label="Include buttons to view the survey and person"
+                                            bordered
+                                        />
+                                    )}
+                                </Field>
+                            </>
+                        ) : null}
+
+                        {notificationForm.destination === 'discord' ? (
+                            <>
+                                <Field name="discordWebhookUrl" label="Discord webhook URL">
+                                    {({ value, onChange }) => (
+                                        <LemonInput
+                                            value={value}
+                                            onChange={onChange}
+                                            placeholder="https://discord.com/api/webhooks/..."
+                                            fullWidth
+                                        />
+                                    )}
+                                </Field>
+                                <Field name="discordMessage" label="Message">
+                                    {({ value, onChange }) => (
+                                        <div className="flex flex-col gap-2">
+                                            <TemplateEditor
+                                                value={value}
+                                                onChange={onChange}
+                                                globals={templateGlobals}
+                                            />
+                                            {messageFormattingActions ? (
+                                                <MessageFormattingActions {...messageFormattingActions} />
+                                            ) : null}
+                                        </div>
+                                    )}
+                                </Field>
+                            </>
+                        ) : null}
+
+                        {notificationForm.destination === 'microsoft-teams' ? (
+                            <>
+                                <Field name="teamsWebhookUrl" label="Microsoft Teams webhook URL">
+                                    {({ value, onChange }) => (
+                                        <LemonInput
+                                            value={value}
+                                            onChange={onChange}
+                                            placeholder="https://..."
+                                            fullWidth
+                                        />
+                                    )}
+                                </Field>
+                                <Field name="teamsMessage" label="Message">
+                                    {({ value, onChange }) => (
+                                        <div className="flex flex-col gap-2">
+                                            <TemplateEditor
+                                                value={value}
+                                                onChange={onChange}
+                                                globals={templateGlobals}
+                                            />
+                                            {messageFormattingActions ? (
+                                                <MessageFormattingActions {...messageFormattingActions} />
+                                            ) : null}
+                                        </div>
+                                    )}
+                                </Field>
+                            </>
+                        ) : null}
+
+                        {notificationForm.destination === 'webhook' ? (
+                            <>
+                                <Field name="webhookUrl" label="Webhook URL">
+                                    {({ value, onChange }) => (
+                                        <LemonInput
+                                            value={value}
+                                            onChange={onChange}
+                                            placeholder="https://..."
+                                            fullWidth
+                                        />
+                                    )}
+                                </Field>
+                                <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:gap-4">
+                                    <div className="flex min-w-48 flex-col gap-2">
+                                        <Field name="webhookMethod" label="HTTP method">
+                                            {({ value, onChange }) => (
+                                                <LemonSelect
+                                                    value={value}
+                                                    onChange={onChange}
+                                                    options={WEBHOOK_METHOD_OPTIONS}
+                                                    fullWidth
+                                                />
+                                            )}
+                                        </Field>
+                                    </div>
+                                    <div className="flex-1 rounded border border-dashed bg-surface-primary p-3 text-xs text-muted">
+                                        Survey webhooks send the survey metadata, person context, and one answer field
+                                        per question. You can tailor the payload before saving it.
+                                    </div>
+                                </div>
+                                <Field name="webhookBody" label="JSON body">
+                                    {({ value, onChange }) => (
+                                        <CodeEditorResizeable
+                                            embedded
+                                            language="json"
+                                            value={value}
+                                            onChange={(nextValue) => onChange(nextValue ?? '')}
+                                            minHeight="14rem"
+                                            maxHeight="20rem"
+                                            allowManualResize={false}
+                                            options={{
+                                                minimap: { enabled: false },
+                                                scrollBeyondLastLine: false,
+                                                fixedOverflowWidgets: true,
+                                            }}
+                                        />
+                                    )}
+                                </Field>
+                            </>
+                        ) : null}
+
+                        <div className="rounded border bg-fill-secondary p-3">
+                            <div className="mb-2 text-sm font-medium">Available survey placeholders</div>
+                            <div className="mb-3 text-xs text-muted">
+                                Need deeper customization later? After you create a notification, open it from the
+                                survey notifications list to use the full Hog function editor.
+                            </div>
+                            <SurveyResponseKeysReference questions={survey.questions} />
+                        </div>
                     </div>
-                    <SurveyResponseKeysReference questions={survey.questions} />
-                </div>
+                </Form>
             </div>
         </LemonModal>
     )

--- a/frontend/src/scenes/surveys/components/SurveyNotificationModal.tsx
+++ b/frontend/src/scenes/surveys/components/SurveyNotificationModal.tsx
@@ -1,0 +1,816 @@
+import { useActions, useValues } from 'kea'
+import { useEffect, useMemo, useState } from 'react'
+
+import { LemonButton, LemonInput, LemonSelect, LemonSwitch } from '@posthog/lemon-ui'
+
+import api from 'lib/api'
+import { IntegrationChoice } from 'lib/components/CyclotronJob/integrations/IntegrationChoice'
+import { integrationsLogic } from 'lib/integrations/integrationsLogic'
+import { SlackChannelPicker, SlackNotConfiguredBanner } from 'lib/integrations/SlackIntegrationHelpers'
+import { LemonModal } from 'lib/lemon-ui/LemonModal'
+import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
+import { CodeEditorResizeable } from 'lib/monaco/CodeEditorResizable'
+import { DESTINATION_OPTIONS, DestinationKey } from 'scenes/hog-functions/list/newNotificationDialogLogic'
+import {
+    HOG_FUNCTION_SUB_TEMPLATE_COMMON_PROPERTIES,
+    HOG_FUNCTION_SUB_TEMPLATES,
+} from 'scenes/hog-functions/sub-templates/sub-templates'
+import { SurveyResponseKeysReference } from 'scenes/surveys/components/SurveyResponseKeysReference'
+import { NEW_SURVEY } from 'scenes/surveys/constants'
+import { surveyLogic } from 'scenes/surveys/surveyLogic'
+import { getSurveyNotificationFilters, getSurveyIdBasedResponseKey } from 'scenes/surveys/utils'
+
+import { HogFunctionTemplateType, HogFunctionType, SurveyQuestionType } from '~/types'
+
+const WEBHOOK_METHOD_OPTIONS = [
+    { value: 'POST', label: 'POST' },
+    { value: 'PUT', label: 'PUT' },
+    { value: 'PATCH', label: 'PATCH' },
+    { value: 'GET', label: 'GET' },
+    { value: 'DELETE', label: 'DELETE' },
+]
+
+type SurveyQuestionForNotification = {
+    id?: string
+    question: string | null | undefined
+    type: SurveyQuestionType
+}
+
+const MAX_EXAMPLE_QUESTIONS = 3
+const SURVEY_NAME_TOKEN = "{event.properties['$survey_name']}"
+const SURVEY_ID_TOKEN = "{event.properties['$survey_id']}"
+const RESPONDENT_NAME_TOKEN = '{person.name}'
+const RESPONDENT_EMAIL_TOKEN = '{person.properties.email}'
+
+function getResponseToken(questionId: string): string {
+    return `{event.properties['${getSurveyIdBasedResponseKey(questionId)}']}`
+}
+
+function getQuestionLabel(question: SurveyQuestionForNotification, index: number): string {
+    return question.question?.trim() || `Question ${index + 1}`
+}
+
+function getQuestionLine(question: SurveyQuestionForNotification, index: number): string {
+    return `- ${getQuestionLabel(question, index)}: ${getResponseToken(question.id!)}`
+}
+
+function getDefaultSurveyMessage(questions: SurveyQuestionForNotification[] = []): string {
+    const exampleQuestions = questions
+        .filter((question) => question.id && question.type !== SurveyQuestionType.Link)
+        .slice(0, MAX_EXAMPLE_QUESTIONS)
+
+    return [
+        '*New survey response*',
+        `Survey: *${SURVEY_NAME_TOKEN}*`,
+        `Respondent: ${RESPONDENT_NAME_TOKEN}`,
+        `Email: ${RESPONDENT_EMAIL_TOKEN}`,
+        ...(exampleQuestions.length > 0
+            ? ['', '*Responses*', ...exampleQuestions.map((question, index) => getQuestionLine(question, index))]
+            : []),
+    ].join('\n')
+}
+
+function isValidHttpUrl(value: string): boolean {
+    return URL.canParse(value) && /^https?:\/\//.test(value)
+}
+
+function buildSlackBlocks(message: string, includeButtons: boolean): Record<string, unknown>[] {
+    return [
+        {
+            type: 'section',
+            text: {
+                type: 'mrkdwn',
+                text: message,
+            },
+        },
+        ...(includeButtons
+            ? [
+                  {
+                      type: 'actions',
+                      elements: [
+                          {
+                              url: "{project.url}/surveys/{event.properties['$survey_id']}",
+                              text: { text: 'View survey', type: 'plain_text' },
+                              type: 'button',
+                          },
+                          {
+                              url: '{person.url}',
+                              text: { text: 'View person', type: 'plain_text' },
+                              type: 'button',
+                          },
+                      ],
+                  },
+              ]
+            : []),
+    ]
+}
+
+function buildWebhookBodyTemplate(questions: SurveyQuestionForNotification[]): Record<string, unknown> {
+    return {
+        survey: {
+            id: SURVEY_ID_TOKEN,
+            name: SURVEY_NAME_TOKEN,
+            url: `{project.url}/surveys/${SURVEY_ID_TOKEN}`,
+        },
+        person: {
+            name: RESPONDENT_NAME_TOKEN,
+            email: RESPONDENT_EMAIL_TOKEN,
+            url: '{person.url}',
+        },
+        responses: questions
+            .filter((question) => question.id && question.type !== SurveyQuestionType.Link)
+            .map((question, index) => ({
+                question: getQuestionLabel(question, index),
+                answer: getResponseToken(question.id!),
+            })),
+    }
+}
+
+function appendQuestionToken(value: string, question: SurveyQuestionForNotification, index: number): string {
+    if (!question.id) {
+        return value
+    }
+
+    const line = getQuestionLine(question, index)
+    const trimmedValue = value.trim()
+
+    if (trimmedValue.includes(line)) {
+        return trimmedValue
+    }
+
+    if (!trimmedValue) {
+        return getDefaultSurveyMessage([question])
+    }
+
+    if (trimmedValue.includes('*Responses*')) {
+        return `${trimmedValue}\n${line}`
+    }
+
+    return `${trimmedValue}\n\n*Responses*\n${line}`
+}
+
+function appendTemplateLine(value: string, line: string): string {
+    const trimmedValue = value.trim()
+
+    if (trimmedValue.includes(line)) {
+        return trimmedValue
+    }
+
+    return trimmedValue ? `${trimmedValue}\n${line}` : line
+}
+
+function notificationNameFor(destination: DestinationKey, surveyName?: string | null): string {
+    const destinationLabel = DESTINATION_OPTIONS.find((option) => option.value === destination)?.label || 'Notification'
+    const baseName = surveyName?.trim() || 'Survey'
+    return `${baseName} → ${destinationLabel}`
+}
+
+function destinationDeliveryDescription(destination: DestinationKey): string {
+    switch (destination) {
+        case 'slack':
+            return 'Slack messages are sent as a formatted post with buttons to view the survey and person.'
+        case 'discord':
+            return 'Discord sends a single message to your webhook URL using the content below.'
+        case 'microsoft-teams':
+            return 'Microsoft Teams sends an Adaptive Card message using the text below.'
+        case 'webhook':
+            return 'Webhooks send a JSON request. You can tailor the method and request body here.'
+    }
+}
+
+function TemplateEditor({
+    value,
+    onChange,
+    globals,
+    minHeight = '7rem',
+}: {
+    value: string
+    onChange: (value: string) => void
+    globals: Record<string, any>
+    minHeight?: string
+}): JSX.Element {
+    return (
+        <CodeEditorResizeable
+            embedded
+            language="hogTemplate"
+            value={value}
+            onChange={(nextValue) => onChange(nextValue ?? '')}
+            globals={globals}
+            minHeight={minHeight}
+            maxHeight="14rem"
+            allowManualResize={false}
+            options={{
+                wordWrap: 'on',
+                minimap: { enabled: false },
+                lineNumbers: 'off',
+                scrollBeyondLastLine: false,
+                fixedOverflowWidgets: true,
+                suggest: {
+                    showInlineDetails: true,
+                },
+                quickSuggestionsDelay: 200,
+            }}
+        />
+    )
+}
+
+function MessageFormattingActions({
+    questions,
+    onReset,
+    onInsertSurveyName,
+    onInsertRespondent,
+    onInsertEmail,
+    onInsertQuestion,
+}: {
+    questions: SurveyQuestionForNotification[]
+    onReset: () => void
+    onInsertSurveyName: () => void
+    onInsertRespondent: () => void
+    onInsertEmail: () => void
+    onInsertQuestion: (question: SurveyQuestionForNotification, index: number) => void
+}): JSX.Element {
+    const applicableQuestions = questions.filter((question) => question.id && question.type !== SurveyQuestionType.Link)
+
+    return (
+        <div className="rounded border border-dashed bg-surface-primary p-2">
+            <div className="mb-2 text-xs text-muted">
+                Start with a readable template, then add survey answers or metadata as needed.
+            </div>
+            <div className="flex flex-wrap gap-1.5">
+                <LemonButton size="xsmall" type="secondary" onClick={onReset}>
+                    Use suggested format
+                </LemonButton>
+                <LemonButton size="xsmall" type="secondary" onClick={onInsertSurveyName}>
+                    Insert survey name
+                </LemonButton>
+                <LemonButton size="xsmall" type="secondary" onClick={onInsertRespondent}>
+                    Insert respondent
+                </LemonButton>
+                <LemonButton size="xsmall" type="secondary" onClick={onInsertEmail}>
+                    Insert email
+                </LemonButton>
+                {applicableQuestions.map((question, index) => (
+                    <LemonButton
+                        key={question.id}
+                        size="xsmall"
+                        type="secondary"
+                        onClick={() => onInsertQuestion(question, index)}
+                    >
+                        Insert: {getQuestionLabel(question, index)}
+                    </LemonButton>
+                ))}
+            </div>
+        </div>
+    )
+}
+
+function createSurveyNotificationPayload({
+    template,
+    destination,
+    surveyName,
+    surveyId,
+    slackIntegrationId,
+    slackChannel,
+    slackMessage,
+    includeSlackButtons,
+    discordWebhookUrl,
+    discordMessage,
+    teamsWebhookUrl,
+    teamsMessage,
+    webhookUrl,
+    webhookMethod,
+    webhookBody,
+}: {
+    template: HogFunctionTemplateType
+    destination: DestinationKey
+    surveyName?: string | null
+    surveyId: string
+    slackIntegrationId: number | null
+    slackChannel: string | null
+    slackMessage: string
+    includeSlackButtons: boolean
+    discordWebhookUrl: string
+    discordMessage: string
+    teamsWebhookUrl: string
+    teamsMessage: string
+    webhookUrl: string
+    webhookMethod: string
+    webhookBody: string
+}): Partial<HogFunctionType> {
+    const destinationOption = DESTINATION_OPTIONS.find((option) => option.value === destination)
+    if (!destinationOption) {
+        throw new Error('Unsupported destination')
+    }
+
+    const subTemplate = HOG_FUNCTION_SUB_TEMPLATES['survey-response'].find(
+        (template) => template.template_id === destinationOption.templateId
+    )
+
+    const inputs: Record<string, { value: unknown }> = {}
+
+    for (const schema of template.inputs_schema ?? []) {
+        if (schema.default !== undefined) {
+            inputs[schema.key] = { value: schema.default }
+        }
+    }
+
+    if (subTemplate?.inputs) {
+        for (const [key, value] of Object.entries(subTemplate.inputs)) {
+            inputs[key] = value as { value: unknown }
+        }
+    }
+
+    switch (destination) {
+        case 'slack':
+            if (!slackIntegrationId || !slackChannel) {
+                throw new Error('Select a Slack workspace and channel.')
+            }
+            inputs.slack_workspace = { value: slackIntegrationId }
+            inputs.channel = { value: slackChannel.split('|')[0] }
+            inputs.text = { value: slackMessage.trim() }
+            inputs.blocks = { value: buildSlackBlocks(slackMessage.trim(), includeSlackButtons) }
+            break
+        case 'discord':
+            inputs.webhookUrl = { value: discordWebhookUrl.trim() }
+            inputs.content = { value: discordMessage.trim() }
+            break
+        case 'microsoft-teams':
+            inputs.webhookUrl = { value: teamsWebhookUrl.trim() }
+            inputs.text = { value: teamsMessage.trim() }
+            break
+        case 'webhook':
+            inputs.url = { value: webhookUrl.trim() }
+            inputs.method = { value: webhookMethod }
+            inputs.body = { value: JSON.parse(webhookBody) }
+            break
+    }
+
+    return {
+        template_id: destinationOption.templateId,
+        type: HOG_FUNCTION_SUB_TEMPLATE_COMMON_PROPERTIES['survey-response'].type,
+        name: notificationNameFor(destination, surveyName),
+        description: subTemplate?.description ?? `Survey notification for ${destinationOption.label}`,
+        inputs,
+        inputs_schema: template.inputs_schema,
+        filters: getSurveyNotificationFilters(surveyId),
+        hog: template.code,
+        icon_url: template.icon_url,
+        enabled: true,
+    }
+}
+
+export function SurveyNotificationModal({ surveyId }: { surveyId: string }): JSX.Element {
+    const logic = surveyLogic({ id: surveyId })
+    const { survey, surveyNotificationModalOpen } = useValues(logic)
+    const { closeSurveyNotificationModal, loadSurveyNotifications } = useActions(logic)
+    const { integrations } = useValues(integrationsLogic)
+
+    const [destination, setDestination] = useState<DestinationKey>('slack')
+    const [slackIntegrationId, setSlackIntegrationId] = useState<number | null>(null)
+    const [slackChannel, setSlackChannel] = useState<string | null>(null)
+    const [slackMessage, setSlackMessage] = useState(() => getDefaultSurveyMessage(survey.questions))
+    const [includeSlackButtons, setIncludeSlackButtons] = useState(true)
+    const [discordWebhookUrl, setDiscordWebhookUrl] = useState('')
+    const [discordMessage, setDiscordMessage] = useState(() => getDefaultSurveyMessage(survey.questions))
+    const [teamsWebhookUrl, setTeamsWebhookUrl] = useState('')
+    const [teamsMessage, setTeamsMessage] = useState(() => getDefaultSurveyMessage(survey.questions))
+    const [webhookUrl, setWebhookUrl] = useState('')
+    const [webhookMethod, setWebhookMethod] = useState('POST')
+    const [webhookBody, setWebhookBody] = useState('')
+    const [isSubmitting, setIsSubmitting] = useState(false)
+    const [error, setError] = useState<string | null>(null)
+
+    const selectedSlackIntegration = integrations?.find((integration) => integration.id === slackIntegrationId) ?? null
+    const hasSlackIntegration = integrations?.some((integration) => integration.kind === 'slack') ?? false
+
+    const defaultWebhookBody = useMemo(
+        () => JSON.stringify(buildWebhookBodyTemplate(survey.questions), null, 2),
+        [survey.questions]
+    )
+    const templateGlobals = useMemo(() => {
+        const responseProperties = Object.fromEntries(
+            survey.questions
+                .filter((question) => question.id && question.type !== SurveyQuestionType.Link)
+                .map((question, index) => [
+                    getSurveyIdBasedResponseKey(question.id!),
+                    question.question || `Example answer ${index + 1}`,
+                ])
+        )
+
+        return {
+            project: {
+                id: 1,
+                name: 'Project',
+                url: 'https://app.posthog.com/project/1',
+            },
+            event: {
+                event: 'survey sent',
+                uuid: '00000000-0000-0000-0000-000000000000',
+                distinct_id: 'example-distinct-id',
+                timestamp: '2026-04-09T12:00:00Z',
+                properties: {
+                    $survey_id: survey.id === NEW_SURVEY.id ? 'survey-id' : survey.id,
+                    $survey_name: survey.name || 'Survey',
+                    $survey_completed: true,
+                    ...responseProperties,
+                },
+                url: 'https://app.posthog.com/project/1/events/example/2026-04-09T12%3A00%3A00Z',
+            },
+            person: {
+                id: 'person-id',
+                name: 'Jane Doe',
+                url: 'https://app.posthog.com/project/1/person/example-distinct-id',
+                properties: {
+                    email: 'jane@example.com',
+                },
+            },
+            groups: {},
+        }
+    }, [survey.id, survey.name, survey.questions])
+
+    useEffect(() => {
+        if (!surveyNotificationModalOpen) {
+            return
+        }
+
+        setDestination('slack')
+        setSlackIntegrationId(null)
+        setSlackChannel(null)
+        setSlackMessage(getDefaultSurveyMessage(survey.questions))
+        setIncludeSlackButtons(true)
+        setDiscordWebhookUrl('')
+        setDiscordMessage(getDefaultSurveyMessage(survey.questions))
+        setTeamsWebhookUrl('')
+        setTeamsMessage(getDefaultSurveyMessage(survey.questions))
+        setWebhookUrl('')
+        setWebhookMethod('POST')
+        setWebhookBody(defaultWebhookBody)
+        setIsSubmitting(false)
+        setError(null)
+    }, [defaultWebhookBody, survey.questions, surveyNotificationModalOpen])
+
+    const submitDisabledReason = useMemo(() => {
+        if (survey.id === NEW_SURVEY.id) {
+            return 'Save the survey before creating notifications.'
+        }
+        if (isSubmitting) {
+            return 'Creating notification...'
+        }
+
+        switch (destination) {
+            case 'slack':
+                if (!hasSlackIntegration) {
+                    return 'Configure Slack for this project first.'
+                }
+                if (!slackIntegrationId) {
+                    return 'Select a Slack workspace.'
+                }
+                if (!slackChannel) {
+                    return 'Select a Slack channel.'
+                }
+                if (!slackMessage.trim()) {
+                    return 'Enter the Slack message.'
+                }
+                return undefined
+            case 'discord':
+                if (!discordMessage.trim()) {
+                    return 'Enter the Discord message.'
+                }
+                if (!isValidHttpUrl(discordWebhookUrl.trim())) {
+                    return 'Enter a valid Discord webhook URL.'
+                }
+                return undefined
+            case 'microsoft-teams':
+                if (!teamsMessage.trim()) {
+                    return 'Enter the Microsoft Teams message.'
+                }
+                if (!isValidHttpUrl(teamsWebhookUrl.trim())) {
+                    return 'Enter a valid Microsoft Teams webhook URL.'
+                }
+                return undefined
+            case 'webhook':
+                if (!isValidHttpUrl(webhookUrl.trim())) {
+                    return 'Enter a valid webhook URL.'
+                }
+                try {
+                    JSON.parse(webhookBody)
+                } catch {
+                    return 'Enter valid JSON for the webhook body.'
+                }
+                return undefined
+        }
+    }, [
+        destination,
+        discordMessage,
+        discordWebhookUrl,
+        hasSlackIntegration,
+        isSubmitting,
+        slackChannel,
+        slackIntegrationId,
+        slackMessage,
+        survey.id,
+        teamsMessage,
+        teamsWebhookUrl,
+        webhookBody,
+        webhookUrl,
+    ])
+
+    const onSubmit = async (): Promise<void> => {
+        if (submitDisabledReason) {
+            return
+        }
+
+        setError(null)
+        setIsSubmitting(true)
+
+        try {
+            const templateId = DESTINATION_OPTIONS.find((option) => option.value === destination)?.templateId
+            const template = await api.hogFunctions.getTemplate(templateId || 'template-slack')
+
+            const payload = createSurveyNotificationPayload({
+                template,
+                destination,
+                surveyName: survey.name,
+                surveyId: survey.id,
+                slackIntegrationId,
+                slackChannel,
+                slackMessage,
+                includeSlackButtons,
+                discordWebhookUrl,
+                discordMessage,
+                teamsWebhookUrl,
+                teamsMessage,
+                webhookUrl,
+                webhookMethod,
+                webhookBody,
+            })
+
+            const response = await api.hogFunctions.create(payload)
+
+            await loadSurveyNotifications()
+            closeSurveyNotificationModal()
+            lemonToast.success(`Notification "${response.name}" created`)
+        } catch (e) {
+            const message = e instanceof Error ? e.message : 'Failed to create notification. Please try again.'
+            setError(message)
+        } finally {
+            setIsSubmitting(false)
+        }
+    }
+
+    return (
+        <LemonModal
+            isOpen={surveyNotificationModalOpen}
+            onClose={closeSurveyNotificationModal}
+            title="Add survey notification"
+            description="Send survey responses to Slack, Discord, Microsoft Teams, or a webhook without leaving this page."
+            width={720}
+            footer={
+                <>
+                    <LemonButton type="secondary" onClick={closeSurveyNotificationModal}>
+                        Cancel
+                    </LemonButton>
+                    <LemonButton
+                        type="primary"
+                        onClick={() => void onSubmit()}
+                        loading={isSubmitting}
+                        disabledReason={submitDisabledReason}
+                    >
+                        Add notification
+                    </LemonButton>
+                </>
+            }
+        >
+            <div className="flex flex-col gap-4">
+                {error ? <div className="text-sm text-danger">{error}</div> : null}
+
+                <div className="flex flex-col gap-2">
+                    <label className="text-sm font-medium">Destination</label>
+                    <LemonSelect
+                        value={destination}
+                        onChange={(value) => setDestination(value)}
+                        options={DESTINATION_OPTIONS.map((option) => ({
+                            value: option.value,
+                            label: option.label,
+                            icon: <img src={option.iconUrl} alt="" className="h-5 w-5 object-contain" />,
+                        }))}
+                        fullWidth
+                    />
+                    <div className="text-xs text-muted">{destinationDeliveryDescription(destination)}</div>
+                    <div className="text-xs text-muted">
+                        Tailored to surveys: notifications fire only for completed submissions by default.
+                    </div>
+                </div>
+
+                {destination === 'slack' ? (
+                    <>
+                        {!hasSlackIntegration ? (
+                            <SlackNotConfiguredBanner />
+                        ) : (
+                            <>
+                                <div className="flex flex-col gap-2">
+                                    <label className="text-sm font-medium">Slack workspace</label>
+                                    <IntegrationChoice
+                                        integration="slack"
+                                        value={slackIntegrationId ?? undefined}
+                                        onChange={(value) => {
+                                            setSlackIntegrationId(value ?? null)
+                                            setSlackChannel(null)
+                                        }}
+                                    />
+                                </div>
+                                {selectedSlackIntegration ? (
+                                    <div className="flex flex-col gap-2">
+                                        <label className="text-sm font-medium">Channel</label>
+                                        <SlackChannelPicker
+                                            value={slackChannel ?? undefined}
+                                            onChange={(value) => setSlackChannel(value ?? null)}
+                                            integration={selectedSlackIntegration}
+                                        />
+                                    </div>
+                                ) : null}
+                            </>
+                        )}
+                        <div className="flex flex-col gap-2">
+                            <label className="text-sm font-medium">Message</label>
+                            <TemplateEditor value={slackMessage} onChange={setSlackMessage} globals={templateGlobals} />
+                            <MessageFormattingActions
+                                questions={survey.questions}
+                                onReset={() => setSlackMessage(getDefaultSurveyMessage(survey.questions))}
+                                onInsertSurveyName={() =>
+                                    setSlackMessage((currentValue) =>
+                                        appendTemplateLine(currentValue, `Survey: *${SURVEY_NAME_TOKEN}*`)
+                                    )
+                                }
+                                onInsertRespondent={() =>
+                                    setSlackMessage((currentValue) =>
+                                        appendTemplateLine(currentValue, `Respondent: ${RESPONDENT_NAME_TOKEN}`)
+                                    )
+                                }
+                                onInsertEmail={() =>
+                                    setSlackMessage((currentValue) =>
+                                        appendTemplateLine(currentValue, `Email: ${RESPONDENT_EMAIL_TOKEN}`)
+                                    )
+                                }
+                                onInsertQuestion={(question, index) =>
+                                    setSlackMessage((currentValue) =>
+                                        appendQuestionToken(currentValue, question, index)
+                                    )
+                                }
+                            />
+                        </div>
+                        <LemonSwitch
+                            checked={includeSlackButtons}
+                            onChange={setIncludeSlackButtons}
+                            label="Include buttons to view the survey and person"
+                            bordered
+                        />
+                    </>
+                ) : null}
+
+                {destination === 'discord' ? (
+                    <>
+                        <div className="flex flex-col gap-2">
+                            <label className="text-sm font-medium">Discord webhook URL</label>
+                            <LemonInput
+                                value={discordWebhookUrl}
+                                onChange={setDiscordWebhookUrl}
+                                placeholder="https://discord.com/api/webhooks/..."
+                                fullWidth
+                            />
+                        </div>
+                        <div className="flex flex-col gap-2">
+                            <label className="text-sm font-medium">Message</label>
+                            <TemplateEditor
+                                value={discordMessage}
+                                onChange={setDiscordMessage}
+                                globals={templateGlobals}
+                            />
+                            <MessageFormattingActions
+                                questions={survey.questions}
+                                onReset={() => setDiscordMessage(getDefaultSurveyMessage(survey.questions))}
+                                onInsertSurveyName={() =>
+                                    setDiscordMessage((currentValue) =>
+                                        appendTemplateLine(currentValue, `Survey: *${SURVEY_NAME_TOKEN}*`)
+                                    )
+                                }
+                                onInsertRespondent={() =>
+                                    setDiscordMessage((currentValue) =>
+                                        appendTemplateLine(currentValue, `Respondent: ${RESPONDENT_NAME_TOKEN}`)
+                                    )
+                                }
+                                onInsertEmail={() =>
+                                    setDiscordMessage((currentValue) =>
+                                        appendTemplateLine(currentValue, `Email: ${RESPONDENT_EMAIL_TOKEN}`)
+                                    )
+                                }
+                                onInsertQuestion={(question, index) =>
+                                    setDiscordMessage((currentValue) =>
+                                        appendQuestionToken(currentValue, question, index)
+                                    )
+                                }
+                            />
+                        </div>
+                    </>
+                ) : null}
+
+                {destination === 'microsoft-teams' ? (
+                    <>
+                        <div className="flex flex-col gap-2">
+                            <label className="text-sm font-medium">Microsoft Teams webhook URL</label>
+                            <LemonInput
+                                value={teamsWebhookUrl}
+                                onChange={setTeamsWebhookUrl}
+                                placeholder="https://..."
+                                fullWidth
+                            />
+                        </div>
+                        <div className="flex flex-col gap-2">
+                            <label className="text-sm font-medium">Message</label>
+                            <TemplateEditor value={teamsMessage} onChange={setTeamsMessage} globals={templateGlobals} />
+                            <MessageFormattingActions
+                                questions={survey.questions}
+                                onReset={() => setTeamsMessage(getDefaultSurveyMessage(survey.questions))}
+                                onInsertSurveyName={() =>
+                                    setTeamsMessage((currentValue) =>
+                                        appendTemplateLine(currentValue, `Survey: *${SURVEY_NAME_TOKEN}*`)
+                                    )
+                                }
+                                onInsertRespondent={() =>
+                                    setTeamsMessage((currentValue) =>
+                                        appendTemplateLine(currentValue, `Respondent: ${RESPONDENT_NAME_TOKEN}`)
+                                    )
+                                }
+                                onInsertEmail={() =>
+                                    setTeamsMessage((currentValue) =>
+                                        appendTemplateLine(currentValue, `Email: ${RESPONDENT_EMAIL_TOKEN}`)
+                                    )
+                                }
+                                onInsertQuestion={(question, index) =>
+                                    setTeamsMessage((currentValue) =>
+                                        appendQuestionToken(currentValue, question, index)
+                                    )
+                                }
+                            />
+                        </div>
+                    </>
+                ) : null}
+
+                {destination === 'webhook' ? (
+                    <>
+                        <div className="flex flex-col gap-2">
+                            <label className="text-sm font-medium">Webhook URL</label>
+                            <LemonInput
+                                value={webhookUrl}
+                                onChange={setWebhookUrl}
+                                placeholder="https://..."
+                                fullWidth
+                            />
+                        </div>
+                        <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:gap-4">
+                            <div className="flex min-w-48 flex-col gap-2">
+                                <label className="text-sm font-medium">HTTP method</label>
+                                <LemonSelect
+                                    value={webhookMethod}
+                                    onChange={setWebhookMethod}
+                                    options={WEBHOOK_METHOD_OPTIONS}
+                                    fullWidth
+                                />
+                            </div>
+                            <div className="flex-1 rounded border border-dashed bg-surface-primary p-3 text-xs text-muted">
+                                Survey webhooks send the survey metadata, person context, and one answer field per
+                                question. You can tailor the payload before saving it.
+                            </div>
+                        </div>
+                        <div className="flex flex-col gap-2">
+                            <label className="text-sm font-medium">JSON body</label>
+                            <CodeEditorResizeable
+                                embedded
+                                language="json"
+                                value={webhookBody}
+                                onChange={(nextValue) => setWebhookBody(nextValue ?? '')}
+                                minHeight="14rem"
+                                maxHeight="20rem"
+                                allowManualResize={false}
+                                options={{
+                                    minimap: { enabled: false },
+                                    scrollBeyondLastLine: false,
+                                    fixedOverflowWidgets: true,
+                                }}
+                            />
+                        </div>
+                    </>
+                ) : null}
+
+                <div className="rounded border bg-fill-secondary p-3">
+                    <div className="mb-2 text-sm font-medium">Available survey placeholders</div>
+                    <div className="mb-3 text-xs text-muted">
+                        Need deeper customization later? After you create a notification, open it from the survey
+                        notifications list to use the full Hog function editor.
+                    </div>
+                    <SurveyResponseKeysReference questions={survey.questions} />
+                </div>
+            </div>
+        </LemonModal>
+    )
+}

--- a/frontend/src/scenes/surveys/components/SurveyNotificationModal.tsx
+++ b/frontend/src/scenes/surveys/components/SurveyNotificationModal.tsx
@@ -10,8 +10,7 @@ import { CodeEditorResizeable } from 'lib/monaco/CodeEditorResizable'
 import { DESTINATION_OPTIONS } from 'scenes/hog-functions/list/newNotificationDialogLogic'
 import { SurveyResponseKeysReference } from 'scenes/surveys/components/SurveyResponseKeysReference'
 import {
-    RESPONDENT_EMAIL_TOKEN,
-    RESPONDENT_NAME_TOKEN,
+    RESPONDENT_DETAILS_LINE,
     SURVEY_NAME_TOKEN,
     SurveyNotificationForm,
     SurveyQuestionForNotification,
@@ -71,8 +70,7 @@ type MessageFormattingActionProps = {
     questions: SurveyQuestionForNotification[]
     onReset: () => void
     onInsertSurveyName: () => void
-    onInsertRespondent: () => void
-    onInsertEmail: () => void
+    onInsertRespondentDetails: () => void
     onInsertQuestion: (question: SurveyQuestionForNotification, index: number) => void
 }
 
@@ -80,15 +78,15 @@ function MessageFormattingActions({
     questions,
     onReset,
     onInsertSurveyName,
-    onInsertRespondent,
-    onInsertEmail,
+    onInsertRespondentDetails,
     onInsertQuestion,
 }: MessageFormattingActionProps): JSX.Element {
     const applicableQuestions = questions.filter((question) => question.id && question.type !== SurveyQuestionType.Link)
 
     return (
-        <div className="border-t border-border pt-3">
-            <div className="mb-2 flex flex-col gap-1 sm:flex-row sm:items-baseline sm:justify-between">
+        <div className="space-y-3">
+            <div className="border-t border-border" />
+            <div className="flex flex-col gap-1 sm:flex-row sm:items-baseline sm:justify-between">
                 <div className="text-xs font-medium text-default">Quick inserts</div>
                 <div className="text-xs text-muted">Keep the default compact, then add context only where needed.</div>
             </div>
@@ -99,11 +97,8 @@ function MessageFormattingActions({
                 <LemonButton size="xsmall" type="tertiary" onClick={onInsertSurveyName}>
                     Insert survey name
                 </LemonButton>
-                <LemonButton size="xsmall" type="tertiary" onClick={onInsertRespondent}>
-                    Insert respondent
-                </LemonButton>
-                <LemonButton size="xsmall" type="tertiary" onClick={onInsertEmail}>
-                    Insert email
+                <LemonButton size="xsmall" type="tertiary" onClick={onInsertRespondentDetails}>
+                    Insert respondent details
                 </LemonButton>
                 {applicableQuestions.map((question, index) => (
                     <LemonButton
@@ -136,10 +131,8 @@ function getMessageFormattingActions({
         onReset: () => setNotificationFormValue(field, getDefaultSurveyMessage(questions)),
         onInsertSurveyName: () =>
             setNotificationFormValue(field, appendTemplateLine(value, `Survey: *${SURVEY_NAME_TOKEN}*`)),
-        onInsertRespondent: () =>
-            setNotificationFormValue(field, appendTemplateLine(value, `Respondent: ${RESPONDENT_NAME_TOKEN}`)),
-        onInsertEmail: () =>
-            setNotificationFormValue(field, appendTemplateLine(value, `Email: ${RESPONDENT_EMAIL_TOKEN}`)),
+        onInsertRespondentDetails: () =>
+            setNotificationFormValue(field, appendTemplateLine(value, RESPONDENT_DETAILS_LINE)),
         onInsertQuestion: (question, index) =>
             setNotificationFormValue(field, appendQuestionToken(value, question, index)),
     }
@@ -177,7 +170,7 @@ export function SurveyNotificationModal({ surveyId }: { surveyId: string }): JSX
             isOpen={isOpen}
             onClose={closeDialog}
             title="Add survey notification"
-            description="Send survey responses to Slack, Discord, Microsoft Teams, or a webhook without leaving this page."
+            description="Send survey responses to Slack, Discord, Microsoft Teams, or a webhook."
             width={720}
             footer={
                 <>
@@ -196,7 +189,7 @@ export function SurveyNotificationModal({ surveyId }: { surveyId: string }): JSX
                 </>
             }
         >
-            <div className="flex flex-col gap-4">
+            <div className="flex flex-col gap-3">
                 {notificationSubmissionError ? (
                     <div className="text-sm text-danger">{notificationSubmissionError}</div>
                 ) : null}
@@ -208,51 +201,38 @@ export function SurveyNotificationModal({ surveyId }: { surveyId: string }): JSX
                     id="survey-notification-form"
                     enableFormOnSubmit
                 >
-                    <div className="flex flex-col gap-4">
-                        <div className="rounded-xl bg-fill-secondary p-4 shadow-xs">
-                            <SectionEyebrow>Setup</SectionEyebrow>
-                            <div className="mt-3 grid gap-4 md:grid-cols-[minmax(0,1.35fr)_minmax(18rem,1fr)]">
-                                <div className="flex flex-col gap-2">
-                                    <Field name="destination" label="Destination">
-                                        {({ value, onChange }) => (
-                                            <LemonSelect
-                                                value={value}
-                                                onChange={onChange}
-                                                options={DESTINATION_OPTIONS.map((option) => ({
-                                                    value: option.value,
-                                                    label: option.label,
-                                                    icon: (
-                                                        <img
-                                                            src={option.iconUrl}
-                                                            alt=""
-                                                            className="h-5 w-5 object-contain"
-                                                        />
-                                                    ),
-                                                }))}
-                                                fullWidth
-                                            />
-                                        )}
-                                    </Field>
-                                    <div className="text-xs text-muted">
-                                        {destinationDeliveryDescription(notificationForm.destination)}
-                                    </div>
-                                </div>
-                                <div className="rounded-lg bg-surface-primary p-3 shadow-xs">
-                                    <Field name="onlyCompletedResponses">
-                                        {({ value, onChange }) => (
-                                            <LemonSwitch
-                                                checked={value}
-                                                onChange={onChange}
-                                                label="Only notify for full responses"
-                                                bordered
-                                            />
-                                        )}
-                                    </Field>
-                                    <div className="mt-2 text-xs text-muted">
-                                        Leave this on to avoid partial-response noise, or turn it off if early answers
-                                        matter for this survey.
-                                    </div>
-                                </div>
+                    <div className="flex flex-col gap-3">
+                        <div className="space-y-2">
+                            <Field name="destination" label="Destination">
+                                {({ value, onChange }) => (
+                                    <LemonSelect
+                                        value={value}
+                                        onChange={onChange}
+                                        options={DESTINATION_OPTIONS.map((option) => ({
+                                            value: option.value,
+                                            label: option.label,
+                                            icon: (
+                                                <img src={option.iconUrl} alt="" className="h-5 w-5 object-contain" />
+                                            ),
+                                        }))}
+                                        fullWidth
+                                    />
+                                )}
+                            </Field>
+                            <div className="text-xs text-muted">
+                                {destinationDeliveryDescription(notificationForm.destination)}
+                            </div>
+                            <Field name="onlyCompletedResponses">
+                                {({ value, onChange }) => (
+                                    <LemonSwitch
+                                        checked={value}
+                                        onChange={onChange}
+                                        label="Only notify for full responses"
+                                    />
+                                )}
+                            </Field>
+                            <div className="text-xs text-muted">
+                                Turn this off if partial responses matter for this survey.
                             </div>
                         </div>
 
@@ -289,13 +269,16 @@ export function SurveyNotificationModal({ surveyId }: { surveyId: string }): JSX
                                 )}
                                 <Field name="slackMessage">
                                     {({ value, onChange }) => (
-                                        <div className="rounded-xl border bg-surface-primary p-4 shadow-xs">
-                                            <SectionEyebrow>Message</SectionEyebrow>
-                                            <div className="mt-1 text-sm font-medium text-default">
-                                                Slack message template
-                                            </div>
-                                            <div className="mb-3 mt-1 text-xs text-muted">
-                                                Built for scanning fast in busy channels, with optional details below.
+                                        <div className="space-y-3">
+                                            <div className="border-t border-border" />
+                                            <div className="space-y-1">
+                                                <div className="text-sm font-medium text-default">
+                                                    Slack message template
+                                                </div>
+                                                <div className="text-xs text-muted">
+                                                    Built for scanning fast in busy channels, with optional details
+                                                    below.
+                                                </div>
                                             </div>
                                             <TemplateEditor
                                                 value={value}
@@ -305,14 +288,14 @@ export function SurveyNotificationModal({ surveyId }: { surveyId: string }): JSX
                                             {messageFormattingActions ? (
                                                 <MessageFormattingActions {...messageFormattingActions} />
                                             ) : null}
-                                            <div className="mt-3 border-t border-border pt-3">
+                                            <div className="space-y-3">
+                                                <div className="border-t border-border" />
                                                 <Field name="includeSlackButtons">
                                                     {({ value: switchValue, onChange: switchOnChange }) => (
                                                         <LemonSwitch
                                                             checked={switchValue}
                                                             onChange={switchOnChange}
                                                             label="Include buttons to view the survey and person"
-                                                            bordered
                                                         />
                                                     )}
                                                 </Field>
@@ -337,14 +320,16 @@ export function SurveyNotificationModal({ surveyId }: { surveyId: string }): JSX
                                 </Field>
                                 <Field name="discordMessage">
                                     {({ value, onChange }) => (
-                                        <div className="rounded-xl border bg-surface-primary p-4 shadow-xs">
-                                            <SectionEyebrow>Message</SectionEyebrow>
-                                            <div className="mt-1 text-sm font-medium text-default">
-                                                Discord message template
-                                            </div>
-                                            <div className="mb-3 mt-1 text-xs text-muted">
-                                                Keep it compact by default, then use quick inserts when you need more
-                                                context.
+                                        <div className="space-y-3">
+                                            <div className="border-t border-border" />
+                                            <div className="space-y-1">
+                                                <div className="text-sm font-medium text-default">
+                                                    Discord message template
+                                                </div>
+                                                <div className="text-xs text-muted">
+                                                    Keep it compact by default, then use quick inserts when you need
+                                                    more context.
+                                                </div>
                                             </div>
                                             <TemplateEditor
                                                 value={value}
@@ -374,14 +359,16 @@ export function SurveyNotificationModal({ surveyId }: { surveyId: string }): JSX
                                 </Field>
                                 <Field name="teamsMessage">
                                     {({ value, onChange }) => (
-                                        <div className="rounded-xl border bg-surface-primary p-4 shadow-xs">
-                                            <SectionEyebrow>Message</SectionEyebrow>
-                                            <div className="mt-1 text-sm font-medium text-default">
-                                                Microsoft Teams message template
-                                            </div>
-                                            <div className="mb-3 mt-1 text-xs text-muted">
-                                                Default to a high-signal summary and add metadata only if the team needs
-                                                it.
+                                        <div className="space-y-3">
+                                            <div className="border-t border-border" />
+                                            <div className="space-y-1">
+                                                <div className="text-sm font-medium text-default">
+                                                    Microsoft Teams message template
+                                                </div>
+                                                <div className="text-xs text-muted">
+                                                    Default to a high-signal summary and add metadata only if the team
+                                                    needs it.
+                                                </div>
                                             </div>
                                             <TemplateEditor
                                                 value={value}
@@ -409,12 +396,14 @@ export function SurveyNotificationModal({ surveyId }: { surveyId: string }): JSX
                                         />
                                     )}
                                 </Field>
-                                <div className="rounded-xl border bg-surface-primary p-4 shadow-xs">
-                                    <SectionEyebrow>Payload</SectionEyebrow>
-                                    <div className="mt-1 text-sm font-medium text-default">Webhook request body</div>
-                                    <div className="mb-3 mt-1 text-xs text-muted">
-                                        Survey webhooks send the survey metadata, person context, and one answer field
-                                        per question.
+                                <div className="space-y-3">
+                                    <div className="border-t border-border" />
+                                    <div className="space-y-1">
+                                        <div className="text-sm font-medium text-default">Webhook request body</div>
+                                        <div className="text-xs text-muted">
+                                            Survey webhooks send the survey metadata, person context, and one answer
+                                            field per question.
+                                        </div>
                                     </div>
                                     <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:gap-4">
                                         <div className="flex min-w-48 flex-col gap-2">
@@ -429,7 +418,7 @@ export function SurveyNotificationModal({ surveyId }: { surveyId: string }): JSX
                                                 )}
                                             </Field>
                                         </div>
-                                        <div className="flex-1 rounded-lg bg-fill-secondary p-3 text-xs text-muted">
+                                        <div className="flex-1 text-xs text-muted">
                                             Tailor the JSON before saving it if your endpoint expects a specific shape.
                                         </div>
                                     </div>
@@ -455,12 +444,15 @@ export function SurveyNotificationModal({ surveyId }: { surveyId: string }): JSX
                             </>
                         ) : null}
 
-                        <div className="rounded-xl bg-fill-secondary p-4 shadow-xs">
+                        <div className="space-y-3">
+                            <div className="border-t border-border" />
                             <SectionEyebrow>Reference</SectionEyebrow>
-                            <div className="mb-2 mt-1 text-sm font-medium">Available survey placeholders</div>
-                            <div className="mb-3 text-xs text-muted">
-                                Need deeper customization later? After you create a notification, open it from the
-                                survey notifications list to use the full Hog function editor.
+                            <div className="space-y-1">
+                                <div className="text-sm font-medium">Available survey placeholders</div>
+                                <div className="text-xs text-muted">
+                                    Need deeper customization later? After you create a notification, open it from the
+                                    survey notifications list to use the full Hog function editor.
+                                </div>
                             </div>
                             <SurveyResponseKeysReference questions={survey.questions} />
                         </div>

--- a/frontend/src/scenes/surveys/components/SurveyNotificationModal.tsx
+++ b/frontend/src/scenes/surveys/components/SurveyNotificationModal.tsx
@@ -148,6 +148,7 @@ export function SurveyNotificationModal({ surveyId }: { surveyId: string }): JSX
         isNotificationFormSubmitting,
         selectedSlackIntegration,
         hasSlackIntegration,
+        canNotifyOnPartialResponses,
         templateGlobals,
         submitDisabledReason,
         notificationSubmissionError,
@@ -222,18 +223,22 @@ export function SurveyNotificationModal({ surveyId }: { surveyId: string }): JSX
                             <div className="text-xs text-muted">
                                 {destinationDeliveryDescription(notificationForm.destination)}
                             </div>
-                            <Field name="onlyCompletedResponses">
-                                {({ value, onChange }) => (
-                                    <LemonSwitch
-                                        checked={value}
-                                        onChange={onChange}
-                                        label="Only notify for full responses"
-                                    />
-                                )}
-                            </Field>
-                            <div className="text-xs text-muted">
-                                Turn this off if partial responses matter for this survey.
-                            </div>
+                            {canNotifyOnPartialResponses ? (
+                                <>
+                                    <Field name="onlyCompletedResponses">
+                                        {({ value, onChange }) => (
+                                            <LemonSwitch
+                                                checked={value}
+                                                onChange={onChange}
+                                                label="Only notify for full responses"
+                                            />
+                                        )}
+                                    </Field>
+                                    <div className="text-xs text-muted">
+                                        Turn this off if partial responses matter for this survey.
+                                    </div>
+                                </>
+                            ) : null}
                         </div>
 
                         {notificationForm.destination === 'slack' ? (

--- a/frontend/src/scenes/surveys/components/SurveyNotifications.tsx
+++ b/frontend/src/scenes/surveys/components/SurveyNotifications.tsx
@@ -6,6 +6,7 @@ import { LemonButton, LemonSkeleton, LemonSwitch } from '@posthog/lemon-ui'
 import { HogFunctionIcon } from 'scenes/hog-functions/configuration/HogFunctionIcon'
 import { NEW_SURVEY } from 'scenes/surveys/constants'
 import { surveyLogic } from 'scenes/surveys/surveyLogic'
+import { surveyNotificationModalLogic } from 'scenes/surveys/surveyNotificationModalLogic'
 import { urls } from 'scenes/urls'
 
 import { HogFunctionType } from '~/types'
@@ -43,8 +44,10 @@ export function SurveyNotifications({
     buttonFullWidth = false,
 }: SurveyNotificationsProps): JSX.Element {
     const logic = surveyLogic({ id: surveyId })
+    const notificationModalLogic = surveyNotificationModalLogic({ surveyId })
     const { survey, surveyNotifications, surveyNotificationsLoading } = useValues(logic)
-    const { toggleSurveyNotificationEnabled, openSurveyNotificationModal } = useActions(logic)
+    const { toggleSurveyNotificationEnabled } = useActions(logic)
+    const { openDialog } = useActions(notificationModalLogic)
 
     const isUnsavedSurvey = survey.id === NEW_SURVEY.id
 
@@ -93,7 +96,7 @@ export function SurveyNotifications({
                 type="secondary"
                 size="small"
                 icon={<IconPlus />}
-                onClick={openSurveyNotificationModal}
+                onClick={openDialog}
                 fullWidth={buttonFullWidth}
                 data-attr="survey-new-notification"
                 disabledReason={isUnsavedSurvey ? 'Save the survey before adding notifications.' : undefined}

--- a/frontend/src/scenes/surveys/components/SurveyNotifications.tsx
+++ b/frontend/src/scenes/surveys/components/SurveyNotifications.tsx
@@ -1,0 +1,105 @@
+import { useActions, useValues } from 'kea'
+
+import { IconPlus } from '@posthog/icons'
+import { LemonButton, LemonSkeleton, LemonSwitch } from '@posthog/lemon-ui'
+
+import { HogFunctionIcon } from 'scenes/hog-functions/configuration/HogFunctionIcon'
+import { NEW_SURVEY } from 'scenes/surveys/constants'
+import { surveyLogic } from 'scenes/surveys/surveyLogic'
+import { urls } from 'scenes/urls'
+
+import { HogFunctionType } from '~/types'
+
+interface SurveyNotificationsProps {
+    surveyId: string
+    description?: string
+    buttonFullWidth?: boolean
+}
+
+function getNotificationDescription(fn: HogFunctionType): string | null {
+    const inputs = fn.inputs
+    if (!inputs) {
+        return null
+    }
+    if (inputs.url?.value) {
+        try {
+            return new URL(String(inputs.url.value)).hostname
+        } catch {
+            return String(inputs.url.value)
+        }
+    }
+    if (inputs.channel?.value) {
+        return String(inputs.channel.value)
+    }
+    if (inputs.email?.value) {
+        return String(inputs.email.value)
+    }
+    return null
+}
+
+export function SurveyNotifications({
+    surveyId,
+    description,
+    buttonFullWidth = false,
+}: SurveyNotificationsProps): JSX.Element {
+    const logic = surveyLogic({ id: surveyId })
+    const { survey, surveyNotifications, surveyNotificationsLoading } = useValues(logic)
+    const { toggleSurveyNotificationEnabled, openSurveyNotificationModal } = useActions(logic)
+
+    const isUnsavedSurvey = survey.id === NEW_SURVEY.id
+
+    return (
+        <div className="flex flex-col gap-3">
+            {description ? <p className="m-0 text-sm text-muted">{description}</p> : null}
+            {surveyNotificationsLoading ? (
+                <div className="flex flex-col gap-2">
+                    <LemonSkeleton className="h-12" />
+                    <LemonSkeleton className="h-12" />
+                </div>
+            ) : surveyNotifications.length > 0 ? (
+                <div className="flex flex-col gap-1.5">
+                    {surveyNotifications.map((fn) => {
+                        const notificationDescription = getNotificationDescription(fn)
+                        return (
+                            <div key={fn.id} className="flex items-center gap-2 rounded border p-2">
+                                <HogFunctionIcon src={fn.icon_url} size="small" />
+                                <div className="flex-1 min-w-0">
+                                    <LemonButton
+                                        type="tertiary"
+                                        size="xsmall"
+                                        to={urls.hogFunction(fn.id)}
+                                        className="font-medium p-0 h-auto min-h-0"
+                                        noPadding
+                                    >
+                                        <span className="truncate">{fn.name}</span>
+                                    </LemonButton>
+                                    {notificationDescription ? (
+                                        <div className="text-xs text-muted truncate">{notificationDescription}</div>
+                                    ) : null}
+                                </div>
+                                <LemonSwitch
+                                    checked={fn.enabled}
+                                    onChange={() => toggleSurveyNotificationEnabled(fn.id, !fn.enabled)}
+                                    size="small"
+                                />
+                            </div>
+                        )
+                    })}
+                </div>
+            ) : (
+                <p className="text-xs text-muted m-0">No notifications configured yet.</p>
+            )}
+            <LemonButton
+                type="secondary"
+                size="small"
+                icon={<IconPlus />}
+                onClick={openSurveyNotificationModal}
+                fullWidth={buttonFullWidth}
+                data-attr="survey-new-notification"
+                disabledReason={isUnsavedSurvey ? 'Save the survey before adding notifications.' : undefined}
+            >
+                Add notification
+            </LemonButton>
+        </div>
+    )
+}

--- a/frontend/src/scenes/surveys/components/SurveyNotificationsCallout.tsx
+++ b/frontend/src/scenes/surveys/components/SurveyNotificationsCallout.tsx
@@ -5,11 +5,13 @@ import { LemonBanner, LemonButton } from '@posthog/lemon-ui'
 
 import { NEW_SURVEY } from 'scenes/surveys/constants'
 import { surveyLogic } from 'scenes/surveys/surveyLogic'
+import { surveyNotificationModalLogic } from 'scenes/surveys/surveyNotificationModalLogic'
 
 export function SurveyNotificationsCallout({ surveyId }: { surveyId: string }): JSX.Element | null {
     const logic = surveyLogic({ id: surveyId })
+    const notificationModalLogic = surveyNotificationModalLogic({ surveyId })
     const { survey, surveyNotifications, surveyNotificationsLoading } = useValues(logic)
-    const { openSurveyNotificationModal } = useActions(logic)
+    const { openDialog } = useActions(notificationModalLogic)
 
     const shouldShow =
         survey.id !== NEW_SURVEY.id &&
@@ -32,7 +34,7 @@ export function SurveyNotificationsCallout({ surveyId }: { surveyId: string }): 
                         survey-specific message without leaving this page.
                     </div>
                 </div>
-                <LemonButton type="primary" size="small" icon={<IconBell />} onClick={openSurveyNotificationModal}>
+                <LemonButton type="primary" size="small" icon={<IconBell />} onClick={openDialog}>
                     Set up notifications
                 </LemonButton>
             </div>

--- a/frontend/src/scenes/surveys/components/SurveyNotificationsCallout.tsx
+++ b/frontend/src/scenes/surveys/components/SurveyNotificationsCallout.tsx
@@ -1,0 +1,41 @@
+import { useActions, useValues } from 'kea'
+
+import { IconBell } from '@posthog/icons'
+import { LemonBanner, LemonButton } from '@posthog/lemon-ui'
+
+import { NEW_SURVEY } from 'scenes/surveys/constants'
+import { surveyLogic } from 'scenes/surveys/surveyLogic'
+
+export function SurveyNotificationsCallout({ surveyId }: { surveyId: string }): JSX.Element | null {
+    const logic = surveyLogic({ id: surveyId })
+    const { survey, surveyNotifications, surveyNotificationsLoading } = useValues(logic)
+    const { openSurveyNotificationModal } = useActions(logic)
+
+    const shouldShow =
+        survey.id !== NEW_SURVEY.id &&
+        !!survey.start_date &&
+        !survey.end_date &&
+        !surveyNotificationsLoading &&
+        surveyNotifications.length === 0
+
+    if (!shouldShow) {
+        return null
+    }
+
+    return (
+        <LemonBanner type="info">
+            <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+                <div className="space-y-1">
+                    <div className="text-sm font-medium">Stay on top of incoming survey responses</div>
+                    <div className="text-sm text-muted">
+                        Send every new reply to Slack, Discord, Microsoft Teams, or a webhook, and customize the
+                        survey-specific message without leaving this page.
+                    </div>
+                </div>
+                <LemonButton type="primary" size="small" icon={<IconBell />} onClick={openSurveyNotificationModal}>
+                    Set up notifications
+                </LemonButton>
+            </div>
+        </LemonBanner>
+    )
+}

--- a/frontend/src/scenes/surveys/components/SurveyNotificationsCallout.tsx
+++ b/frontend/src/scenes/surveys/components/SurveyNotificationsCallout.tsx
@@ -25,7 +25,7 @@ export function SurveyNotificationsCallout({ surveyId }: { surveyId: string }): 
     }
 
     return (
-        <LemonBanner type="info">
+        <LemonBanner type="info" dismissKey={`survey-notifications-callout-${surveyId}`}>
             <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
                 <div className="space-y-1">
                     <div className="text-sm font-medium">Stay on top of incoming survey responses</div>

--- a/frontend/src/scenes/surveys/components/SurveyResponseKeysReference.tsx
+++ b/frontend/src/scenes/surveys/components/SurveyResponseKeysReference.tsx
@@ -11,24 +11,43 @@ export function SurveyResponseKeysReference({ questions }: { questions: SurveyQu
     const applicableQuestions = questions
         .map((q, index) => ({ question: q, originalIndex: index }))
         .filter(({ question }) => question.type !== SurveyQuestionType.Link && question.id)
-
-    if (applicableQuestions.length === 0) {
-        return null
-    }
+    const commonFields = [
+        { label: 'Survey name', templateKey: "{event.properties['$survey_name']}" },
+        { label: 'Survey ID', templateKey: "{event.properties['$survey_id']}" },
+        { label: 'Respondent name', templateKey: '{person.name}' },
+        { label: 'Respondent email', templateKey: '{person.properties.email}' },
+    ]
 
     return (
         <LemonCollapse
             panels={[
                 {
-                    key: 'response-keys',
-                    header: 'Response property keys',
+                    key: 'survey-keys',
+                    header: 'Survey placeholders',
                     content: (
                         <div className="flex flex-col gap-1.5">
                             <p className="text-xs text-muted m-0">
-                                Use these in notification message templates to include survey responses.
+                                Use these in notification message templates to include survey context and responses.
                             </p>
+                            {commonFields.map(({ label, templateKey }) => (
+                                <div
+                                    key={label}
+                                    className="flex items-center justify-between gap-2 rounded border p-1.5"
+                                >
+                                    <span className="text-xs truncate min-w-0">{label}</span>
+                                    <LemonButton
+                                        size="xsmall"
+                                        type="secondary"
+                                        icon={<IconCopy />}
+                                        onClick={() => void copyToClipboard(templateKey, label.toLowerCase())}
+                                        tooltip={templateKey}
+                                        noPadding
+                                        className="shrink-0 p-0.5"
+                                    />
+                                </div>
+                            ))}
                             {applicableQuestions.map(({ question, originalIndex }) => {
-                                const templateKey = `{event.properties.${getSurveyIdBasedResponseKey(question.id!)}}`
+                                const templateKey = `{event.properties['${getSurveyIdBasedResponseKey(question.id!)}']}`
                                 return (
                                     <div
                                         key={question.id}

--- a/frontend/src/scenes/surveys/surveyLogic.tsx
+++ b/frontend/src/scenes/surveys/surveyLogic.tsx
@@ -561,6 +561,8 @@ export const surveyLogic = kea<surveyLogicType>([
         unarchiveResponse: (responseUuid: string) => ({ responseUuid }),
         startResultsRequery: true,
         markResultsRequeryCompleted: true,
+        openSurveyNotificationModal: true,
+        closeSurveyNotificationModal: true,
         toggleSurveyNotificationEnabled: (notificationId: string, enabled: boolean) => ({
             notificationId,
             enabled,
@@ -1306,6 +1308,13 @@ export const surveyLogic = kea<surveyLogicType>([
             false,
             {
                 editingSurvey: (_, { editing }) => editing,
+            },
+        ],
+        surveyNotificationModalOpen: [
+            false,
+            {
+                openSurveyNotificationModal: () => true,
+                closeSurveyNotificationModal: () => false,
             },
         ],
         surveyMissing: [

--- a/frontend/src/scenes/surveys/surveyLogic.tsx
+++ b/frontend/src/scenes/surveys/surveyLogic.tsx
@@ -561,8 +561,6 @@ export const surveyLogic = kea<surveyLogicType>([
         unarchiveResponse: (responseUuid: string) => ({ responseUuid }),
         startResultsRequery: true,
         markResultsRequeryCompleted: true,
-        openSurveyNotificationModal: true,
-        closeSurveyNotificationModal: true,
         toggleSurveyNotificationEnabled: (notificationId: string, enabled: boolean) => ({
             notificationId,
             enabled,
@@ -1308,13 +1306,6 @@ export const surveyLogic = kea<surveyLogicType>([
             false,
             {
                 editingSurvey: (_, { editing }) => editing,
-            },
-        ],
-        surveyNotificationModalOpen: [
-            false,
-            {
-                openSurveyNotificationModal: () => true,
-                closeSurveyNotificationModal: () => false,
             },
         ],
         surveyMissing: [

--- a/frontend/src/scenes/surveys/surveyNotificationModalLogic.ts
+++ b/frontend/src/scenes/surveys/surveyNotificationModalLogic.ts
@@ -32,6 +32,7 @@ export type SurveyQuestionForNotification = {
 
 export interface SurveyNotificationForm {
     destination: DestinationKey
+    onlyCompletedResponses: boolean
     slackIntegrationId: number | null
     slackChannel: string | null
     slackMessage: string
@@ -75,10 +76,8 @@ export function getDefaultSurveyMessage(questions: SurveyQuestionForNotification
         .slice(0, MAX_EXAMPLE_QUESTIONS)
 
     return [
-        '*New survey response*',
-        `Survey: *${SURVEY_NAME_TOKEN}*`,
-        `Respondent: ${RESPONDENT_NAME_TOKEN}`,
-        `Email: ${RESPONDENT_EMAIL_TOKEN}`,
+        `*New response on ${SURVEY_NAME_TOKEN}*`,
+        `${RESPONDENT_NAME_TOKEN} · ${RESPONDENT_EMAIL_TOKEN}`,
         ...(exampleQuestions.length > 0
             ? ['', '*Responses*', ...exampleQuestions.map((question, index) => getQuestionLine(question, index))]
             : []),
@@ -179,6 +178,7 @@ function buildSurveyNotificationForm(survey: Survey): SurveyNotificationForm {
 
     return {
         destination: 'slack',
+        onlyCompletedResponses: true,
         slackIntegrationId: null,
         slackChannel: null,
         slackMessage: defaultMessage,
@@ -322,7 +322,7 @@ function createSurveyNotificationPayload({
         description: subTemplate?.description ?? `Survey notification for ${destinationOption.label}`,
         inputs,
         inputs_schema: template.inputs_schema,
-        filters: getSurveyNotificationFilters(surveyId),
+        filters: getSurveyNotificationFilters(surveyId, form.onlyCompletedResponses),
         hog: template.code,
         icon_url: template.icon_url,
         enabled: true,

--- a/frontend/src/scenes/surveys/surveyNotificationModalLogic.ts
+++ b/frontend/src/scenes/surveys/surveyNotificationModalLogic.ts
@@ -57,6 +57,7 @@ export const SURVEY_NAME_TOKEN = "{event.properties['$survey_name']}"
 export const SURVEY_ID_TOKEN = "{event.properties['$survey_id']}"
 export const RESPONDENT_NAME_TOKEN = '{person.name}'
 export const RESPONDENT_EMAIL_TOKEN = '{person.properties.email}'
+export const RESPONDENT_DETAILS_LINE = `${RESPONDENT_NAME_TOKEN} · ${RESPONDENT_EMAIL_TOKEN}`
 
 function getResponseToken(questionId: string): string {
     return `{event.properties['${getSurveyIdBasedResponseKey(questionId)}']}`
@@ -77,7 +78,7 @@ export function getDefaultSurveyMessage(questions: SurveyQuestionForNotification
 
     return [
         `*New response on ${SURVEY_NAME_TOKEN}*`,
-        `${RESPONDENT_NAME_TOKEN} · ${RESPONDENT_EMAIL_TOKEN}`,
+        RESPONDENT_DETAILS_LINE,
         ...(exampleQuestions.length > 0
             ? ['', '*Responses*', ...exampleQuestions.map((question, index) => getQuestionLine(question, index))]
             : []),

--- a/frontend/src/scenes/surveys/surveyNotificationModalLogic.ts
+++ b/frontend/src/scenes/surveys/surveyNotificationModalLogic.ts
@@ -1,0 +1,500 @@
+import { actions, connect, kea, key, listeners, path, props, reducers, selectors } from 'kea'
+import { forms } from 'kea-forms'
+
+import { lemonToast } from '@posthog/lemon-ui'
+
+import api from 'lib/api'
+import { integrationsLogic } from 'lib/integrations/integrationsLogic'
+import { DESTINATION_OPTIONS, DestinationKey } from 'scenes/hog-functions/list/newNotificationDialogLogic'
+import {
+    HOG_FUNCTION_SUB_TEMPLATE_COMMON_PROPERTIES,
+    HOG_FUNCTION_SUB_TEMPLATES,
+} from 'scenes/hog-functions/sub-templates/sub-templates'
+import { NEW_SURVEY } from 'scenes/surveys/constants'
+import { surveyLogic } from 'scenes/surveys/surveyLogic'
+import { getSurveyNotificationFilters, getSurveyIdBasedResponseKey } from 'scenes/surveys/utils'
+
+import { HogFunctionTemplateType, HogFunctionType, Survey, SurveyQuestionType } from '~/types'
+
+export const WEBHOOK_METHOD_OPTIONS = [
+    { value: 'POST', label: 'POST' },
+    { value: 'PUT', label: 'PUT' },
+    { value: 'PATCH', label: 'PATCH' },
+    { value: 'GET', label: 'GET' },
+    { value: 'DELETE', label: 'DELETE' },
+]
+
+export type SurveyQuestionForNotification = {
+    id?: string
+    question: string | null | undefined
+    type: SurveyQuestionType
+}
+
+export interface SurveyNotificationForm {
+    destination: DestinationKey
+    slackIntegrationId: number | null
+    slackChannel: string | null
+    slackMessage: string
+    includeSlackButtons: boolean
+    discordWebhookUrl: string
+    discordMessage: string
+    teamsWebhookUrl: string
+    teamsMessage: string
+    webhookUrl: string
+    webhookMethod: string
+    webhookBody: string
+}
+
+export interface SurveyNotificationModalLogicProps {
+    surveyId: string
+}
+
+type SurveyMessageField = 'slackMessage' | 'discordMessage' | 'teamsMessage'
+
+const MAX_EXAMPLE_QUESTIONS = 3
+export const SURVEY_NAME_TOKEN = "{event.properties['$survey_name']}"
+export const SURVEY_ID_TOKEN = "{event.properties['$survey_id']}"
+export const RESPONDENT_NAME_TOKEN = '{person.name}'
+export const RESPONDENT_EMAIL_TOKEN = '{person.properties.email}'
+
+function getResponseToken(questionId: string): string {
+    return `{event.properties['${getSurveyIdBasedResponseKey(questionId)}']}`
+}
+
+export function getQuestionLabel(question: SurveyQuestionForNotification, index: number): string {
+    return question.question?.trim() || `Question ${index + 1}`
+}
+
+function getQuestionLine(question: SurveyQuestionForNotification, index: number): string {
+    return `- ${getQuestionLabel(question, index)}: ${getResponseToken(question.id!)}`
+}
+
+export function getDefaultSurveyMessage(questions: SurveyQuestionForNotification[] = []): string {
+    const exampleQuestions = questions
+        .filter((question) => question.id && question.type !== SurveyQuestionType.Link)
+        .slice(0, MAX_EXAMPLE_QUESTIONS)
+
+    return [
+        '*New survey response*',
+        `Survey: *${SURVEY_NAME_TOKEN}*`,
+        `Respondent: ${RESPONDENT_NAME_TOKEN}`,
+        `Email: ${RESPONDENT_EMAIL_TOKEN}`,
+        ...(exampleQuestions.length > 0
+            ? ['', '*Responses*', ...exampleQuestions.map((question, index) => getQuestionLine(question, index))]
+            : []),
+    ].join('\n')
+}
+
+export function appendQuestionToken(value: string, question: SurveyQuestionForNotification, index: number): string {
+    if (!question.id) {
+        return value
+    }
+
+    const line = getQuestionLine(question, index)
+    const trimmedValue = value.trim()
+
+    if (trimmedValue.includes(line)) {
+        return trimmedValue
+    }
+
+    if (!trimmedValue) {
+        return getDefaultSurveyMessage([question])
+    }
+
+    if (trimmedValue.includes('*Responses*')) {
+        return `${trimmedValue}\n${line}`
+    }
+
+    return `${trimmedValue}\n\n*Responses*\n${line}`
+}
+
+export function appendTemplateLine(value: string, line: string): string {
+    const trimmedValue = value.trim()
+
+    if (trimmedValue.includes(line)) {
+        return trimmedValue
+    }
+
+    return trimmedValue ? `${trimmedValue}\n${line}` : line
+}
+
+function isValidHttpUrl(value: string): boolean {
+    return URL.canParse(value) && /^https?:\/\//.test(value)
+}
+
+function buildSlackBlocks(message: string, includeButtons: boolean): Record<string, unknown>[] {
+    return [
+        {
+            type: 'section',
+            text: {
+                type: 'mrkdwn',
+                text: message,
+            },
+        },
+        ...(includeButtons
+            ? [
+                  {
+                      type: 'actions',
+                      elements: [
+                          {
+                              url: "{project.url}/surveys/{event.properties['$survey_id']}",
+                              text: { text: 'View survey', type: 'plain_text' },
+                              type: 'button',
+                          },
+                          {
+                              url: '{person.url}',
+                              text: { text: 'View person', type: 'plain_text' },
+                              type: 'button',
+                          },
+                      ],
+                  },
+              ]
+            : []),
+    ]
+}
+
+function buildWebhookBodyTemplate(questions: SurveyQuestionForNotification[]): Record<string, unknown> {
+    return {
+        survey: {
+            id: SURVEY_ID_TOKEN,
+            name: SURVEY_NAME_TOKEN,
+            url: `{project.url}/surveys/${SURVEY_ID_TOKEN}`,
+        },
+        person: {
+            name: RESPONDENT_NAME_TOKEN,
+            email: RESPONDENT_EMAIL_TOKEN,
+            url: '{person.url}',
+        },
+        responses: questions
+            .filter((question) => question.id && question.type !== SurveyQuestionType.Link)
+            .map((question, index) => ({
+                question: getQuestionLabel(question, index),
+                answer: getResponseToken(question.id!),
+            })),
+    }
+}
+
+function buildSurveyNotificationForm(survey: Survey): SurveyNotificationForm {
+    const defaultMessage = getDefaultSurveyMessage(survey.questions)
+
+    return {
+        destination: 'slack',
+        slackIntegrationId: null,
+        slackChannel: null,
+        slackMessage: defaultMessage,
+        includeSlackButtons: true,
+        discordWebhookUrl: '',
+        discordMessage: defaultMessage,
+        teamsWebhookUrl: '',
+        teamsMessage: defaultMessage,
+        webhookUrl: '',
+        webhookMethod: 'POST',
+        webhookBody: JSON.stringify(buildWebhookBodyTemplate(survey.questions), null, 2),
+    }
+}
+
+function buildTemplateGlobals(survey: Survey): Record<string, unknown> {
+    const responseProperties = Object.fromEntries(
+        survey.questions
+            .filter((question) => question.id && question.type !== SurveyQuestionType.Link)
+            .map((question, index) => [
+                getSurveyIdBasedResponseKey(question.id!),
+                question.question || `Example answer ${index + 1}`,
+            ])
+    )
+    const previewTimestamp = new Date().toISOString()
+
+    return {
+        project: {
+            id: 1,
+            name: 'Project',
+            url: 'https://app.posthog.com/project/1',
+        },
+        event: {
+            event: 'survey sent',
+            uuid: '00000000-0000-0000-0000-000000000000',
+            distinct_id: 'example-distinct-id',
+            timestamp: previewTimestamp,
+            properties: {
+                $survey_id: survey.id === NEW_SURVEY.id ? 'survey-id' : survey.id,
+                $survey_name: survey.name || 'Survey',
+                $survey_completed: true,
+                ...responseProperties,
+            },
+            url: `https://app.posthog.com/project/1/events/example/${encodeURIComponent(previewTimestamp)}`,
+        },
+        person: {
+            id: 'person-id',
+            name: 'Jane Doe',
+            url: 'https://app.posthog.com/project/1/person/example-distinct-id',
+            properties: {
+                email: 'jane@example.com',
+            },
+        },
+        groups: {},
+    }
+}
+
+function notificationNameFor(destination: DestinationKey, surveyName?: string | null): string {
+    const destinationLabel = DESTINATION_OPTIONS.find((option) => option.value === destination)?.label || 'Notification'
+    const baseName = surveyName?.trim() || 'Survey'
+    return `${baseName} → ${destinationLabel}`
+}
+
+export function destinationDeliveryDescription(destination: DestinationKey): string {
+    switch (destination) {
+        case 'slack':
+            return 'Slack messages are sent as a formatted post with buttons to view the survey and person.'
+        case 'discord':
+            return 'Discord sends a single message to your webhook URL using the content below.'
+        case 'microsoft-teams':
+            return 'Microsoft Teams sends an Adaptive Card message using the text below.'
+        case 'webhook':
+            return 'Webhooks send a JSON request. You can tailor the method and request body here.'
+    }
+}
+
+function createSurveyNotificationPayload({
+    template,
+    destination,
+    surveyName,
+    surveyId,
+    form,
+}: {
+    template: HogFunctionTemplateType
+    destination: DestinationKey
+    surveyName?: string | null
+    surveyId: string
+    form: SurveyNotificationForm
+}): Partial<HogFunctionType> {
+    const destinationOption = DESTINATION_OPTIONS.find((option) => option.value === destination)
+    if (!destinationOption) {
+        throw new Error('Unsupported destination')
+    }
+
+    const subTemplate = HOG_FUNCTION_SUB_TEMPLATES['survey-response'].find(
+        (subTemplateValue) => subTemplateValue.template_id === destinationOption.templateId
+    )
+
+    const inputs: Record<string, { value: unknown }> = {}
+
+    for (const schema of template.inputs_schema ?? []) {
+        if (schema.default !== undefined) {
+            inputs[schema.key] = { value: schema.default }
+        }
+    }
+
+    if (subTemplate?.inputs) {
+        for (const [key, value] of Object.entries(subTemplate.inputs)) {
+            inputs[key] = value as { value: unknown }
+        }
+    }
+
+    switch (destination) {
+        case 'slack':
+            if (!form.slackIntegrationId || !form.slackChannel) {
+                throw new Error('Select a Slack workspace and channel.')
+            }
+            inputs.slack_workspace = { value: form.slackIntegrationId }
+            inputs.channel = { value: form.slackChannel.split('|')[0] }
+            inputs.text = { value: form.slackMessage.trim() }
+            inputs.blocks = { value: buildSlackBlocks(form.slackMessage.trim(), form.includeSlackButtons) }
+            break
+        case 'discord':
+            inputs.webhookUrl = { value: form.discordWebhookUrl.trim() }
+            inputs.content = { value: form.discordMessage.trim() }
+            break
+        case 'microsoft-teams':
+            inputs.webhookUrl = { value: form.teamsWebhookUrl.trim() }
+            inputs.text = { value: form.teamsMessage.trim() }
+            break
+        case 'webhook':
+            inputs.url = { value: form.webhookUrl.trim() }
+            inputs.method = { value: form.webhookMethod }
+            inputs.body = { value: JSON.parse(form.webhookBody) }
+            break
+    }
+
+    return {
+        template_id: destinationOption.templateId,
+        type: HOG_FUNCTION_SUB_TEMPLATE_COMMON_PROPERTIES['survey-response'].type,
+        name: notificationNameFor(destination, surveyName),
+        description: subTemplate?.description ?? `Survey notification for ${destinationOption.label}`,
+        inputs,
+        inputs_schema: template.inputs_schema,
+        filters: getSurveyNotificationFilters(surveyId),
+        hog: template.code,
+        icon_url: template.icon_url,
+        enabled: true,
+    }
+}
+
+function getNotificationFormErrors(
+    form: SurveyNotificationForm,
+    survey: Survey,
+    hasSlackIntegration: boolean
+): Partial<Record<keyof SurveyNotificationForm, string>> {
+    if (survey.id === NEW_SURVEY.id) {
+        return {}
+    }
+
+    switch (form.destination) {
+        case 'slack':
+            return {
+                slackIntegrationId: !hasSlackIntegration
+                    ? 'Configure Slack for this project first.'
+                    : !form.slackIntegrationId
+                      ? 'Select a Slack workspace.'
+                      : undefined,
+                slackChannel: form.slackIntegrationId && !form.slackChannel ? 'Select a Slack channel.' : undefined,
+                slackMessage: !form.slackMessage.trim() ? 'Enter the Slack message.' : undefined,
+            }
+        case 'discord':
+            return {
+                discordWebhookUrl: !isValidHttpUrl(form.discordWebhookUrl.trim())
+                    ? 'Enter a valid Discord webhook URL.'
+                    : undefined,
+                discordMessage: !form.discordMessage.trim() ? 'Enter the Discord message.' : undefined,
+            }
+        case 'microsoft-teams':
+            return {
+                teamsWebhookUrl: !isValidHttpUrl(form.teamsWebhookUrl.trim())
+                    ? 'Enter a valid Microsoft Teams webhook URL.'
+                    : undefined,
+                teamsMessage: !form.teamsMessage.trim() ? 'Enter the Microsoft Teams message.' : undefined,
+            }
+        case 'webhook':
+            try {
+                if (!isValidHttpUrl(form.webhookUrl.trim())) {
+                    return { webhookUrl: 'Enter a valid webhook URL.' }
+                }
+                if (!form.webhookBody.trim()) {
+                    return { webhookBody: 'Enter valid JSON for the webhook body.' }
+                }
+                JSON.parse(form.webhookBody)
+                return {}
+            } catch {
+                return { webhookBody: 'Enter valid JSON for the webhook body.' }
+            }
+    }
+}
+
+export const surveyNotificationModalLogic = kea([
+    path(['scenes', 'surveys', 'surveyNotificationModalLogic']),
+    props({} as SurveyNotificationModalLogicProps),
+    key((props) => props.surveyId),
+    connect((props: SurveyNotificationModalLogicProps) => ({
+        values: [integrationsLogic, ['integrations'], surveyLogic({ id: props.surveyId }), ['survey']],
+        actions: [surveyLogic({ id: props.surveyId }), ['loadSurveyNotifications']],
+    })),
+
+    actions({
+        openDialog: true,
+        closeDialog: true,
+        setNotificationSubmissionError: (error: string | null) => ({ error }),
+    }),
+
+    reducers({
+        isOpen: [
+            false,
+            {
+                openDialog: () => true,
+                closeDialog: () => false,
+            },
+        ],
+        notificationSubmissionError: [
+            null as string | null,
+            {
+                setNotificationSubmissionError: (_, { error }) => error,
+                openDialog: () => null,
+                closeDialog: () => null,
+            },
+        ],
+    }),
+
+    forms(({ values }) => ({
+        notificationForm: {
+            defaults: buildSurveyNotificationForm(NEW_SURVEY as Survey),
+            errors: (form: SurveyNotificationForm) =>
+                getNotificationFormErrors(
+                    form,
+                    values.survey,
+                    (values.integrations?.some((integration) => integration.kind === 'slack') ?? false) as boolean
+                ),
+            submit: async (form: SurveyNotificationForm) => {
+                const templateId = DESTINATION_OPTIONS.find((option) => option.value === form.destination)?.templateId
+                const template = await api.hogFunctions.getTemplate(templateId || 'template-slack')
+
+                const payload = createSurveyNotificationPayload({
+                    template,
+                    destination: form.destination,
+                    surveyName: values.survey.name,
+                    surveyId: values.survey.id,
+                    form,
+                })
+
+                return await api.hogFunctions.create(payload)
+            },
+        },
+    })),
+
+    selectors({
+        hasSlackIntegration: [
+            (s) => [s.integrations],
+            (integrations) => integrations?.some((integration) => integration.kind === 'slack') ?? false,
+        ],
+        selectedSlackIntegration: [
+            (s) => [s.integrations, s.notificationForm],
+            (integrations, form) =>
+                integrations?.find((integration) => integration.id === form.slackIntegrationId) ?? null,
+        ],
+        templateGlobals: [(s) => [s.survey], (survey) => buildTemplateGlobals(survey)],
+        submitDisabledReason: [
+            (s) => [s.survey, s.notificationFormErrors, s.isNotificationFormSubmitting],
+            (survey, errors, isSubmitting): string | undefined => {
+                if (survey.id === NEW_SURVEY.id) {
+                    return 'Save the survey before creating notifications.'
+                }
+                if (isSubmitting) {
+                    return 'Creating notification...'
+                }
+                return (Object.values(errors).find(Boolean) as string | undefined) ?? undefined
+            },
+        ],
+    }),
+
+    listeners(({ actions, values }) => ({
+        openDialog: () => {
+            actions.resetNotificationForm()
+            actions.setNotificationFormValues(buildSurveyNotificationForm(values.survey))
+        },
+        closeDialog: () => {
+            actions.resetNotificationForm()
+        },
+        submitNotificationFormSuccess: async () => {
+            await actions.loadSurveyNotifications()
+            actions.closeDialog()
+            lemonToast.success(
+                `Notification "${notificationNameFor(values.notificationForm.destination, values.survey.name)}" created`
+            )
+        },
+        submitNotificationFormFailure: ({ error }) => {
+            actions.setNotificationSubmissionError(
+                error instanceof Error ? error.message : 'Failed to create notification. Please try again.'
+            )
+        },
+    })),
+])
+
+export function getMessageFieldForDestination(destination: DestinationKey): SurveyMessageField | null {
+    switch (destination) {
+        case 'slack':
+            return 'slackMessage'
+        case 'discord':
+            return 'discordMessage'
+        case 'microsoft-teams':
+            return 'teamsMessage'
+        case 'webhook':
+            return null
+    }
+}

--- a/frontend/src/scenes/surveys/surveyNotificationModalLogic.ts
+++ b/frontend/src/scenes/surveys/surveyNotificationModalLogic.ts
@@ -14,7 +14,9 @@ import { NEW_SURVEY } from 'scenes/surveys/constants'
 import { surveyLogic } from 'scenes/surveys/surveyLogic'
 import { getSurveyNotificationFilters, getSurveyIdBasedResponseKey } from 'scenes/surveys/utils'
 
-import { HogFunctionTemplateType, HogFunctionType, Survey, SurveyQuestionType } from '~/types'
+import { HogFunctionTemplateType, HogFunctionType, IntegrationType, Survey, SurveyQuestionType } from '~/types'
+
+import type { surveyNotificationModalLogicType } from './surveyNotificationModalLogicType'
 
 export const WEBHOOK_METHOD_OPTIONS = [
     { value: 'POST', label: 'POST' },
@@ -51,6 +53,8 @@ export interface SurveyNotificationModalLogicProps {
 }
 
 type SurveyMessageField = 'slackMessage' | 'discordMessage' | 'teamsMessage'
+type SurveyNotificationContext = Pick<Survey, 'id' | 'name' | 'questions' | 'enable_partial_responses'>
+type SurveyNotificationFormErrors = Partial<Record<keyof SurveyNotificationForm, string>>
 
 const MAX_EXAMPLE_QUESTIONS = 3
 export const SURVEY_NAME_TOKEN = "{event.properties['$survey_name']}"
@@ -174,7 +178,7 @@ function buildWebhookBodyTemplate(questions: SurveyQuestionForNotification[]): R
     }
 }
 
-function buildSurveyNotificationForm(survey: Survey): SurveyNotificationForm {
+function buildSurveyNotificationForm(survey: SurveyNotificationContext): SurveyNotificationForm {
     const defaultMessage = getDefaultSurveyMessage(survey.questions)
 
     return {
@@ -194,7 +198,7 @@ function buildSurveyNotificationForm(survey: Survey): SurveyNotificationForm {
     }
 }
 
-function buildTemplateGlobals(survey: Survey): Record<string, unknown> {
+function buildTemplateGlobals(survey: SurveyNotificationContext): Record<string, unknown> {
     const responseProperties = Object.fromEntries(
         survey.questions
             .filter((question) => question.id && question.type !== SurveyQuestionType.Link)
@@ -260,12 +264,14 @@ function createSurveyNotificationPayload({
     destination,
     surveyName,
     surveyId,
+    canNotifyOnPartialResponses,
     form,
 }: {
     template: HogFunctionTemplateType
     destination: DestinationKey
     surveyName?: string | null
     surveyId: string
+    canNotifyOnPartialResponses: boolean
     form: SurveyNotificationForm
 }): Partial<HogFunctionType> {
     const destinationOption = DESTINATION_OPTIONS.find((option) => option.value === destination)
@@ -323,7 +329,10 @@ function createSurveyNotificationPayload({
         description: subTemplate?.description ?? `Survey notification for ${destinationOption.label}`,
         inputs,
         inputs_schema: template.inputs_schema,
-        filters: getSurveyNotificationFilters(surveyId, form.onlyCompletedResponses),
+        filters: getSurveyNotificationFilters(
+            surveyId,
+            canNotifyOnPartialResponses ? form.onlyCompletedResponses : true
+        ),
         hog: template.code,
         icon_url: template.icon_url,
         enabled: true,
@@ -332,9 +341,9 @@ function createSurveyNotificationPayload({
 
 function getNotificationFormErrors(
     form: SurveyNotificationForm,
-    survey: Survey,
+    survey: SurveyNotificationContext,
     hasSlackIntegration: boolean
-): Partial<Record<keyof SurveyNotificationForm, string>> {
+): SurveyNotificationFormErrors {
     if (survey.id === NEW_SURVEY.id) {
         return {}
     }
@@ -380,7 +389,7 @@ function getNotificationFormErrors(
     }
 }
 
-export const surveyNotificationModalLogic = kea([
+export const surveyNotificationModalLogic = kea<surveyNotificationModalLogicType>([
     path(['scenes', 'surveys', 'surveyNotificationModalLogic']),
     props({} as SurveyNotificationModalLogicProps),
     key((props) => props.surveyId),
@@ -415,12 +424,13 @@ export const surveyNotificationModalLogic = kea([
 
     forms(({ values }) => ({
         notificationForm: {
-            defaults: buildSurveyNotificationForm(NEW_SURVEY as Survey),
+            defaults: buildSurveyNotificationForm(NEW_SURVEY),
             errors: (form: SurveyNotificationForm) =>
                 getNotificationFormErrors(
                     form,
                     values.survey,
-                    (values.integrations?.some((integration) => integration.kind === 'slack') ?? false) as boolean
+                    (values.integrations?.some((integration: IntegrationType) => integration.kind === 'slack') ??
+                        false) as boolean
                 ),
             submit: async (form: SurveyNotificationForm) => {
                 const templateId = DESTINATION_OPTIONS.find((option) => option.value === form.destination)?.templateId
@@ -431,10 +441,11 @@ export const surveyNotificationModalLogic = kea([
                     destination: form.destination,
                     surveyName: values.survey.name,
                     surveyId: values.survey.id,
+                    canNotifyOnPartialResponses: values.survey.enable_partial_responses === true,
                     form,
                 })
 
-                return await api.hogFunctions.create(payload)
+                await api.hogFunctions.create(payload)
             },
         },
     })),
@@ -442,17 +453,27 @@ export const surveyNotificationModalLogic = kea([
     selectors({
         hasSlackIntegration: [
             (s) => [s.integrations],
-            (integrations) => integrations?.some((integration) => integration.kind === 'slack') ?? false,
+            (integrations: IntegrationType[] | null) =>
+                integrations?.some((integration: IntegrationType) => integration.kind === 'slack') ?? false,
         ],
         selectedSlackIntegration: [
             (s) => [s.integrations, s.notificationForm],
-            (integrations, form) =>
-                integrations?.find((integration) => integration.id === form.slackIntegrationId) ?? null,
+            (integrations: IntegrationType[] | null, form: SurveyNotificationForm) =>
+                integrations?.find((integration: IntegrationType) => integration.id === form.slackIntegrationId) ??
+                null,
         ],
-        templateGlobals: [(s) => [s.survey], (survey) => buildTemplateGlobals(survey)],
+        canNotifyOnPartialResponses: [
+            (s) => [s.survey],
+            (survey: SurveyNotificationContext) => survey.enable_partial_responses === true,
+        ],
+        templateGlobals: [(s) => [s.survey], (survey: SurveyNotificationContext) => buildTemplateGlobals(survey)],
         submitDisabledReason: [
             (s) => [s.survey, s.notificationFormErrors, s.isNotificationFormSubmitting],
-            (survey, errors, isSubmitting): string | undefined => {
+            (
+                survey: SurveyNotificationContext,
+                errors: SurveyNotificationFormErrors,
+                isSubmitting: boolean
+            ): string | undefined => {
                 if (survey.id === NEW_SURVEY.id) {
                     return 'Save the survey before creating notifications.'
                 }
@@ -468,6 +489,9 @@ export const surveyNotificationModalLogic = kea([
         openDialog: () => {
             actions.resetNotificationForm()
             actions.setNotificationFormValues(buildSurveyNotificationForm(values.survey))
+            if (values.survey.enable_partial_responses !== true) {
+                actions.setNotificationFormValue('onlyCompletedResponses', true)
+            }
         },
         closeDialog: () => {
             actions.resetNotificationForm()

--- a/frontend/src/scenes/surveys/utils.test.ts
+++ b/frontend/src/scenes/surveys/utils.test.ts
@@ -9,6 +9,8 @@ import {
     Survey,
     SurveyAppearance,
     SurveyDisplayConditions,
+    SurveyEventName,
+    SurveyEventProperties,
     SurveyQuestionType,
     SurveyType,
     SurveyWidgetType,
@@ -19,6 +21,7 @@ import {
     buildSurveyTimestampFilter,
     calculateNpsBreakdown,
     createAnswerFilterHogQLExpression,
+    getSurveyNotificationFilters,
     getResolvedSurveyDateRange,
     getSurveyAudienceSummaryValue,
     getSurveyDisplayConditionsSummary,
@@ -149,6 +152,39 @@ describe('survey utils', () => {
             expect(sanitizeColor('#ff0000')).toBe('#ff0000')
             expect(sanitizeColor('rgb(255, 0, 0)')).toBe('rgb(255, 0, 0)')
             expect(sanitizeColor('red')).toBe('red')
+        })
+    })
+
+    describe('getSurveyNotificationFilters', () => {
+        it('builds survey-specific notification filters', () => {
+            expect(getSurveyNotificationFilters('survey-123')).toEqual({
+                events: [
+                    {
+                        id: SurveyEventName.SENT,
+                        type: 'events',
+                        properties: [
+                            {
+                                key: SurveyEventProperties.SURVEY_RESPONSE,
+                                type: PropertyFilterType.Event,
+                                value: 'is_set',
+                                operator: PropertyOperator.IsSet,
+                            },
+                            {
+                                key: SurveyEventProperties.SURVEY_ID,
+                                type: PropertyFilterType.Event,
+                                value: 'survey-123',
+                                operator: PropertyOperator.Exact,
+                            },
+                            {
+                                key: SurveyEventProperties.SURVEY_COMPLETED,
+                                type: PropertyFilterType.Event,
+                                value: true,
+                                operator: PropertyOperator.Exact,
+                            },
+                        ],
+                    },
+                ],
+            })
         })
     })
 

--- a/frontend/src/scenes/surveys/utils.test.ts
+++ b/frontend/src/scenes/surveys/utils.test.ts
@@ -186,6 +186,31 @@ describe('survey utils', () => {
                 ],
             })
         })
+
+        it('can include partial responses when requested', () => {
+            expect(getSurveyNotificationFilters('survey-123', false)).toEqual({
+                events: [
+                    {
+                        id: SurveyEventName.SENT,
+                        type: 'events',
+                        properties: [
+                            {
+                                key: SurveyEventProperties.SURVEY_RESPONSE,
+                                type: PropertyFilterType.Event,
+                                value: 'is_set',
+                                operator: PropertyOperator.IsSet,
+                            },
+                            {
+                                key: SurveyEventProperties.SURVEY_ID,
+                                type: PropertyFilterType.Event,
+                                value: 'survey-123',
+                                operator: PropertyOperator.Exact,
+                            },
+                        ],
+                    },
+                ],
+            })
+        })
     })
 
     describe('sanitizeSurveyAppearance', () => {

--- a/frontend/src/scenes/surveys/utils.ts
+++ b/frontend/src/scenes/surveys/utils.ts
@@ -1,6 +1,5 @@
 import DOMPurify from 'dompurify'
 import { DeepPartialMap, ValidationErrorType } from 'kea-forms'
-import { combineUrl } from 'kea-router'
 import posthog from 'posthog-js'
 
 import { dayjs } from 'lib/dayjs'
@@ -8,10 +7,10 @@ import { dateStringToDayJs } from 'lib/utils'
 import { getAppContext } from 'lib/utils/getAppContext'
 import { NEW_SURVEY, NewSurvey, SURVEY_CREATED_SOURCE, SURVEY_RATING_SCALE } from 'scenes/surveys/constants'
 import { SurveyRatingResults } from 'scenes/surveys/surveyLogic'
-import { urls } from 'scenes/urls'
 
 import {
     BasicSurveyQuestion,
+    CyclotronJobFiltersType,
     EventPropertyFilter,
     FeatureFlagFilters,
     LinkSurveyQuestion,
@@ -1025,22 +1024,33 @@ export function getSurveyDisplayConditionsSummary(survey: Survey | NewSurvey): S
     return parts
 }
 
-export function newSurveyNotificationUrl(surveyId: string, templateId: string = 'template-webhook'): string {
-    const filters = {
+export function getSurveyNotificationFilters(surveyId: string): CyclotronJobFiltersType {
+    return {
         events: [
             {
                 id: SurveyEventName.SENT,
                 type: 'events',
                 properties: [
                     {
+                        key: SurveyEventProperties.SURVEY_RESPONSE,
+                        type: PropertyFilterType.Event,
+                        value: 'is_set',
+                        operator: PropertyOperator.IsSet,
+                    },
+                    {
                         key: SurveyEventProperties.SURVEY_ID,
                         type: PropertyFilterType.Event,
                         value: surveyId,
+                        operator: PropertyOperator.Exact,
+                    },
+                    {
+                        key: SurveyEventProperties.SURVEY_COMPLETED,
+                        type: PropertyFilterType.Event,
+                        value: true,
                         operator: PropertyOperator.Exact,
                     },
                 ],
             },
         ],
     }
-    return combineUrl(urls.hogFunctionNew(templateId), {}, { configuration: { filters } }).url
 }

--- a/frontend/src/scenes/surveys/utils.ts
+++ b/frontend/src/scenes/surveys/utils.ts
@@ -1024,32 +1024,40 @@ export function getSurveyDisplayConditionsSummary(survey: Survey | NewSurvey): S
     return parts
 }
 
-export function getSurveyNotificationFilters(surveyId: string): CyclotronJobFiltersType {
+export function getSurveyNotificationFilters(
+    surveyId: string,
+    onlyCompletedResponses: boolean = true
+): CyclotronJobFiltersType {
+    const properties: EventPropertyFilter[] = [
+        {
+            key: SurveyEventProperties.SURVEY_RESPONSE,
+            type: PropertyFilterType.Event,
+            value: 'is_set',
+            operator: PropertyOperator.IsSet,
+        },
+        {
+            key: SurveyEventProperties.SURVEY_ID,
+            type: PropertyFilterType.Event,
+            value: surveyId,
+            operator: PropertyOperator.Exact,
+        },
+    ]
+
+    if (onlyCompletedResponses) {
+        properties.push({
+            key: SurveyEventProperties.SURVEY_COMPLETED,
+            type: PropertyFilterType.Event,
+            value: true,
+            operator: PropertyOperator.Exact,
+        })
+    }
+
     return {
         events: [
             {
                 id: SurveyEventName.SENT,
                 type: 'events',
-                properties: [
-                    {
-                        key: SurveyEventProperties.SURVEY_RESPONSE,
-                        type: PropertyFilterType.Event,
-                        value: 'is_set',
-                        operator: PropertyOperator.IsSet,
-                    },
-                    {
-                        key: SurveyEventProperties.SURVEY_ID,
-                        type: PropertyFilterType.Event,
-                        value: surveyId,
-                        operator: PropertyOperator.Exact,
-                    },
-                    {
-                        key: SurveyEventProperties.SURVEY_COMPLETED,
-                        type: PropertyFilterType.Event,
-                        value: true,
-                        operator: PropertyOperator.Exact,
-                    },
-                ],
+                properties,
             },
         ],
     }


### PR DESCRIPTION
## Problem

Survey notifications currently route users from a survey into the generic Hog function creation flow. That adds friction for one of the most common survey follow-up jobs: sending completed responses to Slack, Discord, Microsoft Teams, or external webhooks.

The generic flow also leaves too much message authoring work to the user. Survey-specific context like survey name, respondent details, and answer fields should be discoverable and easy to insert without leaving the survey page.

## Changes

- add a survey-specific notification creation modal that stays on the survey page
- reuse the survey page notifications surfaces in both the legacy and redesigned views
- add empty-state callouts from survey results/summary when no notifications exist yet
- scope created notifications to the current survey and require completed submissions by default
- add survey-aware message formatting helpers, placeholder references, and prefilled webhook payloads

![CleanShot 2026-04-10 at 01 30 02@2x](https://github.com/user-attachments/assets/4da6346e-3852-48d2-8b35-53cfc5b81ec5)

new screen for surveys notifications

![CleanShot 2026-04-10 at 01 30 20@2x](https://github.com/user-attachments/assets/0dc6c4b6-91cd-4a5f-82ba-6013226285d6)

callout when there is none

## How did you test this code?

- `pnpm --filter=@posthog/frontend exec oxlint src/scenes/surveys/components/SurveyNotificationModal.tsx src/scenes/surveys/components/SurveyResponseKeysReference.tsx src/scenes/surveys/utils.ts src/scenes/surveys/utils.test.ts`
- `hogli test frontend/src/scenes/surveys/utils.test.ts`

## Publish to changelog?

yes

## Docs update

No docs update.

## 🤖 LLM context

This PR was authored by Codex in the local repo workspace. I used repo-local inspection, targeted linting, and focused Jest coverage for the survey notification filter behavior. Manual QA.
