### PR TITLE
feat(remote-config): add array.js cache source metrics

### DIFF
--- a/posthog/api/remote_config.py
+++ b/posthog/api/remote_config.py
@@ -1,4 +1,5 @@
 import re
+from collections.abc import Callable
 
 from django.conf import settings
 from django.http import Http404, HttpResponse, JsonResponse
@@ -32,16 +33,16 @@ ARRAY_JS_MANIFEST_SOURCE_COUNTER = Counter(
 tracer = trace.get_tracer(__name__)
 
 
-def _observe_array_js_config_source(source: str) -> None:
-    ARRAY_JS_CONFIG_SOURCE_COUNTER.labels(source=source).inc()
+def _make_source_observer(counter: Counter) -> Callable[[str], None]:
+    def _observe(source: str) -> None:
+        counter.labels(source=source).inc()
+
+    return _observe
 
 
-def _observe_array_js_content_source(source: str) -> None:
-    ARRAY_JS_CONTENT_SOURCE_COUNTER.labels(source=source).inc()
-
-
-def _observe_array_js_manifest_source(source: str) -> None:
-    ARRAY_JS_MANIFEST_SOURCE_COUNTER.labels(source=source).inc()
+_observe_array_js_config_source = _make_source_observer(ARRAY_JS_CONFIG_SOURCE_COUNTER)
+_observe_array_js_content_source = _make_source_observer(ARRAY_JS_CONTENT_SOURCE_COUNTER)
+_observe_array_js_manifest_source = _make_source_observer(ARRAY_JS_MANIFEST_SOURCE_COUNTER)
 
 
 def add_vary_headers(response):

--- a/posthog/api/remote_config.py
+++ b/posthog/api/remote_config.py
@@ -4,13 +4,44 @@ from django.conf import settings
 from django.http import Http404, HttpResponse, JsonResponse
 
 from opentelemetry import trace
+from prometheus_client import Counter
 from rest_framework.exceptions import ValidationError
 from rest_framework.views import APIView
 
 from posthog.models.js_snippet_versioning import DEFAULT_SNIPPET_VERSION
-from posthog.models.remote_config import RemoteConfig
+from posthog.models.remote_config import ArrayJSObservers, RemoteConfig
+
+ARRAY_JS_CONFIG_SOURCE_COUNTER = Counter(
+    "posthog_array_js_config_source",
+    "Origin config source used to serve /array/{token}/array.js.",
+    labelnames=["source"],
+)
+
+ARRAY_JS_CONTENT_SOURCE_COUNTER = Counter(
+    "posthog_array_js_content_source",
+    "Origin JS artifact source used to serve /array/{token}/array.js.",
+    labelnames=["source"],
+)
+
+ARRAY_JS_MANIFEST_SOURCE_COUNTER = Counter(
+    "posthog_array_js_manifest_source",
+    "Manifest source used while resolving snippet versions for /array/{token}/array.js.",
+    labelnames=["source"],
+)
 
 tracer = trace.get_tracer(__name__)
+
+
+def _observe_array_js_config_source(source: str) -> None:
+    ARRAY_JS_CONFIG_SOURCE_COUNTER.labels(source=source).inc()
+
+
+def _observe_array_js_content_source(source: str) -> None:
+    ARRAY_JS_CONTENT_SOURCE_COUNTER.labels(source=source).inc()
+
+
+def _observe_array_js_manifest_source(source: str) -> None:
+    ARRAY_JS_MANIFEST_SOURCE_COUNTER.labels(source=source).inc()
 
 
 def add_vary_headers(response):
@@ -113,16 +144,32 @@ class RemoteConfigArrayJSAPIView(BaseRemoteConfigAPIView):
     @tracer.start_as_current_span("RemoteConfig.ArrayJSAPIView.get")
     def get(self, request, token: str, *args, **kwargs):
         token = self.check_token(token)
-
-        try:
-            meta = RemoteConfig.compute_array_js_metadata(token)
-        except RemoteConfig.DoesNotExist:
+        observers = ArrayJSObservers(
+            config_source=_observe_array_js_config_source,
+            manifest_source=_observe_array_js_manifest_source,
+            js_content_source=_observe_array_js_content_source,
+        )
+        prepared = RemoteConfig.prepare_array_js_response(
+            token,
+            if_none_match=request.META.get("HTTP_IF_NONE_MATCH"),
+            observers=observers,
+        )
+        if prepared.is_missing:
             raise Http404()
 
-        if request.META.get("HTTP_IF_NONE_MATCH") == meta.etag:
+        meta = prepared.metadata
+        assert meta is not None
+
+        if prepared.not_modified:
             response = HttpResponse(status=304)
             return add_cache_headers(response, token, meta.etag, snippet_version=meta.requested_version)
 
-        content = RemoteConfig.build_array_js_content(token, meta.config, meta.resolved_version, request=request)
+        content = RemoteConfig.build_array_js_content(
+            token,
+            meta.config,
+            meta.resolved_version,
+            request=request,
+            js_content_source_observer=observers.js_content_source,
+        )
         response = HttpResponse(content, content_type="application/javascript")
         return add_cache_headers(response, token, meta.etag, snippet_version=meta.requested_version)

--- a/posthog/api/test/test_remote_config.py
+++ b/posthog/api/test/test_remote_config.py
@@ -1,7 +1,7 @@
 from decimal import Decimal
 
 from posthog.test.base import APIBaseTest, FuzzyInt, QueryMatchingTest
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from parameterized import parameterized
 from rest_framework import status
@@ -210,6 +210,82 @@ class TestRemoteConfig(APIBaseTest, QueryMatchingTest):
             response.headers["Cache-Control"]
             == "public, max-age=3600, stale-while-revalidate=86400, stale-if-error=86400"
         )
