### PR TITLE
fix: error on unset HogQL variables instead of silently passing NULL

### DIFF
--- a/posthog/hogql/variables.py
+++ b/posthog/hogql/variables.py
@@ -56,6 +56,12 @@ class ReplaceVariables(CloningVisitor):
                 else matching_insight_variable[0].default_value
             )
 
+            if value is None:
+                raise QueryError(
+                    f"Variable '{variable_code_name}' has no value and no default. "
+                    f"Set a value or define a default for this variable."
+                )
+
             return ast.Constant(value=value)
 
         return super().visit_placeholder(node)

--- a/posthog/hogql_queries/test/test_hogql_query_runner.py
+++ b/posthog/hogql_queries/test/test_hogql_query_runner.py
@@ -187,6 +187,59 @@ class TestHogQLQueryRunner(ClickhouseTestMixin, APIBaseTest):
         result_false = runner_false.calculate()
         self.assertEqual(result_false.results[0][0], 1)
 
+    def test_variable_with_no_value_raises_error(self):
+        variable = InsightVariable.objects.create(team=self.team, name="End", code_name="endtime", type="String")
+        variable_id = str(variable.id)
+
+        runner = self._create_runner(
+            HogQLQuery(
+                query="select count() from events where timestamp <= {variables.endtime}",
+                variables={variable_id: HogQLVariable(code_name=variable.code_name, variableId=variable_id)},
+            )
+        )
+
+        from posthog.hogql.errors import QueryError
+
+        with self.assertRaises(QueryError) as ctx:
+            runner.calculate()
+        self.assertIn("endtime", str(ctx.exception))
+        self.assertIn("no value", str(ctx.exception))
+
+    def test_variable_with_explicit_null_value_raises_error(self):
+        variable = InsightVariable.objects.create(team=self.team, name="Days", code_name="days", type="Number")
+        variable_id = str(variable.id)
+
+        runner = self._create_runner(
+            HogQLQuery(
+                query="select count() from events where timestamp >= now() - toIntervalDay({variables.days})",
+                variables={
+                    variable_id: HogQLVariable(code_name=variable.code_name, variableId=variable_id, value=None)
+                },
+            )
+        )
+
+        from posthog.hogql.errors import QueryError
+
+        with self.assertRaises(QueryError) as ctx:
+            runner.calculate()
+        self.assertIn("days", str(ctx.exception))
+
+    def test_variable_with_default_value_used_when_no_value(self):
+        variable = InsightVariable.objects.create(
+            team=self.team, name="Days", code_name="days", type="Number", default_value=7
+        )
+        variable_id = str(variable.id)
+
+        runner = self._create_runner(
+            HogQLQuery(
+                query="select {variables.days}",
+                variables={variable_id: HogQLVariable(code_name=variable.code_name, variableId=variable_id)},
+            )
+        )
+
+        response = runner.calculate()
+        self.assertEqual(response.results[0][0], 7)
+
     def test_invalid_connection_id_raises_exposed_hogql_error(self):
         runner = self._create_runner(
             HogQLQuery(


### PR DESCRIPTION
## Problem

When a HogQL variable has no value and no `default_value`, the variable resolution silently produces `NULL` in the compiled SQL. This turns queries like `e.timestamp <= {variables.endtime}` into `e.timestamp <= NULL` — a no-op WHERE clause that still triggers a full table scan.

## Impact (30-day analysis)

| Region | Queries | Data scanned | % of all non-offline reads |
|--------|---------|-------------|---------------------------|
| US | 406 | 25.5 PiB | ~20% |
| EU | 6 | 0.35 PiB | — |
| **Total** | **412** | **25.9 PiB** | — |

All 412 queries confirmed to have unset variable values (not intentional all-time scans). The top offender was a single DataVisualizationNode insight (team 75032, insight 3584617) with 5 variables — only 2 had values, the other 3 silently became NULL, causing 387 queries averaging 63 TiB each.

**Root cause** is in `posthog/hogql/variables.py` — when `matching_variable.value` is None and `default_value` is also None, the code returns `ast.Constant(value=None)` which the SQL printer renders as the literal `NULL`.

## Fix

Raise a `QueryError` when a variable resolves to None (no value AND no default), so the user sees "Variable 'endtime' has no value — set a value or define a default" instead of running a 190 TiB scan that returns zero results.

Queries with `isNull: true` explicitly set still work as before (intentional NULL).

## Test plan

- [x] New test: variable with no value raises `QueryError`
- [x] New test: variable with explicit `value=None` raises `QueryError`
- [x] New test: variable with no value but a `default_value` uses the default
- [x] Existing tests: `test_variables_in_hog_expression` and `test_variables_in_hog_expression_sql` still pass
- [x] All 15 tests in `test_hogql_query_runner.py` pass

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*