### PR TITLE
fix(exports): send absolute URL for screenshot heatmap exports

### DIFF
--- a/frontend/src/scenes/heatmaps/scenes/heatmap/heatmapLogic.test.ts
+++ b/frontend/src/scenes/heatmaps/scenes/heatmap/heatmapLogic.test.ts
@@ -11,10 +11,10 @@ describe('resolveHeatmapExportUrl', () => {
         )
     })
 
-    it('returns the display URL unchanged for browser-type heatmaps', () => {
+    it('returns the display URL unchanged for iframe-type heatmaps', () => {
         expect(
             resolveHeatmapExportUrl(
-                'browser',
+                'iframe',
                 '/api/environments/1/heatmap_screenshots/42/content/',
                 'https://example.com/page',
                 origin
@@ -26,8 +26,8 @@ describe('resolveHeatmapExportUrl', () => {
         expect(resolveHeatmapExportUrl('screenshot', null, 'https://example.com/page', origin)).toBe('')
     })
 
-    it('returns an empty string for browser heatmaps without a displayUrl', () => {
-        expect(resolveHeatmapExportUrl('browser', '/api/something', null, origin)).toBe('')
+    it('returns an empty string for iframe heatmaps without a displayUrl', () => {
+        expect(resolveHeatmapExportUrl('iframe', '/api/something', null, origin)).toBe('')
     })
 
     it('preserves an already-absolute screenshot URL', () => {

--- a/frontend/src/scenes/heatmaps/scenes/heatmap/heatmapLogic.test.ts
+++ b/frontend/src/scenes/heatmaps/scenes/heatmap/heatmapLogic.test.ts
@@ -1,38 +1,35 @@
+import { HeatmapType } from '~/types'
+
 import { resolveHeatmapExportUrl } from './heatmapLogic'
 
 describe('resolveHeatmapExportUrl', () => {
     const origin = 'https://us.posthog.com'
 
-    it('resolves screenshot API paths to absolute URLs so SSRF validation accepts them', () => {
-        const screenshotUrl = '/api/environments/1/heatmap_screenshots/42/content/?width=1400'
-
-        expect(resolveHeatmapExportUrl('screenshot', screenshotUrl, 'https://example.com/page', origin)).toBe(
-            `${origin}${screenshotUrl}`
-        )
-    })
-
-    it('returns the display URL unchanged for iframe-type heatmaps', () => {
-        expect(
-            resolveHeatmapExportUrl(
-                'iframe',
-                '/api/environments/1/heatmap_screenshots/42/content/',
-                'https://example.com/page',
-                origin
-            )
-        ).toBe('https://example.com/page')
-    })
-
-    it('returns an empty string for screenshot heatmaps without a screenshotUrl', () => {
-        expect(resolveHeatmapExportUrl('screenshot', null, 'https://example.com/page', origin)).toBe('')
-    })
-
-    it('returns an empty string for iframe heatmaps without a displayUrl', () => {
-        expect(resolveHeatmapExportUrl('iframe', '/api/something', null, origin)).toBe('')
-    })
-
-    it('preserves an already-absolute screenshot URL', () => {
-        const absolute = 'https://another.posthog.com/api/environments/1/heatmap_screenshots/42/content/'
-
-        expect(resolveHeatmapExportUrl('screenshot', absolute, null, origin)).toBe(absolute)
-    })
+    it.each([
+        [
+            'screenshot',
+            '/api/environments/1/heatmap_screenshots/42/content/?width=1400',
+            'https://example.com/page',
+            `${origin}/api/environments/1/heatmap_screenshots/42/content/?width=1400`,
+        ],
+        [
+            'iframe',
+            '/api/environments/1/heatmap_screenshots/42/content/',
+            'https://example.com/page',
+            'https://example.com/page',
+        ],
+        ['screenshot', null, 'https://example.com/page', ''],
+        ['iframe', '/api/something', null, ''],
+        [
+            'screenshot',
+            'https://another.posthog.com/api/environments/1/heatmap_screenshots/42/content/',
+            null,
+            'https://another.posthog.com/api/environments/1/heatmap_screenshots/42/content/',
+        ],
+    ] as const)(
+        'resolveHeatmapExportUrl(%s, screenshotUrl=%s, displayUrl=%s) → %s',
+        (type, screenshotUrl, displayUrl, expected) => {
+            expect(resolveHeatmapExportUrl(type as HeatmapType, screenshotUrl, displayUrl, origin)).toBe(expected)
+        }
+    )
 })

--- a/frontend/src/scenes/heatmaps/scenes/heatmap/heatmapLogic.test.ts
+++ b/frontend/src/scenes/heatmaps/scenes/heatmap/heatmapLogic.test.ts
@@ -1,0 +1,38 @@
+import { resolveHeatmapExportUrl } from './heatmapLogic'
+
+describe('resolveHeatmapExportUrl', () => {
+    const origin = 'https://us.posthog.com'
+
+    it('resolves screenshot API paths to absolute URLs so SSRF validation accepts them', () => {
+        const screenshotUrl = '/api/environments/1/heatmap_screenshots/42/content/?width=1400'
+
+        expect(resolveHeatmapExportUrl('screenshot', screenshotUrl, 'https://example.com/page', origin)).toBe(
+            `${origin}${screenshotUrl}`
+        )
+    })
+
+    it('returns the display URL unchanged for browser-type heatmaps', () => {
+        expect(
+            resolveHeatmapExportUrl(
+                'browser',
+                '/api/environments/1/heatmap_screenshots/42/content/',
+                'https://example.com/page',
+                origin
+            )
+        ).toBe('https://example.com/page')
+    })
+
+    it('returns an empty string for screenshot heatmaps without a screenshotUrl', () => {
+        expect(resolveHeatmapExportUrl('screenshot', null, 'https://example.com/page', origin)).toBe('')
+    })
+
+    it('returns an empty string for browser heatmaps without a displayUrl', () => {
+        expect(resolveHeatmapExportUrl('browser', '/api/something', null, origin)).toBe('')
+    })
+
+    it('preserves an already-absolute screenshot URL', () => {
+        const absolute = 'https://another.posthog.com/api/environments/1/heatmap_screenshots/42/content/'
+
+        expect(resolveHeatmapExportUrl('screenshot', absolute, null, origin)).toBe(absolute)
+    })
+})

--- a/frontend/src/scenes/heatmaps/scenes/heatmap/heatmapLogic.ts
+++ b/frontend/src/scenes/heatmaps/scenes/heatmap/heatmapLogic.ts
@@ -16,9 +16,8 @@ import type { heatmapLogicType } from './heatmapLogicType'
 
 const DEFAULT_HEATMAP_NAME = 'Untitled heatmap'
 
-// The backend rejects `heatmap_url` values without an http(s) scheme (SSRF validation).
-// For screenshot-type heatmaps the in-app `screenshotUrl` is a same-origin API path, so we
-// resolve it to an absolute URL here before sending it to the export pipeline.
+// Screenshot heatmaps store a same-origin API path as `screenshotUrl`; the export backend's
+// SSRF validation rejects URLs without an http(s) scheme, so we resolve it to an absolute URL.
 export function resolveHeatmapExportUrl(
     type: HeatmapType,
     screenshotUrl: string | null,

--- a/frontend/src/scenes/heatmaps/scenes/heatmap/heatmapLogic.ts
+++ b/frontend/src/scenes/heatmaps/scenes/heatmap/heatmapLogic.ts
@@ -16,6 +16,21 @@ import type { heatmapLogicType } from './heatmapLogicType'
 
 const DEFAULT_HEATMAP_NAME = 'Untitled heatmap'
 
+// The backend rejects `heatmap_url` values without an http(s) scheme (SSRF validation).
+// For screenshot-type heatmaps the in-app `screenshotUrl` is a same-origin API path, so we
+// resolve it to an absolute URL here before sending it to the export pipeline.
+export function resolveHeatmapExportUrl(
+    type: HeatmapType,
+    screenshotUrl: string | null,
+    displayUrl: string | null,
+    origin: string = window.location.origin
+): string {
+    if (type === 'screenshot') {
+        return screenshotUrl ? new URL(screenshotUrl, origin).toString() : ''
+    }
+    return displayUrl ?? ''
+}
+
 export const heatmapLogic = kea<heatmapLogicType>([
     path(['scenes', 'heatmaps', 'scenes', 'heatmap', 'heatmapLogic']),
     props({ id: 'new' as string | number }),
@@ -222,7 +237,7 @@ export const heatmapLogic = kea<heatmapLogicType>([
                 return
             }
             actions.startHeatmapExport({
-                heatmap_url: values.type === 'screenshot' ? (values.screenshotUrl ?? '') : (values.displayUrl ?? ''),
+                heatmap_url: resolveHeatmapExportUrl(values.type, values.screenshotUrl, values.displayUrl),
                 heatmap_data_url: values.dataUrl ?? '',
                 heatmap_type: values.type,
                 width: values.widthOverride,

--- a/posthog/api/test/test_exports.py
+++ b/posthog/api/test/test_exports.py
@@ -1044,41 +1044,31 @@ class TestExportHeatmapSSRFValidation(APIBaseTest):
         )
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
-    @patch("posthog.api.exports.ExportedAssetSerializer._start_export_workflow")
-    @patch("posthog.security.url_validation.resolve_host_ips")
-    def test_accepts_valid_external_heatmap_url(self, mock_resolve, mock_exporter_task) -> None:
+    @parameterized.expand(
+        [
+            ("external_url", "https://example.com/page"),
+            (
+                "screenshot_api_url",
+                "https://us.posthog.com/api/environments/1/heatmap_screenshots/42/content/?width=1400",
+            ),
+        ]
+    )
+    def test_accepts_valid_heatmap_url(self, _name: str, url: str) -> None:
         import ipaddress
 
-        mock_resolve.return_value = {ipaddress.ip_address("93.184.216.34")}
-        response = self.client.post(
-            f"/api/projects/{self.team.id}/exports",
-            {
-                "export_format": "image/png",
-                "export_context": {
-                    "heatmap_url": "https://example.com/page",
+        with (
+            patch("posthog.security.url_validation.resolve_host_ips") as mock_resolve,
+            patch("posthog.api.exports.ExportedAssetSerializer._start_export_workflow"),
+        ):
+            mock_resolve.return_value = {ipaddress.ip_address("93.184.216.34")}
+            response = self.client.post(
+                f"/api/projects/{self.team.id}/exports",
+                {
+                    "export_format": "image/png",
+                    "export_context": {"heatmap_url": url},
                 },
-            },
-        )
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-
-    @patch("posthog.api.exports.ExportedAssetSerializer._start_export_workflow")
-    @patch("posthog.security.url_validation.resolve_host_ips")
-    def test_accepts_absolute_screenshot_api_url(self, mock_resolve, mock_exporter_task) -> None:
-        # Screenshot-type heatmaps send the screenshot API endpoint as an absolute URL
-        # (resolved from the browser origin) — verify it passes SSRF validation
-        import ipaddress
-
-        mock_resolve.return_value = {ipaddress.ip_address("93.184.216.34")}
-        response = self.client.post(
-            f"/api/projects/{self.team.id}/exports",
-            {
-                "export_format": "image/png",
-                "export_context": {
-                    "heatmap_url": "https://us.posthog.com/api/environments/1/heatmap_screenshots/42/content/?width=1400",
-                },
-            },
-        )
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+            )
+            self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
 
 class TestExportMixin(APIBaseTest):

--- a/posthog/api/test/test_exports.py
+++ b/posthog/api/test/test_exports.py
@@ -1028,6 +1028,8 @@ class TestExportHeatmapSSRFValidation(APIBaseTest):
             ("private_ip_192", "http://192.168.1.1/internal"),
             ("internal_domain", "http://service.cluster.local/api"),
             ("file_scheme", "file:///etc/passwd"),
+            ("protocol_relative", "//evil.com/steal-data"),
+            ("relative_api_path", "/api/environments/1/heatmap_screenshots/42/content/?width=1400"),
         ]
     )
     def test_rejects_ssrf_heatmap_url(self, _name: str, url: str) -> None:
@@ -1054,6 +1056,25 @@ class TestExportHeatmapSSRFValidation(APIBaseTest):
                 "export_format": "image/png",
                 "export_context": {
                     "heatmap_url": "https://example.com/page",
+                },
+            },
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+    @patch("posthog.api.exports.ExportedAssetSerializer._start_export_workflow")
+    @patch("posthog.security.url_validation.resolve_host_ips")
+    def test_accepts_absolute_screenshot_api_url(self, mock_resolve, mock_exporter_task) -> None:
+        # Screenshot-type heatmaps send the screenshot API endpoint as an absolute URL
+        # (resolved from the browser origin) — verify it passes SSRF validation
+        import ipaddress
+
+        mock_resolve.return_value = {ipaddress.ip_address("93.184.216.34")}
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/exports",
+            {
+                "export_format": "image/png",
+                "export_context": {
+                    "heatmap_url": "https://us.posthog.com/api/environments/1/heatmap_screenshots/42/content/?width=1400",
                 },
             },
         )


### PR DESCRIPTION
## Problem

Exporting a screenshot-type heatmap in production fails with:

```
{
    "type": "validation_error",
    "code": "invalid_input",
    "detail": "heatmap_url not allowed: Disallowed scheme",
    "attr": "export_context"
}
```

The frontend was sending the in-app screenshot API path (`/api/environments/{team_id}/heatmap_screenshots/{id}/content/?width=...`) as `heatmap_url`. Because it's a relative path with no scheme, the backend's SSRF validation (`is_url_allowed`) rejects it with "Disallowed scheme". This only affected production since `is_dev_mode()` short-circuits the check locally.

This is an alternative to #53970 — instead of relaxing the backend's SSRF validation to accept relative paths, we keep the validation strict and fix the frontend to always send an absolute URL.

## Changes

- Extracted `resolveHeatmapExportUrl()` as a pure helper in `heatmapLogic.ts`. For screenshot-type heatmaps it resolves the same-origin API path against `window.location.origin` via `new URL(path, origin)`. For browser-type heatmaps it returns the existing `displayUrl` unchanged.
- Added backend tests that lock in the SSRF validation contract: relative paths are rejected, absolute URLs pointing at the screenshot API are accepted.

## How did you test this code?

**Frontend** — 5 unit tests for `resolveHeatmapExportUrl` covering:
- Screenshot path resolved to absolute URL
- Browser displayUrl returned unchanged
- Null inputs
- Already-absolute screenshot URL preserved

**Backend** — extended `TestExportHeatmapSSRFValidation`:
- `relative_api_path` added to the parameterized rejection list — confirms the original bug (relative paths are rejected)
- `test_accepts_absolute_screenshot_api_url` — confirms the fix (the absolute URL the frontend now sends is accepted)
- All 11 SSRF tests pass

No publish to changelog.