### PR TITLE
fix: add allowed_updates to plan services and improve pricing details

### DIFF
--- a/ee/api/agentic_provisioning/test/test_services.py
+++ b/ee/api/agentic_provisioning/test/test_services.py
@@ -95,6 +95,31 @@ class TestProvisioningServices(StripeProvisioningTestBase):
 
     @patch("ee.api.agentic_provisioning.views.requests.get", return_value=_mock_billing_response())
     @patch("ee.api.agentic_provisioning.views.cache", new_callable=_mock_cache_empty)
+    def test_free_plan_can_upgrade_to_pay_as_you_go(self, mock_cache, mock_get):
+        res = self._get_signed("/api/agentic/provisioning/services")
+        free = res.json()["data"][0]
+        assert free["id"] == "free"
+        assert free["allowed_updates"] == ["pay_as_you_go"]
+
+    @patch("ee.api.agentic_provisioning.views.requests.get", return_value=_mock_billing_response())
+    @patch("ee.api.agentic_provisioning.views.cache", new_callable=_mock_cache_empty)
+    def test_pay_as_you_go_plan_can_downgrade_to_free(self, mock_cache, mock_get):
+        res = self._get_signed("/api/agentic/provisioning/services")
+        payg = res.json()["data"][1]
+        assert payg["id"] == "pay_as_you_go"
+        assert payg["allowed_updates"] == ["free"]
+
+    @patch("ee.api.agentic_provisioning.views.requests.get", return_value=_mock_billing_response())
+    @patch("ee.api.agentic_provisioning.views.cache", new_callable=_mock_cache_empty)
+    def test_pay_as_you_go_pricing_includes_rates(self, mock_cache, mock_get):
+        res = self._get_signed("/api/agentic/provisioning/services")
+        payg = res.json()["data"][1]
+        freeform = payg["pricing"]["paid"]["freeform"]
+        assert "$0/mo base" in freeform
+        assert "posthog.com/pricing" in freeform
+
+    @patch("ee.api.agentic_provisioning.views.requests.get", return_value=_mock_billing_response())
+    @patch("ee.api.agentic_provisioning.views.cache", new_callable=_mock_cache_empty)
     def test_analytics_deployable_has_component_pricing(self, mock_cache, mock_get):
         res = self._get_signed("/api/agentic/provisioning/services")
         analytics = res.json()["data"][2]

--- a/ee/api/agentic_provisioning/views.py
+++ b/ee/api/agentic_provisioning/views.py
@@ -90,6 +90,15 @@ _EXCLUDED_PRODUCT_TYPES = {"platform_and_support", "integrations"}
 _FALLBACK_DESCRIPTION = "PostHog — product analytics, session replay, realtime destinations, feature flags & experiments, surveys, data warehouse, error tracking, llm analytics, logs, posthog ai, emails, and more."
 
 
+_PAY_AS_YOU_GO_PRICING_SUMMARY = (
+    "$0/mo base. Usage-based: "
+    "1M free events then $0.00005/event, "
+    "5K free recordings then $0.005/recording, "
+    "1M free feature flag requests then $0.0001/request, "
+    "and more. See posthog.com/pricing for full details."
+)
+
+
 def _build_free_plan_service() -> dict[str, Any]:
     return {
         "id": FREE_PLAN_SERVICE_ID,
@@ -97,6 +106,7 @@ def _build_free_plan_service() -> dict[str, Any]:
         "categories": ALL_CATEGORIES,
         "pricing": {"type": "free"},
         "kind": "plan",
+        "allowed_updates": [PAY_AS_YOU_GO_SERVICE_ID],
     }
 
 
@@ -107,9 +117,10 @@ def _build_pay_as_you_go_service() -> dict[str, Any]:
         "categories": ALL_CATEGORIES,
         "pricing": {
             "type": "paid",
-            "paid": {"type": "freeform", "freeform": "Usage-based pricing, pay only for what you use."},
+            "paid": {"type": "freeform", "freeform": _PAY_AS_YOU_GO_PRICING_SUMMARY},
         },
         "kind": "plan",
+        "allowed_updates": [FREE_PLAN_SERVICE_ID],
     }
 
 
@@ -126,7 +137,7 @@ def _build_analytics_service(description: str) -> dict[str, Any]:
                     {
                         "parent_service_ids": [PAY_AS_YOU_GO_SERVICE_ID],
                         "type": "paid",
-                        "paid": {"type": "freeform", "freeform": "Usage-based pricing, pay only for what you use."},
+                        "paid": {"type": "freeform", "freeform": _PAY_AS_YOU_GO_PRICING_SUMMARY},
                     },
                 ]
             },


### PR DESCRIPTION
## Problem

Two issues flagged by Rami from Stripe:

1. Plan services (free, pay_as_you_go) were self-referencing in `updateable_to` because they didn't have `allowed_updates`. This meant `stripe projects update` couldn't upgrade from free to paid or vice versa.
2. The freeform pricing string was generic ("Usage-based pricing, pay only for what you use") instead of showing actual rates.

Slack thread: https://posthog.slack.com/archives/C0AAZGWD83A/p1775790042712619

## Changes

- `free` plan: added `allowed_updates: ["pay_as_you_go"]`
- `pay_as_you_go` plan: added `allowed_updates: ["free"]`
- Updated freeform pricing with actual rates from billing: 1M free events then $0.00005/event, 5K free recordings then $0.005/recording, etc. with link to posthog.com/pricing

## How did you test this code?

- Ran posthog-spec-toolkit `services-list` against local dev server - 200 OK, all three services pass orchestrator validation
- Verified `allowed_updates` on plans: free -> ["pay_as_you_go"], pay_as_you_go -> ["free"]
- Verified pricing string includes actual rates and posthog.com/pricing link
- New tests: `test_free_plan_can_upgrade_to_pay_as_you_go`, `test_pay_as_you_go_plan_can_downgrade_to_free`, `test_pay_as_you_go_pricing_includes_rates` - all pass locally
- Pricing numbers verified against billing API (`/api/products-v2?plan=standard`)

## Changelog

No