+
+    @patch("posthog.api.remote_config.ARRAY_JS_CONFIG_SOURCE_COUNTER")
+    @patch("posthog.models.remote_config.get_js_content", return_value="[MOCKED_ARRAY_JS_CONTENT]")
+    def test_array_js_tracks_config_source_on_200(
+        self,
+        _mock_get_array_js_content,
+        mock_config_source_counter,
+    ):
+        config_source_metric = MagicMock()
+        mock_config_source_counter.labels.return_value = config_source_metric
+
+        response = self.client.get(f"/array/{self.team.api_token}/array.js")
+
+        assert response.status_code == status.HTTP_200_OK
+        mock_config_source_counter.labels.assert_called_once_with(source="db")
+        config_source_metric.inc.assert_called_once()
+
+    @patch("posthog.api.remote_config.ARRAY_JS_CONFIG_SOURCE_COUNTER")
+    @patch("posthog.models.remote_config.get_js_content", return_value="[MOCKED_ARRAY_JS_CONTENT]")
+    def test_array_js_tracks_config_source_on_304(
+        self,
+        _mock_get_array_js_content,
+        mock_config_source_counter,
+    ):
+        etag = self.client.get(f"/array/{self.team.api_token}/array.js").headers["ETag"]
+
+        mock_config_source_counter.reset_mock()
+
+        config_source_metric = MagicMock()
+        mock_config_source_counter.labels.return_value = config_source_metric
+
+        response = self.client.get(
+            f"/array/{self.team.api_token}/array.js",
+            HTTP_IF_NONE_MATCH=etag,
+        )
+
+        assert response.status_code == status.HTTP_304_NOT_MODIFIED
+        mock_config_source_counter.labels.assert_called_once_with(source="redis")
+        config_source_metric.inc.assert_called_once()
+
+    @patch("posthog.api.remote_config.ARRAY_JS_CONTENT_SOURCE_COUNTER")
+    @patch("posthog.api.remote_config.ARRAY_JS_MANIFEST_SOURCE_COUNTER")
+    @patch("posthog.models.remote_config.resolve_version")
+    @patch("posthog.models.remote_config.get_js_content")
+    def test_array_js_tracks_manifest_and_content_sources(
+        self,
+        mock_get_js_content,
+        mock_resolve_version,
+        mock_manifest_source_counter,
+        mock_content_source_counter,
+    ):
+        manifest_metric = MagicMock()
+        content_metric = MagicMock()
+        mock_manifest_source_counter.labels.return_value = manifest_metric
+        mock_content_source_counter.labels.return_value = content_metric
+
+        def fake_resolve_version(requested_version, *, strict=False, manifest_source_observer=None):
+            if manifest_source_observer is not None:
+                manifest_source_observer("redis")
+            return "1.358.0"
+
+        def fake_get_js_content(version, *, source_observer=None):
+            if source_observer is not None:
+                source_observer("s3")
+            return "[MOCKED_ARRAY_JS_CONTENT]"
+
+        mock_resolve_version.side_effect = fake_resolve_version
+        mock_get_js_content.side_effect = fake_get_js_content
+
+        response = self.client.get(f"/array/{self.team.api_token}/array.js")
+
+        assert response.status_code == status.HTTP_200_OK
+        mock_manifest_source_counter.labels.assert_called_once_with(source="redis")
+        manifest_metric.inc.assert_called_once()
+        mock_content_source_counter.labels.assert_called_once_with(source="s3")
+        content_metric.inc.assert_called_once()
 
     @patch("posthog.models.remote_config.get_js_content", return_value="[MOCKED_ARRAY_JS_CONTENT]")
     def test_valid_array_uses_config_js_cache(self, mock_get_array_js_content):

