### PR TITLE
feat(debug): add query performance admin scene scaffolding

### DIFF
--- a/frontend/src/lib/components/Account/AccountMenu.tsx
+++ b/frontend/src/lib/components/Account/AccountMenu.tsx
@@ -434,18 +434,6 @@ export function AccountMenu({ trigger, ...props }: AccountMenuProps): JSX.Elemen
                                     Instance panel
                                 </Link>
                             </DropdownMenuItem>
-                            <DropdownMenuItem asChild>
-                                <Link
-                                    to={urls.queryPerformance()}
-                                    buttonProps={{
-                                        menuItem: true,
-                                    }}
-                                    data-attr="top-menu-query-performance"
-                                >
-                                    <IconDatabase />
-                                    Query performance
-                                </Link>
-                            </DropdownMenuItem>
 
                             {user?.is_impersonated ||
                             preflight?.is_debug ||

--- a/frontend/src/lib/components/Account/AccountMenu.tsx
+++ b/frontend/src/lib/components/Account/AccountMenu.tsx
@@ -434,6 +434,18 @@ export function AccountMenu({ trigger, ...props }: AccountMenuProps): JSX.Elemen
                                     Instance panel
                                 </Link>
                             </DropdownMenuItem>
+                            <DropdownMenuItem asChild>
+                                <Link
+                                    to={urls.queryPerformance()}
+                                    buttonProps={{
+                                        menuItem: true,
+                                    }}
+                                    data-attr="top-menu-query-performance"
+                                >
+                                    <IconDatabase />
+                                    Query performance
+                                </Link>
+                            </DropdownMenuItem>
 
                             {user?.is_impersonated ||
                             preflight?.is_debug ||

--- a/frontend/src/lib/components/Account/NewAccountMenu.tsx
+++ b/frontend/src/lib/components/Account/NewAccountMenu.tsx
@@ -1,7 +1,15 @@
 import { Menu } from '@base-ui/react/menu'
 import { useActions, useValues } from 'kea'
 
-import { IconGear, IconLeave, IconPlusSmall, IconReceipt } from '@posthog/icons'
+import {
+    IconDatabase,
+    IconGear,
+    IconLeave,
+    IconPlusSmall,
+    IconReceipt,
+    IconServer,
+    IconShieldLock,
+} from '@posthog/icons'
 
 import { FEATURE_FLAGS } from 'lib/constants'
 import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
@@ -331,6 +339,61 @@ export function NewAccountMenu({ isLayoutNavCollapsed }: AccountMenuProps): JSX.
                                         </Link>
                                     )}
                                 />
+
+                                {user?.is_staff && (
+                                    <>
+                                        <Label intent="menu" className="px-2 mt-2">
+                                            Staff
+                                        </Label>
+                                        <DropdownMenuSeparator />
+                                        <Menu.Item
+                                            render={(props) => (
+                                                <Link
+                                                    {...props}
+                                                    to="/admin/"
+                                                    buttonProps={{
+                                                        menuItem: true,
+                                                    }}
+                                                    data-attr="new-account-menu-django-admin"
+                                                    disableClientSideRouting
+                                                >
+                                                    <IconShieldLock />
+                                                    Django admin
+                                                </Link>
+                                            )}
+                                        />
+                                        <Menu.Item
+                                            render={(props) => (
+                                                <Link
+                                                    {...props}
+                                                    to={urls.instanceStatus()}
+                                                    buttonProps={{
+                                                        menuItem: true,
+                                                    }}
+                                                    data-attr="new-account-menu-instance-panel"
+                                                >
+                                                    <IconServer />
+                                                    Instance panel
+                                                </Link>
+                                            )}
+                                        />
+                                        <Menu.Item
+                                            render={(props) => (
+                                                <Link
+                                                    {...props}
+                                                    to={urls.queryPerformance()}
+                                                    buttonProps={{
+                                                        menuItem: true,
+                                                    }}
+                                                    data-attr="new-account-menu-query-performance"
+                                                >
+                                                    <IconDatabase />
+                                                    Query performance
+                                                </Link>
+                                            )}
+                                        />
+                                    </>
+                                )}
 
                                 <Label intent="menu" className="px-2 mt-2">
                                     Account

