### PR TITLE
chore(quill): export ButtonProps and small primitives/tokens fixes

### DIFF
--- a/packages/quill/packages/primitives/src/button.tsx
+++ b/packages/quill/packages/primitives/src/button.tsx
@@ -5,7 +5,7 @@ import * as React from 'react'
 import { cn } from './lib/utils'
 
 const buttonVariants = cva(
-    "group/button cursor-pointer inline-flex shrink-0 items-center justify-center rounded-md border border-transparent bg-clip-padding text-xs/relaxed font-medium whitespace-nowrap transition-all duration-100 outline-none select-none focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-ring/30 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-2 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 active:translate-y-px [&_kbd]:-mr-1 has-data-[slot=dot]:ps-1.5",
+    "group/button cursor-pointer inline-flex shrink-0 items-center justify-center rounded-md border border-transparent bg-clip-padding text-xs/relaxed font-medium whitespace-nowrap transition-all duration-100 outline-none select-none focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-ring/30 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-2 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 not-disabled:active:translate-y-px [&_kbd]:-mr-1 has-data-[slot=dot]:ps-1.5",
     {
         variants: {
             variant: {
@@ -47,7 +47,9 @@ const buttonVariants = cva(
     }
 )
 
-const Button = React.forwardRef<HTMLButtonElement, ButtonPrimitive.Props & VariantProps<typeof buttonVariants>>(
+export type ButtonProps = ButtonPrimitive.Props & VariantProps<typeof buttonVariants>
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
     (
         { className, variant = 'default', size = 'default', focusableWhenDisabled = true, left = false, ...props },
         ref

--- a/packages/quill/packages/primitives/src/index.ts
+++ b/packages/quill/packages/primitives/src/index.ts
@@ -1,6 +1,6 @@
 export { Accordion, AccordionItem, AccordionTrigger, AccordionContent } from './accordion'
 export { Badge, badgeVariants } from './badge'
-export { Button, buttonVariants } from './button'
+export { Button, buttonVariants, type ButtonProps } from './button'
 export { ButtonGroup, ButtonGroupSeparator, ButtonGroupText, buttonGroupVariants } from './button-group'
 export { Card, CardHeader, CardFooter, CardTitle, CardDescription, CardContent } from './card'
 export { CardGroup } from './card-group'

--- a/packages/quill/packages/primitives/src/menuLabel.tsx
+++ b/packages/quill/packages/primitives/src/menuLabel.tsx
@@ -7,7 +7,7 @@ function MenuLabel({ className, ...props }: React.ComponentProps<'label'>): Reac
         <label
             data-slot="menu-label"
             className={cn(
-                'px-2 py-1.5 text-muted-foreground/50 uppercase font-semibold text-[0.6875rem] leading-5 tracking-[0.075em]',
+                'px-2 py-1.5 text-muted-foreground/50 dark:text-muted-foreground/80 uppercase font-semibold text-xxs leading-5 tracking-[0.075em]',
                 className
             )}
             {...props}

--- a/packages/quill/packages/tokens/src/typography.ts
+++ b/packages/quill/packages/tokens/src/typography.ts
@@ -4,20 +4,20 @@
 
 import { fontFamilyValue } from './css'
 
-const ROOT_FONT_SIZE = 14
+const ROOT_FONT_SIZE = 16
 
 function rem(px: number): string {
     return `${px / ROOT_FONT_SIZE}rem`
 }
 
 export const fontSize = {
-    xxs: [rem(10), { lineHeight: rem(12) }], // 0.7143rem (10px)
-    xs: [rem(12), { lineHeight: rem(16) }], // 0.8571rem (12px)
-    sm: [rem(14), { lineHeight: rem(14) }], // 1rem (14px)
-    base: [rem(16), { lineHeight: rem(24) }], // 1.1429rem (16px)
-    lg: [rem(18), { lineHeight: rem(28) }], // 1.2857rem (18px)
-    xl: [rem(20), { lineHeight: rem(28) }], // 1.4286rem (20px)
-    '2xl': [rem(24), { lineHeight: rem(32) }], // 1.7143rem (24px)
+    xxs: [rem(10), { lineHeight: rem(12) }],   // 0.625rem (10px), 0.75rem (12px)
+    xs: [rem(12), { lineHeight: rem(16) }],    // 0.75rem (12px), 1rem (16px)
+    sm: [rem(14), { lineHeight: rem(20) }],    // 0.875rem (14px), 1.25rem (20px)
+    base: [rem(16), { lineHeight: rem(24) }],  // 1rem (16px), 1.5rem (24px)
+    lg: [rem(18), { lineHeight: rem(28) }],    // 1.125rem (18px), 1.75rem (28px)
+    xl: [rem(20), { lineHeight: rem(28) }],    // 1.25rem (20px), 1.75rem (28px)
+    '2xl': [rem(24), { lineHeight: rem(32) }], // 1.5rem (24px), 2rem (32px)
 } as const
 
 export const fontFamily = {


### PR DESCRIPTION
## Problem

Consumers of `@posthog/quill-primitives` couldn't access the `Button` props type directly, so extending or wrapping `Button` in downstream apps required re-deriving the intersection manually. Alongside that, a few small primitive/token issues needed cleanup.

## Changes

- **`button.tsx`**: extract and export `ButtonProps = ButtonPrimitive.Props & VariantProps<typeof buttonVariants>` so it can be imported from the package. Also gate the `active:translate-y-px` press animation behind `not-disabled:` so disabled buttons no longer shift down on click.
- **`index.ts`**: re-export `type ButtonProps` from the package entrypoint.
- **`menuLabel.tsx`**: use the `xxs` font-size token instead of a hard-coded `text-[0.6875rem]`, and bump dark-mode label color to `text-muted-foreground/80` for better contrast.
- **`tokens/src/typography.ts`**: change `ROOT_FONT_SIZE` from 14 → 16 (standard browser default) and refresh the `sm` line-height so token-derived rem values line up with expected px sizes.

## How did you test this code?

No automated tests — changes are type/style tweaks in the quill primitives and tokens packages. Verified the new `ButtonProps` export is importable from `@posthog/quill-primitives` via TypeScript resolution. Visual/animation tweaks were not manually tested by the agent.

## Publish to changelog?

no

## 🤖 LLM context

Co-authored with Claude Code. Session scope: add `ButtonProps` type export for external consumers; committed together with unrelated in-flight quill primitive/token fixes at the author's request.