### PR TITLE
feat(stripe-app): add custom action to trigger posthog workflows

### DIFF
--- a/posthog/api/test/test_integration.py
+++ b/posthog/api/test/test_integration.py
@@ -1057,6 +1057,13 @@ class TestStripeIntegrationOAuthTokens:
 
         calls = mock_client.apps.secrets.create.call_args_list
         assert len(calls) == 3
+        names = {call.kwargs["params"]["name"] for call in calls}
+        assert names == {"posthog_region", "posthog_access_token", "posthog_refresh_token"}
+        # The access token is stored as the full Authorization header value so
+        # the Stripe Scripts egress can inject it verbatim for the Custom
+        # Workflow Action extension.
+        access_token_call = next(call for call in calls if call.kwargs["params"]["name"] == "posthog_access_token")
+        assert access_token_call.kwargs["params"]["payload"].startswith("Bearer ")
         for call in calls:
             assert call.kwargs["params"]["scope"] == {"type": "account"}
             assert call.kwargs["options"] == {"stripe_account": "acct_456"}
@@ -1082,6 +1089,8 @@ class TestStripeIntegrationOAuthTokens:
 
         calls = mock_client.apps.secrets.delete_where.call_args_list
         assert len(calls) == 3
+        names = {call.kwargs["params"]["name"] for call in calls}
+        assert names == {"posthog_region", "posthog_access_token", "posthog_refresh_token"}
         for call in calls:
             assert call.kwargs["params"]["scope"] == {"type": "account"}
             assert call.kwargs["options"] == {"stripe_account": "acct_789"}

--- a/posthog/models/integration.py
+++ b/posthog/models/integration.py
@@ -3064,9 +3064,14 @@ class StripeIntegration:
 
         region = get_instance_region() or "us"
 
+        # `posthog_access_token` stores the full "Bearer <token>" Authorization
+        # header value. The Stripe Scripts egress system (used by the Custom
+        # Workflow Action extension) injects secret payloads verbatim as header
+        # values, with no "Bearer " template. The UI-extension Stripe app side
+        # strips the prefix on load so the Node client sees the raw token.
         secrets = {
             "posthog_region": region.lower(),
-            "posthog_access_token": access_token_value,
+            "posthog_access_token": f"Bearer {access_token_value}",
             "posthog_refresh_token": refresh_token_value,
         }
 

