### PR TITLE
chore(heatmaps): capture playwright diagnostics on screenshot failure

### DIFF
--- a/posthog/models/resource_transfer/test/__snapshots__/test_visitor_field_snapshots.ambr
+++ b/posthog/models/resource_transfer/test/__snapshots__/test_visitor_field_snapshots.ambr
@@ -451,7 +451,6 @@
   list([
     'DoesNotExist',
     'MultipleObjectsReturned',
-    '__annotations__',
     '__doc__',
     '__module__',
     '__repr__',

--- a/posthog/tasks/heatmap_screenshot.py
+++ b/posthog/tasks/heatmap_screenshot.py
@@ -1,9 +1,12 @@
 import os
+from collections import deque
+from typing import Any
 
 import structlog
 import posthoganalytics
 from celery import shared_task
 from playwright.sync_api import (
+    ConsoleMessage,
     Page,
     ProxySettings,
     TimeoutError as PlaywrightTimeoutError,
@@ -19,6 +22,57 @@ from posthog.tasks.utils import CeleryQueue
 logger = structlog.get_logger(__name__)
 
 TMP_DIR = "/tmp"
+
+# Bound per-page console tail to avoid unbounded memory on noisy pages.
+CONSOLE_TAIL_LIMIT = 50
+
+
+def _attach_console_listener(page: Page) -> deque[dict[str, str]]:
+    """Collect a bounded tail of browser console messages for post-mortem diagnostics."""
+    tail: deque[dict[str, str]] = deque(maxlen=CONSOLE_TAIL_LIMIT)
+
+    def _on_console(message: ConsoleMessage) -> None:
+        try:
+            tail.append({"type": message.type, "text": message.text[:500]})
+        except Exception:
+            pass
+
+    page.on("console", _on_console)
+    return tail
+
+
+def _capture_page_diagnostics(page: Page | None, console_tail: deque[dict[str, str]] | None) -> dict[str, Any]:
+    """Best-effort snapshot of page state + console tail for failure reporting."""
+    diagnostics: dict[str, Any] = {}
+    if page is not None:
+        try:
+            diagnostics["page_url"] = page.url
+        except Exception:
+            pass
+        try:
+            diagnostics["page_title"] = page.title()
+        except Exception:
+            pass
+    if console_tail is not None:
+        diagnostics["console_tail"] = list(console_tail)
+        first_error = next(
+            (entry.get("text") for entry in console_tail if entry.get("type") in {"error", "warning"}),
+            None,
+        )
+        if first_error:
+            diagnostics["first_console_error"] = first_error
+    return diagnostics
+
+
+def _format_diagnostic_suffix(diagnostics: dict[str, Any]) -> str:
+    parts: list[str] = []
+    if diagnostics.get("page_url"):
+        parts.append(f"url={diagnostics['page_url']}")
+    if diagnostics.get("page_title"):
+        parts.append(f"title={diagnostics['page_title']}")
+    if diagnostics.get("first_console_error"):
+        parts.append(f"console_error={diagnostics['first_console_error'][:200]}")
+    return f" ({', '.join(parts)})" if parts else ""
 
 
 def _dismiss_cookie_banners(page: Page) -> None:
@@ -210,8 +264,11 @@ def generate_heatmap_screenshot(screenshot_id: str) -> None:
             )
 
         except Exception as e:
+            diagnostics = getattr(e, "heatmap_diagnostics", {}) or {}
+            exception_text = f"{type(e).__name__}: {e}{_format_diagnostic_suffix(diagnostics)}"
+
             screenshot.status = SavedHeatmap.Status.FAILED
-            screenshot.exception = str(e)
+            screenshot.exception = exception_text
             screenshot.save(update_fields=["status", "exception"])
 
             logger.exception(
@@ -221,6 +278,7 @@ def generate_heatmap_screenshot(screenshot_id: str) -> None:
                 url=screenshot.url,
                 exception=str(e),
                 exc_info=True,
+                **diagnostics,
             )
 
             capture_exception(
@@ -229,6 +287,7 @@ def generate_heatmap_screenshot(screenshot_id: str) -> None:
                     "celery_task": "heatmap_screenshot",
                     "team_id": screenshot.team_id,
                     "screenshot_id": screenshot.id,
+                    **{f"heatmap_{k}": v for k, v in diagnostics.items()},
                 },
             )
             raise
@@ -281,32 +340,50 @@ def _generate_screenshots(screenshot: SavedHeatmap) -> None:
                     ),
                 )
                 page = ctx.new_page()
