### PR TITLE
feat(onboarding): add breadcrumbs experiment

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -385,6 +385,7 @@ export const FEATURE_FLAGS = {
     ONBOARDING_SIMPLIFIED_PRODUCT_SELECTION: 'onboarding-simplified-product-selection', // owner: @fercgomes #team-growth multivariate=control,test — DEPRECATED: use PRODUCT_SELECTION_SCREEN_VARIANT
     PRODUCT_SELECTION_SCREEN_VARIANT: 'product-selection-screen-variant', // owner: @fercgomes #team-growth multivariate=control,spotlight,multiproduct
     ONBOARDING_SOCIAL_PROOF_INFO: 'onboarding-social-proof-info', // owner: @fercgomes #team-growth, payload overrides social proof strings per product
+    ONBOARDING_HIDE_BREADCRUMBS: 'onboarding-hide-breadcrumbs', // owner: @fercgomes #team-growth, multivariate=true, hides breadcrumbs during onboarding to reduce distractions
     ONBOARDING_SKIP_INSTALL_STEP: 'onboarding-skip-install-step', // owner: @rafaeelaudibert #team-growth multivariate=true
     ONBOARDING_WIZARD_PROMINENCE: 'onboarding-wizard-prominence', // owner: #team-growth multivariate=control,wizard-hero,wizard-tab,wizard-only
     ONBOARDING_WIZARD_INSTALLATION_IMPROVED_COPY: 'onboarding-wizard-installation-improved-copy', // owner: @fercgomes #team-growth multivariate=control,test

--- a/frontend/src/scenes/onboarding/OnboardingBreadcrumbs.tsx
+++ b/frontend/src/scenes/onboarding/OnboardingBreadcrumbs.tsx
@@ -1,0 +1,58 @@
+import clsx from 'clsx'
+import { useActions, useValues } from 'kea'
+import React from 'react'
+
+import { IconChevronRight } from '@posthog/icons'
+import { Link } from '@posthog/lemon-ui'
+
+import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
+
+import { OnboardingStepKey } from '~/types'
+
+import { onboardingLogic, stepKeyToTitle } from './onboardingLogic'
+
+interface OnboardingBreadcrumbsProps {
+    stepKey: OnboardingStepKey
+    breadcrumbHighlightName?: OnboardingStepKey
+}
+
+export function OnboardingBreadcrumbs({
+    stepKey,
+    breadcrumbHighlightName,
+}: OnboardingBreadcrumbsProps): JSX.Element | null {
+    const { onboardingStepKeys } = useValues(onboardingLogic)
+    const { setStepKey } = useActions(onboardingLogic)
+    const hideBreadcrumbs = useFeatureFlag('ONBOARDING_HIDE_BREADCRUMBS', 'test')
+
+    if (hideBreadcrumbs) {
+        return null
+    }
+
+    const stepCount = onboardingStepKeys.length
+
+    return (
+        <div
+            className="flex items-center justify-start gap-x-3 px-4 sm:px-2 w-full overflow-x-auto [mask-image:linear-gradient(to_right,black_calc(100%-24px),transparent)] sm:[mask-image:none]"
+            data-attr="onboarding-breadcrumbs"
+        >
+            {onboardingStepKeys.map((stepName, idx) => {
+                const highlightStep = [stepKey, breadcrumbHighlightName].includes(stepName)
+                return (
+                    <React.Fragment key={`stepKey-${idx}`}>
+                        <Link
+                            className={clsx('text-sm shrink-0 whitespace-nowrap', highlightStep && 'font-bold')}
+                            data-text={stepKeyToTitle(stepName)}
+                            key={stepName}
+                            onClick={() => setStepKey(stepName)}
+                        >
+                            <span className={clsx('text-sm', !highlightStep && 'text-muted')}>
+                                {stepKeyToTitle(stepName)}
+                            </span>
+                        </Link>
+                        {stepCount > 1 && idx !== stepCount - 1 && <IconChevronRight className="text-xl shrink-0" />}
+                    </React.Fragment>
+                )
+            })}
+        </div>
+    )
+}

--- a/frontend/src/scenes/onboarding/OnboardingStep.tsx
+++ b/frontend/src/scenes/onboarding/OnboardingStep.tsx
@@ -1,15 +1,15 @@
 import clsx from 'clsx'
 import { useActions, useValues } from 'kea'
-import React from 'react'
 
-import { IconArrowRight, IconChevronRight } from '@posthog/icons'
-import { LemonButton, Link } from '@posthog/lemon-ui'
+import { IconArrowRight } from '@posthog/icons'
+import { LemonButton } from '@posthog/lemon-ui'
 
 import { supportLogic } from 'lib/components/Support/supportLogic'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 
 import { OnboardingStepKey } from '~/types'
 
+import { OnboardingBreadcrumbs } from './OnboardingBreadcrumbs'
 import { onboardingLogic, stepKeyToTitle } from './onboardingLogic'
 
 export const OnboardingStep = ({
@@ -45,9 +45,9 @@ export const OnboardingStep = ({
     fullWidth?: boolean
     actions?: JSX.Element
 }): JSX.Element => {
-    const { hasNextStep, onboardingStepKeys } = useValues(onboardingLogic)
+    const { hasNextStep } = useValues(onboardingLogic)
 
-    const { completeOnboarding, goToNextStep, setStepKey } = useActions(onboardingLogic)
+    const { completeOnboarding, goToNextStep } = useActions(onboardingLogic)
     const { reportOnboardingStepCompleted, reportOnboardingStepSkipped } = useActions(eventUsageLogic)
     const { openSupportForm } = useActions(supportLogic)
 
@@ -65,40 +65,11 @@ export const OnboardingStep = ({
         advance()
     }
 
-    const onboardingLength = onboardingStepKeys.length
-
     return (
         <>
             <div className="pb-2">
                 <div className={`text-secondary max-w-screen-md mx-auto ${hideHeader && 'hidden'}`}>
-                    <div
-                        className="flex items-center justify-start gap-x-3 px-4 sm:px-2 w-full overflow-x-auto [mask-image:linear-gradient(to_right,black_calc(100%-24px),transparent)] sm:[mask-image:none]"
-                        data-attr="onboarding-breadcrumbs"
-                    >
-                        {onboardingStepKeys.map((stepName, idx) => {
-                            const highlightStep = [stepKey, breadcrumbHighlightName].includes(stepName)
-                            return (
-                                <React.Fragment key={`stepKey-${idx}`}>
-                                    <Link
-                                        className={clsx(
-                                            'text-sm shrink-0 whitespace-nowrap',
-                                            highlightStep && 'font-bold'
-                                        )}
-                                        data-text={stepKeyToTitle(stepName)}
-                                        key={stepName}
-                                        onClick={() => setStepKey(stepName)}
-                                    >
-                                        <span className={clsx('text-sm', !highlightStep && 'text-muted')}>
-                                            {stepKeyToTitle(stepName)}
-                                        </span>
-                                    </Link>
-                                    {onboardingLength > 1 && idx !== onboardingLength - 1 && (
-                                        <IconChevronRight className="text-xl shrink-0" />
-                                    )}
-                                </React.Fragment>
-                            )
-                        })}
-                    </div>
+                    <OnboardingBreadcrumbs stepKey={stepKey} breadcrumbHighlightName={breadcrumbHighlightName} />
                     <div className="flex flex-col sm:flex-row sm:justify-between sm:items-center items-start gap-2 mt-3 px-4 sm:px-0">
                         <h1 className={clsx('font-bold m-0 px-0 sm:px-2', fullWidth && 'text-center')}>
                             {title || stepKeyToTitle(stepKey)}


### PR DESCRIPTION
## Problem

We want to test whether hiding the onboarding breadcrumbs improves completion rates — the breadcrumb bar may be causing users to skip ahead or adding visual noise that doesn't help on mobile.

## Changes

- New feature flag `ONBOARDING_HIDE_BREADCRUMBS` (`#team-growth`, multivariate `control,test`)
- Extracted breadcrumbs from `OnboardingStep.tsx` into a standalone `OnboardingBreadcrumbs.tsx` component
- When the flag is `test`, breadcrumbs return `null` — the title row and step content are unaffected

No behavioral changes for users not in the experiment.

## How did you test this code?

- Lint + format clean
- Previewed locally with the flag forced to `test` (breadcrumbs hidden) and without (breadcrumbs shown)

## Publish to changelog?

No — behind a feature flag.

## Docs update

No docs impact.

## 🤖 LLM context

Claude co-authored under supervision from @fercgomes.

> **Stacked PR:** base is `feat/onb-mobile-install` (PR #54000).