### PR TITLE
chore: support goes into beta

### DIFF
--- a/frontend/src/products.tsx
+++ b/frontend/src/products.tsx
@@ -1607,7 +1607,7 @@ export const getTreeItemsProducts = (): FileSystemImport[] => [
         href: urls.supportTickets(),
         type: 'conversations',
         flag: FEATURE_FLAGS.PRODUCT_SUPPORT,
-        tags: ['alpha'],
+        tags: ['beta'],
         iconType: 'conversations',
         iconColor: ['var(--color-product-support-light)'] as FileSystemIconColor,
         sceneKey: 'SupportTickets',

--- a/products/conversations/frontend/components/ScenesTabs/index.tsx
+++ b/products/conversations/frontend/components/ScenesTabs/index.tsx
@@ -18,8 +18,8 @@ export function ScenesTabs(): JSX.Element {
                 action={{ children: 'Send feedback', id: 'support-feedback-button' }}
             >
                 <p>
-                    Support is in private alpha. Please let us know what you'd like to see here and/or report any issues
-                    directly to us!
+                    Support is in beta. Please let us know what you'd like to see here and/or report any issues directly
+                    to us!
                 </p>
             </LemonBanner>
             <LemonTabs

--- a/products/conversations/manifest.tsx
+++ b/products/conversations/manifest.tsx
@@ -51,7 +51,7 @@ export const manifest: ProductManifest = {
             href: urls.supportTickets(),
             type: 'conversations',
             flag: FEATURE_FLAGS.PRODUCT_SUPPORT,
-            tags: ['alpha'],
+            tags: ['beta'],
             iconType: 'conversations',
             iconColor: ['var(--color-product-support-light)'] as FileSystemIconColor,
             sceneKey: 'SupportTickets',


### PR DESCRIPTION
## Problem

Support is out of private alpha 

## Changes

#### Before
<img width="153" height="57" alt="Screenshot 2026-04-10 at 16 28 23" src="https://github.com/user-attachments/assets/95cc77e5-b842-4c2e-bd55-ba72d78a93a2" />


#### After
<img width="169" height="60" alt="Screenshot 2026-04-10 at 16 34 09" src="https://github.com/user-attachments/assets/63a55c55-6009-48fa-8383-459bf6a5f06e" />
