### PR TITLE
feat(exports): surface failure type and exception details in side panel

### DIFF
--- a/frontend/src/generated/core/api.schemas.ts
+++ b/frontend/src/generated/core/api.schemas.ts
@@ -856,6 +856,10 @@ export interface ExportedAssetApi {
     readonly expires_after: string | null
     /** @nullable */
     readonly exception: string | null
+    /** @nullable */
+    readonly exception_type: string | null
+    /** @nullable */
+    readonly failure_type: string | null
 }
 
 export interface PaginatedExportedAssetListApi {

--- a/frontend/src/layout/navigation-3000/sidepanel/panels/exports/SidePanelExports.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/exports/SidePanelExports.tsx
@@ -10,12 +10,20 @@ import { dayjs } from 'lib/dayjs'
 import { IconWithCount } from 'lib/lemon-ui/icons'
 import { humanFriendlyNumber } from 'lib/utils'
 
-import { ExportedAssetType, ExporterFormat } from '~/types'
+import { ExportedAssetFailureType, ExportedAssetType, ExporterFormat } from '~/types'
 
 import { SidePanelPaneHeader } from '../../components/SidePanelPaneHeader'
 import { sidePanelExportsLogic } from './sidePanelExportsLogic'
 
 const ROW_LIMIT_IN_THOUSANDS = 300
+
+const FAILURE_TYPE_LABELS: Record<ExportedAssetFailureType, { label: string; className: string }> = {
+    user: { label: 'User error', className: 'text-warning' },
+    system: { label: 'System error', className: 'text-danger' },
+    timeout_generation: { label: 'Timed out', className: 'text-warning' },
+    stuck: { label: 'Stuck', className: 'text-warning' },
+    unknown: { label: 'Failed', className: 'text-danger' },
+}
 
 export const SidePanelExportsIcon = (): JSX.Element => {
     const { freshUndownloadedExports } = useValues(sidePanelExportsLogic)
@@ -78,6 +86,13 @@ function ExportRow({ asset }: { asset: ExportedAssetType }): JSX.Element {
 
     const isNotDownloaded = freshUndownloadedExports.some((fresh) => fresh.id === asset.id)
     const stillCalculating = !asset.has_content && !asset.exception
+    const hasFailure = !!asset.exception && !asset.has_content
+    const failureMeta =
+        hasFailure && asset.failure_type
+            ? (FAILURE_TYPE_LABELS[asset.failure_type] ?? FAILURE_TYPE_LABELS.unknown)
+            : hasFailure
+              ? FAILURE_TYPE_LABELS.unknown
+              : null
     let disabledReason: string | undefined = undefined
     if (asset.exception) {
         disabledReason = asset.exception
@@ -106,6 +121,20 @@ function ExportRow({ asset }: { asset: ExportedAssetType }): JSX.Element {
                                 : `${ROW_LIMIT_IN_THOUSANDS}k`}{' '}
                             row limit
                         </span>
+                    )}
+                    {failureMeta && (
+                        <div className="mt-1 flex items-start gap-1 text-xs">
+                            <IconWarning className={`${failureMeta.className} mt-0.5 shrink-0`} />
+                            <div className="flex flex-col">
+                                <span className={`font-medium ${failureMeta.className}`}>
+                                    {failureMeta.label}
+                                    {asset.exception_type ? ` · ${asset.exception_type}` : ''}
+                                </span>
+                                {asset.exception && (
+                                    <span className="text-secondary break-words">{asset.exception}</span>
+                                )}
+                            </div>
+                        </div>
                     )}
                 </div>
             </div>

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -5147,6 +5147,8 @@ export type ExportContext = (
     variables_override?: Record<string, any>
 }
 
+export type ExportedAssetFailureType = 'user' | 'system' | 'timeout_generation' | 'stuck' | 'unknown'
+
 export interface ExportedAssetType {
     id: number
     export_format: ExporterFormat
@@ -5158,6 +5160,8 @@ export interface ExportedAssetType {
     created_at: string
     expires_after?: string
     exception?: string
+    exception_type?: string | null
+    failure_type?: ExportedAssetFailureType | null
 }
 
 export enum FeatureFlagReleaseType {

--- a/posthog/api/exports.py
+++ b/posthog/api/exports.py
@@ -58,8 +58,19 @@ class ExportedAssetSerializer(serializers.ModelSerializer):
             "filename",
             "expires_after",
             "exception",
+            "exception_type",
+            "failure_type",
         ]
-        read_only_fields = ["id", "created_at", "has_content", "filename", "expires_after", "exception"]
+        read_only_fields = [
+            "id",
+            "created_at",
+            "has_content",
+            "filename",
+            "expires_after",
+            "exception",
+            "exception_type",
+            "failure_type",
+        ]
 
     def to_representation(self, instance):
         """Override to show stuck exports as having an exception."""
@@ -74,8 +85,13 @@ class ExportedAssetSerializer(serializers.ModelSerializer):
             and not instance.has_content
             and not instance.exception
         ):
-            timeout_message = f"Export failed without throwing an exception. Please try to rerun this export and contact support if it fails to complete multiple times."
+            timeout_message = (
+                "Export is stuck — the worker never reported success or failure. "
+                "This usually means the task was hard-killed (timeout or OOM). "
+                "Please retry; if it keeps failing, contact support."
+            )
             data["exception"] = timeout_message
+            data["failure_type"] = "stuck"
 
             distinct_id = (
                 self.context["request"].user.distinct_id

--- a/posthog/api/test/test_exports.py
+++ b/posthog/api/test/test_exports.py
@@ -112,6 +112,8 @@ class TestExports(APIBaseTest):
             "created_at": data["created_at"],
             "dashboard": self.dashboard.id,
             "exception": None,
+            "exception_type": None,
+            "failure_type": None,
             "export_format": "image/png",
             "filename": f"export-example-dashboard-{created_date}.png",
             "has_content": False,
@@ -155,6 +157,8 @@ class TestExports(APIBaseTest):
             "created_at": data["created_at"],
             "dashboard": self.dashboard.id,
             "exception": None,
+            "exception_type": None,
+            "failure_type": None,
             "export_format": "image/png",
             "filename": f"export-example-dashboard-{created_date}.png",
             "has_content": False,
@@ -209,6 +213,8 @@ class TestExports(APIBaseTest):
                 "has_content": False,
                 "dashboard": None,
                 "exception": None,
+                "exception_type": None,
+                "failure_type": None,
                 "export_context": None,
                 # PNG format gets 180 days (6 months) expiry
                 "expires_after": (now() + timedelta(days=180))
@@ -575,13 +581,16 @@ class TestExports(APIBaseTest):
 
         stuck_result = results_by_id[stuck_export.id]
         self.assertIsNotNone(stuck_result["exception"])
-        self.assertIn(f"Export failed without throwing an exception", stuck_result["exception"])
+        self.assertIn("Export is stuck", stuck_result["exception"])
+        self.assertEqual(stuck_result["failure_type"], "stuck")
 
         recent_result = results_by_id[recent_export.id]
         self.assertIsNone(recent_result["exception"])
+        self.assertIsNone(recent_result["failure_type"])
 
         completed_result = results_by_id[completed_export.id]
         self.assertIsNone(completed_result["exception"])
+        self.assertIsNone(completed_result["failure_type"])
 
         completed_result = results_by_id[errored_export.id]
         self.assertEqual("exception", completed_result["exception"])
@@ -615,11 +624,13 @@ class TestExports(APIBaseTest):
 
         # Check that the stuck export appears to have an exception in the response
         self.assertIsNotNone(result["exception"])
-        self.assertIn(f"Export failed without throwing an exception", result["exception"])
+        self.assertIn("Export is stuck", result["exception"])
+        self.assertEqual(result["failure_type"], "stuck")
 
         # Verify that the database wasn't actually modified
         stuck_export.refresh_from_db()
         self.assertIsNone(stuck_export.exception)
+        self.assertIsNone(stuck_export.failure_type)
 
     @parameterized.expand(
         [

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -15009,6 +15009,10 @@ export namespace Schemas {
       readonly expires_after: string | null;
       /** @nullable */
       readonly exception: string | null;
+      /** @nullable */
+      readonly exception_type: string | null;
+      /** @nullable */
+      readonly failure_type: string | null;
     }
 
     /**


### PR DESCRIPTION
## Problem

When an export fails, the side panel only shows a generic message on the disabled download button's tooltip — the exports viewset already tracks the structured `exception_type` and `failure_type` on `ExportedAsset`, but neither is exposed on the API or surfaced in the UI, so users can't tell why an export failed at a glance.

The synthesized "stuck" fallback message ("Export failed without throwing an exception…") is also confusing because it sounds like a silent failure when in reality the task was most likely hard-killed by a timeout or OOM.

## Changes

- `ExportedAssetSerializer` now exposes `exception_type` and `failure_type` as read-only fields.
- The stuck-export synthesizer in `to_representation` sets `failure_type="stuck"` and uses a clearer message that names the likely root cause and suggests retrying.
- Frontend: new `ExportedAssetFailureType` union and matching fields on `ExportedAssetType`, plus an inline failure block in `ExportRow` that renders an icon and color-coded label (user / system / timed out / stuck / unknown) above the existing download button.

## How did you test this code?

I'm an agent — I ran the affected tests locally and confirmed they pass:

- `pytest -q posthog/api/test/test_exports.py` → 51 passed.
- `tsc --noEmit` scoped to the touched frontend files → clean.

I did not manually click through the UI in this session. A human reviewer should confirm by opening the exports side panel with at least one stuck export and checking the inline block shows up with the expected color and message.

## Publish to changelog?

no

## Docs update

No docs update needed.

## 🤖 LLM context

- Backend: `ExportedAssetSerializer.Meta` + `to_representation` in `posthog/api/exports.py`.
- Frontend: `ExportRow` + `FAILURE_TYPE_LABELS` in `frontend/src/layout/navigation-3000/sidepanel/panels/exports/SidePanelExports.tsx`.
- `failure_type` values are defined by `posthog/tasks/exports/failure_handler.py`; the new `"stuck"` value is synthesised only in the API layer and is not persisted.