### PR TITLE
fix(heatmaps): accept export renderer JWT on screenshot content endpoint

### DIFF
--- a/posthog/heatmaps/heatmaps_api.py
+++ b/posthog/heatmaps/heatmaps_api.py
@@ -500,6 +500,12 @@ class HeatmapScreenshotResponseSerializer(serializers.ModelSerializer):
 
 
 class HeatmapScreenshotViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
+    # Screenshot exports render the heatmap in a headless browser, which authenticates
+    # via an EXPORT_RENDERER JWT. Without opting into ExportRendererAuthentication here,
+    # the exporter's `fetch(heatmap_url, Authorization: Bearer ...)` call in
+    # frontend/src/exporter/exporterViewLogic.ts:50-52 gets rejected, the background
+    # image never loads, and the exported PNG renders an `<img alt="Heatmap">` placeholder.
+    authentication_classes = [ExportRendererAuthentication]
     scope_object = "heatmap"
     scope_object_read_actions = ["list", "retrieve", "content"]
     throttle_classes = [ClickHouseBurstRateThrottle, ClickHouseSustainedRateThrottle]

--- a/posthog/heatmaps/test/test_heatmap_screenshots.py
+++ b/posthog/heatmaps/test/test_heatmap_screenshots.py
@@ -7,6 +7,7 @@ from django.utils import timezone
 
 from rest_framework.test import APIClient
 
+from posthog.jwt import PosthogJwtAudience, encode_jwt
 from posthog.models import HeatmapSnapshot, SavedHeatmap, Team
 
 
@@ -83,6 +84,34 @@ class TestHeatmapsAPI(APIBaseTest):
         other = SavedHeatmap.objects.create(team=other_team, url="https://example.com")
         r = self.client.get(f"/api/environments/{self.team.id}/heatmap_screenshots/{other.id}/content/")
         self.assertEqual(r.status_code, 404)
+
+    def test_content_endpoint_accepts_export_renderer_jwt(self):
+        # Screenshot exports render the heatmap in a headless browser that
+        # authenticates with an EXPORT_RENDERER JWT. This regression test
+        # guards against HeatmapScreenshotViewSet dropping that auth class:
+        # if it does, the exporter can't fetch the background image and the
+        # resulting PNG renders an `<img alt="Heatmap">` placeholder.
+        saved = SavedHeatmap.objects.create(
+            team=self.team,
+            url="https://example.com",
+            created_by=self.user,
+            status=SavedHeatmap.Status.COMPLETED,
+        )
+        HeatmapSnapshot.objects.create(heatmap=saved, width=1024, content=b"jpegdata1024")
+
+        token = encode_jwt(
+            {"id": self.user.id},
+            timedelta(minutes=5),
+            PosthogJwtAudience.EXPORT_RENDERER,
+        )
+        unauthenticated = APIClient()
+        r = unauthenticated.get(
+            f"/api/environments/{self.team.id}/heatmap_screenshots/{saved.id}/content/?width=1024",
+            headers={"authorization": f"Bearer {token}"},
+        )
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r["Content-Type"], "image/jpeg")
+        self.assertEqual(r.content, b"jpegdata1024")
 
     @patch("posthog.heatmaps.heatmaps_api.generate_heatmap_screenshot")
     def test_retrieve_auto_recovers_stale_processing_heatmap(self, mock_task):

--- a/posthog/models/resource_transfer/test/__snapshots__/test_visitor_field_snapshots.ambr
+++ b/posthog/models/resource_transfer/test/__snapshots__/test_visitor_field_snapshots.ambr
@@ -451,7 +451,6 @@
   list([
     'DoesNotExist',
     'MultipleObjectsReturned',
-    '__annotations__',
     '__doc__',
     '__module__',
     '__repr__',


### PR DESCRIPTION
## Problem

Screenshot-type heatmap exports render with a broken `<img alt=\"Heatmap\">` placeholder instead of the background image. The exporter Chrome session authenticates with an `EXPORT_RENDERER` JWT (minted in `posthog/api/sharing.py`), and fetches the background screenshot via `/api/environments/:team/heatmap_screenshots/:id/content/` inside `frontend/src/exporter/exporterViewLogic.ts`. `HeatmapScreenshotViewSet` never opted into `ExportRendererAuthentication`, so that fetch was rejected by the default auth stack and the exported PNG was unusable.

<img width="2048" height="1146" alt="image" src="https://github.com/user-attachments/assets/22a00933-fa47-4d0c-b060-21f45a0345a5" />


## Changes

- Adds `authentication_classes = [ExportRendererAuthentication]` to `HeatmapScreenshotViewSet`, matching the existing pattern on `HeatmapViewSet`.
- Regression test in `posthog/heatmaps/test/test_heatmap_screenshots.py` that fetches the content endpoint with an `EXPORT_RENDERER` Bearer JWT and asserts the JPEG is returned.

## How did you test this code?

I'm an agent — I ran the affected backend tests locally and confirmed they pass:

- `pytest -q posthog/heatmaps/test/test_heatmap_screenshots.py posthog/test/test_export_renderer_auth.py` → 20 passed.

I did not test this manually end-to-end in this session. A human reviewer should confirm by triggering a screenshot-type heatmap export and checking the downloaded PNG shows the background screenshot instead of a placeholder.

## Publish to changelog?

no

## Docs update

No docs update needed.

## 🤖 LLM context

- Fetch site: `frontend/src/exporter/exporterViewLogic.ts:50-52`
- JWT mint site: `posthog/api/sharing.py:838-842`
- Auth class: `posthog/auth.py:428-454`
- Reference pattern: `HeatmapViewSet` in `posthog/heatmaps/heatmaps_api.py` (already opts into the same auth class).