### PR TITLE
fix(data-warehouse): better handling for empty status response

### DIFF
--- a/frontend/src/scenes/data-warehouse/external/forms/SyncProgressStep.tsx
+++ b/frontend/src/scenes/data-warehouse/external/forms/SyncProgressStep.tsx
@@ -1,6 +1,16 @@
 import { useActions, useValues } from 'kea'
 
-import { LemonButton, LemonTable, LemonTableColumns, LemonTag, LemonTagType, Link } from '@posthog/lemon-ui'
+import { IconWarning } from '@posthog/icons'
+import {
+    LemonBanner,
+    LemonButton,
+    LemonTable,
+    LemonTableColumns,
+    LemonTag,
+    LemonTagType,
+    Link,
+    Tooltip,
+} from '@posthog/lemon-ui'
 
 import { sourceWizardLogic } from 'scenes/data-warehouse/new/sourceWizardLogic'
 import { dataWarehouseSettingsLogic } from 'scenes/data-warehouse/settings/dataWarehouseSettingsLogic'
@@ -35,7 +45,7 @@ export const SyncProgressStep = (): JSX.Element => {
             }
         }
 
-        if (schema.status === 'Running') {
+        if (!schema.status || schema.status === 'Running') {
             return {
                 status: 'Syncing...',
                 tagType: 'primary',
@@ -46,6 +56,20 @@ export const SyncProgressStep = (): JSX.Element => {
             return {
                 status: 'Completed',
                 tagType: 'success',
+            }
+        }
+
+        if (schema.status === 'Paused') {
+            return {
+                status: 'Paused',
+                tagType: 'default',
+            }
+        }
+
+        if (schema.status === 'Cancelled') {
+            return {
+                status: 'Cancelled',
+                tagType: 'default',
             }
         }
 
@@ -80,6 +104,19 @@ export const SyncProgressStep = (): JSX.Element => {
             render: function RenderStatus(_, schema) {
                 const { status, tagType } = getSyncStatus(schema)
 
+                if (tagType === 'danger' && schema.latest_error) {
+                    return (
+                        <Tooltip title={schema.latest_error}>
+                            <span className="inline-flex items-center gap-1">
+                                <LemonTag type={tagType}>
+                                    <IconWarning className="mr-1" />
+                                    {status}
+                                </LemonTag>
+                            </span>
+                        </Tooltip>
+                    )
+                }
+
                 return <LemonTag type={tagType}>{status}</LemonTag>
             },
         },
@@ -108,6 +145,11 @@ export const SyncProgressStep = (): JSX.Element => {
         })
     }
 
+    const schemasWithErrors = schemas.filter(
+        (schema) =>
+            schema.should_sync && schema.status !== 'Running' && schema.status !== 'Completed' && schema.latest_error
+    )
+
     return (
         <SceneSection
             title={
@@ -116,6 +158,19 @@ export const SyncProgressStep = (): JSX.Element => {
                     : "You're all set! We'll import the data in the background, and after it's done, you will be able to query it in PostHog."
             }
         >
+            {schemasWithErrors.length > 0 && (
+                <LemonBanner type="warning" className="mb-4">
+                    <p className="font-semibold mb-1">
+                        {schemasWithErrors.length === 1
+                            ? '1 table failed to sync'
+                            : `${schemasWithErrors.length} tables failed to sync`}
+                    </p>
+                    <p className="text-sm">
+                        Syncs will be retried automatically. You can continue setup — the remaining tables will keep
+                        syncing in the background. Hover over the error status for details.
+                    </p>
+                </LemonBanner>
+            )}
             <LemonTable
                 emptyState="No schemas selected"
                 dataSource={schemas}


### PR DESCRIPTION
## Problem

During onboarding, the data warehouse sync progress step shows tables as "Error" when they haven't started syncing yet. The `status` field is optional — when undefined, it falls through all checks and hits the error fallback. Users also get no details when a table genuinely fails.

## Changes

- Treat undefined/null status as "Syncing..." instead of falling through to "Error"
- Explicitly handle `Paused` and `Cancelled` statuses so only `Failed` shows as error
- Show a warning banner when tables have genuine sync errors
- Add a tooltip with `latest_error` details on error status tags

## ![Screenshot 2026-04-10 at 16.55.34.png](https://app.graphite.com/user-attachments/assets/1f8a2848-07e6-4db2-88cd-a0fdd289a424.png)



## How did you test this code?

Tested locally by connecting a Postgres source through the onboarding flow. Verified that tables with no status show "Syncing..." and that hardcoded error states render the banner and tooltip correctly.

## Publish to changelog?

no

## 🤖 LLM context

Co-authored with Claude Code.