### PR TITLE
feat(cdp): add Google Analytics 4 destination via Measurement Protocol

### DIFF
--- a/nodejs/src/cdp/templates/_destinations/coming-soon/coming-soon-destinations.template.ts
+++ b/nodejs/src/cdp/templates/_destinations/coming-soon/coming-soon-destinations.template.ts
@@ -185,12 +185,6 @@ const destinationDefinitions: DestinationConfig[] = [
         category: ['Analytics'],
     },
     {
-        name: 'Google Analytics 4',
-        id: 'coming-soon-google-analytics-4',
-        icon_url: '/static/coming-soon-destinations/Google_Analytics_4.svg',
-        category: ['Analytics'],
-    },
-    {
         name: 'Hotjar',
         id: 'coming-soon-hotjar',
         icon_url: '/static/coming-soon-destinations/Hotjar.svg',

--- a/nodejs/src/cdp/templates/_destinations/google_analytics_4/ga4.template.test.ts
+++ b/nodejs/src/cdp/templates/_destinations/google_analytics_4/ga4.template.test.ts
@@ -1,0 +1,167 @@
+import { TemplateTester } from '../../test/test-helpers'
+import { template } from './ga4.template'
+
+jest.setTimeout(60 * 1000)
+
+describe('google analytics 4 template', () => {
+    const tester = new TemplateTester(template)
+
+    beforeEach(async () => {
+        await tester.beforeEach()
+    })
+
+    it('sends a page_view event', async () => {
+        const response = await tester.invokeMapping(
+            'Page view',
+            {
+                measurementId: 'G-XXXXXXXXXX',
+                apiSecret: 'test-api-secret',
+            },
+            {
+                event: {
+                    event: '$pageview',
+                    properties: {
+                        $current_url: 'https://posthog.com/docs',
+                        $referrer: 'https://google.com',
+                        title: 'PostHog Docs',
+                    },
+                    distinct_id: 'user-123',
+                    uuid: 'event-id',
+                    timestamp: '2025-01-01T00:00:00Z',
+                },
+            }
+        )
+
+        expect(response.error).toBeUndefined()
+        expect(response.finished).toEqual(false)
+        expect(response.invocation.queueParameters).toMatchInlineSnapshot(`
+            {
+              "body": "{"client_id":"user-123","events":[{"name":"page_view","params":{"page_location":"https://posthog.com/docs","page_referrer":"https://google.com","page_title":"PostHog Docs"}}]}",
+              "headers": {
+                "Content-Type": "application/json",
+              },
+              "method": "POST",
+              "type": "fetch",
+              "url": "https://www.google-analytics.com/mp/collect?measurement_id=G-XXXXXXXXXX&api_secret=test-api-secret",
+            }
+        `)
+
+        const fetchResponse = await tester.invokeFetchResponse(response.invocation, {
+            status: 204,
+            body: {},
+        })
+
+        expect(fetchResponse.finished).toBe(true)
+        expect(fetchResponse.error).toBeUndefined()
+    })
+
+    it('sends a custom event with user_id', async () => {
+        const response = await tester.invokeMapping(
+            'Custom event',
+            {
+                measurementId: 'G-XXXXXXXXXX',
+                apiSecret: 'test-api-secret',
+            },
+            {
+                event: {
+                    event: 'purchase',
+                    properties: {
+                        value: '99.99',
+                        currency: 'USD',
+                    },
+                    distinct_id: 'user-123',
+                    uuid: 'event-id',
+                    timestamp: '2025-01-01T00:00:00Z',
+                },
+            },
+            {
+                userId: '{event.distinct_id}',
+                eventParameters: {
+                    value: '{event.properties.value}',
+                    currency: '{event.properties.currency}',
+                },
+            }
+        )
+
+        expect(response.error).toBeUndefined()
+        expect(response.finished).toEqual(false)
+        expect(response.invocation.queueParameters).toMatchInlineSnapshot(`
+            {
+              "body": "{"client_id":"user-123","events":[{"name":"purchase","params":{"value":"99.99","currency":"USD"}}],"user_id":"user-123"}",
+              "headers": {
+                "Content-Type": "application/json",
+              },
+              "method": "POST",
+              "type": "fetch",
+              "url": "https://www.google-analytics.com/mp/collect?measurement_id=G-XXXXXXXXXX&api_secret=test-api-secret",
+            }
+        `)
+
+        const fetchResponse = await tester.invokeFetchResponse(response.invocation, {
+            status: 204,
+            body: {},
+        })
+
+        expect(fetchResponse.finished).toBe(true)
+        expect(fetchResponse.error).toBeUndefined()
+    })
+
+    it('skips when clientId is empty', async () => {
+        const response = await tester.invokeMapping(
+            'Custom event',
+            {
+                measurementId: 'G-XXXXXXXXXX',
+                apiSecret: 'test-api-secret',
+            },
+            {
+                event: {
+                    event: 'test_event',
+                    distinct_id: '',
+                    uuid: 'event-id',
+                    timestamp: '2025-01-01T00:00:00Z',
+                },
+                person: {
+                    properties: {},
+                },
+            }
+        )
+
+        expect(response.logs.filter((log) => log.level === 'info').map((log) => log.message)).toMatchInlineSnapshot(`
+            [
+              "Empty \`clientId\`. Skipping...",
+            ]
+        `)
+        expect(response.finished).toEqual(true)
+    })
+
+    it('handles error responses', async () => {
+        const response = await tester.invokeMapping(
+            'Custom event',
+            {
+                measurementId: 'G-XXXXXXXXXX',
+                apiSecret: 'test-api-secret',
+            },
+            {
+                event: {
+                    event: 'test_event',
+                    distinct_id: 'user-123',
+                    uuid: 'event-id',
+                    timestamp: '2025-01-01T00:00:00Z',
+                },
+            }
+        )
+
+        expect(response.error).toBeUndefined()
+        expect(response.finished).toEqual(false)
+
+        const fetchResponse = await tester.invokeFetchResponse(response.invocation, {
+            status: 400,
+            body: { error: 'Invalid measurement_id' },
+        })
+
+        expect(fetchResponse.finished).toBe(true)
+        expect(fetchResponse.error).toMatchInlineSnapshot(
+            `"Error from Google Analytics 4 (status 400): {'error': 'Invalid measurement_id'}"`
+        )
+    })
+})

--- a/nodejs/src/cdp/templates/_destinations/google_analytics_4/ga4.template.ts
+++ b/nodejs/src/cdp/templates/_destinations/google_analytics_4/ga4.template.ts
@@ -1,0 +1,145 @@
+import { HogFunctionInputSchemaType } from '~/cdp/types'
+import { HogFunctionTemplate } from '~/cdp/types'
+
+// Based on https://developers.google.com/analytics/devguide/collection/protocol/ga4/reference
+
+const build_inputs = (): HogFunctionInputSchemaType[] => {
+    return [
+        {
+            key: 'clientId',
+            type: 'string',
+            label: 'Client ID',
+            description:
+                'A unique identifier for the client. Use the GA client_id if available, otherwise falls back to distinct_id.',
+            default: '{person.properties.$ga_client_id ?? event.distinct_id}',
+            secret: false,
+            required: true,
+        },
+        {
+            key: 'eventName',
+            type: 'string',
+            label: 'Event name',
+            description:
+                'The name of the event to send to GA4. Can be a standard GA4 event name (e.g. purchase, sign_up) or a custom event name.',
+            default: '{event.event}',
+            secret: false,
+            required: true,
+        },
+        {
+            key: 'eventParameters',
+            type: 'dictionary',
+            label: 'Event parameters',
+            description: 'Additional parameters to include with the event.',
+            default: {},
+            secret: false,
+            required: false,
+        },
+        {
+            key: 'userId',
+            type: 'string',
+            label: 'User ID',
+            description: 'A unique identifier for the user. Maps to the user_id field in GA4.',
+            default: '',
+            secret: false,
+            required: false,
+        },
+    ]
+}
+
+export const template: HogFunctionTemplate = {
+    free: false,
+    status: 'alpha',
+    type: 'destination',
+    id: 'template-google-analytics-4',
+    name: 'Google Analytics 4',
+    description: 'Send events to Google Analytics 4 via the Measurement Protocol',
+    icon_url: '/static/coming-soon-destinations/Google_Analytics_4.svg',
+    category: ['Analytics'],
+    code_language: 'hog',
+    code: `
+if (empty(inputs.clientId)) {
+    print('Empty \`clientId\`. Skipping...')
+    return
+}
+
+let event := {
+    'name': inputs.eventName,
+    'params': inputs.eventParameters ?? {}
+}
+
+let body := {
+    'client_id': inputs.clientId,
+    'events': [event]
+}
+
+if (not empty(inputs.userId)) {
+    body.user_id := inputs.userId
+}
+
+let res := fetch(f'https://www.google-analytics.com/mp/collect?measurement_id={inputs.measurementId}&api_secret={inputs.apiSecret}', {
+    'method': 'POST',
+    'headers': {
+        'Content-Type': 'application/json'
+    },
+    'body': body
+})
+
+if (res.status >= 400) {
+    throw Error(f'Error from Google Analytics 4 (status {res.status}): {res.body}')
+}
+`,
+    inputs_schema: [
+        {
+            key: 'measurementId',
+            type: 'string',
+            label: 'Measurement ID',
+            description: 'Your GA4 Measurement ID (e.g. G-XXXXXXXXXX). Found in Admin > Data Streams.',
+            secret: false,
+            required: true,
+        },
+        {
+            key: 'apiSecret',
+            type: 'string',
+            label: 'API Secret',
+            description:
+                'Measurement Protocol API Secret. Create one in Admin > Data Streams > Measurement Protocol API secrets.',
+            secret: true,
+            required: true,
+        },
+    ],
+    mapping_templates: [
+        {
+            name: 'Page view',
+            include_by_default: true,
+            filters: {
+                events: [{ id: '$pageview', type: 'events' }],
+            },
+            inputs_schema: [
+                ...build_inputs().map((input) => {
+                    if (input.key === 'eventName') {
+                        return { ...input, default: 'page_view' }
+                    }
+                    if (input.key === 'eventParameters') {
+                        return {
+                            ...input,
+                            default: {
+                                page_location: '{event.properties.$current_url}',
+                                page_referrer: '{event.properties.$referrer}',
+                                page_title: '{event.properties.title}',
+                            },
+                        }
+                    }
+                    return input
+                }),
+            ],
+        },
+        {
+            name: 'Custom event',
+            include_by_default: false,
+            filters: {
+                events: [],
+            },
+            inputs_schema: [...build_inputs()],
+        },
+    ],
+}

--- a/nodejs/src/cdp/templates/index.ts
+++ b/nodejs/src/cdp/templates/index.ts
@@ -10,6 +10,7 @@ import { template as githubTemplate } from './_destinations/github/github.templa
 import { template as gitlabTemplate } from './_destinations/gitlab/gitlab.template'
 import { template as googleTagManagerTemplate } from './_destinations/google-tag-manager/google-tag-manager.template'
 import { template as googleAdsTemplate } from './_destinations/google_ads/google.template'
+import { template as ga4Template } from './_destinations/google_analytics_4/ga4.template'
 import { template as googleSheetsTemplate } from './_destinations/google_sheets/google_sheets.template'
 import { template as hubspotCompanyTemplate } from './_destinations/hubspot/hubspot.template'
 import { template as klimeTemplate } from './_destinations/klime/klime.template'
@@ -54,6 +55,7 @@ export const HOG_FUNCTION_TEMPLATES_DESTINATIONS: HogFunctionTemplate[] = [
     githubTemplate,
     gitlabTemplate,
     googleAdsTemplate,
+    ga4Template,
     linkedinAdsTemplate,
     redditAdsTemplate,
     twilioTemplate,


### PR DESCRIPTION
Add a new GA4 destination template that sends events to Google Analytics 4 using the Measurement Protocol API. Supports page views and custom events with configurable event parameters, client ID, and user ID mapping.

Includes two mapping templates:
- Page view: maps $pageview events with URL, referrer, and title
- Custom event: flexible mapping for any event type