### PR TITLE
fix(security): suppress aiohttp-missing-trust-env for internal ClickHouse client

### DIFF
--- a/posthog/temporal/common/clickhouse.py
+++ b/posthog/temporal/common/clickhouse.py
@@ -826,6 +826,7 @@ class ClickHouseClient:
             return sock
 
         self.connector = aiohttp.TCPConnector(ssl=self.ssl, socket_factory=socket_factory)
+        # nosemgrep: aiohttp-missing-trust-env (internal ClickHouse connection, must bypass HTTP proxy)
         self.session = aiohttp.ClientSession(connector=self.connector, timeout=self.timeout, trust_env=False)
         return self
 


### PR DESCRIPTION
## Problem

The `semgrep-python` CI job fails on master with a blocking `aiohttp-missing-trust-env` finding in `posthog/temporal/common/clickhouse.py:829`. The ClickHouse HTTP client intentionally sets `trust_env=False` because it's an internal service-to-service connection that should bypass the HTTP proxy.

## Changes

Added a `# nosemgrep: aiohttp-missing-trust-env` annotation with an explanation, following the rule's own guidance for internal calls that must bypass the proxy.

## How did you test this code?

- Ran the `aiohttp-missing-trust-env` semgrep rule locally via Docker against the file — 0 findings after the fix

## Publish to changelog?

no

## Docs update

n/a

## 🤖 LLM context

Authored with Claude Code. Single-line nosemgrep annotation for an intentional proxy bypass.