--- a/posthog/api/test/test_remote_config.py
+++ b/posthog/api/test/test_remote_config.py
@@ -3,6 +3,8 @@ from decimal import Decimal
 from posthog.test.base import APIBaseTest, FuzzyInt, QueryMatchingTest
 from unittest.mock import MagicMock, patch
 
+from django.test import override_settings
+
 from parameterized import parameterized
 from rest_framework import status
 
@@ -10,6 +12,7 @@ from rest_framework import status
 CONFIG_REFRESH_QUERY_COUNT = 5
 
 
+@override_settings(POSTHOG_JS_S3_BUCKET="")
 class TestRemoteConfig(APIBaseTest, QueryMatchingTest):
     def setUp(self):
         self.client.logout()

--- a/posthog/api/test/test_remote_config.py
+++ b/posthog/api/test/test_remote_config.py
@@ -1,7 +1,7 @@
 from decimal import Decimal
 
 from posthog.test.base import APIBaseTest, FuzzyInt, QueryMatchingTest
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 from django.test import override_settings
 
@@ -214,35 +214,28 @@ class TestRemoteConfig(APIBaseTest, QueryMatchingTest):
             == "public, max-age=3600, stale-while-revalidate=86400, stale-if-error=86400"
         )
 
-    @patch("posthog.api.remote_config.ARRAY_JS_CONFIG_SOURCE_COUNTER")
+    @patch("posthog.api.remote_config._observe_array_js_config_source")
     @patch("posthog.models.remote_config.get_js_content", return_value="[MOCKED_ARRAY_JS_CONTENT]")
     def test_array_js_tracks_config_source_on_200(
         self,
         _mock_get_array_js_content,
-        mock_config_source_counter,
+        mock_observe_config_source,
     ):
-        config_source_metric = MagicMock()
-        mock_config_source_counter.labels.return_value = config_source_metric
-
         response = self.client.get(f"/array/{self.team.api_token}/array.js")
 
         assert response.status_code == status.HTTP_200_OK
-        mock_config_source_counter.labels.assert_called_once_with(source="db")
-        config_source_metric.inc.assert_called_once()
+        mock_observe_config_source.assert_called_once_with("db")
 
-    @patch("posthog.api.remote_config.ARRAY_JS_CONFIG_SOURCE_COUNTER")
+    @patch("posthog.api.remote_config._observe_array_js_config_source")
     @patch("posthog.models.remote_config.get_js_content", return_value="[MOCKED_ARRAY_JS_CONTENT]")
     def test_array_js_tracks_config_source_on_304(
         self,
         _mock_get_array_js_content,
-        mock_config_source_counter,
+        mock_observe_config_source,
     ):
         etag = self.client.get(f"/array/{self.team.api_token}/array.js").headers["ETag"]
 
-        mock_config_source_counter.reset_mock()
-
-        config_source_metric = MagicMock()
-        mock_config_source_counter.labels.return_value = config_source_metric
+        mock_observe_config_source.reset_mock()
 
         response = self.client.get(
             f"/array/{self.team.api_token}/array.js",
@@ -250,25 +243,19 @@ class TestRemoteConfig(APIBaseTest, QueryMatchingTest):
         )
 
         assert response.status_code == status.HTTP_304_NOT_MODIFIED
-        mock_config_source_counter.labels.assert_called_once_with(source="redis")
-        config_source_metric.inc.assert_called_once()
+        mock_observe_config_source.assert_called_once_with("redis")
 
-    @patch("posthog.api.remote_config.ARRAY_JS_CONTENT_SOURCE_COUNTER")
-    @patch("posthog.api.remote_config.ARRAY_JS_MANIFEST_SOURCE_COUNTER")
+    @patch("posthog.api.remote_config._observe_array_js_content_source")
+    @patch("posthog.api.remote_config._observe_array_js_manifest_source")
     @patch("posthog.models.remote_config.resolve_version")
     @patch("posthog.models.remote_config.get_js_content")
     def test_array_js_tracks_manifest_and_content_sources(
         self,
         mock_get_js_content,
         mock_resolve_version,
-        mock_manifest_source_counter,
-        mock_content_source_counter,
+        mock_observe_manifest_source,
+        mock_observe_content_source,
     ):
