### PR TITLE
fix(sql-editor): add null safety for source.connectionId access

### DIFF
--- a/frontend/src/scenes/data-warehouse/editor/sqlEditorLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/sqlEditorLogic.tsx
@@ -179,10 +179,10 @@ function getTabHash(values: sqlEditorLogicType['values']): Record<string, any> {
         q: values.queryInput ?? '',
         output_tab: values.outputActiveTab,
     }
-    const connectionId = values.sourceQuery?.source.connectionId
+    const connectionId = values.sourceQuery?.source?.connectionId
     if (values.featureFlags[FEATURE_FLAGS.DWH_POSTGRES_DIRECT_QUERY] && connectionId) {
         hash['c'] = connectionId
-        if (values.sourceQuery?.source.sendRawQuery) {
+        if (values.sourceQuery?.source?.sendRawQuery) {
             hash['raw'] = '1'
         }
     }
@@ -1453,21 +1453,21 @@ export const sqlEditorLogic = kea<sqlEditorLogicType>([
     subscriptions(({ actions, values, cache }) => ({
         showLegacyFilters: (showLegacyFilters: boolean) => {
             if (showLegacyFilters) {
-                if (typeof values.sourceQuery.source.filters !== 'object') {
+                if (typeof values.sourceQuery?.source?.filters !== 'object') {
                     actions.setSourceQuery({
                         ...values.sourceQuery,
                         source: {
-                            ...values.sourceQuery.source,
+                            ...values.sourceQuery?.source,
                             filters: {},
                         },
                     })
                 }
             } else {
-                if (values.sourceQuery.source.filters !== undefined) {
+                if (values.sourceQuery?.source?.filters !== undefined) {
                     actions.setSourceQuery({
                         ...values.sourceQuery,
                         source: {
-                            ...values.sourceQuery.source,
+                            ...values.sourceQuery?.source,
                             filters: undefined,
                         },
                     })
@@ -1581,7 +1581,7 @@ export const sqlEditorLogic = kea<sqlEditorLogicType>([
                 if (!featureFlags[FEATURE_FLAGS.DWH_POSTGRES_DIRECT_QUERY]) {
                     return undefined
                 }
-                return sourceQuery.source && 'connectionId' in sourceQuery.source
+                return sourceQuery?.source && 'connectionId' in sourceQuery.source
                     ? sourceQuery.source.connectionId
                     : undefined
             },
@@ -1594,7 +1594,7 @@ export const sqlEditorLogic = kea<sqlEditorLogicType>([
         ],
         sendRawQueryEnabled: [
             (s) => [s.sourceQuery, s.selectedConnectionId],
-            (sourceQuery, selectedConnectionId) => !!selectedConnectionId && (sourceQuery.source.sendRawQuery ?? false),
+            (sourceQuery, selectedConnectionId) => !!selectedConnectionId && (sourceQuery?.source?.sendRawQuery ?? false),
         ],
         isEditingMaterializedView: [
             (s) => [s.editingView],
@@ -1605,7 +1605,7 @@ export const sqlEditorLogic = kea<sqlEditorLogicType>([
         isSourceQueryLastRun: [
             (s) => [s.queryInput, s.lastRunQuery, s.sourceQuery],
             (queryInput, lastRunQuery, sourceQuery) => {
-                const lastRunQueryText = lastRunQuery?.source.query ?? sourceQuery.source.query
+                const lastRunQueryText = lastRunQuery?.source?.query ?? sourceQuery?.source?.query
                 return queryInput === lastRunQueryText
             },
         ],
@@ -1910,14 +1910,14 @@ export const sqlEditorLogic = kea<sqlEditorLogicType>([
                 connectionIdFromHash !== undefined &&
                 values.featureFlags[FEATURE_FLAGS.DWH_POSTGRES_DIRECT_QUERY] &&
                 String(hashParams.raw) === '1'
-            const currentConnectionId = values.sourceQuery.source.connectionId || undefined
-            const currentSendRawQuery = values.sourceQuery.source.sendRawQuery ?? false
+            const currentConnectionId = values.sourceQuery?.source?.connectionId || undefined
+            const currentSendRawQuery = values.sourceQuery?.source?.sendRawQuery ?? false
 
             if (connectionIdFromHash !== currentConnectionId || sendRawQueryFromHash !== currentSendRawQuery) {
                 actions.setSourceQuery({
                     ...values.sourceQuery,
                     source: {
-                        ...values.sourceQuery.source,
+                        ...values.sourceQuery?.source,
                         connectionId: connectionIdFromHash,
                         sendRawQuery: sendRawQueryFromHash || undefined,
                     },


### PR DESCRIPTION
## Problem

A `TypeError: Cannot read properties of undefined (reading 'connectionId')` crashes URL sync in the SQL editor on every keystroke when `sourceQuery.source` is undefined. This happens during a race between tab creation and source query initialization, introduced in commit 8f20613 (direct postgres frontend, part 5).

## Changes

Added optional chaining (`?.`) on `.source` in all unsafe access sites in `sqlEditorLogic.tsx`:

- `getTabHash()` (lines 182, 185) — the crash site reported in error tracking
- `urlToAction` (lines 1913–1914, 1920) — same pattern with no null guard at all
- `selectedConnectionId` selector (line 1584)
- `sendRawQueryEnabled` selector (line 1597)
- `showLegacyFilters` subscription (lines 1456, 1460, 1466, 1470)
- `isSourceQueryLastRun` selector (line 1608)

## How did you test this code?

This is a straightforward addition of optional chaining. The change is purely defensive — when `source` is defined, behavior is identical. When `source` is undefined, accesses now return `undefined` instead of throwing a TypeError.

This PR was authored by an agent and has not been manually tested.

## 🤖 LLM context

Automated fix for error tracking issue 019d753a-e7ea-7821-b35e-5065d3ba0bba. The root cause is that `sourceQuery.source` can be undefined during tab initialization, but several access sites only guard against `sourceQuery` being nullish, not `source`.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*