+                console_tail = _attach_console_listener(page)
                 _block_internal_requests(page)
 
-                # Start navigation and try to wait for DOM ready, but only up to 5s
-                dom_ready = True
                 try:
-                    page.goto(screenshot.url, wait_until="domcontentloaded", timeout=5_000)
-                except PlaywrightTimeoutError:
-                    dom_ready = False
-                    # Navigation may still continue in the background; we just won't block on it.
+                    # Start navigation and try to wait for DOM ready, but only up to 5s
+                    dom_ready = True
+                    try:
+                        page.goto(screenshot.url, wait_until="domcontentloaded", timeout=5_000)
+                    except PlaywrightTimeoutError:
+                        dom_ready = False
+                        # Navigation may still continue in the background; we just won't block on it.
 
-                # Small settle: if DOM was ready, give JS time to render (SPAs). Otherwise, brief paint time.
-                page.wait_for_timeout(3000 if dom_ready else 1000)
+                    # Small settle: if DOM was ready, give JS time to render (SPAs). Otherwise, brief paint time.
+                    page.wait_for_timeout(3000 if dom_ready else 1000)
 
-                # Try to clear overlays/cookie banners if present
-                _dismiss_cookie_banners(page)
-                page.wait_for_timeout(500)
+                    # Try to clear overlays/cookie banners if present
+                    _dismiss_cookie_banners(page)
+                    page.wait_for_timeout(500)
 
-                # Scroll to bottom and back to top to trigger lazy-loaded content
-                _scroll_page(page)
+                    # Scroll to bottom and back to top to trigger lazy-loaded content
+                    _scroll_page(page)
 
-                # Take full-page screenshot without resizing viewport
-                # (resizing viewport causes elements with vh units to expand)
-                image_data: bytes = page.screenshot(full_page=True, type="jpeg", quality=70)
-                snapshot_bytes.append((w, image_data))
-
-                ctx.close()
+                    # Take full-page screenshot without resizing viewport
+                    # (resizing viewport causes elements with vh units to expand)
+                    image_data: bytes = page.screenshot(full_page=True, type="jpeg", quality=70)
+                    snapshot_bytes.append((w, image_data))
+                except Exception as e:
+                    diagnostics = _capture_page_diagnostics(page, console_tail)
+                    logger.warning(
+                        "heatmap_screenshot.page_failed",
+                        screenshot_id=screenshot.id,
+                        team_id=screenshot.team_id,
+                        url=screenshot.url,
+                        width=w,
+                        exception=str(e),
+                        **diagnostics,
+                    )
+                    # Attach diagnostics to the original exception so the outer handler
+                    # can include them in the user-visible SavedHeatmap.exception field.
+                    # This preserves the original exception class for Sentry/classification.
+                    e.heatmap_diagnostics = diagnostics  # type: ignore[attr-defined]
+                    raise
+                finally:
+                    ctx.close()
         finally:
             browser.close()
 

--- a/posthog/tasks/heatmap_screenshot.py
+++ b/posthog/tasks/heatmap_screenshot.py
@@ -380,10 +380,16 @@ def _generate_screenshots(screenshot: SavedHeatmap) -> None:
                     # Attach diagnostics to the original exception so the outer handler
                     # can include them in the user-visible SavedHeatmap.exception field.
                     # This preserves the original exception class for Sentry/classification.
-                    e.heatmap_diagnostics = diagnostics  # type: ignore[attr-defined]
+                    try:
+                        e.heatmap_diagnostics = diagnostics  # type: ignore[attr-defined]
+                    except AttributeError:
+                        pass
                     raise
                 finally:
-                    ctx.close()
+                    try:
+                        ctx.close()
+                    except Exception:
+                        pass
         finally:
             browser.close()
 

--- a/posthog/tasks/test/test_heatmap_screenshot.py
+++ b/posthog/tasks/test/test_heatmap_screenshot.py
@@ -73,3 +73,50 @@ class TestHeatmapScreenshotTask(APIBaseTest):
         heatmap.refresh_from_db()
         assert heatmap.status == SavedHeatmap.Status.FAILED
         assert "boom" in (heatmap.exception or "")
