### PR TITLE
fix(sql-editor): wrap DataTableNode insights into DataVisualizationNode

### DIFF
--- a/frontend/src/scenes/data-warehouse/editor/sqlEditorLogic.test.ts
+++ b/frontend/src/scenes/data-warehouse/editor/sqlEditorLogic.test.ts
@@ -10,7 +10,7 @@ import { urls } from 'scenes/urls'
 
 import { useMocks } from '~/mocks/jest'
 import * as queryRunner from '~/queries/query'
-import { DataVisualizationNode, NodeKind } from '~/queries/schema/schema-general'
+import { DataTableNode, DataVisualizationNode, HogQLQuery, NodeKind } from '~/queries/schema/schema-general'
 import { initKeaTests } from '~/test/init'
 import { ChartDisplayType, InsightShortId, QueryBasedInsightModel } from '~/types'
 
@@ -32,6 +32,45 @@ const MOCK_INSIGHT_QUERY: DataVisualizationNode = {
         query: 'SELECT count() FROM events',
     },
 }
+
+const MOCK_DATA_TABLE_INSIGHT_SHORT_ID = 'def456' as InsightShortId
+
+const MOCK_DATA_TABLE_INSIGHT_QUERY: DataTableNode = {
+    kind: NodeKind.DataTableNode,
+    source: {
+        kind: NodeKind.HogQLQuery,
+        query: 'SELECT count() FROM persons',
+    },
+}
+
+const MOCK_DATA_TABLE_INSIGHT: QueryBasedInsightModel = {
+    id: 2,
+    short_id: MOCK_DATA_TABLE_INSIGHT_SHORT_ID,
+    name: 'DataTable Insight',
+    query: MOCK_DATA_TABLE_INSIGHT_QUERY,
+    result: null,
+    dashboards: [],
+    dashboard_tiles: [],
+    saved: true,
+    order: null,
+    last_refresh: null,
+    created_at: '2024-01-01T00:00:00.000Z',
+    created_by: null,
+    deleted: false,
+    description: '',
+    is_sample: false,
+    is_shared: null,
+    pinned: null,
+    refresh_interval: null,
+    updated_at: '2024-01-01T00:00:00.000Z',
+    updated_by: null,
+    visibility: null,
+    last_modified_at: '2024-01-01T00:00:00.000Z',
+    last_modified_by: null,
+    layouts: {},
+    color: null,
+    user_access_level: 'none',
+} as QueryBasedInsightModel
 
 const MOCK_INSIGHT: QueryBasedInsightModel = {
     id: 1,
@@ -128,6 +167,9 @@ describe('sqlEditorLogic', () => {
                     const shortId = req.url.searchParams.get('short_id')
                     if (shortId === MOCK_INSIGHT_SHORT_ID) {
                         return [200, { results: [MOCK_INSIGHT] }]
+                    }
+                    if (shortId === MOCK_DATA_TABLE_INSIGHT_SHORT_ID) {
+                        return [200, { results: [MOCK_DATA_TABLE_INSIGHT] }]
                     }
                     return [200, { results: [] }]
                 },
@@ -374,6 +416,35 @@ describe('sqlEditorLogic', () => {
                         short_id: MOCK_INSIGHT_SHORT_ID,
                     }),
                 })
