### PR TITLE
fix(replay): polling status on single summaries

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -4035,6 +4035,23 @@ const api = {
             )
         },
 
+        async summarize(
+            recordingId: SessionRecordingType['id']
+        ): Promise<{ job_id: string; status: string; progress?: string; result?: any }> {
+            return await new ApiRequest().recording(recordingId).withAction('summarize').create()
+        },
+
+        async getSummarizeStatus(
+            recordingId: SessionRecordingType['id'],
+            jobId: string
+        ): Promise<{ status: string; progress?: string; result?: any; error_message?: string; job_id?: string }> {
+            return await new ApiRequest()
+                .recording(recordingId)
+                .withAction('summarize')
+                .withQueryString({ job_id: jobId })
+                .get()
+        },
+
         async similarRecordings(recordingId: SessionRecordingType['id']): Promise<[string, number][]> {
             return await new ApiRequest().recording(recordingId).withAction('similar_sessions').get()
         },

--- a/frontend/src/scenes/session-recordings/player/player-meta/playerMetaLogic.test.ts
+++ b/frontend/src/scenes/session-recordings/player/player-meta/playerMetaLogic.test.ts
@@ -64,4 +64,19 @@ describe('playerMetaLogic', () => {
                 .toMatchValues({ loading: false })
         })
     })
+
+    describe('summary progress', () => {
+        it('clears progress when summary content arrives', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.setSummaryProgress('Analyzing...')
+            }).toMatchValues({ summaryProgress: 'Analyzing...' })
+
+            await expectLogic(logic, () => {
+                logic.actions.setSessionSummaryContent({ segments: [] } as any)
+            }).toMatchValues({
+                summaryProgress: null,
+                sessionSummaryLoading: false,
+            })
+        })
+    })
 })

--- a/frontend/src/scenes/session-recordings/player/player-meta/playerMetaLogic.tsx
+++ b/frontend/src/scenes/session-recordings/player/player-meta/playerMetaLogic.tsx
@@ -132,6 +132,8 @@ export const playerMetaLogic = kea<playerMetaLogicType>([
         sessionSummaryFeedback: (feedback: 'good' | 'bad') => ({ feedback }),
         setSessionSummaryContent: (content: SessionSummaryContent) => ({ content }),
         summarizeSession: () => ({}),
+        pollSessionSummary: (id: string) => ({ id }),
+        streamSessionSummary: (id: string) => ({ id }),
         setSessionSummaryLoading: (isLoading: boolean) => ({ isLoading }),
         setIsPropertyPopoverOpen: (isOpen: boolean) => ({ isOpen }),
     }),
