### PR TITLE
chore(error-tracking): support ip anonymizing

### DIFF
--- a/nodejs/src/ingestion/error-tracking/prepare-event-step.test.ts
+++ b/nodejs/src/ingestion/error-tracking/prepare-event-step.test.ts
@@ -150,6 +150,36 @@ describe('createErrorTrackingPrepareEventStep', () => {
         }
     })
 
+    it('should delete $ip when team.anonymize_ips is true', async () => {
+        const event = createTestPluginEvent({
+            event: '$exception',
+            properties: { $ip: '1.2.3.4', other: 'kept' },
+        })
+        const anonymizedTeam = createTestTeam({ id: 123, project_id: 456 as any, anonymize_ips: true })
+
+        const result = await step({ event, team: anonymizedTeam, person: null, headers: createTestHeaders() })
+
+        expect(result.type).toBe(PipelineResultType.OK)
+        if (isOkResult(result)) {
+            expect(result.value.preparedEvent.properties['$ip']).toBeUndefined()
+            expect(result.value.preparedEvent.properties['other']).toBe('kept')
+        }
+    })
+
+    it('should keep $ip when team.anonymize_ips is false', async () => {
+        const event = createTestPluginEvent({
+            event: '$exception',
+            properties: { $ip: '1.2.3.4' },
+        })
+
+        const result = await step({ event, team, person: null, headers: createTestHeaders() })
+
+        expect(result.type).toBe(PipelineResultType.OK)
+        if (isOkResult(result)) {
+            expect(result.value.preparedEvent.properties['$ip']).toBe('1.2.3.4')
+        }
+    })
+
     it('removes $set from properties to prevent incorrect person_properties merging', async () => {
         // Error tracking events ($exception) are in NO_PERSON_UPDATE_EVENTS, so person
         // updates are never written. However, createEvent() merges $set into person_properties

--- a/nodejs/src/ingestion/error-tracking/prepare-event-step.ts
+++ b/nodejs/src/ingestion/error-tracking/prepare-event-step.ts
@@ -51,6 +51,10 @@ export function createErrorTrackingPrepareEventStep<T extends ErrorTrackingPrepa
         delete properties.$set
         delete properties.$set_once
 
+        if (properties['$ip'] && input.team.anonymize_ips) {
+            delete properties['$ip']
+        }
+
         // Timestamp is already validated by the cymbal processing step
         const timestamp = event.timestamp as ISOTimestamp
 


### PR DESCRIPTION
## Problem

the new error tracking pipeline isn't dropping ips from the event when anonymize ips is true.

## Changes

- drop ips in prepare step if anonymizing is enabled
- this matches how the main analytics pipeline handles it