### PR TITLE
fix: Retry forever on merge conflicts in BigQuery

### DIFF
--- a/products/batch_exports/backend/temporal/destinations/bigquery_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/bigquery_batch_export.py
@@ -19,6 +19,7 @@ import google.auth.exceptions
 import google.auth.transport.requests
 import google.auth.impersonated_credentials
 from google.api_core.exceptions import (
+    BadRequest,
     Forbidden,
     GatewayTimeout,
     GoogleAPICallError,
@@ -72,7 +73,11 @@ from products.batch_exports.backend.temporal.spmc import (
     raise_on_task_failure,
     wait_for_schema_or_producer,
 )
-from products.batch_exports.backend.temporal.utils import JsonType, handle_non_retryable_errors
+from products.batch_exports.backend.temporal.utils import (
+    JsonType,
+    handle_non_retryable_errors,
+    make_retryable_with_exponential_backoff,
+)
 
 NON_RETRYABLE_ERROR_TYPES = (
     # Raised on missing permissions.
@@ -514,6 +519,10 @@ def impersonate_service_account(
     return their_credentials
 
 
+def _is_contention_exception(exc: Exception) -> bool:
+    return "concurrent update" in str(exc)
+
+
 class BigQueryClient:
     """Async client to interact with BigQuery.
 
@@ -934,7 +943,16 @@ class BigQueryClient:
         """
 
         self.logger.info("Merging into final table", table_id=final.name, stage_table_id=stage.name)
-        return await self.execute_query(merge_query)
+        query_job = make_retryable_with_exponential_backoff(
+            self.execute_query,
+            retryable_exceptions=(BadRequest,),
+            max_attempts=None,
+            # In case BadRequest is raised for other type of errors, we ensure we only
+            # retry forever when it is a contention problem by checking the exception
+            # message
+            is_exception_retryable=_is_contention_exception,
+        )
+        return await query_job(merge_query)
 
     async def load_file(self, file, format: FileFormat, table: BigQueryTable):
         """Load a file into BigQuery table."""

--- a/products/batch_exports/backend/temporal/utils.py
+++ b/products/batch_exports/backend/temporal/utils.py
@@ -267,7 +267,7 @@ def make_retryable_with_exponential_backoff(
     Arguments:
         func: The coroutine to retry.
         timeout: How long to wait for the coroutine to run.
-        max_attempts: Limit number of retry attempts. Set to 0 for no limit.
+        max_attempts: Limit number of retry attempts. Set to 0 or `None` for no limit.
         initial_retry_delay: Delay for the first retry.
         max_retry_delay: Maximum possible delay between any attempts.
         exponential_backoff_coefficient: Exponential factor used to scale
@@ -279,6 +279,21 @@ def make_retryable_with_exponential_backoff(
             example, the same exception class can be retried or not depending on a code
             or message attribute.
         max_delay_jitter: Maximum jitter added to every retry delay.
+
+    Examples:
+        Retry an error forever:
+
+        >>> class MyError(Exception):
+        ...     pass
+        >>> async def my_coro():
+        ...     raise MyError
+        >>> retryable_coro = make_retryable_with_exponential_backoff(my_coro, max_attempts=None, retryable_exceptions=(MyError,))
+
+        Filter which errors to retry on based on message contents:
+
+        >>> def _is_exception_retryable(exc: Exception):
+        ...     return "message" in str(exc)
+        >>> retryable_coro = make_retryable_with_exponential_backoff(my_coro, is_exception_retryable=_is_exception_retryable)
     """
 
     @functools.wraps(func)

--- a/products/batch_exports/backend/temporal/utils.py
+++ b/products/batch_exports/backend/temporal/utils.py
@@ -267,7 +267,7 @@ def make_retryable_with_exponential_backoff(
     Arguments:
         func: The coroutine to retry.
         timeout: How long to wait for the coroutine to run.
-        max_attempts: Limit number of retry attempts. Set to 0 or `None` for no limit.
+        max_attempts: Limit number of retry attempts. Set to `None` for no limit.
         initial_retry_delay: Delay for the first retry.
         max_retry_delay: Maximum possible delay between any attempts.
         exponential_backoff_coefficient: Exponential factor used to scale

--- a/products/batch_exports/backend/tests/temporal/destinations/bigquery/test_client.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/bigquery/test_client.py
@@ -113,10 +113,11 @@ async def test_from_service_account_integration(
     integration,
 ):
     """Can initialize client from integration configured."""
-    if not await has_valid_aws_credentials() and not integration.has_key():
+    google_integration = GoogleCloudServiceAccountIntegration(integration)
+    if not await has_valid_aws_credentials() and not google_integration.has_key():
         pytest.skip("AWS credentials not available and required for impersonated integration")
 
-    client = BigQueryClient.from_service_account_integration(GoogleCloudServiceAccountIntegration(integration))
+    client = BigQueryClient.from_service_account_integration(google_integration)
     # This triggers a credential refresh, just to make sure it is correctly set up.
     results = list(client.sync_client.query("SELECT 1").result())
 


### PR DESCRIPTION
## Problem

Merge queries can conflict with other concurrent updates from, for example, backfills. We should retry them until they succeed in this particular error. BigQuery raises a `BadRequest` for this error, which is a bit generic, so we should be careful we are only retrying on concurrency errors.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Retry forever on merge query errors caused by `BadRequest` when the message includes "concurrent update".

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took, and what steps reviewers must take to get to where changes are, and what is the expected behavior. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
