### PR TITLE
chore(modeling): only preempt cancel self saved query

### DIFF
--- a/posthog/temporal/data_modeling/run_workflow.py
+++ b/posthog/temporal/data_modeling/run_workflow.py
@@ -1381,23 +1381,41 @@ async def create_job_model_activity(inputs: CreateJobModelInputs) -> str:
 @dataclasses.dataclass
 class CleanupRunningJobsActivityInputs:
     team_id: int
+    saved_query_ids: list[str] = dataclasses.field(default_factory=list)
 
 
 @database_sync_to_async
-def _preempt_running_jobs(team_id: int) -> list[DataModelingJob]:
+def _preempt_running_jobs(team_id: int, saved_query_ids: list[str] | None = None) -> list[DataModelingJob]:
     """Atomically fetch and mark orphaned RUNNING jobs as FAILED.
+
+    When saved_query_ids is provided, only jobs belonging to those saved queries
+    are preempted (self-preemption). Otherwise, falls back to team-wide cleanup
+    for backwards compatibility.
 
     The SELECT and UPDATE run inside a single transaction with row-level locks
     so concurrent cleanups cannot process the same jobs twice.
     """
     with transaction.atomic():
-        orphaned_jobs = list(
-            DataModelingJob.objects.select_for_update().filter(
-                team_id=team_id,
-                status=DataModelingJob.Status.RUNNING,
-                engine=DataModelingJob.Engine.CLICKHOUSE,
-            )
-        )
+        filters: dict[str, typing.Any] = {
+            "team_id": team_id,
+            "status": DataModelingJob.Status.RUNNING,
+            "engine": DataModelingJob.Engine.CLICKHOUSE,
+        }
+        if saved_query_ids:
+            resolved_uuids: list[uuid.UUID] = []
+            for label in saved_query_ids:
+                try:
+                    resolved_uuids.append(uuid.UUID(label))
+                except ValueError:
+                    try:
+                        sq = DataWarehouseSavedQuery.objects.exclude(deleted=True).get(team_id=team_id, name=label)
+                        resolved_uuids.append(sq.id)
+                    except DataWarehouseSavedQuery.DoesNotExist:
+                        pass
+            if resolved_uuids:
+                filters["saved_query_id__in"] = resolved_uuids
+
+        orphaned_jobs = list(DataModelingJob.objects.select_for_update().filter(**filters))
 
         if not orphaned_jobs:
             return []
@@ -1414,14 +1432,11 @@ def _preempt_running_jobs(team_id: int) -> list[DataModelingJob]:
 
 @temporalio.activity.defn
 async def cleanup_running_jobs_activity(inputs: CleanupRunningJobsActivityInputs) -> None:
-    """Mark all existing RUNNING DataModelingJobs as FAILED when starting a new run.
-    Since only one job can run at a time per team, any existing RUNNING jobs
-    are orphaned when a new run starts.
-    """
+    """Marks orphaned RUNNING DataModelingJobs for this saved query as FAILED when starting a new run."""
     bind_contextvars(team_id=inputs.team_id)
     logger = LOGGER.bind()
 
-    orphaned_jobs = await _preempt_running_jobs(inputs.team_id)
+    orphaned_jobs = await _preempt_running_jobs(inputs.team_id, inputs.saved_query_ids or None)
 
     if not orphaned_jobs:
         await logger.adebug("No orphaned jobs found")
@@ -1614,9 +1629,10 @@ class RunWorkflow(PostHogWorkflow):
 
     @temporalio.workflow.run
     async def run(self, inputs: RunWorkflowInputs) -> Results:
+        saved_query_ids = [s.label for s in inputs.select]
         await temporalio.workflow.execute_activity(
             cleanup_running_jobs_activity,
-            CleanupRunningJobsActivityInputs(team_id=inputs.team_id),
+            CleanupRunningJobsActivityInputs(team_id=inputs.team_id, saved_query_ids=saved_query_ids),
             start_to_close_timeout=dt.timedelta(minutes=20),
             retry_policy=temporalio.common.RetryPolicy(maximum_attempts=3),
         )

