### PR TITLE
fix(esbuilder): add CSS fallback when hashed stylesheet fails to load

### DIFF
--- a/common/esbuilder/utils.mjs
+++ b/common/esbuilder/utils.mjs
@@ -119,12 +119,25 @@ export function copyIndexHtml(
         window.ESBUILD_LOAD_CHUNKS('index');
     `
 
-    // Modified CSS loader to handle both files
+    // CSS loader with fallback to non-hashed file (with cache-busting build ID)
+    // when the hashed version fails to load (e.g. CDN returns 403).
+    // This mirrors the JS fallback pattern above.
+    const cssFileFallback = `${entry}.css?t=${buildId}`
     const cssLoader = `
         const link = document.createElement("link");
         link.rel = "stylesheet";
         link.crossOrigin = "anonymous";
         link.href = (window.JS_URL || '') + "/static/" + ${JSON.stringify(cssFile)};
+        link.onerror = function() {
+            if (${JSON.stringify(cssFile)} !== ${JSON.stringify(cssFileFallback)}) {
+                console.warn('Failed to load stylesheet "' + ${JSON.stringify(cssFile)} + '", trying fallback');
+                var fallbackLink = document.createElement("link");
+                fallbackLink.rel = "stylesheet";
+                fallbackLink.crossOrigin = "anonymous";
+                fallbackLink.href = (window.JS_URL || '') + "/static/" + ${JSON.stringify(cssFileFallback)};
+                document.head.appendChild(fallbackLink);
+            }
+        };
         document.head.appendChild(link)
     `
 

--- a/common/esbuilder/utils.mjs
+++ b/common/esbuilder/utils.mjs
@@ -82,7 +82,7 @@ export function copyIndexHtml(
     const cssFile =
         relativeFiles.length > 0 ? relativeFiles.find((e) => e.endsWith('.css')) : `${entry}.css?t=${buildId}`
 
-    const jsFileFallback = `${entry}.js`
+    const jsFileFallback = `${entry}.js?t=${buildId}`
     const scriptCode = `
         window.ESBUILD_LOAD_SCRIPT = async function (file) {
             try {
@@ -124,7 +124,7 @@ export function copyIndexHtml(
     const cssFileFallback = `${entry}.css?t=${buildId}`
     const needsCssFallback = cssFile !== cssFileFallback
     const cssLoader = `
-        var link = document.createElement("link");
+        const link = document.createElement("link");
         link.rel = "stylesheet";
         link.crossOrigin = "anonymous";
         link.href = (window.JS_URL || '') + "/static/" + ${JSON.stringify(cssFile)};

--- a/common/esbuilder/utils.mjs
+++ b/common/esbuilder/utils.mjs
@@ -119,25 +119,28 @@ export function copyIndexHtml(
         window.ESBUILD_LOAD_CHUNKS('index');
     `
 
-    // CSS loader with fallback to non-hashed file (with cache-busting build ID)
-    // when the hashed version fails to load (e.g. CDN returns 403).
-    // This mirrors the JS fallback pattern above.
+    // Fallback to non-hashed CSS (with cache-busting build ID) when the hashed
+    // version fails to load (e.g. CDN returns 403). Mirrors the JS fallback above.
     const cssFileFallback = `${entry}.css?t=${buildId}`
+    const needsCssFallback = cssFile !== cssFileFallback
     const cssLoader = `
-        const link = document.createElement("link");
+        var link = document.createElement("link");
         link.rel = "stylesheet";
         link.crossOrigin = "anonymous";
         link.href = (window.JS_URL || '') + "/static/" + ${JSON.stringify(cssFile)};
-        link.onerror = function() {
-            if (${JSON.stringify(cssFile)} !== ${JSON.stringify(cssFileFallback)}) {
-                console.warn('Failed to load stylesheet "' + ${JSON.stringify(cssFile)} + '", trying fallback');
-                var fallbackLink = document.createElement("link");
-                fallbackLink.rel = "stylesheet";
-                fallbackLink.crossOrigin = "anonymous";
-                fallbackLink.href = (window.JS_URL || '') + "/static/" + ${JSON.stringify(cssFileFallback)};
-                document.head.appendChild(fallbackLink);
-            }
-        };
+        ${
+            needsCssFallback
+                ? `link.onerror = function() {
+            link.onerror = null;
+            console.warn('Failed to load stylesheet "' + ${JSON.stringify(cssFile)} + '", trying fallback');
+            var fallbackLink = document.createElement("link");
+            fallbackLink.rel = "stylesheet";
+            fallbackLink.crossOrigin = "anonymous";
+            fallbackLink.href = (window.JS_URL || '') + "/static/" + ${JSON.stringify(cssFileFallback)};
+            document.head.appendChild(fallbackLink);
+        };`
+                : ''
+        }
         document.head.appendChild(link)
     `
 

--- a/playwright/e2e/shared-dashboard-styling.spec.ts
+++ b/playwright/e2e/shared-dashboard-styling.spec.ts
@@ -1,91 +1,58 @@
 /**
- * Test shared dashboard/insight styling loads correctly
- *
- * This test verifies that CSS properly loads on shared dashboards/insights.
- * It was added as a regression test after a bug where the hashed CSS file
- * returned 403 errors, breaking all shared dashboard styling.
+ * Regression test: shared dashboard/insight CSS loading and fallback.
+ * Added after hashed CSS files returned 403, breaking all shared dashboard styling.
  */
-import { expect } from '@playwright/test'
+import { expect, Page } from '@playwright/test'
 
 import { InsightVizNode, NodeKind, TrendsQuery } from '../../frontend/src/queries/schema/schema-general'
 import { SharingConfigurationType } from '../../frontend/src/types'
+import { PlaywrightSetup } from '../utils/playwright-setup'
 import { test } from '../utils/workspace-test-base'
 
-type InsightCreationPayload = {
-    name: string
-    query: InsightVizNode<TrendsQuery>
+async function createSharedInsight(
+    page: Page,
+    playwrightSetup: PlaywrightSetup,
+    orgName: string
+): Promise<{ sharingData: SharingConfigurationType }> {
+    const workspace = await playwrightSetup.createWorkspace(orgName)
+
+    const payload: { name: string; query: InsightVizNode<TrendsQuery> } = {
+        name: 'Shared Styling Test Insight',
+        query: {
+            kind: NodeKind.InsightVizNode,
+            source: {
+                kind: NodeKind.TrendsQuery,
+                series: [{ kind: NodeKind.EventsNode, event: '$pageview' }],
+                dateRange: { date_from: '2024-10-04', date_to: '2024-11-03', explicitDate: true },
+            },
+        },
+    }
+
+    const insightResponse = await page.request.post(`/api/projects/${workspace.team_id}/insights/`, {
+        headers: { Authorization: `Bearer ${workspace.personal_api_key}`, 'Content-Type': 'application/json' },
+        data: payload,
+    })
+    expect(insightResponse.ok()).toBe(true)
+    const insightData = await insightResponse.json()
+
+    const sharingResponse = await page.request.patch(
+        `/api/projects/${workspace.team_id}/insights/${insightData.id}/sharing`,
+        {
+            headers: { Authorization: `Bearer ${workspace.personal_api_key}`, 'Content-Type': 'application/json' },
+            data: { enabled: true },
+        }
+    )
+    expect(sharingResponse.ok()).toBe(true)
+    const sharingData: SharingConfigurationType = await sharingResponse.json()
+    expect(sharingData.access_token).toBeTruthy()
+
+    return { sharingData }
 }
 
 test.describe('Shared dashboard styling', () => {
     test('CSS loads correctly on shared insight page', async ({ page, playwrightSetup }) => {
-        // Create workspace with API key
-        const workspace = await playwrightSetup.createWorkspace('Shared Styling Test Org')
+        const { sharingData } = await createSharedInsight(page, playwrightSetup, 'Shared Styling Test Org')
 
-        // Create a trends insight via API
-        const payload: InsightCreationPayload = {
-            name: 'Shared Styling Test Insight',
-            query: {
-                kind: NodeKind.InsightVizNode,
-                source: {
-                    kind: NodeKind.TrendsQuery,
-                    series: [
-                        {
-                            kind: NodeKind.EventsNode,
-                            event: '$pageview',
-                        },
-                    ],
-                    dateRange: {
-                        date_from: '2024-10-04',
-                        date_to: '2024-11-03',
-                        explicitDate: true,
-                    },
-                },
-            },
-        }
-
-        const insightResponse = await page.request.post(`/api/projects/${workspace.team_id}/insights/`, {
-            headers: {
-                Authorization: `Bearer ${workspace.personal_api_key}`,
-                'Content-Type': 'application/json',
-            },
-            data: payload,
-        })
-
-        expect(insightResponse.ok()).toBe(true)
-        const insightData = await insightResponse.json()
-        expect(insightData.short_id).toBeTruthy()
-
-        // Enable sharing (without password protection)
-        const sharingResponse = await page.request.patch(
-            `/api/projects/${workspace.team_id}/insights/${insightData.id}/sharing`,
-            {
-                headers: {
-                    Authorization: `Bearer ${workspace.personal_api_key}`,
-                    'Content-Type': 'application/json',
-                },
-                data: {
-                    enabled: true,
-                },
-            }
-        )
-
-        expect(sharingResponse.ok()).toBe(true)
-        const sharingData: SharingConfigurationType = await sharingResponse.json()
-        expect(sharingData.enabled).toBe(true)
-        expect(sharingData.access_token).toBeTruthy()
-
-        // Navigate to the shared insight URL (without being logged in)
-        const sharedUrl = `/shared/${sharingData.access_token}`
-
-        // Track CSS loading errors
-        const cssErrors: string[] = []
-        page.on('console', (msg) => {
-            if (msg.type() === 'error' && msg.text().includes('CSS')) {
-                cssErrors.push(msg.text())
-            }
-        })
-
-        // Track failed network requests for CSS files
         const failedCssRequests: string[] = []
         page.on('response', (response) => {
             if (response.url().includes('.css') && !response.ok()) {
@@ -93,122 +60,37 @@ test.describe('Shared dashboard styling', () => {
             }
         })
 
-        await page.goto(sharedUrl)
-
-        // Wait for the insight to load
+        await page.goto(`/shared/${sharingData.access_token}`)
         await expect(page.locator('[data-attr="insights-graph"]')).toBeVisible({ timeout: 30000 })
-
-        // Verify the insight title is visible (proves JS loaded)
         await expect(page.locator('text=Shared Styling Test Insight')).toBeVisible()
 
-        // Verify no CSS loading errors occurred
-        expect(cssErrors).toHaveLength(0)
         expect(failedCssRequests).toHaveLength(0)
-
-        // Verify that the ExporterBody class is styled (background should not be default white/transparent)
-        // This is a basic check that CSS has been applied
-        const body = page.locator('body.ExporterBody')
-        await expect(body).toBeVisible()
-
-        // Verify the insight container has proper styling by checking it has the expected classes
-        const insightContainer = page.locator('.InsightCard, .Insight, [data-attr="insights-graph"]').first()
-        await expect(insightContainer).toBeVisible()
-
-        // Take a screenshot to verify styling visually (this will be compared in CI)
-        await expect(page).toHaveScreenshot('shared-insight-with-styling.png', {
-            fullPage: true,
-            // Allow some threshold for minor rendering differences
-            maxDiffPixelRatio: 0.1,
-        })
+        await expect(page.locator('body.ExporterBody')).toBeVisible()
     })
 
     test('CSS fallback works when hashed CSS returns error', async ({ page, playwrightSetup }) => {
-        // Create workspace with API key
-        const workspace = await playwrightSetup.createWorkspace('CSS Fallback Test Org')
+        const { sharingData } = await createSharedInsight(page, playwrightSetup, 'CSS Fallback Test Org')
 
-        // Create a trends insight via API
-        const payload: InsightCreationPayload = {
-            name: 'CSS Fallback Test Insight',
-            query: {
-                kind: NodeKind.InsightVizNode,
-                source: {
-                    kind: NodeKind.TrendsQuery,
-                    series: [
-                        {
-                            kind: NodeKind.EventsNode,
-                            event: '$pageview',
-                        },
-                    ],
-                    dateRange: {
-                        date_from: '2024-10-04',
-                        date_to: '2024-11-03',
-                        explicitDate: true,
-                    },
-                },
-            },
-        }
-
-        const insightResponse = await page.request.post(`/api/projects/${workspace.team_id}/insights/`, {
-            headers: {
-                Authorization: `Bearer ${workspace.personal_api_key}`,
-                'Content-Type': 'application/json',
-            },
-            data: payload,
-        })
-
-        expect(insightResponse.ok()).toBe(true)
-        const insightData = await insightResponse.json()
-
-        // Enable sharing
-        const sharingResponse = await page.request.patch(
-            `/api/projects/${workspace.team_id}/insights/${insightData.id}/sharing`,
-            {
-                headers: {
-                    Authorization: `Bearer ${workspace.personal_api_key}`,
-                    'Content-Type': 'application/json',
-                },
-                data: {
-                    enabled: true,
-                },
-            }
-        )
-
-        expect(sharingResponse.ok()).toBe(true)
-        const sharingData: SharingConfigurationType = await sharingResponse.json()
-
-        // Intercept hashed CSS requests and make them fail to test the fallback
         let fallbackCssLoaded = false
-        await page.route('**/static/exporter-*.css', (route) => {
-            // Block the hashed CSS file to simulate CDN 403 error
-            route.abort('blockedbyclient')
-        })
-
-        // Track when fallback CSS is requested
+        await page.route('**/static/exporter-*.css', (route) => route.abort('blockedbyclient'))
         page.on('request', (request) => {
             if (request.url().includes('/static/exporter.css')) {
                 fallbackCssLoaded = true
             }
         })
 
-        // Track console warnings about CSS fallback
         let fallbackWarningLogged = false
         page.on('console', (msg) => {
-            if (msg.type() === 'warn' && msg.text().includes('Failed to load CSS')) {
+            if (msg.type() === 'warn' && msg.text().includes('Failed to load stylesheet')) {
                 fallbackWarningLogged = true
             }
         })
 
         await page.goto(`/shared/${sharingData.access_token}`)
-
-        // Wait for the insight to load (proves the page still works even with CSS issues)
         await expect(page.locator('[data-attr="insights-graph"]')).toBeVisible({ timeout: 30000 })
 
-        // Verify fallback was triggered
         expect(fallbackCssLoaded).toBe(true)
         expect(fallbackWarningLogged).toBe(true)
-
-        // Verify the page still has styling (fallback worked)
-        const body = page.locator('body.ExporterBody')
-        await expect(body).toBeVisible()
+        await expect(page.locator('body.ExporterBody')).toBeVisible()
     })
 })

--- a/playwright/e2e/shared-dashboard-styling.spec.ts
+++ b/playwright/e2e/shared-dashboard-styling.spec.ts
@@ -1,0 +1,214 @@
+/**
+ * Test shared dashboard/insight styling loads correctly
+ *
+ * This test verifies that CSS properly loads on shared dashboards/insights.
+ * It was added as a regression test after a bug where the hashed CSS file
+ * returned 403 errors, breaking all shared dashboard styling.
+ */
+import { expect } from '@playwright/test'
+
+import { InsightVizNode, NodeKind, TrendsQuery } from '../../frontend/src/queries/schema/schema-general'
+import { SharingConfigurationType } from '../../frontend/src/types'
+import { test } from '../utils/workspace-test-base'
+
+type InsightCreationPayload = {
+    name: string
+    query: InsightVizNode<TrendsQuery>
+}
+
+test.describe('Shared dashboard styling', () => {
+    test('CSS loads correctly on shared insight page', async ({ page, playwrightSetup }) => {
+        // Create workspace with API key
+        const workspace = await playwrightSetup.createWorkspace('Shared Styling Test Org')
+
+        // Create a trends insight via API
+        const payload: InsightCreationPayload = {
+            name: 'Shared Styling Test Insight',
+            query: {
+                kind: NodeKind.InsightVizNode,
+                source: {
+                    kind: NodeKind.TrendsQuery,
+                    series: [
+                        {
+                            kind: NodeKind.EventsNode,
+                            event: '$pageview',
+                        },
+                    ],
+                    dateRange: {
+                        date_from: '2024-10-04',
+                        date_to: '2024-11-03',
+                        explicitDate: true,
+                    },
+                },
+            },
+        }
+
+        const insightResponse = await page.request.post(`/api/projects/${workspace.team_id}/insights/`, {
+            headers: {
+                Authorization: `Bearer ${workspace.personal_api_key}`,
+                'Content-Type': 'application/json',
+            },
+            data: payload,
+        })
+
+        expect(insightResponse.ok()).toBe(true)
+        const insightData = await insightResponse.json()
+        expect(insightData.short_id).toBeTruthy()
+
+        // Enable sharing (without password protection)
+        const sharingResponse = await page.request.patch(
+            `/api/projects/${workspace.team_id}/insights/${insightData.id}/sharing`,
+            {
+                headers: {
+                    Authorization: `Bearer ${workspace.personal_api_key}`,
+                    'Content-Type': 'application/json',
+                },
+                data: {
+                    enabled: true,
+                },
+            }
+        )
+
+        expect(sharingResponse.ok()).toBe(true)
+        const sharingData: SharingConfigurationType = await sharingResponse.json()
+        expect(sharingData.enabled).toBe(true)
+        expect(sharingData.access_token).toBeTruthy()
+
+        // Navigate to the shared insight URL (without being logged in)
+        const sharedUrl = `/shared/${sharingData.access_token}`
+
+        // Track CSS loading errors
+        const cssErrors: string[] = []
+        page.on('console', (msg) => {
+            if (msg.type() === 'error' && msg.text().includes('CSS')) {
+                cssErrors.push(msg.text())
+            }
+        })
+
+        // Track failed network requests for CSS files
+        const failedCssRequests: string[] = []
+        page.on('response', (response) => {
+            if (response.url().includes('.css') && !response.ok()) {
+                failedCssRequests.push(`${response.url()} - ${response.status()}`)
+            }
+        })
+
+        await page.goto(sharedUrl)
+
+        // Wait for the insight to load
+        await expect(page.locator('[data-attr="insights-graph"]')).toBeVisible({ timeout: 30000 })
+
+        // Verify the insight title is visible (proves JS loaded)
+        await expect(page.locator('text=Shared Styling Test Insight')).toBeVisible()
+
+        // Verify no CSS loading errors occurred
+        expect(cssErrors).toHaveLength(0)
+        expect(failedCssRequests).toHaveLength(0)
+
+        // Verify that the ExporterBody class is styled (background should not be default white/transparent)
+        // This is a basic check that CSS has been applied
+        const body = page.locator('body.ExporterBody')
+        await expect(body).toBeVisible()
+
+        // Verify the insight container has proper styling by checking it has the expected classes
+        const insightContainer = page.locator('.InsightCard, .Insight, [data-attr="insights-graph"]').first()
+        await expect(insightContainer).toBeVisible()
+
+        // Take a screenshot to verify styling visually (this will be compared in CI)
+        await expect(page).toHaveScreenshot('shared-insight-with-styling.png', {
+            fullPage: true,
+            // Allow some threshold for minor rendering differences
+            maxDiffPixelRatio: 0.1,
+        })
+    })
+
+    test('CSS fallback works when hashed CSS returns error', async ({ page, playwrightSetup }) => {
+        // Create workspace with API key
+        const workspace = await playwrightSetup.createWorkspace('CSS Fallback Test Org')
+
+        // Create a trends insight via API
+        const payload: InsightCreationPayload = {
+            name: 'CSS Fallback Test Insight',
+            query: {
+                kind: NodeKind.InsightVizNode,
+                source: {
+                    kind: NodeKind.TrendsQuery,
+                    series: [
+                        {
+                            kind: NodeKind.EventsNode,
+                            event: '$pageview',
+                        },
+                    ],
+                    dateRange: {
+                        date_from: '2024-10-04',
+                        date_to: '2024-11-03',
+                        explicitDate: true,
+                    },
+                },
+            },
+        }
+
+        const insightResponse = await page.request.post(`/api/projects/${workspace.team_id}/insights/`, {
+            headers: {
+                Authorization: `Bearer ${workspace.personal_api_key}`,
+                'Content-Type': 'application/json',
+            },
+            data: payload,
+        })
+
+        expect(insightResponse.ok()).toBe(true)
+        const insightData = await insightResponse.json()
+
+        // Enable sharing
+        const sharingResponse = await page.request.patch(
+            `/api/projects/${workspace.team_id}/insights/${insightData.id}/sharing`,
+            {
+                headers: {
+                    Authorization: `Bearer ${workspace.personal_api_key}`,
+                    'Content-Type': 'application/json',
+                },
+                data: {
+                    enabled: true,
+                },
+            }
+        )
+
+        expect(sharingResponse.ok()).toBe(true)
+        const sharingData: SharingConfigurationType = await sharingResponse.json()
+
+        // Intercept hashed CSS requests and make them fail to test the fallback
+        let fallbackCssLoaded = false
+        await page.route('**/static/exporter-*.css', (route) => {
+            // Block the hashed CSS file to simulate CDN 403 error
+            route.abort('blockedbyclient')
+        })
+
+        // Track when fallback CSS is requested
+        page.on('request', (request) => {
+            if (request.url().includes('/static/exporter.css')) {
+                fallbackCssLoaded = true
+            }
+        })
+
+        // Track console warnings about CSS fallback
+        let fallbackWarningLogged = false
+        page.on('console', (msg) => {
+            if (msg.type() === 'warn' && msg.text().includes('Failed to load CSS')) {
+                fallbackWarningLogged = true
+            }
+        })
+
+        await page.goto(`/shared/${sharingData.access_token}`)
+
+        // Wait for the insight to load (proves the page still works even with CSS issues)
+        await expect(page.locator('[data-attr="insights-graph"]')).toBeVisible({ timeout: 30000 })
+
+        // Verify fallback was triggered
+        expect(fallbackCssLoaded).toBe(true)
+        expect(fallbackWarningLogged).toBe(true)
+
+        // Verify the page still has styling (fallback worked)
+        const body = page.locator('body.ExporterBody')
+        await expect(body).toBeVisible()
+    })
+})

--- a/playwright/e2e/shared-dashboard-styling.spec.ts
+++ b/playwright/e2e/shared-dashboard-styling.spec.ts
@@ -81,7 +81,7 @@ test.describe('Shared dashboard styling', () => {
 
         let fallbackWarningLogged = false
         page.on('console', (msg) => {
-            if (msg.type() === 'warn' && msg.text().includes('Failed to load stylesheet')) {
+            if (msg.type() === 'warning' && msg.text().includes('Failed to load stylesheet')) {
                 fallbackWarningLogged = true
             }
         })


### PR DESCRIPTION
## Problem

Shared dashboards have broken styling when the hashed CSS file (e.g., `exporter-HASH.css`) is unavailable from the CDN. The JS loader already falls back to `exporter.js` when the hashed version fails, but the CSS loader had no equivalent — a 403 on the hashed CSS meant zero styling.

This was presumably triggered by a deploy race condition where pods served HTML referencing a CSS hash that hadn't been uploaded to the CDN yet (e.g. the hashed file wasn't present in the S3 bucket). The JS fallback masked the issue for scripts, but CSS was completely broken. This completely breaks the rendering on shared dashboards. 

Slack thread: https://posthog.slack.com/archives/C0ACRAMJUAG/p1775806249290649?thread_ts=1775806069.989399&cid=C0ACRAMJUAG

## Changes

- **`common/esbuilder/utils.mjs`**: Adds `onerror` handler to the CSS `<link>` element that falls back to the non-hashed version with a cache-busting timestamp (e.g., `exporter.css?t=BUILD_TIMESTAMP`), also backporting this to the existing JS fallback pattern.
- **`playwright/e2e/shared-dashboard-styling.spec.ts`**: Regression tests for shared dashboard CSS loading and the fallback mechanism.

## How did you test this code?

- Built frontend locally, verified generated HTML includes CSS fallback with cache-busting timestamp
- Confirmed non-hashed `exporter.css` returns 200 from production CDN
- Added Playwright e2e tests (require full backend to run)

I'm an agent and have not tested this manually beyond the above.

## Publish to changelog?

no

## 🤖 LLM context

Agent-authored. Session: https://claude.ai/code/session_01QEcHC24rXcv83ngtSxACb7