### PR TITLE
chore: move source maps and releases to tabs

### DIFF
--- a/frontend/src/scenes/settings/SettingsMap.tsx
+++ b/frontend/src/scenes/settings/SettingsMap.tsx
@@ -2,9 +2,7 @@ import { LemonTag, Link, Tooltip } from '@posthog/lemon-ui'
 import { ErrorTrackingAlerting } from '@posthog/products-error-tracking/frontend/scenes/ErrorTrackingConfigurationScene/alerting/ErrorTrackingAlerting'
 import { AssignmentRules } from '@posthog/products-error-tracking/frontend/scenes/ErrorTrackingConfigurationScene/assignment_rules/AssignmentRules'
 import { GroupingRules } from '@posthog/products-error-tracking/frontend/scenes/ErrorTrackingConfigurationScene/grouping_rules/GroupingRules'
-import { Releases } from '@posthog/products-error-tracking/frontend/scenes/ErrorTrackingConfigurationScene/releases/Releases'
 import { SpikeDetectionSettings } from '@posthog/products-error-tracking/frontend/scenes/ErrorTrackingConfigurationScene/spike_detection/SpikeDetectionSettings'
-import { SymbolSets } from '@posthog/products-error-tracking/frontend/scenes/ErrorTrackingConfigurationScene/symbol_sets/SymbolSets'
 import { LLMProviderKeysSettings } from '@posthog/products-llm-analytics/frontend/settings/LLMProviderKeysSettings'
 import { McpStoreSettings } from '@posthog/products-mcp-store/frontend/McpStoreSettings'
 import { EventConfiguration } from '@posthog/products-revenue-analytics/frontend/settings/EventConfiguration'
@@ -575,22 +573,6 @@ export const SETTINGS_MAP: SettingSection[] = [
                 description: 'Define rules for how errors are grouped together into issues.',
                 component: <GroupingRules />,
                 keywords: ['group', 'merge', 'fingerprint', 'dedup'],
-            },
-            {
-                id: 'error-tracking-symbol-sets',
-                title: 'Symbol sets',
-                description: 'Upload source maps to get readable stack traces from minified code.',
-                docsUrl: 'https://posthog.com/docs/error-tracking/upload-source-maps',
-                component: <SymbolSets />,
-                keywords: ['source map', 'sourcemap', 'debug', 'minified', 'stack trace'],
-            },
-            {
-                id: 'error-tracking-releases',
-                title: 'Releases',
-                description: 'Track releases to see which version introduced errors and monitor deployment health.',
-                docsUrl: 'https://posthog.com/docs/error-tracking/releases',
-                component: <Releases />,
-                keywords: ['version', 'deploy', 'release', 'regression'],
             },
         ],
     },

--- a/products/error_tracking/frontend/scenes/ErrorTrackingConfigurationScene/ErrorTrackingConfigurationScene.tsx
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingConfigurationScene/ErrorTrackingConfigurationScene.tsx
@@ -20,8 +20,6 @@ export type ConfigurationSceneTabType =
     | 'error-tracking-auto-assignment'
     | 'error-tracking-custom-grouping'
     | 'error-tracking-alerting'
-    | 'error-tracking-symbol-sets'
-    | 'error-tracking-releases'
 
 export interface ErrorTrackingConfigurationSceneLogicProps {
     initialTab?: ConfigurationSceneTabType

--- a/products/error_tracking/frontend/scenes/ErrorTrackingScene/ErrorTrackingScene.tsx
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingScene/ErrorTrackingScene.tsx
@@ -23,6 +23,8 @@ import { exceptionIngestionLogic } from '../../components/SetupPrompt/exceptionI
 import { ErrorTrackingSetupPrompt } from '../../components/SetupPrompt/SetupPrompt'
 import { StyleVariables } from '../../components/StyleVariables'
 import { ERROR_TRACKING_LOGIC_KEY } from '../../utils'
+import { Releases } from '../ErrorTrackingConfigurationScene/releases/Releases'
+import { SymbolSets } from '../ErrorTrackingConfigurationScene/symbol_sets/SymbolSets'
 import {
     ERROR_TRACKING_SCENE_LOGIC_KEY,
     ErrorTrackingSceneActiveTab,
@@ -89,6 +91,16 @@ export function ErrorTrackingScene(): JSX.Element {
                   },
               ]
             : []),
+        {
+            key: 'symbol-sets' as const,
+            label: 'Symbol sets',
+            content: <SymbolSets />,
+        },
+        {
+            key: 'releases' as const,
+            label: 'Releases',
+            content: <Releases />,
+        },
         {
             key: 'configuration',
             label: 'Configuration',

--- a/products/error_tracking/frontend/scenes/ErrorTrackingScene/errorTrackingSceneLogic.ts
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingScene/errorTrackingSceneLogic.ts
@@ -32,7 +32,7 @@ export const ERROR_TRACKING_SCENE_LOGIC_KEY = 'ErrorTrackingScene'
 
 const DEFAULT_ACTIVE_TAB = 'issues'
 
-export type ErrorTrackingSceneActiveTab = 'issues' | 'insights' | 'configuration'
+export type ErrorTrackingSceneActiveTab = 'issues' | 'insights' | 'configuration' | 'symbol-sets' | 'releases'
 
 export const errorTrackingSceneLogic = kea<errorTrackingSceneLogicType>([
     path(['products', 'error_tracking', 'scenes', 'ErrorTrackingScene', 'errorTrackingSceneLogic']),


### PR DESCRIPTION
## Problem

Symbol sets and releases are nested under the configuration tab, but feel like they should be more directly accessible. 

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Move symbol sets and releases to their own tabs outside of the configuration tab.
<img width="1355" height="383" alt="Screenshot 2026-04-10 at 10 28 08 AM" src="https://github.com/user-attachments/assets/dcd84152-547e-4b1c-adb0-0daf04c15cbe" />

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Manually

<!-- Briefly describe the steps you took, and what steps reviewers must take to get to where changes are, and what is the expected behavior. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
