### PR TITLE
chore: persist filters in feature flags

### DIFF
--- a/frontend/src/scenes/feature-flags/featureFlagsLogic.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagsLogic.ts
@@ -238,6 +238,7 @@ export const featureFlagsLogic = kea<featureFlagsLogicType>([
         ],
         filters: [
             DEFAULT_FILTERS,
+            { persist: true },
             {
                 setFeatureFlagsFilters: (state, { filters, replace }) => {
                     if (replace) {


### PR DESCRIPTION
## Problem

Every time when i check feature flags i filter them by "Created by". But if i click on the wrong one i go back i need to do it again.

## Changes

Persist the filters.
