### PR TITLE
fix(ingestion): catch asyncio.TimeoutError from asyncio.wait_for

### DIFF
--- a/posthog/temporal/ingestion_acceptance_test/activities.py
+++ b/posthog/temporal/ingestion_acceptance_test/activities.py
@@ -60,7 +60,7 @@ async def run_ingestion_acceptance_tests() -> dict:
             asyncio.to_thread(run_tests, config, tests, client, executor, running_tests),
             timeout=config.activity_timeout_seconds,
         )
-    except TimeoutError:
+    except asyncio.TimeoutError:
         still_running = running_tests.snapshot_with_polls(client)
         send_slack_timeout_notification(config, running_tests=still_running)
         raise


### PR DESCRIPTION
## Problem

`asyncio.wait_for` raises `asyncio.TimeoutError`, but the code was catching the built-in `TimeoutError`.

This causes the timeout handling block to be skipped, meaning Slack timeout notifications and debugging information are not triggered when the activity exceeds its timeout.

## Changes

- Catch `asyncio.TimeoutError` instead of `TimeoutError` to correctly handle timeouts from `asyncio.wait_for`.

## How did you test this code?

- Verified that `asyncio.wait_for` raises `asyncio.TimeoutError`
- Confirmed that the updated exception handler correctly captures the timeout and executes the expected logic

## Publish to changelog?

no