-        manifest_metric = MagicMock()
-        content_metric = MagicMock()
-        mock_manifest_source_counter.labels.return_value = manifest_metric
-        mock_content_source_counter.labels.return_value = content_metric
-
         def fake_resolve_version(requested_version, *, strict=False, manifest_source_observer=None):
             if manifest_source_observer is not None:
                 manifest_source_observer("redis")
@@ -285,10 +272,8 @@ class TestRemoteConfig(APIBaseTest, QueryMatchingTest):
         response = self.client.get(f"/array/{self.team.api_token}/array.js")
 
         assert response.status_code == status.HTTP_200_OK
-        mock_manifest_source_counter.labels.assert_called_once_with(source="redis")
-        manifest_metric.inc.assert_called_once()
-        mock_content_source_counter.labels.assert_called_once_with(source="s3")
-        content_metric.inc.assert_called_once()
+        mock_observe_manifest_source.assert_called_once_with("redis")
+        mock_observe_content_source.assert_called_once_with("s3")
 
     @patch("posthog.models.remote_config.get_js_content", return_value="[MOCKED_ARRAY_JS_CONTENT]")
     def test_valid_array_uses_config_js_cache(self, mock_get_array_js_content):

--- a/posthog/models/js_snippet_versioning.py
+++ b/posthog/models/js_snippet_versioning.py
@@ -5,6 +5,7 @@ import time
 import hashlib
 import threading
 from collections import OrderedDict
+from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any, NotRequired, Optional, TypedDict
 
@@ -70,6 +71,14 @@ def s3_head(key: str) -> bool:
     except Exception as e:
         capture_exception(e, additional_properties={"tag": "js_snippet_versioning", "s3_op": "head", "key": key})
         raise ObjectStorageError("head failed") from e
+
+
+SourceObserver = Callable[[str], None]
+
+
+def _observe_source(source_observer: Optional[SourceObserver], source: str) -> None:
+    if source_observer is not None:
+        source_observer(source)
 
 
 # Disk fallback: the array.js shipped with the current deploy
@@ -231,7 +240,7 @@ def _get_redis_key(version: str) -> str:
     return f"{REDIS_JS_KEY_PREFIX}:{version}"
 
 
-def get_js_content(version: Optional[str]) -> str:
+def get_js_content(version: Optional[str], *, source_observer: Optional[SourceObserver] = None) -> str:
     """
     Fetch JS content for a resolved exact version.
 
@@ -242,15 +251,18 @@ def get_js_content(version: Optional[str]) -> str:
     4. Disk (frontend/dist/array.js from current deploy)
     """
     if version is None:
+        _observe_source(source_observer, "disk")
         return _get_disk_js_content()
 
     if not _EXACT_VERSION_RE.match(version):
         logger.warning("Invalid resolved version, falling back to disk", version=version)
+        _observe_source(source_observer, "disk")
         return _get_disk_js_content()
 
     # 1. In-process LRU cache (immutable content, bounded size)
     cached_content = _content_cache_get(version)
     if cached_content is not None:
+        _observe_source(source_observer, "memory")
         return cached_content
 
     # 2. Try Redis
@@ -258,6 +270,7 @@ def get_js_content(version: Optional[str]) -> str:
     cached = cache.get(redis_key)
     if cached is not None:
         _content_cache_put(version, cached)
+        _observe_source(source_observer, "redis")
         return cached
 
     # 3. Try S3
@@ -267,12 +280,14 @@ def get_js_content(version: Optional[str]) -> str:
         if content is not None:
             cache.set(redis_key, content, REDIS_JS_CONTENT_TTL)
             _content_cache_put(version, content)
+            _observe_source(source_observer, "s3")
             return content
     except ObjectStorageError:
         logger.exception("Failed to read JS content from S3", version=version)
 
     # 4. Disk fallback
     logger.warning("Falling back to disk JS content", version=version)
+    _observe_source(source_observer, "disk")
     return _get_disk_js_content()
 
 
@@ -302,7 +317,7 @@ def _recover_manifest_from_s3() -> Optional[CachedManifest]:
         return None
 
 
