### PR TITLE
fix(batch-exports): make `--overlap-policy` case-insensitive in backfill command

### DIFF
--- a/posthog/management/commands/backfill_batch_export_runs.py
+++ b/posthog/management/commands/backfill_batch_export_runs.py
@@ -207,12 +207,12 @@ class Command(BaseCommand):
         )
         parser.add_argument(
             "--overlap-policy",
-            type=str,
-            choices=["buffer_all", "allow_all"],
-            default="buffer_all",
+            type=str.upper,
+            choices=["BUFFER_ALL", "ALLOW_ALL"],
+            default="BUFFER_ALL",
             help=(
-                "Temporal schedule overlap policy for backfills (default: buffer_all). "
-                "Only use allow_all when: (1) you are backfilling only the events model, "
+                "Temporal schedule overlap policy for backfills (default: BUFFER_ALL). "
+                "Only use ALLOW_ALL when: (1) you are backfilling only the events model, "
                 "and (2) there are not many backfill intervals to run"
             ),
         )
@@ -376,11 +376,7 @@ class Command(BaseCommand):
                 self.stdout.write(self.style.WARNING("Aborted"))
                 return
 
-        overlap_policy_map = {
-            "buffer_all": temporalio.client.ScheduleOverlapPolicy.BUFFER_ALL,
-            "allow_all": temporalio.client.ScheduleOverlapPolicy.ALLOW_ALL,
-        }
-        overlap_policy = overlap_policy_map[options["overlap_policy"]]
+        overlap_policy = temporalio.client.ScheduleOverlapPolicy[options["overlap_policy"]]
 
         total_backfills, failures = asyncio.run(
             self._run_backfills(missing_by_export, options["dry_run"], overlap_policy, options["no_delay"]),

--- a/posthog/management/commands/test/test_backfill_batch_export_runs.py
+++ b/posthog/management/commands/test/test_backfill_batch_export_runs.py
@@ -516,6 +516,20 @@ class TestBackfillCommand:
         workflows = list_schedule_workflows(temporal, str(export.id))
         assert len(workflows) == 0
 
+    def test_allow_all_overlap_policy(self, team, temporal):
+        export = create_noop_export_with_schedule(team, interval="hour")
+        start, end = hour_window(2)
+
+        run_backfill_command(
+            f"--batch-export-id={export.id}",
+            f"--start={start.isoformat()}",
+            f"--end={end.isoformat()}",
+            "--overlap-policy=ALLOW_ALL",
+        )
+
+        workflows = sync_wait_for_workflows(temporal, str(export.id), expected_count=2)
+        assert len(workflows) == 2
+
     def test_schedule_not_found_does_not_raise(self, team, temporal):
         export = create_noop_export_with_schedule(team, interval="hour")
         start, end = hour_window(2)


### PR DESCRIPTION
## Problem

The `backfill_batch_export_runs` management command's `--overlap-policy` argument is case-sensitive, requiring exact lowercase input (`buffer_all` / `allow_all`).

## Changes

- Changed `type=str` to `type=str.upper` on the `--overlap-policy` argparse argument so input is normalized to uppercase before validation
- Switched choices to `BUFFER_ALL` / `ALLOW_ALL` to match Temporal's `ScheduleOverlapPolicy` enum names directly
- Added an e2e test to `TestBackfillCommand` that passes `--overlap-policy=ALLOW_ALL` and verifies backfills are triggered correctly

## How did you test this code?

- Ran `TestBackfillCommand::test_allow_all_overlap_policy` against real Temporal — passes

## Publish to changelog?

No

## Docs update

N/A

## 🤖 LLM context

Co-authored with Claude.