### PR TITLE
fix: sanitize CSV/XLSX export cell values to prevent formula injection

### DIFF
--- a/posthog/tasks/exports/csv_exporter.py
+++ b/posthog/tasks/exports/csv_exporter.py
@@ -48,6 +48,23 @@ RESULT_LIMIT_KEYS = ("distinct_ids",)
 RESULT_LIMIT_LENGTH = 10
 QUERY_PAGE_SIZE = 10000
 
+# Characters that can trigger formula execution in spreadsheet applications
+_FORMULA_TRIGGER_CHARS = ("=", "+", "-", "@", "\t", "\r")
+
+
+def _sanitize_formula_injection(value: Any) -> Any:
+    """Prefix dangerous cell values with a single quote to prevent formula injection.
+
+    Spreadsheet applications like Excel and Google Sheets interpret cells
+    starting with =, +, -, @, tab, or carriage return as formulas. Prefixing
+    with a single quote forces them to be treated as plain text.
+    """
+    if not isinstance(value, str):
+        return value
+    if value and value[0] in _FORMULA_TRIGGER_CHARS:
+        return f"'{value}"
+    return value
+
 
 def sanitize_value_for_excel(value: Any) -> Any:
     if not isinstance(value, str):
@@ -72,7 +89,7 @@ class CsvWriter(TabularWriter):
 
     def write_row(self, row: dict) -> None:
         assert self._writer is not None
-        self._writer.writerow(row)
+        self._writer.writerow({k: _sanitize_formula_injection(v) for k, v in row.items()})
 
     def finish(self) -> str:
         self._tmp.close()
@@ -103,6 +120,7 @@ class ExcelWriter(TabularWriter):
             value = row.get(col)
             if value is not None and not isinstance(value, str | int | float | bool):
                 value = str(value)
+            value = _sanitize_formula_injection(value)
             values.append(sanitize_value_for_excel(value))
         try:
             self._worksheet.append(values)


### PR DESCRIPTION
## Problem

Closes #54149

CSV and XLSX exports from PostHog do not sanitize cell values that begin with formula trigger characters (`=`, `+`, `-`, `@`, `\t`, `\r`). When users open these exported files in Excel or Google Sheets, injected formulas can execute arbitrary commands or exfiltrate data.

## Changes

Added a `_sanitize_formula_injection` helper that prefixes dangerous string values with a single quote (`'`), the standard spreadsheet formula injection mitigation. Applied it in both `CsvWriter.write_row` and `ExcelWriter.write_row` so all exported cell values are sanitized before being written.

## How did you test this code?

Verified the sanitization function correctly prefixes strings starting with each trigger character while leaving normal strings, numbers, and `None` values untouched. Confirmed both writer classes invoke the sanitization on every cell value.

## Publish to changelog?

No