### PR TITLE
feat(capture): ensure capture monitoring skill is EU aware

### DIFF
--- a/.agents/skills/monitoring-capture-service/SKILL.md
+++ b/.agents/skills/monitoring-capture-service/SKILL.md
@@ -36,15 +36,15 @@ Cross-environment comparison requires switching Grafana instances (not possible 
 Capture spans seven telemetry domains.
 Each has a Grafana datasource and a discovery entry point.
 
-| Domain                        | Datasource UID             | Discovery tool                 | Scope filter                              |
-| ----------------------------- | -------------------------- | ------------------------------ | ----------------------------------------- |
-| App metrics (VictoriaMetrics) | `victoriametrics`          | `list_prometheus_metric_names` | `regex: "capture_.*"`                     |
-| App metrics (realtime)        | `victoriametrics-realtime` | same                           | same (lower retention, higher resolution) |
-| Logs                          | `P8E80F9AEF21F6940`        | `list_loki_label_names`        | `app=~"capture.*"`                        |
-| Profiling                     | `pyroscope`                | `list_pyroscope_profile_types` | `service_name="capture/capture"`          |
-| Dashboards                    | n/a                        | `search_dashboards`            | query `"capture"` or `"ingestion"`        |
-| CloudWatch (ElastiCache, MSK) | `P034F075C744B399F`        | `query_prometheus`             | `environment="prod-us"`                   |
-| CloudWatch Root               | `PAAE47F430CFD1449`        | same                           | root account AWS metrics                  |
+| Domain                         | Datasource UID                  | Discovery tool                 | Scope filter                                         |
+| ------------------------------ | ------------------------------- | ------------------------------ | ---------------------------------------------------- |
+| App metrics (VictoriaMetrics)  | `victoriametrics`               | `list_prometheus_metric_names` | `regex: "capture_.*"`                                |
+| App metrics (realtime)         | `victoriametrics-realtime`      | same                           | same (lower retention, higher resolution)            |
+| Logs                           | `P44D702D3E93867EC` (Loki-logs) | `list_loki_label_names`        | `app=~"capture.*"`                                   |
+| Profiling                      | `pyroscope`                     | `list_pyroscope_profile_types` | `service_name="capture/capture"`                     |
+| Dashboards                     | n/a                             | `search_dashboards`            | query `"capture"` or `"ingestion"`                   |
+| CloudWatch (ElastiCache, MSK)  | `P034F075C744B399F`             | `query_prometheus`             | `environment="prod-us"`                              |
+| CloudWatch Root (prod-us only) | `PAAE47F430CFD1449`             | same                           | root account AWS metrics (does NOT exist in prod-eu) |
 
 ## Stable waypoints
 
@@ -61,6 +61,9 @@ The `role` label on all `capture_*` and `http_requests_*` metrics distinguishes 
 | `capture-replay` | Session recordings | `CAPTURE_MODE=recordings`   |
 
 `capture-logs` is a **separate deployment** (not a `role` value on capture metrics).
+It exists in both prod-us and prod-eu. Pyroscope service names follow the same
+`{namespace}/{deployment}` pattern in both envs: `capture/capture`, `capture/capture-ai`,
+`capture-replay/capture-replay`, `capture-logs/capture-logs`.
 
 ### Envoy cluster naming
 
@@ -82,7 +85,7 @@ metrics and CloudWatch ElastiCache metrics.
 
 **1. Primary Redis** (`REDIS_URL` env var)
 
-- ElastiCache: `posthog-solo` (prod-us legacy) or `ingestion-{env}-redis` (prod-eu)
+- ElastiCache: `posthog-solo` (prod-us) or `posthog-prod-redis-encripted` (prod-eu; sic — typo in actual cluster name)
 - Backs: billing/quota limits (`CaptureQuotaLimiter`), session replay overflow limiter
 - Capture metrics: `capture_billing_limits_loaded_tokens` (by `cache_key`),
   `capture_quota_limit_exceeded` (by `resource`)
@@ -188,7 +191,7 @@ Profile types: `process_cpu:cpu:nanoseconds:cpu:nanoseconds`,
 
 ### Loki (logs)
 
-1. `list_loki_label_names` — `datasourceUid: "P8E80F9AEF21F6940"`
+1. `list_loki_label_names` — `datasourceUid: "P44D702D3E93867EC"` (Loki-logs; do NOT use primary Loki `P8E80F9AEF21F6940` which 502s intermittently)
 2. `list_loki_label_values` for `app` or `namespace` — find capture containers
 3. `query_loki_logs` — e.g. `{app=~"capture.*"} |= "error"`
 

--- a/.agents/skills/monitoring-capture-service/references/investigation-playbooks.md
+++ b/.agents/skills/monitoring-capture-service/references/investigation-playbooks.md
@@ -139,7 +139,7 @@ Then check infrastructure health:
    Key metrics: `EngineCPUUtilization`, `DatabaseMemoryUsagePercentage`,
    `CurrConnections`, `Evictions`, `ReplicationLag`.
    Cluster IDs:
-   - Primary: `posthog-solo` (prod-us) or `ingestion-{env}-redis` (prod-eu)
+   - Primary: `posthog-solo` (prod-us) or `posthog-prod-redis-encripted` (prod-eu; sic — typo in actual name)
    - GRL: `capture-globalratelimit-prod-redis`
    - Rate limit: `ratelimit-prod-redis`
 


### PR DESCRIPTION
## Problem
While implementing the ingestion pipeline monitoring skill I realized I could make some targeted improvements that will save a few Grafana MCP calls and tokens in live use by doing some discovery in prod-eu and mapping that in with more than a mention.
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
* Make capture monitoring skill natively EU aware
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally and in CI. It's pretty nice ✨ 
<!-- Briefly describe the steps you took, and what steps reviewers must take to get to where changes are, and what is the expected behavior. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
N/A
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update
N/A
<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
