### PR TITLE
fix: Allow intra-day syncs for Bing ads

### DIFF
--- a/posthog/temporal/data_imports/sources/bing_ads/tests/test_bing_ads.py
+++ b/posthog/temporal/data_imports/sources/bing_ads/tests/test_bing_ads.py
@@ -93,6 +93,32 @@ class TestBingAdsHelperFunctions:
         assert mock_client.get_data_by_resource.call_count == 3
 
     @patch("posthog.temporal.data_imports.sources.bing_ads.utils.logger")
+    def test_fetch_data_in_yearly_chunks_same_day(self, mock_logger):
+        mock_client = Mock()
+        mock_client.get_data_by_resource.return_value = iter([[{"CampaignId": "123", "Clicks": "100"}]])
+
+        today = dt.date(2026, 4, 10)
+
+        result = list(
+            fetch_data_in_yearly_chunks(
+                client=mock_client,
+                resource=BingAdsResource.CAMPAIGN_PERFORMANCE_REPORT,
+                account_id=12345,
+                start_date=today,
+                end_date=today,
+            )
+        )
+
+        assert len(result) == 1
+        assert result[0][0]["CampaignId"] == "123"
+        mock_client.get_data_by_resource.assert_called_once_with(
+            resource=BingAdsResource.CAMPAIGN_PERFORMANCE_REPORT,
+            account_id=12345,
+            start_date=dt.datetime.combine(today, dt.time.min),
+            end_date=dt.datetime.combine(today, dt.time.max),
+        )
+
+    @patch("posthog.temporal.data_imports.sources.bing_ads.utils.logger")
     def test_fetch_data_in_yearly_chunks_with_errors(self, mock_logger):
         """Test fetching data with some chunks failing."""
         mock_client = Mock()

--- a/posthog/temporal/data_imports/sources/bing_ads/utils.py
+++ b/posthog/temporal/data_imports/sources/bing_ads/utils.py
@@ -51,7 +51,7 @@ def fetch_data_in_yearly_chunks(
     current_start = start_date
     errors: list[dict[str, typing.Any]] = []
 
-    while current_start < end_date:
+    while current_start <= end_date:
         chunk_end = min(
             current_start + relativedelta(years=1),
             end_date,


### PR DESCRIPTION
## Problem

We were effectively skipping intra-day syncs in this `while` loop (e.g. if customers had hourly syncs setup), and since Bing Ads can update data within a day, this was leaving customers with stale data until the first sync of the next day. Each intra-day sync would result in 0 updated rows.

https://posthoghelp.zendesk.com/agent/tickets/55067 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/56387)

## Changes

https://learn.microsoft.com/en-us/advertising/reporting-service/reporttime?view=bingads-13&tabs=xml - the API supports setting the same `start_date` as `end_date`, so use `<=` rather than `<` when comparing `current_start` and `end_date`

## How did you test this code?

Unit test