### PR TITLE
feat(experiments): Surface team experiments config in django admin

### DIFF
--- a/posthog/admin/admins/team_admin.py
+++ b/posthog/admin/admins/team_admin.py
@@ -23,6 +23,7 @@ from temporalio import common
 from temporalio.client import WorkflowExecutionStatus
 
 from posthog.admin.inlines.organization_member_for_related_inline import OrganizationMemberForRelatedInline
+from posthog.admin.inlines.team_experiments_config_inline import TeamExperimentsConfigInline
 from posthog.admin.inlines.team_marketing_analytics_config_inline import TeamMarketingAnalyticsConfigInline
 from posthog.admin.inlines.user_product_list_inline import UserProductListInline
 from posthog.cloud_utils import is_cloud
@@ -92,7 +93,12 @@ class TeamAdmin(admin.ModelAdmin):
     ]
 
     exclude = DEPRECATED_ATTRS
-    inlines = [OrganizationMemberForRelatedInline, TeamMarketingAnalyticsConfigInline, UserProductListInline]
+    inlines = [
+        OrganizationMemberForRelatedInline,
+        TeamMarketingAnalyticsConfigInline,
+        TeamExperimentsConfigInline,
+        UserProductListInline,
+    ]
 
     def changeform_view(self, request, object_id=None, form_url="", extra_context=None):
         self._current_request = request

--- a/posthog/admin/inlines/team_experiments_config_inline.py
+++ b/posthog/admin/inlines/team_experiments_config_inline.py
@@ -1,0 +1,27 @@
+from django.contrib import admin
+
+from products.experiments.backend.models.team_experiments_config import TeamExperimentsConfig
+
+
+class TeamExperimentsConfigInline(admin.StackedInline):
+    model = TeamExperimentsConfig
+    extra = 0
+    max_num = 1
+    classes = ("collapse",)
+
+    fieldsets = [
+        (
+            "Experiments",
+            {
+                "fields": [
+                    "experiment_recalculation_time",
+                    "default_experiment_confidence_level",
+                    "default_experiment_stats_method",
+                    "experiment_precomputation_enabled",
+                ],
+            },
+        ),
+    ]
+
+    def has_delete_permission(self, request, obj=None):
+        return False


### PR DESCRIPTION
## Problem

The Django team admin page exposes product-specific toggles (Surveys, Session replay, etc.) as fieldsets on `Team`, but the newer Team Extension models — including `TeamExperimentsConfig` — aren't surfaced anywhere.

## Changes

Added `TeamExperimentsConfigInline` and registered it on `TeamAdmin`, following the existing `TeamMarketingAnalyticsConfigInline` pattern.

## How did you test this code?

Loaded a team in the local Django admin and confirmed the collapsed "Team experiments config" section appears with the four fields and persists edits.