### PR TITLE
fix(data-warehouse): treat empty passphrase as no passphrase for Snowflake key pair auth

### DIFF
--- a/posthog/temporal/data_imports/sources/snowflake/snowflake.py
+++ b/posthog/temporal/data_imports/sources/snowflake/snowflake.py
@@ -121,7 +121,7 @@ def _get_connection(
 
     p_key = serialization.load_pem_private_key(
         private_key.encode("utf-8"),
-        password=passphrase.encode() if passphrase is not None else None,
+        password=passphrase.encode() if passphrase else None,
         backend=default_backend(),
     )
 


### PR DESCRIPTION
## Problem

When a user configures a Snowflake source with key pair authentication and leaves the passphrase field blank, the frontend saves it as an empty string `""` rather than `null`. The `_get_connection` function only checked `is not None`, so it would pass `b""` to `serialization.load_pem_private_key` — which treats it as an actual password and attempts to decrypt the key with it. For unencrypted private keys this causes a decryption error.

The other two call sites (`get_schemas` and `get_primary_keys_for_schemas`) already had the correct guard (`if passphrase and len(passphrase) > 0`), so schema discovery worked fine but the actual data sync would fail.

## Changes

- Changed the passphrase check in `_get_connection` from `if passphrase is not None` to `if passphrase`, so empty strings are treated the same as `None`.

## How did you test this code?

I'm an agent and haven't tested this manually. The change is a one-line fix aligning `_get_connection` with the existing behavior in the two other Snowflake connection call sites.

## 🤖 LLM context

Agent-authored fix. Identified the inconsistency between three Snowflake connection code paths in how they handle empty-string passphrases.