### PR TITLE
feat: collapse connected apps scopes with write-first accordion

### DIFF
--- a/frontend/src/scenes/settings/user/ConnectedApps.tsx
+++ b/frontend/src/scenes/settings/user/ConnectedApps.tsx
@@ -1,10 +1,60 @@
 import { useActions, useValues } from 'kea'
+import { useState } from 'react'
 
 import { LemonButton, LemonDialog, LemonTable, LemonTag } from '@posthog/lemon-ui'
 
+import { DetectiveHog } from 'lib/components/hedgehogs'
+import { IconKey } from 'lib/lemon-ui/icons'
 import { humanFriendlyDetailedTime } from 'lib/utils'
 
 import { connectedAppsLogic, ConnectedApp } from './connectedAppsLogic'
+
+function sortScopesWriteFirst(scopes: string[]): string[] {
+    return [...scopes].sort((a, b) => {
+        const aIsWrite = a.endsWith(':write')
+        const bIsWrite = b.endsWith(':write')
+        if (aIsWrite && !bIsWrite) {
+            return -1
+        }
+        if (!aIsWrite && bIsWrite) {
+            return 1
+        }
+        return 0
+    })
+}
+
+function ScopesAccordion({ scopes }: { scopes: string[] }): JSX.Element {
+    const [expanded, setExpanded] = useState(false)
+    const visibleCount = 3
+    const sorted = sortScopesWriteFirst(scopes)
+
+    if (sorted.length <= visibleCount) {
+        return (
+            <div className="flex flex-wrap gap-1">
+                {sorted.map((scope) => (
+                    <LemonTag key={scope} size="small" type={scope.endsWith(':write') ? 'caution' : 'default'}>
+                        {scope}
+                    </LemonTag>
+                ))}
+            </div>
+        )
+    }
+
+    const visible = expanded ? sorted : sorted.slice(0, visibleCount)
+
+    return (
+        <div className="flex flex-wrap gap-1">
+            {visible.map((scope) => (
+                <LemonTag key={scope} size="small" type={scope.endsWith(':write') ? 'caution' : 'default'}>
+                    {scope}
+                </LemonTag>
+            ))}
+            <LemonButton size="xsmall" type="secondary" onClick={() => setExpanded(!expanded)}>
+                {expanded ? 'Show less' : `+${sorted.length - visibleCount} more`}
+            </LemonButton>
+        </div>
+    )
+}
 
 export function ConnectedApps(): JSX.Element {
     const { connectedApps, connectedAppsLoading } = useValues(connectedAppsLogic)
@@ -66,13 +116,7 @@ export function ConnectedApps(): JSX.Element {
                     dataIndex: 'scopes',
                     render: (_, app) =>
                         app.scopes.length > 0 ? (
-                            <div className="flex flex-wrap gap-1">
-                                {app.scopes.map((scope) => (
-                                    <LemonTag key={scope} size="small">
-                                        {scope}
-                                    </LemonTag>
-                                ))}
-                            </div>
+                            <ScopesAccordion scopes={app.scopes} />
                         ) : (
                             <span className="text-muted">No scopes</span>
                         ),
@@ -91,7 +135,20 @@ export function ConnectedApps(): JSX.Element {
                     ),
                 },
             ]}
-            emptyState="No connected applications"
+            emptyState={
+                <div className="flex items-center gap-4 py-4">
+                    <DetectiveHog className="w-16 h-16" />
+                    <div>
+                        <div className="flex items-center gap-2 font-semibold">
+                            <IconKey className="text-xl text-secondary" />
+                            No connected applications
+                        </div>
+                        <p className="text-secondary mt-1 mb-0">
+                            Apps will appear here when third-party tools connect to your account.
+                        </p>
+                    </div>
+                </div>
+            }
         />
     )
 }

--- a/frontend/src/scenes/settings/user/ConnectedApps.tsx
+++ b/frontend/src/scenes/settings/user/ConnectedApps.tsx
@@ -27,20 +27,8 @@ function ScopesAccordion({ scopes }: { scopes: string[] }): JSX.Element {
     const [expanded, setExpanded] = useState(false)
     const visibleCount = 3
     const sorted = sortScopesWriteFirst(scopes)
-
-    if (sorted.length <= visibleCount) {
-        return (
-            <div className="flex flex-wrap gap-1">
-                {sorted.map((scope) => (
-                    <LemonTag key={scope} size="small" type={scope.endsWith(':write') ? 'caution' : 'default'}>
-                        {scope}
-                    </LemonTag>
-                ))}
-            </div>
-        )
-    }
-
-    const visible = expanded ? sorted : sorted.slice(0, visibleCount)
+    const needsAccordion = sorted.length > visibleCount
+    const visible = expanded || !needsAccordion ? sorted : sorted.slice(0, visibleCount)
 
     return (
         <div className="flex flex-wrap gap-1">
@@ -49,9 +37,11 @@ function ScopesAccordion({ scopes }: { scopes: string[] }): JSX.Element {
                     {scope}
                 </LemonTag>
             ))}
-            <LemonButton size="xsmall" type="secondary" onClick={() => setExpanded(!expanded)}>
-                {expanded ? 'Show less' : `+${sorted.length - visibleCount} more`}
-            </LemonButton>
+            {needsAccordion && (
+                <LemonButton size="xsmall" type="secondary" onClick={() => setExpanded(!expanded)}>
+                    {expanded ? 'Show less' : `+${sorted.length - visibleCount} more`}
+                </LemonButton>
+            )}
         </div>
     )
 }


### PR DESCRIPTION
## Problem

Rafael flagged that the scopes list on the Connected Applications page is overwhelming for MCP server connections, which require ~22 scopes. Every scope was rendered as its own flat tag, creating a wall of tags that's hard to scan.

Slack thread: https://posthog.slack.com/archives/C043VJ93L3B/p1775873289795049

## Changes

- **Write scopes sorted first**: The most important (riskiest) scopes - write permissions - are shown first with caution-colored tags so users immediately see what write access an app has
- **Accordion collapse**: Only the first 3 scopes are shown by default, with a "+N more" button to expand. Apps with 3 or fewer scopes show all tags with no toggle
- **Detective hog empty state**: Replaces the plain text empty state with the detective hedgehog illustration and friendly copy

<img width="1728" height="995" alt="image" src="https://github.com/user-attachments/assets/c61b58c6-1cbc-4fdf-85a9-2c1c403a50a2" />


https://github.com/user-attachments/assets/e3251fa3-0151-484d-8b3d-6e44abf17780


## How did you test this code?

This PR was authored by an agent. The design was reviewed across 5 candidate variants by multiple AI reviewers scoring on brand fit, information value, implementation simplicity, and PostHog UI consistency. The winning variant (write-scopes-first accordion) scored highest across all criteria.

Manual testing was not performed against the live dev server due to auth requirements. The component should be visually verified before merge.

## Publish to changelog?

No

## 🤖 LLM context

Authored by Claude Code. Reviewed 5 design variants with whimsical PostHog branding (hedgehog illustrations, playful empty states). The write-scopes-first approach was selected because it surfaces the riskiest permissions upfront rather than showing benign identity scopes (openid, profile, email) in the preview.