### PR TITLE
fix(cdp): prevent background task self-await deadlock in kafka consumer

### DIFF
--- a/nodejs/src/kafka/consumer.test.ts
+++ b/nodejs/src/kafka/consumer.test.ts
@@ -408,6 +408,56 @@ describe('consumer', () => {
             p3.resolve()
             await delay(100)
         })
+
+        it('should not deadlock when previous background tasks resolve before backpressure check', async () => {
+            // Regression test: when all previous background tasks resolve between
+            // pushing the new task and the backpressure await, the array gets spliced
+            // and this.backgroundTask[0] becomes the task we just pushed — awaiting
+            // itself is a deadlock.
+            //
+            // The fix captures the promise to await BEFORE pushing the new task,
+            // so even if microtasks splice the array, we never await ourselves.
+
+            const consumeCountBefore = mockRdKafkaConsumer.consume.mock.calls.length
+
+            const p1 = triggerablePromise()
+            await simulateMessageWithBackgroundTask([createKafkaMessage({ offset: 1, partition: 0 })], p1.promise)
+
+            const p2 = triggerablePromise()
+            await simulateMessageWithBackgroundTask([createKafkaMessage({ offset: 2, partition: 0 })], p2.promise)
+
+            const p3 = triggerablePromise()
+            await simulateMessageWithBackgroundTask([createKafkaMessage({ offset: 3, partition: 0 })], p3.promise)
+            await delay(1)
+
+            expect(consumer['backgroundTask'].length).toBe(3)
+
+            // Resolve all 3 tasks before the next batch arrives.
+            // Their .finally() microtasks will splice them out of the array.
+            p1.resolve()
+            p2.resolve()
+            p3.resolve()
+            await delay(1)
+
+            // Now simulate the 4th batch. With the bug, the consumer would push task4,
+            // then await this.backgroundTask[0] which IS task4 — deadlock.
+            // With the fix, the taskToAwait was captured before pushing, so it's either
+            // null (no backpressure needed) or a previous task that already resolved.
+            const p4 = triggerablePromise()
+            await simulateMessageWithBackgroundTask([createKafkaMessage({ offset: 4, partition: 0 })], p4.promise)
+
+            // If we reach here without timing out, the deadlock is fixed.
+            await delay(10)
+
+            // Consumer should have advanced — the exact count depends on timing,
+            // but it must be at least 4 (one per batch).
+            expect(mockRdKafkaConsumer.consume.mock.calls.length).toBeGreaterThanOrEqual(consumeCountBefore + 4)
+
+            p4.resolve()
+            await delay(10)
+
+            expect(consumer['backgroundTask']).toEqual([])
+        })
     })
 
     describe('background task timeout', () => {

--- a/nodejs/src/kafka/consumer.ts
+++ b/nodejs/src/kafka/consumer.ts
@@ -812,20 +812,27 @@ export class KafkaConsumer {
                         }
                     })
 
-                    // At first we just add the background work to the queue with metadata
+                    // Capture the oldest task to await BEFORE pushing the new one.
+                    // This prevents a race condition where .finally() microtasks from
+                    // resolving tasks splice the array, causing us to await the task
+                    // we just pushed (deadlock — it can never resolve while we're blocked).
+                    // We use length + 1 to account for the task we're about to push.
+                    const taskToAwait =
+                        this.backgroundTask.length + 1 >= this.maxBackgroundTasks
+                            ? this.backgroundTask[0]?.promise
+                            : null
+
                     this.backgroundTask.push({
                         promise: backgroundTask,
                         createdAt: taskCreatedAt,
                     })
 
-                    // If we have too much "backpressure" we need to await one of the background tasks. We await the oldest one on purpose
-                    if (this.backgroundTask.length >= this.maxBackgroundTasks) {
+                    if (taskToAwait) {
                         const stopTimer = consumedBatchBackpressureDuration.startTimer({
                             topic: this.config.topic,
                             groupId: this.config.groupId,
                         })
-                        // If we have more than the max, we need to await one
-                        await this.backgroundTask[0].promise
+                        await taskToAwait
                         stopTimer()
                     }
                 }


### PR DESCRIPTION
Fix a race condition where the backpressure check could await the task it just pushed. When previous background tasks resolve between the push and the await, their .finally() microtasks splice the array, making backgroundTask[0] point to the current task creating a deadlock.

The fix captures the reference to the oldest task before pushing, so we always await a previous task, never ourselves. 