-def _get_manifest() -> Optional[CachedManifest]:
+def _get_manifest(*, source_observer: Optional[SourceObserver] = None) -> Optional[CachedManifest]:
     """Get version manifest from in-process cache -> Redis -> S3.
 
     Returns None (with disk fallback) when the manifest can't be loaded.
@@ -314,19 +329,24 @@ def _get_manifest() -> Optional[CachedManifest]:
 
     if _cached_manifest is not None and _cached_manifest.is_fresh:
         if isinstance(_cached_manifest, _ManifestMiss):
+            _observe_source(source_observer, "negative_cache")
             return None
+        _observe_source(source_observer, "memory")
         return _cached_manifest
 
+    redis_error = False
     try:
         raw = cache.get(REDIS_POINTER_MAP_KEY)
     except Exception as e:
         logger.exception("Failed to read manifest from Redis")
         capture_exception(e, additional_properties={"tag": "js_snippet_versioning", "redis_key": REDIS_POINTER_MAP_KEY})
         raw = None
+        redis_error = True
 
     if raw is not None:
         try:
             _cached_manifest = CachedManifest.from_json(raw)
+            _observe_source(source_observer, "redis")
             return _cached_manifest
         except Exception as e:
             capture_exception(
@@ -338,9 +358,11 @@ def _get_manifest() -> Optional[CachedManifest]:
         recovered = _recover_manifest_from_s3()
         if recovered is not None:
             _cached_manifest = recovered
+            _observe_source(source_observer, "s3_recovery")
             return _cached_manifest
 
     _cached_manifest = _ManifestMiss(cached_at=time.time())
+    _observe_source(source_observer, "redis_error" if redis_error else "miss")
     return None
 
 
@@ -467,7 +489,12 @@ def sync_manifest_from_s3() -> VersionManifest:
     return manifest
 
 
-def resolve_version(requested_version: Optional[str], *, strict: bool = False) -> Optional[str]:
+def resolve_version(
+    requested_version: Optional[str],
+    *,
+    strict: bool = False,
+    manifest_source_observer: Optional[SourceObserver] = None,
+) -> Optional[str]:
     """
     Resolve a requested version to a concrete version string.
 
@@ -487,7 +514,7 @@ def resolve_version(requested_version: Optional[str], *, strict: bool = False) -
     if not settings.POSTHOG_JS_S3_BUCKET:
         return None
 
-    manifest = _get_manifest()
+    manifest = _get_manifest(source_observer=manifest_source_observer)
     if manifest is None:
         return None
 

--- a/posthog/models/remote_config.py
+++ b/posthog/models/remote_config.py
@@ -1,6 +1,8 @@
 import copy
 import json
 import hashlib
+from collections.abc import Callable
+from dataclasses import dataclass
 from typing import Any, NamedTuple, Optional
 
 from django.conf import settings
@@ -92,6 +94,23 @@ class ArrayJSMetadata(NamedTuple):
     requested_version: str  # The snippet version pin (e.g. "1", "1.358") for Cache-Tag
     resolved_version: Optional[str]  # Exact version the request resolved to (e.g. "1.360.1")
     config: dict  # Pre-loaded config — pass to build_array_js_content to avoid a second cache read
+
+
+@dataclass
+class ArrayJSObservers:
+    config_source: Optional[Callable[[str], None]] = None
+    manifest_source: Optional[Callable[[str], None]] = None
+    js_content_source: Optional[Callable[[str], None]] = None
+
+
+@dataclass
+class ArrayJSPreparedResponse:
+    metadata: Optional[ArrayJSMetadata]
+    not_modified: bool = False
+
+    @property
+    def is_missing(self) -> bool:
+        return self.metadata is None
 
 
 class RemoteConfig(UUIDTModel):
@@ -420,10 +439,11 @@ class RemoteConfig(UUIDTModel):
         return site_apps_js + site_functions_js
 
     @classmethod
-    def _get_config_via_cache(cls, token: str) -> dict:
-        # source tells us where the result came from ("redis", "s3", or None).
+    def _get_config_via_cache_with_source(cls, token: str) -> tuple[dict | None, str]:
+        # source tells us where the result came from ("redis", "s3", or "db").
         # When data is None, source disambiguates: a cache hit returning None means
-        # the team was explicitly cached as missing, while no source means a true cache miss.
+        # the team was explicitly cached as missing, while "db" means a true cache miss
+        # that resolved to a missing team in the fallback loader.
         data, source = cls.get_hypercache().get_from_cache_with_source(token)
 
         if data is None:
@@ -431,12 +451,18 @@ class RemoteConfig(UUIDTModel):
                 REMOTE_CONFIG_CACHE_COUNTER.labels(result="hit_but_missing").inc()
             else:
                 REMOTE_CONFIG_CACHE_COUNTER.labels(result="miss_but_missing").inc()
-            raise cls.DoesNotExist()
-
-        if source in ("redis", "s3"):
+        elif source in ("redis", "s3"):
             REMOTE_CONFIG_CACHE_COUNTER.labels(result="hit").inc()
         else:
             REMOTE_CONFIG_CACHE_COUNTER.labels(result="miss").inc()
+
+        return data, source
+
+    @classmethod
+    def _get_config_via_cache(cls, token: str) -> dict:
+        data, _source = cls._get_config_via_cache_with_source(token)
+        if data is None:
+            raise cls.DoesNotExist()
         return data
 
     @staticmethod
