### PR TITLE
fix(ingesiton): acceptance tests query syntax

### DIFF
--- a/posthog/temporal/ingestion_acceptance_test/client.py
+++ b/posthog/temporal/ingestion_acceptance_test/client.py
@@ -393,8 +393,8 @@ class PostHogClient:
         """
         query = """
             SELECT p.id, p.properties, p.created_at
-            FROM person FINAL AS p
-            JOIN person_distinct_id2 FINAL AS pdi ON p.id = pdi.person_id AND pdi.team_id = %(team_id)s
+            FROM person AS p FINAL
+            JOIN person_distinct_id2 AS pdi FINAL ON p.id = pdi.person_id AND pdi.team_id = %(team_id)s
             WHERE p.team_id = %(team_id)s
               AND pdi.distinct_id = %(distinct_id)s
               AND pdi.is_deleted = 0

--- a/posthog/temporal/tests/ingestion_acceptance_test/test_client.py
+++ b/posthog/temporal/tests/ingestion_acceptance_test/test_client.py
@@ -133,8 +133,8 @@ class TestFetchPersonByDistinctId:
         query = mock_sync_execute.call_args[0][0]
         params = mock_sync_execute.call_args[0][1]
 
-        assert "FROM person FINAL AS p" in query
-        assert "JOIN person_distinct_id2 FINAL AS pdi" in query
+        assert "FROM person AS p FINAL" in query
+        assert "JOIN person_distinct_id2 AS pdi FINAL" in query
         assert "pdi.distinct_id = %(distinct_id)s" in query
         assert "pdi.is_deleted = 0" in query
         assert "p.is_deleted = 0" in query


### PR DESCRIPTION
## Problem

The ingestion acceptance tests had wrong Clickhouse query syntax when using FINAL with an alias

## Changes

Moves the ordering of FINAL and AS in a CH query that drives ingestion acceptance tests

## How did you test this code?

- Simple grammar fix, only change on acceptance tests taht are already broken so is safe
