### PR TITLE
fix(llma): guard breakdown column against missing type

### DIFF
--- a/frontend/src/scenes/insights/views/InsightsTable/InsightsTable.tsx
+++ b/frontend/src/scenes/insights/views/InsightsTable/InsightsTable.tsx
@@ -226,7 +226,7 @@ export function InsightsTable({
         },
     })
 
-    if (breakdownFilter?.breakdown) {
+    if (isValidBreakdown(breakdownFilter) && breakdownFilter.breakdown) {
         if (!isSingleSeriesWithBreakdown) {
             columns.push({
                 title: (

--- a/posthog/models/resource_transfer/test/__snapshots__/test_visitor_field_snapshots.ambr
+++ b/posthog/models/resource_transfer/test/__snapshots__/test_visitor_field_snapshots.ambr
@@ -451,7 +451,6 @@
   list([
     'DoesNotExist',
     'MultipleObjectsReturned',
-    '__annotations__',
     '__doc__',
     '__module__',
     '__repr__',

--- a/products/llm_analytics/backend/dashboard_templates.py
+++ b/products/llm_analytics/backend/dashboard_templates.py
@@ -259,6 +259,7 @@ def get_llm_analytics_default_template() -> DashboardTemplate:
                             }
                         ],
                         "breakdownFilter": {
+                            "breakdown_type": "event",
                             "breakdown": "$ai_model",
                         },
                         "trendsFilter": {


### PR DESCRIPTION
## Problem

Addresses the bug where clicking "Discard overrides" on the LLM analytics "Generation latency by model" insight
crashes the module. 

Error: logic remounts without cached data, loading the stored query which lacks `breakdown_type`. 

Closes #ISSUE_ID
https://posthoghelp.zendesk.com/agent/tickets/55137 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/56402)

## Changes

Fix: to guard by using `isValidBreakdown` consistently, and adds the missing `breakdown_type` to the dashboard template.

## How did you test this code?

Reproduced bug locally and fixed locally with data.

## Publish to changelog?

No

## Docs update

No

<!-- ## 🤖 LLM context -->

🤖🤖🤖🤖🤖🤖🤖