@@ -500,26 +526,75 @@ class RemoteConfig(UUIDTModel):
         config = cls._get_config_via_cache(token)
         return cls._build_config_js(config, token, request=request)
 
+    @staticmethod
+    def _compute_array_js_metadata_from_config(
+        config: dict,
+        *,
+        manifest_source_observer: Optional[Callable[[str], None]] = None,
+    ) -> ArrayJSMetadata:
+        sdk_version = config.get("sdkVersion", {})
+        requested = sdk_version.get("requested", DEFAULT_SNIPPET_VERSION)
+
+        # ETag derived from inputs (resolved version + config hash) rather than
+        # hashing the full ~200KB response body.
+        resolved = resolve_version(requested, manifest_source_observer=manifest_source_observer)
+        etag_version = resolved or get_disk_js_hash()
+        config_hash = hashlib.sha256(json.dumps(config, sort_keys=True).encode()).hexdigest()[:16]
+        etag = f'"{etag_version}:{config_hash}"'
+
+        return ArrayJSMetadata(etag=etag, requested_version=requested, resolved_version=resolved, config=config)
+
     @classmethod
     @tracer.start_as_current_span("RemoteConfig.compute_array_js_metadata")
-    def compute_array_js_metadata(cls, token: str) -> ArrayJSMetadata:
+    def compute_array_js_metadata(
+        cls,
+        token: str,
+        *,
+        manifest_source_observer: Optional[Callable[[str], None]] = None,
+    ) -> ArrayJSMetadata:
         """Compute an ETag for the array.js response without building it.
 
         Returns metadata including the pre-loaded config. Pass this to
         build_array_js_content to build the response without a second cache read.
         """
         config = cls._get_config_via_cache(token)
-        sdk_version = config.get("sdkVersion", {})
-        requested = sdk_version.get("requested", DEFAULT_SNIPPET_VERSION)
+        return cls._compute_array_js_metadata_from_config(
+            config,
+            manifest_source_observer=manifest_source_observer,
+        )
 
-        # ETag derived from inputs (resolved version + config hash) rather than
-        # hashing the full ~200KB response body.
-        resolved = resolve_version(requested)
-        etag_version = resolved or get_disk_js_hash()
-        config_hash = hashlib.sha256(json.dumps(config, sort_keys=True).encode()).hexdigest()[:16]
-        etag = f'"{etag_version}:{config_hash}"'
+    @classmethod
+    def prepare_array_js_response(
+        cls,
+        token: str,
+        *,
+        if_none_match: Optional[str] = None,
+        observers: Optional[ArrayJSObservers] = None,
+    ) -> ArrayJSPreparedResponse:
+        """Prepare the domain-level array.js response state for a request.
 
-        return ArrayJSMetadata(etag=etag, requested_version=requested, resolved_version=resolved, config=config)
+        This owns config lookup, source observation, version resolution, and
+        the conditional GET decision so the API view only has to translate the
+        result into HTTP responses and request-level metrics.
+        """
+        config, config_source = cls._get_config_via_cache_with_source(token)
+
+        if config is None:
+            if observers and observers.config_source:
+                observers.config_source("missing")
+            return ArrayJSPreparedResponse(metadata=None)
+
+        if observers and observers.config_source:
+            observers.config_source(config_source)
+
+        metadata = cls._compute_array_js_metadata_from_config(
+            config,
+            manifest_source_observer=observers.manifest_source if observers else None,
+        )
+        return ArrayJSPreparedResponse(
+            metadata=metadata,
+            not_modified=if_none_match == metadata.etag,
+        )
 
     @classmethod
     @tracer.start_as_current_span("RemoteConfig.build_array_js_content")
@@ -529,6 +604,7 @@ class RemoteConfig(UUIDTModel):
         config: dict,
         resolved_version: Optional[str] = None,
         request: Optional[HttpRequest] = None,
+        js_content_source_observer: Optional[Callable[[str], None]] = None,
     ) -> str:
         """Build the full array.js + config JS response body.
 
@@ -536,7 +612,7 @@ class RemoteConfig(UUIDTModel):
         a redundant cache read. resolved_version is the exact version string
         (e.g. "1.360.1") from ArrayJSMetadata.
         """
-        array_js = get_js_content(resolved_version)
+        array_js = get_js_content(resolved_version, source_observer=js_content_source_observer)
         config_js = cls._build_config_js(config, token, request=request, resolved_version=resolved_version)
         return f"""{config_js}\n\n{array_js}"""
 