+        })
+
+        it('wraps a DataTableNode insight into a DataVisualizationNode so saves do not fail', async () => {
+            logic = sqlEditorLogic({
+                tabId: TAB_ID,
+                monaco: createMockMonaco(),
+                editor: createMockEditor(),
+            })
+            logic.mount()
+
+            router.actions.push(urls.sqlEditor(), { open_insight: MOCK_DATA_TABLE_INSIGHT_SHORT_ID })
+
+            await expectLogic(logic)
+                .toDispatchActions(['editInsight', 'createTab', 'updateTab'])
+                .toMatchValues({
+                    editingInsight: partial({
+                        short_id: MOCK_DATA_TABLE_INSIGHT_SHORT_ID,
+                    }),
+                    sourceQuery: partial({
+                        kind: NodeKind.DataVisualizationNode,
+                        source: partial({
+                            kind: NodeKind.HogQLQuery,
+                            query: (MOCK_DATA_TABLE_INSIGHT_QUERY.source as HogQLQuery).query,
+                        }),
+                    }),
+                })
+
+            // The button should not appear "dirty" immediately after load
+            expect(logic.values.updateInsightButtonEnabled).toEqual(false)
         })
 
         it('does not dispatch syncUrlWithQuery before the API responds', async () => {

--- a/frontend/src/scenes/data-warehouse/editor/sqlEditorLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/sqlEditorLogic.tsx
@@ -792,7 +792,10 @@ export const sqlEditorLogic = kea<sqlEditorLogicType>([
         createTab: async ({ query = '', view, insight, draft }) => {
             // Use tabId to ensure each browser tab has its own unique Monaco model
             const tabName = draft?.name || view?.name || insight?.name || NEW_QUERY
-            const insightVisualizationQuery = toDataVisualizationNode(insight?.query)
+            const rawInsightVisualizationQuery = toDataVisualizationNode(insight?.query)
+            const insightVisualizationQuery = rawInsightVisualizationQuery
+                ? sanitizeSourceQuery(rawInsightVisualizationQuery)
+                : undefined
 
             if (props.monaco) {
                 const uri = props.monaco.Uri.parse(`tab-${props.tabId}`)
@@ -822,7 +825,7 @@ export const sqlEditorLogic = kea<sqlEditorLogicType>([
                 })
             }
             if (insightVisualizationQuery) {
-                actions.setLastRunQuery(sanitizeSourceQuery(insightVisualizationQuery))
+                actions.setLastRunQuery(insightVisualizationQuery)
             }
             if (query) {
                 actions.setQueryInput(query)

--- a/frontend/src/scenes/data-warehouse/editor/sqlEditorLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/sqlEditorLogic.tsx
@@ -49,6 +49,7 @@ import { dataVisualizationLogic } from '~/queries/nodes/DataVisualization/dataVi
 import { queryExportContext } from '~/queries/query'
 import { Query } from '~/queries/Query/Query'
 import {
+    DataTableNode,
     DataVisualizationNode,
     DatabaseSchemaViewTable,
     FileSystemIconType,
@@ -158,6 +159,29 @@ function sanitizeSourceQuery(sourceQuery: DataVisualizationNode): DataVisualizat
         ...sanitizedSourceQuery,
         source: normalizeRawQuerySource(sourceQuery.source),
     }
+}
+
+function toDataVisualizationNode(
+    query: QueryBasedInsightModel['query'] | null | undefined
+): DataVisualizationNode | undefined {
+    if (!query) {
+        return undefined
+    }
+    if (query.kind === NodeKind.DataVisualizationNode) {
+        return query as DataVisualizationNode
+    }
+    // Insights created from the old DataTableNode path store the HogQLQuery under `.source`.
+    // Wrap it so the SQL editor can render and save it through the visualization pipeline.
+    if (query.kind === NodeKind.DataTableNode) {
+        const source = (query as DataTableNode).source
+        if (source?.kind === NodeKind.HogQLQuery) {
+            return {
+                kind: NodeKind.DataVisualizationNode,
+                source: source as HogQLQuery,
+            }
+        }
+    }
+    return undefined
 }
 
 function getCurrentVisualizationQuery(
@@ -768,6 +792,7 @@ export const sqlEditorLogic = kea<sqlEditorLogicType>([
         createTab: async ({ query = '', view, insight, draft }) => {
             // Use tabId to ensure each browser tab has its own unique Monaco model
             const tabName = draft?.name || view?.name || insight?.name || NEW_QUERY
+            const insightVisualizationQuery = toDataVisualizationNode(insight?.query)
 
             if (props.monaco) {
                 const uri = props.monaco.Uri.parse(`tab-${props.tabId}`)
@@ -792,12 +817,12 @@ export const sqlEditorLogic = kea<sqlEditorLogicType>([
                     view,
                     insight,
                     name: tabName,
-                    sourceQuery: insight?.query as DataVisualizationNode | undefined,
+                    sourceQuery: insightVisualizationQuery,
                     draft: draft,
                 })
             }
-            if (insight?.query?.kind === NodeKind.DataVisualizationNode) {
-                actions.setLastRunQuery(sanitizeSourceQuery(insight.query as DataVisualizationNode))
+            if (insightVisualizationQuery) {
+                actions.setLastRunQuery(sanitizeSourceQuery(insightVisualizationQuery))
             }
             if (query) {
                 actions.setQueryInput(query)
@@ -805,11 +830,8 @@ export const sqlEditorLogic = kea<sqlEditorLogicType>([
                 actions.setQueryInput(draft.query.query)
             } else if (view) {
                 actions.setQueryInput(view.query?.query ?? '')
-            } else if (insight) {
-                const queryObject = (insight.query as DataVisualizationNode | null)?.source || insight.query
-                if (queryObject && 'query' in queryObject) {
-                    actions.setQueryInput(queryObject.query || '')
-                }
+            } else if (insightVisualizationQuery) {
+                actions.setQueryInput(insightVisualizationQuery.source.query || '')
             }
 
             // Focus the editor after creating a new tab
@@ -1620,10 +1642,12 @@ export const sqlEditorLogic = kea<sqlEditorLogicType>([
                 const currentVisualizationQuery = getCurrentVisualizationQuery(dataLogicKey, sourceQuery)
 
                 const sourceQueryWithoutUndefinedAndNullKeys = removeUndefinedAndNull(currentVisualizationQuery)
+                // Normalize so DataTableNode-based insights don't look "changed" immediately after load.
+                const editingInsightQuery = toDataVisualizationNode(editingInsight.query) ?? editingInsight.query
 
                 return (
                     updatedName ||
-                    !isEqual(sourceQueryWithoutUndefinedAndNullKeys, removeUndefinedAndNull(editingInsight.query))
+                    !isEqual(sourceQueryWithoutUndefinedAndNullKeys, removeUndefinedAndNull(editingInsightQuery))
                 )
             },
         ],
@@ -2043,15 +2067,13 @@ export const sqlEditorLogic = kea<sqlEditorLogicType>([
                         return
                     }
 
-                    let query = ''
-                    if (insight.query?.kind === NodeKind.DataVisualizationNode) {
-                        query = (insight.query as DataVisualizationNode).source.query
-                    }
+                    const insightVisualizationQuery = toDataVisualizationNode(insight.query)
+                    const query = insightVisualizationQuery?.source.query ?? ''
 
                     const queryToOpen = searchParams.open_query ? searchParams.open_query : query
 
-                    if (insight.query) {
-                        actions.setSourceQuery(insight.query as DataVisualizationNode)
+                    if (insightVisualizationQuery) {
+                        actions.setSourceQuery(insightVisualizationQuery)
                     }
                     actions.editInsight(queryToOpen, insight)
                     if (!outputTabFromUrl) {
@@ -2059,11 +2081,7 @@ export const sqlEditorLogic = kea<sqlEditorLogicType>([
                     }
 
                     // Only run the query if the results aren't already cached locally and we're not using the open_query search param
-                    if (
-                        insight.query?.kind === NodeKind.DataVisualizationNode &&
-                        insight.query &&
-                        !searchParams.open_query
-                    ) {
+                    if (insightVisualizationQuery && !searchParams.open_query) {
                         const mountedDataLogic = dataNodeLogic.findMounted({ key: values.dataLogicKey })
                         const response = mountedDataLogic?.values.response
                         const responseLoading = mountedDataLogic?.values.responseLoading ?? false


### PR DESCRIPTION
## Problem

Clicking **Update insight** in the SQL editor on an insight originally saved as a `DataTableNode` silently failed. PR #53896 shipped error handling so the failure is no longer silent — users now see a toast — but it did not address the underlying save failure.

**Root cause:** The SQL editor unsafely cast every loaded insight's query to `DataVisualizationNode`. For insights persisted as `DataTableNode`, the query kept its runtime `kind: "DataTableNode"` but was fed into the visualization pipeline. On save, the visualization layer attached `chartSettings` / `tableSettings` / `display`, and the backend rejected the PATCH because `DataTableNode` is declared `extra="forbid"`. The mismatch became reliably observable after #53055, which started routing in-flight visualization edits back into the save payload via `getCurrentVisualizationQuery`.

## Changes

Normalize the insight query to a `DataVisualizationNode` at both load sites in `sqlEditorLogic.tsx`:

- New helper `toDataVisualizationNode` — passes `DataVisualizationNode` through unchanged; for `DataTableNode` with a `HogQLQuery` source, unwraps `.source` and wraps it in a `DataVisualizationNode`.
- `createTab` listener: builds `insightVisualizationQuery` once and uses it for `sourceQuery`, `setLastRunQuery`, and the `setQueryInput` fallback.
- `open_insight` URL handler: same normalization before `setSourceQuery` / running the query.
- `updateInsightButtonEnabled` selector: normalizes `editingInsight.query` for the equality check so a `DataTableNode`-sourced insight doesn't immediately look dirty after load.

## How did you test this code?

- Added a Jest test (`wraps a DataTableNode insight into a DataVisualizationNode so saves do not fail`) that opens a `DataTableNode`-backed insight via `open_insight` and asserts (1) `sourceQuery.kind === DataVisualizationNode` with the wrapped `HogQLQuery`, and (2) `updateInsightButtonEnabled === false` right after load.
- `pnpm --filter=@posthog/frontend exec jest src/scenes/data-warehouse/editor/sqlEditorLogic.test.ts` — all 36 tests pass (including the new one).
- TypeScript check introduces zero new errors in the touched files (pre-existing implicit-`any` errors unchanged, count identical with and without the diff).

## Publish to changelog?

no

## 🤖 LLM context

Authored by Claude (Opus 4.6) via Claude Code. Continues the investigation started in #53896 by Christiaan Hendriksen, which shipped the UX fix (error toast + loading state). The regression was introduced by #53055 (`feat(sql-editor): update formatting immediately`). Scope was kept tight: normalize at load, don't touch the save/update paths themselves.