### PR TITLE
posthog#53759

### DIFF
--- a/frontend/src/queries/nodes/DataVisualization/DataVisualization.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/DataVisualization.tsx
@@ -272,19 +272,6 @@ function InternalDataTableVisualization(props: DataTableVisualizationProps): JSX
                                 <div className="flex gap-4 items-center flex-wrap">
                                     <AddVariableButton />
 
-                                    {sourceFeatures.has(QueryFeature.dateRangePicker) &&
-                                        !router.values.location.pathname.includes(urls.sqlEditor()) && ( // decouple this component from insights tab and datawarehouse scene
-                                            <DateRange
-                                                key="date-range"
-                                                query={query.source}
-                                                setQuery={(query) => {
-                                                    if (query.kind === NodeKind.HogQLQuery) {
-                                                        setQuerySource(query)
-                                                    }
-                                                }}
-                                            />
-                                        )}
-
                                     <TableDisplay />
 
                                     <LemonButton
@@ -320,6 +307,19 @@ function InternalDataTableVisualization(props: DataTableVisualizationProps): JSX
                 )}
 
                 {!props.embedded && <VariablesForInsight />}
+
+                {sourceFeatures.has(QueryFeature.dateRangePicker) &&
+                    !router.values.location.pathname.includes(urls.sqlEditor()) && (
+                        <DateRange
+                            key="date-range"
+                            query={query.source}
+                            setQuery={(query) => {
+                                if (query.kind === NodeKind.HogQLQuery) {
+                                    setQuerySource(query)
+                                }
+                            }}
+                        />
+                    )}
 
                 <div className="flex flex-1 flex-row gap-4">
                     <div className="w-full h-full flex-1 overflow-auto">{component}</div>


### PR DESCRIPTION
Closes #53759 

## Problem

Date range picker supported by queries, but does not show up on the UI except in edit mode (which defeats the point).

## Changes

Frontend changes only

Before:
<img width="1693" height="327" alt="image" src="https://github.com/user-attachments/assets/1c440ca0-6e25-4ce9-a4af-d23150dadf50" />

After:
<img width="1693" height="327" alt="image" src="https://github.com/user-attachments/assets/5ba1cdbd-2f8f-4e29-9a33-a194a5b1a887" />

## How did you test this code?

Through the storybook entries and on a local deployment

## Publish to changelog?

I don't know if this qualifies as a feature. I'll leave that judgment call to the maintainers.