--- a/posthog/models/remote_config.py
+++ b/posthog/models/remote_config.py
@@ -1,7 +1,6 @@
 import copy
 import json
 import hashlib
-from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any, NamedTuple, Optional
 
@@ -23,6 +22,7 @@ from posthog.models.feature_flag.feature_flag import FeatureFlag
 from posthog.models.hog_functions.hog_function import HogFunction
 from posthog.models.js_snippet_versioning import (
     DEFAULT_SNIPPET_VERSION,
+    SourceObserver,
     get_disk_js_hash,
     get_js_content,
     resolve_version,
@@ -98,9 +98,9 @@ class ArrayJSMetadata(NamedTuple):
 
 @dataclass
 class ArrayJSObservers:
-    config_source: Optional[Callable[[str], None]] = None
-    manifest_source: Optional[Callable[[str], None]] = None
-    js_content_source: Optional[Callable[[str], None]] = None
+    config_source: Optional[SourceObserver] = None
+    manifest_source: Optional[SourceObserver] = None
+    js_content_source: Optional[SourceObserver] = None
 
 
 @dataclass
@@ -530,7 +530,7 @@ class RemoteConfig(UUIDTModel):
     def _compute_array_js_metadata_from_config(
         config: dict,
         *,
-        manifest_source_observer: Optional[Callable[[str], None]] = None,
+        manifest_source_observer: Optional[SourceObserver] = None,
     ) -> ArrayJSMetadata:
         sdk_version = config.get("sdkVersion", {})
         requested = sdk_version.get("requested", DEFAULT_SNIPPET_VERSION)
@@ -550,7 +550,7 @@ class RemoteConfig(UUIDTModel):
         cls,
         token: str,
         *,
-        manifest_source_observer: Optional[Callable[[str], None]] = None,
+        manifest_source_observer: Optional[SourceObserver] = None,
     ) -> ArrayJSMetadata:
         """Compute an ETag for the array.js response without building it.
 
@@ -604,7 +604,7 @@ class RemoteConfig(UUIDTModel):
         config: dict,
         resolved_version: Optional[str] = None,
         request: Optional[HttpRequest] = None,
-        js_content_source_observer: Optional[Callable[[str], None]] = None,
+        js_content_source_observer: Optional[SourceObserver] = None,
     ) -> str:
         """Build the full array.js + config JS response body.
 

--- a/posthog/test/test_js_snippet_versioning.py
+++ b/posthog/test/test_js_snippet_versioning.py
@@ -188,6 +188,62 @@ class TestGetJsContent(SimpleTestCase):
         assert len(content) > 0  # falls back to disk
 
 
+class TestSourceObservers(SimpleTestCase):
+    def setUp(self):
+        _reset_caches()
+        self._disk_patcher = patch(
+            "posthog.models.js_snippet_versioning._get_disk_js_content", return_value="mock-disk-js-content"
+        )
+        self._disk_patcher.start()
+
+    def tearDown(self):
+        self._disk_patcher.stop()
+        cache.delete(REDIS_POINTER_MAP_KEY)
+        _reset_caches()
+
+    def test_get_js_content_reports_memory_source(self):
+        sv._js_content_cache["1.358.0"] = "memory-js-content"
+        observed: list[str] = []
+
+        content = get_js_content("1.358.0", source_observer=observed.append)
+
+        assert content == "memory-js-content"
+        assert observed == ["memory"]
+
+    def test_get_js_content_reports_redis_source(self):
+        cache.set(f"{REDIS_JS_KEY_PREFIX}:1.358.0", "cached-js-content", 3600)
+        observed: list[str] = []
+
+        try:
+            content = get_js_content("1.358.0", source_observer=observed.append)
+            assert content == "cached-js-content"
+            assert observed == ["redis"]
+        finally:
+            cache.delete(f"{REDIS_JS_KEY_PREFIX}:1.358.0")
+
+    @override_settings(POSTHOG_JS_S3_BUCKET="test-bucket")
+    @patch("posthog.models.js_snippet_versioning.s3_read")
+    def test_resolve_version_reports_s3_recovery_source(self, mock_read):
+        manifest = _make_manifest(
+            versions=["1.358.0"],
+            pointers={"1": "1.358.0", "1.358": "1.358.0"},
+        )
+        mock_read.return_value = json.dumps(manifest)
+        observed: list[str] = []
+
+        assert resolve_version("1", manifest_source_observer=observed.append) == "1.358.0"
+        assert observed == ["s3_recovery"]
+
+    @override_settings(POSTHOG_JS_S3_BUCKET="test-bucket")
+    @patch("posthog.models.js_snippet_versioning.s3_read", return_value=None)
+    def test_resolve_version_reports_negative_cache_source(self, _mock_read):
+        assert resolve_version("1") is None
+
+        observed: list[str] = []
+        assert resolve_version("1", manifest_source_observer=observed.append) is None
+        assert observed == ["negative_cache"]
+
+
 class TestValidateArtifacts(SimpleTestCase):
     @override_settings(POSTHOG_JS_S3_BUCKET="test-bucket")
     @patch("posthog.models.js_snippet_versioning.s3_head")

