### PR TITLE
feat(replay): move the ai summary to player bar

### DIFF
--- a/frontend/src/queries/nodes/DataVisualization/Components/Heatmap/TwoDimensionalHeatmap.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Heatmap/TwoDimensionalHeatmap.tsx
@@ -161,7 +161,7 @@ export function TwoDimensionalHeatmap({ allowSorting = true }: { allowSorting?: 
     const { xAxisColumn, yAxisColumn, valueColumn, nullLabel, nullValue } = heatmapSettings
     const sorting = useMemo(
         () => getSortingFromHeatmapSettings(heatmapSettings),
-        [heatmapSettings.sortColumn, heatmapSettings.sortOrder]
+        [heatmapSettings.sortColumn, heatmapSettings.sortOrder, heatmapSettings]
     )
     const selectedColumns = [xAxisColumn, yAxisColumn, valueColumn]
     const rows =

--- a/frontend/src/scenes/session-recordings/player/controller/PlayerController.tsx
+++ b/frontend/src/scenes/session-recordings/player/controller/PlayerController.tsx
@@ -1,24 +1,30 @@
 import { useActions, useValues } from 'kea'
 import { useEffect, useRef, useState } from 'react'
 
-import { IconCamera, IconPause, IconPlay, IconRewindPlay } from '@posthog/icons'
+import { IconCamera, IconChevronDown, IconMagicWand, IconPause, IconPlay, IconRewindPlay } from '@posthog/icons'
 import { LemonButton } from '@posthog/lemon-ui'
 
+import { FEATURE_FLAGS } from 'lib/constants'
 import { isChristmas, isHalloween } from 'lib/holidays'
 import { useKeyboardHotkeys } from 'lib/hooks/useKeyboardHotkeys'
 import { useResizeBreakpoints } from 'lib/hooks/useResizeObserver'
 import { IconFullScreen, IconGhost, IconSanta, IconSkipEnd, IconSkipStart } from 'lib/lemon-ui/icons'
+import { Popover } from 'lib/lemon-ui/Popover'
+import { Spinner } from 'lib/lemon-ui/Spinner'
 import { Tooltip } from 'lib/lemon-ui/Tooltip'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { cn } from 'lib/utils/css-classes'
 import {
     CommentOnRecordingButton,
     EmojiCommentOnRecordingButton,
 } from 'scenes/session-recordings/player/commenting/CommentOnRecordingButton'
+import { playerMetaLogic } from 'scenes/session-recordings/player/player-meta/playerMetaLogic'
 import {
     ModesWithInteractions,
     SessionRecordingPlayerMode,
     sessionRecordingPlayerLogic,
 } from 'scenes/session-recordings/player/sessionRecordingPlayerLogic'
+import { SessionSummary } from 'scenes/session-recordings/player/sidebar/PlayerSidebarSessionSummary'
 
 import { KeyboardShortcut } from '~/layout/navigation-3000/components/KeyboardShortcut'
 import { SessionPlayerState } from '~/types'
@@ -202,6 +208,78 @@ export function Screenshot({ className }: { className?: string }): JSX.Element {
     )
 }
 
+function AIChaptersButton(): JSX.Element | null {
+    const { featureFlags } = useValues(featureFlagLogic)
+    const { logicProps } = useValues(sessionRecordingPlayerLogic)
+    const { sessionSummary, sessionSummaryLoading } = useValues(playerMetaLogic(logicProps))
+    const { summarizeSession } = useActions(playerMetaLogic(logicProps))
+    const [dropupVisible, setDropupVisible] = useState(false)
+
+    if (!featureFlags[FEATURE_FLAGS.AI_SESSION_SUMMARY] && !featureFlags[FEATURE_FLAGS.MAX_SESSION_SUMMARIZATION]) {
+        return null
+    }
+
+    const hasSummary = !!sessionSummary
+
+    const handleClick = (): void => {
+        if (!hasSummary && !sessionSummaryLoading) {
+            summarizeSession()
+        } else {
+            setDropupVisible(!dropupVisible)
+        }
+    }
+
+    if (!hasSummary && !sessionSummaryLoading) {
+        return (
+            <LemonButton
+                size="small"
+                type="secondary"
+                icon={<IconMagicWand />}
+                onClick={handleClick}
+                data-attr="ai-chapters-button"
+                className="whitespace-nowrap"
+            >
+                <span className="text-xs font-medium">AI chapters</span>
+            </LemonButton>
+        )
+    }
+
+    return (
+        <Popover
+            visible={dropupVisible}
+            onClickOutside={() => setDropupVisible(false)}
+            placement="top-end"
+            padded={false}
+            overlay={
+                <div className="w-[36rem] max-h-[70vh] overflow-y-auto p-2">
+                    {sessionSummaryLoading && !hasSummary ? (
+                        <div className="flex items-center gap-2 px-3 py-4">
+                            <Spinner textColored />
+                            <span className="text-sm text-secondary">Generating chapters...</span>
+                        </div>
+                    ) : hasSummary ? (
+                        <SessionSummary />
+                    ) : (
+                        <div className="px-3 py-4 text-sm text-secondary text-center">No chapters available</div>
+                    )}
+                </div>
+            }
+        >
+            <LemonButton
+                size="small"
+                type="secondary"
+                icon={sessionSummaryLoading ? <Spinner textColored /> : <IconMagicWand />}
+                sideIcon={<IconChevronDown className="rotate-180" />}
+                onClick={handleClick}
+                data-attr="ai-chapters-button"
+                className="whitespace-nowrap"
+            >
+                <span className="text-xs font-medium">AI chapters</span>
+            </LemonButton>
+        </Popover>
+    )
+}
+
 export function PlayerController(): JSX.Element {
     const { logicProps, hoverModeIsEnabled, showPlayerChrome } = useValues(sessionRecordingPlayerLogic)
 
@@ -237,6 +315,7 @@ export function PlayerController(): JSX.Element {
                 <div className="flex gap-0.5 justify-end items-center">
                     {ModesWithInteractions.includes(playerMode) && (
                         <>
+                            <AIChaptersButton />
                             <CommentOnRecordingButton />
                             <EmojiCommentOnRecordingButton />
                             <Screenshot />

--- a/frontend/src/scenes/session-recordings/player/sidebar/PlayerSidebarSessionSummary.tsx
+++ b/frontend/src/scenes/session-recordings/player/sidebar/PlayerSidebarSessionSummary.tsx
@@ -655,7 +655,7 @@ export const SessionSummaryComponent = {
     Subtitle: SessionSummarySubtitle,
 }
 
-function SessionSummary(): JSX.Element {
+export function SessionSummary(): JSX.Element {
     const { logicProps } = useValues(sessionRecordingPlayerLogic)
     const { sessionSummary } = useValues(playerMetaLogic(logicProps))
 

--- a/frontend/src/scenes/web-analytics/LiveMetricsDashboard/LiveAnimatedTable.tsx
+++ b/frontend/src/scenes/web-analytics/LiveMetricsDashboard/LiveAnimatedTable.tsx
@@ -110,7 +110,7 @@ export function LiveAnimatedTable<T>({
 
     useLayoutEffect(() => {
         prevPositionsRef.current = new Map(items.map((item, index) => [keyExtractor(item), index]))
-    }, [items])
+    }, [items, keyExtractor])
 
     return (
         <div className={clsx('bg-bg-light rounded-lg border p-4', className)}>


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->
activity panel is crowded and slightly hidden. Try moving the ai summary a bit more front and center.
## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->
- Relocated the ai summary button and summary itself to the player bar
<img width="1276" height="963" alt="Screenshot 2026-04-10 at 18 26 18" src="https://github.com/user-attachments/assets/e5999928-f883-4766-8c3e-7444c3e2972d" />


## How did you test this code?

<!-- Briefly describe the steps you took, and what steps reviewers must take to get to where changes are, and what is the expected behavior. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
