### PR TITLE
fix(activity): ensure show more is present in activity

### DIFF
--- a/frontend/src/queries/nodes/DataTable/defaultEventsQuery.test.ts
+++ b/frontend/src/queries/nodes/DataTable/defaultEventsQuery.test.ts
@@ -1,0 +1,47 @@
+import { TeamType } from '~/types'
+
+import { HOGQL_COLUMNS_KEY, getDefaultEventsQueryForTeam } from './defaultEventsQuery'
+
+describe('getDefaultEventsQueryForTeam', () => {
+    it('returns null when live_events_columns is unset', () => {
+        expect(getDefaultEventsQueryForTeam({} as Partial<TeamType>)).toBeNull()
+    })
+
+    it.each([
+        {
+            name: 'prepends * for HOGQL columns that do not include it',
+            columns: [HOGQL_COLUMNS_KEY, 'event', 'timestamp'],
+            expectedSelect: ['*', 'event', 'timestamp'],
+            expectedOrderBy: ['timestamp DESC'],
+        },
+        {
+            name: 'does not duplicate * when HOGQL columns already include it',
+            columns: [HOGQL_COLUMNS_KEY, '*', 'event', 'timestamp'],
+            expectedSelect: ['*', 'event', 'timestamp'],
+            expectedOrderBy: ['timestamp DESC'],
+        },
+        {
+            name: 'does not duplicate * for legacy columns (cleanLiveEventsColumns already adds one)',
+            columns: ['event', 'url'],
+            expectedSelect: [
+                '*',
+                'event',
+                'coalesce(properties.$current_url, properties.$screen_name) -- Url / Screen',
+                'timestamp',
+            ],
+            expectedOrderBy: ['timestamp DESC'],
+        },
+        {
+            name: 'omits orderBy when timestamp is not in the column list',
+            columns: [HOGQL_COLUMNS_KEY, 'event'],
+            expectedSelect: ['*', 'event'],
+            expectedOrderBy: [],
+        },
+    ])('$name', ({ columns, expectedSelect, expectedOrderBy }) => {
+        const query = getDefaultEventsQueryForTeam({ live_events_columns: columns } as Partial<TeamType>)
+        expect(query).not.toBeNull()
+        expect(query!.select).toEqual(expectedSelect)
+        expect(query!.orderBy).toEqual(expectedOrderBy)
+        expect(query!.after).toBe('-1h')
+    })
+})

--- a/frontend/src/queries/nodes/DataTable/defaultEventsQuery.ts
+++ b/frontend/src/queries/nodes/DataTable/defaultEventsQuery.ts
@@ -34,12 +34,17 @@ export function cleanLiveEventsColumns(columns: string[]): string[] {
 export function getDefaultEventsQueryForTeam(team: Partial<TeamType>): EventsQuery | null {
     const liveColumns = team?.live_events_columns ? cleanLiveEventsColumns(team.live_events_columns) : null
 
-    return liveColumns
+    // Always prepend '*' — the column configurator saves `live_events_columns` without it
+    // (see ColumnConfigurator.tsx), but the row-expand toggle relies on '*' being present in
+    // the response columns.
+    const select = liveColumns ? (liveColumns.includes('*') ? liveColumns : ['*', ...liveColumns]) : null
+
+    return select
         ? {
               kind: NodeKind.EventsQuery,
-              select: liveColumns,
+              select,
               after: '-1h',
-              orderBy: liveColumns.includes('timestamp') ? ['timestamp DESC'] : [],
+              orderBy: select.includes('timestamp') ? ['timestamp DESC'] : [],
           }
         : null
 }


### PR DESCRIPTION
## Problem

The project-level default events query was dropping the `*` column, which broke the row-expand toggle in the events data table (the expand arrow relies on the full event row being present in the response).

The column configurator saves `live_events_columns` without `*` — it's only there for legacy entries — so projects that had saved custom default columns ended up with a query that couldn't be expanded.

## Changes

- Prepend `*` to the `select` list in `getDefaultEventsQueryForTeam` when it isn't already there
- Keep `orderBy` aware of the adjusted column list

## How did you test this code?

Tests

## Publish to changelog?
no
<!-- ## 🤖 LLM context -->

<!-- Authored by Claude Code. Small targeted fix — the missing `*` was noticed while investigating why row expansion was broken for teams with custom live_events_columns. -->