### PR TITLE
chore: increase impersonation timeout to 8h

### DIFF
--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -263,9 +263,9 @@ CSRF_COOKIE_NAME = "posthog_csrftoken"
 CSRF_COOKIE_AGE = get_from_env("CSRF_COOKIE_AGE", SESSION_COOKIE_AGE, type_cast=int)
 
 # The total time allowed for an impersonated session
-IMPERSONATION_TIMEOUT_SECONDS = get_from_env("IMPERSONATION_TIMEOUT_SECONDS", 60 * 60 * 2, type_cast=int)
+IMPERSONATION_TIMEOUT_SECONDS = get_from_env("IMPERSONATION_TIMEOUT_SECONDS", 60 * 60 * 8, type_cast=int)
 # The time allowed for an impersonated session to be idle before it expires
-IMPERSONATION_IDLE_TIMEOUT_SECONDS = get_from_env("IMPERSONATION_IDLE_TIMEOUT_SECONDS", 30 * 60, type_cast=int)
+IMPERSONATION_IDLE_TIMEOUT_SECONDS = get_from_env("IMPERSONATION_IDLE_TIMEOUT_SECONDS", 60 * 60 * 8, type_cast=int)
 # Impersonation cookie last activity key
 IMPERSONATION_COOKIE_LAST_ACTIVITY_KEY = get_from_env(
     "IMPERSONATION_COOKIE_LAST_ACTIVITY_KEY", "impersonation_last_activity"


### PR DESCRIPTION
## Problem

When investigating issues, it can be helpful to leave an impersonation session open for a longer period of time, especially when open in a containerized session. The 30 minute auto logout can often be far too short. 

There may be some security implications that I'm not aware of as to why we can't increase this, or perhaps not by this _much_ – so pitching this PR for now.

## Changes

Increases the maximum impersonation and idle timeout to 8h so that a total session can be up to 8h. 

## How did you test this code?

Tested locally.

## Publish to changelog?

No