@@ -457,13 +459,62 @@ export const playerMetaLogic = kea<playerMetaLogicType>([
                 return
             }
 
-            // Give up waiting after 10 minutes. If the workflow finishes later,
+            if (posthog.isFeatureEnabled('session-summary-polling')) {
+                await actions.pollSessionSummary(id)
+            } else {
+                await actions.streamSessionSummary(id)
+            }
+        },
+        pollSessionSummary: async ({ id }: { id: string }) => {
+            try {
+                const startResponse = await api.recordings.summarize(id)
+
+                if (startResponse.status === 'complete' && startResponse.result) {
+                    actions.setSessionSummaryContent(startResponse.result)
+                    return
+                }
+
+                const jobId = startResponse.job_id
+                const POLL_INTERVAL = 5000
+                const MAX_POLL_TIME = 20 * 60 * 1000
+
+                const pollStartTime = Date.now()
+                const interval = setInterval(async () => {
+                    if (Date.now() - pollStartTime > MAX_POLL_TIME) {
+                        clearInterval(interval)
+                        actions.setSessionSummaryLoading(false)
+                        return
+                    }
+                    try {
+                        const pollResponse = await api.recordings.getSummarizeStatus(id, jobId)
+                        if (pollResponse.status === 'complete' && pollResponse.result) {
+                            clearInterval(interval)
+                            actions.setSessionSummaryContent(pollResponse.result)
+                        } else if (pollResponse.status === 'error') {
+                            clearInterval(interval)
+                            lemonToast.error(pollResponse.error_message || 'Summary generation failed')
+                            actions.setSessionSummaryLoading(false)
+                        }
+                    } catch {
+                        clearInterval(interval)
+                        actions.setSessionSummaryLoading(false)
+                    }
+                }, POLL_INTERVAL)
+            } catch (err) {
+                if (err instanceof ApiError) {
+                    lemonToast.error(err.message)
+                }
+                actions.setSessionSummaryLoading(false)
+            }
+        },
+        streamSessionSummary: async ({ id }: { id: string }) => {
+            // Give up waiting after 20 minutes. If the workflow finishes later,
             // the summary will show up next time the user opens this recording
             const timeout = setTimeout(
                 () => {
                     actions.setSessionSummaryLoading(false)
                 },
-                10 * 60 * 1000
+                20 * 60 * 1000
             )
 
             try {

--- a/frontend/src/scenes/session-recordings/player/player-meta/playerMetaLogic.tsx
+++ b/frontend/src/scenes/session-recordings/player/player-meta/playerMetaLogic.tsx
@@ -135,6 +135,7 @@ export const playerMetaLogic = kea<playerMetaLogicType>([
         pollSessionSummary: (id: string) => ({ id }),
         streamSessionSummary: (id: string) => ({ id }),
         setSessionSummaryLoading: (isLoading: boolean) => ({ isLoading }),
+        setSummaryProgress: (progress: string | null) => ({ progress }),
         setIsPropertyPopoverOpen: (isOpen: boolean) => ({ isOpen }),
     }),
     reducers(() => ({
@@ -156,6 +157,14 @@ export const playerMetaLogic = kea<playerMetaLogicType>([
                 summarizeSession: () => true,
                 setSessionSummaryContent: () => false,
                 setSessionSummaryLoading: (_, { isLoading }) => isLoading,
+            },
+        ],
+        summaryProgress: [
+            null as string | null,
+            {
+                setSummaryProgress: (_, { progress }) => progress,
+                setSessionSummaryContent: () => null,
+                setSessionSummaryLoading: () => null,
             },
         ],
         isPropertyPopoverOpen: [
@@ -465,41 +474,40 @@ export const playerMetaLogic = kea<playerMetaLogicType>([
                 await actions.streamSessionSummary(id)
             }
         },
-        pollSessionSummary: async ({ id }: { id: string }) => {
+        pollSessionSummary: async ({ id }: { id: string }, breakpoint: () => Promise<void>) => {
+            const POLL_INTERVAL = 5000
+            const MAX_POLL_TIME = 20 * 60 * 1000
+
             try {
                 const startResponse = await api.recordings.summarize(id)
+                breakpoint()
 
                 if (startResponse.status === 'complete' && startResponse.result) {
                     actions.setSessionSummaryContent(startResponse.result)
                     return
                 }
 
+                actions.setSummaryProgress(startResponse.progress || 'Starting summary generation...')
                 const jobId = startResponse.job_id
-                const POLL_INTERVAL = 5000
-                const MAX_POLL_TIME = 20 * 60 * 1000
-
                 const pollStartTime = Date.now()
-                const interval = setInterval(async () => {
-                    if (Date.now() - pollStartTime > MAX_POLL_TIME) {
-                        clearInterval(interval)
+
+                while (Date.now() - pollStartTime < MAX_POLL_TIME) {
+                    await breakpoint(POLL_INTERVAL)
+                    const pollResponse = await api.recordings.getSummarizeStatus(id, jobId)
+                    breakpoint()
+
+                    if (pollResponse.status === 'complete' && pollResponse.result) {
+                        actions.setSessionSummaryContent(pollResponse.result)
+                        return
+                    } else if (pollResponse.status === 'error') {
+                        lemonToast.error(pollResponse.error_message || 'Summary generation failed')
                         actions.setSessionSummaryLoading(false)
                         return
                     }
-                    try {
-                        const pollResponse = await api.recordings.getSummarizeStatus(id, jobId)
-                        if (pollResponse.status === 'complete' && pollResponse.result) {
-                            clearInterval(interval)
-                            actions.setSessionSummaryContent(pollResponse.result)
-                        } else if (pollResponse.status === 'error') {
-                            clearInterval(interval)
-                            lemonToast.error(pollResponse.error_message || 'Summary generation failed')
-                            actions.setSessionSummaryLoading(false)
-                        }
-                    } catch {
-                        clearInterval(interval)
-                        actions.setSessionSummaryLoading(false)
-                    }
-                }, POLL_INTERVAL)
+                    actions.setSummaryProgress(pollResponse.progress || 'Generating summary...')
+                }
+
+                actions.setSessionSummaryLoading(false)
             } catch (err) {
                 if (err instanceof ApiError) {
                     lemonToast.error(err.message)

--- a/frontend/src/scenes/session-recordings/player/player-meta/playerMetaLogic.tsx
+++ b/frontend/src/scenes/session-recordings/player/player-meta/playerMetaLogic.tsx
@@ -474,7 +474,7 @@ export const playerMetaLogic = kea<playerMetaLogicType>([
                 await actions.streamSessionSummary(id)
             }
         },
-        pollSessionSummary: async ({ id }: { id: string }, breakpoint: () => Promise<void>) => {
+        pollSessionSummary: async ({ id }, breakpoint) => {
             const POLL_INTERVAL = 5000
             const MAX_POLL_TIME = 20 * 60 * 1000
 

--- a/frontend/src/scenes/session-recordings/player/sidebar/PlayerSidebarSessionSummary.tsx
+++ b/frontend/src/scenes/session-recordings/player/sidebar/PlayerSidebarSessionSummary.tsx
@@ -717,7 +717,7 @@ function LoadSessionSummaryButton(): JSX.Element {
 
 export function PlayerSidebarSessionSummary(): JSX.Element | null {
     const { logicProps } = useValues(sessionRecordingPlayerLogic)
-    const { sessionSummary, sessionSummaryLoading } = useValues(playerMetaLogic(logicProps))
+    const { sessionSummary, sessionSummaryLoading, summaryProgress } = useValues(playerMetaLogic(logicProps))
 
     return (
         <div className="rounded border bg-surface-primary px-2 py-1">
@@ -725,7 +725,7 @@ export function PlayerSidebarSessionSummary(): JSX.Element | null {
                 <>
                     <div className="flex items-center justify-between">
                         <div>
-                            Researching the session... <Spinner />
+                            {summaryProgress || 'Researching the session...'} <Spinner />
                         </div>
                         <div className="flex items-center gap-1 ml-auto">
                             <LoadingTimer />

--- a/posthog/session_recordings/session_recording_api.py
+++ b/posthog/session_recordings/session_recording_api.py
@@ -94,7 +94,10 @@ from posthog.session_recordings.utils import (
     query_as_params_to_dict,
 )
 from posthog.settings.session_replay import SESSION_REPLAY_AI_REGEX_MODEL
-from posthog.temporal.session_replay.session_summary.summarize_session import execute_summarize_session
+from posthog.temporal.session_replay.session_summary.summarize_session import (
+    execute_summarize_session,
+    execute_summarize_session_async,
+)
 
 from ee.hogai.session_summaries.llm.call import get_openai_client
 from ee.hogai.session_summaries.session.output_data import OutcomeSerializer
@@ -1423,7 +1426,7 @@ class SessionRecordingViewSet(
             )
 
     @extend_schema(exclude=True)
-    @action(methods=["POST"], detail=True)
+    @action(methods=["POST", "GET"], detail=True)
     def summarize(self, request: request.Request, **kwargs):
         if not request.user.is_authenticated:
             raise exceptions.NotAuthenticated()
@@ -1438,6 +1441,9 @@ class SessionRecordingViewSet(
         cached_response = cache.get(cache_key)
         if cached_response is not None:
             return Response(cached_response)
+
+        if request.method == "GET":
+            return self._summarize_poll(request, recording)
 
         if not SessionReplayEvents().exists(session_id=str(recording.session_id), team=self.team):
             raise exceptions.NotFound("Recording not found")
@@ -1459,6 +1465,14 @@ class SessionRecordingViewSet(
         session_id = str(recording.session_id)
         tracking_id = generate_tracking_id()
         video_based_summarization_enabled = self._determine_video_based_summarization_enabled(user)
+
+        use_polling = posthoganalytics.feature_enabled(
+            "session-summary-polling",
+            str(user.distinct_id),
+            send_feature_flag_events=False,
+        )
+        if use_polling:
+            return self._summarize_start(session_id, user, video_based_summarization_enabled, tracking_id)
 
         if video_based_summarization_enabled:
             # Use non-streaming workflow for video-based summarization
@@ -1494,6 +1508,103 @@ class SessionRecordingViewSet(
                 stream_recording_summary(session_id=session_id, user=user, team=self.team),
                 content_type=ServerSentEventRenderer.media_type,
             )
+
+    def _summarize_poll(self, request: request.Request, recording) -> Response:
+        """GET handler: poll for summary job status."""
+        from posthog.session_recordings.session_summary_job_status import SummaryJobStatusManager
+
+        from ee.models.session_summaries import SingleSessionSummary
+
+        job_id = request.query_params.get("job_id")
+        if not job_id:
+            raise exceptions.ValidationError("job_id query parameter is required")
+
+        manager = SummaryJobStatusManager(team_id=self.team.pk, job_id=job_id)
+        status = manager.get_status()
+
+        if status and status.status == "complete":
+            return Response({"status": "complete", "result": status.result})
+        if status and status.status == "error":
+            return Response(
+                {"status": "error", "error_message": status.error_message},
+                status=400,
+            )
+
+        # DB fallback: the workflow may have completed but failed to update Redis
+        summary_row = SingleSessionSummary.objects.get_summary(
+            team_id=self.team.pk,
+            session_id=str(recording.session_id),
+        )
+        if summary_row:
+            manager.mark_complete(summary_row.summary)
+            return Response({"status": "complete", "result": summary_row.summary})
+
+        if not status:
+            raise exceptions.NotFound("Summary job not found or expired")
+
+        return Response(
+            {"status": status.status, "progress": status.progress, "job_id": job_id},
+            status=202,
+        )
+
+    def _summarize_start(
+        self,
+        session_id: str,
+        user: User,
+        video_based: bool,
+        tracking_id: str,
+    ) -> Response:
+        """POST handler: start a summary job and return immediately."""
+        from posthog.session_recordings.session_summary_job_status import SummaryJobStatus, SummaryJobStatusManager
+
+        # Check if there's already a running job for this session
+        existing_job_id = SummaryJobStatusManager.get_running_job_for_session(self.team.pk, session_id)
+        if existing_job_id:
+            manager = SummaryJobStatusManager(team_id=self.team.pk, job_id=existing_job_id)
+            status = manager.get_status()
+            if status and status.status in ("pending", "running"):
+                return Response(
+                    {"job_id": existing_job_id, "status": status.status, "progress": status.progress},
+                    status=202,
+                )
+
+        # Start a new job
+        manager = SummaryJobStatusManager(team_id=self.team.pk)
+        job_status = SummaryJobStatus(
+            job_id=manager.job_id,
+            session_id=session_id,
+            team_id=self.team.pk,
+        )
+        manager.store_status(job_status)
+        SummaryJobStatusManager.register_running_session(self.team.pk, session_id, manager.job_id)
+
+        # Start the workflow. Returns the cached summary if one exists, otherwise None.
+        existing_result = async_to_sync(execute_summarize_session_async)(
+            session_id=session_id,
+            user=user,
+            team=self.team,
+            video_validation_enabled="full" if video_based else None,
+            job_id=manager.job_id,
+        )
+        if existing_result is not None:
+            manager.mark_complete(existing_result)
+            return Response({"status": "complete", "result": existing_result})
+
+        capture_session_summary_started(
+            user=user,
+            team=self.team,
+            tracking_id=tracking_id,
+            summary_source="api",
+            summary_type="single",
+            is_streaming=False,
+            session_ids=[session_id],
+            video_validation_enabled="full" if video_based else None,
+        )
+
+        return Response(
+            {"job_id": manager.job_id, "status": "pending"},
+            status=202,
+        )
 
     async def _stream_lts_blob_v2_to_client_async(
         self,

--- a/posthog/session_recordings/session_summary_job_status.py
+++ b/posthog/session_recordings/session_summary_job_status.py
@@ -58,7 +58,7 @@ class SummaryJobStatusManager:
             status.result = result
             status.progress = None
             self.store_status(status)
-        self.unregister_running_session(self.team_id, status.session_id if status else "")
+            self.unregister_running_session(self.team_id, status.session_id)
 
     def mark_error(self, error_message: str) -> None:
         status = self.get_status()
@@ -67,7 +67,7 @@ class SummaryJobStatusManager:
             status.error_message = error_message
             status.progress = None
             self.store_status(status)
-        self.unregister_running_session(self.team_id, status.session_id if status else "")
+            self.unregister_running_session(self.team_id, status.session_id)
 
     @classmethod
     def get_running_job_for_session(cls, team_id: int, session_id: str) -> str | None:

--- a/posthog/session_recordings/session_summary_job_status.py
+++ b/posthog/session_recordings/session_summary_job_status.py
@@ -1,0 +1,91 @@
+import json
+from dataclasses import asdict, dataclass
+from uuid import uuid4
+
+from posthog.redis import get_client
+
+STATUS_TTL_SECONDS = 20 * 60  # 20 minutes
+
+
+@dataclass
+class SummaryJobStatus:
+    job_id: str
+    session_id: str
+    team_id: int
+    status: str = "pending"  # pending, running, complete, error
+    progress: str | None = None
+    result: dict | None = None
+    error_message: str | None = None
+
+
+def _job_key(team_id: int, job_id: str) -> str:
+    return f"summary_job:{team_id}:{job_id}"
+
+
+def _running_key(team_id: int, session_id: str) -> str:
+    return f"summary_running:{team_id}:{session_id}"
+
+
+class SummaryJobStatusManager:
+    def __init__(self, team_id: int, job_id: str | None = None):
+        self.team_id = team_id
+        self.job_id = job_id or uuid4().hex
+        self.redis_client = get_client()
+
+    def store_status(self, status: SummaryJobStatus) -> None:
+        key = _job_key(self.team_id, self.job_id)
+        self.redis_client.setex(key, STATUS_TTL_SECONDS, json.dumps(asdict(status)))
+
+    def get_status(self) -> SummaryJobStatus | None:
+        key = _job_key(self.team_id, self.job_id)
+        raw = self.redis_client.get(key)
+        if not raw:
+            return None
+        data = json.loads(raw)
+        return SummaryJobStatus(**data)
+
+    def update_progress(self, progress: str) -> None:
+        status = self.get_status()
+        if status:
+            status.progress = progress
+            status.status = "running"
+            self.store_status(status)
+
+    def mark_complete(self, result: dict) -> None:
+        status = self.get_status()
+        if status:
+            status.status = "complete"
+            status.result = result
+            status.progress = None
+            self.store_status(status)
+        self.unregister_running_session(self.team_id, status.session_id if status else "")
+
+    def mark_error(self, error_message: str) -> None:
+        status = self.get_status()
+        if status:
+            status.status = "error"
+            status.error_message = error_message
+            status.progress = None
+            self.store_status(status)
+        self.unregister_running_session(self.team_id, status.session_id if status else "")
+
+    @classmethod
+    def get_running_job_for_session(cls, team_id: int, session_id: str) -> str | None:
+        client = get_client()
+        key = _running_key(team_id, session_id)
+        raw = client.get(key)
+        if raw:
+            return raw.decode() if isinstance(raw, bytes) else raw
+        return None
+
+    @classmethod
+    def register_running_session(cls, team_id: int, session_id: str, job_id: str) -> None:
+        client = get_client()
+        key = _running_key(team_id, session_id)
+        client.setex(key, STATUS_TTL_SECONDS, job_id)
+
+    @classmethod
+    def unregister_running_session(cls, team_id: int, session_id: str) -> None:
+        client = get_client()
+        key = _running_key(team_id, session_id)
+        client.delete(key)

--- a/posthog/session_recordings/test/test_session_recordings.py
+++ b/posthog/session_recordings/test/test_session_recordings.py
@@ -2105,6 +2105,8 @@ class TestSessionRecordings(APIBaseTest, ClickhouseTestMixin, QueryMatchingTest)
         def feature_flag_side_effect(flag_name, *args, **kwargs):
             if flag_name == "max-session-summarization-video-as-base":
                 return video_based_enabled
+            if flag_name == "session-summary-polling":
+                return False
             return True
 
         mock_feature_enabled.side_effect = feature_flag_side_effect
@@ -2132,6 +2134,118 @@ class TestSessionRecordings(APIBaseTest, ClickhouseTestMixin, QueryMatchingTest)
         else:
             mock_stream_summary.assert_called_once_with(session_id=session_id, user=self.user, team=self.team)
             mock_execute_summarize.assert_not_called()
+
+    @patch("posthog.session_recordings.session_recording_api.execute_summarize_session_async")
+    @patch("posthog.session_recordings.session_recording_api.is_cloud", return_value=True)
+    @patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"})
+    @patch("posthoganalytics.feature_enabled")
+    def test_summarize_polling_start_returns_pending(
+        self,
+        mock_feature_enabled: MagicMock,
+        mock_is_cloud: MagicMock,
+        mock_execute_async: MagicMock,
+    ):
+        session_id = str(uuid7())
+        self.produce_replay_summary(
+            distinct_id="user",
+            session_id=session_id,
+            timestamp=now() - timedelta(hours=1),
+        )
+        mock_feature_enabled.return_value = True
+
+        async def async_return_none(*args, **kwargs):
+            return None
+
+        mock_execute_async.side_effect = async_return_none
+
+        response = self.client.post(f"/api/projects/{self.team.id}/session_recordings/{session_id}/summarize")
+
+        assert response.status_code == status.HTTP_202_ACCEPTED
+        data = response.json()
+        assert data["status"] == "pending"
+        assert "job_id" in data
+
+    @patch("posthog.session_recordings.session_recording_api.execute_summarize_session_async")
+    @patch("posthog.session_recordings.session_recording_api.is_cloud", return_value=True)
+    @patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"})
+    @patch("posthoganalytics.feature_enabled")
+    def test_summarize_polling_start_returns_cached_result(
+        self,
+        mock_feature_enabled: MagicMock,
+        mock_is_cloud: MagicMock,
+        mock_execute_async: MagicMock,
+    ):
+        session_id = str(uuid7())
+        self.produce_replay_summary(
+            distinct_id="user",
+            session_id=session_id,
+            timestamp=now() - timedelta(hours=1),
+        )
+        mock_feature_enabled.return_value = True
+
+        cached = {"summary": "already done"}
+
+        async def async_return_cached(*args, **kwargs):
+            return cached
+
+        mock_execute_async.side_effect = async_return_cached
+
+        response = self.client.post(f"/api/projects/{self.team.id}/session_recordings/{session_id}/summarize")
+
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data["status"] == "complete"
+        assert data["result"] == cached
+
+    @patch("posthog.session_recordings.session_recording_api.is_cloud", return_value=True)
+    @patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"})
+    @patch("posthoganalytics.feature_enabled")
+    def test_summarize_poll_returns_job_status(
+        self,
+        mock_feature_enabled: MagicMock,
+        mock_is_cloud: MagicMock,
+    ):
+        from posthog.session_recordings.session_summary_job_status import SummaryJobStatus, SummaryJobStatusManager
+
+        session_id = str(uuid7())
+        self.produce_replay_summary(
+            distinct_id="user",
+            session_id=session_id,
+            timestamp=now() - timedelta(hours=1),
+        )
+        mock_feature_enabled.return_value = True
+
+        manager = SummaryJobStatusManager(team_id=self.team.pk, job_id="poll-test-job")
+        manager.store_status(
+            SummaryJobStatus(
+                job_id="poll-test-job",
+                session_id=session_id,
+                team_id=self.team.pk,
+                status="running",
+                progress="Analyzing events...",
+            )
+        )
+
+        response = self.client.get(
+            f"/api/projects/{self.team.id}/session_recordings/{session_id}/summarize?job_id=poll-test-job"
+        )
+
+        assert response.status_code == status.HTTP_202_ACCEPTED
+        data = response.json()
+        assert data["status"] == "running"
+        assert data["progress"] == "Analyzing events..."
+
+    def test_summarize_poll_requires_job_id(self):
+        session_id = str(uuid7())
+        self.produce_replay_summary(
+            distinct_id="user",
+            session_id=session_id,
+            timestamp=now() - timedelta(hours=1),
+        )
+
+        response = self.client.get(f"/api/projects/{self.team.id}/session_recordings/{session_id}/summarize")
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
 
     @patch(
         "posthog.session_recordings.session_recording_api.SessionRecordingViewSet._delete_via_recording_api",

--- a/posthog/session_recordings/test/test_session_summary_job_status.py
+++ b/posthog/session_recordings/test/test_session_summary_job_status.py
@@ -1,0 +1,55 @@
+from posthog.test.base import BaseTest
+
+from parameterized import parameterized
+
+from posthog.session_recordings.session_summary_job_status import SummaryJobStatus, SummaryJobStatusManager
+
+
+class TestSummaryJobStatusManager(BaseTest):
+    def _create_manager(self, job_id: str = "test-job-1") -> SummaryJobStatusManager:
+        return SummaryJobStatusManager(team_id=self.team.pk, job_id=job_id)
+
+    def _store_pending_status(self, manager: SummaryJobStatusManager, session_id: str = "session-1") -> None:
+        manager.store_status(
+            SummaryJobStatus(
+                job_id=manager.job_id,
+                session_id=session_id,
+                team_id=self.team.pk,
+            )
+        )
+
+    def test_mark_complete(self):
+        manager = self._create_manager()
+        self._store_pending_status(manager)
+        SummaryJobStatusManager.register_running_session(self.team.pk, "session-1", manager.job_id)
+
+        result = {"summary": "test summary"}
+        manager.mark_complete(result)
+
+        status = manager.get_status()
+        assert status is not None
+        assert status.status == "complete"
+        assert status.result == result
+        assert status.progress is None
+        assert SummaryJobStatusManager.get_running_job_for_session(self.team.pk, "session-1") is None
+
+    def test_mark_error(self):
+        manager = self._create_manager()
+        self._store_pending_status(manager)
+        SummaryJobStatusManager.register_running_session(self.team.pk, "session-1", manager.job_id)
+
+        manager.mark_error("LLM timeout")
+
+        status = manager.get_status()
+        assert status is not None
+        assert status.status == "error"
+        assert status.error_message == "LLM timeout"
+        assert status.progress is None
+        assert SummaryJobStatusManager.get_running_job_for_session(self.team.pk, "session-1") is None
+
+    @parameterized.expand(
+        [("complete", "mark_complete", {"summary": "test"}), ("error", "mark_error", "something failed")]
+    )
+    def test_noop_when_status_expired(self, _name: str, method: str, arg: object):
+        manager = self._create_manager()
+        getattr(manager, method)(arg)

--- a/posthog/temporal/session_replay/session_summary/__init__.py
+++ b/posthog/temporal/session_replay/session_summary/__init__.py
@@ -23,6 +23,7 @@ from posthog.temporal.session_replay.session_summary.summarize_session import (
     fetch_session_data_activity,
     get_llm_single_session_summary_activity,
     stream_llm_single_session_summary_activity,
+    update_job_status_activity,
 )
 from posthog.temporal.session_replay.session_summary.summarize_session_group import (
     SummarizeSessionGroupWorkflow,
@@ -53,4 +54,5 @@ SESSION_SUMMARY_ACTIVITIES = [
     cleanup_gemini_file_activity,
     consolidate_video_segments_activity,
     capture_timing_activity,
+    update_job_status_activity,
 ]

--- a/posthog/temporal/session_replay/session_summary/summarize_session.py
+++ b/posthog/temporal/session_replay/session_summary/summarize_session.py
@@ -24,6 +24,7 @@ from posthog.exceptions_capture import capture_exception
 from posthog.models.team.team import Team
 from posthog.models.user import User
 from posthog.redis import get_client
+from posthog.session_recordings.session_summary_job_status import SummaryJobStatusManager
 from posthog.sync import database_sync_to_async
 from posthog.temporal.common.base import PostHogWorkflow
 from posthog.temporal.common.client import async_connect
@@ -82,6 +83,32 @@ logger = structlog.get_logger(__name__)
 
 # How often to poll for new chunks from the LLM stream
 SESSION_SUMMARIES_STREAM_INTERVAL = 0.1  # 100ms
+
+
+@dataclasses.dataclass(frozen=True)
+class UpdateJobStatusInputs:
+    team_id: int
+    session_id: str
+    job_id: str
+    status: str  # "complete" or "error"
+    error_message: str | None = None
+
+
+@temporalio.activity.defn
+async def update_job_status_activity(inputs: UpdateJobStatusInputs) -> None:
+    manager = SummaryJobStatusManager(team_id=inputs.team_id, job_id=inputs.job_id)
+    if inputs.status == "complete":
+        summary_row = await database_sync_to_async(SingleSessionSummary.objects.get_summary, thread_sensitive=False)(
+            team_id=inputs.team_id, session_id=inputs.session_id
+        )
+        if summary_row:
+            manager.mark_complete(summary_row.summary)
+        else:
+            manager.mark_error("Summary was not found after workflow completed")
+    elif inputs.status == "error":
+        manager.mark_error(inputs.error_message or "Unknown error")
+
+
 # How large the chunks should be when analyzing videos
 SESSION_VIDEO_CHUNK_DURATION_S = 60
 # How large should the active period be, so we still analyze it (or skip it, if it's smaller)
@@ -409,32 +436,60 @@ class SummarizeSingleSessionWorkflow(PostHogWorkflow):
     @temporalio.workflow.run
     async def run(self, inputs: SingleSessionSummaryInputs) -> None:
         start_time = temporalio.workflow.now()
-        session_got_data = await temporalio.workflow.execute_activity(
-            fetch_session_data_activity,
-            inputs,
-            start_to_close_timeout=timedelta(minutes=3),
-            retry_policy=RetryPolicy(maximum_attempts=3),
-        )
-        if not session_got_data:
-            return None  # If the session got no data, skip it
-        await ensure_llm_single_session_summary(inputs)
-        duration_seconds = (temporalio.workflow.now() - start_time).total_seconds()
-        await temporalio.workflow.execute_activity(
-            capture_timing_activity,
-            CaptureTimingInputs(
-                distinct_id=inputs.user_distinct_id_to_log,
-                team_id=inputs.team_id,
-                session_id=inputs.session_id,
-                timing_type="single_session_flow",
-                duration_seconds=duration_seconds,
-                success=True,
-                extra_properties={
-                    "video_validation_enabled": inputs.video_validation_enabled,
-                },
-            ),
-            start_to_close_timeout=timedelta(seconds=30),
-            retry_policy=RetryPolicy(maximum_attempts=2),
-        )
+        try:
+            session_got_data = await temporalio.workflow.execute_activity(
+                fetch_session_data_activity,
+                inputs,
+                start_to_close_timeout=timedelta(minutes=3),
+                retry_policy=RetryPolicy(maximum_attempts=3),
+            )
+            if not session_got_data:
+                return None  # If the session got no data, skip it
+            await ensure_llm_single_session_summary(inputs)
+            duration_seconds = (temporalio.workflow.now() - start_time).total_seconds()
+            await temporalio.workflow.execute_activity(
+                capture_timing_activity,
+                CaptureTimingInputs(
+                    distinct_id=inputs.user_distinct_id_to_log,
+                    team_id=inputs.team_id,
+                    session_id=inputs.session_id,
+                    timing_type="single_session_flow",
+                    duration_seconds=duration_seconds,
+                    success=True,
+                    extra_properties={
+                        "video_validation_enabled": inputs.video_validation_enabled,
+                    },
+                ),
+                start_to_close_timeout=timedelta(seconds=30),
+                retry_policy=RetryPolicy(maximum_attempts=2),
+            )
+            if inputs.job_id:
+                await temporalio.workflow.execute_activity(
+                    update_job_status_activity,
+                    UpdateJobStatusInputs(
+                        team_id=inputs.team_id,
+                        session_id=inputs.session_id,
+                        job_id=inputs.job_id,
+                        status="complete",
+                    ),
+                    start_to_close_timeout=timedelta(seconds=30),
+                    retry_policy=RetryPolicy(maximum_attempts=2),
+                )
+        except Exception as e:
+            if inputs.job_id:
+                await temporalio.workflow.execute_activity(
+                    update_job_status_activity,
+                    UpdateJobStatusInputs(
+                        team_id=inputs.team_id,
+                        session_id=inputs.session_id,
+                        job_id=inputs.job_id,
+                        status="error",
+                        error_message=str(e),
+                    ),
+                    start_to_close_timeout=timedelta(seconds=30),
+                    retry_policy=RetryPolicy(maximum_attempts=2),
+                )
+            raise
 
 
 def _validate_period(
@@ -799,6 +854,7 @@ def _prepare_execution(
     extra_summary_context: ExtraSummaryContext | None = None,
     local_reads_prod: bool = False,
     video_validation_enabled: bool | Literal["full"] | None = None,
+    job_id: str | None = None,
 ) -> tuple[Redis, str, str, SingleSessionSummaryInputs, str]:
     # Use shared identifier to be able to construct all the ids to check/debug
     # Using session id instead of random UUID to be able to check the data in Redis
@@ -830,6 +886,7 @@ def _prepare_execution(
         redis_key_base=redis_key_base,
         model_to_use=model_to_use,
         video_validation_enabled=video_validation_enabled,
+        job_id=job_id,
     )
     workflow_id = (
         f"session-summary:single:{'stream' if stream else 'direct'}:{team.id}:{session_id}:{shared_id}:{uuid.uuid4()}"
@@ -892,6 +949,58 @@ async def execute_summarize_session(
         raise ValueError(msg)
     summary = summary_row.summary
     return summary
+
+
+async def execute_summarize_session_async(
+    session_id: str,
+    user: User,
+    team: Team,
+    model_to_use: str | None = None,
+    extra_summary_context: ExtraSummaryContext | None = None,
+    local_reads_prod: bool = False,
+    video_validation_enabled: bool | Literal["full"] | None = None,
+    job_id: str | None = None,
+) -> dict[str, Any] | None:
+    """
+    Start the summarization workflow without waiting for completion.
+    Returns the existing summary if cached, otherwise starts the workflow and returns None.
+    """
+    existing_summary = await database_sync_to_async(SingleSessionSummary.objects.get_summary, thread_sensitive=False)(
+        team_id=team.id,
+        session_id=session_id,
+        extra_summary_context=extra_summary_context,
+    )
+    if existing_summary is not None:
+        return existing_summary.summary
+    if model_to_use is None:
+        model_to_use = (
+            SESSION_SUMMARIES_SYNC_MODEL if video_validation_enabled != "full" else DEFAULT_VIDEO_UNDERSTANDING_MODEL
+        )
+    _, _, _, session_input, workflow_id = _prepare_execution(
+        session_id=session_id,
+        user=user,
+        team=team,
+        stream=False,
+        model_to_use=model_to_use,
+        extra_summary_context=extra_summary_context,
+        local_reads_prod=local_reads_prod,
+        video_validation_enabled=video_validation_enabled,
+        job_id=job_id,
+    )
+    try:
+        client = await async_connect()
+        retry_policy = RetryPolicy(maximum_attempts=int(settings.TEMPORAL_WORKFLOW_MAX_ATTEMPTS))
+        await client.start_workflow(
+            "summarize-session",
+            session_input,
+            id=workflow_id,
+            id_reuse_policy=WorkflowIDReusePolicy.ALLOW_DUPLICATE_FAILED_ONLY,
+            task_queue=settings.SESSION_REPLAY_TASK_QUEUE,
+            retry_policy=retry_policy,
+        )
+    except WorkflowAlreadyStartedError:
+        pass
+    return None
 
 
 def execute_summarize_session_stream(

--- a/posthog/temporal/session_replay/session_summary/types/single.py
+++ b/posthog/temporal/session_replay/session_summary/types/single.py
@@ -17,3 +17,4 @@ class SingleSessionSummaryInputs:
     extra_summary_context: ExtraSummaryContext | None = None
     local_reads_prod: bool = False
     video_validation_enabled: bool | Literal["full"] | None = None
+    job_id: str | None = None

--- a/posthog/temporal/tests/ai/test_module_integrity.py
+++ b/posthog/temporal/tests/ai/test_module_integrity.py
@@ -137,6 +137,7 @@ class TestSessionSummaryTemporalModuleIntegrity:
             "cleanup_gemini_file_activity",
             "consolidate_video_segments_activity",
             "capture_timing_activity",
+            "update_job_status_activity",
         ]
         actual_activity_names = [a.__name__ for a in session_summary.SESSION_SUMMARY_ACTIVITIES]
         assert len(actual_activity_names) == len(expected_activities), (


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->
The summarization pipeline runs on the background but on the UI it looks like it stopped after 10 minute.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->
- Poll the status of the summarization job to more accurately check on the summary status

## How did you test this code?

<!-- Briefly describe the steps you took, and what steps reviewers must take to get to where changes are, and what is the expected behavior. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