--- a/posthog/models/resource_transfer/test/__snapshots__/test_visitor_field_snapshots.ambr
+++ b/posthog/models/resource_transfer/test/__snapshots__/test_visitor_field_snapshots.ambr
@@ -451,7 +451,6 @@
   list([
     'DoesNotExist',
     'MultipleObjectsReturned',
-    '__annotations__',
     '__doc__',
     '__module__',
     '__repr__',

--- a/products/workflows/backend/test/test_stripe_app_oauth.py
+++ b/products/workflows/backend/test/test_stripe_app_oauth.py
@@ -1,0 +1,179 @@
+import json
+from datetime import timedelta
+
+from posthog.test.base import APIBaseTest
+
+from django.conf import settings
+from django.test import override_settings
+from django.utils import timezone
+
+from rest_framework import status
+
+from posthog.api.oauth.test_dcr import generate_rsa_key
+from posthog.models.hog_flow.hog_flow import HogFlow
+from posthog.models.integration import StripeIntegration
+from posthog.models.oauth import OAuthAccessToken, OAuthApplication
+from posthog.models.utils import generate_random_oauth_access_token
+
+WEBHOOK_TRIGGER_ACTION = {
+    "id": "trigger_node",
+    "name": "trigger_1",
+    "type": "trigger",
+    "config": {"type": "webhook"},
+}
+
+EVENT_TRIGGER_ACTION = {
+    "id": "trigger_node",
+    "name": "trigger_1",
+    "type": "trigger",
+    "config": {"type": "event"},
+}
+
+
+@override_settings(
+    OAUTH2_PROVIDER={
+        **settings.OAUTH2_PROVIDER,
+        "OIDC_RSA_PRIVATE_KEY": generate_rsa_key(),
+    }
+)
+class TestStripeAppOAuthWorkflowAccess(APIBaseTest):
+    """
+    The PostHog Stripe app's Trigger PostHog Workflow custom action lists hog
+    flows via the Django API and fires them via the public webhook. This test
+    guards the Django-side prerequisites: the OAuth token minted for the Stripe
+    app (using the exact StripeIntegration.SCOPES string) must be able to list
+    webhook-triggered workflows and retrieve a workflow with its variables so
+    the extension can render a dynamic form.
+
+    The public webhook endpoint itself is served by the CDP API in Node.js and
+    is covered by that service's own tests — we do not re-test dispatch here.
+    """
+
+    def setUp(self):
+        super().setUp()
+
+        self.webhook_flow = HogFlow.objects.create(
+            team=self.team,
+            name="Webhook flow",
+            status=HogFlow.State.ACTIVE,
+            trigger={"type": "webhook"},
+            actions=[WEBHOOK_TRIGGER_ACTION],
+            edges=[],
+            variables=[{"key": "customer_email", "default": ""}],
+        )
+        self.event_flow = HogFlow.objects.create(
+            team=self.team,
+            name="Event flow",
+            status=HogFlow.State.ACTIVE,
+            trigger={"type": "event"},
+            actions=[EVENT_TRIGGER_ACTION],
+            edges=[],
+        )
+
+        oauth_app = OAuthApplication.objects.create(
+            name="PostHog Stripe App (test)",
+            client_type=OAuthApplication.CLIENT_CONFIDENTIAL,
+            authorization_grant_type=OAuthApplication.GRANT_AUTHORIZATION_CODE,
+            redirect_uris="https://localhost",
+            algorithm="RS256",
+            organization=self.organization,
+            user=self.user,
+        )
+        self.access_token_value = generate_random_oauth_access_token(None)
+        OAuthAccessToken.objects.create(
+            application=oauth_app,
+            token=self.access_token_value,
+            user=self.user,
+            expires=timezone.now() + timedelta(hours=1),
+            scope=StripeIntegration.SCOPES,
+            scoped_teams=[self.team.id],
+        )
+
+        # Drop the session auth that APIBaseTest sets up so we exercise the OAuth path.
+        self.client.logout()
+
+    def _auth_headers(self):
+        return {"HTTP_AUTHORIZATION": f"Bearer {self.access_token_value}"}
+
+    def test_stripe_integration_scopes_include_hog_flow_read(self):
+        # Guard against a future refactor that trims StripeIntegration.SCOPES.
+        # Both scopes are currently granted and both are used by the Stripe app.
+        assert "hog_flow:read" in StripeIntegration.SCOPES
+        assert "hog_flow:write" in StripeIntegration.SCOPES
+
+    def test_token_lists_webhook_triggered_workflows(self):
+        response = self.client.get(
+            f"/api/projects/{self.team.id}/hog_flows/?trigger={json.dumps({'type': 'webhook'})}",
+            **self._auth_headers(),
+        )
+        assert response.status_code == status.HTTP_200_OK, response.content
+        ids = [w["id"] for w in response.json()["results"]]
+        assert str(self.webhook_flow.id) in ids
+        assert str(self.event_flow.id) not in ids
+
+    def test_token_lists_all_workflows_without_filter(self):
+        response = self.client.get(
+            f"/api/projects/{self.team.id}/hog_flows/",
+            **self._auth_headers(),
+        )
+        assert response.status_code == status.HTTP_200_OK, response.content
+        ids = [w["id"] for w in response.json()["results"]]
+        assert str(self.webhook_flow.id) in ids
+        assert str(self.event_flow.id) in ids
+
+    def test_token_retrieves_workflow_with_variables(self):
+        response = self.client.get(
+            f"/api/projects/{self.team.id}/hog_flows/{self.webhook_flow.id}/",
+            **self._auth_headers(),
+        )
+        assert response.status_code == status.HTTP_200_OK, response.content
+        body = response.json()
+        assert body["id"] == str(self.webhook_flow.id)
+        # Drives the dynamic_schema the extension builds in get_form_state.
+        assert any(v.get("key") == "customer_email" for v in body["variables"])
+
+    def test_list_response_follows_limit_offset_pagination_shape(self):
+        # The extension paginates by following response.next until it's null,
+        # so the response must use LimitOffsetPagination (default at
+        # posthog/settings/web.py). Lock down the shape.
+        response = self.client.get(
+            f"/api/projects/{self.team.id}/hog_flows/?limit=1",
+            **self._auth_headers(),
+        )
+        assert response.status_code == status.HTTP_200_OK, response.content
+        body = response.json()
+        assert "count" in body
+        assert "next" in body
+        assert "previous" in body
+        assert "results" in body
+        assert len(body["results"]) == 1
+
+    def test_token_without_hog_flow_scope_cannot_list(self):
+        # Negative: a token with the same shape but no hog_flow scope must be rejected.
+        # This isolates the dependency on hog_flow:read in the Stripe scope string.
+        oauth_app = OAuthApplication.objects.create(
+            name="Narrower App",
+            client_type=OAuthApplication.CLIENT_CONFIDENTIAL,
+            authorization_grant_type=OAuthApplication.GRANT_AUTHORIZATION_CODE,
+            redirect_uris="https://localhost",
+            algorithm="RS256",
+            organization=self.organization,
+            user=self.user,
+        )
+        narrow_token = generate_random_oauth_access_token(None)
+        OAuthAccessToken.objects.create(
+            application=oauth_app,
+            token=narrow_token,
+            user=self.user,
+            expires=timezone.now() + timedelta(hours=1),
+            scope="project:read",
+            scoped_teams=[self.team.id],
+        )
+        response = self.client.get(
+            f"/api/projects/{self.team.id}/hog_flows/",
+            HTTP_AUTHORIZATION=f"Bearer {narrow_token}",
+        )
+        assert response.status_code in (
+            status.HTTP_401_UNAUTHORIZED,
+            status.HTTP_403_FORBIDDEN,
+        ), response.content

--- a/services/stripe-app/README.md
+++ b/services/stripe-app/README.md
@@ -27,11 +27,18 @@ Connecting PostHog to Stripe requires **two** OAuth exchanges in sequence:
 
 The three secrets stored in Stripe are:
 
-| Secret name             | Value                 |
-| ----------------------- | --------------------- |
-| `posthog_region`        | `us` or `eu`          |
-| `posthog_access_token`  | PostHog OAuth token   |
-| `posthog_refresh_token` | PostHog OAuth refresh |
+| Secret name             | Value                          |
+| ----------------------- | ------------------------------ |
+| `posthog_region`        | `us` or `eu`                   |
+| `posthog_access_token`  | `Bearer` + PostHog OAuth token |
+| `posthog_refresh_token` | PostHog OAuth refresh          |
+
+`posthog_access_token` stores the full HTTP `Authorization` header value
+(`Bearer <token>`). The Stripe Scripts egress used by the Custom Workflow
+Action extension (`extensions/trigger_workflow/`) injects secret payloads
+verbatim as header values, with no `Bearer` template — so we persist the
+full header string. The UI-extension code in `src/posthog/auth.ts` strips the
+prefix on load so the rest of the Node client sees the raw token.
 
 ### PostHog backend
 
@@ -49,11 +56,22 @@ Key files:
 - `src/components/PostHogConnect.tsx` — connection status UI + dev-mode token entry
 - `src/views/` — Stripe Dashboard view entry points (Home, Settings, Onboarding)
 - `src/constants.ts` — typed access to manifest constants (PostHog URLs)
+- `extensions/trigger_workflow/` — Stripe Workflows Custom Action that fires a PostHog workflow
+  (Script implementation calling the public webhook URL)
 
 ### Manifest files
 
-- `stripe-app.json` — production manifest: PostHog URLs, permissions, CSP
-- `stripe-app.dev.json` — extends the production manifest, overrides URLs to `localhost:8010`
+- `stripe-app.json` — production manifest: PostHog URLs, permissions, CSP.
+- `stripe-app.dev.json` — extends the production manifest, overrides URLs to `localhost:8010`.
+- `stripe-app.yaml` — Manifest v2 entry that holds only the
+  Stripe Workflows `extensions:` block. Per the Stripe Extensions private
+  preview spec, the v2 YAML coexists with `stripe-app.json` rather than
+  replacing it.
+
+Manifest v2 requires the Stripe CLI apps plugin v1.15.5 or later. The `APP_MANIFEST_VERSION_TWO=true`
+environment variable is already baked into the `dev` and `upload`
+scripts in `package.json`, so nothing extra is needed when running them
+via `pnpm --filter=@posthog/stripe dev` / `pnpm --filter=@posthog/stripe upload`.
 
 ## Development
 
@@ -74,7 +92,7 @@ hogli start:stripe:app
 pnpm --filter=@posthog/stripe dev
 ```
 
-This runs `stripe apps start --manifest stripe-app.dev.json`,
+This runs `APP_MANIFEST_VERSION_TWO=true stripe apps start --manifest stripe-app.dev.json`,
 which serves the app UI inside the Stripe Dashboard in test mode.
 
 ### Connecting to PostHog locally

--- a/services/stripe-app/extensions/trigger_workflow/src/custom_input.schema.json
+++ b/services/stripe-app/extensions/trigger_workflow/src/custom_input.schema.json
@@ -1,0 +1,18 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "properties": {
+        "workflow_id": {
+            "type": "string",
+            "title": "PostHog workflow",
+            "description": "Only workflows with a webhook trigger are shown"
+        },
+        "variables": {
+            "type": "object",
+            "title": "Workflow variables",
+            "description": "Values for the selected workflow's declared variables"
+        }
+    },
+    "required": ["workflow_id"],
+    "additionalProperties": false
+}

--- a/services/stripe-app/extensions/trigger_workflow/src/custom_input.ui.schema.json
+++ b/services/stripe-app/extensions/trigger_workflow/src/custom_input.ui.schema.json
@@ -1,0 +1,19 @@
+{
+    "type": "VerticalLayout",
+    "elements": [
+        {
+            "type": "Control",
+            "scope": "#/properties/workflow_id",
+            "options": {
+                "format": "dynamic_select"
+            }
+        },
+        {
+            "type": "Control",
+            "scope": "#/properties/variables",
+            "options": {
+                "format": "dynamic_schema"
+            }
+        }
+    ]
+}

--- a/services/stripe-app/extensions/trigger_workflow/src/index.ts
+++ b/services/stripe-app/extensions/trigger_workflow/src/index.ts
@@ -1,0 +1,350 @@
+// Stripe Workflows Custom Action: trigger a PostHog workflow.
+//
+// This extension implements the `core.workflows.custom_action` interface as a
+// Script (TypeScript running in Stripe's sandbox). It uses the PostHog OAuth
+// access token that the main app writes to the Stripe Apps Secret Store: the
+// egress system injects `Authorization: <posthog_access_token>` (which is
+// already stored as "Bearer <token>") on calls to the declared PostHog API
+// endpoints. Triggering a workflow uses the unauthenticated public webhook URL
+// served by the CDP API service.
+//
+// Region detection: the script sandbox can't read the `posthog_region` secret
+// directly — secrets only flow in via endpoint auth-header injection. Instead
+// we probe US first and fall back to EU on 401/403 for authenticated calls,
+// and on 404 for the public webhook (the webhook id is a UUID that only exists
+// in one region's database). This costs one extra request for EU merchants per
+// invocation — acceptable for an interactive Stripe action.
+//
+// TODO: resolve the US/EU split at the PostHog ingress. There's an in-flight
+// effort to route a single `posthog.com` host based on an `X-PostHog-Region`
+// header set at the edge. Once that ships, we can collapse `posthog_api_us`
+// and `posthog_api_eu` into a single declared endpoint and drop the probing
+// fallback — provided Stripe Scripts lets us inject the region header
+// alongside the Authorization header on that endpoint. If the ingress ends up
+// inferring the region from the bearer token itself (since each token is
+// team-scoped and teams live in exactly one region), we don't even need the
+// second header and this file just talks to one host.
+//
+// The `@stripe/apps-extensibility-sdk/extensions-prototype` package is in
+// private preview. Until it's installed, we define local interfaces that match
+// the shape from STRIPE-WORKFLOWS.md.
+
+interface ExecuteCustomActionRequest {
+    customInput?: Record<string, unknown>
+}
+
+interface ExecuteCustomActionResponse {
+    [key: string]: unknown
+}
+
+interface GetFormStateRequest {
+    values: Record<string, unknown>
+    changedField: string | null
+}
+
+interface FieldConfig {
+    options?: Array<{ value: string; label: string }>
+    schema?: JSONSchemaObject | null
+    disabled?: boolean
+    hidden?: boolean
+    warning?: string
+    error?: string
+}
+
+interface GetFormStateResponse {
+    values?: Record<string, unknown>
+    config: Record<string, FieldConfig>
+}
+
+interface JSONSchemaObject {
+    type: 'object'
+    properties: Record<string, JSONSchemaProperty>
+}
+
+interface JSONSchemaProperty {
+    type: 'string'
+    title?: string
+    description?: string
+    default?: string
+}
+
+interface HogFlow {
+    id: string
+    name: string
+    variables?: Array<Record<string, string>>
+}
+
+interface PaginatedResponse<T> {
+    count: number
+    next: string | null
+    previous: string | null
+    results: T[]
+}
+
+class PostHogApiError extends Error {
+    status: number
+
+    constructor(message: string, status: number) {
+        super(message)
+        this.name = 'PostHogApiError'
+        this.status = status
+    }
+}
+
+type Region = 'us' | 'eu'
+
+const REGIONS: readonly Region[] = ['us', 'eu']
+
+const POSTHOG_API_HOSTS: Record<Region, string> = {
+    us: 'https://us.posthog.com',
+    eu: 'https://eu.posthog.com',
+}
+
+const POSTHOG_WEBHOOK_HOSTS: Record<Region, string> = {
+    us: 'https://webhooks.us.posthog.com',
+    eu: 'https://webhooks.eu.posthog.com',
+}
+
+const PAGINATION_PAGE_SIZE = 200
+// Hard cap on pagination iterations. 50 pages * 200 items = 10,000 workflows —
+// well beyond any realistic merchant, and a safeguard against a malformed
+// `next` link spinning forever inside `get_form_state`.
+const MAX_PAGINATION_PAGES = 50
+
+function apiHost(region: Region): string {
+    return POSTHOG_API_HOSTS[region]
+}
+
+function webhookHost(region: Region): string {
+    return POSTHOG_WEBHOOK_HOSTS[region]
+}
+
+async function fetchJson<T>(url: string): Promise<T> {
+    const response = await fetch(url)
+    if (!response.ok) {
+        const body = await response.text().catch(() => '<unreadable>')
+        throw new PostHogApiError(`PostHog request to ${url} failed (${response.status}): ${body}`, response.status)
+    }
+    return (await response.json()) as T
+}
+
+function isAuthError(error: unknown): boolean {
+    return error instanceof PostHogApiError && (error.status === 401 || error.status === 403)
+}
+
+function isNotFoundError(error: unknown): boolean {
+    return error instanceof PostHogApiError && error.status === 404
+}
+
+// Try `operation` against each region in turn, returning the first success
+// and remembering which region worked. Auth errors (401/403) on an API call
+// mean the token isn't valid for that region, so we advance; any other error
+// bubbles up.
+async function probeRegions<T>(operation: (region: Region) => Promise<T>): Promise<{ region: Region; value: T }> {
+    let lastError: unknown
+    for (const region of REGIONS) {
+        try {
+            const value = await operation(region)
+            return { region, value }
+        } catch (error) {
+            lastError = error
+            if (isAuthError(error)) {
+                continue
+            }
+            throw error
+        }
+    }
+    throw lastError ?? new PostHogApiError('All PostHog regions rejected the request', 401)
+}
+
+async function listWebhookWorkflows(region: Region): Promise<HogFlow[]> {
+    const triggerFilter = encodeURIComponent(JSON.stringify({ type: 'webhook' }))
+    let nextUrl: string | null =
+        `${apiHost(region)}/api/projects/@current/hog_flows/?trigger=${triggerFilter}&limit=${PAGINATION_PAGE_SIZE}`
+
+    const all: HogFlow[] = []
+    for (let page = 0; page < MAX_PAGINATION_PAGES && nextUrl !== null; page++) {
+        const data: PaginatedResponse<HogFlow> = await fetchJson<PaginatedResponse<HogFlow>>(nextUrl)
+        all.push(...data.results)
+        nextUrl = data.next
+    }
+    return all
+}
+
+async function retrieveWorkflow(region: Region, workflowId: string): Promise<HogFlow | null> {
+    try {
+        return await fetchJson<HogFlow>(`${apiHost(region)}/api/projects/@current/hog_flows/${workflowId}/`)
+    } catch (error) {
+        if (isNotFoundError(error)) {
+            return null
+        }
+        throw error
+    }
+}
+
+function buildVariablesSchema(workflow: HogFlow | null): JSONSchemaObject | null {
+    const variables = workflow?.variables
+    if (!variables || variables.length === 0) {
+        return null
+    }
+
+    const properties: Record<string, JSONSchemaProperty> = {}
+    for (const variable of variables) {
+        const key = variable['key']
+        if (!key) {
+            continue
+        }
+        const property: JSONSchemaProperty = { type: 'string' }
+        property.title = variable['label'] ?? key
+        if (variable['description']) {
+            property.description = variable['description']
+        }
+        if (variable['default']) {
+            property.default = variable['default']
+        }
+        properties[key] = property
+    }
+
+    return { type: 'object', properties }
+}
+
+function pruneVariablesToSchema(
+    previous: Record<string, unknown> | undefined,
+    schema: JSONSchemaObject | null
+): Record<string, unknown> {
+    if (!schema || !previous) {
+        return {}
+    }
+    const validKeys = new Set(Object.keys(schema.properties))
+    const pruned: Record<string, unknown> = {}
+    for (const [key, value] of Object.entries(previous)) {
+        if (validKeys.has(key)) {
+            pruned[key] = value
+        }
+    }
+    return pruned
+}
+
+function reconnectErrorMessage(): string {
+    return 'PostHog connection expired — reopen the PostHog app in Stripe to reconnect.'
+}
+
+async function getFormState(_config: unknown, request: GetFormStateRequest): Promise<GetFormStateResponse> {
+    const values: Record<string, unknown> = { ...request.values }
+
+    let workflowsByRegion: { region: Region; value: HogFlow[] }
+    try {
+        workflowsByRegion = await probeRegions(listWebhookWorkflows)
+    } catch (error) {
+        return {
+            values,
+            config: {
+                workflow_id: {
+                    options: [],
+                    error: isAuthError(error) ? reconnectErrorMessage() : 'Failed to list PostHog workflows.',
+                },
+                variables: { hidden: true },
+            },
+        }
+    }
+
+    const { region, value: workflows } = workflowsByRegion
+    const workflowOptions = workflows.map((w) => ({ value: w.id, label: w.name || w.id }))
+
+    const selectedWorkflowId = typeof values.workflow_id === 'string' ? values.workflow_id : null
+    const selectedIsKnown = !selectedWorkflowId || workflowOptions.some((option) => option.value === selectedWorkflowId)
+
+    let variablesSchema: JSONSchemaObject | null = null
+    let variablesError: string | undefined
+    if (selectedWorkflowId) {
+        try {
+            const workflow = await retrieveWorkflow(region, selectedWorkflowId)
+            variablesSchema = buildVariablesSchema(workflow)
+        } catch (error) {
+            if (isAuthError(error)) {
+                variablesError = reconnectErrorMessage()
+            } else if (error instanceof PostHogApiError) {
+                variablesError = `Failed to load workflow variables (${error.status}).`
+            } else {
+                variablesError = 'Failed to load workflow variables.'
+            }
+        }
+    }
+
+    // Prune saved variable keys that no longer exist in the selected workflow.
+    if (request.changedField === 'workflow_id') {
+        values.variables = pruneVariablesToSchema(
+            values.variables as Record<string, unknown> | undefined,
+            variablesSchema
+        )
+    }
+
+    const workflowIdConfig: FieldConfig = { options: workflowOptions }
+    if (!selectedIsKnown) {
+        workflowIdConfig.warning = 'This workflow no longer exists in PostHog.'
+    }
+
+    const variablesConfig: FieldConfig = {
+        schema: variablesSchema,
+        hidden: variablesSchema === null,
+    }
+    if (variablesError) {
+        variablesConfig.error = variablesError
+    }
+
+    return {
+        values,
+        config: {
+            workflow_id: workflowIdConfig,
+            variables: variablesConfig,
+        },
+    }
+}
+
+async function postWebhook(region: Region, workflowId: string, body: string): Promise<Response> {
+    return fetch(`${webhookHost(region)}/public/webhooks/${workflowId}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body,
+    })
+}
+
+async function execute(_config: unknown, request: ExecuteCustomActionRequest): Promise<ExecuteCustomActionResponse> {
+    const input = (request.customInput ?? {}) as Record<string, unknown>
+    const workflowId = input.workflow_id
+    const variables = (input.variables as Record<string, unknown> | undefined) ?? {}
+
+    if (typeof workflowId !== 'string' || workflowId.length === 0) {
+        // 4xx-style permanent failure — no retry (spec §Runtime).
+        throw new PostHogApiError('Missing workflow_id in custom action input', 400)
+    }
+
+    // The public webhook is unauthenticated, so we can't use 401 to detect
+    // region. Instead, try US first and fall back to EU on 404 — a given
+    // workflow id exists in exactly one region's database.
+    const body = JSON.stringify(variables)
+    let lastResponse: Response | null = null
+    for (const region of REGIONS) {
+        const response = await postWebhook(region, workflowId, body)
+        if (response.ok) {
+            return {}
+        }
+        lastResponse = response
+        if (response.status !== 404) {
+            break
+        }
+    }
+
+    // Surface the terminal failure so Stripe Workflows can retry on 5xx and
+    // short-circuit on 4xx per STRIPE-WORKFLOWS.md §Runtime.
+    const status = lastResponse?.status ?? 500
+    const errorBody = lastResponse ? await lastResponse.text().catch(() => '<unreadable>') : 'no response'
+    throw new PostHogApiError(`PostHog webhook for workflow ${workflowId} returned ${status}: ${errorBody}`, status)
+}
+
+const customAction = {
+    execute,
+    getFormState,
+}
+
+export default customAction