+
+    @patch("posthog.tasks.heatmap_screenshot.sync_playwright")
+    def test_page_failure_captures_diagnostics_in_exception(self, mock_sync_playwright: MagicMock) -> None:
+        # Arrange Playwright mocks that get through browser setup but fail on the screenshot call
+        mock_p = MagicMock()
+        mock_browser = MagicMock()
+        mock_context = MagicMock()
+        mock_page = MagicMock()
+
+        mock_sync_playwright.return_value.__enter__.return_value = mock_p
+        mock_p.chromium.launch.return_value = mock_browser
+        mock_browser.new_context.return_value = mock_context
+        mock_context.new_page.return_value = mock_page
+
+        # Make page look like a real page with a URL/title so diagnostics can be captured.
+        mock_page.url = "https://example.com/failing-page"
+        mock_page.title.return_value = "Broken Page"
+        mock_page.evaluate.return_value = 1200
+
+        # Fail during the screenshot step so we exercise the per-page except block.
+        mock_page.screenshot.side_effect = RuntimeError("screenshot failed")
+
+        heatmap = SavedHeatmap.objects.create(
+            team=self.team,
+            url="https://example.com/failing-page",
+            created_by=self.user,
+            target_widths=[320],
+            status=SavedHeatmap.Status.PROCESSING,
+        )
+
+        # Act
+        try:
+            generate_heatmap_screenshot(heatmap.id)
+        except RuntimeError:
+            pass
+
+        # Assert: the saved exception should include the wrapped diagnostics.
+        heatmap.refresh_from_db()
+        assert heatmap.status == SavedHeatmap.Status.FAILED
+        assert heatmap.exception is not None
+        assert "RuntimeError" in heatmap.exception
+        assert "screenshot failed" in heatmap.exception
+        assert "url=https://example.com/failing-page" in heatmap.exception
+        assert "title=Broken Page" in heatmap.exception
+        # Context should be torn down even on failure
+        mock_context.close.assert_called_once()
+        mock_browser.close.assert_called_once()


### PR DESCRIPTION
## Problem

When the playwright-based `SavedHeatmap` background screenshot path fails, the saved `SavedHeatmap.exception` is just `str(e)` and the `heatmap_screenshot.failed` structlog line has no browser-side context. Triage has to rely on local repros, and there's no signal on which width errored or what the page state was at the time.

## Changes

- Bounded per-page console listener (`CONSOLE_TAIL_LIMIT = 50`) attached before navigation via `page.on("console", ...)`.
- New `_capture_page_diagnostics` and `_format_diagnostic_suffix` helpers snapshot `page.url`, `page.title()`, the tail of console messages, and the first error/warning entry.
- Per-width `try/except` inside `_generate_screenshots` wraps the navigation → settle → cookie dismiss → scroll → screenshot flow. On failure, the diagnostics are logged as `heatmap_screenshot.page_failed` and attached to the original exception via `e.heatmap_diagnostics` (preserving the original class for Sentry/classification).
- Outer handler in `generate_heatmap_screenshot` reads `heatmap_diagnostics` off the exception and composes a human-readable `SavedHeatmap.exception` including the exception class and a compact `url=... title=... console_error=...` suffix.
- New test `test_page_failure_captures_diagnostics_in_exception` exercises the per-page failure path with a mocked playwright session.

## How did you test this code?

I'm an agent — I ran the affected tests locally and confirmed they pass:

- `pytest -q posthog/tasks/test/test_heatmap_screenshot.py` → 3 passed (2 existing + 1 new).

I did not trigger a real playwright failure end-to-end in this session. A human reviewer should confirm by pointing a heatmap screenshot at a URL that returns an error and checking that the celery-worker pane shows `heatmap_screenshot.page_failed` with diagnostics and the `SavedHeatmap` row ends up with a compact exception string including `url=` / `title=`.

## Publish to changelog?

no

## Docs update

No docs update needed.

## 🤖 LLM context

- Helpers + per-page try/except live in `posthog/tasks/heatmap_screenshot.py` inside `_generate_screenshots`.
- Outer handler update is in `generate_heatmap_screenshot`.
- Mirrors the diagnostic-capture pattern added to the selenium exporter path in a separate PR.