### PR TITLE
chore(insights): add trends click handler for hog-charts

### DIFF
--- a/frontend/src/scenes/trends/viz/datasetToActorsQuery.ts
+++ b/frontend/src/scenes/trends/viz/datasetToActorsQuery.ts
@@ -1,8 +1,13 @@
 import { InsightActorsQuery, NodeKind } from '~/queries/schema/schema-general'
 import { GraphDataset } from '~/types'
 
+type DatasetToActorsInput = Pick<
+    GraphDataset,
+    'action' | 'breakdown_value' | 'compare_label' | 'status' | 'breakdownValues' | 'compareLabels'
+>
+
 interface DatasetToActorsQueryProps {
-    dataset: GraphDataset
+    dataset: DatasetToActorsInput
     query: InsightActorsQuery['source']
     day?: string | number
     index?: number

--- a/frontend/src/scenes/trends/viz/handleTrendsLineChartClick.test.tsx
+++ b/frontend/src/scenes/trends/viz/handleTrendsLineChartClick.test.tsx
@@ -1,0 +1,224 @@
+import { NodeKind } from '~/queries/schema/schema-general'
+import { CompareLabelType, EntityTypes } from '~/types'
+
+import type { IndexedTrendResult } from '../types'
+import { handleTrendsLineChartClick, type TrendsLineChartClickDeps } from './handleTrendsLineChartClick'
+
+function makeTrendResult(overrides: Partial<IndexedTrendResult> = {}): IndexedTrendResult {
+    return {
+        id: 0,
+        seriesIndex: 0,
+        colorIndex: 0,
+        action: {
+            id: '$pageview',
+            type: EntityTypes.EVENTS,
+            order: 0,
+            name: '$pageview',
+            days: ['2024-06-10', '2024-06-11', '2024-06-12'],
+        },
+        label: '$pageview',
+        count: 10,
+        aggregated_value: 10,
+        data: [1, 2, 3],
+        labels: ['Mon', 'Tue', 'Wed'],
+        days: ['2024-06-10', '2024-06-11', '2024-06-12'],
+        ...overrides,
+    }
+}
+
+function keyFor(trendResult: IndexedTrendResult): string {
+    return `${trendResult.id}`
+}
+
+function makeDeps(overrides: Partial<TrendsLineChartClickDeps> = {}): TrendsLineChartClickDeps {
+    const trendResult = makeTrendResult()
+    return {
+        hasPersonsModal: true,
+        interval: 'day',
+        timezone: 'UTC',
+        weekStartDay: 0,
+        resolvedDateRange: null,
+        querySource: {
+            kind: NodeKind.TrendsQuery,
+            series: [{ kind: NodeKind.EventsNode, event: '$pageview' }],
+        },
+        indexedResults: [trendResult],
+        openPersonsModal: jest.fn(),
+        ...overrides,
+    }
+}
+
+describe('handleTrendsLineChartClick', () => {
+    it('opens the persons modal with the correct actors query for a basic click', () => {
+        const openPersonsModal = jest.fn()
+        const trendResult = makeTrendResult()
+        const deps = makeDeps({ openPersonsModal, indexedResults: [trendResult] })
+
+        handleTrendsLineChartClick(keyFor(trendResult), 1, deps)
+
+        expect(openPersonsModal).toHaveBeenCalledTimes(1)
+        const call = openPersonsModal.mock.calls[0][0]
+        expect(call.query).toMatchObject({
+            kind: NodeKind.InsightActorsQuery,
+            day: '2024-06-11',
+            series: 0,
+            includeRecordings: true,
+        })
+        expect(call.additionalSelect).toEqual({
+            value_at_data_point: 'event_count',
+            matched_recordings: 'matched_recordings',
+        })
+        expect(call.orderBy).toEqual(['event_count DESC, actor_id DESC'])
+    })
+
+    it('passes breakdown_value through to the actors query', () => {
+        const openPersonsModal = jest.fn()
+        const trendResult = makeTrendResult({ breakdown_value: 'Spike' })
+        const deps = makeDeps({ openPersonsModal, indexedResults: [trendResult] })
+
+        handleTrendsLineChartClick(keyFor(trendResult), 2, deps)
+
+        expect(openPersonsModal.mock.calls[0][0].query).toMatchObject({
+            day: '2024-06-12',
+            breakdown: 'Spike',
+        })
+    })
+
+    it('passes compare_label through to the actors query', () => {
+        const openPersonsModal = jest.fn()
+        const trendResult = makeTrendResult({ compare_label: CompareLabelType.Previous })
+        const deps = makeDeps({ openPersonsModal, indexedResults: [trendResult] })
+
+        handleTrendsLineChartClick(keyFor(trendResult), 0, deps)
+
+        expect(openPersonsModal.mock.calls[0][0].query).toMatchObject({
+            day: '2024-06-10',
+            compare: 'previous',
+        })
+    })
+
+    it('calls context.onDataPointClick instead of opening the modal when provided', () => {
+        const openPersonsModal = jest.fn()
+        const onDataPointClick = jest.fn()
+        const trendResult = makeTrendResult({ breakdown_value: 'Spike' })
+        const referenceResult = makeTrendResult({ id: 99 })
+        const deps = makeDeps({
+            openPersonsModal,
+            indexedResults: [referenceResult, trendResult],
+            context: { onDataPointClick },
+        })
+
+        handleTrendsLineChartClick(keyFor(trendResult), 1, deps)
+
+        expect(openPersonsModal).not.toHaveBeenCalled()
+        expect(onDataPointClick).toHaveBeenCalledTimes(1)
+        expect(onDataPointClick).toHaveBeenCalledWith(
+            { day: '2024-06-11', breakdown: 'Spike', compare: undefined },
+            referenceResult
+        )
+    })
+
+    it('forwards compare_label to context.onDataPointClick', () => {
+        const openPersonsModal = jest.fn()
+        const onDataPointClick = jest.fn()
+        const trendResult = makeTrendResult({ compare_label: CompareLabelType.Previous })
+        const deps = makeDeps({
+            openPersonsModal,
+            indexedResults: [trendResult],
+            context: { onDataPointClick },
+        })
+
+        handleTrendsLineChartClick(keyFor(trendResult), 0, deps)
+
+        expect(onDataPointClick).toHaveBeenCalledWith(
+            expect.objectContaining({ compare: 'previous' }),
+            expect.anything()
+        )
+    })
+
+    it('does nothing when hasPersonsModal is false and no context callback', () => {
+        const openPersonsModal = jest.fn()
+        const trendResult = makeTrendResult()
+        const deps = makeDeps({ openPersonsModal, hasPersonsModal: false, indexedResults: [trendResult] })
+
+        handleTrendsLineChartClick(keyFor(trendResult), 1, deps)
+
+        expect(openPersonsModal).not.toHaveBeenCalled()
+    })
+
+    it('still fires context.onDataPointClick when hasPersonsModal is false', () => {
+        const openPersonsModal = jest.fn()
+        const onDataPointClick = jest.fn()
+        const trendResult = makeTrendResult()
+        const deps = makeDeps({
+            openPersonsModal,
+            hasPersonsModal: false,
+            indexedResults: [trendResult],
+            context: { onDataPointClick },
+        })
+
+        handleTrendsLineChartClick(keyFor(trendResult), 1, deps)
+
+        expect(onDataPointClick).toHaveBeenCalledTimes(1)
+        expect(openPersonsModal).not.toHaveBeenCalled()
+    })
+
+    it('no-ops when the clicked series has no matching indexedResult', () => {
+        const openPersonsModal = jest.fn()
+        const onDataPointClick = jest.fn()
+        const trendResult = makeTrendResult({ id: 42 })
+        const deps = makeDeps({
+            openPersonsModal,
+            indexedResults: [trendResult],
+            context: { onDataPointClick },
+        })
+
+        expect(() => handleTrendsLineChartClick('999', 1, deps)).not.toThrow()
+        expect(openPersonsModal).not.toHaveBeenCalled()
+        expect(onDataPointClick).not.toHaveBeenCalled()
+    })
+
+    it('uses trendResult.days[index] as fallback when action.days is missing', () => {
+        const openPersonsModal = jest.fn()
+        const trendResult = makeTrendResult({
+            // ActionFilter without a `days` array — the adapter should fall
+            // back to reading from the top-level trend result `days`.
+            action: { id: '$pageview', type: EntityTypes.EVENTS, order: 0, name: '$pageview' },
+            days: ['D0', 'D1', 'D2'],
+        })
+        const deps = makeDeps({ openPersonsModal, indexedResults: [trendResult] })
+
+        handleTrendsLineChartClick(keyFor(trendResult), 2, deps)
+
+        expect(openPersonsModal.mock.calls[0][0].query).toMatchObject({ day: 'D2' })
+    })
+
+    it('no-ops when neither action.days nor trendResult.days can supply a day', () => {
+        const openPersonsModal = jest.fn()
+        const onDataPointClick = jest.fn()
+        const trendResult = makeTrendResult({
+            action: { id: '$pageview', type: EntityTypes.EVENTS, order: 0, name: '$pageview' },
+            days: [],
+        })
+        const deps = makeDeps({
+            openPersonsModal,
+            indexedResults: [trendResult],
+            context: { onDataPointClick },
+        })
+
+        handleTrendsLineChartClick(keyFor(trendResult), 2, deps)
+
+        expect(openPersonsModal).not.toHaveBeenCalled()
+        expect(onDataPointClick).not.toHaveBeenCalled()
+    })
+
+    it('does nothing when querySource is missing and no context callback', () => {
+        const openPersonsModal = jest.fn()
+        const trendResult = makeTrendResult()
+        const deps = makeDeps({ openPersonsModal, querySource: null, indexedResults: [trendResult] })
+
+        handleTrendsLineChartClick(keyFor(trendResult), 1, deps)
+
+        expect(openPersonsModal).not.toHaveBeenCalled()
+    })
+})

--- a/frontend/src/scenes/trends/viz/handleTrendsLineChartClick.test.tsx
+++ b/frontend/src/scenes/trends/viz/handleTrendsLineChartClick.test.tsx
@@ -71,70 +71,41 @@ describe('handleTrendsLineChartClick', () => {
         expect(call.orderBy).toEqual(['event_count DESC, actor_id DESC'])
     })
 
-    it('passes breakdown_value through to the actors query', () => {
+    it.each([
+        ['breakdown_value', { breakdown_value: 'Spike' }, 2, { day: '2024-06-12', breakdown: 'Spike' }],
+        ['compare_label', { compare_label: CompareLabelType.Previous }, 0, { day: '2024-06-10', compare: 'previous' }],
+    ])('passes %s through to the actors query', (_field, override, dataIndex, expected) => {
         const openPersonsModal = jest.fn()
-        const trendResult = makeTrendResult({ breakdown_value: 'Spike' })
+        const trendResult = makeTrendResult(override)
         const deps = makeDeps({ openPersonsModal, indexedResults: [trendResult] })
 
-        handleTrendsLineChartClick(keyFor(trendResult), 2, deps)
+        handleTrendsLineChartClick(keyFor(trendResult), dataIndex, deps)
 
-        expect(openPersonsModal.mock.calls[0][0].query).toMatchObject({
-            day: '2024-06-12',
-            breakdown: 'Spike',
-        })
+        expect(openPersonsModal.mock.calls[0][0].query).toMatchObject(expected)
     })
 
-    it('passes compare_label through to the actors query', () => {
-        const openPersonsModal = jest.fn()
-        const trendResult = makeTrendResult({ compare_label: CompareLabelType.Previous })
-        const deps = makeDeps({ openPersonsModal, indexedResults: [trendResult] })
+    it.each([
+        ['breakdown_value', { breakdown_value: 'Spike' }, 1, { day: '2024-06-11', breakdown: 'Spike' }],
+        ['compare_label', { compare_label: CompareLabelType.Previous }, 0, { day: '2024-06-10', compare: 'previous' }],
+    ])(
+        'forwards %s to context.onDataPointClick instead of opening the modal',
+        (_field, override, dataIndex, expected) => {
+            const openPersonsModal = jest.fn()
+            const onDataPointClick = jest.fn()
+            const trendResult = makeTrendResult(override)
+            const deps = makeDeps({
+                openPersonsModal,
+                indexedResults: [trendResult],
+                context: { onDataPointClick },
+            })
 
-        handleTrendsLineChartClick(keyFor(trendResult), 0, deps)
+            handleTrendsLineChartClick(keyFor(trendResult), dataIndex, deps)
 
-        expect(openPersonsModal.mock.calls[0][0].query).toMatchObject({
-            day: '2024-06-10',
-            compare: 'previous',
-        })
-    })
-
-    it('calls context.onDataPointClick instead of opening the modal when provided', () => {
-        const openPersonsModal = jest.fn()
-        const onDataPointClick = jest.fn()
-        const trendResult = makeTrendResult({ breakdown_value: 'Spike' })
-        const referenceResult = makeTrendResult({ id: 99 })
-        const deps = makeDeps({
-            openPersonsModal,
-            indexedResults: [referenceResult, trendResult],
-            context: { onDataPointClick },
-        })
-
-        handleTrendsLineChartClick(keyFor(trendResult), 1, deps)
-
-        expect(openPersonsModal).not.toHaveBeenCalled()
-        expect(onDataPointClick).toHaveBeenCalledTimes(1)
-        expect(onDataPointClick).toHaveBeenCalledWith(
-            { day: '2024-06-11', breakdown: 'Spike', compare: undefined },
-            referenceResult
-        )
-    })
-
-    it('forwards compare_label to context.onDataPointClick', () => {
-        const openPersonsModal = jest.fn()
-        const onDataPointClick = jest.fn()
-        const trendResult = makeTrendResult({ compare_label: CompareLabelType.Previous })
-        const deps = makeDeps({
-            openPersonsModal,
-            indexedResults: [trendResult],
-            context: { onDataPointClick },
-        })
-
-        handleTrendsLineChartClick(keyFor(trendResult), 0, deps)
-
-        expect(onDataPointClick).toHaveBeenCalledWith(
-            expect.objectContaining({ compare: 'previous' }),
-            expect.anything()
-        )
-    })
+            expect(openPersonsModal).not.toHaveBeenCalled()
+            expect(onDataPointClick).toHaveBeenCalledTimes(1)
+            expect(onDataPointClick).toHaveBeenCalledWith(expect.objectContaining(expected), expect.anything())
+        }
+    )
 
     it('does nothing when hasPersonsModal is false and no context callback', () => {
         const openPersonsModal = jest.fn()

--- a/frontend/src/scenes/trends/viz/handleTrendsLineChartClick.tsx
+++ b/frontend/src/scenes/trends/viz/handleTrendsLineChartClick.tsx
@@ -1,0 +1,80 @@
+import { DateDisplay } from 'lib/components/DateDisplay'
+
+import { InsightActorsQuery, InsightVizNode, ResolvedDateRangeResponse } from '~/queries/schema/schema-general'
+import { QueryContext } from '~/queries/types'
+import { IntervalType } from '~/types'
+
+import type { OpenPersonsModalProps } from '../persons-modal/PersonsModal'
+import type { IndexedTrendResult } from '../types'
+import { datasetToActorsQuery } from './datasetToActorsQuery'
+
+export interface TrendsLineChartClickDeps {
+    context?: QueryContext<InsightVizNode>
+    hasPersonsModal: boolean
+    interval: IntervalType | null | undefined
+    timezone: string
+    weekStartDay: number | null | undefined
+    resolvedDateRange: ResolvedDateRangeResponse | null | undefined
+    querySource: InsightActorsQuery['source'] | null | undefined
+    indexedResults: IndexedTrendResult[]
+    // Injected so the adapter stays decoupled from PersonsModal's dep graph.
+    openPersonsModal: (props: OpenPersonsModalProps) => void
+}
+
+// TrendsLineChartD3 keys each hog-charts Series by `${r.id}`, so we can
+// resolve back to the source IndexedTrendResult without stashing it on meta.
+function resolveDataset(seriesKey: string, indexedResults: IndexedTrendResult[]): IndexedTrendResult | null {
+    return indexedResults.find((r) => String(r.id) === seriesKey) ?? null
+}
+
+export function handleTrendsLineChartClick(seriesKey: string, dataIndex: number, deps: TrendsLineChartClickDeps): void {
+    const dataset = resolveDataset(seriesKey, deps.indexedResults)
+    if (!dataset) {
+        return
+    }
+
+    const day = dataset.action?.days?.[dataIndex] ?? dataset.days?.[dataIndex]
+    if (day == null || day === '') {
+        return
+    }
+
+    if (deps.context?.onDataPointClick) {
+        deps.context.onDataPointClick(
+            {
+                breakdown: dataset.breakdown_value,
+                compare: dataset.compare_label || undefined,
+                day,
+            },
+            // Legacy parity with ActionsLineGraph — passes the first result, not the clicked one.
+            deps.indexedResults[0]
+        )
+        return
+    }
+
+    if (!deps.hasPersonsModal || !deps.querySource) {
+        return
+    }
+
+    const title = (actorLabel: string): JSX.Element => (
+        <>
+            {actorLabel} on{' '}
+            <DateDisplay
+                interval={deps.interval || 'day'}
+                resolvedDateRange={deps.resolvedDateRange ?? undefined}
+                timezone={deps.timezone}
+                weekStartDay={deps.weekStartDay ?? undefined}
+                date={day?.toString() || ''}
+            />
+        </>
+    )
+
+    deps.openPersonsModal({
+        title,
+        query: datasetToActorsQuery({ dataset, query: deps.querySource, day }),
+        additionalSelect: {
+            value_at_data_point: 'event_count',
+            matched_recordings: 'matched_recordings',
+        },
+        orderBy: ['event_count DESC, actor_id DESC'],
+    })
+}

--- a/frontend/src/scenes/trends/viz/handleTrendsLineChartClick.tsx
+++ b/frontend/src/scenes/trends/viz/handleTrendsLineChartClick.tsx
@@ -63,7 +63,7 @@ export function handleTrendsLineChartClick(seriesKey: string, dataIndex: number,
                 resolvedDateRange={deps.resolvedDateRange ?? undefined}
                 timezone={deps.timezone}
                 weekStartDay={deps.weekStartDay ?? undefined}
-                date={day?.toString() || ''}
+                date={day}
             />
         </>
     )


### PR DESCRIPTION
## Problem

Adds the click-handler function used by the next PR to open the persons modal from a hog-charts trends line chart click. Pure function, no component wiring yet.

## Changes

- New \`handleTrendsLineChartClick\` that opens the persons modal (or fires \`context.onDataPointClick\`) for a clicked trends series
- Narrows \`datasetToActorsQuery\`'s param type so both chart.js and hog-charts paths can use it without casts

## How did you test this code?

Agent-authored. 11 unit tests on the new handler, no manual testing — the component wire-up and integration tests are in the follow-up.

## Publish to changelog?

## Docs update

<!-- ## 🤖 LLM context -->