### PR TITLE
feat(logs): prioritize exact or part matches higher in attributes list

### DIFF
--- a/products/logs/backend/log_attributes_query_runner.py
+++ b/products/logs/backend/log_attributes_query_runner.py
@@ -54,15 +54,16 @@ class LogAttributesQueryRunner(AnalyticsQueryRunner[LogAttributesQueryResponse],
                 WHERE time_bucket >= {date_from_start_of_interval}
                 AND time_bucket <= {date_to_start_of_interval} + {one_interval_period}
                 AND attribute_type = {attributeType}
-                AND attribute_key LIKE {search}
+                AND attribute_key ILIKE {search}
                 AND {where}
                 GROUP BY team_id, attribute_key
-                ORDER BY sum(attribute_count) desc, attribute_key asc
+                ORDER BY lower(attribute_key) = lower({exact}) DESC, has(splitByNonAlpha(lower(attribute_key)), lower({exact})) DESC, sum(attribute_count) desc, attribute_key asc
                 OFFSET {offset}
             )
             """,
             placeholders={
                 "search": ast.Constant(value=f"%{self.query.search}%"),
+                "exact": ast.Constant(value=f"{self.query.search}"),
                 "attributeType": ast.Constant(value=self.query.attributeType),
                 "limit": ast.Constant(value=self.query.limit),
                 "offset": ast.Constant(value=self.query.offset),

--- a/products/logs/backend/log_attributes_query_runner.py
+++ b/products/logs/backend/log_attributes_query_runner.py
@@ -63,7 +63,7 @@ class LogAttributesQueryRunner(AnalyticsQueryRunner[LogAttributesQueryResponse],
             """,
             placeholders={
                 "search": ast.Constant(value=f"%{self.query.search}%"),
-                "exact": ast.Constant(value=f"{self.query.search}"),
+                "exact": ast.Constant(value=self.query.search),
                 "attributeType": ast.Constant(value=self.query.attributeType),
                 "limit": ast.Constant(value=self.query.limit),
                 "offset": ast.Constant(value=self.query.offset),

--- a/products/logs/backend/log_values_query_runner.py
+++ b/products/logs/backend/log_values_query_runner.py
@@ -58,12 +58,13 @@ class LogValuesQueryRunner(AnalyticsQueryRunner[LogValuesQueryResponse], LogsQue
                 AND attribute_value ILIKE {search}
                 AND {where}
                 GROUP BY team_id, attribute_value
-                ORDER BY sum(attribute_count) desc, attribute_value asc
+                ORDER BY lower(attribute_value) = lower({exact}) DESC, has(splitByNonAlpha(lower(attribute_value)), lower({exact})) DESC, sum(attribute_count) desc, attribute_value asc
                 OFFSET {offset}
             )
             """,
             placeholders={
                 "search": ast.Constant(value=f"%{self.query.search}%"),
+                "exact": ast.Constant(value=f"{self.query.search}"),
                 "attributeType": ast.Constant(value=self.query.attributeType),
                 "attributeKey": ast.Constant(value=self.query.attributeKey),
                 "limit": ast.Constant(value=self.query.limit),

--- a/products/logs/backend/log_values_query_runner.py
+++ b/products/logs/backend/log_values_query_runner.py
@@ -64,7 +64,7 @@ class LogValuesQueryRunner(AnalyticsQueryRunner[LogValuesQueryResponse], LogsQue
             """,
             placeholders={
                 "search": ast.Constant(value=f"%{self.query.search}%"),
-                "exact": ast.Constant(value=f"{self.query.search}"),
+                "exact": ast.Constant(value=self.query.search),
                 "attributeType": ast.Constant(value=self.query.attributeType),
                 "attributeKey": ast.Constant(value=self.query.attributeKey),
                 "limit": ast.Constant(value=self.query.limit),

--- a/products/logs/backend/test/test_log_values_attributes.py
+++ b/products/logs/backend/test/test_log_values_attributes.py
@@ -158,3 +158,30 @@ class TestLogValuesAttributesTimezones(ClickhouseTestMixin, APIBaseTest):
         empty_names = {r["name"] for r in empty_results}
         self.assertEqual(all_names, empty_names, "Empty value filter should return same values as no filter")
         self.assertEqual(set(all_names), {"info", "DEBUG", "PING", "more", "error"})
+
+    def test_log_attributes_search_trace_id_before_pid(self):
+        """Test that searching attributes for 'id' returns trace_id before pid"""
+
+        query_params = {
+            "dateRange": '{"date_from": "2025-12-16T09:00:00Z", "date_to": "2025-12-16T11:00:00Z"}',
+            "attribute_type": "log",
+            "search": "id",
+        }
+
+        response = self.client.get(f"/api/projects/{self.team.pk}/logs/attributes", query_params)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        results = response.json()["results"]
+        result_names = [r["name"] for r in results]
+
+        self.assertIn("trace_id", result_names, "trace_id should be in results when searching for 'id'")
+        self.assertIn("brokers.0.id", result_names, "brokers.0.id should be in results when searching for 'id'")
+        self.assertIn("pid", result_names, "pid should be in results when searching for 'id'")
+
+        trace_id_index = result_names.index("trace_id")
+        brokers_id_index = result_names.index("brokers.0.id")
+        pid_index = result_names.index("pid")
+        self.assertLess(
+            trace_id_index, brokers_id_index, "trace_id should appear before brokers.0.id when searching for 'id'"
+        )
+        self.assertLess(brokers_id_index, pid_index, "brokers.0.id should appear before pid when searching for 'id'")


### PR DESCRIPTION
## Problem

when searching for very common substrings in attributes often the one you are looking for is buried

## Changes

prioritize ordering of attributes to show exact match before anything else, and partial matches (e.g. _id or .id for "id") next

before:
<img width="636" height="374" alt="image" src="https://github.com/user-attachments/assets/70d64416-4594-43f0-9328-5c9102241010" />


after:
<img width="603" height="363" alt="image" src="https://github.com/user-attachments/assets/c875c98d-a32f-4c99-b038-e15e89b7aa05" />

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
locally, test
<!-- Briefly describe the steps you took, and what steps reviewers must take to get to where changes are, and what is the expected behavior. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
no
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