--- a/frontend/src/scenes/appScenes.ts
+++ b/frontend/src/scenes/appScenes.ts
@@ -30,6 +30,7 @@ export const appScenes: Record<Scene | string, () => any> = {
     [Scene.DataWarehouseSource]: () => import('./data-warehouse/settings/DataWarehouseSourceScene'),
     [Scene.DataOps]: () => import('./data-warehouse/DataWarehouseScene'),
     [Scene.DeadLetterQueue]: () => import('./instance/DeadLetterQueue/DeadLetterQueue'),
+    [Scene.QueryPerformance]: () => import('./instance/QueryPerformance/QueryPerformance'),
     [Scene.Destinations]: () => import('./data-pipelines/DestinationsScene'),
     [Scene.DebugHog]: () => import('./debug/hog/HogRepl'),
     [Scene.DebugQuery]: () => import('./debug/DebugScene'),

--- a/frontend/src/scenes/instance/QueryPerformance/QueryPerformance.tsx
+++ b/frontend/src/scenes/instance/QueryPerformance/QueryPerformance.tsx
@@ -1,0 +1,53 @@
+import { useValues } from 'kea'
+
+import { IconDatabase } from '@posthog/icons'
+
+import { SceneExport } from 'scenes/sceneTypes'
+import { userLogic } from 'scenes/userLogic'
+
+import { SceneContent } from '~/layout/scenes/components/SceneContent'
+import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
+
+export const scene: SceneExport = {
+    component: QueryPerformance,
+}
+
+export function QueryPerformance(): JSX.Element {
+    const { user } = useValues(userLogic)
+
+    if (!user?.is_staff) {
+        return (
+            <>
+                <SceneTitleSection
+                    name="Query performance"
+                    description="Internal tooling for monitoring and managing query performance across all projects."
+                    resourceType={{
+                        type: 'query_performance',
+                        forceIcon: <IconDatabase />,
+                    }}
+                />
+                <p>
+                    Only users with staff access can view query performance tooling. Please contact your instance admin.
+                </p>
+                <p>
+                    If you're an admin and don't have access, set <code>is_staff=true</code> for your user on the
+                    PostgreSQL <code>posthog_user</code> table.
+                </p>
+            </>
+        )
+    }
+
+    return (
+        <SceneContent>
+            <SceneTitleSection
+                name="Query performance"
+                description="Internal tooling for monitoring and managing query performance across all projects."
+                resourceType={{
+                    type: 'query_performance',
+                    forceIcon: <IconDatabase />,
+                }}
+            />
+            <p className="text-muted">Coming soon.</p>
+        </SceneContent>
+    )
+}

--- a/frontend/src/scenes/sceneTypes.ts
+++ b/frontend/src/scenes/sceneTypes.ts
@@ -118,6 +118,7 @@ export enum Scene {
     PropertyDefinition = 'PropertyDefinition',
     PropertyDefinitions = 'PropertyDefinitions',
     PropertyDefinitionEdit = 'PropertyDefinitionEdit',
+    QueryPerformance = 'QueryPerformance',
     Replay = 'Replay',
     ReplayFilePlayback = 'ReplayFilePlayback',
     ReplayPlaylist = 'ReplayPlaylist',

--- a/frontend/src/scenes/scenes.ts
+++ b/frontend/src/scenes/scenes.ts
@@ -187,6 +187,7 @@ export const sceneConfigurations: Record<Scene | string, SceneConfig> = {
         },
     },
     [Scene.DeadLetterQueue]: { instanceLevel: true },
+    [Scene.QueryPerformance]: { instanceLevel: true, name: 'Query performance' },
     [Scene.Destinations]: {
         projectBased: true,
         name: 'Destinations',
@@ -923,6 +924,7 @@ export const routes: Record<string, [Scene | string, string]> = {
     [urls.webScriptsNew()]: [Scene.DataPipelinesNew, 'webScriptsNew'],
     [urls.asyncMigrationsSettings()]: [Scene.AsyncMigrations, 'asyncMigrationsSettings'],
     [urls.deadLetterQueue()]: [Scene.DeadLetterQueue, 'deadLetterQueue'],
+    [urls.queryPerformance()]: [Scene.QueryPerformance, 'queryPerformance'],
     [urls.destinations()]: [Scene.Destinations, 'destinations'],
     [urls.materializedColumns()]: [Scene.MaterializedColumns, 'materializedColumns'],
     [urls.models()]: [Scene.Models, 'models'],

--- a/frontend/src/scenes/urls.ts
+++ b/frontend/src/scenes/urls.ts
@@ -196,6 +196,7 @@ export const urls = {
     asyncMigrationsFuture: (): string => '/instance/async_migrations/future',
     asyncMigrationsSettings: (): string => '/instance/async_migrations/settings',
     deadLetterQueue: (): string => '/instance/dead_letter_queue',
+    queryPerformance: (): string => '/instance/query_performance',
     materializedColumns: (): string => '/data-management/materialized-columns',
     unsubscribe: (): string => '/unsubscribe',
     integrationsRedirect: (kind: string): string => `/integrations/${kind}/callback`,


### PR DESCRIPTION
## Problem

No dedicated admin page for cross-project query performance tooling.

Also: when the account menu was replaced with \`NewAccountMenu\`, the entire staff-only section was dropped. Staff users lost the in-UI entry points to Django admin and Instance panel — they still existed, but only reachable via direct URL.

## Changes

- Add empty \`/instance/query_performance\` scene, gated by \`is_staff\`, with "Coming soon" placeholder
- Restore the staff section in \`NewAccountMenu\` with Django admin, Instance panel, and the new Query performance link

## How did you test this code?

Verified the new "Staff" section appears in the account menu for staff users and the direct URL \`/instance/query_performance\` loads correctly.