### PR TITLE
feat(tasks): pin modal sandboxes to region based on cloud deployment

### DIFF
--- a/products/tasks/backend/services/modal_sandbox.py
+++ b/products/tasks/backend/services/modal_sandbox.py
@@ -20,6 +20,7 @@ import modal
 import requests
 
 from posthog.exceptions_capture import capture_exception
+from posthog.settings import CLOUD_DEPLOYMENT
 
 from products.tasks.backend.models import SandboxSnapshot
 from products.tasks.backend.services.agentsh import (
@@ -54,6 +55,19 @@ SANDBOX_BASE_IMAGE = "ghcr.io/posthog/posthog-sandbox-base"
 SANDBOX_NOTEBOOK_IMAGE = "ghcr.io/posthog/posthog-sandbox-notebook"
 SANDBOX_IMAGE = SANDBOX_BASE_IMAGE
 AGENT_SERVER_PORT = 8080  # Modal connect tokens require port 8080
+
+# Modal region mapping based on cloud deployment
+MODAL_REGION_BY_DEPLOYMENT: dict[str | None, str] = {
+    "EU": "eu-central-1",
+    "US": "us-east-1",
+}
+DEFAULT_MODAL_REGION = "us-east-1"
+
+
+def _get_modal_region() -> str:
+    return MODAL_REGION_BY_DEPLOYMENT.get(CLOUD_DEPLOYMENT, DEFAULT_MODAL_REGION)
+
+
 LOCAL_BUILT_SKILLS_PATH = Path("products/posthog_ai/dist/skills")
 LOCAL_SOURCE_SKILLS_PATHS = (Path(".agents/skills"), Path("products/posthog_ai/skills"))
 LOCAL_MODAL_DOCKERFILES = {
@@ -270,6 +284,8 @@ class ModalSandbox:
 
             sandbox_name = f"{config.name}-{uuid.uuid4().hex[:6]}"
 
+            region = _get_modal_region()
+
             create_kwargs: dict[str, object] = {
                 "app": app,
                 "name": sandbox_name,
@@ -277,6 +293,7 @@ class ModalSandbox:
                 "timeout": config.ttl_seconds,
                 "cpu": float(config.cpu_cores),
                 "memory": int(config.memory_gb * 1024),
+                "region": region,
                 "verbose": True,
             }
 

--- a/products/tasks/backend/services/tests/test_modal_sandbox.py
+++ b/products/tasks/backend/services/tests/test_modal_sandbox.py
@@ -7,8 +7,10 @@ from requests.exceptions import ConnectionError, Timeout
 
 from products.tasks.backend.services.modal_sandbox import (
     AGENT_SERVER_PORT,
+    DEFAULT_MODAL_REGION,
     SANDBOX_IMAGE,
     ModalSandbox,
+    _get_modal_region,
     _get_sandbox_image_reference,
 )
 from products.tasks.backend.services.sandbox import AgentServerResult, ExecutionResult, SandboxConfig
@@ -124,6 +126,22 @@ class TestGetSandboxImageReferenceIntegration:
         digest_part = result.split("@")[1]
         assert digest_part.startswith("sha256:")
         assert len(digest_part) == 71  # "sha256:" + 64 hex chars
+
+
+class TestGetModalRegion:
+    @pytest.mark.parametrize(
+        "cloud_deployment,expected_region",
+        [
+            ("EU", "eu-central-1"),
+            ("US", "us-east-1"),
+            ("DEV", DEFAULT_MODAL_REGION),
+            (None, DEFAULT_MODAL_REGION),
+            ("LOCAL", DEFAULT_MODAL_REGION),
+        ],
+    )
+    def test_returns_correct_region(self, cloud_deployment, expected_region):
+        with patch("products.tasks.backend.services.modal_sandbox.CLOUD_DEPLOYMENT", cloud_deployment):
+            assert _get_modal_region() == expected_region
 
 
 class TestModalSandboxAgentServer:


### PR DESCRIPTION
## Problem

Modal sandboxes were being created without region pinning, meaning they could land in any region regardless of which PostHog cloud deployment they belong to. This adds latency and may have data residency implications for EU customers.

## Changes

- Added region pinning to `modal.Sandbox.create()` calls based on the `CLOUD_DEPLOYMENT` setting
- EU cloud (`CLOUD_DEPLOYMENT=EU`) uses `eu-central-1`
- US cloud (`CLOUD_DEPLOYMENT=US`) uses `us-east-1`
- All other environments (dev, local, self-hosted) default to `us-east-1`

## How did you test this code?

Added parameterized unit tests for `_get_modal_region()` covering EU, US, DEV, None, and LOCAL deployment values. This PR was authored by an agent and has not been manually tested.

## Publish to changelog?

No

## Docs update

No docs changes needed.

## 🤖 LLM context

Agent-authored PR. Region is passed as the `region` kwarg to `modal.Sandbox.create()` per the Modal SDK API.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*