### PR TITLE
fix(tasks): use broader Modal regions for better sandbox availability

### DIFF
--- a/products/tasks/backend/services/modal_sandbox.py
+++ b/products/tasks/backend/services/modal_sandbox.py
@@ -64,10 +64,10 @@ AGENT_SERVER_PORT = 8080  # Modal connect tokens require port 8080
 
 # Modal region mapping based on cloud deployment
 MODAL_REGION_BY_DEPLOYMENT: dict[str | None, str] = {
-    "EU": "eu-central-1",
-    "US": "us-east-1",
+    "EU": "eu-west",
+    "US": "us-east",
 }
-DEFAULT_MODAL_REGION = "us-east-1"
+DEFAULT_MODAL_REGION = "us-east"
 
 
 def _get_modal_region() -> str:

--- a/products/tasks/backend/services/tests/test_modal_sandbox.py
+++ b/products/tasks/backend/services/tests/test_modal_sandbox.py
@@ -136,8 +136,8 @@ class TestGetModalRegion:
     @pytest.mark.parametrize(
         "cloud_deployment,expected_region",
         [
-            ("EU", "eu-central-1"),
-            ("US", "us-east-1"),
+            ("EU", "eu-west"),
+            ("US", "us-east"),
             ("DEV", DEFAULT_MODAL_REGION),
             (None, DEFAULT_MODAL_REGION),
             ("LOCAL", DEFAULT_MODAL_REGION),


### PR DESCRIPTION
## Problem

Modal sandbox region pinning used specific AZs (`us-east-1`, `eu-central-1`) which limits sandbox availability to a single availability zone.

## Changes

Update `MODAL_REGION_BY_DEPLOYMENT` to use broader region identifiers:
- `us-east-1` → `us-east`
- `eu-central-1` → `eu-west`
- Default region: `us-east`

This gives Modal more flexibility to place sandboxes across availability zones within each region, improving availability.

Docs here on region pinning: https://modal.com/docs/guide/region-selection

## LLM context

Simple constant change in `products/tasks/backend/services/modal_sandbox.py` with corresponding test update.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*