### PR TITLE
fix(workflow): conditional branch delete logic

### DIFF
--- a/products/workflows/frontend/Workflows/hogflows/steps/StepConditionalBranch.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/steps/StepConditionalBranch.tsx
@@ -23,7 +23,7 @@ export function StepConditionalBranchConfiguration({
     const action = node.data
     const { conditions } = action.config
 
-    const { edgesByActionId, selectedNodeCanBeDeleted } = useValues(hogFlowEditorLogic)
+    const { edgesByActionId } = useValues(hogFlowEditorLogic)
     const { setWorkflowAction, setWorkflowActionEdges } = useActions(hogFlowEditorLogic)
 
     const nodeEdges = edgesByActionId[action.id] ?? []
@@ -31,9 +31,6 @@ export function StepConditionalBranchConfiguration({
     const setConditions = (
         conditions: Extract<HogFlowAction, { type: 'conditional_branch' }>['config']['conditions']
     ): void => {
-        // TODO: Find all related edges. We can only delete those that are the same as the continue edge.
-        // All others should be disabled for deletion until the subbranch is removed
-
         // For condition modifiers we need to setup the branches as well
         setWorkflowAction(action.id, {
             ...action,
@@ -58,8 +55,9 @@ export function StepConditionalBranchConfiguration({
         return [branchEdges.sort((a, b) => (a.index ?? 0) - (b.index ?? 0)), nonBranchEdges]
     }, [nodeEdges, action.id])
 
+    const continueEdge = nodeEdges.find((edge) => edge.type === 'continue' && edge.from === action.id)
+
     const addCondition = (): void => {
-        const continueEdge = nodeEdges.find((edge) => edge.type === 'continue' && edge.from === action.id)
         if (!continueEdge) {
             throw new Error('Continue edge not found')
         }
@@ -97,7 +95,11 @@ export function StepConditionalBranchConfiguration({
                             size="xsmall"
                             icon={<IconX />}
                             onClick={() => removeCondition(index)}
-                            disabledReason={selectedNodeCanBeDeleted ? undefined : 'Clean up branching steps first'}
+                            disabledReason={
+                                branchEdges[index]?.to === continueEdge?.to
+                                    ? undefined
+                                    : 'Clean up branching steps first'
+                            }
                         />
                     </div>
 


### PR DESCRIPTION
## Problem

The conditional branch step deletion logic was using a global `selectedNodeCanBeDeleted` flag to determine whether condition branches could be removed. This approach doesn't accurately reflect the actual constraints—a branch should only be deletable if it doesn't have sub-branches attached to it.

<img width="1803" height="1169" alt="Screenshot 2026-04-09 at 23 39 34" src="https://github.com/user-attachments/assets/5a0e7333-4b26-4e0a-bba5-fef7543ee389" />


## Changes

- Refactored the edge filtering logic to explicitly identify and track the `continueEdge` (the default path when no conditions match)
- Updated the delete button's `disabledReason` to check if a branch's target matches the continue edge's target- only branches that lead directly to the continue path can be safely deleted

A condition branch can only be removed if it doesn't have sub-branches; this is now determined by comparing the branch target with the continue edge target. 

## How did you test this code?
Manually opened workflow, tried deleting conditions. 

![2026-04-10 15 10 32](https://github.com/user-attachments/assets/918b3470-9476-40e5-ad72-0bccf50b429c)


## Publish to changelog?
no