### PR TITLE
chore(quill): document npm publishing in readme

### DIFF
--- a/packages/quill/README.md
+++ b/packages/quill/README.md
@@ -166,6 +166,33 @@ pnpm build
 pnpm storybook
 ```
 
+## Publishing
+
+Quill is published to npm via a manually triggered GitHub Actions workflow: [`.github/workflows/publish-quill-npm.yml`](../../.github/workflows/publish-quill-npm.yml).
+
+The umbrella `@posthog/quill` package is private — only the four sub-packages under `packages/quill/packages/*` are published:
+
+- `@posthog/quill-tokens`
+- `@posthog/quill-primitives`
+- `@posthog/quill-components`
+- `@posthog/quill-blocks`
+
+### How it works
+
+1. **Trigger** — `workflow_dispatch` only. A maintainer runs "Publish Quill npm packages" from the Actions tab and picks an npm dist-tag (`alpha` or `latest`).
+2. **Auth** — runs under the `Release` GitHub environment with `id-token: write`, publishing with npm provenance (`NPM_CONFIG_PROVENANCE: true`) via OIDC trusted publishing — no long-lived npm token.
+3. **Build** — installs the quill workspace with pnpm and runs `pnpm quill:build` (fans out to each sub-package's `vite build`).
+4. **Publish** — loops over the four sub-packages in dependency order and runs `pnpm --filter "@posthog/$pkg" publish --tag "$NPM_TAG" --no-git-checks --access public`. Each sub-package declares `"publishConfig": { "access": "public" }` and ships `src` + `dist`.
+5. **Notify** — posts success/failure and the published versions to the client-libraries Slack channel.
+
+### Versioning
+
+There's no changesets or semantic-release setup — versions are bumped manually. To cut a release:
+
+1. Bump `version` in each of the four sub-package `package.json` files.
+2. Merge to `master`.
+3. Go to Actions → "Publish Quill npm packages" → Run workflow → pick `alpha` or `latest`.
+
 ## Component checklist
 
 - [x] Tokens (colors, shadows, spacing, typography)


### PR DESCRIPTION
## Problem

The quill package README didn't explain how sub-packages get published to npm. New contributors had to dig into `.github/workflows/publish-quill-npm.yml` to figure out the release process.

## Changes

Added a "Publishing" section to `packages/quill/README.md` that covers:

- Which sub-packages are published (the umbrella `@posthog/quill` is private)
- How the manually-triggered workflow authenticates via OIDC trusted publishing with npm provenance
- The build → publish loop order
- The manual version-bump release flow (no changesets/semantic-release)

## How did you test this code?

Docs-only change. I'm an agent (Claude Code) — no manual verification beyond reading the workflow file to make sure the described behavior matches what actually runs.

## Publish to changelog?

no

## 🤖 LLM context

Authored by Claude Code. Task was to document how `packages/quill` is published to npmjs.org after reading `.github/workflows/publish-quill-npm.yml` and the sub-package `package.json` files.