--- a/posthog/temporal/tests/data_modeling/test_run_workflow.py
+++ b/posthog/temporal/tests/data_modeling/test_run_workflow.py
@@ -1336,50 +1336,85 @@ async def test_materialize_model_with_decimal256_downscale_to_decimal128(ateam, 
         assert saved_query.is_materialized is True
 
 
-async def test_cleanup_running_jobs_activity(activity_environment, ateam):
-    """Test cleanup marks all existing RUNNING jobs as FAILED when starting a new run."""
-    old_job = await database_sync_to_async(DataModelingJob.objects.create)(
-        team=ateam, status=DataModelingJob.Status.RUNNING, workflow_id="old-1", workflow_run_id="run-1"
+@pytest.mark.parametrize(
+    "saved_query_ids_fn, expected_a, expected_b",
+    [
+        pytest.param(
+            lambda sq_a, sq_b: [sq_a.id.hex],
+            DataModelingJob.Status.FAILED,
+            DataModelingJob.Status.RUNNING,
+            id="uuid_hex",
+        ),
+        pytest.param(
+            lambda sq_a, sq_b: [sq_a.name],
+            DataModelingJob.Status.FAILED,
+            DataModelingJob.Status.RUNNING,
+            id="name_label",
+        ),
+        pytest.param(
+            lambda sq_a, sq_b: [], DataModelingJob.Status.FAILED, DataModelingJob.Status.FAILED, id="team_wide_fallback"
+        ),
+    ],
+)
+async def test_cleanup_running_jobs_activity(activity_environment, ateam, saved_query_ids_fn, expected_a, expected_b):
+    sq_a = await database_sync_to_async(DataWarehouseSavedQuery.objects.create)(
+        team=ateam, name="query_a", query={"query": "SELECT 1", "kind": "HogQLQuery"}
     )
-    recent_job = await database_sync_to_async(DataModelingJob.objects.create)(
-        team=ateam, status=DataModelingJob.Status.RUNNING, workflow_id="recent-1", workflow_run_id="run-2"
+    sq_b = await database_sync_to_async(DataWarehouseSavedQuery.objects.create)(
+        team=ateam, name="query_b", query={"query": "SELECT 2", "kind": "HogQLQuery"}
+    )
+    job_a = await database_sync_to_async(DataModelingJob.objects.create)(
+        team=ateam, saved_query=sq_a, status=DataModelingJob.Status.RUNNING, workflow_id="wf-a", workflow_run_id="run-a"
     )
     completed_job = await database_sync_to_async(DataModelingJob.objects.create)(
-        team=ateam, status=DataModelingJob.Status.COMPLETED, workflow_id="completed-1", workflow_run_id="run-3"
+        team=ateam,
+        saved_query=sq_a,
+        status=DataModelingJob.Status.COMPLETED,
+        workflow_id="wf-c",
+        workflow_run_id="run-c",
+    )
+    job_b = await database_sync_to_async(DataModelingJob.objects.create)(
+        team=ateam, saved_query=sq_b, status=DataModelingJob.Status.RUNNING, workflow_id="wf-b", workflow_run_id="run-b"
     )
 
-    await activity_environment.run(cleanup_running_jobs_activity, CleanupRunningJobsActivityInputs(team_id=ateam.pk))
+    saved_query_ids = saved_query_ids_fn(sq_a, sq_b)
+    inputs = CleanupRunningJobsActivityInputs(team_id=ateam.pk)
+    if saved_query_ids:
+        inputs.saved_query_ids = saved_query_ids
+    await activity_environment.run(cleanup_running_jobs_activity, inputs)
 
-    await database_sync_to_async(old_job.refresh_from_db)()
-    await database_sync_to_async(recent_job.refresh_from_db)()
+    await database_sync_to_async(job_a.refresh_from_db)()
     await database_sync_to_async(completed_job.refresh_from_db)()
+    await database_sync_to_async(job_b.refresh_from_db)()
 
-    assert old_job.status == DataModelingJob.Status.FAILED
-    assert old_job.rows_materialized == 0
-    assert old_job.error is not None
-    assert "Preempted" in old_job.error
-    assert recent_job.status == DataModelingJob.Status.FAILED
-    assert recent_job.rows_materialized == 0
-    assert recent_job.error is not None
-    assert "Preempted" in recent_job.error
+    assert job_a.status == expected_a
+    assert job_a.error is not None if expected_a == DataModelingJob.Status.FAILED else job_a.error is None
     assert completed_job.status == DataModelingJob.Status.COMPLETED
+    assert job_b.status == expected_b
 
 
 async def test_create_job_model_activity_cleans_up_running_jobs(activity_environment, ateam, temporal_client):
     """Test that orphaned jobs are cleaned up when running the full workflow."""
-    # Create old orphaned job
+    saved_query = await database_sync_to_async(DataWarehouseSavedQuery.objects.create)(
+        team=ateam, name="test_query", query={"query": "SELECT * FROM events LIMIT 10", "kind": "HogQLQuery"}
+    )
+
+    # Create old orphaned job for the same saved query
     orphaned_job = await database_sync_to_async(DataModelingJob.objects.create)(
-        team=ateam, status=DataModelingJob.Status.RUNNING, workflow_id="orphaned-1", workflow_run_id="run-1"
+        team=ateam,
+        saved_query=saved_query,
+        status=DataModelingJob.Status.RUNNING,
+        workflow_id="orphaned-1",
+        workflow_run_id="run-1",
     )
     await database_sync_to_async(DataModelingJob.objects.filter(id=orphaned_job.id).update)(
         updated_at=dt.datetime.now(dt.UTC) - dt.timedelta(hours=2)
     )
 
-    saved_query = await database_sync_to_async(DataWarehouseSavedQuery.objects.create)(
-        team=ateam, name="test_query", query={"query": "SELECT * FROM events LIMIT 10", "kind": "HogQLQuery"}
+    await activity_environment.run(
+        cleanup_running_jobs_activity,
+        CleanupRunningJobsActivityInputs(team_id=ateam.pk, saved_query_ids=[saved_query.id.hex]),
     )
-
-    await activity_environment.run(cleanup_running_jobs_activity, CleanupRunningJobsActivityInputs(team_id=ateam.pk))
 
     await database_sync_to_async(orphaned_job.refresh_from_db)()
     assert orphaned_job.status == DataModelingJob.Status.FAILED


### PR DESCRIPTION
## Problem

currently, our `cleanup_running_jobs_activity` cancels any running modeling jobs - regardless of depedendencies and other schedules. this means that if even by accident two saved queries' schedules are kicked off around the same time, one will have to win and cancel the other one.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

## Changes

- the saved_query_ids input to the activity, so that we can filter the jobs to cancel on that saved query only



there is some nuance here around dependencies and whether we should try to be smart and cancel upstream/downstream saved queries and all that. I think this is the best, simplest approach to handle the bug. 

Assume:

- SQ A runs at 9am
- SQ B also runs at 9am (SQ B depends on SQ A)

We should prefer having a model have stale data from a dependency that ran yesterday, than potentially never finishing and updating. Until we migrate everything to DAGs where dependencies will be handled, that is. 

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

- unit tests and ran the scenario locally by seeding running jobs in the DB

<!-- Briefly describe the steps you took, and what steps reviewers must take to get to where changes are, and what is the expected behavior. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

no

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->