--- a/services/stripe-app/package.json
+++ b/services/stripe-app/package.json
@@ -4,8 +4,8 @@
     "description": "PostHog Stripe app",
     "license": "MIT",
     "scripts": {
-        "dev": "stripe apps start --manifest stripe-app.dev.json",
-        "upload": "npm install --package-lock-only && stripe apps upload",
+        "dev": "APP_MANIFEST_VERSION_TWO=true stripe apps start --manifest stripe-app.dev.json",
+        "upload": "npm install --package-lock-only && APP_MANIFEST_VERSION_TWO=true stripe apps upload",
         "test": "jest --passWithNoTests"
     },
     "dependencies": {

--- a/services/stripe-app/src/components/PostHogConnect.tsx
+++ b/services/stripe-app/src/components/PostHogConnect.tsx
@@ -125,7 +125,13 @@ const DevTokenEntry = ({ onSaved }: { onSaved: () => void }): JSX.Element => {
         setSaving(true)
         setError(null)
         try {
-            await saveCredentials(stripe, { region, accessToken, refreshToken })
+            // The dev command prints raw tokens; the rest of the app treats
+            // `accessToken` as the full Authorization header value.
+            await saveCredentials(stripe, {
+                region,
+                accessToken: `Bearer ${accessToken}`,
+                refreshToken,
+            })
             setAccessToken('')
             setRefreshToken('')
             onSaved()

--- a/services/stripe-app/src/posthog/auth.ts
+++ b/services/stripe-app/src/posthog/auth.ts
@@ -5,7 +5,14 @@ import { logger } from '../logger'
 
 export type Region = 'us' | 'eu'
 
-// Keep in sync with the secret names defined in posthog/models/integration.py
+// Keep in sync with the secret names written by the PostHog backend's Stripe
+// integration OAuth callback.
+//
+// NOTE: `posthog_access_token` stores the full HTTP Authorization header
+// value ("Bearer <token>") so the Stripe Scripts egress system can inject it
+// verbatim on calls from the Custom Workflow Action extension — the egress
+// has no template for prefixing header values. The app uses the same prefixed
+// form in memory, so no transformation happens at the storage boundary.
 export const SECRET_NAMES = {
     region: 'posthog_region',
     accessToken: 'posthog_access_token',
@@ -14,6 +21,7 @@ export const SECRET_NAMES = {
 
 export interface StoredCredentials {
     region: Region
+    /** Full HTTP Authorization header value, e.g. "Bearer pha_..." */
     accessToken: string
     refreshToken: string
 }
@@ -69,7 +77,11 @@ export async function saveCredentials(stripe: Stripe, credentials: StoredCredent
     try {
         await Promise.all([
             stripe.apps.secrets.create({ name: SECRET_NAMES.region, payload: credentials.region, scope }),
-            stripe.apps.secrets.create({ name: SECRET_NAMES.accessToken, payload: credentials.accessToken, scope }),
+            stripe.apps.secrets.create({
+                name: SECRET_NAMES.accessToken,
+                payload: credentials.accessToken,
+                scope,
+            }),
             stripe.apps.secrets.create({
                 name: SECRET_NAMES.refreshToken,
                 payload: credentials.refreshToken,

--- a/services/stripe-app/src/posthog/client.ts
+++ b/services/stripe-app/src/posthog/client.ts
@@ -5,6 +5,7 @@ import { saveCredentials } from './auth'
 export class PostHogClient {
     private baseUrl: string
     private clientId: string
+    /** Full HTTP Authorization header value, e.g. "Bearer pha_..." */
     private accessToken: string
     private refreshToken: string
     private stripe: Stripe
@@ -46,7 +47,10 @@ export class PostHogClient {
             throw new Error('Token refresh response missing access_token')
         }
 
-        this.accessToken = tokenData.access_token
+        // The OAuth server hands us the raw token; everywhere else in the app
+        // treats `accessToken` as the full Authorization header value, so we
+        // prepend once, here, at the boundary where it enters the system.
+        this.accessToken = `Bearer ${tokenData.access_token}`
         if (tokenData.refresh_token) {
             this.refreshToken = tokenData.refresh_token
         }
@@ -64,7 +68,7 @@ export class PostHogClient {
     async request(path: string, options?: RequestInit): Promise<Response> {
         const url = `${this.baseUrl}${path}`
         const headers = {
-            Authorization: `Bearer ${this.accessToken}`,
+            Authorization: this.accessToken,
             ...options?.headers,
         }
 
@@ -73,7 +77,7 @@ export class PostHogClient {
         // If we get a 401, try refreshing the token and retrying once
         if (response.status === 401) {
             await this.refreshAccessToken()
-            headers.Authorization = `Bearer ${this.accessToken}`
+            headers.Authorization = this.accessToken
             response = await fetch(url, { ...options, headers })
         }
 

--- a/services/stripe-app/stripe-app.yaml
+++ b/services/stripe-app/stripe-app.yaml
@@ -1,0 +1,61 @@
+id: com.posthog.stripe
+name: PostHog
+version: 1.0.0
+
+# During the private preview of Stripe Extensions, the v2 YAML manifest lives
+# alongside stripe-app.json and only holds the `extensions:` block. All other
+# manifest fields (declarations, permissions, provisioning, ui_extension,
+# constants, allowed_redirect_uris, etc.) stay in stripe-app.json.
+
+extensions:
+    - id: trigger_workflow
+      name: Trigger PostHog workflow
+      interface_id: core.workflows.custom_action
+      version: 0.0.1
+
+      script:
+          type: typescript
+          content: extensions/trigger_workflow/src/index.ts
+
+      endpoints:
+          - id: posthog_api_us
+            type: custom_http
+            live:
+                url: https://us.posthog.com
+                purpose: List and retrieve PostHog workflows so the merchant can configure the action (US region)
+                auth:
+                    type: header
+                    header_name: Authorization
+                    secret_name: posthog_access_token
+          - id: posthog_api_eu
+            type: custom_http
+            live:
+                url: https://eu.posthog.com
+                purpose: List and retrieve PostHog workflows so the merchant can configure the action (EU region)
+                auth:
+                    type: header
+                    header_name: Authorization
+                    secret_name: posthog_access_token
+          - id: posthog_webhook_us
+            type: custom_http
+            live:
+                url: https://webhooks.us.posthog.com
+                purpose: Fire the selected PostHog workflow via its public webhook (US region)
+          - id: posthog_webhook_eu
+            type: custom_http
+            live:
+                url: https://webhooks.eu.posthog.com
+                purpose: Fire the selected PostHog workflow via its public webhook (EU region)
+
+      methods:
+          execute:
+              implementation_type: script
+              custom_input:
+                  input_schema:
+                      type: json_schema
+                      content: extensions/trigger_workflow/src/custom_input.schema.json
+                  ui_schema:
+                      type: jsonforms
+                      content: extensions/trigger_workflow/src/custom_input.ui.schema.json
+          get_form_state:
+              implementation_type: script


### PR DESCRIPTION
## Problem

Stripe Workflows now supports Custom Actions via an "Extensions" mechanism:
third-party Stripe apps can expose configurable steps that merchants drop
into their own workflows.
This PR adds a Stripe Workflows Custom Action to the PostHog Stripe app that
fires a PostHog workflow (a HogFlow with a webhook trigger) when the Stripe
workflow executes.
The merchant picks which PostHog workflow to trigger from a dropdown and
fills in typed fields for each of its declared variables — the values flow
through as the HTTP POST body on the public webhook URL.

## Changes

New extension under `services/stripe-app/extensions/trigger_workflow/`,
implemented as a TypeScript Script running in Stripe's sandbox (no
PostHog-side infrastructure required).
Manifest v2 YAML holds only the `extensions:` block and coexists with the
existing `stripe-app.json` per the Stripe Extensions private preview spec.
`package.json` prefixes `APP_MANIFEST_VERSION_TWO=true` on the `dev` and
`upload` scripts so the new YAML is picked up automatically.

The extension implements two methods from `core.workflows.custom_action`:

* `get_form_state` — paginates the merchant's webhook-triggered workflows
  via the existing HogFlow listing endpoint, builds a JSONForms
  `dynamic_select` dropdown, then fetches the chosen workflow to build a
  `dynamic_schema` with one typed input per declared variable.
  Stale variable keys get pruned on workflow switch, deleted workflows
  surface a warning, and 401/403 on the API surfaces a "reconnect the
  PostHog app" error message.
* `execute` — POSTs the configured variables as JSON to the public webhook
  URL served by PostHog's CDP API.
  No auth needed — the webhook id already acts as a capability.

### Region handling

The Script sandbox can't read secrets directly — secrets only flow in via
endpoint auth-header injection.
To avoid polluting the data contract with a `region` field, the script
probes US first and falls back to EU on 401/403 for authenticated calls and
on 404 for the public webhook (the webhook id is a UUID that only exists in
one region's database).
A TODO comment in the script notes the in-flight work to collapse this via
an `X-PostHog-Region` header at the PostHog ingress, which would let us
drop the fallback entirely.

### Single secret format

The Stripe Scripts egress system injects secret payloads verbatim as header
values (no `Bearer ` template), so `posthog_access_token` now stores the
full `Authorization` header value `"Bearer <token>"` — in the secret
store, in memory, and on the wire.
This is a non-backwards-compatible change to the secret format.
The only transforms happen at the three places raw tokens enter the system:
the Django OAuth callback, the Node client's refresh-token flow, and the
dev-mode paste field.
Everywhere else, `accessToken` is treated as an opaque header-value string.
`clear_posthog_secrets`, the test mocks, and the README secret table are
updated to match.

### E2E guardrail

A new Django test at
`products/workflows/backend/test/test_stripe_app_oauth.py` mints an OAuth
token with the exact `StripeIntegration.SCOPES` string and asserts it can
list webhook-triggered workflows, retrieve a workflow with its variables,
paginate via DRF's `LimitOffsetPagination`, and that a narrower token
without `hog_flow:read` is rejected.
If somebody trims `StripeIntegration.SCOPES` later, the extension breaks
and this test catches it.

## How did you test this code?

I'm an agent and I have not run the extension inside a live Stripe sandbox —
the changes are covered by unit and integration tests only:

* `products/workflows/backend/test/test_stripe_app_oauth.py` — 6 new tests,
  all pass
* `posthog/api/test/test_integration.py::TestStripeIntegrationOAuthTokens`
  — updated for the 3-secret layout, all pass
* `pnpm --filter=@posthog/stripe exec tsc --noEmit` — clean on new and
  modified files (pre-existing React resolution errors in untouched view
  files remain)
* `ruff check` + `ruff format --check` on modified Python files — clean

Manual validation a reviewer should do before merging:

1. Upload the app via `pnpm run upload` from `services/stripe-app/` and
   confirm both the JSON and new YAML manifests are accepted together
2. Create a webhook-triggered workflow in PostHog with a couple of declared
   variables
3. In a Stripe sandbox, add the new "Trigger PostHog workflow" action to a
   workflow; confirm the dropdown lists only webhook-triggered flows and
   picking one renders typed inputs per variable
4. Fire the Stripe workflow and check that the PostHog workflow ran with the
   merchant-entered variable values
5. Disconnect/reconnect the app and confirm the new prefixed
   `posthog_access_token` secret is written correctly (existing installs
   will need to reconnect because the secret format changed)

## Publish to changelog?

no

## 🤖 LLM context

Authored by a Claude Code agent across several iterations:

* Initial Script pass cached region in `values.region`; reworked to a
  probe-and-fallback approach with no schema field after feedback on
  data-contract pollution.
* First version stored both a raw `posthog_access_token` and a prefixed
  `posthog_access_token_bearer`; collapsed to a single prefixed secret
  after feedback on redundant storage.
* Attempted a full manifest YAML migration at one point; reverted to the
  spec-compliant layout (JSON stays, YAML holds extensions only) after
  re-reading the private-preview spec semantics.
* `stripBearer`/`withBearer` helpers and the raw-vs-prefixed asymmetry
  were eliminated in favor of treating the access token as the full
  `Authorization` header value everywhere — storage format matches wire
  format, transforms live only at the three entry points for raw tokens.
* A proposal for extending the Stripe Extensions spec to support arbitrary
  parameter injection (OpenAPI-style `parameters` array with `in: header
  | query | path` and a tagged `value` union) is being discussed with
  Stripe out of band.