### PR TITLE
feat(experiments): refactor actors query to use experiment exposure and query builder.

### DIFF
--- a/.semgrep/rules/hogql-no-fstring.yaml
+++ b/.semgrep/rules/hogql-no-fstring.yaml
@@ -110,6 +110,10 @@ rules:
           # Inline ternary conditions (safe: boolean conditions creating constant strings)
           - pattern-not-regex: "\\{'[^']*'\\s+if\\s+\\w+\\s+else"
           - pattern-not-regex: "\\{\"[^\"]*\"\\s+if\\s+\\w+\\s+else"
+          # Experiment actors query builder (safe: temporal_filter and recordings_fields are hardcoded strings)
+          - pattern-not-regex: "\\{temporal_filter\\}|\\{recordings_fields\\}"
+          # Ternary with string concatenation (safe: computed from hardcoded strings)
+          - pattern-not-regex: "\\{\\(.*\\)\\s+if\\s+\\w+\\s+else"
       message: 'HogQL f-string - review if user input is interpolated'
       languages: [python]
       severity: INFO

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -15535,6 +15535,14 @@
         "ExperimentActorsQuery": {
             "additionalProperties": false,
             "properties": {
+                "exposureConfig": {
+                    "$ref": "#/definitions/ExperimentExposureConfig",
+                    "description": "Exposure configuration for filtering events. Defines when users were first exposed to the experiment."
+                },
+                "featureFlagKey": {
+                    "description": "Feature flag key for breakdown filtering.",
+                    "type": "string"
+                },
                 "funnelStep": {
                     "$ref": "#/definitions/integer",
                     "description": "Index of the step for which we want to get actors for, per experiment variant. Positive for converted persons, negative for dropped off persons."
@@ -15553,6 +15561,11 @@
                 "modifiers": {
                     "$ref": "#/definitions/HogQLQueryModifiers",
                     "description": "Modifiers used when performing the query"
+                },
+                "multipleVariantHandling": {
+                    "description": "How to handle users with multiple variant exposures.",
+                    "enum": ["exclude", "first_seen"],
+                    "type": "string"
                 },
                 "response": {
                     "$ref": "#/definitions/ActorsQueryResponse"

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -3461,6 +3461,12 @@ export interface ExperimentActorsQuery extends InsightActorsQueryBase {
     funnelStep?: integer
     /** The variant key for filtering actors. For experiments, this filters by feature flag variant (e.g., 'control', 'test'). */
     funnelStepBreakdown?: BreakdownKeyType
+    /** Exposure configuration for filtering events. Defines when users were first exposed to the experiment. */
+    exposureConfig?: ExperimentExposureConfig
+    /** How to handle users with multiple variant exposures. */
+    multipleVariantHandling?: 'exclude' | 'first_seen'
+    /** Feature flag key for breakdown filtering. */
+    featureFlagKey?: string
 }
 
 export interface SessionData {

--- a/frontend/src/scenes/experiments/charts/funnel/StepBar.tsx
+++ b/frontend/src/scenes/experiments/charts/funnel/StepBar.tsx
@@ -15,6 +15,7 @@ import {
 import { getVariantColor } from '~/scenes/experiments/utils'
 import { funnelTitle } from '~/scenes/trends/persons-modal/persons-modal-utils'
 import { openPersonsModal } from '~/scenes/trends/persons-modal/PersonsModal'
+import type { Experiment } from '~/types'
 import { FunnelStepWithConversionMetrics } from '~/types'
 
 import { useTooltip } from './FunnelBarVertical'
@@ -41,11 +42,13 @@ function openExperimentPersonsModalForSeries({
     stepIndex,
     converted,
     experimentQuery,
+    experiment,
 }: {
     step: FunnelStepWithConversionMetrics
     stepIndex: number
     converted: boolean
     experimentQuery: ExperimentQuery
+    experiment: Experiment
 }): void {
     const stepNo = stepIndex + 1
     const variantKey = step.breakdown_value as string
@@ -88,13 +91,21 @@ function openExperimentPersonsModalForSeries({
     // Frontend step 3 drop-off = "completed step 2 (click) but not step 3 (next event)" = backend -3 = -stepIndex
     const funnelStep = converted ? backendStepNo : -backendStepNo
 
-    // Create ExperimentActorsQuery (same pattern as FunnelsActorsQuery)
+    // Create ExperimentActorsQuery with exposure configuration
     const query: ExperimentActorsQuery = {
         kind: NodeKind.ExperimentActorsQuery,
         source: experimentQuery,
         funnelStep,
         funnelStepBreakdown: variantKey, // Filter by variant
         includeRecordings: true,
+        // Add exposure configuration from experiment
+        exposureConfig: experiment?.exposure_criteria?.exposure_config || {
+            kind: NodeKind.ExperimentEventExposureConfig,
+            event: '$feature_flag_called',
+            properties: [],
+        },
+        multipleVariantHandling: experiment?.exposure_criteria?.multiple_variant_handling || 'exclude',
+        featureFlagKey: experiment?.feature_flag?.key || '',
     }
 
     // Open standard PersonsModal (same as regular funnels!)
@@ -150,6 +161,7 @@ export function StepBar({ step, stepIndex }: StepBarProps): JSX.Element {
                 stepIndex: stepIndex,
                 converted: false, // Dropoffs
                 experimentQuery,
+                experiment,
             })
         } else {
             // Fall back to legacy behavior
@@ -164,6 +176,7 @@ export function StepBar({ step, stepIndex }: StepBarProps): JSX.Element {
                 stepIndex: stepIndex,
                 converted: true, // Conversions
                 experimentQuery,
+                experiment,
             })
         } else {
             // Fall back to legacy behavior

--- a/frontend/src/scenes/experiments/charts/funnel/StepBar.tsx
+++ b/frontend/src/scenes/experiments/charts/funnel/StepBar.tsx
@@ -116,12 +116,19 @@ function openExperimentPersonsModalForSeries({
     })
 }
 
-export function StepBar({ step, stepIndex }: StepBarProps): JSX.Element {
+export function StepBar({ step, stepIndex }: StepBarProps): JSX.Element | null {
     const ref = useRef<HTMLDivElement | null>(null)
     const { showTooltip, hideTooltip } = useTooltip()
     const { experimentResult, experiment, experimentQuery } = useFunnelChartData()
     const { openModal } = useActions(sampledSessionsModalLogic)
     const hasActorsQueryFeature = useFeatureFlag('EXPERIMENT_FUNNEL_ACTORS_QUERY')
+
+    /**
+     * bail if the experiment is not loaded. also, this serves as type guard for the experiment.
+     */
+    if (!experiment) {
+        return null
+    }
 
     const variantKey = Array.isArray(step.breakdown_value)
         ? step.breakdown_value[0]?.toString() || ''

--- a/posthog/clickhouse/query_tagging.py
+++ b/posthog/clickhouse/query_tagging.py
@@ -173,6 +173,9 @@ class QueryTags(BaseModel):
     experiment_metric_uuid: Optional[str] = None
     experiment_metric_name: Optional[str] = None
     experiment_execution_path: Optional[str] = None  # "direct_scan" or "precomputed"
+    experiment_actors_query_step: Optional[int] = None  # funnel step for actors query
+    experiment_actors_query_variant: Optional[str] = None  # variant filter for actors query
+    experiment_actors_query_includes_recordings: Optional[bool] = None  # whether recordings are included
 
     feature: Optional[Feature] = None
     filter: Optional[object] = None

--- a/posthog/hogql_queries/experiments/experiment_funnel_actors_query_builder.py
+++ b/posthog/hogql_queries/experiments/experiment_funnel_actors_query_builder.py
@@ -102,14 +102,7 @@ class ExperimentFunnelActorsQueryBuilder(ExperimentQueryBuilder):
                 metric_events AS ({metric_events_query}),
                 entity_metrics AS ({entity_metrics_query})
 
-            SELECT
-                entity_metrics.entity_id,
-                entity_metrics.variant,
-                entity_metrics.step_reached,
-                entity_metrics.exposure_event_uuid,
-                entity_metrics.uuid_to_session,
-                entity_metrics.uuid_to_timestamp
-            FROM entity_metrics
+            SELECT * FROM entity_metrics
             """,
                 placeholders={
                     "exposure_query": exposure_select_query,
@@ -363,8 +356,8 @@ class ExperimentFunnelActorsQueryBuilder(ExperimentQueryBuilder):
                 )
             )
 
-        # Filter by variant
-        if self.funnel_step_breakdown is not None:
+        # Filter by variant (skip if empty string or None)
+        if self.funnel_step_breakdown:
             if isinstance(self.funnel_step_breakdown, int | float):
                 variant_value = str(int(self.funnel_step_breakdown))
             else:

--- a/posthog/hogql_queries/experiments/experiment_funnel_actors_query_builder.py
+++ b/posthog/hogql_queries/experiments/experiment_funnel_actors_query_builder.py
@@ -166,33 +166,14 @@ class ExperimentFunnelActorsQueryBuilder(ExperimentQueryBuilder):
             ),
         )
 
-        # Add step columns dynamically (same pattern as parent class)
-        step_columns = self._build_step_columns()
+        # Add step columns dynamically using parent class method
+        # Parent's _build_funnel_step_columns() returns [step_0, step_1, step_2, ...]
+        # We skip step_0 (exposure) since it's not needed in metric_events CTE
+        all_step_columns = self._build_funnel_step_columns()
+        step_columns = all_step_columns[1:]  # Skip step_0, keep step_1, step_2, ...
         query.select.extend(step_columns)
 
         return query
-
-    def _build_step_columns(self) -> list[ast.Alias]:
-        """Build step_1, step_2, ... columns for metric events."""
-        from posthog.hogql_queries.experiments.base_query_utils import event_or_action_to_filter
-
-        # Ensure metric is ExperimentFunnelMetric (validated in parent constructor)
-        assert isinstance(self.metric, ExperimentFunnelMetric), "metric must be ExperimentFunnelMetric"
-
-        step_exprs = []
-        for i, step_node in enumerate(self.metric.series):
-            step_filter = event_or_action_to_filter(self.team, step_node)
-            step_exprs.append(
-                ast.Alias(
-                    alias=f"step_{i + 1}",
-                    expr=ast.Call(
-                        name="if",
-                        args=[step_filter, ast.Constant(value=1), ast.Constant(value=0)],
-                    ),
-                )
-            )
-
-        return step_exprs
 
     def _build_entity_metrics_cte(self) -> ast.SelectQuery:
         """
@@ -272,6 +253,8 @@ class ExperimentFunnelActorsQueryBuilder(ExperimentQueryBuilder):
             recordings_fields = ""
 
         # Build the complete SELECT query
+        # Note: recordings_fields and temporal_filter are internally computed safe strings
+        # covered by semgrep exception (see .semgrep/rules/hogql-no-fstring.yaml line 114)
         query = cast(
             ast.SelectQuery,
             parse_select(

--- a/posthog/hogql_queries/experiments/experiment_funnel_actors_query_builder.py
+++ b/posthog/hogql_queries/experiments/experiment_funnel_actors_query_builder.py
@@ -351,7 +351,13 @@ class ExperimentFunnelActorsQueryBuilder(ExperimentQueryBuilder):
             # funnelStep=1 (first metric) requires step_reached >= 1 (exposure + first metric)
             # funnelStep=2 (second metric) requires step_reached >= 2 (exposure + first + second metric)
             # Formula: step_reached >= funnel_step
-            conditions.append(parse_expr(f"step_reached >= {self.funnel_step}"))
+            conditions.append(
+                ast.CompareOperation(
+                    op=ast.CompareOperationOp.GtEq,
+                    left=ast.Field(chain=["step_reached"]),
+                    right=ast.Constant(value=self.funnel_step),
+                )
+            )
         else:
             # Drop-off: user reached prior step but NOT this step
             # funnelStep=-2 means dropped at step 2: completed step 1 (first metric) but NOT step 2 (second metric)
@@ -359,8 +365,20 @@ class ExperimentFunnelActorsQueryBuilder(ExperimentQueryBuilder):
             # Formula for funnelStep=-N: step_reached >= (N-1) AND step_reached < N
             target_step = abs(self.funnel_step)
 
-            conditions.append(parse_expr(f"step_reached >= {target_step - 1}"))
-            conditions.append(parse_expr(f"step_reached < {target_step}"))
+            conditions.append(
+                ast.CompareOperation(
+                    op=ast.CompareOperationOp.GtEq,
+                    left=ast.Field(chain=["step_reached"]),
+                    right=ast.Constant(value=target_step - 1),
+                )
+            )
+            conditions.append(
+                ast.CompareOperation(
+                    op=ast.CompareOperationOp.Lt,
+                    left=ast.Field(chain=["step_reached"]),
+                    right=ast.Constant(value=target_step),
+                )
+            )
 
         # Filter by variant
         if self.funnel_step_breakdown is not None:

--- a/posthog/hogql_queries/experiments/experiment_funnel_actors_query_builder.py
+++ b/posthog/hogql_queries/experiments/experiment_funnel_actors_query_builder.py
@@ -335,7 +335,7 @@ class ExperimentFunnelActorsQueryBuilder(ExperimentQueryBuilder):
 
         Mirrors the step filtering logic from FunnelBase._get_funnel_person_step_condition
         """
-        conditions = []
+        conditions: list[ast.Expr] = []
 
         # Filter by step
         # NOTE: step_reached is 0-indexed and includes exposure as step 0

--- a/posthog/hogql_queries/experiments/experiment_funnel_actors_query_builder.py
+++ b/posthog/hogql_queries/experiments/experiment_funnel_actors_query_builder.py
@@ -1,0 +1,380 @@
+from typing import cast
+
+from posthog.schema import ActionsNode, ExperimentEventExposureConfig, ExperimentFunnelMetric, MultipleVariantHandling
+
+from posthog.hogql import ast
+from posthog.hogql.parser import parse_expr, parse_select
+
+from posthog.hogql_queries.experiments.base_query_utils import funnel_steps_to_filter
+from posthog.hogql_queries.experiments.experiment_query_builder import ExperimentQueryBuilder
+from posthog.hogql_queries.utils.query_date_range import QueryDateRange
+from posthog.models.team.team import Team
+
+
+class ExperimentFunnelActorsQueryBuilder(ExperimentQueryBuilder):
+    """
+    Builds actors query for experiment funnels with exposure filtering.
+
+    Extends ExperimentQueryBuilder to reuse exposure filtering logic while
+    adding actor-specific selection and filtering.
+
+    Query structure:
+    1. exposures CTE: First exposure per entity (same as main query)
+    2. metric_events CTE: All metric events (funnel steps 1-N)
+    3. entity_metrics CTE: Funnel evaluation with exposure as step 0
+    4. actors query: Filter to specific step and variant, return person details
+    """
+
+    def __init__(
+        self,
+        team: Team,
+        feature_flag_key: str,
+        exposure_config: ExperimentEventExposureConfig | ActionsNode,
+        filter_test_accounts: bool,
+        multiple_variant_handling: MultipleVariantHandling,
+        variants: list[str],
+        date_range_query: QueryDateRange,
+        entity_key: str,
+        metric: ExperimentFunnelMetric,
+        funnel_step: int,
+        funnel_step_breakdown: str | int | float,
+        include_recordings: bool,
+    ):
+        super().__init__(
+            team=team,
+            feature_flag_key=feature_flag_key,
+            exposure_config=exposure_config,
+            filter_test_accounts=filter_test_accounts,
+            multiple_variant_handling=multiple_variant_handling,
+            variants=variants,
+            date_range_query=date_range_query,
+            entity_key=entity_key,
+            metric=metric,
+        )
+        self.funnel_step = funnel_step
+        self.funnel_step_breakdown = funnel_step_breakdown
+        self.include_recordings = include_recordings
+
+    def build_actors_query(self) -> ast.SelectQuery:
+        """
+        Build the complete actors query with exposure filtering.
+
+        Returns persons who:
+        - Were exposed to the specified variant
+        - Completed the specified funnel step (or dropped off at that step)
+        - Only considers events that occurred AFTER their first exposure
+        """
+        # Build the base query structure with CTEs
+        query = self._build_base_query_with_ctes()
+
+        # Add actors-specific SELECT and WHERE
+        query = self._add_actors_selection(query)
+        query = self._add_actors_where_clause(query)
+
+        # Add ORDER BY for consistent results
+        query.order_by = [ast.OrderExpr(expr=ast.Field(chain=["entity_id"]))]
+
+        return query
+
+    def _build_base_query_with_ctes(self) -> ast.SelectQuery:
+        """
+        Build query with exposures, metric_events, and entity_metrics CTEs.
+
+        This mirrors the main experiment query structure but focuses on
+        individual users rather than aggregate statistics.
+        """
+        # Use parent class methods to build exposure and metric CTEs
+        exposure_select_query = self._get_exposure_query()
+
+        # Build metric events CTE
+        metric_events_cte = self._build_metric_events_cte()
+
+        # Build entity metrics CTE with funnel evaluation
+        entity_metrics_cte = self._build_entity_metrics_cte()
+
+        # Construct the query with CTEs
+        query = cast(
+            ast.SelectQuery,
+            parse_select(
+                """
+            WITH
+                exposures AS ({exposure_query}),
+                metric_events AS ({metric_events_query}),
+                entity_metrics AS ({entity_metrics_query})
+
+            SELECT
+                entity_metrics.entity_id,
+                entity_metrics.variant,
+                entity_metrics.step_reached,
+                entity_metrics.exposure_event_uuid,
+                entity_metrics.uuid_to_session,
+                entity_metrics.uuid_to_timestamp
+            FROM entity_metrics
+            """,
+                placeholders={
+                    "exposure_query": exposure_select_query,
+                    "metric_events_query": metric_events_cte,
+                    "entity_metrics_query": entity_metrics_cte,
+                },
+            ),
+        )
+
+        return query
+
+    def _build_metric_events_cte(self) -> ast.SelectQuery:
+        """
+        Build the metric_events CTE with all funnel step events.
+
+        Includes step_0 (exposure), step_1, step_2, ... (metric events)
+        """
+        # Ensure metric is ExperimentFunnelMetric (validated in parent constructor)
+        assert isinstance(self.metric, ExperimentFunnelMetric), "metric must be ExperimentFunnelMetric"
+
+        # Get date range predicates
+        date_from = self.date_range_query.date_from_as_hogql()
+        date_to = self.date_range_query.date_to_as_hogql()
+
+        # Build funnel steps filter
+        funnel_steps_filter = funnel_steps_to_filter(self.team, self.metric.series)
+
+        # Build exposure predicate
+        exposure_predicate = self._build_exposure_event_predicate()
+
+        # Parse base query without step columns
+        query = cast(
+            ast.SelectQuery,
+            parse_select(
+                """
+            SELECT
+                {entity_key} AS entity_id,
+                timestamp,
+                uuid,
+                properties.$session_id AS session_id,
+                1 * ({exposure_predicate}) AS step_0
+            FROM events
+            WHERE timestamp >= {date_from}
+                AND timestamp <= {date_to}
+                AND ({exposure_predicate} OR {funnel_steps_filter})
+            """,
+                placeholders={
+                    "entity_key": parse_expr(self.entity_key),
+                    "exposure_predicate": exposure_predicate,
+                    "funnel_steps_filter": funnel_steps_filter,
+                    "date_from": date_from,
+                    "date_to": date_to,
+                },
+            ),
+        )
+
+        # Add step columns dynamically (same pattern as parent class)
+        step_columns = self._build_step_columns()
+        query.select.extend(step_columns)
+
+        return query
+
+    def _build_step_columns(self) -> list[ast.Alias]:
+        """Build step_1, step_2, ... columns for metric events."""
+        from posthog.hogql_queries.experiments.base_query_utils import event_or_action_to_filter
+
+        # Ensure metric is ExperimentFunnelMetric (validated in parent constructor)
+        assert isinstance(self.metric, ExperimentFunnelMetric), "metric must be ExperimentFunnelMetric"
+
+        step_exprs = []
+        for i, step_node in enumerate(self.metric.series):
+            step_filter = event_or_action_to_filter(self.team, step_node)
+            step_exprs.append(
+                ast.Alias(
+                    alias=f"step_{i + 1}",
+                    expr=ast.Call(
+                        name="if",
+                        args=[step_filter, ast.Constant(value=1), ast.Constant(value=0)],
+                    ),
+                )
+            )
+
+        return step_exprs
+
+    def _build_entity_metrics_cte(self) -> ast.SelectQuery:
+        """
+        Build entity_metrics CTE with funnel evaluation.
+
+        Uses aggregate_funnel_array UDF with exposure as step 0.
+        Includes matched_events_array for recording support.
+        """
+        # Ensure metric is ExperimentFunnelMetric (validated in parent constructor)
+        assert isinstance(self.metric, ExperimentFunnelMetric), "metric must be ExperimentFunnelMetric"
+
+        # Determine if unordered funnel (needs temporal filter)
+        is_unordered = self.metric.funnel_order_type == "unordered"
+        temporal_filter = "AND metric_events.timestamp >= exposures.first_exposure_time" if is_unordered else ""
+
+        # Build conversion window
+        if self.metric.conversion_window is not None and self.metric.conversion_window_unit is not None:
+            from posthog.hogql_queries.experiments.base_query_utils import conversion_window_to_seconds
+
+            conversion_window_seconds = conversion_window_to_seconds(
+                self.metric.conversion_window, self.metric.conversion_window_unit
+            )
+        else:
+            # Default to 3 years
+            conversion_window_seconds = 3 * 365 * 24 * 60 * 60
+
+        num_steps = len(self.metric.series) + 1  # +1 for exposure
+        funnel_order_type = self.metric.funnel_order_type or "ordered"
+
+        # Build step conditions for aggregate_funnel_array
+        step_conditions = [f"{i + 1} * metric_events.step_{i}" for i in range(num_steps)]
+        step_conditions_str = ", ".join(step_conditions)
+
+        # Build recordings support fields if requested
+        if self.include_recordings:
+            recordings_fields = """
+                groupArray(tuple(metric_events.timestamp, metric_events.uuid, metric_events.session_id, '')) as user_events,
+                mapFromArrays(arrayMap(x -> x.2, user_events), user_events) as user_events_map,
+                arraySort(x -> -x.1,
+                    aggregate_funnel_array(
+                        {num_steps},
+                        {conversion_window_seconds},
+                        'first_touch',
+                        '{funnel_order_type}',
+                        array(array('')),
+                        [],
+                        arraySort(t -> t.1, groupArray(tuple(
+                            toFloat(metric_events.timestamp),
+                            metric_events.uuid,
+                            array(''),
+                            arrayFilter(x -> x > 0, [{step_conditions_str}])
+                        )))
+                    )
+                )[1] as af_tuple,
+                af_tuple.1 as step_reached,
+                af_tuple.4 as matched_event_uuids_array_array,
+                arrayMap(matched_event_uuids_array -> arrayMap(event_uuid -> user_events_map[event_uuid], arrayDistinct(matched_event_uuids_array)), matched_event_uuids_array_array) as matched_events_array
+            """.format(
+                num_steps=num_steps,
+                conversion_window_seconds=conversion_window_seconds,
+                funnel_order_type=funnel_order_type,
+                step_conditions_str=step_conditions_str,
+            )
+        else:
+            # Without recordings, just compute step_reached using funnel_evaluation_expr
+            from posthog.hogql_queries.experiments.base_query_utils import funnel_evaluation_expr
+
+            funnel_agg_expr = funnel_evaluation_expr(
+                self.team,
+                self.metric,
+                events_alias="metric_events",
+                include_exposure=True,
+            )
+            # Extract step_reached from the funnel evaluation result
+            # The result is arraySort with tuple(step_reached, uuid_string)
+            # We want the .1 element which is step_reached
+            recordings_fields = ""
+
+        # Build the complete SELECT query
+        query = cast(
+            ast.SelectQuery,
+            parse_select(
+                f"""
+            SELECT
+                exposures.entity_id AS entity_id,
+                exposures.variant AS variant,
+                exposures.exposure_event_uuid AS exposure_event_uuid
+                {("," + recordings_fields) if recordings_fields else ""}
+            FROM exposures
+            LEFT JOIN metric_events
+                ON exposures.entity_id = metric_events.entity_id
+                {temporal_filter}
+            GROUP BY
+                exposures.entity_id,
+                exposures.variant,
+                exposures.exposure_event_uuid
+            """
+            ),
+        )
+
+        # If not including recordings, add step_reached using funnel_evaluation_expr
+        if not self.include_recordings:
+            query.select.append(
+                ast.Alias(
+                    alias="step_reached",
+                    expr=ast.TupleAccess(tuple=funnel_agg_expr, index=1, nullish=False),
+                )
+            )
+
+        return query
+
+    def _add_actors_selection(self, query: ast.SelectQuery) -> ast.SelectQuery:
+        """
+        Add actor-specific SELECT columns.
+
+        Returns entity_id, variant, and optionally matching_events for recordings support.
+        """
+        select_exprs: list[ast.Expr] = [
+            ast.Alias(alias="actor_id", expr=ast.Field(chain=["entity_id"])),
+            ast.Alias(alias="variant", expr=ast.Field(chain=["variant"])),
+        ]
+
+        # Add matching_events field only when recordings are requested
+        if self.include_recordings:
+            # For conversions and drop-offs, select events from the reached step
+            # step_reached is 0-indexed, so we add 1 to get the array index
+            select_exprs.append(
+                ast.Alias(
+                    alias="matching_events",
+                    expr=parse_expr("matched_events_array[step_reached + 1]"),
+                )
+            )
+
+        query.select = select_exprs
+        return query
+
+    def _add_actors_where_clause(self, query: ast.SelectQuery) -> ast.SelectQuery:
+        """
+        Add WHERE clause to filter to specific step and variant.
+
+        Mirrors the step filtering logic from FunnelBase._get_funnel_person_step_condition
+        """
+        conditions = []
+
+        # Filter by step
+        # NOTE: step_reached is 0-indexed and includes exposure as step 0
+        # - step_reached = 0: completed exposure only
+        # - step_reached = 1: completed exposure + first metric
+        # - step_reached = 2: completed exposure + first + second metric
+        # funnelStep is 1-indexed for metric steps (exposure is not counted):
+        # - funnelStep = 1: first metric step
+        # - funnelStep = 2: second metric step
+
+        if self.funnel_step >= 0:
+            # Conversion: user reached this step
+            # funnelStep=1 (first metric) requires step_reached >= 1 (exposure + first metric)
+            # funnelStep=2 (second metric) requires step_reached >= 2 (exposure + first + second metric)
+            # Formula: step_reached >= funnel_step
+            conditions.append(parse_expr(f"step_reached >= {self.funnel_step}"))
+        else:
+            # Drop-off: user reached prior step but NOT this step
+            # funnelStep=-2 means dropped at step 2: completed step 1 (first metric) but NOT step 2 (second metric)
+            # In step_reached terms: step_reached >= 1 AND step_reached < 2
+            # Formula for funnelStep=-N: step_reached >= (N-1) AND step_reached < N
+            target_step = abs(self.funnel_step)
+
+            conditions.append(parse_expr(f"step_reached >= {target_step - 1}"))
+            conditions.append(parse_expr(f"step_reached < {target_step}"))
+
+        # Filter by variant
+        if self.funnel_step_breakdown is not None:
+            if isinstance(self.funnel_step_breakdown, int | float):
+                variant_value = str(int(self.funnel_step_breakdown))
+            else:
+                variant_value = self.funnel_step_breakdown
+
+            conditions.append(
+                parse_expr(
+                    "variant = {variant}",
+                    {"variant": ast.Constant(value=variant_value)},
+                )
+            )
+
+        query.where = ast.And(exprs=conditions) if conditions else None
+        return query

--- a/posthog/hogql_queries/experiments/experiment_query_runner.py
+++ b/posthog/hogql_queries/experiments/experiment_query_runner.py
@@ -440,36 +440,23 @@ class ExperimentQueryRunner(QueryRunner):
 
     def to_actors_query(self) -> ast.SelectQuery:
         """
-        Generate actors query for experiment funnels.
+        Generate actors query for experiment funnels with exposure filtering.
 
-        This method reuses the existing funnel actors query infrastructure by:
-        1. Creating a FunnelsQuery-like structure from the ExperimentFunnelMetric
-        2. Building a FunnelQueryContext with the experiment parameters
-        3. Delegating to FunnelUDF.actor_query() which handles all the complexity
+        This method builds an actors query that applies the SAME temporal filtering
+        as the main experiment query by including exposure as step 0.
 
-        This ensures we get the same behavior as regular funnel actors queries,
-        including proper conversion/dropoff filtering and recording support.
+        Key differences from main query:
+        - Returns individual users instead of aggregate statistics
+        - Filters to specific step and variant
+        - Includes matched recordings when requested
 
-        IMPORTANT: Exposure step exclusion
-        --------------------------------------
-        The actors query funnel does NOT include the exposure step, only metric events.
+        The query structure mirrors the main experiment query:
+        - Step 0: Exposure event (filters events to only those AFTER exposure)
+        - Step 1-N: Metric events from funnel.series
 
-        Main experiment query (calculates conversion rates):
-            - Structure: Exposure (step 0) → Metric 1 (step 1) → Metric 2 (step 2)
-            - Includes exposure to enforce temporal ordering (only count events AFTER exposure)
-            - Returns highest step reached for each exposed user
-
-        Actors query (retrieves individual users):
-            - Structure: Metric 1 (step 1) → Metric 2 (step 2) - NO exposure
-            - Queries WITHIN the already-filtered exposed population
-            - Exposure filtering is inherited through variant breakdown
-
-        Frontend-to-backend step mapping:
-            - Frontend shows: Step 0 (Exposure), Step 1 (Metric 1), Step 2 (Metric 2)
-            - Backend actors query: Step 1 (Metric 1), Step 2 (Metric 2)
-            - Frontend step index maps directly to backend step number (stepIndex = backendStepNo)
+        This ensures counts match between funnel visualization and PersonModal.
         """
-        # Ensure actors_query is set (should be set by InsightActorsQueryRunner before calling this)
+        # Ensure actors_query is set
         if self.actors_query is None:
             raise ValidationError("actors_query must be set before calling to_actors_query()")
 
@@ -477,23 +464,19 @@ class ExperimentQueryRunner(QueryRunner):
         if not isinstance(self.metric, ExperimentFunnelMetric):
             raise ValidationError("Actors query only supported for funnel experiment metrics")
 
-        # Validate funnelStep for experiment funnels
-        # Experiment funnels have a unique structure: Exposure → Metric Events
-        # The actors query excludes exposure and only queries metric events
+        # Validate funnelStep
         funnel_step = self.actors_query.funnelStep
         if funnel_step is None:
             raise ValidationError("funnelStep is required for experiment actors query")
 
         num_metric_steps = len(self.metric.series)
 
+        # Validate step range (same validation as before)
         if funnel_step == -1:
-            # -1 would mean "dropped before first metric step" which is invalid
-            # because we only query exposed users who are already past the exposure checkpoint
-            # Build event names string (handle both EventsNode and ActionsNode)
             from posthog.schema import EventsNode
 
             event_names: list[str] = []
-            for step in self.metric.series[:2]:  # Show first 2 for brevity
+            for step in self.metric.series[:2]:
                 if isinstance(step, EventsNode):
                     event_names.append(step.event or "All events")
                 else:  # ActionsNode
@@ -518,7 +501,6 @@ class ExperimentQueryRunner(QueryRunner):
             )
 
         if funnel_step < -1:
-            # Check if drop-off step is out of range
             max_drop_off = -(num_metric_steps + 1)
             if funnel_step < max_drop_off:
                 raise ValidationError(
@@ -532,63 +514,72 @@ class ExperimentQueryRunner(QueryRunner):
                 f"Valid conversion steps: 1 (first metric step) to {num_metric_steps}."
             )
 
-        # Import here to avoid circular dependencies
-        from posthog.schema import BreakdownFilter, BreakdownType, FunnelsActorsQuery, FunnelsFilter, FunnelsQuery
+        # Extract exposure configuration from actors query
+        # Fall back to experiment exposure_criteria if not provided
+        from posthog.schema import ActionsNode, ExperimentEventExposureConfig
 
-        from posthog.hogql_queries.insights.funnels import FunnelUDF
-        from posthog.hogql_queries.insights.funnels.funnel_query_context import FunnelQueryContext
+        exposure_config: ExperimentEventExposureConfig | ActionsNode
+        if self.actors_query.exposureConfig is not None:
+            exposure_config = self.actors_query.exposureConfig
+        elif self.experiment.exposure_criteria and self.experiment.exposure_criteria.get("exposure_config"):
+            from posthog.hogql_queries.experiments.experiment_query_builder import normalize_to_exposure_criteria
 
-        # Build a FunnelsQuery from the experiment configuration
-        # This allows us to reuse all the existing funnel query infrastructure
-        # Note: We add breakdown by feature flag to enable variant filtering via funnelStepBreakdown
-        funnels_query = FunnelsQuery(
-            kind="FunnelsQuery",
-            series=self.metric.series,
-            dateRange=self.date_range,
-            filterTestAccounts=self.experiment.exposure_criteria.get("filterTestAccounts", True)
-            if self.experiment.exposure_criteria
-            else False,
-            funnelsFilter=FunnelsFilter(
-                funnelOrderType=self.metric.funnel_order_type,
-                funnelWindowInterval=self.metric.conversion_window or 14,
-                funnelWindowIntervalUnit=self.metric.conversion_window_unit,
-            ),
-            # Set aggregation group type if experiment uses groups
-            aggregation_group_type_index=self.group_type_index,
-            # CRITICAL: Add breakdown by feature flag to enable filtering by variant
-            # Without this, funnelStepBreakdown won't work to filter actors by variant
-            breakdownFilter=BreakdownFilter(
-                breakdown=f"$feature/{self.feature_flag.key}",
-                breakdown_type=BreakdownType.EVENT,
-            ),
+            criteria = normalize_to_exposure_criteria(self.experiment.exposure_criteria)
+            if criteria and criteria.exposure_config:
+                exposure_config = criteria.exposure_config
+            else:
+                # Default to $feature_flag_called
+                exposure_config = ExperimentEventExposureConfig(event="$feature_flag_called", properties=[])
+        else:
+            # Default to $feature_flag_called
+            exposure_config = ExperimentEventExposureConfig(event="$feature_flag_called", properties=[])
+
+        # Get multiple variant handling
+        if self.actors_query.multipleVariantHandling is not None:
+            multiple_variant_handling = self.actors_query.multipleVariantHandling
+        else:
+            multiple_variant_handling = self.multiple_variant_handling
+
+        # Get feature flag key
+        if self.actors_query.featureFlagKey:
+            feature_flag_key = self.actors_query.featureFlagKey
+        else:
+            feature_flag_key = self.feature_flag.key
+
+        # Import builder here to avoid circular dependencies
+        from posthog.hogql_queries.experiments.experiment_funnel_actors_query_builder import (
+            ExperimentFunnelActorsQueryBuilder,
         )
 
-        # Create a FunnelQueryContext
-        funnel_context = FunnelQueryContext(
-            query=funnels_query,
+        # Extract funnel_step_breakdown and ensure it's a simple type
+        funnel_step_breakdown_raw = self.actors_query.funnelStepBreakdown
+        if funnel_step_breakdown_raw is None:
+            funnel_step_breakdown: str | int | float = ""
+        elif isinstance(funnel_step_breakdown_raw, list):
+            # If it's a list, take the first element
+            funnel_step_breakdown = funnel_step_breakdown_raw[0] if funnel_step_breakdown_raw else ""
+        else:
+            funnel_step_breakdown = funnel_step_breakdown_raw
+
+        # Build the actors query using the same infrastructure as main query
+        builder = ExperimentFunnelActorsQueryBuilder(
             team=self.team,
-            timings=self.timings,
-            modifiers=self.modifiers,
-            limit_context=self.limit_context,
+            feature_flag_key=feature_flag_key,
+            exposure_config=exposure_config,
+            filter_test_accounts=self.experiment.exposure_criteria.get("filterTestAccounts", True)
+            if self.experiment.exposure_criteria
+            else True,
+            multiple_variant_handling=multiple_variant_handling,
+            variants=self.variants,
+            date_range_query=self.date_range_query,
+            entity_key=self.entity_key,
+            metric=self.metric,
+            funnel_step=funnel_step,
+            funnel_step_breakdown=funnel_step_breakdown,
+            include_recordings=self.actors_query.includeRecordings or False,
         )
 
-        # Adapt the ExperimentActorsQuery to FunnelsActorsQuery format
-        # This maps variant filtering (funnelStepBreakdown) to the breakdown system
-        funnel_actors_query = FunnelsActorsQuery(
-            kind="FunnelsActorsQuery",
-            source=funnels_query,
-            funnelStep=self.actors_query.funnelStep,
-            funnelStepBreakdown=self.actors_query.funnelStepBreakdown,  # Variant key
-            includeRecordings=self.actors_query.includeRecordings,
-        )
-
-        # Set the actors query on the context
-        funnel_context.actorsQuery = funnel_actors_query
-
-        # Use FunnelUDF to generate the actors query
-        # This is the same code path used by regular funnel actors queries
-        funnel_udf = FunnelUDF(context=funnel_context)
-        return funnel_udf.actor_query()
+        return builder.build_actors_query()
 
     def to_query(self) -> ast.SelectQuery:
         raise ValidationError(f"Cannot convert source query of type {self.query.metric.kind} to query")

--- a/posthog/hogql_queries/experiments/experiment_query_runner.py
+++ b/posthog/hogql_queries/experiments/experiment_query_runner.py
@@ -561,6 +561,20 @@ class ExperimentQueryRunner(QueryRunner):
         else:
             funnel_step_breakdown = funnel_step_breakdown_raw
 
+        # Add experiment-specific tags for monitoring and alerting
+        metric_name = self.metric.name or get_default_metric_title(self.metric.model_dump())
+        tag_queries(
+            product=Product.EXPERIMENTS,
+            experiment_id=self.experiment.id,
+            experiment_name=self.experiment.name,
+            experiment_feature_flag_key=feature_flag_key,
+            experiment_metric_uuid=self.metric.uuid,
+            experiment_metric_name=metric_name,
+            experiment_actors_query_step=funnel_step,
+            experiment_actors_query_variant=str(funnel_step_breakdown) if funnel_step_breakdown else "",
+            experiment_actors_query_includes_recordings=self.actors_query.includeRecordings or False,
+        )
+
         # Build the actors query using the same infrastructure as main query
         builder = ExperimentFunnelActorsQueryBuilder(
             team=self.team,

--- a/posthog/hogql_queries/experiments/experiment_query_runner.py
+++ b/posthog/hogql_queries/experiments/experiment_query_runner.py
@@ -582,7 +582,7 @@ class ExperimentQueryRunner(QueryRunner):
             exposure_config=exposure_config,
             filter_test_accounts=self.experiment.exposure_criteria.get("filterTestAccounts", True)
             if self.experiment.exposure_criteria
-            else True,
+            else False,
             multiple_variant_handling=multiple_variant_handling,
             variants=self.variants,
             date_range_query=self.date_range_query,

--- a/posthog/hogql_queries/experiments/test/__snapshots__/test_experiment_actors_query.ambr
+++ b/posthog/hogql_queries/experiments/test/__snapshots__/test_experiment_actors_query.ambr
@@ -21,7 +21,7 @@
            HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
         LEFT JOIN
           (SELECT person.id AS id,
-                  nullIf(nullIf(person.pmat_email, ''), 'null') AS properties___email
+                  replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'email'), ''), 'null'), '^"|"$', '') AS properties___email
            FROM person
            WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
                                                          (SELECT person.id AS id, max(person.version) AS version
@@ -101,7 +101,7 @@
            HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
         LEFT JOIN
           (SELECT person.id AS id,
-                  nullIf(nullIf(person.pmat_email, ''), 'null') AS properties___email
+                  replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'email'), ''), 'null'), '^"|"$', '') AS properties___email
            FROM person
            WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
                                                          (SELECT person.id AS id, max(person.version) AS version
@@ -181,7 +181,7 @@
            HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
         LEFT JOIN
           (SELECT person.id AS id,
-                  nullIf(nullIf(person.pmat_email, ''), 'null') AS properties___email
+                  replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'email'), ''), 'null'), '^"|"$', '') AS properties___email
            FROM person
            WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
                                                          (SELECT person.id AS id, max(person.version) AS version
@@ -261,7 +261,7 @@
            HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
         LEFT JOIN
           (SELECT person.id AS id,
-                  nullIf(nullIf(person.pmat_email, ''), 'null') AS properties___email
+                  replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'email'), ''), 'null'), '^"|"$', '') AS properties___email
            FROM person
            WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
                                                          (SELECT person.id AS id, max(person.version) AS version
@@ -341,7 +341,7 @@
            HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
         LEFT JOIN
           (SELECT person.id AS id,
-                  nullIf(nullIf(person.pmat_email, ''), 'null') AS properties___email
+                  replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'email'), ''), 'null'), '^"|"$', '') AS properties___email
            FROM person
            WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
                                                          (SELECT person.id AS id, max(person.version) AS version
@@ -421,7 +421,7 @@
            HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
         LEFT JOIN
           (SELECT person.id AS id,
-                  nullIf(nullIf(person.pmat_email, ''), 'null') AS properties___email
+                  replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'email'), ''), 'null'), '^"|"$', '') AS properties___email
            FROM person
            WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
                                                          (SELECT person.id AS id, max(person.version) AS version
@@ -501,7 +501,7 @@
            HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
         LEFT JOIN
           (SELECT person.id AS id,
-                  nullIf(nullIf(person.pmat_email, ''), 'null') AS properties___email
+                  replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'email'), ''), 'null'), '^"|"$', '') AS properties___email
            FROM person
            WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
                                                          (SELECT person.id AS id, max(person.version) AS version
@@ -582,7 +582,7 @@
            HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
         LEFT JOIN
           (SELECT person.id AS id,
-                  nullIf(nullIf(person.pmat_email, ''), 'null') AS properties___email
+                  replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'email'), ''), 'null'), '^"|"$', '') AS properties___email
            FROM person
            WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
                                                          (SELECT person.id AS id, max(person.version) AS version

--- a/posthog/hogql_queries/experiments/test/__snapshots__/test_experiment_actors_query.ambr
+++ b/posthog/hogql_queries/experiments/test/__snapshots__/test_experiment_actors_query.ambr
@@ -4,46 +4,65 @@
   SELECT source.id,
          source.id AS id
   FROM
-    (SELECT aggregation_target AS actor_id,
-            actor_id AS id
-     FROM
-       (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, arrayMap(x -> ifNull(x, ''), prop_basic), arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1)])))) AS events_array,
-               argMinIf(prop_basic, timestamp, notEmpty(arrayFilter(x -> notEmpty(x), prop_basic))) AS prop,
-               arrayJoin(aggregate_funnel_array(2, 1209600, 'first_touch', 'None', [if(empty(prop), [''], prop)], [], arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
-                                                                                                                                                                                                                    and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
-                                                                                                                                                                                                                                                    and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
-                                                                                                                                                                                                                                                                                   and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
-                                                                                                                                                                                                                                                                                                                   and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
-               af_tuple.1 AS step_reached,
-               plus(af_tuple.1, 1) AS steps,
-               af_tuple.2 AS breakdown,
-               af_tuple.3 AS timings,
-               af_tuple.5 AS steps_bitfield,
-               aggregation_target AS aggregation_target
-        FROM
-          (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                  if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
-                  e.uuid AS uuid,
-                  e.`$session_id` AS `$session_id`,
-                  e.`$window_id` AS `$window_id`,
-                  if(equals(e.event, 'signup'), 1, 0) AS step_0,
-                  if(equals(e.event, 'purchase'), 1, 0) AS step_1,
-                  [ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$feature/test-experiment'), ''), 'null'), '^"|"$', '')), '')] AS prop_basic,
-                  prop_basic AS prop
-           FROM events AS e
-           LEFT OUTER JOIN
-             (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
-                     person_distinct_id_overrides.distinct_id AS distinct_id
-              FROM person_distinct_id_overrides
-              WHERE equals(person_distinct_id_overrides.team_id, 99999)
-              GROUP BY person_distinct_id_overrides.distinct_id
-              HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-           WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('today', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))), in(e.event, tuple('purchase', 'signup'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))
-        GROUP BY aggregation_target
-        HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
-     WHERE and(bitTest(steps_bitfield, 0), ifNull(equals(arrayFlatten(array(breakdown)), arrayFlatten(array('control'))), isNull(arrayFlatten(array(breakdown)))
-                                                  and isNull(arrayFlatten(array('control')))))
-     ORDER BY aggregation_target ASC SETTINGS join_algorithm='auto') AS source
+    (WITH exposures AS
+       (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS entity_id,
+               if(ifNull(greater(uniqExact(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', '')), 1), 0), '$multiple', any(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', ''))) AS variant,
+               min(toTimeZone(events.timestamp, 'UTC')) AS first_exposure_time,
+               max(toTimeZone(events.timestamp, 'UTC')) AS last_exposure_time,
+               argMin(events.uuid, toTimeZone(events.timestamp, 'UTC')) AS exposure_event_uuid,
+               argMin(events.`$session_id`, toTimeZone(events.timestamp, 'UTC')) AS exposure_session_id
+        FROM events
+        LEFT OUTER JOIN
+          (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
+                  person_distinct_id_overrides.distinct_id AS distinct_id
+           FROM person_distinct_id_overrides
+           WHERE equals(person_distinct_id_overrides.team_id, 99999)
+           GROUP BY person_distinct_id_overrides.distinct_id
+           HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+        LEFT JOIN
+          (SELECT person.id AS id,
+                  nullIf(nullIf(person.pmat_email, ''), 'null') AS properties___email
+           FROM person
+           WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
+                                                         (SELECT person.id AS id, max(person.version) AS version
+                                                          FROM person
+                                                          WHERE equals(person.team_id, 99999)
+                                                          GROUP BY person.id
+                                                          HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0))))) SETTINGS optimize_aggregation_in_order=1) AS events__person ON equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), events__person.id)
+        WHERE and(equals(events.team_id, 99999), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2020-01-01 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2020-01-15 12:00:00', 'UTC'))), and(equals(events.event, '$feature_flag_called'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag'), ''), 'null'), '^"|"$', ''), 'test-experiment'), 0)), ifNull(notILike(toString(events__person.properties___email), '%@posthog.com%'), 1), in(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', ''), ['control', 'test']))
+        GROUP BY entity_id),
+          metric_events AS
+       (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS entity_id,
+               toTimeZone(events.timestamp, 'UTC') AS timestamp,
+               events.uuid AS uuid,
+               nullIf(nullIf(events.`$session_id`, ''), 'null') AS session_id,
+               multiply(1, and(equals(events.event, '$feature_flag_called'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag'), ''), 'null'), '^"|"$', ''), 'test-experiment'), 0))) AS step_0,
+               if(equals(events.event, 'signup'), 1, 0) AS step_1,
+               if(equals(events.event, 'purchase'), 1, 0) AS step_2
+        FROM events
+        LEFT OUTER JOIN
+          (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
+                  person_distinct_id_overrides.distinct_id AS distinct_id
+           FROM person_distinct_id_overrides
+           WHERE equals(person_distinct_id_overrides.team_id, 99999)
+           GROUP BY person_distinct_id_overrides.distinct_id
+           HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+        WHERE and(equals(events.team_id, 99999), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2020-01-01 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2020-01-15 12:00:00', 'UTC'))), or(and(equals(events.event, '$feature_flag_called'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag'), ''), 'null'), '^"|"$', ''), 'test-experiment'), 0)), or(equals(events.event, 'signup'), equals(events.event, 'purchase'))))),
+          entity_metrics AS
+       (SELECT exposures.entity_id AS entity_id,
+               exposures.variant AS variant,
+               exposures.exposure_event_uuid AS exposure_event_uuid,
+               (arraySort(x -> minus(0, x.1), arrayMap(result -> tuple(result.1, if(and(ifNull(greaterOrEquals(result.1, 0), 0), ifNull(greater(length(result.4), result.1), 0)), if(ifNull(greater(length(arrayElement(result.4, plus(result.1, 1))), 0), 0), toString(arrayElement(result.4, plus(result.1, 1))[1]), ''), '')), aggregate_funnel_array(3, 94608000, 'first_touch', 'ordered', array(array('')), [], arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(toTimeZone(metric_events.timestamp, 'UTC'), 'Float64'), metric_events.uuid, array(''), arrayFilter(x -> ifNull(greater(x, 0), 0), [multiply(1, metric_events.step_0), multiply(2, metric_events.step_1), multiply(3, metric_events.step_2)])))))))[1]).1 AS step_reached
+        FROM exposures
+        LEFT JOIN metric_events ON equals(exposures.entity_id, metric_events.entity_id)
+        GROUP BY exposures.entity_id,
+                 exposures.variant,
+                 exposures.exposure_event_uuid) SELECT entity_metrics.entity_id AS actor_id,
+                                                       entity_metrics.variant AS variant,
+                                                       actor_id AS id
+     FROM entity_metrics
+     WHERE and(ifNull(greaterOrEquals(entity_metrics.step_reached, 1), 0), ifNull(equals(variant, 'control'), 0))
+     ORDER BY entity_metrics.entity_id ASC) AS source
   ORDER BY source.id ASC
   LIMIT 101
   OFFSET 0 SETTINGS optimize_aggregation_in_order=1,
@@ -65,46 +84,65 @@
   SELECT source.id,
          source.id AS id
   FROM
-    (SELECT aggregation_target AS actor_id,
-            actor_id AS id
-     FROM
-       (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, arrayMap(x -> ifNull(x, ''), prop_basic), arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1)])))) AS events_array,
-               argMinIf(prop_basic, timestamp, notEmpty(arrayFilter(x -> notEmpty(x), prop_basic))) AS prop,
-               arrayJoin(aggregate_funnel_array(2, 1209600, 'first_touch', 'None', [if(empty(prop), [''], prop)], [], arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
-                                                                                                                                                                                                                    and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
-                                                                                                                                                                                                                                                    and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
-                                                                                                                                                                                                                                                                                   and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
-                                                                                                                                                                                                                                                                                                                   and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
-               af_tuple.1 AS step_reached,
-               plus(af_tuple.1, 1) AS steps,
-               af_tuple.2 AS breakdown,
-               af_tuple.3 AS timings,
-               af_tuple.5 AS steps_bitfield,
-               aggregation_target AS aggregation_target
-        FROM
-          (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                  if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
-                  e.uuid AS uuid,
-                  e.`$session_id` AS `$session_id`,
-                  e.`$window_id` AS `$window_id`,
-                  if(equals(e.event, 'signup'), 1, 0) AS step_0,
-                  if(equals(e.event, 'purchase'), 1, 0) AS step_1,
-                  [ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$feature/test-experiment'), ''), 'null'), '^"|"$', '')), '')] AS prop_basic,
-                  prop_basic AS prop
-           FROM events AS e
-           LEFT OUTER JOIN
-             (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
-                     person_distinct_id_overrides.distinct_id AS distinct_id
-              FROM person_distinct_id_overrides
-              WHERE equals(person_distinct_id_overrides.team_id, 99999)
-              GROUP BY person_distinct_id_overrides.distinct_id
-              HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-           WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('today', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))), in(e.event, tuple('purchase', 'signup'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))
-        GROUP BY aggregation_target
-        HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
-     WHERE and(bitTest(steps_bitfield, 1), ifNull(equals(arrayFlatten(array(breakdown)), arrayFlatten(array('control'))), isNull(arrayFlatten(array(breakdown)))
-                                                  and isNull(arrayFlatten(array('control')))))
-     ORDER BY aggregation_target ASC SETTINGS join_algorithm='auto') AS source
+    (WITH exposures AS
+       (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS entity_id,
+               if(ifNull(greater(uniqExact(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', '')), 1), 0), '$multiple', any(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', ''))) AS variant,
+               min(toTimeZone(events.timestamp, 'UTC')) AS first_exposure_time,
+               max(toTimeZone(events.timestamp, 'UTC')) AS last_exposure_time,
+               argMin(events.uuid, toTimeZone(events.timestamp, 'UTC')) AS exposure_event_uuid,
+               argMin(events.`$session_id`, toTimeZone(events.timestamp, 'UTC')) AS exposure_session_id
+        FROM events
+        LEFT OUTER JOIN
+          (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
+                  person_distinct_id_overrides.distinct_id AS distinct_id
+           FROM person_distinct_id_overrides
+           WHERE equals(person_distinct_id_overrides.team_id, 99999)
+           GROUP BY person_distinct_id_overrides.distinct_id
+           HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+        LEFT JOIN
+          (SELECT person.id AS id,
+                  nullIf(nullIf(person.pmat_email, ''), 'null') AS properties___email
+           FROM person
+           WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
+                                                         (SELECT person.id AS id, max(person.version) AS version
+                                                          FROM person
+                                                          WHERE equals(person.team_id, 99999)
+                                                          GROUP BY person.id
+                                                          HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0))))) SETTINGS optimize_aggregation_in_order=1) AS events__person ON equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), events__person.id)
+        WHERE and(equals(events.team_id, 99999), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2020-01-01 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2020-01-15 12:00:00', 'UTC'))), and(equals(events.event, '$feature_flag_called'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag'), ''), 'null'), '^"|"$', ''), 'test-experiment'), 0)), ifNull(notILike(toString(events__person.properties___email), '%@posthog.com%'), 1), in(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', ''), ['control', 'test']))
+        GROUP BY entity_id),
+          metric_events AS
+       (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS entity_id,
+               toTimeZone(events.timestamp, 'UTC') AS timestamp,
+               events.uuid AS uuid,
+               nullIf(nullIf(events.`$session_id`, ''), 'null') AS session_id,
+               multiply(1, and(equals(events.event, '$feature_flag_called'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag'), ''), 'null'), '^"|"$', ''), 'test-experiment'), 0))) AS step_0,
+               if(equals(events.event, 'signup'), 1, 0) AS step_1,
+               if(equals(events.event, 'purchase'), 1, 0) AS step_2
+        FROM events
+        LEFT OUTER JOIN
+          (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
+                  person_distinct_id_overrides.distinct_id AS distinct_id
+           FROM person_distinct_id_overrides
+           WHERE equals(person_distinct_id_overrides.team_id, 99999)
+           GROUP BY person_distinct_id_overrides.distinct_id
+           HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+        WHERE and(equals(events.team_id, 99999), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2020-01-01 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2020-01-15 12:00:00', 'UTC'))), or(and(equals(events.event, '$feature_flag_called'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag'), ''), 'null'), '^"|"$', ''), 'test-experiment'), 0)), or(equals(events.event, 'signup'), equals(events.event, 'purchase'))))),
+          entity_metrics AS
+       (SELECT exposures.entity_id AS entity_id,
+               exposures.variant AS variant,
+               exposures.exposure_event_uuid AS exposure_event_uuid,
+               (arraySort(x -> minus(0, x.1), arrayMap(result -> tuple(result.1, if(and(ifNull(greaterOrEquals(result.1, 0), 0), ifNull(greater(length(result.4), result.1), 0)), if(ifNull(greater(length(arrayElement(result.4, plus(result.1, 1))), 0), 0), toString(arrayElement(result.4, plus(result.1, 1))[1]), ''), '')), aggregate_funnel_array(3, 94608000, 'first_touch', 'ordered', array(array('')), [], arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(toTimeZone(metric_events.timestamp, 'UTC'), 'Float64'), metric_events.uuid, array(''), arrayFilter(x -> ifNull(greater(x, 0), 0), [multiply(1, metric_events.step_0), multiply(2, metric_events.step_1), multiply(3, metric_events.step_2)])))))))[1]).1 AS step_reached
+        FROM exposures
+        LEFT JOIN metric_events ON equals(exposures.entity_id, metric_events.entity_id)
+        GROUP BY exposures.entity_id,
+                 exposures.variant,
+                 exposures.exposure_event_uuid) SELECT entity_metrics.entity_id AS actor_id,
+                                                       entity_metrics.variant AS variant,
+                                                       actor_id AS id
+     FROM entity_metrics
+     WHERE and(ifNull(greaterOrEquals(entity_metrics.step_reached, 2), 0), ifNull(equals(variant, 'control'), 0))
+     ORDER BY entity_metrics.entity_id ASC) AS source
   ORDER BY source.id ASC
   LIMIT 101
   OFFSET 0 SETTINGS optimize_aggregation_in_order=1,
@@ -126,46 +164,65 @@
   SELECT source.id,
          source.id AS id
   FROM
-    (SELECT aggregation_target AS actor_id,
-            actor_id AS id
-     FROM
-       (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, arrayMap(x -> ifNull(x, ''), prop_basic), arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1)])))) AS events_array,
-               argMinIf(prop_basic, timestamp, notEmpty(arrayFilter(x -> notEmpty(x), prop_basic))) AS prop,
-               arrayJoin(aggregate_funnel_array(2, 1209600, 'first_touch', 'None', [if(empty(prop), [''], prop)], [], arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
-                                                                                                                                                                                                                    and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
-                                                                                                                                                                                                                                                    and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
-                                                                                                                                                                                                                                                                                   and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
-                                                                                                                                                                                                                                                                                                                   and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
-               af_tuple.1 AS step_reached,
-               plus(af_tuple.1, 1) AS steps,
-               af_tuple.2 AS breakdown,
-               af_tuple.3 AS timings,
-               af_tuple.5 AS steps_bitfield,
-               aggregation_target AS aggregation_target
-        FROM
-          (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                  if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
-                  e.uuid AS uuid,
-                  e.`$session_id` AS `$session_id`,
-                  e.`$window_id` AS `$window_id`,
-                  if(equals(e.event, 'signup'), 1, 0) AS step_0,
-                  if(equals(e.event, 'purchase'), 1, 0) AS step_1,
-                  [ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$feature/test-experiment'), ''), 'null'), '^"|"$', '')), '')] AS prop_basic,
-                  prop_basic AS prop
-           FROM events AS e
-           LEFT OUTER JOIN
-             (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
-                     person_distinct_id_overrides.distinct_id AS distinct_id
-              FROM person_distinct_id_overrides
-              WHERE equals(person_distinct_id_overrides.team_id, 99999)
-              GROUP BY person_distinct_id_overrides.distinct_id
-              HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-           WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('today', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))), in(e.event, tuple('purchase', 'signup'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))
-        GROUP BY aggregation_target
-        HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
-     WHERE and(bitTest(steps_bitfield, 0), not(bitTest(steps_bitfield, 1)), ifNull(equals(arrayFlatten(array(breakdown)), arrayFlatten(array('control'))), isNull(arrayFlatten(array(breakdown)))
-                                                                                   and isNull(arrayFlatten(array('control')))))
-     ORDER BY aggregation_target ASC SETTINGS join_algorithm='auto') AS source
+    (WITH exposures AS
+       (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS entity_id,
+               if(ifNull(greater(uniqExact(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', '')), 1), 0), '$multiple', any(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', ''))) AS variant,
+               min(toTimeZone(events.timestamp, 'UTC')) AS first_exposure_time,
+               max(toTimeZone(events.timestamp, 'UTC')) AS last_exposure_time,
+               argMin(events.uuid, toTimeZone(events.timestamp, 'UTC')) AS exposure_event_uuid,
+               argMin(events.`$session_id`, toTimeZone(events.timestamp, 'UTC')) AS exposure_session_id
+        FROM events
+        LEFT OUTER JOIN
+          (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
+                  person_distinct_id_overrides.distinct_id AS distinct_id
+           FROM person_distinct_id_overrides
+           WHERE equals(person_distinct_id_overrides.team_id, 99999)
+           GROUP BY person_distinct_id_overrides.distinct_id
+           HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+        LEFT JOIN
+          (SELECT person.id AS id,
+                  nullIf(nullIf(person.pmat_email, ''), 'null') AS properties___email
+           FROM person
+           WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
+                                                         (SELECT person.id AS id, max(person.version) AS version
+                                                          FROM person
+                                                          WHERE equals(person.team_id, 99999)
+                                                          GROUP BY person.id
+                                                          HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0))))) SETTINGS optimize_aggregation_in_order=1) AS events__person ON equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), events__person.id)
+        WHERE and(equals(events.team_id, 99999), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2020-01-01 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2020-01-15 12:00:00', 'UTC'))), and(equals(events.event, '$feature_flag_called'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag'), ''), 'null'), '^"|"$', ''), 'test-experiment'), 0)), ifNull(notILike(toString(events__person.properties___email), '%@posthog.com%'), 1), in(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', ''), ['control', 'test']))
+        GROUP BY entity_id),
+          metric_events AS
+       (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS entity_id,
+               toTimeZone(events.timestamp, 'UTC') AS timestamp,
+               events.uuid AS uuid,
+               nullIf(nullIf(events.`$session_id`, ''), 'null') AS session_id,
+               multiply(1, and(equals(events.event, '$feature_flag_called'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag'), ''), 'null'), '^"|"$', ''), 'test-experiment'), 0))) AS step_0,
+               if(equals(events.event, 'signup'), 1, 0) AS step_1,
+               if(equals(events.event, 'purchase'), 1, 0) AS step_2
+        FROM events
+        LEFT OUTER JOIN
+          (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
+                  person_distinct_id_overrides.distinct_id AS distinct_id
+           FROM person_distinct_id_overrides
+           WHERE equals(person_distinct_id_overrides.team_id, 99999)
+           GROUP BY person_distinct_id_overrides.distinct_id
+           HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+        WHERE and(equals(events.team_id, 99999), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2020-01-01 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2020-01-15 12:00:00', 'UTC'))), or(and(equals(events.event, '$feature_flag_called'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag'), ''), 'null'), '^"|"$', ''), 'test-experiment'), 0)), or(equals(events.event, 'signup'), equals(events.event, 'purchase'))))),
+          entity_metrics AS
+       (SELECT exposures.entity_id AS entity_id,
+               exposures.variant AS variant,
+               exposures.exposure_event_uuid AS exposure_event_uuid,
+               (arraySort(x -> minus(0, x.1), arrayMap(result -> tuple(result.1, if(and(ifNull(greaterOrEquals(result.1, 0), 0), ifNull(greater(length(result.4), result.1), 0)), if(ifNull(greater(length(arrayElement(result.4, plus(result.1, 1))), 0), 0), toString(arrayElement(result.4, plus(result.1, 1))[1]), ''), '')), aggregate_funnel_array(3, 94608000, 'first_touch', 'ordered', array(array('')), [], arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(toTimeZone(metric_events.timestamp, 'UTC'), 'Float64'), metric_events.uuid, array(''), arrayFilter(x -> ifNull(greater(x, 0), 0), [multiply(1, metric_events.step_0), multiply(2, metric_events.step_1), multiply(3, metric_events.step_2)])))))))[1]).1 AS step_reached
+        FROM exposures
+        LEFT JOIN metric_events ON equals(exposures.entity_id, metric_events.entity_id)
+        GROUP BY exposures.entity_id,
+                 exposures.variant,
+                 exposures.exposure_event_uuid) SELECT entity_metrics.entity_id AS actor_id,
+                                                       entity_metrics.variant AS variant,
+                                                       actor_id AS id
+     FROM entity_metrics
+     WHERE and(ifNull(greaterOrEquals(entity_metrics.step_reached, 1), 0), ifNull(less(entity_metrics.step_reached, 2), 0), ifNull(equals(variant, 'control'), 0))
+     ORDER BY entity_metrics.entity_id ASC) AS source
   ORDER BY source.id ASC
   LIMIT 101
   OFFSET 0 SETTINGS optimize_aggregation_in_order=1,
@@ -187,46 +244,65 @@
   SELECT source.id,
          source.id AS id
   FROM
-    (SELECT aggregation_target AS actor_id,
-            actor_id AS id
-     FROM
-       (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, arrayMap(x -> ifNull(x, ''), prop_basic), arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1)])))) AS events_array,
-               argMinIf(prop_basic, timestamp, notEmpty(arrayFilter(x -> notEmpty(x), prop_basic))) AS prop,
-               arrayJoin(aggregate_funnel_array(2, 1209600, 'first_touch', 'None', [if(empty(prop), [''], prop)], [], arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
-                                                                                                                                                                                                                    and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
-                                                                                                                                                                                                                                                    and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
-                                                                                                                                                                                                                                                                                   and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
-                                                                                                                                                                                                                                                                                                                   and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
-               af_tuple.1 AS step_reached,
-               plus(af_tuple.1, 1) AS steps,
-               af_tuple.2 AS breakdown,
-               af_tuple.3 AS timings,
-               af_tuple.5 AS steps_bitfield,
-               aggregation_target AS aggregation_target
-        FROM
-          (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                  if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
-                  e.uuid AS uuid,
-                  e.`$session_id` AS `$session_id`,
-                  e.`$window_id` AS `$window_id`,
-                  if(equals(e.event, 'signup'), 1, 0) AS step_0,
-                  if(equals(e.event, 'purchase'), 1, 0) AS step_1,
-                  [ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$feature/test-experiment'), ''), 'null'), '^"|"$', '')), '')] AS prop_basic,
-                  prop_basic AS prop
-           FROM events AS e
-           LEFT OUTER JOIN
-             (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
-                     person_distinct_id_overrides.distinct_id AS distinct_id
-              FROM person_distinct_id_overrides
-              WHERE equals(person_distinct_id_overrides.team_id, 99999)
-              GROUP BY person_distinct_id_overrides.distinct_id
-              HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-           WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('today', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))), in(e.event, tuple('purchase', 'signup'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))
-        GROUP BY aggregation_target
-        HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
-     WHERE and(bitTest(steps_bitfield, 0), ifNull(equals(arrayFlatten(array(breakdown)), arrayFlatten(array('test'))), isNull(arrayFlatten(array(breakdown)))
-                                                  and isNull(arrayFlatten(array('test')))))
-     ORDER BY aggregation_target ASC SETTINGS join_algorithm='auto') AS source
+    (WITH exposures AS
+       (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS entity_id,
+               if(ifNull(greater(uniqExact(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', '')), 1), 0), '$multiple', any(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', ''))) AS variant,
+               min(toTimeZone(events.timestamp, 'UTC')) AS first_exposure_time,
+               max(toTimeZone(events.timestamp, 'UTC')) AS last_exposure_time,
+               argMin(events.uuid, toTimeZone(events.timestamp, 'UTC')) AS exposure_event_uuid,
+               argMin(events.`$session_id`, toTimeZone(events.timestamp, 'UTC')) AS exposure_session_id
+        FROM events
+        LEFT OUTER JOIN
+          (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
+                  person_distinct_id_overrides.distinct_id AS distinct_id
+           FROM person_distinct_id_overrides
+           WHERE equals(person_distinct_id_overrides.team_id, 99999)
+           GROUP BY person_distinct_id_overrides.distinct_id
+           HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+        LEFT JOIN
+          (SELECT person.id AS id,
+                  nullIf(nullIf(person.pmat_email, ''), 'null') AS properties___email
+           FROM person
+           WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
+                                                         (SELECT person.id AS id, max(person.version) AS version
+                                                          FROM person
+                                                          WHERE equals(person.team_id, 99999)
+                                                          GROUP BY person.id
+                                                          HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0))))) SETTINGS optimize_aggregation_in_order=1) AS events__person ON equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), events__person.id)
+        WHERE and(equals(events.team_id, 99999), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2020-01-01 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2020-01-15 12:00:00', 'UTC'))), and(equals(events.event, '$feature_flag_called'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag'), ''), 'null'), '^"|"$', ''), 'test-experiment'), 0)), ifNull(notILike(toString(events__person.properties___email), '%@posthog.com%'), 1), in(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', ''), ['control', 'test']))
+        GROUP BY entity_id),
+          metric_events AS
+       (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS entity_id,
+               toTimeZone(events.timestamp, 'UTC') AS timestamp,
+               events.uuid AS uuid,
+               nullIf(nullIf(events.`$session_id`, ''), 'null') AS session_id,
+               multiply(1, and(equals(events.event, '$feature_flag_called'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag'), ''), 'null'), '^"|"$', ''), 'test-experiment'), 0))) AS step_0,
+               if(equals(events.event, 'signup'), 1, 0) AS step_1,
+               if(equals(events.event, 'purchase'), 1, 0) AS step_2
+        FROM events
+        LEFT OUTER JOIN
+          (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
+                  person_distinct_id_overrides.distinct_id AS distinct_id
+           FROM person_distinct_id_overrides
+           WHERE equals(person_distinct_id_overrides.team_id, 99999)
+           GROUP BY person_distinct_id_overrides.distinct_id
+           HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+        WHERE and(equals(events.team_id, 99999), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2020-01-01 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2020-01-15 12:00:00', 'UTC'))), or(and(equals(events.event, '$feature_flag_called'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag'), ''), 'null'), '^"|"$', ''), 'test-experiment'), 0)), or(equals(events.event, 'signup'), equals(events.event, 'purchase'))))),
+          entity_metrics AS
+       (SELECT exposures.entity_id AS entity_id,
+               exposures.variant AS variant,
+               exposures.exposure_event_uuid AS exposure_event_uuid,
+               (arraySort(x -> minus(0, x.1), arrayMap(result -> tuple(result.1, if(and(ifNull(greaterOrEquals(result.1, 0), 0), ifNull(greater(length(result.4), result.1), 0)), if(ifNull(greater(length(arrayElement(result.4, plus(result.1, 1))), 0), 0), toString(arrayElement(result.4, plus(result.1, 1))[1]), ''), '')), aggregate_funnel_array(3, 94608000, 'first_touch', 'ordered', array(array('')), [], arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(toTimeZone(metric_events.timestamp, 'UTC'), 'Float64'), metric_events.uuid, array(''), arrayFilter(x -> ifNull(greater(x, 0), 0), [multiply(1, metric_events.step_0), multiply(2, metric_events.step_1), multiply(3, metric_events.step_2)])))))))[1]).1 AS step_reached
+        FROM exposures
+        LEFT JOIN metric_events ON equals(exposures.entity_id, metric_events.entity_id)
+        GROUP BY exposures.entity_id,
+                 exposures.variant,
+                 exposures.exposure_event_uuid) SELECT entity_metrics.entity_id AS actor_id,
+                                                       entity_metrics.variant AS variant,
+                                                       actor_id AS id
+     FROM entity_metrics
+     WHERE and(ifNull(greaterOrEquals(entity_metrics.step_reached, 1), 0), ifNull(equals(variant, 'test'), 0))
+     ORDER BY entity_metrics.entity_id ASC) AS source
   ORDER BY source.id ASC
   LIMIT 101
   OFFSET 0 SETTINGS optimize_aggregation_in_order=1,
@@ -248,46 +324,65 @@
   SELECT source.id,
          source.id AS id
   FROM
-    (SELECT aggregation_target AS actor_id,
-            actor_id AS id
-     FROM
-       (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, arrayMap(x -> ifNull(x, ''), prop_basic), arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1)])))) AS events_array,
-               argMinIf(prop_basic, timestamp, notEmpty(arrayFilter(x -> notEmpty(x), prop_basic))) AS prop,
-               arrayJoin(aggregate_funnel_array(2, 1209600, 'first_touch', 'None', [if(empty(prop), [''], prop)], [], arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
-                                                                                                                                                                                                                    and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
-                                                                                                                                                                                                                                                    and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
-                                                                                                                                                                                                                                                                                   and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
-                                                                                                                                                                                                                                                                                                                   and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
-               af_tuple.1 AS step_reached,
-               plus(af_tuple.1, 1) AS steps,
-               af_tuple.2 AS breakdown,
-               af_tuple.3 AS timings,
-               af_tuple.5 AS steps_bitfield,
-               aggregation_target AS aggregation_target
-        FROM
-          (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                  if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
-                  e.uuid AS uuid,
-                  e.`$session_id` AS `$session_id`,
-                  e.`$window_id` AS `$window_id`,
-                  if(equals(e.event, 'signup'), 1, 0) AS step_0,
-                  if(equals(e.event, 'purchase'), 1, 0) AS step_1,
-                  [ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$feature/test-experiment'), ''), 'null'), '^"|"$', '')), '')] AS prop_basic,
-                  prop_basic AS prop
-           FROM events AS e
-           LEFT OUTER JOIN
-             (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
-                     person_distinct_id_overrides.distinct_id AS distinct_id
-              FROM person_distinct_id_overrides
-              WHERE equals(person_distinct_id_overrides.team_id, 99999)
-              GROUP BY person_distinct_id_overrides.distinct_id
-              HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-           WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('today', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))), in(e.event, tuple('purchase', 'signup'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))
-        GROUP BY aggregation_target
-        HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
-     WHERE and(bitTest(steps_bitfield, 1), ifNull(equals(arrayFlatten(array(breakdown)), arrayFlatten(array('test'))), isNull(arrayFlatten(array(breakdown)))
-                                                  and isNull(arrayFlatten(array('test')))))
-     ORDER BY aggregation_target ASC SETTINGS join_algorithm='auto') AS source
+    (WITH exposures AS
+       (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS entity_id,
+               if(ifNull(greater(uniqExact(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', '')), 1), 0), '$multiple', any(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', ''))) AS variant,
+               min(toTimeZone(events.timestamp, 'UTC')) AS first_exposure_time,
+               max(toTimeZone(events.timestamp, 'UTC')) AS last_exposure_time,
+               argMin(events.uuid, toTimeZone(events.timestamp, 'UTC')) AS exposure_event_uuid,
+               argMin(events.`$session_id`, toTimeZone(events.timestamp, 'UTC')) AS exposure_session_id
+        FROM events
+        LEFT OUTER JOIN
+          (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
+                  person_distinct_id_overrides.distinct_id AS distinct_id
+           FROM person_distinct_id_overrides
+           WHERE equals(person_distinct_id_overrides.team_id, 99999)
+           GROUP BY person_distinct_id_overrides.distinct_id
+           HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+        LEFT JOIN
+          (SELECT person.id AS id,
+                  nullIf(nullIf(person.pmat_email, ''), 'null') AS properties___email
+           FROM person
+           WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
+                                                         (SELECT person.id AS id, max(person.version) AS version
+                                                          FROM person
+                                                          WHERE equals(person.team_id, 99999)
+                                                          GROUP BY person.id
+                                                          HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0))))) SETTINGS optimize_aggregation_in_order=1) AS events__person ON equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), events__person.id)
+        WHERE and(equals(events.team_id, 99999), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2020-01-01 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2020-01-15 12:00:00', 'UTC'))), and(equals(events.event, '$feature_flag_called'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag'), ''), 'null'), '^"|"$', ''), 'test-experiment'), 0)), ifNull(notILike(toString(events__person.properties___email), '%@posthog.com%'), 1), in(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', ''), ['control', 'test']))
+        GROUP BY entity_id),
+          metric_events AS
+       (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS entity_id,
+               toTimeZone(events.timestamp, 'UTC') AS timestamp,
+               events.uuid AS uuid,
+               nullIf(nullIf(events.`$session_id`, ''), 'null') AS session_id,
+               multiply(1, and(equals(events.event, '$feature_flag_called'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag'), ''), 'null'), '^"|"$', ''), 'test-experiment'), 0))) AS step_0,
+               if(equals(events.event, 'signup'), 1, 0) AS step_1,
+               if(equals(events.event, 'purchase'), 1, 0) AS step_2
+        FROM events
+        LEFT OUTER JOIN
+          (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
+                  person_distinct_id_overrides.distinct_id AS distinct_id
+           FROM person_distinct_id_overrides
+           WHERE equals(person_distinct_id_overrides.team_id, 99999)
+           GROUP BY person_distinct_id_overrides.distinct_id
+           HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+        WHERE and(equals(events.team_id, 99999), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2020-01-01 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2020-01-15 12:00:00', 'UTC'))), or(and(equals(events.event, '$feature_flag_called'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag'), ''), 'null'), '^"|"$', ''), 'test-experiment'), 0)), or(equals(events.event, 'signup'), equals(events.event, 'purchase'))))),
+          entity_metrics AS
+       (SELECT exposures.entity_id AS entity_id,
+               exposures.variant AS variant,
+               exposures.exposure_event_uuid AS exposure_event_uuid,
+               (arraySort(x -> minus(0, x.1), arrayMap(result -> tuple(result.1, if(and(ifNull(greaterOrEquals(result.1, 0), 0), ifNull(greater(length(result.4), result.1), 0)), if(ifNull(greater(length(arrayElement(result.4, plus(result.1, 1))), 0), 0), toString(arrayElement(result.4, plus(result.1, 1))[1]), ''), '')), aggregate_funnel_array(3, 94608000, 'first_touch', 'ordered', array(array('')), [], arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(toTimeZone(metric_events.timestamp, 'UTC'), 'Float64'), metric_events.uuid, array(''), arrayFilter(x -> ifNull(greater(x, 0), 0), [multiply(1, metric_events.step_0), multiply(2, metric_events.step_1), multiply(3, metric_events.step_2)])))))))[1]).1 AS step_reached
+        FROM exposures
+        LEFT JOIN metric_events ON equals(exposures.entity_id, metric_events.entity_id)
+        GROUP BY exposures.entity_id,
+                 exposures.variant,
+                 exposures.exposure_event_uuid) SELECT entity_metrics.entity_id AS actor_id,
+                                                       entity_metrics.variant AS variant,
+                                                       actor_id AS id
+     FROM entity_metrics
+     WHERE and(ifNull(greaterOrEquals(entity_metrics.step_reached, 2), 0), ifNull(equals(variant, 'test'), 0))
+     ORDER BY entity_metrics.entity_id ASC) AS source
   ORDER BY source.id ASC
   LIMIT 101
   OFFSET 0 SETTINGS optimize_aggregation_in_order=1,
@@ -309,46 +404,145 @@
   SELECT source.id,
          source.id AS id
   FROM
-    (SELECT aggregation_target AS actor_id,
-            actor_id AS id
-     FROM
-       (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, arrayMap(x -> ifNull(x, ''), prop_basic), arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1)])))) AS events_array,
-               argMinIf(prop_basic, timestamp, notEmpty(arrayFilter(x -> notEmpty(x), prop_basic))) AS prop,
-               arrayJoin(aggregate_funnel_array(2, 1209600, 'first_touch', 'None', [if(empty(prop), [''], prop)], [], arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
-                                                                                                                                                                                                                    and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
-                                                                                                                                                                                                                                                    and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
-                                                                                                                                                                                                                                                                                   and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
-                                                                                                                                                                                                                                                                                                                   and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
-               af_tuple.1 AS step_reached,
-               plus(af_tuple.1, 1) AS steps,
-               af_tuple.2 AS breakdown,
-               af_tuple.3 AS timings,
-               af_tuple.5 AS steps_bitfield,
-               aggregation_target AS aggregation_target
-        FROM
-          (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                  if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
-                  e.uuid AS uuid,
-                  e.`$session_id` AS `$session_id`,
-                  e.`$window_id` AS `$window_id`,
-                  if(equals(e.event, 'signup'), 1, 0) AS step_0,
-                  if(equals(e.event, 'purchase'), 1, 0) AS step_1,
-                  [ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$feature/test-experiment'), ''), 'null'), '^"|"$', '')), '')] AS prop_basic,
-                  prop_basic AS prop
-           FROM events AS e
-           LEFT OUTER JOIN
-             (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
-                     person_distinct_id_overrides.distinct_id AS distinct_id
-              FROM person_distinct_id_overrides
-              WHERE equals(person_distinct_id_overrides.team_id, 99999)
-              GROUP BY person_distinct_id_overrides.distinct_id
-              HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-           WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('today', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))), in(e.event, tuple('purchase', 'signup'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))
-        GROUP BY aggregation_target
-        HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
-     WHERE and(bitTest(steps_bitfield, 0), not(bitTest(steps_bitfield, 1)), ifNull(equals(arrayFlatten(array(breakdown)), arrayFlatten(array('test'))), isNull(arrayFlatten(array(breakdown)))
-                                                                                   and isNull(arrayFlatten(array('test')))))
-     ORDER BY aggregation_target ASC SETTINGS join_algorithm='auto') AS source
+    (WITH exposures AS
+       (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS entity_id,
+               if(ifNull(greater(uniqExact(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', '')), 1), 0), '$multiple', any(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', ''))) AS variant,
+               min(toTimeZone(events.timestamp, 'UTC')) AS first_exposure_time,
+               max(toTimeZone(events.timestamp, 'UTC')) AS last_exposure_time,
+               argMin(events.uuid, toTimeZone(events.timestamp, 'UTC')) AS exposure_event_uuid,
+               argMin(events.`$session_id`, toTimeZone(events.timestamp, 'UTC')) AS exposure_session_id
+        FROM events
+        LEFT OUTER JOIN
+          (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
+                  person_distinct_id_overrides.distinct_id AS distinct_id
+           FROM person_distinct_id_overrides
+           WHERE equals(person_distinct_id_overrides.team_id, 99999)
+           GROUP BY person_distinct_id_overrides.distinct_id
+           HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+        LEFT JOIN
+          (SELECT person.id AS id,
+                  nullIf(nullIf(person.pmat_email, ''), 'null') AS properties___email
+           FROM person
+           WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
+                                                         (SELECT person.id AS id, max(person.version) AS version
+                                                          FROM person
+                                                          WHERE equals(person.team_id, 99999)
+                                                          GROUP BY person.id
+                                                          HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0))))) SETTINGS optimize_aggregation_in_order=1) AS events__person ON equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), events__person.id)
+        WHERE and(equals(events.team_id, 99999), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2020-01-01 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2020-01-15 12:00:00', 'UTC'))), and(equals(events.event, '$feature_flag_called'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag'), ''), 'null'), '^"|"$', ''), 'test-experiment'), 0)), ifNull(notILike(toString(events__person.properties___email), '%@posthog.com%'), 1), in(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', ''), ['control', 'test']))
+        GROUP BY entity_id),
+          metric_events AS
+       (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS entity_id,
+               toTimeZone(events.timestamp, 'UTC') AS timestamp,
+               events.uuid AS uuid,
+               nullIf(nullIf(events.`$session_id`, ''), 'null') AS session_id,
+               multiply(1, and(equals(events.event, '$feature_flag_called'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag'), ''), 'null'), '^"|"$', ''), 'test-experiment'), 0))) AS step_0,
+               if(equals(events.event, 'signup'), 1, 0) AS step_1,
+               if(equals(events.event, 'purchase'), 1, 0) AS step_2
+        FROM events
+        LEFT OUTER JOIN
+          (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
+                  person_distinct_id_overrides.distinct_id AS distinct_id
+           FROM person_distinct_id_overrides
+           WHERE equals(person_distinct_id_overrides.team_id, 99999)
+           GROUP BY person_distinct_id_overrides.distinct_id
+           HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+        WHERE and(equals(events.team_id, 99999), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2020-01-01 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2020-01-15 12:00:00', 'UTC'))), or(and(equals(events.event, '$feature_flag_called'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag'), ''), 'null'), '^"|"$', ''), 'test-experiment'), 0)), or(equals(events.event, 'signup'), equals(events.event, 'purchase'))))),
+          entity_metrics AS
+       (SELECT exposures.entity_id AS entity_id,
+               exposures.variant AS variant,
+               exposures.exposure_event_uuid AS exposure_event_uuid,
+               (arraySort(x -> minus(0, x.1), arrayMap(result -> tuple(result.1, if(and(ifNull(greaterOrEquals(result.1, 0), 0), ifNull(greater(length(result.4), result.1), 0)), if(ifNull(greater(length(arrayElement(result.4, plus(result.1, 1))), 0), 0), toString(arrayElement(result.4, plus(result.1, 1))[1]), ''), '')), aggregate_funnel_array(3, 94608000, 'first_touch', 'ordered', array(array('')), [], arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(toTimeZone(metric_events.timestamp, 'UTC'), 'Float64'), metric_events.uuid, array(''), arrayFilter(x -> ifNull(greater(x, 0), 0), [multiply(1, metric_events.step_0), multiply(2, metric_events.step_1), multiply(3, metric_events.step_2)])))))))[1]).1 AS step_reached
+        FROM exposures
+        LEFT JOIN metric_events ON equals(exposures.entity_id, metric_events.entity_id)
+        GROUP BY exposures.entity_id,
+                 exposures.variant,
+                 exposures.exposure_event_uuid) SELECT entity_metrics.entity_id AS actor_id,
+                                                       entity_metrics.variant AS variant,
+                                                       actor_id AS id
+     FROM entity_metrics
+     WHERE and(ifNull(greaterOrEquals(entity_metrics.step_reached, 1), 0), ifNull(less(entity_metrics.step_reached, 2), 0), ifNull(equals(variant, 'test'), 0))
+     ORDER BY entity_metrics.entity_id ASC) AS source
+  ORDER BY source.id ASC
+  LIMIT 101
+  OFFSET 0 SETTINGS optimize_aggregation_in_order=1,
+                    join_algorithm='auto',
+                    readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0,
+                    transform_null_in=1,
+                    optimize_min_equality_disjunction_chain_length=4294967295,
+                    allow_experimental_join_condition=1,
+                    use_hive_partitioning=0
+  '''
+# ---
+# name: TestExperimentActorsQuery.test_experiment_funnel_actors_excludes_events_before_exposure
+  '''
+  SELECT source.id,
+         source.id AS id
+  FROM
+    (WITH exposures AS
+       (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS entity_id,
+               if(ifNull(greater(uniqExact(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', '')), 1), 0), '$multiple', any(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', ''))) AS variant,
+               min(toTimeZone(events.timestamp, 'UTC')) AS first_exposure_time,
+               max(toTimeZone(events.timestamp, 'UTC')) AS last_exposure_time,
+               argMin(events.uuid, toTimeZone(events.timestamp, 'UTC')) AS exposure_event_uuid,
+               argMin(events.`$session_id`, toTimeZone(events.timestamp, 'UTC')) AS exposure_session_id
+        FROM events
+        LEFT OUTER JOIN
+          (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
+                  person_distinct_id_overrides.distinct_id AS distinct_id
+           FROM person_distinct_id_overrides
+           WHERE equals(person_distinct_id_overrides.team_id, 99999)
+           GROUP BY person_distinct_id_overrides.distinct_id
+           HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+        LEFT JOIN
+          (SELECT person.id AS id,
+                  nullIf(nullIf(person.pmat_email, ''), 'null') AS properties___email
+           FROM person
+           WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
+                                                         (SELECT person.id AS id, max(person.version) AS version
+                                                          FROM person
+                                                          WHERE equals(person.team_id, 99999)
+                                                          GROUP BY person.id
+                                                          HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0))))) SETTINGS optimize_aggregation_in_order=1) AS events__person ON equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), events__person.id)
+        WHERE and(equals(events.team_id, 99999), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2020-01-01 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2020-01-15 12:00:00', 'UTC'))), and(equals(events.event, '$feature_flag_called'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag'), ''), 'null'), '^"|"$', ''), 'test-experiment'), 0)), ifNull(notILike(toString(events__person.properties___email), '%@posthog.com%'), 1), in(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', ''), ['control', 'test']))
+        GROUP BY entity_id),
+          metric_events AS
+       (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS entity_id,
+               toTimeZone(events.timestamp, 'UTC') AS timestamp,
+               events.uuid AS uuid,
+               nullIf(nullIf(events.`$session_id`, ''), 'null') AS session_id,
+               multiply(1, and(equals(events.event, '$feature_flag_called'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag'), ''), 'null'), '^"|"$', ''), 'test-experiment'), 0))) AS step_0,
+               if(equals(events.event, 'signup'), 1, 0) AS step_1,
+               if(equals(events.event, 'purchase'), 1, 0) AS step_2
+        FROM events
+        LEFT OUTER JOIN
+          (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
+                  person_distinct_id_overrides.distinct_id AS distinct_id
+           FROM person_distinct_id_overrides
+           WHERE equals(person_distinct_id_overrides.team_id, 99999)
+           GROUP BY person_distinct_id_overrides.distinct_id
+           HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+        WHERE and(equals(events.team_id, 99999), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2020-01-01 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2020-01-15 12:00:00', 'UTC'))), or(and(equals(events.event, '$feature_flag_called'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag'), ''), 'null'), '^"|"$', ''), 'test-experiment'), 0)), or(equals(events.event, 'signup'), equals(events.event, 'purchase'))))),
+          entity_metrics AS
+       (SELECT exposures.entity_id AS entity_id,
+               exposures.variant AS variant,
+               exposures.exposure_event_uuid AS exposure_event_uuid,
+               (arraySort(x -> minus(0, x.1), arrayMap(result -> tuple(result.1, if(and(ifNull(greaterOrEquals(result.1, 0), 0), ifNull(greater(length(result.4), result.1), 0)), if(ifNull(greater(length(arrayElement(result.4, plus(result.1, 1))), 0), 0), toString(arrayElement(result.4, plus(result.1, 1))[1]), ''), '')), aggregate_funnel_array(3, 94608000, 'first_touch', 'ordered', array(array('')), [], arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(toTimeZone(metric_events.timestamp, 'UTC'), 'Float64'), metric_events.uuid, array(''), arrayFilter(x -> ifNull(greater(x, 0), 0), [multiply(1, metric_events.step_0), multiply(2, metric_events.step_1), multiply(3, metric_events.step_2)])))))))[1]).1 AS step_reached
+        FROM exposures
+        LEFT JOIN metric_events ON equals(exposures.entity_id, metric_events.entity_id)
+        GROUP BY exposures.entity_id,
+                 exposures.variant,
+                 exposures.exposure_event_uuid) SELECT entity_metrics.entity_id AS actor_id,
+                                                       entity_metrics.variant AS variant,
+                                                       actor_id AS id
+     FROM entity_metrics
+     WHERE and(ifNull(greaterOrEquals(entity_metrics.step_reached, 1), 0), ifNull(less(entity_metrics.step_reached, 2), 0), ifNull(equals(variant, 'control'), 0))
+     ORDER BY entity_metrics.entity_id ASC) AS source
   ORDER BY source.id ASC
   LIMIT 101
   OFFSET 0 SETTINGS optimize_aggregation_in_order=1,
@@ -371,51 +565,71 @@
          source.id AS id,
          source.matching_events AS matching_events
   FROM
-    (SELECT aggregation_target AS actor_id,
-            matched_events_array[2] AS matching_events,
-            actor_id AS id
-     FROM
-       (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, arrayMap(x -> ifNull(x, ''), prop_basic), arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1)])))) AS events_array,
-               argMinIf(prop_basic, timestamp, notEmpty(arrayFilter(x -> notEmpty(x), prop_basic))) AS prop,
-               arrayJoin(aggregate_funnel_array(2, 1209600, 'first_touch', 'None', [if(empty(prop), [''], prop)], [], arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
-                                                                                                                                                                                                                    and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
-                                                                                                                                                                                                                                                    and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
-                                                                                                                                                                                                                                                                                   and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
-                                                                                                                                                                                                                                                                                                                   and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
-               af_tuple.1 AS step_reached,
-               plus(af_tuple.1, 1) AS steps,
-               af_tuple.2 AS breakdown,
-               af_tuple.3 AS timings,
-               af_tuple.4 AS matched_event_uuids_array_array,
-               groupArray(tuple(timestamp, uuid, `$session_id`, `$window_id`)) AS user_events,
+    (WITH exposures AS
+       (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS entity_id,
+               if(ifNull(greater(uniqExact(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', '')), 1), 0), '$multiple', any(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', ''))) AS variant,
+               min(toTimeZone(events.timestamp, 'UTC')) AS first_exposure_time,
+               max(toTimeZone(events.timestamp, 'UTC')) AS last_exposure_time,
+               argMin(events.uuid, toTimeZone(events.timestamp, 'UTC')) AS exposure_event_uuid,
+               argMin(events.`$session_id`, toTimeZone(events.timestamp, 'UTC')) AS exposure_session_id
+        FROM events
+        LEFT OUTER JOIN
+          (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
+                  person_distinct_id_overrides.distinct_id AS distinct_id
+           FROM person_distinct_id_overrides
+           WHERE equals(person_distinct_id_overrides.team_id, 99999)
+           GROUP BY person_distinct_id_overrides.distinct_id
+           HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+        LEFT JOIN
+          (SELECT person.id AS id,
+                  nullIf(nullIf(person.pmat_email, ''), 'null') AS properties___email
+           FROM person
+           WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
+                                                         (SELECT person.id AS id, max(person.version) AS version
+                                                          FROM person
+                                                          WHERE equals(person.team_id, 99999)
+                                                          GROUP BY person.id
+                                                          HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0))))) SETTINGS optimize_aggregation_in_order=1) AS events__person ON equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), events__person.id)
+        WHERE and(equals(events.team_id, 99999), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2020-01-01 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2020-01-15 12:00:00', 'UTC'))), and(equals(events.event, '$feature_flag_called'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag'), ''), 'null'), '^"|"$', ''), 'test-experiment'), 0)), ifNull(notILike(toString(events__person.properties___email), '%@posthog.com%'), 1), in(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', ''), ['control', 'test']))
+        GROUP BY entity_id),
+          metric_events AS
+       (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS entity_id,
+               toTimeZone(events.timestamp, 'UTC') AS timestamp,
+               events.uuid AS uuid,
+               nullIf(nullIf(events.`$session_id`, ''), 'null') AS session_id,
+               multiply(1, and(equals(events.event, '$feature_flag_called'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag'), ''), 'null'), '^"|"$', ''), 'test-experiment'), 0))) AS step_0,
+               if(equals(events.event, 'signup'), 1, 0) AS step_1,
+               if(equals(events.event, 'purchase'), 1, 0) AS step_2
+        FROM events
+        LEFT OUTER JOIN
+          (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
+                  person_distinct_id_overrides.distinct_id AS distinct_id
+           FROM person_distinct_id_overrides
+           WHERE equals(person_distinct_id_overrides.team_id, 99999)
+           GROUP BY person_distinct_id_overrides.distinct_id
+           HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+        WHERE and(equals(events.team_id, 99999), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2020-01-01 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2020-01-15 12:00:00', 'UTC'))), or(and(equals(events.event, '$feature_flag_called'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag'), ''), 'null'), '^"|"$', ''), 'test-experiment'), 0)), or(equals(events.event, 'signup'), equals(events.event, 'purchase'))))),
+          entity_metrics AS
+       (SELECT exposures.entity_id AS entity_id,
+               exposures.variant AS variant,
+               exposures.exposure_event_uuid AS exposure_event_uuid,
+               groupArray(tuple(toTimeZone(metric_events.timestamp, 'UTC'), metric_events.uuid, metric_events.session_id, '')) AS user_events,
                mapFromArrays(arrayMap(x -> x.2, user_events), user_events) AS user_events_map,
-               arrayMap(matched_event_uuids_array -> arrayMap(event_uuid -> user_events_map[event_uuid], arrayDistinct(matched_event_uuids_array)), matched_event_uuids_array_array) AS matched_events_array,
-               af_tuple.5 AS steps_bitfield,
-               aggregation_target AS aggregation_target
-        FROM
-          (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                  if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
-                  e.uuid AS uuid,
-                  e.`$session_id` AS `$session_id`,
-                  e.`$window_id` AS `$window_id`,
-                  if(equals(e.event, 'signup'), 1, 0) AS step_0,
-                  if(equals(e.event, 'purchase'), 1, 0) AS step_1,
-                  [ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$feature/test-experiment'), ''), 'null'), '^"|"$', '')), '')] AS prop_basic,
-                  prop_basic AS prop
-           FROM events AS e
-           LEFT OUTER JOIN
-             (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
-                     person_distinct_id_overrides.distinct_id AS distinct_id
-              FROM person_distinct_id_overrides
-              WHERE equals(person_distinct_id_overrides.team_id, 99999)
-              GROUP BY person_distinct_id_overrides.distinct_id
-              HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-           WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('today', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))), in(e.event, tuple('purchase', 'signup'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))
-        GROUP BY aggregation_target
-        HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
-     WHERE and(bitTest(steps_bitfield, 1), ifNull(equals(arrayFlatten(array(breakdown)), arrayFlatten(array('control'))), isNull(arrayFlatten(array(breakdown)))
-                                                  and isNull(arrayFlatten(array('control')))))
-     ORDER BY aggregation_target ASC SETTINGS join_algorithm='auto') AS source
+               arraySort(x -> minus(0, x.1), aggregate_funnel_array(3, 94608000, 'first_touch', 'ordered', array(array('')), [], arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(toTimeZone(metric_events.timestamp, 'UTC'), 'Float64'), metric_events.uuid, array(''), arrayFilter(x -> ifNull(greater(x, 0), 0), [multiply(1, metric_events.step_0), multiply(2, metric_events.step_1), multiply(3, metric_events.step_2)]))))))[1] AS af_tuple,
+               af_tuple.1 AS step_reached,
+               af_tuple.4 AS matched_event_uuids_array_array,
+               arrayMap(matched_event_uuids_array -> arrayMap(event_uuid -> user_events_map[event_uuid], arrayDistinct(matched_event_uuids_array)), matched_event_uuids_array_array) AS matched_events_array
+        FROM exposures
+        LEFT JOIN metric_events ON equals(exposures.entity_id, metric_events.entity_id)
+        GROUP BY exposures.entity_id,
+                 exposures.variant,
+                 exposures.exposure_event_uuid) SELECT entity_metrics.entity_id AS actor_id,
+                                                       entity_metrics.variant AS variant,
+                                                       entity_metrics.matched_events_array[plus(entity_metrics.step_reached, 1)] AS matching_events,
+                                                       actor_id AS id
+     FROM entity_metrics
+     WHERE and(ifNull(greaterOrEquals(entity_metrics.step_reached, 2), 0), ifNull(equals(variant, 'control'), 0))
+     ORDER BY entity_metrics.entity_id ASC) AS source
   ORDER BY source.id ASC
   LIMIT 101
   OFFSET 0 SETTINGS optimize_aggregation_in_order=1,
@@ -439,7 +653,7 @@
          max(session_replay_events.retention_period_days) AS retention_period_days,
          plus(dateTrunc('DAY', start_time), toIntervalDay(coalesce(retention_period_days, 30))) AS expiry_time
   FROM session_replay_events
-  WHERE and(equals(session_replay_events.team_id, 99999), in(session_replay_events.session_id, ['']))
+  WHERE and(equals(session_replay_events.team_id, 99999), in(session_replay_events.session_id, [NULL]))
   GROUP BY session_replay_events.session_id
   HAVING and(ifNull(greaterOrEquals(expiry_time, toDateTime64('today', 6, 'UTC')), 0), ifNull(equals(max(session_replay_events.is_deleted), 0), 0))
   LIMIT 100 SETTINGS readonly=2,

--- a/posthog/hogql_queries/experiments/test/__snapshots__/test_experiment_actors_query.ambr
+++ b/posthog/hogql_queries/experiments/test/__snapshots__/test_experiment_actors_query.ambr
@@ -19,17 +19,7 @@
            WHERE equals(person_distinct_id_overrides.team_id, 99999)
            GROUP BY person_distinct_id_overrides.distinct_id
            HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-        LEFT JOIN
-          (SELECT person.id AS id,
-                  replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'email'), ''), 'null'), '^"|"$', '') AS properties___email
-           FROM person
-           WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
-                                                         (SELECT person.id AS id, max(person.version) AS version
-                                                          FROM person
-                                                          WHERE equals(person.team_id, 99999)
-                                                          GROUP BY person.id
-                                                          HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0))))) SETTINGS optimize_aggregation_in_order=1) AS events__person ON equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), events__person.id)
-        WHERE and(equals(events.team_id, 99999), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2020-01-01 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2020-01-15 12:00:00', 'UTC'))), and(equals(events.event, '$feature_flag_called'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag'), ''), 'null'), '^"|"$', ''), 'test-experiment'), 0)), ifNull(notILike(toString(events__person.properties___email), '%@posthog.com%'), 1), in(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', ''), ['control', 'test']))
+        WHERE and(equals(events.team_id, 99999), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2020-01-01 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2020-01-15 12:00:00', 'UTC'))), and(equals(events.event, '$feature_flag_called'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag'), ''), 'null'), '^"|"$', ''), 'test-experiment'), 0)), in(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', ''), ['control', 'test']))
         GROUP BY entity_id),
           metric_events AS
        (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS entity_id,
@@ -99,17 +89,7 @@
            WHERE equals(person_distinct_id_overrides.team_id, 99999)
            GROUP BY person_distinct_id_overrides.distinct_id
            HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-        LEFT JOIN
-          (SELECT person.id AS id,
-                  replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'email'), ''), 'null'), '^"|"$', '') AS properties___email
-           FROM person
-           WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
-                                                         (SELECT person.id AS id, max(person.version) AS version
-                                                          FROM person
-                                                          WHERE equals(person.team_id, 99999)
-                                                          GROUP BY person.id
-                                                          HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0))))) SETTINGS optimize_aggregation_in_order=1) AS events__person ON equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), events__person.id)
-        WHERE and(equals(events.team_id, 99999), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2020-01-01 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2020-01-15 12:00:00', 'UTC'))), and(equals(events.event, '$feature_flag_called'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag'), ''), 'null'), '^"|"$', ''), 'test-experiment'), 0)), ifNull(notILike(toString(events__person.properties___email), '%@posthog.com%'), 1), in(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', ''), ['control', 'test']))
+        WHERE and(equals(events.team_id, 99999), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2020-01-01 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2020-01-15 12:00:00', 'UTC'))), and(equals(events.event, '$feature_flag_called'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag'), ''), 'null'), '^"|"$', ''), 'test-experiment'), 0)), in(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', ''), ['control', 'test']))
         GROUP BY entity_id),
           metric_events AS
        (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS entity_id,
@@ -179,17 +159,7 @@
            WHERE equals(person_distinct_id_overrides.team_id, 99999)
            GROUP BY person_distinct_id_overrides.distinct_id
            HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-        LEFT JOIN
-          (SELECT person.id AS id,
-                  replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'email'), ''), 'null'), '^"|"$', '') AS properties___email
-           FROM person
-           WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
-                                                         (SELECT person.id AS id, max(person.version) AS version
-                                                          FROM person
-                                                          WHERE equals(person.team_id, 99999)
-                                                          GROUP BY person.id
-                                                          HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0))))) SETTINGS optimize_aggregation_in_order=1) AS events__person ON equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), events__person.id)
-        WHERE and(equals(events.team_id, 99999), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2020-01-01 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2020-01-15 12:00:00', 'UTC'))), and(equals(events.event, '$feature_flag_called'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag'), ''), 'null'), '^"|"$', ''), 'test-experiment'), 0)), ifNull(notILike(toString(events__person.properties___email), '%@posthog.com%'), 1), in(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', ''), ['control', 'test']))
+        WHERE and(equals(events.team_id, 99999), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2020-01-01 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2020-01-15 12:00:00', 'UTC'))), and(equals(events.event, '$feature_flag_called'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag'), ''), 'null'), '^"|"$', ''), 'test-experiment'), 0)), in(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', ''), ['control', 'test']))
         GROUP BY entity_id),
           metric_events AS
        (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS entity_id,
@@ -259,17 +229,7 @@
            WHERE equals(person_distinct_id_overrides.team_id, 99999)
            GROUP BY person_distinct_id_overrides.distinct_id
            HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-        LEFT JOIN
-          (SELECT person.id AS id,
-                  replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'email'), ''), 'null'), '^"|"$', '') AS properties___email
-           FROM person
-           WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
-                                                         (SELECT person.id AS id, max(person.version) AS version
-                                                          FROM person
-                                                          WHERE equals(person.team_id, 99999)
-                                                          GROUP BY person.id
-                                                          HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0))))) SETTINGS optimize_aggregation_in_order=1) AS events__person ON equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), events__person.id)
-        WHERE and(equals(events.team_id, 99999), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2020-01-01 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2020-01-15 12:00:00', 'UTC'))), and(equals(events.event, '$feature_flag_called'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag'), ''), 'null'), '^"|"$', ''), 'test-experiment'), 0)), ifNull(notILike(toString(events__person.properties___email), '%@posthog.com%'), 1), in(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', ''), ['control', 'test']))
+        WHERE and(equals(events.team_id, 99999), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2020-01-01 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2020-01-15 12:00:00', 'UTC'))), and(equals(events.event, '$feature_flag_called'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag'), ''), 'null'), '^"|"$', ''), 'test-experiment'), 0)), in(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', ''), ['control', 'test']))
         GROUP BY entity_id),
           metric_events AS
        (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS entity_id,
@@ -339,17 +299,7 @@
            WHERE equals(person_distinct_id_overrides.team_id, 99999)
            GROUP BY person_distinct_id_overrides.distinct_id
            HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-        LEFT JOIN
-          (SELECT person.id AS id,
-                  replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'email'), ''), 'null'), '^"|"$', '') AS properties___email
-           FROM person
-           WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
-                                                         (SELECT person.id AS id, max(person.version) AS version
-                                                          FROM person
-                                                          WHERE equals(person.team_id, 99999)
-                                                          GROUP BY person.id
-                                                          HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0))))) SETTINGS optimize_aggregation_in_order=1) AS events__person ON equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), events__person.id)
-        WHERE and(equals(events.team_id, 99999), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2020-01-01 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2020-01-15 12:00:00', 'UTC'))), and(equals(events.event, '$feature_flag_called'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag'), ''), 'null'), '^"|"$', ''), 'test-experiment'), 0)), ifNull(notILike(toString(events__person.properties___email), '%@posthog.com%'), 1), in(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', ''), ['control', 'test']))
+        WHERE and(equals(events.team_id, 99999), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2020-01-01 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2020-01-15 12:00:00', 'UTC'))), and(equals(events.event, '$feature_flag_called'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag'), ''), 'null'), '^"|"$', ''), 'test-experiment'), 0)), in(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', ''), ['control', 'test']))
         GROUP BY entity_id),
           metric_events AS
        (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS entity_id,
@@ -419,17 +369,7 @@
            WHERE equals(person_distinct_id_overrides.team_id, 99999)
            GROUP BY person_distinct_id_overrides.distinct_id
            HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-        LEFT JOIN
-          (SELECT person.id AS id,
-                  replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'email'), ''), 'null'), '^"|"$', '') AS properties___email
-           FROM person
-           WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
-                                                         (SELECT person.id AS id, max(person.version) AS version
-                                                          FROM person
-                                                          WHERE equals(person.team_id, 99999)
-                                                          GROUP BY person.id
-                                                          HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0))))) SETTINGS optimize_aggregation_in_order=1) AS events__person ON equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), events__person.id)
-        WHERE and(equals(events.team_id, 99999), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2020-01-01 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2020-01-15 12:00:00', 'UTC'))), and(equals(events.event, '$feature_flag_called'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag'), ''), 'null'), '^"|"$', ''), 'test-experiment'), 0)), ifNull(notILike(toString(events__person.properties___email), '%@posthog.com%'), 1), in(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', ''), ['control', 'test']))
+        WHERE and(equals(events.team_id, 99999), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2020-01-01 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2020-01-15 12:00:00', 'UTC'))), and(equals(events.event, '$feature_flag_called'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag'), ''), 'null'), '^"|"$', ''), 'test-experiment'), 0)), in(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', ''), ['control', 'test']))
         GROUP BY entity_id),
           metric_events AS
        (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS entity_id,
@@ -499,17 +439,7 @@
            WHERE equals(person_distinct_id_overrides.team_id, 99999)
            GROUP BY person_distinct_id_overrides.distinct_id
            HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-        LEFT JOIN
-          (SELECT person.id AS id,
-                  replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'email'), ''), 'null'), '^"|"$', '') AS properties___email
-           FROM person
-           WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
-                                                         (SELECT person.id AS id, max(person.version) AS version
-                                                          FROM person
-                                                          WHERE equals(person.team_id, 99999)
-                                                          GROUP BY person.id
-                                                          HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0))))) SETTINGS optimize_aggregation_in_order=1) AS events__person ON equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), events__person.id)
-        WHERE and(equals(events.team_id, 99999), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2020-01-01 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2020-01-15 12:00:00', 'UTC'))), and(equals(events.event, '$feature_flag_called'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag'), ''), 'null'), '^"|"$', ''), 'test-experiment'), 0)), ifNull(notILike(toString(events__person.properties___email), '%@posthog.com%'), 1), in(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', ''), ['control', 'test']))
+        WHERE and(equals(events.team_id, 99999), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2020-01-01 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2020-01-15 12:00:00', 'UTC'))), and(equals(events.event, '$feature_flag_called'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag'), ''), 'null'), '^"|"$', ''), 'test-experiment'), 0)), in(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', ''), ['control', 'test']))
         GROUP BY entity_id),
           metric_events AS
        (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS entity_id,
@@ -580,17 +510,7 @@
            WHERE equals(person_distinct_id_overrides.team_id, 99999)
            GROUP BY person_distinct_id_overrides.distinct_id
            HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-        LEFT JOIN
-          (SELECT person.id AS id,
-                  replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'email'), ''), 'null'), '^"|"$', '') AS properties___email
-           FROM person
-           WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
-                                                         (SELECT person.id AS id, max(person.version) AS version
-                                                          FROM person
-                                                          WHERE equals(person.team_id, 99999)
-                                                          GROUP BY person.id
-                                                          HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0))))) SETTINGS optimize_aggregation_in_order=1) AS events__person ON equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), events__person.id)
-        WHERE and(equals(events.team_id, 99999), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2020-01-01 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2020-01-15 12:00:00', 'UTC'))), and(equals(events.event, '$feature_flag_called'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag'), ''), 'null'), '^"|"$', ''), 'test-experiment'), 0)), ifNull(notILike(toString(events__person.properties___email), '%@posthog.com%'), 1), in(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', ''), ['control', 'test']))
+        WHERE and(equals(events.team_id, 99999), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2020-01-01 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2020-01-15 12:00:00', 'UTC'))), and(equals(events.event, '$feature_flag_called'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag'), ''), 'null'), '^"|"$', ''), 'test-experiment'), 0)), in(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', ''), ['control', 'test']))
         GROUP BY entity_id),
           metric_events AS
        (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS entity_id,

--- a/posthog/hogql_queries/experiments/test/__snapshots__/test_experiment_actors_query.ambr
+++ b/posthog/hogql_queries/experiments/test/__snapshots__/test_experiment_actors_query.ambr
@@ -21,7 +21,7 @@
            HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
         LEFT JOIN
           (SELECT person.id AS id,
-                  replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'email'), ''), 'null'), '^"|"$', '') AS properties___email
+                  nullIf(nullIf(person.pmat_email, ''), 'null') AS properties___email
            FROM person
            WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
                                                          (SELECT person.id AS id, max(person.version) AS version
@@ -101,7 +101,7 @@
            HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
         LEFT JOIN
           (SELECT person.id AS id,
-                  replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'email'), ''), 'null'), '^"|"$', '') AS properties___email
+                  nullIf(nullIf(person.pmat_email, ''), 'null') AS properties___email
            FROM person
            WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
                                                          (SELECT person.id AS id, max(person.version) AS version
@@ -181,7 +181,7 @@
            HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
         LEFT JOIN
           (SELECT person.id AS id,
-                  replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'email'), ''), 'null'), '^"|"$', '') AS properties___email
+                  nullIf(nullIf(person.pmat_email, ''), 'null') AS properties___email
            FROM person
            WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
                                                          (SELECT person.id AS id, max(person.version) AS version
@@ -261,7 +261,7 @@
            HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
         LEFT JOIN
           (SELECT person.id AS id,
-                  replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'email'), ''), 'null'), '^"|"$', '') AS properties___email
+                  nullIf(nullIf(person.pmat_email, ''), 'null') AS properties___email
            FROM person
            WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
                                                          (SELECT person.id AS id, max(person.version) AS version
@@ -341,7 +341,7 @@
            HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
         LEFT JOIN
           (SELECT person.id AS id,
-                  replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'email'), ''), 'null'), '^"|"$', '') AS properties___email
+                  nullIf(nullIf(person.pmat_email, ''), 'null') AS properties___email
            FROM person
            WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
                                                          (SELECT person.id AS id, max(person.version) AS version
@@ -421,7 +421,7 @@
            HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
         LEFT JOIN
           (SELECT person.id AS id,
-                  replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'email'), ''), 'null'), '^"|"$', '') AS properties___email
+                  nullIf(nullIf(person.pmat_email, ''), 'null') AS properties___email
            FROM person
            WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
                                                          (SELECT person.id AS id, max(person.version) AS version
@@ -501,7 +501,7 @@
            HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
         LEFT JOIN
           (SELECT person.id AS id,
-                  replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'email'), ''), 'null'), '^"|"$', '') AS properties___email
+                  nullIf(nullIf(person.pmat_email, ''), 'null') AS properties___email
            FROM person
            WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
                                                          (SELECT person.id AS id, max(person.version) AS version
@@ -582,7 +582,7 @@
            HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
         LEFT JOIN
           (SELECT person.id AS id,
-                  replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'email'), ''), 'null'), '^"|"$', '') AS properties___email
+                  nullIf(nullIf(person.pmat_email, ''), 'null') AS properties___email
            FROM person
            WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
                                                          (SELECT person.id AS id, max(person.version) AS version

--- a/posthog/hogql_queries/experiments/test/test_experiment_actors_query.py
+++ b/posthog/hogql_queries/experiments/test/test_experiment_actors_query.py
@@ -62,14 +62,30 @@ class TestExperimentActorsQuery(ExperimentQueryRunnerBaseTest, ClickhouseTestMix
 
     def _create_funnel_data_both_variants(self, feature_flag_property: str):
         """Create test data: control (6 signup, 4 purchase) and test (8 signup, 6 purchase)."""
+        # Extract flag key from feature_flag_property ($feature/test-experiment -> test-experiment)
+        flag_key = feature_flag_property.replace("$feature/", "")
+
         for i in range(10):
             _create_person(distinct_ids=[f"user_control_{i}"], team_id=self.team.pk)
+
+            # Add exposure event FIRST with correct $feature_flag_called properties
+            _create_event(
+                team=self.team,
+                event="$feature_flag_called",
+                distinct_id=f"user_control_{i}",
+                timestamp="2020-01-02T12:00:00Z",
+                properties={
+                    "$feature_flag": flag_key,  # The flag key
+                    "$feature_flag_response": "control",  # The variant
+                },
+            )
+
             if i < 6:
                 _create_event(
                     team=self.team,
                     event="signup",
                     distinct_id=f"user_control_{i}",
-                    timestamp="2020-01-02T13:00:00Z",
+                    timestamp="2020-01-02T13:00:00Z",  # After exposure
                     properties={feature_flag_property: "control"},
                 )
                 if i < 4:
@@ -77,18 +93,31 @@ class TestExperimentActorsQuery(ExperimentQueryRunnerBaseTest, ClickhouseTestMix
                         team=self.team,
                         event="purchase",
                         distinct_id=f"user_control_{i}",
-                        timestamp="2020-01-02T14:00:00Z",
+                        timestamp="2020-01-02T14:00:00Z",  # After signup
                         properties={feature_flag_property: "control"},
                     )
 
         for i in range(10):
             _create_person(distinct_ids=[f"user_test_{i}"], team_id=self.team.pk)
+
+            # Add exposure event FIRST with correct $feature_flag_called properties
+            _create_event(
+                team=self.team,
+                event="$feature_flag_called",
+                distinct_id=f"user_test_{i}",
+                timestamp="2020-01-02T12:00:00Z",
+                properties={
+                    "$feature_flag": flag_key,  # The flag key
+                    "$feature_flag_response": "test",  # The variant
+                },
+            )
+
             if i < 8:
                 _create_event(
                     team=self.team,
                     event="signup",
                     distinct_id=f"user_test_{i}",
-                    timestamp="2020-01-02T13:00:00Z",
+                    timestamp="2020-01-02T13:00:00Z",  # After exposure
                     properties={feature_flag_property: "test"},
                 )
                 if i < 6:
@@ -96,7 +125,7 @@ class TestExperimentActorsQuery(ExperimentQueryRunnerBaseTest, ClickhouseTestMix
                         team=self.team,
                         event="purchase",
                         distinct_id=f"user_test_{i}",
-                        timestamp="2020-01-02T14:00:00Z",
+                        timestamp="2020-01-02T14:00:00Z",  # After signup
                         properties={feature_flag_property: "test"},
                     )
 
@@ -177,6 +206,19 @@ class TestExperimentActorsQuery(ExperimentQueryRunnerBaseTest, ClickhouseTestMix
 
         # Create a user with events (complete both funnel steps)
         _create_person(distinct_ids=["user_with_recording"], team_id=self.team.pk)
+
+        # Exposure event first
+        _create_event(
+            team=self.team,
+            event="$feature_flag_called",
+            distinct_id="user_with_recording",
+            timestamp="2020-01-02T12:00:00Z",
+            properties={
+                "$feature_flag": feature_flag.key,
+                "$feature_flag_response": "control",
+            },
+        )
+
         _create_event(
             team=self.team,
             event="signup",
@@ -335,3 +377,93 @@ class TestExperimentActorsQuery(ExperimentQueryRunnerBaseTest, ClickhouseTestMix
         self.assertIn("2 metric steps", error_message)  # Shows context
         self.assertIn("Valid conversion steps: 1", error_message)  # Shows valid range start
         self.assertIn("(first metric step) to 2", error_message)  # Shows valid range end with explanation
+
+    @freeze_time("2020-01-01T12:00:00Z")
+    @snapshot_clickhouse_queries
+    def test_experiment_funnel_actors_excludes_events_before_exposure(self):
+        """
+        Test that actors query only counts events AFTER exposure, matching main query behavior.
+
+        Scenario:
+        - User does $pageview BEFORE being exposed
+        - User gets exposed
+        - User never does purchase
+
+        Expected:
+        - Main query: NOT counted as drop-off (pageview was before exposure)
+        - Actors query: Also NOT counted (with fix applied)
+        """
+        feature_flag, experiment, experiment_query = self._create_experiment_with_funnel()
+
+        # Create user who did events BEFORE exposure
+        _create_person(distinct_ids=["user_before_exposure"], team_id=self.team.pk)
+
+        # Event BEFORE exposure (should be ignored)
+        _create_event(
+            team=self.team,
+            event="signup",
+            distinct_id="user_before_exposure",
+            timestamp="2020-01-02T10:00:00Z",  # Before exposure
+        )
+
+        # Exposure event with correct properties for $feature_flag_called
+        _create_event(
+            team=self.team,
+            event="$feature_flag_called",
+            distinct_id="user_before_exposure",
+            timestamp="2020-01-02T12:00:00Z",  # Exposure
+            properties={
+                "$feature_flag": feature_flag.key,
+                "$feature_flag_response": "control",
+            },
+        )
+
+        # No purchase event
+
+        # Create user who did events AFTER exposure (should be counted)
+        _create_person(distinct_ids=["user_after_exposure"], team_id=self.team.pk)
+
+        # Exposure event with correct properties for $feature_flag_called
+        _create_event(
+            team=self.team,
+            event="$feature_flag_called",
+            distinct_id="user_after_exposure",
+            timestamp="2020-01-02T12:00:00Z",  # Exposure
+            properties={
+                "$feature_flag": feature_flag.key,
+                "$feature_flag_response": "control",
+            },
+        )
+
+        # Event AFTER exposure (should be counted)
+        _create_event(
+            team=self.team,
+            event="signup",
+            distinct_id="user_after_exposure",
+            timestamp="2020-01-02T13:00:00Z",  # After exposure
+        )
+
+        # No purchase event
+
+        flush_persons_and_events()
+
+        # Query for step 2 drop-offs (did signup after exposure, but no purchase)
+        experiment_actors_query = ExperimentActorsQuery(
+            kind="ExperimentActorsQuery",
+            source=experiment_query,
+            funnelStep=-2,  # Drop-offs at step 2
+            funnelStepBreakdown="control",
+            includeRecordings=False,
+        )
+
+        actors_query = ActorsQuery(
+            source=experiment_actors_query,
+            select=["id", "person"],
+        )
+
+        response = ActorsQueryRunner(query=actors_query, team=self.team).calculate()
+
+        # Should only return 1 user (user_after_exposure)
+        # user_before_exposure should NOT be counted because their signup was before exposure
+        assert len(response.results) == 1
+        assert response.results[0][1]["distinct_ids"][0] == "user_after_exposure"

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -20746,6 +20746,13 @@ class ExperimentActorsQuery(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
+    exposureConfig: ExperimentEventExposureConfig | ActionsNode | None = Field(
+        default=None,
+        description=(
+            "Exposure configuration for filtering events. Defines when users were first exposed to the experiment."
+        ),
+    )
+    featureFlagKey: str | None = Field(default=None, description="Feature flag key for breakdown filtering.")
     funnelStep: int | None = Field(
         default=None,
         description=(
@@ -20764,6 +20771,9 @@ class ExperimentActorsQuery(BaseModel):
     includeRecordings: bool | None = None
     kind: Literal["ExperimentActorsQuery"] = "ExperimentActorsQuery"
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
+    multipleVariantHandling: MultipleVariantHandling | None = Field(
+        default=None, description="How to handle users with multiple variant exposures."
+    )
     response: ActorsQueryResponse | None = None
     source: ExperimentQuery
     tags: QueryLogTags | None = None

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -4050,11 +4050,44 @@ export namespace Schemas {
       version?: number | null;
     }
 
+    export type ExperimentEventExposureConfigKind = typeof ExperimentEventExposureConfigKind[keyof typeof ExperimentEventExposureConfigKind];
+
+
+    export const ExperimentEventExposureConfigKind = {
+      ExperimentEventExposureConfig: 'ExperimentEventExposureConfig',
+    } as const;
+
+    /**
+     * @nullable
+     */
+    export type ExperimentEventExposureConfigResponse = { [key: string]: unknown } | null | null;
+
+    export interface ExperimentEventExposureConfig {
+      event: string;
+      kind?: ExperimentEventExposureConfigKind;
+      properties: (EventPropertyFilter | PersonPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | WorkflowVariablePropertyFilter)[];
+      /** @nullable */
+      response?: ExperimentEventExposureConfigResponse;
+      /**
+       * version of the node, used for schema migrations
+       * @nullable
+       */
+      version?: number | null;
+    }
+
     export type ExperimentActorsQueryKind = typeof ExperimentActorsQueryKind[keyof typeof ExperimentActorsQueryKind];
 
 
     export const ExperimentActorsQueryKind = {
       ExperimentActorsQuery: 'ExperimentActorsQuery',
+    } as const;
+
+    export type MultipleVariantHandling = typeof MultipleVariantHandling[keyof typeof MultipleVariantHandling];
+
+
+    export const MultipleVariantHandling = {
+      Exclude: 'exclude',
+      FirstSeen: 'first_seen',
     } as const;
 
     export type ExperimentQueryKind = typeof ExperimentQueryKind[keyof typeof ExperimentQueryKind];
@@ -4562,6 +4595,13 @@ export namespace Schemas {
     }
 
     export interface ExperimentActorsQuery {
+      /** Exposure configuration for filtering events. Defines when users were first exposed to the experiment. */
+      exposureConfig?: ExperimentEventExposureConfig | ActionsNode | null;
+      /**
+       * Feature flag key for breakdown filtering.
+       * @nullable
+       */
+      featureFlagKey?: string | null;
       /**
        * Index of the step for which we want to get actors for, per experiment variant. Positive for converted persons, negative for dropped off persons.
        * @nullable
@@ -4574,6 +4614,8 @@ export namespace Schemas {
       kind?: ExperimentActorsQueryKind;
       /** Modifiers used when performing the query */
       modifiers?: HogQLQueryModifiers | null;
+      /** How to handle users with multiple variant exposures. */
+      multipleVariantHandling?: MultipleVariantHandling | null;
       response?: ActorsQueryResponse | null;
       source: ExperimentQuery;
       tags?: QueryLogTags | null;
@@ -14800,39 +14842,6 @@ export namespace Schemas {
        */
       readonly user_access_level: string | null;
     }
-
-    export type ExperimentEventExposureConfigKind = typeof ExperimentEventExposureConfigKind[keyof typeof ExperimentEventExposureConfigKind];
-
-
-    export const ExperimentEventExposureConfigKind = {
-      ExperimentEventExposureConfig: 'ExperimentEventExposureConfig',
-    } as const;
-
-    /**
-     * @nullable
-     */
-    export type ExperimentEventExposureConfigResponse = { [key: string]: unknown } | null | null;
-
-    export interface ExperimentEventExposureConfig {
-      event: string;
-      kind?: ExperimentEventExposureConfigKind;
-      properties: (EventPropertyFilter | PersonPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | WorkflowVariablePropertyFilter)[];
-      /** @nullable */
-      response?: ExperimentEventExposureConfigResponse;
-      /**
-       * version of the node, used for schema migrations
-       * @nullable
-       */
-      version?: number | null;
-    }
-
-    export type MultipleVariantHandling = typeof MultipleVariantHandling[keyof typeof MultipleVariantHandling];
-
-
-    export const MultipleVariantHandling = {
-      Exclude: 'exclude',
-      FirstSeen: 'first_seen',
-    } as const;
 
     export interface ExperimentExposureCriteria {
       exposure_config?: ExperimentEventExposureConfig | ActionsNode | null;


### PR DESCRIPTION
## Problem

The experiment actor's query was missing proper query tagging, making it impossible to monitor performance or set up error alerts for specific experiments.
Additionally, semgrep flagged f-string interpolations in the query builder as potential security risks, even though the values were type-validated integers

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

#### Pass experiment exposure as part of the query

Instead of passing an `experiment_id`, we want to make the query as generic as possible, so we pass the exposure criteria, including events and settings, as part of the actors query.

#### Implement ExperimentFunnelActorsQueryBuilder

Created a dedicated query builder that extends ExperimentQueryBuilder to handle experiment-specific funnel actors queries. The builder includes exposure as step 0 in the funnel evaluation, ensuring that only events occurring after a user's first exposure are counted. This matches the temporal filtering logic of the main experiment query and ensures accurate actor counts in the persons modal.

#### Add query tagging for experiment actors queries

Implemented experiment-specific query tags (experiment_id, experiment_name, experiment_actors_query_step, etc.) in the actors query flow. This enables performance dashboards to track query duration by experiment, error alerting for failed actors queries, and usage analytics for which experiments and funnel steps are being queried most frequently.

#### Replace f-string interpolation with AST construction

Replaced three f-string parse_expr() calls with proper AST construction using ast.CompareOperation. While the interpolated values (self.funnel_step) were type-validated integers and safe to use, using AST construction follows security best practices and eliminates semgrep warnings.

#### Add type annotations for mypy compliance

Added explicit type annotation conditions: list[ast.Expr] = [] to fix mypy errors when mixing ast.CompareOperation objects with results from parse_expr().

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

```bash
hogli test posthog/hogql_queries/experiments/test/test_experiment_actors_query.py -v
```

![cat-type](https://github.com/user-attachments/assets/10757f42-8e41-4e4a-a16d-fa2b107d677e)

<!-- Briefly describe the steps you took, and what steps reviewers must take to get to where changes are, and what is the expected behavior. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

do not publish to changelog

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
