### PR TITLE
fix(ingestion): acceptance tests transient errors not caught

### DIFF
--- a/posthog/temporal/ingestion_acceptance_test/client.py
+++ b/posthog/temporal/ingestion_acceptance_test/client.py
@@ -15,6 +15,7 @@ from clickhouse_driver.errors import ErrorCodes
 
 from posthog.clickhouse.client.execute import sync_execute
 from posthog.errors import InternalCHQueryError
+from posthog.exceptions import ClickHouseAtCapacity, ClickHouseQueryMemoryLimitExceeded, ClickHouseQueryTimeOut
 
 from .config import Config
 
@@ -293,7 +294,18 @@ class PostHogClient:
                     )
                 try:
                     result = fetch_fn()
-                except (InternalCHQueryError, EOFError, ConnectionError, OSError) as e:
+                except (
+                    InternalCHQueryError,
+                    # wrap_clickhouse_query_error() converts TOO_MANY_SIMULTANEOUS_QUERIES,
+                    # TIMEOUT_EXCEEDED, and MEMORY_LIMIT_EXCEEDED into APIException subclasses
+                    # (not InternalCHQueryError), so we must catch them explicitly.
+                    ClickHouseAtCapacity,
+                    ClickHouseQueryTimeOut,
+                    ClickHouseQueryMemoryLimitExceeded,
+                    EOFError,
+                    ConnectionError,
+                    OSError,
+                ) as e:
                     is_retryable = not isinstance(e, InternalCHQueryError) or e.code in RETRYABLE_CH_ERROR_CODES
                     if is_retryable:
                         logger.warning(

--- a/posthog/temporal/tests/ingestion_acceptance_test/test_client.py
+++ b/posthog/temporal/tests/ingestion_acceptance_test/test_client.py
@@ -241,10 +241,6 @@ class TestPollUntilFoundRetries:
             pytest.param(ClickHouseAtCapacity(), id="TOO_MANY_SIMULTANEOUS_QUERIES"),
             pytest.param(ClickHouseQueryTimeOut(), id="TIMEOUT_EXCEEDED"),
             pytest.param(ClickHouseQueryMemoryLimitExceeded(), id="MEMORY_LIMIT_EXCEEDED"),
-            pytest.param(
-                InternalCHQueryError("server error", code=999, code_name="UNKNOWN"),
-                id="non-retryable-InternalCHQueryError",
-            ),
         ],
     )
     @patch("posthog.temporal.ingestion_acceptance_test.client.sync_execute")
@@ -258,20 +254,23 @@ class TestPollUntilFoundRetries:
             {"key": "value"},
             datetime(2024, 1, 1),
         )
-        is_fatal = isinstance(exception, InternalCHQueryError)
-
-        # First call raises the transient error, second call succeeds
         mock_sync_execute.side_effect = [exception, [event_row]]
 
-        if is_fatal:
-            with pytest.raises(InternalCHQueryError):
-                client.query_event_by_uuid("00000000-0000-0000-0000-000000000001")
-            assert mock_sync_execute.call_count == 1
-        else:
-            result = client.query_event_by_uuid("00000000-0000-0000-0000-000000000001")
-            assert result is not None
-            assert result.uuid == "00000000-0000-0000-0000-000000000001"
-            assert mock_sync_execute.call_count == 2
+        result = client.query_event_by_uuid("00000000-0000-0000-0000-000000000001")
+
+        assert result is not None
+        assert result.uuid == "00000000-0000-0000-0000-000000000001"
+        assert mock_sync_execute.call_count == 2
+
+    @patch("posthog.temporal.ingestion_acceptance_test.client.sync_execute")
+    def test_raises_on_non_retryable_clickhouse_error(
+        self, mock_sync_execute: MagicMock, client: PostHogClient
+    ) -> None:
+        mock_sync_execute.side_effect = InternalCHQueryError("server error", code=999, code_name="UNKNOWN")
+
+        with pytest.raises(InternalCHQueryError):
+            client.query_event_by_uuid("00000000-0000-0000-0000-000000000001")
+        assert mock_sync_execute.call_count == 1
 
 
 class TestTimestampFiltering:

--- a/posthog/temporal/tests/ingestion_acceptance_test/test_client.py
+++ b/posthog/temporal/tests/ingestion_acceptance_test/test_client.py
@@ -5,6 +5,8 @@ from datetime import UTC, datetime, timedelta
 import pytest
 from unittest.mock import MagicMock, patch
 
