### PR TITLE
fix(insights): pass loaded insight id to debug panel

### DIFF
--- a/frontend/src/scenes/insights/InsightSceneHeader.tsx
+++ b/frontend/src/scenes/insights/InsightSceneHeader.tsx
@@ -4,6 +4,7 @@ import { LemonBanner, LemonButton } from '@posthog/lemon-ui'
 
 import { DebugCHQueries } from 'lib/components/AppShortcuts/utils/DebugCHQueries'
 import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
+import { insightLogic } from 'scenes/insights/insightLogic'
 import { insightSceneLogic } from 'scenes/insights/insightSceneLogic'
 import { ReloadInsight } from 'scenes/saved-insights/ReloadInsight'
 import { urls } from 'scenes/urls'
@@ -21,6 +22,7 @@ export interface InsightSceneHeaderProps {
 export function InsightSceneHeader({ insightLogicProps }: InsightSceneHeaderProps): JSX.Element {
     const { insightMode, hasOverrides, freshQuery } = useValues(insightSceneLogic)
     const { showDebugPanel } = useValues(insightDataLogic(insightLogicProps))
+    const { insight } = useValues(insightLogic(insightLogicProps))
     const editorPanelsEnabled = useFeatureFlag('PRODUCT_ANALYTICS_SIMPLE_EDITOR', 'test')
     const insightId = insightLogicProps.dashboardItemId
 
@@ -52,9 +54,9 @@ export function InsightSceneHeader({ insightLogicProps }: InsightSceneHeaderProp
                     <InsightsNav />
                 ))}
 
-            {showDebugPanel && (
+            {showDebugPanel && insight?.id && (
                 <div className="mb-4">
-                    <DebugCHQueries insightId={insightLogicProps.cachedInsight?.id} />
+                    <DebugCHQueries insightId={insight.id} />
                 </div>
             )}
 


### PR DESCRIPTION
## Problem

The debug panel on the insight page reads the insight ID from `insightLogicProps.cachedInsight?.id`, which is undefined when the component mounts before the insight loads. The API was being called without an `insight_id` param, falling back to the 10-minute user_id mode with no stats or chart.

## Changes

Read `insight` from `insightLogic` via `useValues` and pass `insight.id` once loaded.

## How did you test this code?
Verified the stats and chart now show:

<img width="1183" height="1036" alt="image" src="https://github.com/user-attachments/assets/06af6227-70af-4d23-ad14-761bea3f6146" />