--- a/posthog/test/test_js_snippet_versioning.py
+++ b/posthog/test/test_js_snippet_versioning.py
@@ -5,6 +5,8 @@ from unittest.mock import patch
 from django.core.cache import cache
 from django.test import SimpleTestCase, override_settings
 
+from parameterized import parameterized
+
 import posthog.models.js_snippet_versioning as sv
 from posthog.models.js_snippet_versioning import (
     REDIS_JS_KEY_PREFIX,
@@ -201,25 +203,27 @@ class TestSourceObservers(SimpleTestCase):
         cache.delete(REDIS_POINTER_MAP_KEY)
         _reset_caches()
 
-    def test_get_js_content_reports_memory_source(self):
-        sv._js_content_cache["1.358.0"] = "memory-js-content"
+    @parameterized.expand(
+        [
+            ("memory", "memory-js-content"),
+            ("redis", "cached-js-content"),
+        ]
+    )
+    def test_get_js_content_reports_source(self, source: str, cached_content: str):
         observed: list[str] = []
 
-        content = get_js_content("1.358.0", source_observer=observed.append)
-
-        assert content == "memory-js-content"
-        assert observed == ["memory"]
-
-    def test_get_js_content_reports_redis_source(self):
-        cache.set(f"{REDIS_JS_KEY_PREFIX}:1.358.0", "cached-js-content", 3600)
-        observed: list[str] = []
+        if source == "memory":
+            sv._js_content_cache["1.358.0"] = cached_content
+        else:
+            cache.set(f"{REDIS_JS_KEY_PREFIX}:1.358.0", cached_content, 3600)
 
         try:
             content = get_js_content("1.358.0", source_observer=observed.append)
-            assert content == "cached-js-content"
-            assert observed == ["redis"]
+            assert content == cached_content
+            assert observed == [source]
         finally:
-            cache.delete(f"{REDIS_JS_KEY_PREFIX}:1.358.0")
+            if source == "redis":
+                cache.delete(f"{REDIS_JS_KEY_PREFIX}:1.358.0")
 
     @override_settings(POSTHOG_JS_S3_BUCKET="test-bucket")
     @patch("posthog.models.js_snippet_versioning.s3_read")


### PR DESCRIPTION
## Problem

`/array/{token}/array.js` already has strong request-level observability from ingress and existing HTTP metrics, but it is difficult to see which cache layers are actually serving the request path.

For this endpoint, the main operational question is whether config lookup, snippet manifest resolution, and JS artifact loading are hitting the intended caches or falling back to slower paths like S3, disk, or DB.

## Changes

- add array.js-specific Prometheus counters for:
  - config source (`redis`, `s3`, `db`, `missing`)
  - JS artifact source (`memory`, `redis`, `s3`, `disk`)
  - manifest source (`memory`, `redis`, `s3_recovery`, `negative_cache`, `miss`, `redis_error`)
- thread optional source observers through snippet version resolution and JS content loading
- move array.js request preparation into `RemoteConfig.prepare_array_js_response(...)` so the view stays focused on HTTP response handling
- add tests covering config source metrics and manifest/content source observation

## How did you test this code?

- Ran `flox activate -- bash -lc '.flox/cache/venv/bin/python -m pytest posthog/test/test_js_snippet_versioning.py -q -k "TestSourceObservers"'`
- Ran `flox activate -- bash -lc '.flox/cache/venv/bin/python -m compileall posthog/api/remote_config.py posthog/models/remote_config.py posthog/models/js_snippet_versioning.py posthog/test/test_js_snippet_versioning.py posthog/api/test/test_remote_config.py'`
- I did not run the DB-backed Django test suite locally because Postgres was not available in the local environment

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

do not publish to changelog

## Docs update

No docs update needed.

## 🤖 LLM context

Agent-authored PR.

- Refined the scope to cache-path observability only, intentionally excluding duplicate request duration and response size metrics because equivalent observability already exists at ingress / HTTP layers.
- Added a small domain-level `prepare_array_js_response(...)` helper so the view no longer orchestrates private `RemoteConfig` internals directly.
- Internal planning notes were kept out of the PR on purpose.
