### PR TITLE
fix(signals): lazily initialize tiktoken to avoid startup crash

### DIFF
--- a/products/signals/backend/api.py
+++ b/products/signals/backend/api.py
@@ -1,18 +1,14 @@
+import logging
 from datetime import timedelta
 
+import temporalio
+import tiktoken
 from django.conf import settings
 
-import logging
-
-import tiktoken
-import temporalio
-
-from posthog.schema import SignalInput
-
 from posthog.models import Team
+from posthog.schema import SignalInput
 from posthog.sync import database_sync_to_async
 from posthog.temporal.common.client import async_connect
-
 from products.signals.backend.models import SignalSourceConfig
 from products.signals.backend.temporal.buffer import BufferSignalsWorkflow
 from products.signals.backend.temporal.emitter import SignalEmitterInput, SignalEmitterWorkflow

--- a/products/signals/backend/api.py
+++ b/products/signals/backend/api.py
@@ -2,6 +2,8 @@ from datetime import timedelta
 
 from django.conf import settings
 
+import logging
+
 import tiktoken
 import temporalio
 
@@ -16,8 +18,21 @@ from products.signals.backend.temporal.buffer import BufferSignalsWorkflow
 from products.signals.backend.temporal.emitter import SignalEmitterInput, SignalEmitterWorkflow
 from products.signals.backend.temporal.types import BufferSignalsInput, EmitSignalInputs
 
+logger = logging.getLogger(__name__)
+
 MAX_SIGNAL_DESCRIPTION_TOKENS = 8000
-_tiktoken_encoding = tiktoken.get_encoding("cl100k_base")
+_tiktoken_encoding: tiktoken.Encoding | None = None
+
+
+def _get_tiktoken_encoding() -> tiktoken.Encoding | None:
+    global _tiktoken_encoding
+    if _tiktoken_encoding is None:
+        try:
+            _tiktoken_encoding = tiktoken.get_encoding("cl100k_base")
+        except Exception as e:
+            logger.warning(f"Failed to initialize tiktoken encoding: {e}")
+            return None
+    return _tiktoken_encoding
 
 
 async def emit_signal(
@@ -66,7 +81,12 @@ async def emit_signal(
     if not is_enabled:
         return
 
-    token_count = len(_tiktoken_encoding.encode(description))
+    enc = _get_tiktoken_encoding()
+    if enc is not None:
+        token_count = len(enc.encode(description))
+    else:
+        # Fallback: estimate ~4 chars per token
+        token_count = len(description) // 4
     if token_count > MAX_SIGNAL_DESCRIPTION_TOKENS:
         raise ValueError(
             f"Signal description exceeds {MAX_SIGNAL_DESCRIPTION_TOKENS} tokens ({token_count} tokens). "


### PR DESCRIPTION
## Problem

Celery beat crashes on startup in containers without writable temp directories. The error is a `FileNotFoundError: No usable temporary directory found in ['/tmp', '/var/tmp', '/usr/tmp', '/code']` raised during Django app initialization.

The root cause is that `tiktoken.get_encoding("cl100k_base")` runs at module level in `products/signals/backend/api.py` (line 20), which eagerly downloads and caches BPE token data via `tempfile.gettempdir()` at import time. In the celery beat container, no temp directory is writable, so the call fails before the app finishes starting.

## Changes

- Replace the module-level `tiktoken.get_encoding()` call with a lazy `_get_tiktoken_encoding()` helper that initializes on first use and caches the result
- Add a try/except with character-based fallback (~4 chars per token) when tiktoken can't initialize, matching the existing defensive pattern in `products/signals/backend/temporal/llm.py`

## How did you test this code?

This is an agent-authored PR. Manual testing was not performed. The change is minimal and follows the exact same defensive pattern already used in `temporal/llm.py:50-62`.

## Publish to changelog?

No

## Docs update

N/A

## 🤖 LLM context

Agent-authored fix based on error tracking signal. The crash was first observed 2026-04-11 in the celery beat container. The fix follows the existing defensive pattern in `products/signals/backend/temporal/llm.py`.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*