+from posthog.errors import InternalCHQueryError
+from posthog.exceptions import ClickHouseAtCapacity, ClickHouseQueryMemoryLimitExceeded, ClickHouseQueryTimeOut
 from posthog.temporal.ingestion_acceptance_test.client import CapturedEvent, Person, PostHogClient
 from posthog.temporal.ingestion_acceptance_test.config import Config
 
@@ -228,6 +230,48 @@ class TestFetchEventsByPersonId:
         assert len(result) == 2
         assert result[0].uuid == str(uuid1)
         assert result[1].uuid == str(uuid2)
+
+
+class TestPollUntilFoundRetries:
+    """_poll_until_found must retry on transient ClickHouse errors instead of crashing."""
+
+    @pytest.mark.parametrize(
+        "exception",
+        [
+            pytest.param(ClickHouseAtCapacity(), id="TOO_MANY_SIMULTANEOUS_QUERIES"),
+            pytest.param(ClickHouseQueryTimeOut(), id="TIMEOUT_EXCEEDED"),
+            pytest.param(ClickHouseQueryMemoryLimitExceeded(), id="MEMORY_LIMIT_EXCEEDED"),
+            pytest.param(
+                InternalCHQueryError("server error", code=999, code_name="UNKNOWN"),
+                id="non-retryable-InternalCHQueryError",
+            ),
+        ],
+    )
+    @patch("posthog.temporal.ingestion_acceptance_test.client.sync_execute")
+    def test_retries_transient_clickhouse_errors(
+        self, mock_sync_execute: MagicMock, exception: Exception, client: PostHogClient
+    ) -> None:
+        event_row = (
+            uuid.UUID("00000000-0000-0000-0000-000000000001"),
+            "test_event",
+            "user_1",
+            {"key": "value"},
+            datetime(2024, 1, 1),
+        )
+        is_fatal = isinstance(exception, InternalCHQueryError)
+
+        # First call raises the transient error, second call succeeds
+        mock_sync_execute.side_effect = [exception, [event_row]]
+
+        if is_fatal:
+            with pytest.raises(InternalCHQueryError):
+                client.query_event_by_uuid("00000000-0000-0000-0000-000000000001")
+            assert mock_sync_execute.call_count == 1
+        else:
+            result = client.query_event_by_uuid("00000000-0000-0000-0000-000000000001")
+            assert result is not None
+            assert result.uuid == "00000000-0000-0000-0000-000000000001"
+            assert mock_sync_execute.call_count == 2
 
 
 class TestTimestampFiltering:


### PR DESCRIPTION
## Problem

Ingestion acceptance tests fail immediately when ClickHouse is under load, reporting "Queries are a little too busy right now" instead of retrying. Tests complete in ~98 seconds rather than using the full timeout budget, indicating transient errors aren't being retried at all.

The root cause is an exception type mismatch. When `sync_execute` encounters error code 202 (`TOO_MANY_SIMULTANEOUS_QUERIES`), `wrap_clickhouse_query_error()` converts it to `ClickHouseAtCapacity` -- a DRF `APIException` subclass. But `_poll_until_found` only catches `(InternalCHQueryError, EOFError, ConnectionError, OSError)`. Since `ClickHouseAtCapacity` doesn't inherit from any of those, the exception propagates uncaught and the test crashes.

The same gap exists for `TIMEOUT_EXCEEDED` (`ClickHouseQueryTimeOut`) and `MEMORY_LIMIT_EXCEEDED` (`ClickHouseQueryMemoryLimitExceeded`). The `RETRYABLE_CH_ERROR_CODES` frozenset was correct in intent but was effectively dead code for these three errors -- they're converted to API exceptions before reaching the handler.

## Changes

- Added `ClickHouseAtCapacity`, `ClickHouseQueryTimeOut`, and `ClickHouseQueryMemoryLimitExceeded` to the `except` clause in `_poll_until_found`.
  Since these aren't `InternalCHQueryError` instances, the existing `is_retryable` check (`not isinstance(e, InternalCHQueryError)`) correctly evaluates to `True` for them -- no logic changes needed.
- Added a parameterized test covering all three retryable API exceptions plus a non-retryable `InternalCHQueryError` to verify behavior.

## How did you test this code?

- Added `TestPollUntilFoundRetries` with parameterized cases for `ClickHouseAtCapacity`, `ClickHouseQueryTimeOut`, `ClickHouseQueryMemoryLimitExceeded` (all retried successfully), and a non-retryable `InternalCHQueryError` (raises immediately).
- All 18 tests in `posthog/temporal/tests/ingestion_acceptance_test/test_client.py` pass.
