### PR TITLE
fix(replay): update RECORDING_API_URL default to port 6741 in dev

### DIFF
--- a/posthog/settings/session_replay_v2.py
+++ b/posthog/settings/session_replay_v2.py
@@ -27,6 +27,6 @@ SESSION_RECORDING_V2_S3_BUCKET = os.getenv("SESSION_RECORDING_V2_S3_BUCKET", "po
 SESSION_RECORDING_V2_S3_PREFIX = os.getenv("SESSION_RECORDING_V2_S3_PREFIX", "session_recordings")
 
 if TEST or DEBUG:
-    RECORDING_API_URL = os.getenv("RECORDING_API_URL", "http://localhost:6738")
+    RECORDING_API_URL = os.getenv("RECORDING_API_URL", "http://localhost:6741")
 else:
     RECORDING_API_URL = os.getenv("RECORDING_API_URL", "")


### PR DESCRIPTION
## Problem

The snapshots endpoint returns an empty list for every recording in a fresh local dev stack, so the player silently loads nothing.

`posthog/settings/session_replay_v2.py` defaults `RECORDING_API_URL` to `http://localhost:6738` when `DEBUG` or `TEST` is set. That default was correct when the recording-api lived inside the combined `nodejs` plugin server on 6738 (#48181), but #52571 split it out into a dedicated mprocs entry on port **6741**. The Django default was never updated, so requests for block listings end up at whatever other plugin-server process is bound to 6738 (on my machine that's the CDP api), hit a 404, get caught by the exception handler in `list_blocks()`, and return `[]`.

## Changes

One-line default change: `6738` → `6741`.

## How did you test this code?

Verified locally:

- Before: `GET /api/projects/1/recordings/{session_id}/snapshots` returned `{"sources": []}` for every session; the player sidebar showed no snapshots.
- `curl http://localhost:6741/api/projects/1/recordings/{session_id}/blocks` (with `X-Internal-Api-Secret`) returns the real block list, confirming the service is healthy and it's only the Django default that was wrong.
- `curl http://localhost:6738/...` returns the default Express 404 — that's an unrelated plugin-server process.

I'm an agent and have only tested this via direct curl against the two ports and confirmed the route mount in `bin/mprocs.yaml` — I have not re-run the full player flow end-to-end after the fix.

## Publish to changelog?

no

## 🤖 LLM context

Authored by Claude Code (Opus 4.6) while debugging a separate progress-tracking change against a fresh local stack. The empty-snapshots symptom was the entry point; the root cause turned out to be a stale default from #48181 that was not updated when #52571 moved the recording-api to its own process on 6741.